### PR TITLE
fix+test: stop sending implicit Type field in add commands; add dry-run coverage

### DIFF
--- a/direct_cli/commands/adgroups.py
+++ b/direct_cli/commands/adgroups.py
@@ -92,7 +92,16 @@ def get(
 def add(ctx, name, campaign_id, group_type, region_ids, extra_json, dry_run):
     """Add new ad group"""
     try:
-        adgroup_data = {"Name": name, "CampaignId": campaign_id, "Type": group_type}
+        # Yandex Direct API rejects an explicit top-level "Type" field on
+        # AdGroupAddItem — the group type is inferred from the presence of
+        # MobileAppAdGroup / DynamicTextAdGroup / SmartAdGroup / etc.
+        # sub-objects, exactly like Ads (see fix in commands/ads.py).
+        # The --type CLI option is preserved for backward compatibility but
+        # is no longer forwarded to the API; users wanting non-text group
+        # types must pass the matching sub-object via --json.
+        # Refs: https://yandex.ru/dev/direct/doc/ref-v5/adgroups/add.html
+        adgroup_data = {"Name": name, "CampaignId": campaign_id}
+        _ = group_type  # acknowledged-but-unused
 
         if region_ids:
             adgroup_data["RegionIds"] = parse_ids(region_ids)

--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -97,7 +97,7 @@ def get(
 def add(ctx, adgroup_id, ad_type, title, text, href, extra_json, dry_run):
     """Add new ad"""
     try:
-        ad_data = {"AdGroupId": adgroup_id, "Type": ad_type}
+        ad_data = {"AdGroupId": adgroup_id}
 
         if ad_type == "TEXT_AD":
             ad_data["TextAd"] = {}

--- a/direct_cli/commands/smartadtargets.py
+++ b/direct_cli/commands/smartadtargets.py
@@ -77,7 +77,15 @@ def get(ctx, ids, adgroup_ids, limit, fetch_all, output_format, output, fields):
 def add(ctx, adgroup_id, target_type, extra_json, dry_run):
     """Add smart ad target"""
     try:
-        target_data = {"AdGroupId": adgroup_id, "Type": target_type}
+        # SmartAdTargetAddItem in the Yandex Direct API does NOT have a
+        # top-level "Type" field. Real fields are AdGroupId, TargetingId
+        # (e.g. "VIEWED_PRODUCT"), Bid, Priority. The legacy --type CLI
+        # option does not map cleanly onto the API, so we no longer
+        # forward it; callers should pass the full SmartAdTarget shape
+        # (TargetingId/Bid/Priority) via --json.
+        # Refs: SmartAdTargets service docs and tapi-yandex-direct mapping.
+        target_data = {"AdGroupId": adgroup_id}
+        _ = target_type  # acknowledged-but-unused
 
         if extra_json:
             extra = json.loads(extra_json)
@@ -114,15 +122,15 @@ def update(ctx, target_id, target_type, extra_json, dry_run):
     try:
         target_data = {"Id": target_id}
 
-        if target_type:
-            target_data["Type"] = target_type
+        # See note in `add` above — Type is not a real field on
+        # SmartAdTargetAddItem; the legacy --type CLI option is kept
+        # for backward compatibility but no longer forwarded.
+        _ = target_type  # acknowledged-but-unused
         if extra_json:
             extra = json.loads(extra_json)
             target_data.update(extra)
         if len(target_data) == 1:
-            raise click.ClickException(
-                "Provide at least one of --type or --json for update"
-            )
+            raise click.ClickException("Provide --json with fields to update")
 
         body = {"method": "update", "params": {"SmartAdTargets": [target_data]}}
 

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1,0 +1,617 @@
+"""Dry-run payload tests for direct-cli write commands.
+
+These tests use the ``--dry-run`` flag to verify the JSON request body
+that direct-cli builds for every mutating command, **without** making any
+HTTP calls. They run in the default pytest set (no markers, no token
+needed) and complete in well under a second.
+
+Why this file exists
+--------------------
+
+Until this PR, direct-cli had **zero** test coverage for write
+operations. The Type-field bug in ``ads add`` (sending an explicit
+top-level ``"Type"`` key that the Yandex Direct API rejects) shipped to
+production specifically because no one had ever exercised an ``add``
+command against a real API; the only mutating command anyone happened
+to try was ``ads add``, and only after a user reported the failure
+through the MCP plugin (axisrow/yandex-direct-mcp-plugin#60).
+
+The audit that motivated this file (axisrow/yandex-direct-mcp-plugin#61)
+counted **44 mutating commands across 28 services with 0% coverage**.
+This file closes that gap by exercising every write command that has
+a ``--dry-run`` flag and asserting the exact request body shape.
+
+Two more occurrences of the same Type bug were found by this audit and
+fixed alongside these tests:
+
+* ``adgroups add`` — confirmed against the official Yandex Direct API
+  v5 docs (https://yandex.ru/dev/direct/doc/ref-v5/adgroups/add.html);
+  ``AdGroupAddItem`` has no top-level ``Type``.
+* ``smartadtargets add`` / ``smartadtargets update`` — the legacy
+  ``--type`` CLI option doesn't map to any real ``SmartAdTargetAddItem``
+  field (real fields are ``TargetingId``, ``Bid``, ``Priority``).
+
+Each test for an ``add`` command includes a regression assertion that
+``"Type"`` is **not** present at the top level of the resource item, so
+that re-introducing the bug breaks CI immediately.
+
+Coverage scope
+--------------
+
+Only commands that already implement ``--dry-run`` are covered (this is
+all ``add`` / ``update`` / ``set`` / ``toggle`` write commands).
+Single-action state-change commands (``delete``, ``archive``,
+``unarchive``, ``suspend``, ``resume``, ``moderate``) currently don't
+expose ``--dry-run`` and only send a trivial ``SelectionCriteria``
+payload, so they're out of scope here.
+
+Part of axisrow/yandex-direct-mcp-plugin#61.
+"""
+
+import json
+
+from click.testing import CliRunner
+
+from direct_cli.cli import cli
+
+
+def _dry_run(*args: str) -> dict:
+    """Invoke a CLI command with ``--dry-run`` and return the parsed body."""
+    result = CliRunner().invoke(cli, list(args) + ["--dry-run"])
+    assert result.exit_code == 0, (
+        f"command failed: direct {' '.join(args)} --dry-run\n"
+        f"output: {result.output}\n"
+        f"exception: {result.exception}"
+    )
+    return json.loads(result.output)
+
+
+# ----------------------------------------------------------------------
+# ads
+# ----------------------------------------------------------------------
+
+
+def test_ads_add_text_ad_payload_omits_type():
+    body = _dry_run(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "12345",
+        "--type",
+        "TEXT_AD",
+        "--title",
+        "T",
+        "--text",
+        "Some text",
+        "--href",
+        "https://example.com",
+    )
+    assert body["method"] == "add"
+    ad = body["params"]["Ads"][0]
+    # Regression guard for axisrow/yandex-direct-mcp-plugin#60:
+    # the Yandex Direct API rejects an explicit top-level Type field;
+    # the type is inferred from TextAd / MobileAppAd / DynamicTextAd / ...
+    assert "Type" not in ad
+    assert ad["AdGroupId"] == 12345
+    assert ad["TextAd"] == {
+        "Title": "T",
+        "Text": "Some text",
+        "Href": "https://example.com",
+    }
+
+
+def test_ads_update_payload_status_only():
+    body = _dry_run("ads", "update", "--id", "999", "--status", "SUSPENDED")
+    assert body["method"] == "update"
+    ad = body["params"]["Ads"][0]
+    assert ad == {"Id": 999, "Status": "SUSPENDED"}
+
+
+def test_ads_update_extra_json_merges_into_payload():
+    extra = {"TextAd": {"Title": "Updated"}}
+    body = _dry_run("ads", "update", "--id", "999", "--json", json.dumps(extra))
+    ad = body["params"]["Ads"][0]
+    assert ad["Id"] == 999
+    assert ad["TextAd"] == {"Title": "Updated"}
+
+
+# ----------------------------------------------------------------------
+# adgroups
+# ----------------------------------------------------------------------
+
+
+def test_adgroups_add_payload_omits_type():
+    body = _dry_run(
+        "adgroups",
+        "add",
+        "--name",
+        "Group A",
+        "--campaign-id",
+        "111",
+        "--region-ids",
+        "1,225",
+    )
+    assert body["method"] == "add"
+    group = body["params"]["AdGroups"][0]
+    # Regression guard: AdGroupAddItem has no top-level Type field;
+    # the group type is inferred from MobileAppAdGroup / DynamicTextAdGroup
+    # / SmartAdGroup / ... sub-objects exactly like Ads.
+    # See https://yandex.ru/dev/direct/doc/ref-v5/adgroups/add.html
+    assert "Type" not in group
+    assert group["Name"] == "Group A"
+    assert group["CampaignId"] == 111
+    assert group["RegionIds"] == [1, 225]
+
+
+def test_adgroups_update_payload_name_only():
+    body = _dry_run("adgroups", "update", "--id", "222", "--name", "Renamed")
+    assert body["method"] == "update"
+    group = body["params"]["AdGroups"][0]
+    assert group == {"Id": 222, "Name": "Renamed"}
+
+
+# ----------------------------------------------------------------------
+# campaigns
+# ----------------------------------------------------------------------
+
+
+def test_campaigns_add_default_text_campaign_payload():
+    body = _dry_run(
+        "campaigns",
+        "add",
+        "--name",
+        "C1",
+        "--start-date",
+        "2026-04-10",
+    )
+    assert body["method"] == "add"
+    campaign = body["params"]["Campaigns"][0]
+    assert campaign["Name"] == "C1"
+    assert campaign["StartDate"] == "2026-04-10"
+    assert "TextCampaign" in campaign
+    # CLI currently always builds a TextCampaign and never sets a
+    # top-level Type — confirm both invariants.
+    assert "Type" not in campaign
+
+
+def test_campaigns_add_with_budget_scales_to_micro_units():
+    body = _dry_run(
+        "campaigns",
+        "add",
+        "--name",
+        "C2",
+        "--start-date",
+        "2026-04-10",
+        "--budget",
+        "500",
+    )
+    campaign = body["params"]["Campaigns"][0]
+    assert campaign["DailyBudget"] == {"Amount": 500_000_000, "Mode": "STANDARD"}
+
+
+def test_campaigns_update_with_budget_scales_to_micro_units():
+    body = _dry_run("campaigns", "update", "--id", "555", "--budget", "100")
+    campaign = body["params"]["Campaigns"][0]
+    assert campaign["Id"] == 555
+    assert campaign["DailyBudget"] == {"Amount": 100_000_000, "Mode": "STANDARD"}
+
+
+# ----------------------------------------------------------------------
+# keywords
+# ----------------------------------------------------------------------
+
+
+def test_keywords_add_payload_with_bids_scales_to_micro_units():
+    body = _dry_run(
+        "keywords",
+        "add",
+        "--adgroup-id",
+        "12",
+        "--keyword",
+        "купить пиццу",
+        "--bid",
+        "15",
+        "--context-bid",
+        "5",
+    )
+    assert body["method"] == "add"
+    keyword = body["params"]["Keywords"][0]
+    assert keyword["AdGroupId"] == 12
+    assert keyword["Keyword"] == "купить пиццу"
+    assert keyword["Bid"] == 15_000_000
+    assert keyword["ContextBid"] == 5_000_000
+
+
+def test_keywords_update_payload_status_only():
+    body = _dry_run("keywords", "update", "--id", "777", "--status", "SUSPENDED")
+    keyword = body["params"]["Keywords"][0]
+    assert keyword == {"Id": 777, "Status": "SUSPENDED"}
+
+
+# ----------------------------------------------------------------------
+# bids / keywordbids
+# ----------------------------------------------------------------------
+
+
+def test_bids_set_scales_to_micro_units():
+    body = _dry_run("bids", "set", "--campaign-id", "1", "--bid", "15")
+    assert body["method"] == "set"
+    bid = body["params"]["Bids"][0]
+    assert bid == {"CampaignId": 1, "Bid": 15_000_000}
+
+
+def test_keywordbids_set_search_and_network_scales():
+    body = _dry_run(
+        "keywordbids",
+        "set",
+        "--keyword-id",
+        "42",
+        "--search-bid",
+        "8",
+        "--network-bid",
+        "3",
+    )
+    assert body["method"] == "set"
+    bid = body["params"]["KeywordBids"][0]
+    assert bid == {
+        "KeywordId": 42,
+        "SearchBid": 8_000_000,
+        "NetworkBid": 3_000_000,
+    }
+
+
+# ----------------------------------------------------------------------
+# bidmodifiers
+# ----------------------------------------------------------------------
+
+
+def test_bidmodifiers_set_payload_keeps_modifier_type():
+    # NB: BidModifier ``Type`` (DEMOGRAPHICS / MOBILE / ...) is the
+    # *category* of the modifier and IS a real top-level API field, so
+    # it must be kept — this test does not assert ``Type not in ...``.
+    body = _dry_run(
+        "bidmodifiers",
+        "set",
+        "--campaign-id",
+        "1",
+        "--type",
+        "MOBILE",
+        "--value",
+        "1.5",
+    )
+    assert body["method"] == "set"
+    modifier = body["params"]["BidModifiers"][0]
+    assert modifier == {
+        "CampaignId": 1,
+        "Type": "MOBILE",
+        "BidModifier": 1.5,
+    }
+
+
+def test_bidmodifiers_toggle_enable():
+    body = _dry_run("bidmodifiers", "toggle", "--id", "777", "--enabled")
+    assert body["method"] == "set"
+    modifier = body["params"]["BidModifiers"][0]
+    assert modifier == {"Id": 777, "Enabled": "YES"}
+
+
+def test_bidmodifiers_toggle_disable():
+    body = _dry_run("bidmodifiers", "toggle", "--id", "777", "--disabled")
+    modifier = body["params"]["BidModifiers"][0]
+    assert modifier["Enabled"] == "NO"
+
+
+# ----------------------------------------------------------------------
+# feeds
+# ----------------------------------------------------------------------
+
+
+def test_feeds_add_payload_uses_source_field():
+    body = _dry_run(
+        "feeds",
+        "add",
+        "--name",
+        "Feed A",
+        "--url",
+        "https://example.com/feed.xml",
+    )
+    assert body["method"] == "add"
+    feed = body["params"]["Feeds"][0]
+    assert feed == {"Name": "Feed A", "Source": "https://example.com/feed.xml"}
+
+
+def test_feeds_update_payload_changes_url():
+    body = _dry_run(
+        "feeds",
+        "update",
+        "--id",
+        "9",
+        "--url",
+        "https://example.com/feed-v2.xml",
+    )
+    feed = body["params"]["Feeds"][0]
+    assert feed == {"Id": 9, "Source": "https://example.com/feed-v2.xml"}
+
+
+# ----------------------------------------------------------------------
+# retargeting
+# ----------------------------------------------------------------------
+
+
+def test_retargeting_add_keeps_list_type():
+    # NB: ``Type`` here is the *list category*
+    # (AUDIENCE_SEGMENT / PIXEL / ...), a real top-level API field —
+    # not the same kind of ``Type`` as in ads/adgroups/smartadtargets.
+    body = _dry_run(
+        "retargeting",
+        "add",
+        "--name",
+        "List A",
+        "--type",
+        "AUDIENCE_SEGMENT",
+    )
+    assert body["method"] == "add"
+    rtg = body["params"]["RetargetingLists"][0]
+    assert rtg == {"Name": "List A", "Type": "AUDIENCE_SEGMENT"}
+
+
+# ----------------------------------------------------------------------
+# audiencetargets
+# ----------------------------------------------------------------------
+
+
+def test_audiencetargets_add_scales_bid_to_micro_units():
+    body = _dry_run(
+        "audiencetargets",
+        "add",
+        "--adgroup-id",
+        "100",
+        "--retargeting-list-id",
+        "200",
+        "--bid",
+        "12",
+    )
+    assert body["method"] == "add"
+    target = body["params"]["AudienceTargets"][0]
+    assert target == {
+        "AdGroupId": 100,
+        "RetargetingListId": 200,
+        "Bid": 12_000_000,
+    }
+
+
+# ----------------------------------------------------------------------
+# sitelinks
+# ----------------------------------------------------------------------
+
+
+def test_sitelinks_add_parses_links_array():
+    links = [
+        {"Title": "About", "Href": "https://example.com/about"},
+        {"Title": "Contact", "Href": "https://example.com/contact"},
+    ]
+    body = _dry_run("sitelinks", "add", "--links", json.dumps(links))
+    assert body["method"] == "add"
+    sitelinks_set = body["params"]["SitelinksSets"][0]
+    assert sitelinks_set == {"Sitelinks": links}
+
+
+# ----------------------------------------------------------------------
+# vcards
+# ----------------------------------------------------------------------
+
+
+def test_vcards_add_passes_full_json_through():
+    vcard = {
+        "CampaignId": 555,
+        "Country": "Россия",
+        "City": "Москва",
+        "CompanyName": "Acme",
+    }
+    body = _dry_run("vcards", "add", "--json", json.dumps(vcard))
+    assert body["method"] == "add"
+    assert body["params"]["VCards"] == [vcard]
+
+
+# ----------------------------------------------------------------------
+# adextensions
+# ----------------------------------------------------------------------
+
+
+def test_adextensions_add_merges_type_and_json():
+    body = _dry_run(
+        "adextensions",
+        "add",
+        "--type",
+        "CALLOUT",
+        "--json",
+        json.dumps({"Callout": {"CalloutText": "Free shipping"}}),
+    )
+    assert body["method"] == "add"
+    ext = body["params"]["AdExtensions"][0]
+    # NB: ad-extension Type *is* a real API field
+    # (CALLOUT / SITELINK / ...) — kept on purpose.
+    assert ext["Type"] == "CALLOUT"
+    assert ext["Callout"] == {"CalloutText": "Free shipping"}
+
+
+# ----------------------------------------------------------------------
+# adimages
+# ----------------------------------------------------------------------
+
+
+def test_adimages_add_passes_full_json_through():
+    image = {"ImageData": "BASE64DATA", "Name": "banner.png"}
+    body = _dry_run("adimages", "add", "--json", json.dumps(image))
+    assert body["method"] == "add"
+    assert body["params"]["AdImages"] == [image]
+
+
+# ----------------------------------------------------------------------
+# dynamicads
+# ----------------------------------------------------------------------
+
+
+def test_dynamicads_add_payload_uses_webpages_key():
+    target = {
+        "Name": "Webpage A",
+        "Conditions": [{"Operator": "CONTAINS", "Arguments": ["foo"]}],
+    }
+    body = _dry_run(
+        "dynamicads",
+        "add",
+        "--adgroup-id",
+        "33",
+        "--json",
+        json.dumps(target),
+    )
+    assert body["method"] == "add"
+    webpage = body["params"]["Webpages"][0]
+    assert webpage["AdGroupId"] == 33
+    assert webpage["Name"] == "Webpage A"
+    assert webpage["Conditions"] == target["Conditions"]
+
+
+def test_dynamicads_update_merges_extra_json():
+    body = _dry_run(
+        "dynamicads",
+        "update",
+        "--id",
+        "44",
+        "--json",
+        json.dumps({"Name": "Renamed"}),
+    )
+    assert body["method"] == "update"
+    webpage = body["params"]["Webpages"][0]
+    assert webpage == {"Id": 44, "Name": "Renamed"}
+
+
+# ----------------------------------------------------------------------
+# smartadtargets
+# ----------------------------------------------------------------------
+
+
+def test_smartadtargets_add_payload_omits_type():
+    body = _dry_run(
+        "smartadtargets",
+        "add",
+        "--adgroup-id",
+        "55",
+        "--type",
+        "VIEWED_PRODUCT",
+        "--json",
+        json.dumps({"TargetingId": "VIEWED_PRODUCT"}),
+    )
+    assert body["method"] == "add"
+    target = body["params"]["SmartAdTargets"][0]
+    # Regression guard: ``Type`` is not a field on
+    # ``SmartAdTargetAddItem``. The legacy ``--type`` CLI option is
+    # accepted for backward compatibility but no longer forwarded;
+    # callers must use --json to pass real fields like ``TargetingId``.
+    assert "Type" not in target
+    assert target["AdGroupId"] == 55
+    assert target["TargetingId"] == "VIEWED_PRODUCT"
+
+
+def test_smartadtargets_update_omits_type():
+    body = _dry_run(
+        "smartadtargets",
+        "update",
+        "--id",
+        "66",
+        "--json",
+        json.dumps({"Bid": {"Deposit": 3_000_000, "Currency": "RUB"}}),
+    )
+    target = body["params"]["SmartAdTargets"][0]
+    assert "Type" not in target
+    assert target["Id"] == 66
+    assert target["Bid"] == {"Deposit": 3_000_000, "Currency": "RUB"}
+
+
+# ----------------------------------------------------------------------
+# negativekeywordsharedsets
+# ----------------------------------------------------------------------
+
+
+def test_negativekeywordsharedsets_add_splits_keywords():
+    body = _dry_run(
+        "negativekeywordsharedsets",
+        "add",
+        "--name",
+        "Set A",
+        "--keywords",
+        "купить, продам , скачать",
+    )
+    assert body["method"] == "add"
+    nks = body["params"]["NegativeKeywordSharedSets"][0]
+    assert nks == {
+        "Name": "Set A",
+        "NegativeKeywords": ["купить", "продам", "скачать"],
+    }
+
+
+def test_negativekeywordsharedsets_update_keywords():
+    body = _dry_run(
+        "negativekeywordsharedsets",
+        "update",
+        "--id",
+        "12",
+        "--keywords",
+        "слово,фраза",
+    )
+    nks = body["params"]["NegativeKeywordSharedSets"][0]
+    assert nks == {"Id": 12, "NegativeKeywords": ["слово", "фраза"]}
+
+
+# ----------------------------------------------------------------------
+# turbopages
+# ----------------------------------------------------------------------
+
+
+def test_turbopages_add_uses_href_field():
+    body = _dry_run(
+        "turbopages",
+        "add",
+        "--name",
+        "Page A",
+        "--url",
+        "https://example.com/turbo",
+    )
+    assert body["method"] == "add"
+    page = body["params"]["TurboPages"][0]
+    assert page == {"Name": "Page A", "Href": "https://example.com/turbo"}
+
+
+# ----------------------------------------------------------------------
+# agencyclients
+# ----------------------------------------------------------------------
+
+
+def test_agencyclients_add_passes_full_json_through():
+    client_data = {
+        "Login": "client-login",
+        "Currency": "RUB",
+        "Grants": [],
+    }
+    body = _dry_run("agencyclients", "add", "--json", json.dumps(client_data))
+    assert body["method"] == "add"
+    assert body["params"]["Clients"] == [client_data]
+
+
+# ----------------------------------------------------------------------
+# clients
+# ----------------------------------------------------------------------
+
+
+def test_clients_update_merges_extra_json_with_client_id():
+    body = _dry_run(
+        "clients",
+        "update",
+        "--client-id",
+        "999",
+        "--json",
+        json.dumps({"Phone": "+70000000000"}),
+    )
+    assert body["method"] == "update"
+    client = body["params"]["Clients"][0]
+    assert client == {"ClientId": 999, "Phone": "+70000000000"}


### PR DESCRIPTION
## Summary

This PR closes a long-standing test gap in direct-cli and fixes three instances of the same bug it lets through.

**Three Type-field bugs fixed:**

1. \`ads add\` (originally proposed in #11, included here as the first commit so the regression tests in the same PR can rely on the fix)
2. \`adgroups add\` — confirmed via the official Yandex Direct API v5 docs
3. \`smartadtargets add\` / \`update\` — same root cause; legacy \`--type\` option was forwarded as a top-level Type field that has no place on \`SmartAdTargetAddItem\`

In all three cases the CLI was sending an explicit top-level \`"Type"\` key on a resource item where the API doesn't define one. Yandex Direct rejects every such request with \`InvalidArgumentError\`. The bugs lived in production for months because **only one of the 44 mutating CLI commands had ever been exercised against a real API** — the one (\`ads add\`) where someone happened to notice the failure.

**One dry-run test layer added:**

\`tests/test_dry_run.py\` exercises every add/update/set/toggle command in direct-cli that exposes a \`--dry-run\` flag (32 tests total), parses the printed JSON body, and asserts the exact request shape — no network, no token, runs in ~0.06s in the default \`pytest\` set. Each \`add\` test for ads/adgroups/smartadtargets explicitly asserts \`\"Type\" not in resource_item\` so re-introducing any of the three bugs fails CI immediately.

This is not full integration testing — that's tracked separately and will live in a future \`tests/test_integration_write.py\` against the Yandex Direct sandbox. But the vast majority of CLI write-command bugs are payload-shape bugs (the Type bug is a perfect example), and dry-run tests catch every payload-shape bug for free.

## Test plan

- [x] \`pytest --ignore=tests/test_integration.py\` → **93 passed in 0.11s** (32 new + 61 pre-existing)
- [x] \`black --check tests/test_dry_run.py direct_cli/commands/{adgroups,smartadtargets,ads}.py\` → clean
- [x] \`flake8 --max-line-length=100 …\` → clean
- [x] Manual smoke for each of the three fixed commands:
  \`\`\`
  $ direct ads add --adgroup-id 1 --type TEXT_AD --title T --text X --href https://e.com --dry-run
  $ direct adgroups add --campaign-id 1 --name X --type TEXT_AD_GROUP --region-ids 225 --dry-run
  $ direct smartadtargets add --adgroup-id 1 --type IGNORED --json '{\"TargetingId\":\"VIEWED_PRODUCT\"}' --dry-run
  \`\`\`
  All three printed payloads now omit the bogus top-level \`Type\` key.

## Why \"supersedes #11\"

#11 was a clean focused commit for the \`ads add\` Type fix. This PR includes that same commit (verbatim, just re-authored on this branch) so that the new regression tests can land in the same PR and immediately defend the fix. Once this PR is merged #11 can be closed as superseded — the fix lives on.

## Related

- Refs axisrow/yandex-direct-mcp-plugin#60 (where the original \`ads add\` bug surfaced through the MCP plugin)
- Refs axisrow/yandex-direct-mcp-plugin#61 (the test-coverage tracking issue this PR partially closes)
- Supersedes #11

## Commit log

1. \`fix(ads): stop sending implicit Type field in add command\`
2. \`fix(adgroups): stop sending implicit Type field in add command\`
3. \`fix(smartadtargets): stop sending bogus Type field in add/update\`
4. \`test: add dry-run payload coverage for write commands\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)