### PR TITLE
fix(ads): stop sending implicit Type field in add command

### DIFF
--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -97,7 +97,7 @@ def get(
 def add(ctx, adgroup_id, ad_type, title, text, href, extra_json, dry_run):
     """Add new ad"""
     try:
-        ad_data = {"AdGroupId": adgroup_id, "Type": ad_type}
+        ad_data = {"AdGroupId": adgroup_id}
 
         if ad_type == "TEXT_AD":
             ad_data["TextAd"] = {}


### PR DESCRIPTION
## Summary

Yandex Direct API rejects \`ads/add\` requests that contain an explicit \`"Type"\` key inside the Ad object. The actual ad type must be inferred from the presence of \`TextAd\` / \`DynamicTextAd\` / \`MobileAppAd\` sub-objects, NOT declared as a top-level field.

Before this fix the CLI sent:

\`\`\`json
{"AdGroupId": 12345, "Type": "TEXT_AD", "TextAd": {"Title": "...", ...}}
\`\`\`

which the API responds to with \`InvalidArgumentError\` on the \`Type\` field. After:

\`\`\`json
{"AdGroupId": 12345, "TextAd": {"Title": "...", ...}}
\`\`\`

The \`--type\` CLI option is preserved — it controls which sub-object the CLI builds locally, but it never reaches the wire as a top-level key.

## Why this slipped through

\`ads add\` was the only mutating CLI command that anyone exercised against a real account. The 43 other write commands have **zero** test coverage and may contain similar bugs. That broader gap is tracked in axisrow/yandex-direct-mcp-plugin#61, which proposes adding dry-run unit tests for every write command (this PR is one of the small foundation pieces of that plan).

## Test plan

- [x] \`direct ads add --adgroup-id 1 --type TEXT_AD --title T --text X --href https://example.com --dry-run\` → printed JSON no longer contains \`"Type"\` inside the Ad object
- [ ] (manual, requires sandbox token) \`direct --sandbox ads add ... \` → API accepts the request

## Related

- Refs axisrow/yandex-direct-mcp-plugin#60 (the MCP-side issue where this bug was first observed)
- Refs axisrow/yandex-direct-mcp-plugin#61 (broader direct-cli test-coverage plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)