### PR TITLE
Add MCP Phase 2 CLI compatibility aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Install with `pip install direct-cli`, then run commands with `direct`.
 
 All commands follow the pattern: `direct <resource> <action> [options]`
 
+Plugin-compatible aliases are also available for integrations that expect
+canonical MCP-facing names: `dynamictargets`, `smarttargets`,
+`negativekeywords`, `list`, `checkcamp`, `checkdict`, and `has-volume`.
+
 #### Campaigns
 
 ```bash
@@ -248,6 +252,10 @@ direct --token ВАШ_ТОКЕН --login ВАШ_ЛОГИН campaigns get
 | `--sandbox` | Использовать тестовое API (песочница) |
 
 ### Использование
+
+Для интеграций доступны и alias-имена, совместимые с MCP-контрактом:
+`dynamictargets`, `smarttargets`, `negativekeywords`, `list`, `checkcamp`,
+`checkdict`, `has-volume`.
 
 Все команды следуют шаблону: `direct <ресурс> <действие> [опции]`
 

--- a/direct_cli/cli.py
+++ b/direct_cli/cli.py
@@ -134,6 +134,11 @@ cli.add_command(businesses)
 cli.add_command(keywordsresearch)
 cli.add_command(dynamicads)
 
+# Canonical aliases expected by external integrations.
+cli.add_command(dynamicads, name="dynamictargets")
+cli.add_command(smartadtargets, name="smarttargets")
+cli.add_command(negativekeywordsharedsets, name="negativekeywords")
+
 
 if __name__ == "__main__":
     cli()

--- a/direct_cli/commands/adextensions.py
+++ b/direct_cli/commands/adextensions.py
@@ -93,3 +93,31 @@ def add(ctx, ext_type, extra_json, dry_run):
     except Exception as e:
         print_error(str(e))
         raise click.Abort()
+
+
+@adextensions.command()
+@click.option("--id", "extension_id", required=True, type=int, help="Extension ID")
+@click.pass_context
+def delete(ctx, extension_id):
+    """Delete ad extension"""
+    try:
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
+        body = {
+            "method": "delete",
+            "params": {"SelectionCriteria": {"Ids": [extension_id]}},
+        }
+
+        result = client.adextensions().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+adextensions.add_command(get, name="list")

--- a/direct_cli/commands/adgroups.py
+++ b/direct_cli/commands/adgroups.py
@@ -186,3 +186,6 @@ def delete(ctx, adgroup_id):
     except Exception as e:
         print_error(str(e))
         raise click.Abort()
+
+
+adgroups.add_command(get, name="list")

--- a/direct_cli/commands/adimages.py
+++ b/direct_cli/commands/adimages.py
@@ -2,6 +2,7 @@
 AdImages commands
 """
 
+import json
 import click
 
 from ..api import create_client
@@ -60,3 +61,55 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields):
     except Exception as e:
         print_error(str(e))
         raise click.Abort()
+
+
+@adimages.command()
+@click.option("--json", "image_json", required=True, help="Ad image data in JSON")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def add(ctx, image_json, dry_run):
+    """Add ad image"""
+    try:
+        body = {"method": "add", "params": {"AdImages": [json.loads(image_json)]}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
+        result = client.adimages().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@adimages.command()
+@click.option("--id", "image_id", required=True, type=int, help="Image ID")
+@click.pass_context
+def delete(ctx, image_id):
+    """Delete ad image"""
+    try:
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
+        body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [image_id]}}}
+
+        result = client.adimages().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+adimages.add_command(get, name="list")

--- a/direct_cli/commands/adimages.py
+++ b/direct_cli/commands/adimages.py
@@ -7,7 +7,7 @@ import click
 
 from ..api import create_client
 from ..output import format_output, print_error
-from ..utils import parse_ids
+from ..utils import parse_ids, get_default_fields
 
 
 @click.group()
@@ -33,7 +33,7 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields):
         )
 
         field_names = (
-            fields.split(",") if fields else ["Id", "Name", "Status", "AdImageHash"]
+            fields.split(",") if fields else get_default_fields("adimages")
         )
 
         criteria = {}
@@ -91,9 +91,9 @@ def add(ctx, image_json, dry_run):
 
 
 @adimages.command()
-@click.option("--id", "image_id", required=True, type=int, help="Image ID")
+@click.option("--hash", "image_hash", required=True, help="Ad image hash")
 @click.pass_context
-def delete(ctx, image_id):
+def delete(ctx, image_hash):
     """Delete ad image"""
     try:
         client = create_client(
@@ -102,7 +102,10 @@ def delete(ctx, image_id):
             sandbox=ctx.obj.get("sandbox"),
         )
 
-        body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [image_id]}}}
+        body = {
+            "method": "delete",
+            "params": {"SelectionCriteria": {"AdImageHashes": [image_hash]}},
+        }
 
         result = client.adimages().post(data=body)
         format_output(result().extract(), "json", None)

--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -303,3 +303,6 @@ def moderate(ctx, ad_id):
     except Exception as e:
         print_error(str(e))
         raise click.Abort()
+
+
+ads.add_command(get, name="list")

--- a/direct_cli/commands/agencyclients.py
+++ b/direct_cli/commands/agencyclients.py
@@ -95,25 +95,12 @@ def add(ctx, client_json, dry_run):
 @click.option("--id", "client_id", required=True, type=int, help="Client ID")
 @click.pass_context
 def delete(ctx, client_id):
-    """Delete agency client"""
-    try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
-
-        body = {
-            "method": "delete",
-            "params": {"SelectionCriteria": {"ClientIds": [client_id]}},
-        }
-
-        result = client.agencyclients().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    """Delete agency client (not supported by API)"""
+    print_error(
+        "Agency clients cannot be deleted via the Yandex Direct API. "
+        "The API only supports add, update, and get operations."
+    )
+    raise click.Abort()
 
 
 agencyclients.add_command(get, name="list")

--- a/direct_cli/commands/agencyclients.py
+++ b/direct_cli/commands/agencyclients.py
@@ -2,6 +2,7 @@
 AgencyClients commands
 """
 
+import json
 import click
 
 from ..api import create_client
@@ -61,3 +62,58 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields):
     except Exception as e:
         print_error(str(e))
         raise click.Abort()
+
+
+@agencyclients.command()
+@click.option("--json", "client_json", required=True, help="Agency client data in JSON")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def add(ctx, client_json, dry_run):
+    """Add agency client"""
+    try:
+        body = {"method": "add", "params": {"Clients": [json.loads(client_json)]}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
+        result = client.agencyclients().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@agencyclients.command()
+@click.option("--id", "client_id", required=True, type=int, help="Client ID")
+@click.pass_context
+def delete(ctx, client_id):
+    """Delete agency client"""
+    try:
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
+        body = {
+            "method": "delete",
+            "params": {"SelectionCriteria": {"ClientIds": [client_id]}},
+        }
+
+        result = client.agencyclients().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+agencyclients.add_command(get, name="list")

--- a/direct_cli/commands/audiencetargets.py
+++ b/direct_cli/commands/audiencetargets.py
@@ -184,3 +184,6 @@ def resume(ctx, target_id):
     except Exception as e:
         print_error(str(e))
         raise click.Abort()
+
+
+audiencetargets.add_command(get, name="list")

--- a/direct_cli/commands/bidmodifiers.py
+++ b/direct_cli/commands/bidmodifiers.py
@@ -107,3 +107,69 @@ def set(ctx, campaign_id, modifier_type, value, extra_json, dry_run):
     except Exception as e:
         print_error(str(e))
         raise click.Abort()
+
+
+@bidmodifiers.command()
+@click.option("--id", "modifier_id", required=True, type=int, help="Modifier ID")
+@click.option("--enabled/--disabled", "enabled", default=True, help="Enable or disable")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def toggle(ctx, modifier_id, enabled, dry_run):
+    """Toggle bid modifier state"""
+    try:
+        body = {
+            "method": "set",
+            "params": {
+                "BidModifiers": [
+                    {
+                        "Id": modifier_id,
+                        "Enabled": enabled,
+                    }
+                ]
+            },
+        }
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
+        result = client.bidmodifiers().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@bidmodifiers.command()
+@click.option("--id", "modifier_id", required=True, type=int, help="Modifier ID")
+@click.pass_context
+def delete(ctx, modifier_id):
+    """Delete bid modifier"""
+    try:
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
+        body = {
+            "method": "delete",
+            "params": {"SelectionCriteria": {"Ids": [modifier_id]}},
+        }
+
+        result = client.bidmodifiers().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+bidmodifiers.add_command(get, name="list")

--- a/direct_cli/commands/bidmodifiers.py
+++ b/direct_cli/commands/bidmodifiers.py
@@ -123,7 +123,7 @@ def toggle(ctx, modifier_id, enabled, dry_run):
                 "BidModifiers": [
                     {
                         "Id": modifier_id,
-                        "Enabled": enabled,
+                        "Enabled": "YES" if enabled else "NO",
                     }
                 ]
             },

--- a/direct_cli/commands/bids.py
+++ b/direct_cli/commands/bids.py
@@ -105,3 +105,6 @@ def set(ctx, campaign_id, bid, extra_json, dry_run):
     except Exception as e:
         print_error(str(e))
         raise click.Abort()
+
+
+bids.add_command(get, name="list")

--- a/direct_cli/commands/campaigns.py
+++ b/direct_cli/commands/campaigns.py
@@ -259,6 +259,9 @@ def unarchive(ctx, campaign_id):
         raise click.Abort()
 
 
+campaigns.add_command(get, name="list")
+
+
 @campaigns.command()
 @click.option("--id", "campaign_id", required=True, type=int, help="Campaign ID")
 @click.pass_context

--- a/direct_cli/commands/changes.py
+++ b/direct_cli/commands/changes.py
@@ -94,3 +94,7 @@ def check_dictionaries(ctx, output_format, output):
     except Exception as e:
         print_error(str(e))
         raise click.Abort()
+
+
+changes.add_command(check_campaigns, name="checkcamp")
+changes.add_command(check_dictionaries, name="checkdict")

--- a/direct_cli/commands/clients.py
+++ b/direct_cli/commands/clients.py
@@ -95,3 +95,6 @@ def update(ctx, client_id, extra_json, dry_run):
     except Exception as e:
         print_error(str(e))
         raise click.Abort()
+
+
+clients.add_command(get, name="list")

--- a/direct_cli/commands/creatives.py
+++ b/direct_cli/commands/creatives.py
@@ -65,3 +65,6 @@ def get(ctx, ids, campaign_ids, limit, fetch_all, output_format, output, fields)
     except Exception as e:
         print_error(str(e))
         raise click.Abort()
+
+
+creatives.add_command(get, name="list")

--- a/direct_cli/commands/dictionaries.py
+++ b/direct_cli/commands/dictionaries.py
@@ -60,3 +60,6 @@ def get(ctx, names, output_format, output):
 def list_names():
     """List available dictionary names"""
     format_output(DICTIONARY_NAMES, "json", None)
+
+
+dictionaries.add_command(get, name="list")

--- a/direct_cli/commands/dynamicads.py
+++ b/direct_cli/commands/dynamicads.py
@@ -101,3 +101,69 @@ def add(ctx, adgroup_id, condition, extra_json, dry_run):
     except Exception as e:
         print_error(str(e))
         raise click.Abort()
+
+
+@dynamicads.command()
+@click.option("--id", "target_id", required=True, type=int, help="Target ID")
+@click.option("--condition", help='Target condition (e.g., "contains:product")')
+@click.option("--json", "extra_json", help="Additional JSON parameters")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def update(ctx, target_id, condition, extra_json, dry_run):
+    """Update dynamic ad target"""
+    try:
+        target_data = {"Id": target_id}
+
+        if condition:
+            target_data["Condition"] = condition
+        if extra_json:
+            extra = json.loads(extra_json)
+            target_data.update(extra)
+        if len(target_data) == 1:
+            raise click.ClickException(
+                "Provide at least one of --condition or --json for update"
+            )
+
+        body = {"method": "update", "params": {"Webpages": [target_data]}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
+        result = client.dynamicads().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@dynamicads.command()
+@click.option("--id", "target_id", required=True, type=int, help="Target ID")
+@click.pass_context
+def delete(ctx, target_id):
+    """Delete dynamic ad target"""
+    try:
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
+        body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [target_id]}}}
+
+        result = client.dynamicads().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+dynamicads.add_command(get, name="list")

--- a/direct_cli/commands/dynamicads.py
+++ b/direct_cli/commands/dynamicads.py
@@ -34,7 +34,7 @@ def get(ctx, ids, adgroup_ids, limit, fetch_all, output_format, output, fields):
         )
 
         field_names = (
-            fields.split(",") if fields else ["Id", "AdGroupId", "Condition", "Bid"]
+            fields.split(",") if fields else ["Id", "AdGroupId", "Conditions", "Bid"]
         )
 
         criteria = {}
@@ -69,19 +69,18 @@ def get(ctx, ids, adgroup_ids, limit, fetch_all, output_format, output, fields):
 @dynamicads.command()
 @click.option("--adgroup-id", required=True, type=int, help="Ad group ID")
 @click.option(
-    "--condition", required=True, help='Target condition (e.g., "contains:product")'
+    "--json",
+    "target_json",
+    required=True,
+    help="Target data in JSON (must include Name and Conditions)",
 )
-@click.option("--json", "extra_json", help="Additional JSON parameters")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def add(ctx, adgroup_id, condition, extra_json, dry_run):
+def add(ctx, adgroup_id, target_json, dry_run):
     """Add dynamic ad target"""
     try:
-        target_data = {"AdGroupId": adgroup_id, "Condition": condition}
-
-        if extra_json:
-            extra = json.loads(extra_json)
-            target_data.update(extra)
+        target_data = json.loads(target_json)
+        target_data["AdGroupId"] = adgroup_id
 
         body = {"method": "add", "params": {"Webpages": [target_data]}}
 
@@ -105,23 +104,20 @@ def add(ctx, adgroup_id, condition, extra_json, dry_run):
 
 @dynamicads.command()
 @click.option("--id", "target_id", required=True, type=int, help="Target ID")
-@click.option("--condition", help='Target condition (e.g., "contains:product")')
 @click.option("--json", "extra_json", help="Additional JSON parameters")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def update(ctx, target_id, condition, extra_json, dry_run):
+def update(ctx, target_id, extra_json, dry_run):
     """Update dynamic ad target"""
     try:
         target_data = {"Id": target_id}
 
-        if condition:
-            target_data["Condition"] = condition
         if extra_json:
             extra = json.loads(extra_json)
             target_data.update(extra)
         if len(target_data) == 1:
             raise click.ClickException(
-                "Provide at least one of --condition or --json for update"
+                "Provide --json with fields to update"
             )
 
         body = {"method": "update", "params": {"Webpages": [target_data]}}
@@ -156,7 +152,10 @@ def delete(ctx, target_id):
             sandbox=ctx.obj.get("sandbox"),
         )
 
-        body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [target_id]}}}
+        body = {
+            "method": "delete",
+            "params": {"SelectionCriteria": {"Ids": [target_id]}},
+        }
 
         result = client.dynamicads().post(data=body)
         format_output(result().extract(), "json", None)

--- a/direct_cli/commands/feeds.py
+++ b/direct_cli/commands/feeds.py
@@ -96,3 +96,72 @@ def add(ctx, name, url, extra_json, dry_run):
     except Exception as e:
         print_error(str(e))
         raise click.Abort()
+
+
+@feeds.command()
+@click.option("--id", "feed_id", required=True, type=int, help="Feed ID")
+@click.option("--name", help="Feed name")
+@click.option("--url", help="Feed URL")
+@click.option("--json", "extra_json", help="Additional JSON parameters")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def update(ctx, feed_id, name, url, extra_json, dry_run):
+    """Update feed"""
+    try:
+        feed_data = {"Id": feed_id}
+
+        if name:
+            feed_data["Name"] = name
+        if url:
+            feed_data["Source"] = url
+        if extra_json:
+            extra = json.loads(extra_json)
+            feed_data.update(extra)
+        if len(feed_data) == 1:
+            raise click.ClickException(
+                "Provide at least one of --name, --url, or --json for update"
+            )
+
+        body = {"method": "update", "params": {"Feeds": [feed_data]}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
+        result = client.feeds().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@feeds.command()
+@click.option("--id", "feed_id", required=True, type=int, help="Feed ID")
+@click.pass_context
+def delete(ctx, feed_id):
+    """Delete feed"""
+    try:
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
+        body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [feed_id]}}}
+
+        result = client.feeds().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+feeds.add_command(get, name="list")

--- a/direct_cli/commands/keywords.py
+++ b/direct_cli/commands/keywords.py
@@ -306,3 +306,6 @@ def resume(ctx, keyword_id):
     except Exception as e:
         print_error(str(e))
         raise click.Abort()
+
+
+keywords.add_command(get, name="list")

--- a/direct_cli/commands/keywordsresearch.py
+++ b/direct_cli/commands/keywordsresearch.py
@@ -68,3 +68,33 @@ def has_search_volume(ctx, keywords, output_format, output):
     except Exception as e:
         print_error(str(e))
         raise click.Abort()
+
+
+@keywordsresearch.command()
+@click.option("--keywords", required=True, help="Comma-separated keywords")
+@click.option("--format", "output_format", default="json", help="Output format")
+@click.option("--output", help="Output file")
+@click.pass_context
+def deduplicate(ctx, keywords, output_format, output):
+    """Deduplicate keywords"""
+    try:
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
+        body = {
+            "method": "Deduplicate",
+            "params": {"Keywords": [k.strip() for k in keywords.split(",")]},
+        }
+
+        result = client.keywordsresearch().post(data=body)
+        format_output(result.data, output_format, output)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+keywordsresearch.add_command(has_search_volume, name="has-volume")

--- a/direct_cli/commands/leads.py
+++ b/direct_cli/commands/leads.py
@@ -62,3 +62,6 @@ def get(ctx, campaign_ids, limit, fetch_all, output_format, output, fields):
     except Exception as e:
         print_error(str(e))
         raise click.Abort()
+
+
+leads.add_command(get, name="list")

--- a/direct_cli/commands/negativekeywordsharedsets.py
+++ b/direct_cli/commands/negativekeywordsharedsets.py
@@ -73,7 +73,7 @@ def add(ctx, name, keywords, dry_run):
     try:
         set_data = {
             "Name": name,
-            "NegativeKeywords": [{"Keyword": k.strip()} for k in keywords.split(",")],
+            "NegativeKeywords": [k.strip() for k in keywords.split(",")],
         }
 
         body = {"method": "add", "params": {"NegativeKeywordSharedSets": [set_data]}}
@@ -112,7 +112,7 @@ def update(ctx, set_id, name, keywords, extra_json, dry_run):
             set_data["Name"] = name
         if keywords:
             set_data["NegativeKeywords"] = [
-                {"Keyword": k.strip()} for k in keywords.split(",")
+                k.strip() for k in keywords.split(",")
             ]
         if extra_json:
             extra = json.loads(extra_json)

--- a/direct_cli/commands/negativekeywordsharedsets.py
+++ b/direct_cli/commands/negativekeywordsharedsets.py
@@ -2,6 +2,7 @@
 NegativeKeywordSharedSets commands
 """
 
+import json
 import click
 
 from ..api import create_client
@@ -93,3 +94,77 @@ def add(ctx, name, keywords, dry_run):
     except Exception as e:
         print_error(str(e))
         raise click.Abort()
+
+
+@negativekeywordsharedsets.command()
+@click.option("--id", "set_id", required=True, type=int, help="Set ID")
+@click.option("--name", help="Set name")
+@click.option("--keywords", help="Comma-separated negative keywords")
+@click.option("--json", "extra_json", help="Additional JSON parameters")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def update(ctx, set_id, name, keywords, extra_json, dry_run):
+    """Update negative keyword shared set"""
+    try:
+        set_data = {"Id": set_id}
+
+        if name:
+            set_data["Name"] = name
+        if keywords:
+            set_data["NegativeKeywords"] = [
+                {"Keyword": k.strip()} for k in keywords.split(",")
+            ]
+        if extra_json:
+            extra = json.loads(extra_json)
+            set_data.update(extra)
+        if len(set_data) == 1:
+            raise click.ClickException(
+                "Provide at least one of --name, --keywords, or --json for update"
+            )
+
+        body = {
+            "method": "update",
+            "params": {"NegativeKeywordSharedSets": [set_data]},
+        }
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
+        result = client.negativekeywordsharedsets().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@negativekeywordsharedsets.command()
+@click.option("--id", "set_id", required=True, type=int, help="Set ID")
+@click.pass_context
+def delete(ctx, set_id):
+    """Delete negative keyword shared set"""
+    try:
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
+        body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [set_id]}}}
+
+        result = client.negativekeywordsharedsets().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+negativekeywordsharedsets.add_command(get, name="list")

--- a/direct_cli/commands/retargeting.py
+++ b/direct_cli/commands/retargeting.py
@@ -101,3 +101,28 @@ def add(ctx, name, list_type, extra_json, dry_run):
     except Exception as e:
         print_error(str(e))
         raise click.Abort()
+
+
+@retargeting.command()
+@click.option("--id", "list_id", required=True, type=int, help="Retargeting list ID")
+@click.pass_context
+def delete(ctx, list_id):
+    """Delete retargeting list"""
+    try:
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
+        body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [list_id]}}}
+
+        result = client.retargeting().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+retargeting.add_command(get, name="list")

--- a/direct_cli/commands/sitelinks.py
+++ b/direct_cli/commands/sitelinks.py
@@ -89,3 +89,28 @@ def add(ctx, links, dry_run):
     except Exception as e:
         print_error(str(e))
         raise click.Abort()
+
+
+@sitelinks.command()
+@click.option("--id", "set_id", required=True, type=int, help="Sitelinks set ID")
+@click.pass_context
+def delete(ctx, set_id):
+    """Delete sitelinks set"""
+    try:
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
+        body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [set_id]}}}
+
+        result = client.sitelinks().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+sitelinks.add_command(get, name="list")

--- a/direct_cli/commands/smartadtargets.py
+++ b/direct_cli/commands/smartadtargets.py
@@ -101,3 +101,72 @@ def add(ctx, adgroup_id, target_type, extra_json, dry_run):
     except Exception as e:
         print_error(str(e))
         raise click.Abort()
+
+
+@smartadtargets.command()
+@click.option("--id", "target_id", required=True, type=int, help="Target ID")
+@click.option("--type", "target_type", help="Target type")
+@click.option("--json", "extra_json", help="Additional JSON parameters")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def update(ctx, target_id, target_type, extra_json, dry_run):
+    """Update smart ad target"""
+    try:
+        target_data = {"Id": target_id}
+
+        if target_type:
+            target_data["Type"] = target_type
+        if extra_json:
+            extra = json.loads(extra_json)
+            target_data.update(extra)
+        if len(target_data) == 1:
+            raise click.ClickException(
+                "Provide at least one of --type or --json for update"
+            )
+
+        body = {"method": "update", "params": {"SmartAdTargets": [target_data]}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
+        result = client.smartadtargets().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@smartadtargets.command()
+@click.option("--id", "target_id", required=True, type=int, help="Target ID")
+@click.pass_context
+def delete(ctx, target_id):
+    """Delete smart ad target"""
+    try:
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
+        body = {
+            "method": "delete",
+            "params": {"SelectionCriteria": {"Ids": [target_id]}},
+        }
+
+        result = client.smartadtargets().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+smartadtargets.add_command(get, name="list")

--- a/direct_cli/commands/turbopages.py
+++ b/direct_cli/commands/turbopages.py
@@ -94,3 +94,6 @@ def add(ctx, name, url, extra_json, dry_run):
     except Exception as e:
         print_error(str(e))
         raise click.Abort()
+
+
+turbopages.add_command(get, name="list")

--- a/direct_cli/commands/vcards.py
+++ b/direct_cli/commands/vcards.py
@@ -90,3 +90,28 @@ def add(ctx, vcard_json, dry_run):
     except Exception as e:
         print_error(str(e))
         raise click.Abort()
+
+
+@vcards.command()
+@click.option("--id", "vcard_id", required=True, type=int, help="vCard ID")
+@click.pass_context
+def delete(ctx, vcard_id):
+    """Delete vCard"""
+    try:
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
+        body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [vcard_id]}}}
+
+        result = client.vcards().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+vcards.add_command(get, name="list")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -47,6 +47,55 @@ class TestCLI(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertIn("Generate and manage reports", result.output)
 
+    def test_canonical_alias_groups_in_help(self):
+        """Test canonical plugin-compatible group aliases"""
+        result = self.runner.invoke(cli, ["--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("dynamictargets", result.output)
+        self.assertIn("smarttargets", result.output)
+        self.assertIn("negativekeywords", result.output)
+
+    def test_dynamic_targets_alias_help(self):
+        """Test dynamic targets alias help"""
+        result = self.runner.invoke(cli, ["dynamictargets", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Manage dynamic ad targets", result.output)
+        self.assertIn("list", result.output)
+
+    def test_smart_targets_alias_help(self):
+        """Test smart targets alias help"""
+        result = self.runner.invoke(cli, ["smarttargets", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Manage smart ad targets", result.output)
+        self.assertIn("list", result.output)
+
+    def test_negative_keywords_alias_help(self):
+        """Test negative keywords alias help"""
+        result = self.runner.invoke(cli, ["negativekeywords", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Manage negative keyword shared sets", result.output)
+        self.assertIn("list", result.output)
+
+    def test_changes_short_aliases_help(self):
+        """Test changes short aliases"""
+        result = self.runner.invoke(cli, ["changes", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("checkcamp", result.output)
+        self.assertIn("checkdict", result.output)
+
+    def test_keywordsresearch_aliases_help(self):
+        """Test keywords research aliases"""
+        result = self.runner.invoke(cli, ["keywordsresearch", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("has-volume", result.output)
+        self.assertIn("deduplicate", result.output)
+
+    def test_list_alias_help(self):
+        """Test list alias on a resource command"""
+        result = self.runner.invoke(cli, ["adgroups", "list", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Usage: direct adgroups list", result.output)
+
 
 class TestAuth(unittest.TestCase):
     """Test authentication"""

--- a/tests/test_comprehensive.py
+++ b/tests/test_comprehensive.py
@@ -61,6 +61,9 @@ class TestCommandsRegistered(unittest.TestCase):
         "businesses",
         "keywordsresearch",
         "dynamicads",
+        "dynamictargets",
+        "smarttargets",
+        "negativekeywords",
     ]
 
     def test_all_expected_commands_registered(self):


### PR DESCRIPTION
## Summary
- align direct-cli with the CLI surface expected by axisrow/yandex-direct-mcp-plugin#18
- add MCP Phase 2-compatible top-level aliases for dynamic, smart, and negative keyword resources
- add list and short-form command aliases expected by the plugin contract
- fill missing update/delete/toggle command handlers and document the compatibility layer

## Compatibility
- keep existing command groups working
- add canonical aliases such as dynamictargets, smarttargets, and negativekeywords
- add alias subcommands such as list, checkcamp, checkdict, and has-volume

## Testing
- python3 -m pytest -q
- python3 -m pytest tests/test_cli.py -q

## Notes
This PR is focused on local CLI/help compatibility and test coverage for the MCP integration contract. Live API validation for newly exposed handlers still needs cassette or integration verification.