### PR TITLE
fix: silent-drop audit round 3 (retargeting/reports/adextensions)

### DIFF
--- a/direct_cli/commands/adextensions.py
+++ b/direct_cli/commands/adextensions.py
@@ -68,11 +68,14 @@ def get(ctx, ids, types, limit, fetch_all, output_format, output, fields):
 @click.option(
     "--type",
     "ext_type",
-    required=True,
     help=(
-        "Extension type (UX hint — Callout, Sitelinks, Vcard, …). "
-        "Not sent to the API; the API derives the type from the nested "
-        "field name inside --json."
+        "Legacy UX hint; NOT forwarded to the API. The Yandex Direct "
+        "API derives the extension type from the nested field name "
+        "inside --json (Callout / Sitelinks / Vcard / ...), so the "
+        "only flag that actually matters is --json.  Previously this "
+        "option was required=True but silently discarded, which "
+        "forced every caller to pass a value that did nothing.  See "
+        "axisrow/direct-cli#25."
     ),
 )
 @click.option("--json", "extra_json", required=True, help="Extension data in JSON")
@@ -88,7 +91,7 @@ def add(ctx, ext_type, extra_json, dry_run):
     ``{"Type": ext_type, ...}`` and the sandbox rejected the extra
     key as ``unknown parameter Type``.
     """
-    _ = ext_type  # consumed only for argument validation / UX clarity
+    _ = ext_type  # intentionally unused — kept as UX hint only
     try:
         ext_data = json.loads(extra_json)
 

--- a/direct_cli/commands/reports.py
+++ b/direct_cli/commands/reports.py
@@ -28,7 +28,11 @@ def reports():
     "--type",
     "report_type",
     required=True,
-    help="Report type (CAMPAIGN_PERFORMANCE_REPORT, etc.)",
+    type=click.Choice(REPORT_TYPES, case_sensitive=False),
+    help=(
+        "Report type (case-insensitive). Validated against the official "
+        "Yandex Direct report-type enum — see axisrow/direct-cli#25."
+    ),
 )
 @click.option("--from", "date_from", required=True, help="Start date (YYYY-MM-DD)")
 @click.option("--to", "date_to", required=True, help="End date (YYYY-MM-DD)")
@@ -43,7 +47,6 @@ def reports():
     help="Output format (json/table/csv/tsv)",
 )
 @click.option("--output", help="Output file")
-@click.option("--mode", default="auto", help="Processing mode (online/offline/auto)")
 @click.pass_context
 def get(
     ctx,
@@ -56,9 +59,15 @@ def get(
     adgroup_ids,
     output_format,
     output,
-    mode,
 ):
-    """Get report"""
+    """Get report
+
+    The underlying ``create_client`` uses processing mode ``auto``
+    — previously the CLI also exposed a ``--mode`` option that was
+    declared but never read in the function body, silently dropping
+    any value the user passed.  That dead option was removed in
+    axisrow/direct-cli#25.
+    """
     try:
         client = create_client(
             token=ctx.obj.get("token"),

--- a/direct_cli/commands/retargeting.py
+++ b/direct_cli/commands/retargeting.py
@@ -66,10 +66,26 @@ def get(ctx, ids, types, limit, fetch_all, output_format, output, fields):
         raise click.Abort()
 
 
+#: Valid ``RetargetingListAddItem.Type`` values per Yandex Direct API docs
+#: (ref-v5/retargetinglists/add).  The API defaults to ``RETARGETING`` when
+#: ``Type`` is omitted, so the CLI follows the same default.
+_RETARGETING_LIST_TYPES = ["RETARGETING", "AUDIENCE"]
+
+
 @retargeting.command()
 @click.option("--name", required=True, help="List name")
 @click.option(
-    "--type", "list_type", required=True, help="List type (AUDIENCE_SEGMENT, etc.)"
+    "--type",
+    "list_type",
+    default="RETARGETING",
+    type=click.Choice(_RETARGETING_LIST_TYPES, case_sensitive=False),
+    help=(
+        "Retargeting list type (case-insensitive). Yandex Direct accepts "
+        "only RETARGETING (default — Metrica goals/segments + Audience "
+        "segments, usable in text & image / mobile-app campaigns) or "
+        "AUDIENCE (any goals/segments, usable in display campaigns). "
+        "See axisrow/direct-cli#25."
+    ),
 )
 @click.option("--json", "extra_json", help="Additional JSON parameters")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
@@ -77,6 +93,9 @@ def get(ctx, ids, types, limit, fetch_all, output_format, output, fields):
 def add(ctx, name, list_type, extra_json, dry_run):
     """Add new retargeting list"""
     try:
+        # click.Choice normalizes the case when case_sensitive=False but
+        # leaves the original casing of the canonical choice; pass it
+        # through unchanged.
         list_data = {"Name": name, "Type": list_type}
 
         if extra_json:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "direct-cli"
-version = "0.2.3"
+version = "0.2.4"
 description = "Command-line interface for Yandex Direct API"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -347,10 +347,14 @@ def test_bidmodifiers_toggle_disable():
 
 def test_bidmodifiers_add_mobile_uses_nested_object():
     body = _dry_run(
-        "bidmodifiers", "add",
-        "--campaign-id", "1",
-        "--type", "MOBILE_ADJUSTMENT",
-        "--value", "120",
+        "bidmodifiers",
+        "add",
+        "--campaign-id",
+        "1",
+        "--type",
+        "MOBILE_ADJUSTMENT",
+        "--value",
+        "120",
     )
     assert body["method"] == "add"
     modifier = body["params"]["BidModifiers"][0]
@@ -403,20 +407,63 @@ def test_feeds_update_payload_changes_url():
 
 
 def test_retargeting_add_keeps_list_type():
-    # NB: ``Type`` here is the *list category*
-    # (AUDIENCE_SEGMENT / PIXEL / ...), a real top-level API field —
-    # not the same kind of ``Type`` as in ads/adgroups/smartadtargets.
+    # NB: ``Type`` here is the *list category* and IS a real top-level
+    # API field, unlike the --type hint on ads/adgroups/smartadtargets.
+    # The only two valid values per Yandex Direct docs are ``RETARGETING``
+    # and ``AUDIENCE`` (verified against
+    # https://yandex.ru/dev/direct/doc/ref-v5/retargetinglists/add.html).
+    # This test previously asserted ``AUDIENCE_SEGMENT``, which is not
+    # a real enum value — the drift was fixed together with the
+    # click.Choice validation added in axisrow/direct-cli#25.
     body = _dry_run(
         "retargeting",
         "add",
         "--name",
         "List A",
         "--type",
-        "AUDIENCE_SEGMENT",
+        "AUDIENCE",
     )
     assert body["method"] == "add"
     rtg = body["params"]["RetargetingLists"][0]
-    assert rtg == {"Name": "List A", "Type": "AUDIENCE_SEGMENT"}
+    assert rtg == {"Name": "List A", "Type": "AUDIENCE"}
+
+
+def test_retargeting_add_default_type_is_retargeting():
+    """Without ``--type`` the CLI defaults to the API's default RETARGETING.
+
+    Regression guard for axisrow/direct-cli#25 — before the fix ``--type``
+    was required=True with no validation. Now it's optional and
+    defaults to the same value the API picks when Type is omitted.
+    """
+    body = _dry_run("retargeting", "add", "--name", "List B")
+    rtg = body["params"]["RetargetingLists"][0]
+    assert rtg["Type"] == "RETARGETING"
+
+
+def test_retargeting_add_unknown_type_is_rejected_by_choice():
+    """``click.Choice`` rejects typos / non-enum values up front.
+
+    Regression guard for axisrow/direct-cli#25 — before the fix a
+    typo like ``--type AUDIENCE_SEGMENT`` was forwarded verbatim to
+    the API, which rejected it with a vague error.
+    """
+    result = CliRunner().invoke(
+        cli,
+        [
+            "retargeting",
+            "add",
+            "--name",
+            "List bad",
+            "--type",
+            "AUDIENCE_SEGMENT",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code != 0
+    combined = (result.output or "") + (
+        str(result.exception) if result.exception else ""
+    )
+    assert "AUDIENCE_SEGMENT" in combined or "retargeting" in combined.lower()
 
 
 # ----------------------------------------------------------------------
@@ -498,6 +545,122 @@ def test_adextensions_add_does_not_send_type_field():
     # option is a UX hint and must NOT be forwarded to the request.
     assert "Type" not in ext
     assert ext == {"Callout": {"CalloutText": "Free shipping"}}
+
+
+def test_adextensions_add_type_is_now_optional():
+    """``--type`` is no longer ``required=True`` on ``adextensions add``.
+
+    Regression guard for axisrow/direct-cli#25 — before the fix ``--type``
+    was required but immediately discarded. Users should be able to
+    pass just ``--json`` (which carries the real payload and determines
+    the extension type via its nested field name).
+    """
+    body = _dry_run(
+        "adextensions",
+        "add",
+        "--json",
+        json.dumps({"Sitelinks": [{"Title": "T", "Href": "https://a"}]}),
+    )
+    ext = body["params"]["AdExtensions"][0]
+    assert "Type" not in ext
+    assert ext == {"Sitelinks": [{"Title": "T", "Href": "https://a"}]}
+
+
+# ----------------------------------------------------------------------
+# reports (no dry-run — test CLI-parser-level validation only)
+# ----------------------------------------------------------------------
+
+
+def test_reports_get_type_rejects_unknown_value():
+    """``reports get --type`` is validated by click.Choice against REPORT_TYPES.
+
+    Regression guard for axisrow/direct-cli#25 — previously ``REPORT_TYPES``
+    was defined at module level but never wired into the option, so
+    typos like ``CAMPAING_REPORT`` silently reached the API.
+    """
+    result = CliRunner().invoke(
+        cli,
+        [
+            "reports",
+            "get",
+            "--type",
+            "CAMPAING_REPORT",
+            "--from",
+            "2026-01-01",
+            "--to",
+            "2026-01-31",
+            "--name",
+            "X",
+            "--fields",
+            "Date",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "Invalid value for '--type'" in result.output
+
+
+def test_reports_get_type_is_case_insensitive():
+    """Valid enum spelling in lowercase is accepted.
+
+    click.Choice(..., case_sensitive=False) on REPORT_TYPES normalizes
+    the input — users can type ``campaign_performance_report``.
+    """
+    result = CliRunner().invoke(
+        cli,
+        [
+            "reports",
+            "get",
+            "--type",
+            "campaign_performance_report",
+            "--from",
+            "2026-01-01",
+            "--to",
+            "2026-01-31",
+            "--name",
+            "X",
+            "--fields",
+            "Date",
+        ],
+    )
+    # The command will still fail because it has no --dry-run and no
+    # token is available in the unit-test environment — what we care
+    # about is that Click's parameter parser did NOT reject the value.
+    # The error we expect is from create_client / API, not from
+    # click.Choice.
+    assert "Invalid value for '--type'" not in result.output
+
+
+def test_reports_get_mode_option_removed():
+    """The dead ``--mode`` option is no longer accepted.
+
+    Regression guard for axisrow/direct-cli#25 — previously ``--mode``
+    was declared with ``default="auto"`` and a helpful-looking help
+    string, but the function body never read it; the underlying
+    ``create_client`` hardcodes ``processing_mode="auto"``. Users
+    passing ``--mode offline`` got zero effect. The option was
+    removed so the dead code stops misleading callers.
+    """
+    result = CliRunner().invoke(
+        cli,
+        [
+            "reports",
+            "get",
+            "--type",
+            "CAMPAIGN_PERFORMANCE_REPORT",
+            "--from",
+            "2026-01-01",
+            "--to",
+            "2026-01-31",
+            "--name",
+            "X",
+            "--fields",
+            "Date",
+            "--mode",
+            "offline",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "no such option" in result.output.lower() or "--mode" in result.output
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -605,7 +605,9 @@ def test_reports_get_type_is_case_insensitive():
     click.Choice(..., case_sensitive=False) on REPORT_TYPES normalizes
     the input — users can type ``campaign_performance_report``.
     """
-    result = CliRunner().invoke(
+    result = CliRunner(
+        env={"YANDEX_DIRECT_TOKEN": "", "YANDEX_DIRECT_LOGIN": ""},
+    ).invoke(
         cli,
         [
             "reports",
@@ -622,12 +624,12 @@ def test_reports_get_type_is_case_insensitive():
             "Date",
         ],
     )
-    # The command will still fail because it has no --dry-run and no
-    # token is available in the unit-test environment — what we care
-    # about is that Click's parameter parser did NOT reject the value.
-    # The error we expect is from create_client / API, not from
-    # click.Choice.
+    # Force a missing-token failure so this unit test cannot make a real
+    # reports request when a developer/CI environment has credentials set.
+    # What we care about is that Click's parameter parser did NOT reject
+    # the lowercase enum value.
     assert "Invalid value for '--type'" not in result.output
+    assert result.exit_code != 0
 
 
 def test_reports_get_mode_option_removed():


### PR DESCRIPTION
## Summary

Broader silent-drop audit — not just ``--type``, but every Click option on every write command. Follow-up to PRs #22 and #24 (issues #21 and #23). Found four more instances of the same bug class.

Closes #25

| Severity | File | Bug |
|---|---|---|
| HIGH | \`retargeting.py add --type\` | Free-form string, \`required=True\`, help text lies (suggests \`AUDIENCE_SEGMENT\` which is not a real enum value). Real values per Yandex docs: \`RETARGETING\` (default) and \`AUDIENCE\`. |
| HIGH | \`reports.py get --type\` | \`REPORT_TYPES\` list defined at module level but never wired into the option — typos like \`CAMPAING_REPORT\` reach the API. |
| MEDIUM | \`reports.py get --mode\` | Pure dead option: declared, in signature, **never read anywhere**. \`--mode offline\` had zero effect because \`create_client\` hardcodes \`processing_mode=\"auto\"\`. |
| MEDIUM | \`adextensions.py add --type\` | Same \`required=True\` + \`_ = ext_type\` pattern that PR #24 fixed for \`smartadtargets add --type\`. |

## Fixes

- **\`retargeting add --type\`**: \`click.Choice([\"RETARGETING\", \"AUDIENCE\"], case_sensitive=False)\`, drop \`required=True\`, default to \`\"RETARGETING\"\` (matches the API default per docs).
- **\`reports get --type\`**: \`click.Choice(REPORT_TYPES, case_sensitive=False)\`. Zero-risk — the list is already curated at the top of the file.
- **\`reports get --mode\`**: Remove the option entirely. It was dead code. Wiring it up would require an \`api.py\` refactor (adding a \`processing_mode\` parameter to \`create_client\`), which is out of scope.
- **\`adextensions add --type\`**: Drop \`required=True\`, rewrite help text as \"Legacy UX hint; NOT forwarded to the API\".

## Test plan

- [x] \`pytest tests/test_dry_run.py -v\` — 41/41 passed (6 new + 35 existing)
- [x] \`pytest tests/ --ignore=tests/test_integration.py -q\` — 112 passed, 9 skipped
- [x] \`flake8 direct_cli/commands/{retargeting,reports,adextensions}.py tests/test_dry_run.py\` — clean
- [x] \`black --check\` — clean on all touched files
- [x] Manual dry-run smoke tests of every new path:

\`\`\`bash
# retargeting
direct retargeting add --dry-run --name X --type audience            # normalized to AUDIENCE
direct retargeting add --dry-run --name X --type FOO                 # Choice error
direct retargeting add --dry-run --name X                            # default RETARGETING

# adextensions
direct adextensions add --dry-run --json '{\"Callout\":{\"CalloutText\":\"Free\"}}'  # no --type needed

# reports
direct reports get --type BOGUS --from 2026-01-01 --to 2026-01-31 --name X --fields Date  # Choice error
direct reports get --type CAMPAIGN_PERFORMANCE_REPORT ... --mode offline  # \"No such option: --mode\"
\`\`\`

## Drift fix caught by this round

The existing dry-run test ``test_retargeting_add_keeps_list_type`` asserted ``Type: AUDIENCE_SEGMENT``, which is not a valid Yandex enum value — the test was frozen against a fiction that would have been rejected at record time if anyone had tried to run the real command. Updated to use ``AUDIENCE``. The existing integration write test (``TestWriteRetargeting.test_add_delete``) uses ``--type RETARGETING`` and its cassette replay still passes.

## Out of scope

- Options silently dropped because they forward to a field the API doesn't accept (e.g. \`keywords update --status\` sends a Status field the API can't update directly — suspend/resume/archive/unarchive are the proper verbs). Deserves its own validation pass against the schema.
- Broader refactor of ``add``/``update`` commands into a shared mixin — each fix is intentionally localized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)