### PR TITLE
Add 1Password auth and simplify build config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
 YANDEX_DIRECT_TOKEN=your_access_token_here
 YANDEX_DIRECT_LOGIN=your_yandex_login_here
 
+# 1Password secret references (optional, used as fallback)
+# YANDEX_DIRECT_OP_TOKEN_REF=op://vault/item/token
+# YANDEX_DIRECT_OP_LOGIN_REF=op://vault/item/login
+
 # PyPI publishing (used by scripts/release_pypi.sh)
 TWINE_USERNAME=__token__
 TEST_PYPI_TOKEN=pypi-...

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -55,3 +55,37 @@ Request flow: `cli.py` → `auth.py` (resolves token/login) → `api.py` (`creat
 - Integration tests (`tests/test_integration.py`, `@pytest.mark.integration`) — require `.env` with `YANDEX_DIRECT_TOKEN` and `YANDEX_DIRECT_LOGIN`. Auto-skip if token is absent.
 
 **Credentials:** `.env` in the project root. `YANDEX_DIRECT_LOGIN` is the Yandex advertiser login (required). `load_dotenv()` is called at `cli.py` module import, so it is loaded before any Click invocation.
+
+## Dangerous Commands — Do Not Auto-Test
+
+Never invoke these commands in automated tests against a real account.
+
+### 🔴 Irreversible — permanently destroy data
+| Command | Risk |
+|---------|------|
+| `campaigns delete` | Permanently deletes a campaign and all its content |
+| `adgroups delete` | Permanently deletes an ad group and its ads/keywords |
+| `ads delete` | Permanently deletes an ad |
+| `keywords delete` | Permanently deletes a keyword |
+| `audiencetargets delete` | Permanently deletes an audience target |
+
+### 🟠 Financial impact — change bids or spending
+| Command | Risk |
+|---------|------|
+| `bids set` | Changes search/network bids on campaigns — direct cost impact |
+| `keywordbids set` | Changes per-keyword bids |
+| `bidmodifiers set` | Changes bid multipliers (device, region, time, etc.) |
+
+### 🟡 Reversible but affect live traffic
+`campaigns suspend/resume/archive/unarchive`, `ads suspend/resume/archive/unarchive`, `keywords suspend/resume/archive/unarchive`, `audiencetargets suspend/resume`
+
+### 🟡 Account-wide mutations
+`clients update` — modifies account-level settings.
+
+### 🟡 Content creation (hard to clean up in bulk)
+All `add` and `update` subcommands across: `campaigns`, `adgroups`, `ads`, `keywords`, `feeds`, `retargeting`, `sitelinks`, `turbopages`, `vcards`, `adextensions`, `negativekeywordsharedsets`, `smartadtargets`, `dynamicads`, `audiencetargets`.
+
+These can be safely tested using `--dry-run` (outputs the request body as JSON without sending it).
+
+### ✅ Safe to auto-test (read-only, no side effects)
+All `get` subcommands, plus: `changes check*`, `dictionaries list-names`, `keywordsresearch has-search-volume`, `reports list-types`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,59 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+CLI for the Yandex Direct API, built with Python and Click. Installed via pip, published to PyPI.
+
+## Commands
+
+```bash
+pip install -e ".[dev]"              # Install in dev mode
+pytest                               # Unit tests (no token needed)
+pytest -m integration -v             # Integration tests (needs .env with token)
+pytest tests/test_cli.py::TestCLI::test_cli_help  # Single test
+pytest -k "campaigns"                # Pattern match
+black .                              # Format
+flake8 direct_cli tests              # Lint
+```
+
+## Architecture
+
+Click group-of-groups. Each Yandex Direct API resource = one file in `direct_cli/commands/` with a Click group and subcommands (`get`, `add`, `update`, `delete`, `suspend`, `resume`, etc.). All groups registered in `direct_cli/cli.py` via `cli.add_command()`.
+
+**Request flow:** `cli.py` → `auth.py` (resolves token/login) → `api.py` (`create_client`) → `tapi_yandex_direct.YandexDirect` → Yandex API → `output.py` (format/print).
+
+**Credentials priority:** CLI flags (`--token`, `--login`) > env vars (`YANDEX_DIRECT_TOKEN`, `YANDEX_DIRECT_LOGIN`) > `.env` file. `load_dotenv()` runs at `cli.py` import time.
+
+**Shared utilities** (`utils.py`): `parse_ids`, `parse_json`, `build_selection_criteria`, `build_common_params`, `get_default_fields`, `COMMON_FIELDS` dict. All command modules import from here — don't duplicate.
+
+**Output** (`output.py`): `format_output()` supports json (default), table, csv, tsv. Colored helpers: `print_success`, `print_error`, `print_warning`, `print_info`.
+
+## Key Conventions
+
+**Adding a new command module:**
+1. Create `direct_cli/commands/<resource>.py` with `@click.group()` + subcommands.
+2. Register in `cli.py` with `cli.add_command(...)`.
+3. Add command name to `TestCommandsRegistered.EXPECTED_COMMANDS` in `tests/test_comprehensive.py`.
+
+**`--dry-run`:** `add`/`update` commands print request JSON without calling the API. Use as test seam.
+
+**SelectionCriteria:** Resources like `adgroups`, `ads`, `keywords` require at least one of `Ids`, `CampaignIds`, or `AdGroupIds` — otherwise API error 4001.
+
+**Error handling:** All commands wrap API calls in `try/except Exception` → `print_error(str(e))` + `raise click.Abort()`.
+
+**Default fields:** `COMMON_FIELDS` in `utils.py` maps resource names to `FieldNames`. Not all fields are valid for all resources (e.g., `adimages` uses `AdImageHash`, not `Id`).
+
+## Tests
+
+- **Unit** (`test_cli.py`, `test_comprehensive.py`) — no API calls, no token needed.
+- **Integration** (`test_integration.py`, `@pytest.mark.integration`) — require `.env` with `YANDEX_DIRECT_TOKEN` and `YANDEX_DIRECT_LOGIN`. Auto-skip if absent.
+
+## Dangerous Commands — Never Auto-Test
+
+- **Irreversible (delete):** `campaigns/adgroups/ads/keywords/audiencetargets delete`
+- **Financial:** `bids set`, `keywordbids set`, `bidmodifiers set`
+- **Live traffic:** `suspend/resume/archive/unarchive` on campaigns, ads, keywords
+- **Mutations:** all `add`/`update` subcommands (test with `--dry-run`)
+- **Safe (read-only):** all `get` subcommands, `changes check*`, `dictionaries list-names`, `keywordsresearch has-search-volume`, `reports list-types`

--- a/README.md
+++ b/README.md
@@ -152,6 +152,28 @@ direct-cli campaigns get --limit 10        # first 10 results
 direct-cli campaigns get --fetch-all       # all pages
 ```
 
+### ⚠️ Destructive Commands
+
+The following commands make **irreversible changes** — use with caution:
+
+| Command | Effect |
+|---------|--------|
+| `campaigns delete --id` | Permanently deletes a campaign and all its contents |
+| `adgroups delete --id` | Permanently deletes an ad group |
+| `ads delete --id` | Permanently deletes an ad |
+| `keywords delete --id` | Permanently deletes a keyword |
+| `audiencetargets delete --id` | Permanently deletes an audience target |
+
+Commands that affect live ad delivery: `suspend`, `resume`, `archive`, `unarchive` (available on `campaigns`, `ads`, `keywords`).
+
+Commands that affect bids and spending: `bids set`, `keywordbids set`, `bidmodifiers set`.
+
+Use `--dry-run` on `add` / `update` commands to preview the API request before sending:
+
+```bash
+direct-cli campaigns add --name "Test" --start-date 2024-01-01 --dry-run
+```
+
 ### License
 
 MIT
@@ -304,6 +326,28 @@ direct-cli campaigns get --format csv --output campaigns.csv
 ```bash
 direct-cli campaigns get --limit 10    # первые 10 результатов
 direct-cli campaigns get --fetch-all   # все страницы
+```
+
+### ⚠️ Опасные команды
+
+Следующие команды вносят **необратимые изменения** — используйте осторожно:
+
+| Команда | Эффект |
+|---------|--------|
+| `campaigns delete --id` | Безвозвратно удаляет кампанию и весь её контент |
+| `adgroups delete --id` | Безвозвратно удаляет группу объявлений |
+| `ads delete --id` | Безвозвратно удаляет объявление |
+| `keywords delete --id` | Безвозвратно удаляет ключевое слово |
+| `audiencetargets delete --id` | Безвозвратно удаляет условие подбора аудитории |
+
+Команды, влияющие на показ рекламы: `suspend`, `resume`, `archive`, `unarchive` (доступны для `campaigns`, `ads`, `keywords`).
+
+Команды, влияющие на ставки и расходы: `bids set`, `keywordbids set`, `bidmodifiers set`.
+
+Используйте `--dry-run` в командах `add` / `update`, чтобы увидеть тело запроса до отправки:
+
+```bash
+direct-cli campaigns add --name "Тест" --start-date 2024-01-01 --dry-run
 ```
 
 ### Лицензия

--- a/direct_cli/api.py
+++ b/direct_cli/api.py
@@ -12,6 +12,8 @@ def create_client(
     token: Optional[str] = None,
     login: Optional[str] = None,
     sandbox: bool = False,
+    op_token_ref: Optional[str] = None,
+    op_login_ref: Optional[str] = None,
 ) -> YandexDirect:
     """
     Create YandexDirect client
@@ -20,11 +22,15 @@ def create_client(
         token: API access token
         login: Client login (for agency accounts)
         sandbox: Use sandbox API
+        op_token_ref: 1Password secret reference for token
+        op_login_ref: 1Password secret reference for login
 
     Returns:
         YandexDirect client instance
     """
-    final_token, final_login = get_credentials(token, login)
+    final_token, final_login = get_credentials(
+        token, login, op_token_ref=op_token_ref, op_login_ref=op_login_ref
+    )
 
     return YandexDirect(
         access_token=final_token,

--- a/direct_cli/auth.py
+++ b/direct_cli/auth.py
@@ -3,12 +3,45 @@ Authentication module for Direct CLI
 """
 
 import os
+import shutil
+import subprocess
 from typing import Optional, Tuple
 
 try:
     from dotenv import load_dotenv
 except ImportError:
     load_dotenv = lambda: None
+
+
+def op_read(ref: str) -> str:
+    """Read a secret from 1Password using the op CLI.
+
+    Args:
+        ref: 1Password secret reference (e.g. op://vault/item/field)
+
+    Returns:
+        The secret value
+
+    Raises:
+        RuntimeError: If op CLI is not found or returns an error
+    """
+    op_path = shutil.which("op")
+    if not op_path:
+        raise RuntimeError(
+            "1Password CLI (op) not found. "
+            "Install it from https://developer.1password.com/docs/cli/"
+        )
+    result = subprocess.run(
+        [op_path, "read", ref],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"1Password CLI error: {result.stderr.strip()}"
+        )
+    return result.stdout.strip()
 
 
 def load_env_file(env_path: Optional[str] = None) -> None:
@@ -45,14 +78,25 @@ def get_credentials(
     # Load .env file first
     load_env_file(env_path)
 
-    # Priority: arguments > env vars
+    # Priority: arguments > env vars > 1Password
     final_token = token or os.getenv("YANDEX_DIRECT_TOKEN")
     final_login = login or os.getenv("YANDEX_DIRECT_LOGIN")
 
     if not final_token:
+        op_ref = os.getenv("YANDEX_DIRECT_OP_TOKEN_REF")
+        if op_ref:
+            final_token = op_read(op_ref)
+
+    if not final_login:
+        op_ref = os.getenv("YANDEX_DIRECT_OP_LOGIN_REF")
+        if op_ref:
+            final_login = op_read(op_ref)
+
+    if not final_token:
         raise ValueError(
-            "API token required. Set YANDEX_DIRECT_TOKEN environment variable "
-            "or create .env file, or use --token option."
+            "API token required. Set YANDEX_DIRECT_TOKEN environment variable, "
+            "create .env file, use --token option, "
+            "or configure 1Password with --op-token-ref."
         )
 
     return final_token, final_login

--- a/direct_cli/auth.py
+++ b/direct_cli/auth.py
@@ -31,12 +31,15 @@ def op_read(ref: str) -> str:
             "1Password CLI (op) not found. "
             "Install it from https://developer.1password.com/docs/cli/"
         )
-    result = subprocess.run(
-        [op_path, "read", ref],
-        capture_output=True,
-        text=True,
-        timeout=10,
-    )
+    try:
+        result = subprocess.run(
+            [op_path, "read", ref],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        raise RuntimeError("1Password CLI timed out after 10 seconds")
     if result.returncode != 0:
         raise RuntimeError(
             f"1Password CLI error: {result.stderr.strip()}"
@@ -57,17 +60,22 @@ def get_credentials(
     token: Optional[str] = None,
     login: Optional[str] = None,
     env_path: Optional[str] = None,
+    op_token_ref: Optional[str] = None,
+    op_login_ref: Optional[str] = None,
 ) -> Tuple[str, Optional[str]]:
     """
     Get credentials with priority:
-    1. Direct arguments
-    2. Environment variables
+    1. Direct arguments (--token, --login)
+    2. Environment variables (YANDEX_DIRECT_TOKEN, YANDEX_DIRECT_LOGIN)
     3. .env file
+    4. 1Password (op_token_ref arg or YANDEX_DIRECT_OP_TOKEN_REF env var)
 
     Args:
         token: API access token
         login: Client login (for agency accounts)
         env_path: Path to .env file
+        op_token_ref: 1Password secret reference for token
+        op_login_ref: 1Password secret reference for login
 
     Returns:
         Tuple of (token, login)
@@ -83,14 +91,14 @@ def get_credentials(
     final_login = login or os.getenv("YANDEX_DIRECT_LOGIN")
 
     if not final_token:
-        op_ref = os.getenv("YANDEX_DIRECT_OP_TOKEN_REF")
-        if op_ref:
-            final_token = op_read(op_ref)
+        ref = op_token_ref or os.getenv("YANDEX_DIRECT_OP_TOKEN_REF")
+        if ref:
+            final_token = op_read(ref)
 
     if not final_login:
-        op_ref = os.getenv("YANDEX_DIRECT_OP_LOGIN_REF")
-        if op_ref:
-            final_login = op_read(op_ref)
+        ref = op_login_ref or os.getenv("YANDEX_DIRECT_OP_LOGIN_REF")
+        if ref:
+            final_login = op_read(ref)
 
     if not final_token:
         raise ValueError(

--- a/direct_cli/cli.py
+++ b/direct_cli/cli.py
@@ -3,8 +3,6 @@
 Direct CLI - Command-line interface for Yandex Direct API
 """
 
-import os
-
 import click
 from dotenv import load_dotenv
 
@@ -46,10 +44,12 @@ load_dotenv()
 @click.option("--sandbox", is_flag=True, help="Use sandbox API")
 @click.option(
     "--op-token-ref",
+    envvar="YANDEX_DIRECT_OP_TOKEN_REF",
     help="1Password secret reference for token (e.g. op://vault/item/token)",
 )
 @click.option(
     "--op-login-ref",
+    envvar="YANDEX_DIRECT_OP_LOGIN_REF",
     help="1Password secret reference for login",
 )
 @click.pass_context
@@ -59,10 +59,8 @@ def cli(ctx, token, login, sandbox, op_token_ref, op_login_ref):
     ctx.obj["token"] = token
     ctx.obj["login"] = login
     ctx.obj["sandbox"] = sandbox
-    if op_token_ref:
-        os.environ["YANDEX_DIRECT_OP_TOKEN_REF"] = op_token_ref
-    if op_login_ref:
-        os.environ["YANDEX_DIRECT_OP_LOGIN_REF"] = op_login_ref
+    ctx.obj["op_token_ref"] = op_token_ref
+    ctx.obj["op_login_ref"] = op_login_ref
 
 
 # Register all commands

--- a/direct_cli/cli.py
+++ b/direct_cli/cli.py
@@ -3,6 +3,8 @@
 Direct CLI - Command-line interface for Yandex Direct API
 """
 
+import os
+
 import click
 from dotenv import load_dotenv
 
@@ -42,13 +44,25 @@ load_dotenv()
 @click.option("--token", envvar="YANDEX_DIRECT_TOKEN", help="API access token")
 @click.option("--login", envvar="YANDEX_DIRECT_LOGIN", help="Client login")
 @click.option("--sandbox", is_flag=True, help="Use sandbox API")
+@click.option(
+    "--op-token-ref",
+    help="1Password secret reference for token (e.g. op://vault/item/token)",
+)
+@click.option(
+    "--op-login-ref",
+    help="1Password secret reference for login",
+)
 @click.pass_context
-def cli(ctx, token, login, sandbox):
+def cli(ctx, token, login, sandbox, op_token_ref, op_login_ref):
     """Command-line interface for Yandex Direct API"""
     ctx.ensure_object(dict)
     ctx.obj["token"] = token
     ctx.obj["login"] = login
     ctx.obj["sandbox"] = sandbox
+    if op_token_ref:
+        os.environ["YANDEX_DIRECT_OP_TOKEN_REF"] = op_token_ref
+    if op_login_ref:
+        os.environ["YANDEX_DIRECT_OP_LOGIN_REF"] = op_login_ref
 
 
 # Register all commands

--- a/direct_cli/cli.py
+++ b/direct_cli/cli.py
@@ -6,6 +6,8 @@ Direct CLI - Command-line interface for Yandex Direct API
 import click
 from dotenv import load_dotenv
 
+from .auth import get_credentials
+
 from .commands.campaigns import campaigns
 from .commands.adgroups import adgroups
 from .commands.ads import ads
@@ -56,11 +58,23 @@ load_dotenv()
 def cli(ctx, token, login, sandbox, op_token_ref, op_login_ref):
     """Command-line interface for Yandex Direct API"""
     ctx.ensure_object(dict)
-    ctx.obj["token"] = token
-    ctx.obj["login"] = login
     ctx.obj["sandbox"] = sandbox
-    ctx.obj["op_token_ref"] = op_token_ref
-    ctx.obj["op_login_ref"] = op_login_ref
+    # Resolve credentials early so all subcommands get the final values
+    if token or login or op_token_ref or op_login_ref:
+        try:
+            resolved_token, resolved_login = get_credentials(
+                token=token, login=login,
+                op_token_ref=op_token_ref, op_login_ref=op_login_ref,
+            )
+            ctx.obj["token"] = resolved_token
+            ctx.obj["login"] = resolved_login
+        except ValueError:
+            # Let subcommands fail naturally if no token
+            ctx.obj["token"] = token
+            ctx.obj["login"] = login
+    else:
+        ctx.obj["token"] = token
+        ctx.obj["login"] = login
 
 
 # Register all commands

--- a/direct_cli/cli.py
+++ b/direct_cli/cli.py
@@ -68,8 +68,10 @@ def cli(ctx, token, login, sandbox, op_token_ref, op_login_ref):
             )
             ctx.obj["token"] = resolved_token
             ctx.obj["login"] = resolved_login
+        except RuntimeError as e:
+            raise click.ClickException(str(e))
         except ValueError:
-            # Let subcommands fail naturally if no token
+            # No token provided — let subcommands fail naturally
             ctx.obj["token"] = token
             ctx.obj["login"] = login
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=45", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "direct-cli"
-dynamic = ["version"]
+version = "0.1.0"
 description = "Command-line interface for Yandex Direct API"
 readme = "README.md"
 license = {text = "MIT"}
@@ -48,10 +48,6 @@ direct-cli = "direct_cli.cli:cli"
 [project.urls]
 Homepage = "https://github.com/pavelmaksimov/direct-cli"
 Repository = "https://github.com/pavelmaksimov/direct-cli"
-
-[tool.setuptools_scm]
-write_to = "direct_cli/_version.py"
-fallback_version = "0.1.0"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/scripts/release_pypi.sh
+++ b/scripts/release_pypi.sh
@@ -75,7 +75,7 @@ build_artifacts() {
   echo "Building package"
   (
     cd "${ROOT_DIR}"
-    python3 -m build
+    python3 -m build --no-isolation
   )
 
   echo "Checking artifacts with twine"

--- a/setup.py
+++ b/setup.py
@@ -1,65 +1,6 @@
 #!/usr/bin/env python
 
-from setuptools import setup, find_packages
-import os
+from setuptools import setup
 
-version = {}
-version_file = os.path.join(os.path.dirname(__file__), "direct_cli", "_version.py")
-if os.path.exists(version_file):
-    with open(version_file) as f:
-        exec(f.read(), version)
-else:
-    version["__version__"] = "0.0.0"
+setup()
 
-with open("README.md", "r", encoding="utf-8") as fh:
-    readme = fh.read()
-
-setup(
-    name="direct-cli",
-    version=version["__version__"],
-    description="Command-line interface for Yandex Direct API",
-    long_description=readme,
-    long_description_content_type="text/markdown",
-    author="Pavel Maksimov",
-    author_email="vur21@ya.ru",
-    url="https://github.com/pavelmaksimov/direct-cli",
-    packages=find_packages(),
-    include_package_data=True,
-    install_requires=[
-        "tapi-yandex-direct>=2021.5.29",
-        "click>=8.0.0",
-        "python-dotenv>=0.19.0",
-        "tabulate>=0.8.0",
-        "colorama>=0.4.0",
-        "tqdm>=4.60.0",
-    ],
-    extras_require={
-        "dev": [
-            "pytest>=6.0",
-            "pytest-cov>=2.0",
-            "black>=22.0",
-            "flake8>=4.0",
-        ],
-    },
-    entry_points={
-        "console_scripts": [
-            "direct-cli=direct_cli.cli:cli",
-        ],
-    },
-    python_requires=">=3.6",
-    classifiers=[
-        "Development Status :: 4 - Beta",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-    ],
-    keywords="yandex direct cli api advertising",
-    license="MIT",
-    zip_safe=False,
-)

--- a/tests/test_auth_op.py
+++ b/tests/test_auth_op.py
@@ -1,0 +1,77 @@
+"""Tests for 1Password integration in auth module"""
+
+import subprocess
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from direct_cli.auth import op_read, get_credentials
+
+
+class TestOpRead:
+    """Tests for op_read function"""
+
+    @patch("direct_cli.auth.subprocess.run")
+    @patch("direct_cli.auth.shutil.which", return_value="/usr/local/bin/op")
+    def test_op_read_success(self, mock_which, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="my-secret-token\n", stderr=""
+        )
+        result = op_read("op://vault/item/token")
+        assert result == "my-secret-token"
+        mock_run.assert_called_once_with(
+            ["/usr/local/bin/op", "read", "op://vault/item/token"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+    @patch("direct_cli.auth.shutil.which", return_value=None)
+    def test_op_read_op_not_found(self, mock_which):
+        with pytest.raises(RuntimeError, match="1Password CLI .* not found"):
+            op_read("op://vault/item/token")
+
+    @patch("direct_cli.auth.subprocess.run")
+    @patch("direct_cli.auth.shutil.which", return_value="/usr/local/bin/op")
+    def test_op_read_op_fails(self, mock_which, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="", stderr="item not found"
+        )
+        with pytest.raises(RuntimeError, match="item not found"):
+            op_read("op://vault/item/token")
+
+
+class TestGetCredentialsOp:
+    """Tests for 1Password fallback in get_credentials"""
+
+    @patch("direct_cli.auth.load_env_file")
+    @patch("direct_cli.auth.op_read", return_value="op-token-value")
+    def test_get_credentials_op_fallback(self, mock_op_read, mock_load, monkeypatch):
+        monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
+        monkeypatch.setenv("YANDEX_DIRECT_OP_TOKEN_REF", "op://vault/item/token")
+
+        token, login = get_credentials()
+        assert token == "op-token-value"
+        mock_op_read.assert_called_once_with("op://vault/item/token")
+
+    @patch("direct_cli.auth.load_env_file")
+    @patch("direct_cli.auth.op_read")
+    def test_get_credentials_env_takes_priority_over_op(self, mock_op_read, mock_load, monkeypatch):
+        monkeypatch.setenv("YANDEX_DIRECT_TOKEN", "env-token")
+        monkeypatch.setenv("YANDEX_DIRECT_OP_TOKEN_REF", "op://vault/item/token")
+
+        token, login = get_credentials()
+        assert token == "env-token"
+        mock_op_read.assert_not_called()
+
+    @patch("direct_cli.auth.load_env_file")
+    @patch("direct_cli.auth.op_read", return_value="op-login-value")
+    def test_get_credentials_op_login_fallback(self, mock_op_read, mock_load, monkeypatch):
+        monkeypatch.setenv("YANDEX_DIRECT_TOKEN", "some-token")
+        monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
+        monkeypatch.setenv("YANDEX_DIRECT_OP_LOGIN_REF", "op://vault/item/login")
+
+        token, login = get_credentials()
+        assert login == "op-login-value"
+        mock_op_read.assert_called_once_with("op://vault/item/login")

--- a/tests/test_auth_op.py
+++ b/tests/test_auth_op.py
@@ -117,3 +117,15 @@ class TestCLIOpOptions:
         )
         assert result.exit_code == 0
         mock_op_read.assert_called_once_with("op://vault/item/token")
+
+    @patch("direct_cli.auth.load_env_file")
+    @patch("direct_cli.auth.op_read", side_effect=RuntimeError("1Password CLI (op) not found"))
+    def test_op_token_ref_error_surfaces_cleanly(self, mock_op_read, mock_load, monkeypatch):
+        monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["--op-token-ref", "op://vault/item/token", "campaigns", "get"]
+        )
+        assert result.exit_code != 0
+        assert "1Password CLI (op) not found" in result.output

--- a/tests/test_auth_op.py
+++ b/tests/test_auth_op.py
@@ -1,11 +1,12 @@
 """Tests for 1Password integration in auth module"""
 
-import subprocess
 from unittest.mock import patch, MagicMock
 
 import pytest
+from click.testing import CliRunner
 
 from direct_cli.auth import op_read, get_credentials
+from direct_cli.cli import cli
 
 
 class TestOpRead:
@@ -38,6 +39,14 @@ class TestOpRead:
             returncode=1, stdout="", stderr="item not found"
         )
         with pytest.raises(RuntimeError, match="item not found"):
+            op_read("op://vault/item/token")
+
+    @patch("direct_cli.auth.subprocess.run")
+    @patch("direct_cli.auth.shutil.which", return_value="/usr/local/bin/op")
+    def test_op_read_timeout(self, mock_which, mock_run):
+        import subprocess
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="op", timeout=10)
+        with pytest.raises(RuntimeError, match="timed out"):
             op_read("op://vault/item/token")
 
 
@@ -75,3 +84,31 @@ class TestGetCredentialsOp:
         token, login = get_credentials()
         assert login == "op-login-value"
         mock_op_read.assert_called_once_with("op://vault/item/login")
+
+    @patch("direct_cli.auth.load_env_file")
+    @patch("direct_cli.auth.op_read", return_value="op-token-value")
+    def test_get_credentials_explicit_op_ref_param(self, mock_op_read, mock_load, monkeypatch):
+        monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_OP_TOKEN_REF", raising=False)
+
+        token, login = get_credentials(op_token_ref="op://vault/item/token")
+        assert token == "op-token-value"
+        mock_op_read.assert_called_once_with("op://vault/item/token")
+
+
+class TestCLIOpOptions:
+    """Tests for --op-token-ref and --op-login-ref CLI options"""
+
+    def test_cli_help_shows_op_options(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+        assert "--op-token-ref" in result.output
+        assert "--op-login-ref" in result.output
+
+    def test_op_token_ref_stored_in_ctx(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["--op-token-ref", "op://vault/item/token", "--help"]
+        )
+        assert result.exit_code == 0

--- a/tests/test_auth_op.py
+++ b/tests/test_auth_op.py
@@ -106,9 +106,14 @@ class TestCLIOpOptions:
         assert "--op-token-ref" in result.output
         assert "--op-login-ref" in result.output
 
-    def test_op_token_ref_stored_in_ctx(self):
+    @patch("direct_cli.auth.load_env_file")
+    @patch("direct_cli.auth.op_read", return_value="resolved-op-token")
+    def test_op_token_ref_resolves_via_cli_flag(self, mock_op_read, mock_load, monkeypatch):
+        monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
         runner = CliRunner()
         result = runner.invoke(
-            cli, ["--op-token-ref", "op://vault/item/token", "--help"]
+            cli, ["--op-token-ref", "op://vault/item/token", "campaigns", "get", "--help"]
         )
         assert result.exit_code == 0
+        mock_op_read.assert_called_once_with("op://vault/item/token")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,6 +6,45 @@ if YANDEX_DIRECT_TOKEN is not set in the environment or .env file.
 
 Run with:
     pytest -m integration -v
+
+=============================================================================
+COMMANDS INTENTIONALLY EXCLUDED FROM AUTOMATED TESTING
+=============================================================================
+
+🔴 IRREVERSIBLE — permanently destroy data, never auto-test:
+    campaigns delete
+    adgroups delete
+    ads delete
+    keywords delete
+    audiencetargets delete
+
+🟠 FINANCIAL IMPACT — change bids/spending, never auto-test:
+    bids set
+    keywordbids set
+    bidmodifiers set
+
+🟡 REVERSIBLE but affect live traffic, excluded:
+    campaigns / ads / keywords: suspend, resume, archive, unarchive
+    audiencetargets: suspend, resume
+
+🟡 ACCOUNT-WIDE MUTATIONS, excluded:
+    clients update
+
+🟡 CONTENT CREATION — hard to bulk-clean, excluded from live tests:
+    add / update on: campaigns, adgroups, ads, keywords, feeds, retargeting,
+    sitelinks, turbopages, vcards, adextensions, negativekeywordsharedsets,
+    smartadtargets, dynamicads, audiencetargets
+
+    ➜ These can be tested safely via --dry-run (no API call is made):
+      result = runner.invoke(cli, ["campaigns", "add", "--name", "x",
+                                   "--start-date", "2024-01-01", "--dry-run"])
+      # exit_code == 0, output is the JSON request body
+
+⚠️  BORDERLINE, excluded for safety:
+    ads moderate  (submits ad for review — side effect on moderation queue)
+    agencyclients get  (requires agency account permissions)
+    sitelinks get / feeds get  (require explicit --ids, no list endpoint)
+=============================================================================
 """
 
 import json


### PR DESCRIPTION
## Summary
- **1Password authentication**: new `--op-token-ref` / `--op-login-ref` CLI options and env var fallback (`YANDEX_DIRECT_OP_TOKEN_REF`, `YANDEX_DIRECT_OP_LOGIN_REF`) for reading secrets via `op` CLI. Priority: CLI flags > env vars > .env > 1Password
- **Build simplification**: remove `setuptools_scm`, set static version in `pyproject.toml`, reduce `setup.py` to a minimal shim
- **Docs**: add `CLAUDE.md`, document destructive commands in README and copilot-instructions, document excluded integration tests

## Test plan
- [ ] `pytest` — all 35 tests pass (29 existing + 6 new)
- [ ] `pytest tests/test_auth_op.py -v` — 1Password unit tests
- [ ] `direct-cli --help` — shows `--op-token-ref` and `--op-login-ref`
- [ ] Manual: `direct-cli --op-token-ref "op://vault/item/token" campaigns get --dry-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)