### PR TITLE
feat: add Bitwarden CLI integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@ YANDEX_DIRECT_LOGIN=your_yandex_login_here
 # YANDEX_DIRECT_OP_TOKEN_REF=op://vault/item/token
 # YANDEX_DIRECT_OP_LOGIN_REF=op://vault/item/login
 
+# Bitwarden secret references (optional, used as fallback)
+# YANDEX_DIRECT_BW_TOKEN_REF=yandex-direct-item
+# YANDEX_DIRECT_BW_LOGIN_REF=yandex-direct-item
+
 # PyPI publishing (used by scripts/release_pypi.sh)
 TWINE_USERNAME=__token__
 TEST_PYPI_TOKEN=pypi-...

--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,8 @@ YANDEX_DIRECT_LOGIN=your_yandex_login_here
 # YANDEX_DIRECT_OP_LOGIN_REF=op://vault/item/login
 
 # Bitwarden secret references (optional, used as fallback)
-# YANDEX_DIRECT_BW_TOKEN_REF=yandex-direct-item
-# YANDEX_DIRECT_BW_LOGIN_REF=yandex-direct-item
+# YANDEX_DIRECT_BW_TOKEN_REF=yandex-direct-item  # reads 'password' field
+# YANDEX_DIRECT_BW_LOGIN_REF=yandex-direct-item  # reads 'username' field
 
 # PyPI publishing (used by scripts/release_pypi.sh)
 TWINE_USERNAME=__token__

--- a/direct_cli/auth.py
+++ b/direct_cli/auth.py
@@ -41,9 +41,40 @@ def op_read(ref: str) -> str:
     except subprocess.TimeoutExpired:
         raise RuntimeError("1Password CLI timed out after 10 seconds")
     if result.returncode != 0:
+        raise RuntimeError(f"1Password CLI error: {result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def bw_read(item: str, field: str = "password") -> str:
+    """Read a secret from Bitwarden using the bw CLI.
+
+    Args:
+        item: Bitwarden item name or ID
+        field: Field to read (password, username, notes)
+
+    Returns:
+        The secret value
+
+    Raises:
+        RuntimeError: If bw CLI is not found or returns an error
+    """
+    bw_path = shutil.which("bw")
+    if not bw_path:
         raise RuntimeError(
-            f"1Password CLI error: {result.stderr.strip()}"
+            "Bitwarden CLI (bw) not found. "
+            "Install it from https://bitwarden.com/help/cli/"
         )
+    try:
+        result = subprocess.run(
+            [bw_path, "get", field, item],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        raise RuntimeError("Bitwarden CLI timed out after 10 seconds")
+    if result.returncode != 0:
+        raise RuntimeError(f"Bitwarden CLI error: {result.stderr.strip()}")
     return result.stdout.strip()
 
 
@@ -62,6 +93,8 @@ def get_credentials(
     env_path: Optional[str] = None,
     op_token_ref: Optional[str] = None,
     op_login_ref: Optional[str] = None,
+    bw_token_ref: Optional[str] = None,
+    bw_login_ref: Optional[str] = None,
 ) -> Tuple[str, Optional[str]]:
     """
     Get credentials with priority:
@@ -69,6 +102,7 @@ def get_credentials(
     2. Environment variables (YANDEX_DIRECT_TOKEN, YANDEX_DIRECT_LOGIN)
     3. .env file
     4. 1Password (op_token_ref arg or YANDEX_DIRECT_OP_TOKEN_REF env var)
+    5. Bitwarden (bw_token_ref arg or YANDEX_DIRECT_BW_TOKEN_REF env var)
 
     Args:
         token: API access token
@@ -76,6 +110,8 @@ def get_credentials(
         env_path: Path to .env file
         op_token_ref: 1Password secret reference for token
         op_login_ref: 1Password secret reference for login
+        bw_token_ref: Bitwarden item name/ID for token
+        bw_login_ref: Bitwarden item name/ID for login
 
     Returns:
         Tuple of (token, login)
@@ -86,7 +122,7 @@ def get_credentials(
     # Load .env file first
     load_env_file(env_path)
 
-    # Priority: arguments > env vars > 1Password
+    # Priority: arguments > env vars > 1Password > Bitwarden
     final_token = token or os.getenv("YANDEX_DIRECT_TOKEN")
     final_login = login or os.getenv("YANDEX_DIRECT_LOGIN")
 
@@ -95,16 +131,28 @@ def get_credentials(
         if ref:
             final_token = op_read(ref)
 
+    if not final_token:
+        ref = bw_token_ref or os.getenv("YANDEX_DIRECT_BW_TOKEN_REF")
+        if ref:
+            final_token = bw_read(ref, "password")
+
     if not final_login:
         ref = op_login_ref or os.getenv("YANDEX_DIRECT_OP_LOGIN_REF")
         if ref:
             final_login = op_read(ref)
 
+    if not final_login:
+        ref = bw_login_ref or os.getenv("YANDEX_DIRECT_BW_LOGIN_REF")
+        if ref:
+            final_login = bw_read(ref, "username")
+
     if not final_token:
         raise ValueError(
-            "API token required. Set YANDEX_DIRECT_TOKEN environment variable, "
-            "create .env file, use --token option, "
-            "or configure 1Password with --op-token-ref."
+            "API token required. Set YANDEX_DIRECT_TOKEN "
+            "environment variable, create .env file, "
+            "use --token option, or configure 1Password "
+            "with --op-token-ref or Bitwarden "
+            "with --bw-token-ref."
         )
 
     return final_token, final_login

--- a/direct_cli/auth.py
+++ b/direct_cli/auth.py
@@ -74,7 +74,14 @@ def bw_read(item: str, field: str = "password") -> str:
     except subprocess.TimeoutExpired:
         raise RuntimeError("Bitwarden CLI timed out after 10 seconds")
     if result.returncode != 0:
-        raise RuntimeError(f"Bitwarden CLI error: {result.stderr.strip()}")
+        stderr = result.stderr.strip()
+        if "locked" in stderr.lower():
+            raise RuntimeError(
+                f"Bitwarden CLI error: {stderr}. "
+                "Ensure your vault is unlocked: "
+                "eval $(bw unlock)"
+            )
+        raise RuntimeError(f"Bitwarden CLI error: {stderr}")
     return result.stdout.strip()
 
 

--- a/direct_cli/auth.py
+++ b/direct_cli/auth.py
@@ -50,7 +50,7 @@ def bw_read(item: str, field: str = "password") -> str:
 
     Args:
         item: Bitwarden item name or ID
-        field: Field to read (password, username, notes)
+        field: Field to read (password, username)
 
     Returns:
         The secret value
@@ -129,7 +129,7 @@ def get_credentials(
     # Load .env file first
     load_env_file(env_path)
 
-    # Priority: arguments > env vars > 1Password > Bitwarden
+    # Priority: arguments > env vars/.env > 1Password > Bitwarden
     final_token = token or os.getenv("YANDEX_DIRECT_TOKEN")
     final_login = login or os.getenv("YANDEX_DIRECT_LOGIN")
 

--- a/direct_cli/cli.py
+++ b/direct_cli/cli.py
@@ -75,8 +75,8 @@ def cli(
     ctx.obj["sandbox"] = sandbox
     # Resolve credentials early so all subcommands get the final values
     has_refs = (
-        token or login or op_token_ref
-        or op_login_ref or bw_token_ref or bw_login_ref
+        token or login or op_token_ref or
+        op_login_ref or bw_token_ref or bw_login_ref
     )
     if has_refs:
         try:

--- a/direct_cli/cli.py
+++ b/direct_cli/cli.py
@@ -54,17 +54,39 @@ load_dotenv()
     envvar="YANDEX_DIRECT_OP_LOGIN_REF",
     help="1Password secret reference for login",
 )
+@click.option(
+    "--bw-token-ref",
+    envvar="YANDEX_DIRECT_BW_TOKEN_REF",
+    help="Bitwarden item name/ID for token (reads password field)",
+)
+@click.option(
+    "--bw-login-ref",
+    envvar="YANDEX_DIRECT_BW_LOGIN_REF",
+    help="Bitwarden item name/ID for login (reads username field)",
+)
 @click.pass_context
-def cli(ctx, token, login, sandbox, op_token_ref, op_login_ref):
+def cli(
+    ctx, token, login, sandbox,
+    op_token_ref, op_login_ref,
+    bw_token_ref, bw_login_ref,
+):
     """Command-line interface for Yandex Direct API"""
     ctx.ensure_object(dict)
     ctx.obj["sandbox"] = sandbox
     # Resolve credentials early so all subcommands get the final values
-    if token or login or op_token_ref or op_login_ref:
+    has_refs = (
+        token or login or op_token_ref
+        or op_login_ref or bw_token_ref or bw_login_ref
+    )
+    if has_refs:
         try:
             resolved_token, resolved_login = get_credentials(
-                token=token, login=login,
-                op_token_ref=op_token_ref, op_login_ref=op_login_ref,
+                token=token,
+                login=login,
+                op_token_ref=op_token_ref,
+                op_login_ref=op_login_ref,
+                bw_token_ref=bw_token_ref,
+                bw_login_ref=bw_login_ref,
             )
             ctx.obj["token"] = resolved_token
             ctx.obj["login"] = resolved_login

--- a/tests/test_auth_bw.py
+++ b/tests/test_auth_bw.py
@@ -145,6 +145,8 @@ class TestGetCredentialsBw:
     ):
         monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
         monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_OP_LOGIN_REF", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_BW_LOGIN_REF", raising=False)
         monkeypatch.setenv(
             "YANDEX_DIRECT_OP_TOKEN_REF", "op://vault/item/token"
         )

--- a/tests/test_auth_bw.py
+++ b/tests/test_auth_bw.py
@@ -174,6 +174,8 @@ class TestCLIBwOptions:
         monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
         monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
         monkeypatch.delenv("YANDEX_DIRECT_OP_TOKEN_REF", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_OP_LOGIN_REF", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_BW_LOGIN_REF", raising=False)
         runner = CliRunner()
         result = runner.invoke(
             cli,
@@ -199,6 +201,8 @@ class TestCLIBwOptions:
         monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
         monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
         monkeypatch.delenv("YANDEX_DIRECT_OP_TOKEN_REF", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_OP_LOGIN_REF", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_BW_LOGIN_REF", raising=False)
         runner = CliRunner()
         result = runner.invoke(
             cli, ["--bw-token-ref", "yandex-direct-item", "campaigns", "get"]

--- a/tests/test_auth_bw.py
+++ b/tests/test_auth_bw.py
@@ -88,6 +88,7 @@ class TestGetCredentialsBw:
         monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
         monkeypatch.delenv("YANDEX_DIRECT_OP_TOKEN_REF", raising=False)
         monkeypatch.delenv("YANDEX_DIRECT_OP_LOGIN_REF", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_BW_LOGIN_REF", raising=False)
         monkeypatch.setenv("YANDEX_DIRECT_BW_TOKEN_REF", "yandex-direct-item")
 
         token, login = get_credentials()
@@ -128,7 +129,9 @@ class TestGetCredentialsBw:
         monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
         monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
         monkeypatch.delenv("YANDEX_DIRECT_BW_TOKEN_REF", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_BW_LOGIN_REF", raising=False)
         monkeypatch.delenv("YANDEX_DIRECT_OP_TOKEN_REF", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_OP_LOGIN_REF", raising=False)
 
         token, login = get_credentials(bw_token_ref="yandex-direct-item")
         assert token == "bw-token-value"

--- a/tests/test_auth_bw.py
+++ b/tests/test_auth_bw.py
@@ -1,0 +1,193 @@
+"""Tests for Bitwarden integration in auth module"""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from direct_cli.auth import bw_read, get_credentials
+from direct_cli.cli import cli
+
+
+class TestBwRead:
+    """Tests for bw_read function"""
+
+    @patch("direct_cli.auth.subprocess.run")
+    @patch("direct_cli.auth.shutil.which", return_value="/usr/local/bin/bw")
+    def test_bw_read_success(self, mock_which, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="my-secret-token\n", stderr=""
+        )
+        result = bw_read("yandex-direct-item")
+        assert result == "my-secret-token"
+        mock_run.assert_called_once_with(
+            ["/usr/local/bin/bw", "get", "password", "yandex-direct-item"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+    @patch("direct_cli.auth.subprocess.run")
+    @patch("direct_cli.auth.shutil.which", return_value="/usr/local/bin/bw")
+    def test_bw_read_custom_field(self, mock_which, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="my-username\n", stderr=""
+        )
+        result = bw_read("yandex-direct-item", field="username")
+        assert result == "my-username"
+        mock_run.assert_called_once_with(
+            ["/usr/local/bin/bw", "get", "username", "yandex-direct-item"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+    @patch("direct_cli.auth.shutil.which", return_value=None)
+    def test_bw_read_not_found(self, mock_which):
+        with pytest.raises(RuntimeError, match="Bitwarden CLI .* not found"):
+            bw_read("yandex-direct-item")
+
+    @patch("direct_cli.auth.subprocess.run")
+    @patch("direct_cli.auth.shutil.which", return_value="/usr/local/bin/bw")
+    def test_bw_read_fails(self, mock_which, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="", stderr="Not found."
+        )
+        with pytest.raises(RuntimeError, match="Not found."):
+            bw_read("yandex-direct-item")
+
+    @patch("direct_cli.auth.subprocess.run")
+    @patch("direct_cli.auth.shutil.which", return_value="/usr/local/bin/bw")
+    def test_bw_read_timeout(self, mock_which, mock_run):
+        import subprocess
+
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="bw", timeout=10)
+        with pytest.raises(RuntimeError, match="timed out"):
+            bw_read("yandex-direct-item")
+
+
+class TestGetCredentialsBw:
+    """Tests for Bitwarden fallback in get_credentials"""
+
+    @patch("direct_cli.auth.load_env_file")
+    @patch("direct_cli.auth.bw_read", return_value="bw-token-value")
+    def test_get_credentials_bw_fallback(
+        self, mock_bw_read, mock_load, monkeypatch
+    ):
+        monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_OP_TOKEN_REF", raising=False)
+        monkeypatch.setenv("YANDEX_DIRECT_BW_TOKEN_REF", "yandex-direct-item")
+
+        token, login = get_credentials()
+        assert token == "bw-token-value"
+        mock_bw_read.assert_called_once_with("yandex-direct-item", "password")
+
+    @patch("direct_cli.auth.load_env_file")
+    @patch("direct_cli.auth.bw_read")
+    def test_get_credentials_env_takes_priority_over_bw(
+        self, mock_bw_read, mock_load, monkeypatch
+    ):
+        monkeypatch.setenv("YANDEX_DIRECT_TOKEN", "env-token")
+        monkeypatch.setenv("YANDEX_DIRECT_BW_TOKEN_REF", "yandex-direct-item")
+
+        token, login = get_credentials()
+        assert token == "env-token"
+        mock_bw_read.assert_not_called()
+
+    @patch("direct_cli.auth.load_env_file")
+    @patch("direct_cli.auth.bw_read", return_value="bw-login-value")
+    def test_get_credentials_bw_login_fallback(
+        self, mock_bw_read, mock_load, monkeypatch
+    ):
+        monkeypatch.setenv("YANDEX_DIRECT_TOKEN", "some-token")
+        monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_OP_LOGIN_REF", raising=False)
+        monkeypatch.setenv("YANDEX_DIRECT_BW_LOGIN_REF", "yandex-direct-item")
+
+        token, login = get_credentials()
+        assert login == "bw-login-value"
+        mock_bw_read.assert_called_once_with("yandex-direct-item", "username")
+
+    @patch("direct_cli.auth.load_env_file")
+    @patch("direct_cli.auth.bw_read", return_value="bw-token-value")
+    def test_get_credentials_explicit_bw_ref_param(
+        self, mock_bw_read, mock_load, monkeypatch
+    ):
+        monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_BW_TOKEN_REF", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_OP_TOKEN_REF", raising=False)
+
+        token, login = get_credentials(bw_token_ref="yandex-direct-item")
+        assert token == "bw-token-value"
+        mock_bw_read.assert_called_once_with("yandex-direct-item", "password")
+
+    @patch("direct_cli.auth.load_env_file")
+    @patch("direct_cli.auth.op_read", return_value="op-token-value")
+    @patch("direct_cli.auth.bw_read")
+    def test_op_takes_priority_over_bw(
+        self, mock_bw_read, mock_op_read, mock_load, monkeypatch
+    ):
+        monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
+        monkeypatch.setenv(
+            "YANDEX_DIRECT_OP_TOKEN_REF", "op://vault/item/token"
+        )
+        monkeypatch.setenv(
+            "YANDEX_DIRECT_BW_TOKEN_REF", "yandex-direct-item"
+        )
+
+        token, login = get_credentials()
+        assert token == "op-token-value"
+        mock_bw_read.assert_not_called()
+
+
+class TestCLIBwOptions:
+    """Tests for --bw-token-ref and --bw-login-ref CLI options"""
+
+    def test_cli_help_shows_bw_options(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+        assert "--bw-token-ref" in result.output
+        assert "--bw-login-ref" in result.output
+
+    @patch("direct_cli.auth.load_env_file")
+    @patch("direct_cli.auth.bw_read", return_value="resolved-bw-token")
+    def test_bw_token_ref_resolves_via_cli_flag(
+        self, mock_bw_read, mock_load, monkeypatch
+    ):
+        monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_OP_TOKEN_REF", raising=False)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "--bw-token-ref",
+                "yandex-direct-item",
+                "campaigns",
+                "get",
+                "--help",
+            ],
+        )
+        assert result.exit_code == 0
+        mock_bw_read.assert_called_once_with("yandex-direct-item", "password")
+
+    @patch("direct_cli.auth.load_env_file")
+    @patch(
+        "direct_cli.auth.bw_read",
+        side_effect=RuntimeError("Bitwarden CLI (bw) not found"),
+    )
+    def test_bw_token_ref_error_surfaces_cleanly(
+        self, mock_bw_read, mock_load, monkeypatch
+    ):
+        monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_OP_TOKEN_REF", raising=False)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["--bw-token-ref", "yandex-direct-item", "campaigns", "get"]
+        )
+        assert result.exit_code != 0
+        assert "Bitwarden CLI (bw) not found" in result.output

--- a/tests/test_auth_bw.py
+++ b/tests/test_auth_bw.py
@@ -1,5 +1,6 @@
 """Tests for Bitwarden integration in auth module"""
 
+import subprocess
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -58,9 +59,18 @@ class TestBwRead:
 
     @patch("direct_cli.auth.subprocess.run")
     @patch("direct_cli.auth.shutil.which", return_value="/usr/local/bin/bw")
-    def test_bw_read_timeout(self, mock_which, mock_run):
-        import subprocess
+    def test_bw_read_vault_locked(self, mock_which, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="", stderr="Vault is locked."
+        )
+        with pytest.raises(
+            RuntimeError, match=r"eval \$\(bw unlock\)"
+        ):
+            bw_read("yandex-direct-item")
 
+    @patch("direct_cli.auth.subprocess.run")
+    @patch("direct_cli.auth.shutil.which", return_value="/usr/local/bin/bw")
+    def test_bw_read_timeout(self, mock_which, mock_run):
         mock_run.side_effect = subprocess.TimeoutExpired(cmd="bw", timeout=10)
         with pytest.raises(RuntimeError, match="timed out"):
             bw_read("yandex-direct-item")
@@ -77,6 +87,7 @@ class TestGetCredentialsBw:
         monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
         monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
         monkeypatch.delenv("YANDEX_DIRECT_OP_TOKEN_REF", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_OP_LOGIN_REF", raising=False)
         monkeypatch.setenv("YANDEX_DIRECT_BW_TOKEN_REF", "yandex-direct-item")
 
         token, login = get_credentials()


### PR DESCRIPTION
## Summary
- Add `bw_read()` function in `auth.py` for reading secrets via Bitwarden CLI (`bw get <field> <item>`)
- Add `--bw-token-ref` and `--bw-login-ref` CLI options with corresponding env vars (`YANDEX_DIRECT_BW_TOKEN_REF`, `YANDEX_DIRECT_BW_LOGIN_REF`)
- Bitwarden acts as fallback after 1Password in credential resolution chain: CLI flags → env vars → 1Password → Bitwarden

## Test plan
- [x] 13 new unit tests in `tests/test_auth_bw.py` (all passing)
- [x] Existing 1Password tests unaffected (11 passing)
- [x] Full test suite passes (65 tests)
- [ ] Manual: `direct-cli --bw-token-ref <item> campaigns get --help` resolves token from Bitwarden

🤖 Generated with [Claude Code](https://claude.com/claude-code)