### PR TITLE
test: automated API coverage check via WSDL introspection

### DIFF
--- a/.github/workflows/api-coverage.yml
+++ b/.github/workflows/api-coverage.yml
@@ -1,0 +1,104 @@
+name: API Coverage
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  test-and-report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install package with dev dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run fast coverage suites
+        run: |
+          pytest -q tests/test_api_coverage.py tests/test_dry_run.py tests/test_cli.py tests/test_comprehensive.py
+
+      - name: Build API coverage report
+        run: |
+          python scripts/build_api_coverage_report.py > api_coverage_report.json
+
+      - name: Publish API coverage summary
+        run: |
+          python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          from pathlib import Path
+
+          report = json.loads(Path("api_coverage_report.json").read_text())
+          summary = report["summary"]
+          print("## API coverage summary")
+          print()
+          print(f"- Services checked: {summary['services_checked']}")
+          print(f"- Missing methods: {summary['missing_service_methods']}")
+          print(f"- Unexpected methods: {summary['unexpected_service_methods']}")
+          print(f"- Strict parity OK: {summary['strict_parity_ok']}")
+          print(f"- Alias groups: {len(report['aliases'])}")
+          print(f"- Non-WSDL services: {len(report['non_wsdl_services'])}")
+          print(f"- CLI helpers: {len(report['cli_helpers'])}")
+          PY
+
+      - name: Upload API coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-coverage-report
+          path: api_coverage_report.json
+
+  monitor-live-wsdl:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install package with dev dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Check live WSDL drift
+        run: |
+          python scripts/check_wsdl_drift.py > wsdl_drift_report.json
+
+      - name: Publish WSDL drift summary
+        if: always()
+        run: |
+          python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          from pathlib import Path
+
+          report = json.loads(Path("wsdl_drift_report.json").read_text())
+          print("## WSDL drift summary")
+          print()
+          print(f"- Services checked: {report['services_checked']}")
+          print(f"- Missing cache files: {report['missing_cache_count']}")
+          print(f"- Drifted services: {report['drift_count']}")
+          for item in report["drift"][:10]:
+              print(f"- Drift: {item['service']}")
+          PY
+
+      - name: Upload WSDL drift report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wsdl-drift-report
+          path: wsdl_drift_report.json

--- a/README.md
+++ b/README.md
@@ -197,6 +197,34 @@ pytest -m integration -v            # read-only integration tests (needs token)
 pytest -m integration_write -v      # write cassette replay (no token needed)
 ```
 
+### API Coverage And Drift Monitoring
+
+The project now distinguishes four surfaces:
+
+| Surface | Coverage strategy |
+|---|---|
+| Canonical WSDL-backed SOAP services | `tests/test_api_coverage.py` verifies strict service/method parity and dry-run request-schema coverage or explicit exclusions |
+| Non-WSDL services (`reports`) | Explicit contract tests |
+| Canonical CLI aliases | Checked as aliases, not counted as separate API surface |
+| Intentional CLI-only helpers | Explicitly allowlisted with reasons in `direct_cli/wsdl_coverage.py` |
+
+`100% coverage` in this project means full coverage of the supported
+**canonical API surface**. Alias groups and CLI-only helpers remain supported,
+but they are tracked outside the strict parity metric.
+
+Useful maintenance commands:
+
+```bash
+python scripts/build_api_coverage_report.py
+python scripts/refresh_wsdl_cache.py
+python scripts/check_wsdl_drift.py
+```
+
+CI runs a scheduled API coverage workflow that:
+- runs the fast coverage suites;
+- uploads a machine-readable API coverage report artifact;
+- checks the cached WSDL files against the live Yandex Direct API on schedule.
+
 #### Re-recording write cassettes
 
 The write tests replay HTTP traffic captured from the Yandex Direct **sandbox**

--- a/direct_cli/cli.py
+++ b/direct_cli/cli.py
@@ -35,6 +35,7 @@ from .commands.smartadtargets import smartadtargets
 from .commands.businesses import businesses
 from .commands.keywordsresearch import keywordsresearch
 from .commands.dynamicads import dynamicads
+from .commands.advideos import advideos
 
 # Load .env file
 load_dotenv()
@@ -133,6 +134,7 @@ cli.add_command(smartadtargets)
 cli.add_command(businesses)
 cli.add_command(keywordsresearch)
 cli.add_command(dynamicads)
+cli.add_command(advideos)
 
 # Canonical aliases expected by external integrations.
 cli.add_command(dynamicads, name="dynamictargets")

--- a/direct_cli/commands/adextensions.py
+++ b/direct_cli/commands/adextensions.py
@@ -117,20 +117,25 @@ def add(ctx, ext_type, extra_json, dry_run):
 
 @adextensions.command()
 @click.option("--id", "extension_id", required=True, type=int, help="Extension ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def delete(ctx, extension_id):
+def delete(ctx, extension_id, dry_run):
     """Delete ad extension"""
     try:
+        body = {
+            "method": "delete",
+            "params": {"SelectionCriteria": {"Ids": [extension_id]}},
+        }
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
         client = create_client(
             token=ctx.obj.get("token"),
             login=ctx.obj.get("login"),
             sandbox=ctx.obj.get("sandbox"),
         )
-
-        body = {
-            "method": "delete",
-            "params": {"SelectionCriteria": {"Ids": [extension_id]}},
-        }
 
         result = client.adextensions().post(data=body)
         format_output(result().extract(), "json", None)

--- a/direct_cli/commands/adgroups.py
+++ b/direct_cli/commands/adgroups.py
@@ -196,20 +196,25 @@ def update(ctx, adgroup_id, name, status, extra_json, dry_run):
 
 @adgroups.command()
 @click.option("--id", "adgroup_id", required=True, type=int, help="Ad group ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def delete(ctx, adgroup_id):
+def delete(ctx, adgroup_id, dry_run):
     """Delete ad group"""
     try:
+        body = {
+            "method": "delete",
+            "params": {"SelectionCriteria": {"Ids": [adgroup_id]}},
+        }
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
         client = create_client(
             token=ctx.obj.get("token"),
             login=ctx.obj.get("login"),
             sandbox=ctx.obj.get("sandbox"),
         )
-
-        body = {
-            "method": "delete",
-            "params": {"SelectionCriteria": {"Ids": [adgroup_id]}},
-        }
 
         result = client.adgroups().post(data=body)
         format_output(result().extract(), "json", None)

--- a/direct_cli/commands/adimages.py
+++ b/direct_cli/commands/adimages.py
@@ -92,20 +92,25 @@ def add(ctx, image_json, dry_run):
 
 @adimages.command()
 @click.option("--hash", "image_hash", required=True, help="Ad image hash")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def delete(ctx, image_hash):
+def delete(ctx, image_hash, dry_run):
     """Delete ad image"""
     try:
+        body = {
+            "method": "delete",
+            "params": {"SelectionCriteria": {"AdImageHashes": [image_hash]}},
+        }
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
         client = create_client(
             token=ctx.obj.get("token"),
             login=ctx.obj.get("login"),
             sandbox=ctx.obj.get("sandbox"),
         )
-
-        body = {
-            "method": "delete",
-            "params": {"SelectionCriteria": {"AdImageHashes": [image_hash]}},
-        }
 
         result = client.adimages().post(data=body)
         format_output(result().extract(), "json", None)

--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -221,18 +221,23 @@ def update(ctx, ad_id, status, extra_json, dry_run):
 
 @ads.command()
 @click.option("--id", "ad_id", required=True, type=int, help="Ad ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def delete(ctx, ad_id):
+def delete(ctx, ad_id, dry_run):
     """Delete ad"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
-
         body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [ad_id]}}}
 
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
         result = client.ads().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -243,17 +248,22 @@ def delete(ctx, ad_id):
 
 @ads.command()
 @click.option("--id", "ad_id", required=True, type=int, help="Ad ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def archive(ctx, ad_id):
+def archive(ctx, ad_id, dry_run):
     """Archive ad"""
     try:
+        body = {"method": "archive", "params": {"SelectionCriteria": {"Ids": [ad_id]}}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
         client = create_client(
             token=ctx.obj.get("token"),
             login=ctx.obj.get("login"),
             sandbox=ctx.obj.get("sandbox"),
         )
-
-        body = {"method": "archive", "params": {"SelectionCriteria": {"Ids": [ad_id]}}}
 
         result = client.ads().post(data=body)
         format_output(result().extract(), "json", None)
@@ -265,21 +275,26 @@ def archive(ctx, ad_id):
 
 @ads.command()
 @click.option("--id", "ad_id", required=True, type=int, help="Ad ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def unarchive(ctx, ad_id):
+def unarchive(ctx, ad_id, dry_run):
     """Unarchive ad"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
-
         body = {
             "method": "unarchive",
             "params": {"SelectionCriteria": {"Ids": [ad_id]}},
         }
 
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
         result = client.ads().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -290,18 +305,23 @@ def unarchive(ctx, ad_id):
 
 @ads.command()
 @click.option("--id", "ad_id", required=True, type=int, help="Ad ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def suspend(ctx, ad_id):
+def suspend(ctx, ad_id, dry_run):
     """Suspend ad"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
-
         body = {"method": "suspend", "params": {"SelectionCriteria": {"Ids": [ad_id]}}}
 
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
         result = client.ads().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -312,17 +332,22 @@ def suspend(ctx, ad_id):
 
 @ads.command()
 @click.option("--id", "ad_id", required=True, type=int, help="Ad ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def resume(ctx, ad_id):
+def resume(ctx, ad_id, dry_run):
     """Resume ad"""
     try:
+        body = {"method": "resume", "params": {"SelectionCriteria": {"Ids": [ad_id]}}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
         client = create_client(
             token=ctx.obj.get("token"),
             login=ctx.obj.get("login"),
             sandbox=ctx.obj.get("sandbox"),
         )
-
-        body = {"method": "resume", "params": {"SelectionCriteria": {"Ids": [ad_id]}}}
 
         result = client.ads().post(data=body)
         format_output(result().extract(), "json", None)
@@ -334,17 +359,22 @@ def resume(ctx, ad_id):
 
 @ads.command()
 @click.option("--id", "ad_id", required=True, type=int, help="Ad ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def moderate(ctx, ad_id):
+def moderate(ctx, ad_id, dry_run):
     """Moderate ad"""
     try:
+        body = {"method": "moderate", "params": {"SelectionCriteria": {"Ids": [ad_id]}}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
         client = create_client(
             token=ctx.obj.get("token"),
             login=ctx.obj.get("login"),
             sandbox=ctx.obj.get("sandbox"),
         )
-
-        body = {"method": "moderate", "params": {"SelectionCriteria": {"Ids": [ad_id]}}}
 
         result = client.ads().post(data=body)
         format_output(result().extract(), "json", None)

--- a/direct_cli/commands/advideos.py
+++ b/direct_cli/commands/advideos.py
@@ -1,0 +1,107 @@
+"""
+AdVideos commands
+"""
+
+import click
+
+from ..api import create_client
+from ..output import format_output, print_error
+from ..utils import parse_ids
+
+
+@click.group()
+def advideos():
+    """Manage ad videos"""
+
+
+@advideos.command()
+@click.option("--ids", help="Comma-separated video IDs")
+@click.option("--limit", type=int, help="Limit number of results")
+@click.option("--fetch-all", is_flag=True, help="Fetch all pages")
+@click.option("--format", "output_format", default="json", help="Output format")
+@click.option("--output", help="Output file")
+@click.pass_context
+def get(ctx, ids, limit, fetch_all, output_format, output):
+    """Get ad videos"""
+    try:
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
+        criteria = {}
+        if ids:
+            criteria["Ids"] = parse_ids(ids)
+
+        params = {
+            "SelectionCriteria": criteria,
+            "FieldNames": ["Id", "Status"],
+        }
+
+        if limit:
+            params["Page"] = {"Limit": limit}
+
+        body = {"method": "get", "params": params}
+
+        result = client.advideos().post(data=body)
+
+        if fetch_all:
+            items = []
+            for item in result().iter_items():
+                items.append(item)
+            format_output(items, output_format, output)
+        else:
+            data = result().extract()
+            format_output(data, output_format, output)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@advideos.command()
+@click.option("--url", help="Video URL (mutually exclusive with --video-data)")
+@click.option("--video-data", help="Base64-encoded video binary (mutually exclusive with --url)")
+@click.option("--name", help="Video name")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def add(ctx, url, video_data, name, dry_run):
+    """Add a new ad video (by URL or binary data)"""
+    try:
+        if not url and not video_data:
+            raise click.UsageError("Either --url or --video-data is required.")
+        if url and video_data:
+            raise click.UsageError("Use either --url or --video-data, not both.")
+
+        item = {}
+        if url:
+            item["Url"] = url
+        if video_data:
+            item["VideoData"] = video_data
+        if name:
+            item["Name"] = name
+
+        body = {"method": "add", "params": {"AdVideos": [item]}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
+        result = client.advideos().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except click.UsageError:
+        raise
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+advideos.add_command(get, name="list")

--- a/direct_cli/commands/advideos.py
+++ b/direct_cli/commands/advideos.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import create_client
 from ..output import format_output, print_error
-from ..utils import parse_ids
+from ..utils import parse_ids, get_default_fields
 
 
 @click.group()
@@ -20,8 +20,9 @@ def advideos():
 @click.option("--fetch-all", is_flag=True, help="Fetch all pages")
 @click.option("--format", "output_format", default="json", help="Output format")
 @click.option("--output", help="Output file")
+@click.option("--fields", help="Comma-separated field names")
 @click.pass_context
-def get(ctx, ids, limit, fetch_all, output_format, output):
+def get(ctx, ids, limit, fetch_all, output_format, output, fields):
     """Get ad videos"""
     try:
         client = create_client(
@@ -30,13 +31,15 @@ def get(ctx, ids, limit, fetch_all, output_format, output):
             sandbox=ctx.obj.get("sandbox"),
         )
 
+        field_names = fields.split(",") if fields else get_default_fields("advideos")
+
         criteria = {}
         if ids:
             criteria["Ids"] = parse_ids(ids)
 
         params = {
             "SelectionCriteria": criteria,
-            "FieldNames": ["Id", "Status"],
+            "FieldNames": field_names,
         }
 
         if limit:

--- a/direct_cli/commands/agencyclients.py
+++ b/direct_cli/commands/agencyclients.py
@@ -3,11 +3,12 @@ AgencyClients commands
 """
 
 import json
+
 import click
 
 from ..api import create_client
 from ..output import format_output, print_error
-from ..utils import parse_ids, get_default_fields
+from ..utils import get_default_fields, parse_ids
 
 
 @click.group()
@@ -71,7 +72,7 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields):
 def add(ctx, client_json, dry_run):
     """Add agency client"""
     try:
-        body = {"method": "add", "params": {"Clients": [json.loads(client_json)]}}
+        body = {"method": "add", "params": json.loads(client_json)}
 
         if dry_run:
             format_output(body, "json", None)
@@ -86,6 +87,116 @@ def add(ctx, client_json, dry_run):
         result = client.agencyclients().post(data=body)
         format_output(result().extract(), "json", None)
 
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@agencyclients.command(name="add-passport-organization")
+@click.option("--name", required=True, help="Organization name")
+@click.option("--currency", required=True, help="Account currency")
+@click.option("--notification-json", required=True, help="Notification object JSON")
+@click.option("--json", "extra_json", help="Additional JSON parameters")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def add_passport_organization(ctx, name, currency, notification_json, extra_json, dry_run):
+    """Add passport organization agency client"""
+    try:
+        params = {
+            "Name": name,
+            "Currency": currency,
+            "Notification": json.loads(notification_json),
+        }
+        if extra_json:
+            params.update(json.loads(extra_json))
+
+        body = {"method": "addPassportOrganization", "params": params}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+        result = client.agencyclients().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@agencyclients.command(name="add-passport-organization-member")
+@click.option("--passport-organization-login", required=True, help="Passport organization login")
+@click.option("--role", required=True, help="Organization member role")
+@click.option("--send-invite-to-json", required=True, help="SendInviteTo object JSON")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def add_passport_organization_member(
+    ctx, passport_organization_login, role, send_invite_to_json, dry_run
+):
+    """Invite user to passport organization"""
+    try:
+        body = {
+            "method": "addPassportOrganizationMember",
+            "params": {
+                "PassportOrganizationLogin": passport_organization_login,
+                "Role": role,
+                "SendInviteTo": json.loads(send_invite_to_json),
+            },
+        }
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+        result = client.agencyclients().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@agencyclients.command()
+@click.option("--client-id", required=True, type=int, help="Client ID")
+@click.option("--json", "extra_json", help="Additional JSON parameters")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def update(ctx, client_id, extra_json, dry_run):
+    """Update agency client"""
+    try:
+        client_data = {"ClientId": client_id}
+
+        if extra_json:
+            client_data.update(json.loads(extra_json))
+        if len(client_data) == 1:
+            raise click.UsageError("Provide --json with fields to update")
+
+        body = {"method": "update", "params": {"Clients": [client_data]}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+        result = client.agencyclients().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except click.UsageError:
+        raise
     except Exception as e:
         print_error(str(e))
         raise click.Abort()

--- a/direct_cli/commands/audiencetargets.py
+++ b/direct_cli/commands/audiencetargets.py
@@ -3,6 +3,7 @@ AudienceTargets commands
 """
 
 import json
+
 import click
 
 from ..api import create_client
@@ -43,7 +44,13 @@ def get(ctx, ids, adgroup_ids, campaign_ids, limit, fetch_all, output_format, ou
 
         params = {
             "SelectionCriteria": criteria,
-            "FieldNames": ["Id", "AdGroupId", "RetargetingListId", "State", "Bid"],
+            "FieldNames": [
+                "Id",
+                "AdGroupId",
+                "RetargetingListId",
+                "State",
+                "ContextBid",
+            ],
         }
 
         if limit:
@@ -69,10 +76,8 @@ def get(ctx, ids, adgroup_ids, campaign_ids, limit, fetch_all, output_format, ou
 
 @audiencetargets.command()
 @click.option("--adgroup-id", required=True, type=int, help="Ad group ID")
-@click.option(
-    "--retargeting-list-id", required=True, type=int, help="Retargeting list ID"
-)
-@click.option("--bid", type=float, help="Bid")
+@click.option("--retargeting-list-id", required=True, type=int, help="Retargeting list ID")
+@click.option("--bid", type=float, help="Context bid")
 @click.option("--json", "extra_json", help="Additional JSON parameters")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
@@ -85,13 +90,87 @@ def add(ctx, adgroup_id, retargeting_list_id, bid, extra_json, dry_run):
         }
 
         if bid is not None:
-            target_data["Bid"] = int(bid * 1000000)
+            target_data["ContextBid"] = int(bid * 1000000)
 
         if extra_json:
-            extra = json.loads(extra_json)
-            target_data.update(extra)
+            target_data.update(json.loads(extra_json))
 
         body = {"method": "add", "params": {"AudienceTargets": [target_data]}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+        result = client.audiencetargets().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@audiencetargets.command(name="set-bids")
+@click.option("--id", "target_id", type=int, help="Target ID")
+@click.option("--adgroup-id", type=int, help="Ad group ID")
+@click.option("--campaign-id", type=int, help="Campaign ID")
+@click.option("--context-bid", type=float, help="Context bid")
+@click.option("--priority", help="Strategy priority")
+@click.option("--json", "extra_json", help="Additional JSON parameters")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def set_bids(ctx, target_id, adgroup_id, campaign_id, context_bid, priority, extra_json, dry_run):
+    """Set audience target bids"""
+    try:
+        bid_data = {}
+        if target_id is not None:
+            bid_data["Id"] = target_id
+        if adgroup_id is not None:
+            bid_data["AdGroupId"] = adgroup_id
+        if campaign_id is not None:
+            bid_data["CampaignId"] = campaign_id
+        if context_bid is not None:
+            bid_data["ContextBid"] = int(context_bid * 1000000)
+        if priority:
+            bid_data["StrategyPriority"] = priority
+        if extra_json:
+            bid_data.update(json.loads(extra_json))
+        if not bid_data:
+            raise click.UsageError("Provide target selection and bid fields for set-bids")
+
+        body = {"method": "setBids", "params": {"Bids": [bid_data]}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+        result = client.audiencetargets().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except click.UsageError:
+        raise
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@audiencetargets.command()
+@click.option("--id", "target_id", required=True, type=int, help="Target ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def delete(ctx, target_id, dry_run):
+    """Delete audience target"""
+    try:
+        body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [target_id]}}}
 
         if dry_run:
             format_output(body, "json", None)
@@ -113,45 +192,22 @@ def add(ctx, adgroup_id, retargeting_list_id, bid, extra_json, dry_run):
 
 @audiencetargets.command()
 @click.option("--id", "target_id", required=True, type=int, help="Target ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def delete(ctx, target_id):
-    """Delete audience target"""
-    try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
-
-        body = {
-            "method": "delete",
-            "params": {"SelectionCriteria": {"Ids": [target_id]}},
-        }
-
-        result = client.audiencetargets().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
-
-
-@audiencetargets.command()
-@click.option("--id", "target_id", required=True, type=int, help="Target ID")
-@click.pass_context
-def suspend(ctx, target_id):
+def suspend(ctx, target_id, dry_run):
     """Suspend audience target"""
     try:
+        body = {"method": "suspend", "params": {"SelectionCriteria": {"Ids": [target_id]}}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
         client = create_client(
             token=ctx.obj.get("token"),
             login=ctx.obj.get("login"),
             sandbox=ctx.obj.get("sandbox"),
         )
-
-        body = {
-            "method": "suspend",
-            "params": {"SelectionCriteria": {"Ids": [target_id]}},
-        }
 
         result = client.audiencetargets().post(data=body)
         format_output(result().extract(), "json", None)
@@ -163,20 +219,22 @@ def suspend(ctx, target_id):
 
 @audiencetargets.command()
 @click.option("--id", "target_id", required=True, type=int, help="Target ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def resume(ctx, target_id):
+def resume(ctx, target_id, dry_run):
     """Resume audience target"""
     try:
+        body = {"method": "resume", "params": {"SelectionCriteria": {"Ids": [target_id]}}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
         client = create_client(
             token=ctx.obj.get("token"),
             login=ctx.obj.get("login"),
             sandbox=ctx.obj.get("sandbox"),
         )
-
-        body = {
-            "method": "resume",
-            "params": {"SelectionCriteria": {"Ids": [target_id]}},
-        }
 
         result = client.audiencetargets().post(data=body)
         format_output(result().extract(), "json", None)

--- a/direct_cli/commands/bidmodifiers.py
+++ b/direct_cli/commands/bidmodifiers.py
@@ -72,14 +72,23 @@ _BIDMODIFIER_TYPE_TO_NESTED = {
     "TABLET_ADJUSTMENT": "TabletAdjustment",
     "DESKTOP_ADJUSTMENT": "DesktopAdjustment",
     "DESKTOP_ONLY_ADJUSTMENT": "DesktopOnlyAdjustment",
-    "DEMOGRAPHICS_ADJUSTMENT": "DemographicsAdjustment",
-    "RETARGETING_ADJUSTMENT": "RetargetingAdjustment",
-    "REGIONAL_ADJUSTMENT": "RegionalAdjustment",
+    "DEMOGRAPHICS_ADJUSTMENT": "DemographicsAdjustments",   # plural per WSDL
+    "RETARGETING_ADJUSTMENT": "RetargetingAdjustments",     # plural per WSDL
+    "REGIONAL_ADJUSTMENT": "RegionalAdjustments",           # plural per WSDL
     "VIDEO_ADJUSTMENT": "VideoAdjustment",
     "SMART_AD_ADJUSTMENT": "SmartAdAdjustment",
-    "SERP_LAYOUT_ADJUSTMENT": "SerpLayoutAdjustment",
-    "INCOME_GRADE_ADJUSTMENT": "IncomeGradeAdjustment",
+    "SERP_LAYOUT_ADJUSTMENT": "SerpLayoutAdjustments",      # plural per WSDL
+    "INCOME_GRADE_ADJUSTMENT": "IncomeGradeAdjustments",    # plural per WSDL
     "AD_GROUP_ADJUSTMENT": "AdGroupAdjustment",
+}
+
+# Plural fields require a list value per WSDL BidModifierAddItem
+_PLURAL_NESTED_KEYS = {
+    "DemographicsAdjustments",
+    "RetargetingAdjustments",
+    "RegionalAdjustments",
+    "SerpLayoutAdjustments",
+    "IncomeGradeAdjustments",
 }
 
 
@@ -151,7 +160,11 @@ def add(ctx, campaign_id, adgroup_id, modifier_type, value, extra_json, dry_run)
                 )
             nested.update(extra)
 
-        modifier_data = {nested_key: nested}
+        # Plural fields expect a list per WSDL BidModifierAddItem
+        if nested_key in _PLURAL_NESTED_KEYS:
+            modifier_data = {nested_key: [nested]}
+        else:
+            modifier_data = {nested_key: nested}
         if campaign_id is not None:
             modifier_data["CampaignId"] = campaign_id
         else:

--- a/direct_cli/commands/bidmodifiers.py
+++ b/direct_cli/commands/bidmodifiers.py
@@ -368,20 +368,25 @@ def toggle(ctx, campaign_id, adgroup_id, modifier_type, enabled, dry_run):
 
 @bidmodifiers.command()
 @click.option("--id", "modifier_id", required=True, type=int, help="Modifier ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def delete(ctx, modifier_id):
+def delete(ctx, modifier_id, dry_run):
     """Delete bid modifier"""
     try:
+        body = {
+            "method": "delete",
+            "params": {"SelectionCriteria": {"Ids": [modifier_id]}},
+        }
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
         client = create_client(
             token=ctx.obj.get("token"),
             login=ctx.obj.get("login"),
             sandbox=ctx.obj.get("sandbox"),
         )
-
-        body = {
-            "method": "delete",
-            "params": {"SelectionCriteria": {"Ids": [modifier_id]}},
-        }
 
         result = client.bidmodifiers().post(data=body)
         format_output(result().extract(), "json", None)

--- a/direct_cli/commands/bidmodifiers.py
+++ b/direct_cli/commands/bidmodifiers.py
@@ -82,13 +82,9 @@ _BIDMODIFIER_TYPE_TO_NESTED = {
     "AD_GROUP_ADJUSTMENT": "AdGroupAdjustment",
 }
 
-# Plural fields require a list value per WSDL BidModifierAddItem
+# Plural fields (derived from _BIDMODIFIER_TYPE_TO_NESTED) require a list value per WSDL
 _PLURAL_NESTED_KEYS = {
-    "DemographicsAdjustments",
-    "RetargetingAdjustments",
-    "RegionalAdjustments",
-    "SerpLayoutAdjustments",
-    "IncomeGradeAdjustments",
+    v for v in _BIDMODIFIER_TYPE_TO_NESTED.values() if v.endswith("Adjustments")
 }
 
 

--- a/direct_cli/commands/bids.py
+++ b/direct_cli/commands/bids.py
@@ -3,6 +3,7 @@ Bids commands
 """
 
 import json
+
 import click
 
 from ..api import create_client
@@ -24,9 +25,7 @@ def bids():
 @click.option("--format", "output_format", default="json", help="Output format")
 @click.option("--output", help="Output file")
 @click.pass_context
-def get(
-    ctx, campaign_ids, adgroup_ids, keyword_ids, limit, fetch_all, output_format, output
-):
+def get(ctx, campaign_ids, adgroup_ids, keyword_ids, limit, fetch_all, output_format, output):
     """Get bids"""
     try:
         client = create_client(
@@ -84,8 +83,7 @@ def set(ctx, keyword_id, bid, extra_json, dry_run):
             bid_data["Bid"] = int(bid * 1000000)
 
         if extra_json:
-            extra = json.loads(extra_json)
-            bid_data.update(extra)
+            bid_data.update(json.loads(extra_json))
 
         body = {"method": "set", "params": {"Bids": [bid_data]}}
 
@@ -98,10 +96,85 @@ def set(ctx, keyword_id, bid, extra_json, dry_run):
             login=ctx.obj.get("login"),
             sandbox=ctx.obj.get("sandbox"),
         )
-
         result = client.bids().post(data=body)
         format_output(result().extract(), "json", None)
 
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@bids.command(name="set-auto")
+@click.option("--campaign-id", type=int, help="Campaign ID")
+@click.option("--adgroup-id", type=int, help="Ad group ID")
+@click.option("--keyword-id", type=int, help="Keyword ID")
+@click.option("--max-bid", type=float, help="Maximum bid")
+@click.option("--position", help="Desired position")
+@click.option("--increase-percent", type=int, help="Increase percent")
+@click.option("--calculate-by", help="Calculate-by mode")
+@click.option("--context-coverage", type=int, help="Context coverage")
+@click.option("--scope", multiple=True, help="One or more scope values")
+@click.option("--json", "extra_json", help="Additional JSON parameters")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def set_auto(
+    ctx,
+    campaign_id,
+    adgroup_id,
+    keyword_id,
+    max_bid,
+    position,
+    increase_percent,
+    calculate_by,
+    context_coverage,
+    scope,
+    extra_json,
+    dry_run,
+):
+    """Configure automatic bidding"""
+    try:
+        bid_data = {}
+        if campaign_id is not None:
+            bid_data["CampaignId"] = campaign_id
+        if adgroup_id is not None:
+            bid_data["AdGroupId"] = adgroup_id
+        if keyword_id is not None:
+            bid_data["KeywordId"] = keyword_id
+        if max_bid is not None:
+            bid_data["MaxBid"] = int(max_bid * 1000000)
+        if position:
+            bid_data["Position"] = position
+        if increase_percent is not None:
+            bid_data["IncreasePercent"] = increase_percent
+        if calculate_by:
+            bid_data["CalculateBy"] = calculate_by
+        if context_coverage is not None:
+            bid_data["ContextCoverage"] = context_coverage
+        if scope:
+            bid_data["Scope"] = list(scope)
+        if extra_json:
+            bid_data.update(json.loads(extra_json))
+        if "Scope" not in bid_data:
+            raise click.UsageError(
+                "Provide at least one --scope or include Scope in --json"
+            )
+
+        body = {"method": "setAuto", "params": {"Bids": [bid_data]}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+        result = client.bids().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except click.UsageError:
+        raise
     except Exception as e:
         print_error(str(e))
         raise click.Abort()

--- a/direct_cli/commands/campaigns.py
+++ b/direct_cli/commands/campaigns.py
@@ -211,21 +211,26 @@ def update(ctx, campaign_id, name, status, budget, extra_json, dry_run):
 
 @campaigns.command()
 @click.option("--id", "campaign_id", required=True, type=int, help="Campaign ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def delete(ctx, campaign_id):
+def delete(ctx, campaign_id, dry_run):
     """Delete campaign"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
-
         body = {
             "method": "delete",
             "params": {"SelectionCriteria": {"Ids": [campaign_id]}},
         }
 
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
         result = client.campaigns().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -236,21 +241,26 @@ def delete(ctx, campaign_id):
 
 @campaigns.command()
 @click.option("--id", "campaign_id", required=True, type=int, help="Campaign ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def archive(ctx, campaign_id):
+def archive(ctx, campaign_id, dry_run):
     """Archive campaign"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
-
         body = {
             "method": "archive",
             "params": {"SelectionCriteria": {"Ids": [campaign_id]}},
         }
 
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
         result = client.campaigns().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -261,20 +271,25 @@ def archive(ctx, campaign_id):
 
 @campaigns.command()
 @click.option("--id", "campaign_id", required=True, type=int, help="Campaign ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def unarchive(ctx, campaign_id):
+def unarchive(ctx, campaign_id, dry_run):
     """Unarchive campaign"""
     try:
+        body = {
+            "method": "unarchive",
+            "params": {"SelectionCriteria": {"Ids": [campaign_id]}},
+        }
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
         client = create_client(
             token=ctx.obj.get("token"),
             login=ctx.obj.get("login"),
             sandbox=ctx.obj.get("sandbox"),
         )
-
-        body = {
-            "method": "unarchive",
-            "params": {"SelectionCriteria": {"Ids": [campaign_id]}},
-        }
 
         result = client.campaigns().post(data=body)
         format_output(result().extract(), "json", None)
@@ -289,20 +304,25 @@ campaigns.add_command(get, name="list")
 
 @campaigns.command()
 @click.option("--id", "campaign_id", required=True, type=int, help="Campaign ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def suspend(ctx, campaign_id):
+def suspend(ctx, campaign_id, dry_run):
     """Suspend campaign"""
     try:
+        body = {
+            "method": "suspend",
+            "params": {"SelectionCriteria": {"Ids": [campaign_id]}},
+        }
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
         client = create_client(
             token=ctx.obj.get("token"),
             login=ctx.obj.get("login"),
             sandbox=ctx.obj.get("sandbox"),
         )
-
-        body = {
-            "method": "suspend",
-            "params": {"SelectionCriteria": {"Ids": [campaign_id]}},
-        }
 
         result = client.campaigns().post(data=body)
         format_output(result().extract(), "json", None)
@@ -314,20 +334,25 @@ def suspend(ctx, campaign_id):
 
 @campaigns.command()
 @click.option("--id", "campaign_id", required=True, type=int, help="Campaign ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def resume(ctx, campaign_id):
+def resume(ctx, campaign_id, dry_run):
     """Resume campaign"""
     try:
+        body = {
+            "method": "resume",
+            "params": {"SelectionCriteria": {"Ids": [campaign_id]}},
+        }
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
         client = create_client(
             token=ctx.obj.get("token"),
             login=ctx.obj.get("login"),
             sandbox=ctx.obj.get("sandbox"),
         )
-
-        body = {
-            "method": "resume",
-            "params": {"SelectionCriteria": {"Ids": [campaign_id]}},
-        }
 
         result = client.campaigns().post(data=body)
         format_output(result().extract(), "json", None)

--- a/direct_cli/commands/creatives.py
+++ b/direct_cli/commands/creatives.py
@@ -2,6 +2,8 @@
 Creatives commands
 """
 
+import json
+
 import click
 
 from ..api import create_client
@@ -33,9 +35,7 @@ def get(ctx, ids, campaign_ids, limit, fetch_all, output_format, output, fields)
         )
 
         field_names = (
-            fields.split(",")
-            if fields
-            else ["Id", "Name", "Type", "Status", "CampaignId"]
+            fields.split(",") if fields else ["Id", "Name", "Type", "Status", "CampaignId"]
         )
 
         criteria = {}
@@ -61,6 +61,32 @@ def get(ctx, ids, campaign_ids, limit, fetch_all, output_format, output, fields)
         else:
             data = result().extract()
             format_output(data, output_format, output)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@creatives.command()
+@click.option("--json", "creative_json", required=True, help="Creative data in JSON")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def add(ctx, creative_json, dry_run):
+    """Add creative"""
+    try:
+        body = {"method": "add", "params": {"Creatives": [json.loads(creative_json)]}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+        result = client.creatives().post(data=body)
+        format_output(result().extract(), "json", None)
 
     except Exception as e:
         print_error(str(e))

--- a/direct_cli/commands/dictionaries.py
+++ b/direct_cli/commands/dictionaries.py
@@ -2,6 +2,8 @@
 Dictionaries commands
 """
 
+import json
+
 import click
 
 from ..api import create_client
@@ -47,6 +49,34 @@ def get(ctx, names, output_format, output):
         dictionary_names = [n.strip() for n in names.split(",")]
 
         body = {"method": "get", "params": {"DictionaryNames": dictionary_names}}
+
+        result = client.dictionaries().post(data=body)
+        format_output(result.data, output_format, output)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@dictionaries.command(name="get-geo-regions")
+@click.option("--json", "criteria_json", help="GeoRegions selection criteria JSON")
+@click.option("--fields", required=True, help="Comma-separated field names")
+@click.option("--format", "output_format", default="json", help="Output format")
+@click.option("--output", help="Output file")
+@click.pass_context
+def get_geo_regions(ctx, criteria_json, fields, output_format, output):
+    """Get GeoRegions dictionary entries"""
+    try:
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
+        params = {"FieldNames": [name.strip() for name in fields.split(",")]}
+        params["SelectionCriteria"] = json.loads(criteria_json) if criteria_json else {}
+
+        body = {"method": "getGeoRegions", "params": params}
 
         result = client.dictionaries().post(data=body)
         format_output(result.data, output_format, output)

--- a/direct_cli/commands/dynamicads.py
+++ b/direct_cli/commands/dynamicads.py
@@ -3,6 +3,7 @@ DynamicAds (Webpages) commands
 """
 
 import json
+
 import click
 
 from ..api import create_client
@@ -33,9 +34,7 @@ def get(ctx, ids, adgroup_ids, limit, fetch_all, output_format, output, fields):
             sandbox=ctx.obj.get("sandbox"),
         )
 
-        field_names = (
-            fields.split(",") if fields else ["Id", "AdGroupId", "Conditions", "Bid"]
-        )
+        field_names = fields.split(",") if fields else ["Id", "AdGroupId", "Conditions", "Bid"]
 
         criteria = {}
         if ids:
@@ -93,7 +92,6 @@ def add(ctx, adgroup_id, target_json, dry_run):
             login=ctx.obj.get("login"),
             sandbox=ctx.obj.get("sandbox"),
         )
-
         result = client.dynamicads().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -104,23 +102,12 @@ def add(ctx, adgroup_id, target_json, dry_run):
 
 @dynamicads.command()
 @click.option("--id", "target_id", required=True, type=int, help="Target ID")
-@click.option("--json", "extra_json", help="Additional JSON parameters")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def update(ctx, target_id, extra_json, dry_run):
-    """Update dynamic ad target"""
+def delete(ctx, target_id, dry_run):
+    """Delete dynamic ad target"""
     try:
-        target_data = {"Id": target_id}
-
-        if extra_json:
-            extra = json.loads(extra_json)
-            target_data.update(extra)
-        if len(target_data) == 1:
-            raise click.ClickException(
-                "Provide --json with fields to update"
-            )
-
-        body = {"method": "update", "params": {"Webpages": [target_data]}}
+        body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [target_id]}}}
 
         if dry_run:
             format_output(body, "json", None)
@@ -142,24 +129,103 @@ def update(ctx, target_id, extra_json, dry_run):
 
 @dynamicads.command()
 @click.option("--id", "target_id", required=True, type=int, help="Target ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def delete(ctx, target_id):
-    """Delete dynamic ad target"""
+def suspend(ctx, target_id, dry_run):
+    """Suspend dynamic ad target"""
     try:
+        body = {"method": "suspend", "params": {"SelectionCriteria": {"Ids": [target_id]}}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
         client = create_client(
             token=ctx.obj.get("token"),
             login=ctx.obj.get("login"),
             sandbox=ctx.obj.get("sandbox"),
         )
-
-        body = {
-            "method": "delete",
-            "params": {"SelectionCriteria": {"Ids": [target_id]}},
-        }
-
         result = client.dynamicads().post(data=body)
         format_output(result().extract(), "json", None)
 
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@dynamicads.command()
+@click.option("--id", "target_id", required=True, type=int, help="Target ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def resume(ctx, target_id, dry_run):
+    """Resume dynamic ad target"""
+    try:
+        body = {"method": "resume", "params": {"SelectionCriteria": {"Ids": [target_id]}}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+        result = client.dynamicads().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@dynamicads.command(name="set-bids")
+@click.option("--id", "target_id", type=int, help="Target ID")
+@click.option("--adgroup-id", type=int, help="Ad group ID")
+@click.option("--campaign-id", type=int, help="Campaign ID")
+@click.option("--bid", type=float, help="Search bid")
+@click.option("--context-bid", type=float, help="Context bid")
+@click.option("--priority", help="Strategy priority")
+@click.option("--json", "extra_json", help="Additional JSON parameters")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def set_bids(ctx, target_id, adgroup_id, campaign_id, bid, context_bid, priority, extra_json, dry_run):
+    """Set dynamic ad target bids"""
+    try:
+        bid_data = {}
+        if target_id is not None:
+            bid_data["Id"] = target_id
+        if adgroup_id is not None:
+            bid_data["AdGroupId"] = adgroup_id
+        if campaign_id is not None:
+            bid_data["CampaignId"] = campaign_id
+        if bid is not None:
+            bid_data["Bid"] = int(bid * 1000000)
+        if context_bid is not None:
+            bid_data["ContextBid"] = int(context_bid * 1000000)
+        if priority:
+            bid_data["StrategyPriority"] = priority
+        if extra_json:
+            bid_data.update(json.loads(extra_json))
+        if not bid_data:
+            raise click.UsageError("Provide target selection and bid fields for set-bids")
+
+        body = {"method": "setBids", "params": {"Bids": [bid_data]}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+        result = client.dynamicads().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except click.UsageError:
+        raise
     except Exception as e:
         print_error(str(e))
         raise click.Abort()

--- a/direct_cli/commands/feeds.py
+++ b/direct_cli/commands/feeds.py
@@ -189,17 +189,22 @@ def update(ctx, feed_id, name, url, extra_json, dry_run):
 
 @feeds.command()
 @click.option("--id", "feed_id", required=True, type=int, help="Feed ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def delete(ctx, feed_id):
+def delete(ctx, feed_id, dry_run):
     """Delete feed"""
     try:
+        body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [feed_id]}}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
         client = create_client(
             token=ctx.obj.get("token"),
             login=ctx.obj.get("login"),
             sandbox=ctx.obj.get("sandbox"),
         )
-
-        body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [feed_id]}}}
 
         result = client.feeds().post(data=body)
         format_output(result().extract(), "json", None)

--- a/direct_cli/commands/keywordbids.py
+++ b/direct_cli/commands/keywordbids.py
@@ -3,6 +3,7 @@ KeywordBids commands
 """
 
 import json
+
 import click
 
 from ..api import create_client
@@ -24,9 +25,7 @@ def keywordbids():
 @click.option("--format", "output_format", default="json", help="Output format")
 @click.option("--output", help="Output file")
 @click.pass_context
-def get(
-    ctx, keyword_ids, adgroup_ids, campaign_ids, limit, fetch_all, output_format, output
-):
+def get(ctx, keyword_ids, adgroup_ids, campaign_ids, limit, fetch_all, output_format, output):
     """Get keyword bids"""
     try:
         client = create_client(
@@ -87,8 +86,7 @@ def set(ctx, keyword_id, search_bid, network_bid, extra_json, dry_run):
             bid_data["NetworkBid"] = int(network_bid * 1000000)
 
         if extra_json:
-            extra = json.loads(extra_json)
-            bid_data.update(extra)
+            bid_data.update(json.loads(extra_json))
 
         body = {"method": "set", "params": {"KeywordBids": [bid_data]}}
 
@@ -101,7 +99,43 @@ def set(ctx, keyword_id, search_bid, network_bid, extra_json, dry_run):
             login=ctx.obj.get("login"),
             sandbox=ctx.obj.get("sandbox"),
         )
+        result = client.keywordbids().post(data=body)
+        format_output(result().extract(), "json", None)
 
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@keywordbids.command(name="set-auto")
+@click.option("--campaign-id", type=int, help="Campaign ID")
+@click.option("--adgroup-id", type=int, help="Ad group ID")
+@click.option("--keyword-id", type=int, help="Keyword ID")
+@click.option("--json", "bidding_rule_json", required=True, help="BiddingRule object JSON")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def set_auto(ctx, campaign_id, adgroup_id, keyword_id, bidding_rule_json, dry_run):
+    """Configure automatic keyword bidding"""
+    try:
+        bid_data = {"BiddingRule": json.loads(bidding_rule_json)}
+        if campaign_id is not None:
+            bid_data["CampaignId"] = campaign_id
+        if adgroup_id is not None:
+            bid_data["AdGroupId"] = adgroup_id
+        if keyword_id is not None:
+            bid_data["KeywordId"] = keyword_id
+
+        body = {"method": "setAuto", "params": {"KeywordBids": [bid_data]}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
         result = client.keywordbids().post(data=body)
         format_output(result().extract(), "json", None)
 

--- a/direct_cli/commands/keywords.py
+++ b/direct_cli/commands/keywords.py
@@ -185,21 +185,26 @@ def update(ctx, keyword_id, bid, context_bid, status, extra_json, dry_run):
 
 @keywords.command()
 @click.option("--id", "keyword_id", required=True, type=int, help="Keyword ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def delete(ctx, keyword_id):
+def delete(ctx, keyword_id, dry_run):
     """Delete keyword"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
-
         body = {
             "method": "delete",
             "params": {"SelectionCriteria": {"Ids": [keyword_id]}},
         }
 
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
         result = client.keywords().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -210,21 +215,26 @@ def delete(ctx, keyword_id):
 
 @keywords.command()
 @click.option("--id", "keyword_id", required=True, type=int, help="Keyword ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def archive(ctx, keyword_id):
+def archive(ctx, keyword_id, dry_run):
     """Archive keyword"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
-
         body = {
             "method": "archive",
             "params": {"SelectionCriteria": {"Ids": [keyword_id]}},
         }
 
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
         result = client.keywords().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -235,21 +245,26 @@ def archive(ctx, keyword_id):
 
 @keywords.command()
 @click.option("--id", "keyword_id", required=True, type=int, help="Keyword ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def unarchive(ctx, keyword_id):
+def unarchive(ctx, keyword_id, dry_run):
     """Unarchive keyword"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
-
         body = {
             "method": "unarchive",
             "params": {"SelectionCriteria": {"Ids": [keyword_id]}},
         }
 
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
         result = client.keywords().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -260,21 +275,26 @@ def unarchive(ctx, keyword_id):
 
 @keywords.command()
 @click.option("--id", "keyword_id", required=True, type=int, help="Keyword ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def suspend(ctx, keyword_id):
+def suspend(ctx, keyword_id, dry_run):
     """Suspend keyword"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
-
         body = {
             "method": "suspend",
             "params": {"SelectionCriteria": {"Ids": [keyword_id]}},
         }
 
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
         result = client.keywords().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -285,20 +305,25 @@ def suspend(ctx, keyword_id):
 
 @keywords.command()
 @click.option("--id", "keyword_id", required=True, type=int, help="Keyword ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def resume(ctx, keyword_id):
+def resume(ctx, keyword_id, dry_run):
     """Resume keyword"""
     try:
+        body = {
+            "method": "resume",
+            "params": {"SelectionCriteria": {"Ids": [keyword_id]}},
+        }
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
         client = create_client(
             token=ctx.obj.get("token"),
             login=ctx.obj.get("login"),
             sandbox=ctx.obj.get("sandbox"),
         )
-
-        body = {
-            "method": "resume",
-            "params": {"SelectionCriteria": {"Ids": [keyword_id]}},
-        }
 
         result = client.keywords().post(data=body)
         format_output(result().extract(), "json", None)

--- a/direct_cli/commands/keywordsresearch.py
+++ b/direct_cli/commands/keywordsresearch.py
@@ -15,36 +15,6 @@ def keywordsresearch():
 
 @keywordsresearch.command()
 @click.option("--keywords", required=True, help="Comma-separated keywords")
-@click.option("--limit", type=int, help="Limit number of results")
-@click.option("--format", "output_format", default="json", help="Output format")
-@click.option("--output", help="Output file")
-@click.pass_context
-def get(ctx, keywords, limit, output_format, output):
-    """Get keywords research data"""
-    try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
-
-        params = {"Keywords": [k.strip() for k in keywords.split(",")]}
-
-        if limit:
-            params["Limit"] = limit
-
-        body = {"method": "get", "params": params}
-
-        result = client.keywordsresearch().post(data=body)
-        format_output(result.data, output_format, output)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
-
-
-@keywordsresearch.command()
-@click.option("--keywords", required=True, help="Comma-separated keywords")
 @click.option("--format", "output_format", default="json", help="Output format")
 @click.option("--output", help="Output file")
 @click.pass_context

--- a/direct_cli/commands/negativekeywordsharedsets.py
+++ b/direct_cli/commands/negativekeywordsharedsets.py
@@ -147,17 +147,22 @@ def update(ctx, set_id, name, keywords, extra_json, dry_run):
 
 @negativekeywordsharedsets.command()
 @click.option("--id", "set_id", required=True, type=int, help="Set ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def delete(ctx, set_id):
+def delete(ctx, set_id, dry_run):
     """Delete negative keyword shared set"""
     try:
+        body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [set_id]}}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
         client = create_client(
             token=ctx.obj.get("token"),
             login=ctx.obj.get("login"),
             sandbox=ctx.obj.get("sandbox"),
         )
-
-        body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [set_id]}}}
 
         result = client.negativekeywordsharedsets().post(data=body)
         format_output(result().extract(), "json", None)

--- a/direct_cli/commands/reports.py
+++ b/direct_cli/commands/reports.py
@@ -2,6 +2,8 @@
 Reports commands
 """
 
+from typing import Optional
+
 import click
 
 from ..api import create_client
@@ -16,6 +18,69 @@ REPORT_TYPES = [
     "REACH_AND_FREQUENCY_CAMPAIGN_REPORT",
     "SEARCH_QUERY_PERFORMANCE_REPORT",
 ]
+
+
+def build_report_request(
+    report_type: str,
+    date_from: str,
+    date_to: str,
+    name: str,
+    fields: str,
+    campaign_ids: Optional[str] = None,
+    adgroup_ids: Optional[str] = None,
+    output_format: str = "json",
+) -> dict:
+    """
+    Build the Reports API request body from CLI arguments.
+
+    Args:
+        report_type: Yandex Direct report type enum value.
+        date_from: Start date in ``YYYY-MM-DD`` format.
+        date_to: End date in ``YYYY-MM-DD`` format.
+        name: User-facing report name.
+        fields: Comma-separated field names.
+        campaign_ids: Optional comma-separated campaign IDs filter.
+        adgroup_ids: Optional comma-separated ad group IDs filter.
+        output_format: CLI output format. Reports API itself still receives TSV.
+
+    Returns:
+        Reports API request body with CLI-normalized filters and field names.
+    """
+    field_names = [field.strip() for field in fields.split(",") if field.strip()]
+    selection_criteria = {"DateFrom": date_from, "DateTo": date_to}
+
+    if campaign_ids:
+        selection_criteria["Filter"] = [
+            {
+                "Field": "CampaignId",
+                "Operator": "IN",
+                "Values": [item.strip() for item in campaign_ids.split(",") if item.strip()],
+            }
+        ]
+    elif adgroup_ids:
+        selection_criteria["Filter"] = [
+            {
+                "Field": "AdGroupId",
+                "Operator": "IN",
+                "Values": [item.strip() for item in adgroup_ids.split(",") if item.strip()],
+            }
+        ]
+
+    # The reports endpoint returns tabular data. The CLI later reformats that
+    # response into json/table/csv/tsv, so the API-side format remains TSV.
+    _ = output_format
+    return {
+        "params": {
+            "SelectionCriteria": selection_criteria,
+            "FieldNames": field_names,
+            "ReportName": name,
+            "ReportType": report_type,
+            "DateRangeType": "CUSTOM_DATE",
+            "Format": "TSV",
+            "IncludeVAT": "YES",
+            "IncludeDiscount": "YES",
+        }
+    }
 
 
 @click.group()
@@ -75,39 +140,16 @@ def get(
             sandbox=ctx.obj.get("sandbox"),
         )
 
-        field_names = [f.strip() for f in fields.split(",")]
-
-        selection_criteria = {"DateFrom": date_from, "DateTo": date_to}
-
-        if campaign_ids:
-            selection_criteria["Filter"] = [
-                {
-                    "Field": "CampaignId",
-                    "Operator": "IN",
-                    "Values": campaign_ids.split(","),
-                }
-            ]
-        elif adgroup_ids:
-            selection_criteria["Filter"] = [
-                {
-                    "Field": "AdGroupId",
-                    "Operator": "IN",
-                    "Values": adgroup_ids.split(","),
-                }
-            ]
-
-        body = {
-            "params": {
-                "SelectionCriteria": selection_criteria,
-                "FieldNames": field_names,
-                "ReportName": name,
-                "ReportType": report_type,
-                "DateRangeType": "CUSTOM_DATE",
-                "Format": "TSV" if output_format in ["tsv", "csv"] else "TSV",
-                "IncludeVAT": "YES",
-                "IncludeDiscount": "YES",
-            }
-        }
+        body = build_report_request(
+            report_type=report_type,
+            date_from=date_from,
+            date_to=date_to,
+            name=name,
+            fields=fields,
+            campaign_ids=campaign_ids,
+            adgroup_ids=adgroup_ids,
+            output_format=output_format,
+        )
 
         result = client.reports().post(data=body)
 

--- a/direct_cli/commands/retargeting.py
+++ b/direct_cli/commands/retargeting.py
@@ -3,11 +3,12 @@ RetargetingLists commands
 """
 
 import json
+
 import click
 
 from ..api import create_client
 from ..output import format_output, print_error
-from ..utils import parse_ids, get_default_fields
+from ..utils import get_default_fields, parse_ids
 
 
 @click.group()
@@ -33,9 +34,7 @@ def get(ctx, ids, types, limit, fetch_all, output_format, output, fields):
             sandbox=ctx.obj.get("sandbox"),
         )
 
-        field_names = (
-            fields.split(",") if fields else get_default_fields("retargetinglists")
-        )
+        field_names = fields.split(",") if fields else get_default_fields("retargetinglists")
 
         criteria = {}
         if ids:
@@ -66,9 +65,6 @@ def get(ctx, ids, types, limit, fetch_all, output_format, output, fields):
         raise click.Abort()
 
 
-#: Valid ``RetargetingListAddItem.Type`` values per Yandex Direct API docs
-#: (ref-v5/retargetinglists/add).  The API defaults to ``RETARGETING`` when
-#: ``Type`` is omitted, so the CLI follows the same default.
 _RETARGETING_LIST_TYPES = ["RETARGETING", "AUDIENCE"]
 
 
@@ -93,14 +89,10 @@ _RETARGETING_LIST_TYPES = ["RETARGETING", "AUDIENCE"]
 def add(ctx, name, list_type, extra_json, dry_run):
     """Add new retargeting list"""
     try:
-        # click.Choice normalizes the case when case_sensitive=False but
-        # leaves the original casing of the canonical choice; pass it
-        # through unchanged.
         list_data = {"Name": name, "Type": list_type}
 
         if extra_json:
-            extra = json.loads(extra_json)
-            list_data.update(extra)
+            list_data.update(json.loads(extra_json))
 
         body = {"method": "add", "params": {"RetargetingLists": [list_data]}}
 
@@ -113,7 +105,6 @@ def add(ctx, name, list_type, extra_json, dry_run):
             login=ctx.obj.get("login"),
             sandbox=ctx.obj.get("sandbox"),
         )
-
         result = client.retargeting().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -124,17 +115,57 @@ def add(ctx, name, list_type, extra_json, dry_run):
 
 @retargeting.command()
 @click.option("--id", "list_id", required=True, type=int, help="Retargeting list ID")
+@click.option("--json", "extra_json", help="Additional JSON parameters")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def delete(ctx, list_id):
-    """Delete retargeting list"""
+def update(ctx, list_id, extra_json, dry_run):
+    """Update retargeting list"""
     try:
+        list_data = {"Id": list_id}
+        if extra_json:
+            list_data.update(json.loads(extra_json))
+        if len(list_data) == 1:
+            raise click.UsageError("Provide --json with fields to update")
+
+        body = {"method": "update", "params": {"RetargetingLists": [list_data]}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
         client = create_client(
             token=ctx.obj.get("token"),
             login=ctx.obj.get("login"),
             sandbox=ctx.obj.get("sandbox"),
         )
+        result = client.retargeting().post(data=body)
+        format_output(result().extract(), "json", None)
 
+    except click.UsageError:
+        raise
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@retargeting.command()
+@click.option("--id", "list_id", required=True, type=int, help="Retargeting list ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def delete(ctx, list_id, dry_run):
+    """Delete retargeting list"""
+    try:
         body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [list_id]}}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
 
         result = client.retargeting().post(data=body)
         format_output(result().extract(), "json", None)

--- a/direct_cli/commands/sitelinks.py
+++ b/direct_cli/commands/sitelinks.py
@@ -93,17 +93,22 @@ def add(ctx, links, dry_run):
 
 @sitelinks.command()
 @click.option("--id", "set_id", required=True, type=int, help="Sitelinks set ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def delete(ctx, set_id):
+def delete(ctx, set_id, dry_run):
     """Delete sitelinks set"""
     try:
+        body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [set_id]}}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
         client = create_client(
             token=ctx.obj.get("token"),
             login=ctx.obj.get("login"),
             sandbox=ctx.obj.get("sandbox"),
         )
-
-        body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [set_id]}}}
 
         result = client.sitelinks().post(data=body)
         format_output(result().extract(), "json", None)

--- a/direct_cli/commands/smartadtargets.py
+++ b/direct_cli/commands/smartadtargets.py
@@ -3,6 +3,7 @@ SmartAdTargets commands
 """
 
 import json
+
 import click
 
 from ..api import create_client
@@ -34,9 +35,7 @@ def get(ctx, ids, adgroup_ids, limit, fetch_all, output_format, output, fields):
         )
 
         field_names = (
-            fields.split(",")
-            if fields
-            else ["Id", "CampaignId", "AdGroupId", "Status", "ServingStatus"]
+            fields.split(",") if fields else ["Id", "CampaignId", "AdGroupId", "Status", "ServingStatus"]
         )
 
         criteria = {}
@@ -76,8 +75,7 @@ def get(ctx, ids, adgroup_ids, limit, fetch_all, output_format, output, fields):
     help=(
         "Legacy UX hint; NOT forwarded to the API. SmartAdTargetAddItem "
         "has no top-level Type field — pass real fields like "
-        "``TargetingId`` (e.g. 'VIEWED_PRODUCT'), ``Bid`` and "
-        "``Priority`` via --json instead."
+        "``Name``, ``Audience``, ``Conditions`` and bids via --json."
     ),
 )
 @click.option("--json", "extra_json", help="Additional JSON parameters")
@@ -86,26 +84,16 @@ def get(ctx, ids, adgroup_ids, limit, fetch_all, output_format, output, fields):
 def add(ctx, adgroup_id, target_type, extra_json, dry_run):
     """Add smart ad target"""
     try:
-        # SmartAdTargetAddItem in the Yandex Direct API does NOT have a
-        # top-level "Type" field. Real fields are AdGroupId, TargetingId
-        # (e.g. "VIEWED_PRODUCT"), Bid, Priority. The legacy --type CLI
-        # option was previously ``required=True`` but immediately discarded
-        # — actively hostile UX. It is now optional, documented as a
-        # legacy hint, and not forwarded. See axisrow/direct-cli#23.
         target_data = {"AdGroupId": adgroup_id}
-        _ = target_type  # intentionally unused — kept as UX hint only
+        _ = target_type
 
         if extra_json:
-            extra = json.loads(extra_json)
-            target_data.update(extra)
+            target_data.update(json.loads(extra_json))
 
-        # Without real fields from --json the payload would only contain
-        # AdGroupId, which the API rejects with an opaque "required field
-        # missing" error.  Fail early and tell the user what's missing.
         if len(target_data) == 1:
             raise click.UsageError(
                 "Provide --json with SmartAdTargetAddItem fields "
-                '(e.g. \'{"TargetingId":"VIEWED_PRODUCT"}\').'
+                '(e.g. {"Name":"Audience A","Audience":"ALL_SEGMENTS"}).'
             )
 
         body = {"method": "add", "params": {"SmartAdTargets": [target_data]}}
@@ -119,7 +107,6 @@ def add(ctx, adgroup_id, target_type, extra_json, dry_run):
             login=ctx.obj.get("login"),
             sandbox=ctx.obj.get("sandbox"),
         )
-
         result = client.smartadtargets().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -147,14 +134,9 @@ def update(ctx, target_id, target_type, extra_json, dry_run):
     """Update smart ad target"""
     try:
         target_data = {"Id": target_id}
-
-        # See note in `add` above — Type is not a real field on
-        # SmartAdTargetAddItem; the legacy --type CLI option is kept
-        # for backward compatibility but no longer forwarded.
-        _ = target_type  # intentionally unused — kept as UX hint only
+        _ = target_type
         if extra_json:
-            extra = json.loads(extra_json)
-            target_data.update(extra)
+            target_data.update(json.loads(extra_json))
         if len(target_data) == 1:
             raise click.UsageError("Provide --json with fields to update")
 
@@ -169,7 +151,6 @@ def update(ctx, target_id, target_type, extra_json, dry_run):
             login=ctx.obj.get("login"),
             sandbox=ctx.obj.get("sandbox"),
         )
-
         result = client.smartadtargets().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -182,24 +163,140 @@ def update(ctx, target_id, target_type, extra_json, dry_run):
 
 @smartadtargets.command()
 @click.option("--id", "target_id", required=True, type=int, help="Target ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def delete(ctx, target_id):
+def delete(ctx, target_id, dry_run):
     """Delete smart ad target"""
     try:
+        body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [target_id]}}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
         client = create_client(
             token=ctx.obj.get("token"),
             login=ctx.obj.get("login"),
             sandbox=ctx.obj.get("sandbox"),
         )
 
-        body = {
-            "method": "delete",
-            "params": {"SelectionCriteria": {"Ids": [target_id]}},
-        }
-
         result = client.smartadtargets().post(data=body)
         format_output(result().extract(), "json", None)
 
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@smartadtargets.command()
+@click.option("--id", "target_id", required=True, type=int, help="Target ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def suspend(ctx, target_id, dry_run):
+    """Suspend smart ad target"""
+    try:
+        body = {"method": "suspend", "params": {"SelectionCriteria": {"Ids": [target_id]}}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+        result = client.smartadtargets().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@smartadtargets.command()
+@click.option("--id", "target_id", required=True, type=int, help="Target ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def resume(ctx, target_id, dry_run):
+    """Resume smart ad target"""
+    try:
+        body = {"method": "resume", "params": {"SelectionCriteria": {"Ids": [target_id]}}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+        result = client.smartadtargets().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@smartadtargets.command(name="set-bids")
+@click.option("--id", "target_id", type=int, help="Target ID")
+@click.option("--adgroup-id", type=int, help="Ad group ID")
+@click.option("--campaign-id", type=int, help="Campaign ID")
+@click.option("--average-cpc", type=float, help="Average CPC")
+@click.option("--average-cpa", type=float, help="Average CPA")
+@click.option("--priority", help="Strategy priority")
+@click.option("--json", "extra_json", help="Additional JSON parameters")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def set_bids(
+    ctx,
+    target_id,
+    adgroup_id,
+    campaign_id,
+    average_cpc,
+    average_cpa,
+    priority,
+    extra_json,
+    dry_run,
+):
+    """Set smart ad target bids"""
+    try:
+        bid_data = {}
+        if target_id is not None:
+            bid_data["Id"] = target_id
+        if adgroup_id is not None:
+            bid_data["AdGroupId"] = adgroup_id
+        if campaign_id is not None:
+            bid_data["CampaignId"] = campaign_id
+        if average_cpc is not None:
+            bid_data["AverageCpc"] = int(average_cpc * 1000000)
+        if average_cpa is not None:
+            bid_data["AverageCpa"] = int(average_cpa * 1000000)
+        if priority:
+            bid_data["StrategyPriority"] = priority
+        if extra_json:
+            bid_data.update(json.loads(extra_json))
+        if not bid_data:
+            raise click.UsageError("Provide target selection and bid fields for set-bids")
+
+        body = {"method": "setBids", "params": {"Bids": [bid_data]}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+        result = client.smartadtargets().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except click.UsageError:
+        raise
     except Exception as e:
         print_error(str(e))
         raise click.Abort()

--- a/direct_cli/commands/vcards.py
+++ b/direct_cli/commands/vcards.py
@@ -94,17 +94,22 @@ def add(ctx, vcard_json, dry_run):
 
 @vcards.command()
 @click.option("--id", "vcard_id", required=True, type=int, help="vCard ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def delete(ctx, vcard_id):
+def delete(ctx, vcard_id, dry_run):
     """Delete vCard"""
     try:
+        body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [vcard_id]}}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
         client = create_client(
             token=ctx.obj.get("token"),
             login=ctx.obj.get("login"),
             sandbox=ctx.obj.get("sandbox"),
         )
-
-        body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [vcard_id]}}}
 
         result = client.vcards().post(data=body)
         format_output(result().extract(), "json", None)

--- a/direct_cli/utils.py
+++ b/direct_cli/utils.py
@@ -112,6 +112,7 @@ COMMON_FIELDS = {
     "smartadtargets": ["Id", "CampaignId", "AdGroupId", "Status", "ServingStatus"],
     "businesses": ["Id", "Name", "Url"],
     "retargetinglists": ["Id", "Name", "Type", "Scope"],
+    "advideos": ["Id", "Status"],
 }
 
 

--- a/direct_cli/wsdl_coverage.py
+++ b/direct_cli/wsdl_coverage.py
@@ -29,6 +29,7 @@ CLI_TO_API_SERVICE = {
     "retargeting": "retargetinglists",
     "creatives": "creatives",
     "adimages": "adimages",
+    "advideos": "advideos",
     "adextensions": "adextensions",
     "sitelinks": "sitelinks",
     "vcards": "vcards",
@@ -85,7 +86,7 @@ CANONICAL_API_SERVICES = sorted(
 )
 
 # API services known to be missing from the CLI entirely.
-KNOWN_MISSING_SERVICES = {"advideos"}
+KNOWN_MISSING_SERVICES = set()
 
 # CLI subcommand name -> API method name overrides.
 # Most subcommands map 1:1 (get->get, add->add).

--- a/direct_cli/wsdl_coverage.py
+++ b/direct_cli/wsdl_coverage.py
@@ -254,7 +254,18 @@ def _collect_complex_type_fields(complex_types: dict, type_name: str) -> list[di
 
 
 def get_operation_request_schema(wsdl_xml: str, operation_name: str) -> dict:
-    """Return request schema metadata for a WSDL operation."""
+    """Return request schema metadata for a WSDL operation.
+
+    Known limitations (documented rather than silent):
+    - Types declared in imported XSD namespaces (``<xsd:import>``) are not
+      resolved: ``item_fields`` for any field whose type lives in another
+      namespace is ``[]``. Nested required-field validation therefore only
+      applies to locally-defined inline types.
+    - When a request element uses ``xsd:complexContent/xsd:extension``, only
+      fields from the extension's own ``xsd:sequence`` are returned; inherited
+      base-type fields are dropped. Safe today because no ``get*`` operation
+      (the typical extension user) is included in payload coverage tests.
+    """
     root = ET.fromstring(wsdl_xml)
     ns = {
         "wsdl": "http://schemas.xmlsoap.org/wsdl/",

--- a/direct_cli/wsdl_coverage.py
+++ b/direct_cli/wsdl_coverage.py
@@ -15,8 +15,6 @@ CACHE_DIR = Path(__file__).resolve().parent.parent / "tests" / "wsdl_cache"
 # Mappings
 # ---------------------------------------------------------------------------
 
-# CLI command name -> API WSDL service name.
-# Most are 1:1; divergent mappings are commented.
 CLI_TO_API_SERVICE = {
     "campaigns": "campaigns",
     "adgroups": "adgroups",
@@ -48,11 +46,27 @@ CLI_TO_API_SERVICE = {
     # reports excluded — uses JSON API, not WSDL
 }
 
-# Services that use the JSON API (no WSDL) — excluded from WSDL coverage.
 NON_WSDL_SERVICES = {"reports"}
 
-# All known Yandex Direct API v5 WSDL services.
-# Ground truth for Phase 2 "new service" detection.
+# Canonical CLI alias groups exposed for integrations. These are intentional
+# aliases of real CLI groups and should not count as extra API surface.
+CLI_ALIAS_GROUPS = {
+    "dynamictargets": "dynamicads",
+    "smarttargets": "smartadtargets",
+    "negativekeywords": "negativekeywordsharedsets",
+}
+
+# Non-WSDL service coverage policies. These services still belong to the
+# supported API surface, but they require bespoke contract checks rather than
+# SOAP/WSDL parity tests.
+NON_WSDL_SERVICE_POLICIES = {
+    "reports": {
+        "kind": "json-api",
+        "coverage": "contract-tests",
+        "reason": "Yandex Direct reports use the JSON reporting API, not WSDL.",
+    }
+}
+
 CANONICAL_API_SERVICES = sorted(
     [
         "adextensions",
@@ -85,34 +99,46 @@ CANONICAL_API_SERVICES = sorted(
     ]
 )
 
-# API services known to be missing from the CLI entirely.
 KNOWN_MISSING_SERVICES = set()
 
-# CLI subcommand name -> API method name overrides.
-# Most subcommands map 1:1 (get->get, add->add).
+# Intentional CLI-only methods that are not 1:1 SOAP WSDL operations.
+# They remain part of the supported CLI UX and must be documented explicitly.
+INTENTIONAL_EXTRA_METHODS = {
+    ("agencyclients", "delete"): (
+        "CLI guard command: the Yandex Direct API does not support deleting "
+        "agency clients, so the command aborts with an explicit message."
+    ),
+    ("bidmodifiers", "toggle"): (
+        "JSON-only helper command; no matching SOAP/WSDL operation exists."
+    ),
+    ("keywords", "archive"): (
+        "Legacy lifecycle command preserved for compatibility with existing CLI users."
+    ),
+    ("keywords", "unarchive"): (
+        "Legacy lifecycle command preserved for compatibility with existing CLI users."
+    ),
+}
+
 METHOD_NAME_OVERRIDES = {
+    "add-passport-organization": "addPassportOrganization",
+    "add-passport-organization-member": "addPassportOrganizationMember",
     "check-campaigns": "checkCampaigns",
     "checkcamp": "checkCampaigns",
     "check-dictionaries": "checkDictionaries",
     "checkdict": "checkDictionaries",
+    "get-geo-regions": "getGeoRegions",
     "has-search-volume": "hasSearchVolume",
     "has-volume": "hasSearchVolume",
     "list": "get",
     "list-names": "get",
     "list-types": "get",
+    "set-auto": "setAuto",
+    "set-bids": "setBids",
 }
-
-# ---------------------------------------------------------------------------
-# WSDL fetching & parsing
-# ---------------------------------------------------------------------------
 
 
 def fetch_wsdl(service_name: str, use_cache: bool = True) -> str:
-    """Fetch WSDL XML for a service.
-
-    If *use_cache* is True and a cached file exists, reads from disk.
-    Otherwise fetches from the Yandex API, writes to cache, and returns XML.
-    """
+    """Fetch WSDL XML for a service."""
     cache_file = CACHE_DIR / f"{service_name}.xml"
 
     if use_cache and cache_file.exists():
@@ -133,11 +159,7 @@ def fetch_wsdl(service_name: str, use_cache: bool = True) -> str:
 
 
 def parse_wsdl_operations(wsdl_xml: str) -> list:
-    """Extract unique API method names from WSDL XML.
-
-    Parses ``<wsdl:operation name="...">`` elements and returns a sorted
-    list of unique operation names.
-    """
+    """Extract unique API method names from WSDL XML."""
     root = ET.fromstring(wsdl_xml)
     ns = {"wsdl": "http://schemas.xmlsoap.org/wsdl/"}
     ops = set()
@@ -149,11 +171,7 @@ def parse_wsdl_operations(wsdl_xml: str) -> list:
 
 
 def get_cli_methods_for_service(cli_command_name: str) -> set:
-    """Get the set of API method names that a CLI service implements.
-
-    Imports the CLI, finds the Click group, iterates its subcommands,
-    and maps each subcommand name to the API method name.
-    """
+    """Get the set of API method names that a CLI service implements."""
     from direct_cli.cli import cli
 
     group = cli.commands[cli_command_name]
@@ -168,11 +186,7 @@ def get_cli_methods_for_service(cli_command_name: str) -> set:
 
 
 def refresh_all_caches() -> dict:
-    """Fetch fresh WSDLs for all known services and write to cache.
-
-    Returns a dict ``{service_name: exception}`` for any failures.
-    Services with no error are not in the dict.
-    """
+    """Fetch fresh WSDLs for all known services and write to cache."""
     all_services = set(CANONICAL_API_SERVICES) | set(CLI_TO_API_SERVICE.values())
     all_services -= NON_WSDL_SERVICES
 
@@ -183,3 +197,125 @@ def refresh_all_caches() -> dict:
         except Exception as exc:
             errors[service] = exc
     return errors
+
+
+def get_api_coverage_policy() -> dict:
+    """Return a machine-readable summary of the API coverage model."""
+    return {
+        "wsdl_base_url": WSDL_BASE_URL,
+        "wsdl_services": dict(sorted(CLI_TO_API_SERVICE.items())),
+        "canonical_api_services": list(CANONICAL_API_SERVICES),
+        "non_wsdl_services": NON_WSDL_SERVICE_POLICIES,
+        "cli_alias_groups": dict(sorted(CLI_ALIAS_GROUPS.items())),
+        "intentional_extra_methods": {
+            f"{service}.{method}": reason
+            for (service, method), reason in sorted(INTENTIONAL_EXTRA_METHODS.items())
+        },
+    }
+
+
+def _local_name(qname: str | None) -> str | None:
+    """Return the local part of a QName-like ``prefix:name`` string."""
+    if qname is None:
+        return None
+    return qname.split(":", 1)[1] if ":" in qname else qname
+
+
+def _collect_complex_type_fields(complex_types: dict, type_name: str) -> list[dict]:
+    """Collect fields from a local XSD complex type, following local inheritance."""
+    ns = {"xsd": "http://www.w3.org/2001/XMLSchema"}
+    complex_type = complex_types.get(type_name)
+    if complex_type is None:
+        return []
+
+    fields = []
+    extension = complex_type.find("xsd:complexContent/xsd:extension", ns)
+    if extension is not None:
+        base_type = _local_name(extension.get("base"))
+        if base_type and base_type in complex_types:
+            fields.extend(_collect_complex_type_fields(complex_types, base_type))
+        sequence = extension.find("xsd:sequence", ns)
+    else:
+        sequence = complex_type.find("xsd:sequence", ns)
+
+    if sequence is None:
+        return fields
+
+    for child in sequence.findall("xsd:element", ns):
+        fields.append(
+            {
+                "name": child.get("name"),
+                "type": _local_name(child.get("type")),
+                "min_occurs": int(child.get("minOccurs", "1")),
+                "max_occurs": child.get("maxOccurs", "1"),
+            }
+        )
+    return fields
+
+
+def get_operation_request_schema(wsdl_xml: str, operation_name: str) -> dict:
+    """Return request schema metadata for a WSDL operation."""
+    root = ET.fromstring(wsdl_xml)
+    ns = {
+        "wsdl": "http://schemas.xmlsoap.org/wsdl/",
+        "xsd": "http://www.w3.org/2001/XMLSchema",
+    }
+
+    schema = root.find(".//xsd:schema", ns)
+    if schema is None:
+        raise ValueError("WSDL schema section not found")
+
+    messages = {}
+    for message in root.findall(".//wsdl:message", ns):
+        part = message.find("wsdl:part", ns)
+        if part is not None:
+            messages[message.get("name")] = _local_name(part.get("element"))
+
+    operation = None
+    for op in root.findall(".//wsdl:portType/wsdl:operation", ns):
+        if op.get("name") == operation_name:
+            operation = op
+            break
+    if operation is None:
+        raise KeyError(f"Operation not found in WSDL: {operation_name}")
+
+    input_ref = operation.find("wsdl:input", ns)
+    if input_ref is None:
+        raise ValueError(f"Operation has no input message: {operation_name}")
+
+    message_name = _local_name(input_ref.get("message"))
+    element_name = messages.get(message_name)
+    if element_name is None:
+        raise KeyError(f"Input element not found for operation: {operation_name}")
+
+    elements = {elem.get("name"): elem for elem in schema.findall("xsd:element", ns)}
+    complex_types = {
+        ctype.get("name"): ctype for ctype in schema.findall("xsd:complexType", ns)
+    }
+
+    element = elements.get(element_name)
+    if element is None:
+        raise KeyError(f"Input element schema not found: {element_name}")
+
+    complex_type = element.find("xsd:complexType", ns)
+    if complex_type is None:
+        raise ValueError(f"Input element has no inline complex type: {element_name}")
+
+    extension = complex_type.find("xsd:complexContent/xsd:extension", ns)
+    sequence = extension.find("xsd:sequence", ns) if extension is not None else complex_type.find("xsd:sequence", ns)
+
+    fields = []
+    if sequence is not None:
+        for child in sequence.findall("xsd:element", ns):
+            type_name = _local_name(child.get("type"))
+            fields.append(
+                {
+                    "name": child.get("name"),
+                    "type": type_name,
+                    "min_occurs": int(child.get("minOccurs", "1")),
+                    "max_occurs": child.get("maxOccurs", "1"),
+                    "item_fields": _collect_complex_type_fields(complex_types, type_name),
+                }
+            )
+
+    return {"input_element": element_name, "fields": fields}

--- a/direct_cli/wsdl_coverage.py
+++ b/direct_cli/wsdl_coverage.py
@@ -1,0 +1,184 @@
+"""
+WSDL coverage utilities for Direct CLI.
+
+Fetches and parses Yandex Direct API v5 WSDL definitions to verify
+that the CLI implements all available services and methods.
+"""
+
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+WSDL_BASE_URL = "https://api.direct.yandex.com/v5/{service}?wsdl"
+CACHE_DIR = Path(__file__).resolve().parent.parent / "tests" / "wsdl_cache"
+
+# ---------------------------------------------------------------------------
+# Mappings
+# ---------------------------------------------------------------------------
+
+# CLI command name -> API WSDL service name.
+# Most are 1:1; divergent mappings are commented.
+CLI_TO_API_SERVICE = {
+    "campaigns": "campaigns",
+    "adgroups": "adgroups",
+    "ads": "ads",
+    "keywords": "keywords",
+    "keywordbids": "keywordbids",
+    "bids": "bids",
+    "bidmodifiers": "bidmodifiers",
+    "audiencetargets": "audiencetargets",
+    "retargeting": "retargetinglists",
+    "creatives": "creatives",
+    "adimages": "adimages",
+    "adextensions": "adextensions",
+    "sitelinks": "sitelinks",
+    "vcards": "vcards",
+    "leads": "leads",
+    "clients": "clients",
+    "agencyclients": "agencyclients",
+    "dictionaries": "dictionaries",
+    "changes": "changes",
+    "turbopages": "turbopages",
+    "negativekeywordsharedsets": "negativekeywordsharedsets",
+    "feeds": "feeds",
+    "smartadtargets": "smartadtargets",
+    "businesses": "businesses",
+    "keywordsresearch": "keywordsresearch",
+    "dynamicads": "dynamictextadtargets",
+    # reports excluded — uses JSON API, not WSDL
+}
+
+# Services that use the JSON API (no WSDL) — excluded from WSDL coverage.
+NON_WSDL_SERVICES = {"reports"}
+
+# All known Yandex Direct API v5 WSDL services.
+# Ground truth for Phase 2 "new service" detection.
+CANONICAL_API_SERVICES = sorted(
+    [
+        "adextensions",
+        "adgroups",
+        "adimages",
+        "ads",
+        "advideos",
+        "agencyclients",
+        "audiencetargets",
+        "bids",
+        "bidmodifiers",
+        "businesses",
+        "campaigns",
+        "changes",
+        "clients",
+        "creatives",
+        "dictionaries",
+        "dynamictextadtargets",
+        "feeds",
+        "keywordbids",
+        "keywords",
+        "keywordsresearch",
+        "leads",
+        "negativekeywordsharedsets",
+        "retargetinglists",
+        "sitelinks",
+        "smartadtargets",
+        "turbopages",
+        "vcards",
+    ]
+)
+
+# API services known to be missing from the CLI entirely.
+KNOWN_MISSING_SERVICES = {"advideos"}
+
+# CLI subcommand name -> API method name overrides.
+# Most subcommands map 1:1 (get->get, add->add).
+METHOD_NAME_OVERRIDES = {
+    "check-campaigns": "checkCampaigns",
+    "checkcamp": "checkCampaigns",
+    "check-dictionaries": "checkDictionaries",
+    "checkdict": "checkDictionaries",
+    "has-search-volume": "hasSearchVolume",
+    "has-volume": "hasSearchVolume",
+    "list": "get",
+    "list-names": "get",
+    "list-types": "get",
+}
+
+# ---------------------------------------------------------------------------
+# WSDL fetching & parsing
+# ---------------------------------------------------------------------------
+
+
+def fetch_wsdl(service_name: str, use_cache: bool = True) -> str:
+    """Fetch WSDL XML for a service.
+
+    If *use_cache* is True and a cached file exists, reads from disk.
+    Otherwise fetches from the Yandex API, writes to cache, and returns XML.
+    """
+    cache_file = CACHE_DIR / f"{service_name}.xml"
+
+    if use_cache and cache_file.exists():
+        return cache_file.read_text(encoding="utf-8")
+
+    import requests
+
+    url = WSDL_BASE_URL.format(service=service_name)
+    resp = requests.get(url, timeout=30)
+    resp.raise_for_status()
+
+    xml_text = resp.text
+
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text(xml_text, encoding="utf-8")
+
+    return xml_text
+
+
+def parse_wsdl_operations(wsdl_xml: str) -> list:
+    """Extract unique API method names from WSDL XML.
+
+    Parses ``<wsdl:operation name="...">`` elements and returns a sorted
+    list of unique operation names.
+    """
+    root = ET.fromstring(wsdl_xml)
+    ns = {"wsdl": "http://schemas.xmlsoap.org/wsdl/"}
+    ops = set()
+    for op in root.findall(".//wsdl:operation", ns):
+        name = op.get("name")
+        if name:
+            ops.add(name)
+    return sorted(ops)
+
+
+def get_cli_methods_for_service(cli_command_name: str) -> set:
+    """Get the set of API method names that a CLI service implements.
+
+    Imports the CLI, finds the Click group, iterates its subcommands,
+    and maps each subcommand name to the API method name.
+    """
+    from direct_cli.cli import cli
+
+    group = cli.commands[cli_command_name]
+    methods = set()
+    for subcmd_name in group.commands:
+        mapped = METHOD_NAME_OVERRIDES.get(subcmd_name)
+        if mapped:
+            methods.add(mapped)
+        else:
+            methods.add(subcmd_name)
+    return methods
+
+
+def refresh_all_caches() -> dict:
+    """Fetch fresh WSDLs for all known services and write to cache.
+
+    Returns a dict ``{service_name: exception}`` for any failures.
+    Services with no error are not in the dict.
+    """
+    all_services = set(CANONICAL_API_SERVICES) | set(CLI_TO_API_SERVICE.values())
+    all_services -= NON_WSDL_SERVICES
+
+    errors = {}
+    for service in sorted(all_services):
+        try:
+            fetch_wsdl(service, use_cache=False)
+        except Exception as exc:
+            errors[service] = exc
+    return errors

--- a/docs/superpowers/plans/2026-04-12-issue-32-completion.md
+++ b/docs/superpowers/plans/2026-04-12-issue-32-completion.md
@@ -1,0 +1,548 @@
+# Issue #32 Completion: WSDL Coverage & Known Gaps
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Завершить issue #32 — реализовать модуль `advideos`, исправить payload-баг `BidModifiers.add` (DemographicsAdjustments plural), и добавить скрипт обновления WSDL-кэша.
+
+**Architecture:** Три независимых улучшения: (1) новый CLI-модуль `advideos` с командами `get`/`add`, (2) исправление поля в `bidmodifiers add` — `DemographicsAdjustment` (singular) → `DemographicsAdjustments` (plural array), (3) скрипт `scripts/refresh_wsdl_cache.py` для обновления 27 кэшированных XML. После каждого исправления обновляются `wsdl_coverage.py` (KNOWN_MISSING_SERVICES/KNOWN_MISSING_METHODS) и `test_comprehensive.py` (EXPECTED_COMMANDS).
+
+**Tech Stack:** Python, Click, xml.etree.ElementTree, requests, pytest, click.testing.CliRunner
+
+---
+
+## Файлы затрагиваемые планом
+
+| Действие | Файл |
+|---|---|
+| Создать | `direct_cli/commands/advideos.py` |
+| Создать | `scripts/refresh_wsdl_cache.py` |
+| Изменить | `direct_cli/cli.py` (импорт + регистрация advideos) |
+| Изменить | `direct_cli/wsdl_coverage.py` (убрать advideos из KNOWN_MISSING_SERVICES, добавить в CLI_TO_API_SERVICE) |
+| Изменить | `tests/test_comprehensive.py` (добавить "advideos" в EXPECTED_COMMANDS) |
+| Изменить | `tests/test_dry_run.py` (тест payload advideos add) |
+| Изменить | `tests/test_api_coverage.py` (убрать Demographics из KNOWN_MISSING_METHODS если нужно) |
+| Изменить | `direct_cli/commands/bidmodifiers.py` (исправить DemographicsAdjustments) |
+
+---
+
+## Task 1: Реализовать модуль `advideos`
+
+WSDL (`tests/wsdl_cache/advideos.xml`) объявляет два метода: `get` и `add`.
+- `get` принимает `SelectionCriteria: {Ids: [string]}` и `FieldNames: [AdVideoFieldEnum]` (возможные значения: `Id`, `Status`)
+- `add` принимает список `AdVideos: [{Url?, VideoData?, Name?}]`
+
+**Files:**
+- Create: `direct_cli/commands/advideos.py`
+- Modify: `direct_cli/cli.py`
+- Modify: `tests/test_comprehensive.py`
+- Modify: `direct_cli/wsdl_coverage.py`
+- Test: `tests/test_dry_run.py`
+
+- [ ] **Step 1: Написать failing тест для advideos add dry-run**
+
+Добавить в конец `tests/test_dry_run.py`:
+
+```python
+class TestAdvideosDryRun:
+    def test_add_by_url(self):
+        body = _dry_run(
+            "advideos", "add",
+            "--url", "https://example.com/video.mp4",
+            "--name", "Test Video",
+        )
+        assert body["method"] == "add"
+        item = body["params"]["AdVideos"][0]
+        assert item["Url"] == "https://example.com/video.mp4"
+        assert item["Name"] == "Test Video"
+        assert "Type" not in item
+
+    def test_add_requires_url_or_data(self):
+        from click.testing import CliRunner
+        from direct_cli.cli import cli
+        result = CliRunner().invoke(cli, ["advideos", "add", "--dry-run"])
+        assert result.exit_code != 0
+```
+
+- [ ] **Step 2: Запустить тест и убедиться что FAIL**
+
+```bash
+.venv/bin/pytest tests/test_dry_run.py::TestAdvideosDryRun -v
+```
+
+Ожидается: `FAILED` — команда `advideos` не существует.
+
+- [ ] **Step 3: Создать `direct_cli/commands/advideos.py`**
+
+```python
+"""
+AdVideos commands
+"""
+
+import click
+
+from ..api import create_client
+from ..output import format_output, print_error
+from ..utils import parse_ids
+
+
+@click.group()
+def advideos():
+    """Manage ad videos"""
+
+
+@advideos.command()
+@click.option("--ids", help="Comma-separated video IDs")
+@click.option("--limit", type=int, help="Limit number of results")
+@click.option("--fetch-all", is_flag=True, help="Fetch all pages")
+@click.option("--format", "output_format", default="json", help="Output format")
+@click.option("--output", help="Output file")
+@click.pass_context
+def get(ctx, ids, limit, fetch_all, output_format, output):
+    """Get ad videos"""
+    try:
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
+        criteria = {}
+        if ids:
+            criteria["Ids"] = parse_ids(ids)
+
+        params = {
+            "SelectionCriteria": criteria,
+            "FieldNames": ["Id", "Status"],
+        }
+
+        if limit:
+            params["Page"] = {"Limit": limit}
+
+        body = {"method": "get", "params": params}
+
+        result = client.advideos().post(data=body)
+
+        if fetch_all:
+            items = []
+            for item in result().iter_items():
+                items.append(item)
+            format_output(items, output_format, output)
+        else:
+            data = result().extract()
+            format_output(data, output_format, output)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@advideos.command()
+@click.option("--url", help="Video URL (mutually exclusive with --video-data)")
+@click.option("--video-data", help="Base64-encoded video binary (mutually exclusive with --url)")
+@click.option("--name", help="Video name")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def add(ctx, url, video_data, name, dry_run):
+    """Add a new ad video (by URL or binary data)"""
+    try:
+        if not url and not video_data:
+            raise click.UsageError("Either --url or --video-data is required.")
+        if url and video_data:
+            raise click.UsageError("Use either --url or --video-data, not both.")
+
+        item = {}
+        if url:
+            item["Url"] = url
+        if video_data:
+            item["VideoData"] = video_data
+        if name:
+            item["Name"] = name
+
+        body = {"method": "add", "params": {"AdVideos": [item]}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
+        result = client.advideos().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except click.UsageError:
+        raise
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+advideos.add_command(get, name="list")
+```
+
+- [ ] **Step 4: Зарегистрировать в `direct_cli/cli.py`**
+
+Добавить импорт после строки `from .commands.dynamicads import dynamicads`:
+
+```python
+from .commands.advideos import advideos
+```
+
+Добавить регистрацию после `cli.add_command(dynamicads)`:
+
+```python
+cli.add_command(advideos)
+```
+
+- [ ] **Step 5: Обновить `tests/test_comprehensive.py`**
+
+Найти список `EXPECTED_COMMANDS` и добавить `"advideos"` (в алфавитном порядке, перед `"adextensions"` нет — advideos идёт после adimages):
+
+```python
+# Было:
+        "adimages",
+        "adextensions",
+# Стало:
+        "adimages",
+        "advideos",
+        "adextensions",
+```
+
+- [ ] **Step 6: Обновить `direct_cli/wsdl_coverage.py`**
+
+В `CLI_TO_API_SERVICE` добавить запись (после `"adimages": "adimages"`):
+
+```python
+    "advideos": "advideos",
+```
+
+В `KNOWN_MISSING_SERVICES` убрать `"advideos"`:
+
+```python
+# Было:
+KNOWN_MISSING_SERVICES = {"advideos"}
+# Стало:
+KNOWN_MISSING_SERVICES = set()
+```
+
+- [ ] **Step 7: Запустить тесты и проверить что всё проходит**
+
+```bash
+.venv/bin/pytest tests/test_dry_run.py::TestAdvideosDryRun tests/test_comprehensive.py tests/test_api_coverage.py -v
+```
+
+Ожидается: все PASS.
+
+- [ ] **Step 8: Запустить полный unit-suite**
+
+```bash
+.venv/bin/pytest -m "not integration and not integration_write" -q
+```
+
+Ожидается: все PASS, количество тестов увеличилось на 2.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add direct_cli/commands/advideos.py direct_cli/cli.py tests/test_dry_run.py tests/test_comprehensive.py direct_cli/wsdl_coverage.py
+git commit -m "feat: implement advideos command (get/add) — closes KNOWN_MISSING_SERVICES"
+```
+
+---
+
+## Task 2: Исправить payload-баги `BidModifiers.add` — plural-поля по WSDL
+
+Issue #32 зафиксировал баг с `DemographicsAdjustment` → `DemographicsAdjustments`. Проверка WSDL `BidModifierAddItem` показывает, что plural-форму имеют пять полей:
+
+| CLI --type | Текущее (неверное) | Правильное (по WSDL) |
+|---|---|---|
+| `DEMOGRAPHICS_ADJUSTMENT` | `DemographicsAdjustment` | `DemographicsAdjustments` |
+| `RETARGETING_ADJUSTMENT` | `RetargetingAdjustment` | `RetargetingAdjustments` |
+| `REGIONAL_ADJUSTMENT` | `RegionalAdjustment` | `RegionalAdjustments` |
+| `SERP_LAYOUT_ADJUSTMENT` | `SerpLayoutAdjustment` | `SerpLayoutAdjustments` |
+| `INCOME_GRADE_ADJUSTMENT` | `IncomeGradeAdjustment` | `IncomeGradeAdjustments` |
+
+Одиночные (singular) остаются: `MobileAdjustment`, `TabletAdjustment`, `DesktopAdjustment`, `DesktopOnlyAdjustment`, `VideoAdjustment`, `SmartAdAdjustment`, `AdGroupAdjustment`.
+
+Проверка по WSDL (`tests/wsdl_cache/bidmodifiers.xml`): тип `BidModifierAddItem`.
+
+**Files:**
+- Modify: `direct_cli/commands/bidmodifiers.py`
+- Modify: `tests/test_dry_run.py`
+
+- [ ] **Step 1: Проверить WSDL и убедиться что plural правильный**
+
+```bash
+python3 -c "
+import xml.etree.ElementTree as ET
+from pathlib import Path
+xml = Path('tests/wsdl_cache/bidmodifiers.xml').read_text()
+root = ET.fromstring(xml)
+ns = {'xs': 'http://www.w3.org/2001/XMLSchema'}
+for el in root.findall('.//xs:element', ns):
+    name = el.get('name', '')
+    if 'emographic' in name:
+        print(name, el.attrib)
+"
+```
+
+Ожидается: найти `DemographicsAdjustments` с `maxOccurs`.
+
+- [ ] **Step 2: Написать failing тесты**
+
+Добавить в `tests/test_dry_run.py` новый класс (или в существующий `TestBidModifiersDryRun` если есть):
+
+```python
+class TestBidModifiersAddPluralFields:
+    """WSDL BidModifierAddItem uses plural array fields for 5 adjustment types."""
+
+    def test_demographics_plural(self):
+        body = _dry_run(
+            "bidmodifiers", "add",
+            "--campaign-id", "123",
+            "--type", "DEMOGRAPHICS_ADJUSTMENT",
+            "--value", "150",
+            "--json", '{"Gender": "GENDER_MALE", "Age": "AGE_25_34"}',
+        )
+        item = body["params"]["BidModifiers"][0]
+        assert "DemographicsAdjustments" in item, f"got keys: {list(item.keys())}"
+        assert "DemographicsAdjustment" not in item
+        assert isinstance(item["DemographicsAdjustments"], list)
+        assert item["DemographicsAdjustments"][0]["BidModifier"] == 150
+
+    def test_retargeting_plural(self):
+        body = _dry_run(
+            "bidmodifiers", "add",
+            "--campaign-id", "123",
+            "--type", "RETARGETING_ADJUSTMENT",
+            "--value", "120",
+            "--json", '{"RetargetingConditionId": 456}',
+        )
+        item = body["params"]["BidModifiers"][0]
+        assert "RetargetingAdjustments" in item, f"got keys: {list(item.keys())}"
+        assert isinstance(item["RetargetingAdjustments"], list)
+
+    def test_regional_plural(self):
+        body = _dry_run(
+            "bidmodifiers", "add",
+            "--campaign-id", "123",
+            "--type", "REGIONAL_ADJUSTMENT",
+            "--value", "110",
+            "--json", '{"RegionId": 1}',
+        )
+        item = body["params"]["BidModifiers"][0]
+        assert "RegionalAdjustments" in item, f"got keys: {list(item.keys())}"
+        assert isinstance(item["RegionalAdjustments"], list)
+
+    def test_mobile_singular(self):
+        """MobileAdjustment stays singular — regression guard."""
+        body = _dry_run(
+            "bidmodifiers", "add",
+            "--campaign-id", "123",
+            "--type", "MOBILE_ADJUSTMENT",
+            "--value", "130",
+        )
+        item = body["params"]["BidModifiers"][0]
+        assert "MobileAdjustment" in item
+        assert isinstance(item["MobileAdjustment"], dict)
+```
+
+- [ ] **Step 3: Запустить тесты и убедиться что FAIL**
+
+```bash
+.venv/bin/pytest tests/test_dry_run.py::TestBidModifiersAddPluralFields -v
+```
+
+Ожидается: `FAILED` — поля называются singular (`DemographicsAdjustment`, `RetargetingAdjustment`, `RegionalAdjustment`).
+
+- [ ] **Step 4: Исправить `_BIDMODIFIER_TYPE_TO_NESTED` в `direct_cli/commands/bidmodifiers.py`**
+
+Заменить весь словарь `_BIDMODIFIER_TYPE_TO_NESTED`:
+
+```python
+# Было:
+_BIDMODIFIER_TYPE_TO_NESTED = {
+    "MOBILE_ADJUSTMENT": "MobileAdjustment",
+    "TABLET_ADJUSTMENT": "TabletAdjustment",
+    "DESKTOP_ADJUSTMENT": "DesktopAdjustment",
+    "DESKTOP_ONLY_ADJUSTMENT": "DesktopOnlyAdjustment",
+    "DEMOGRAPHICS_ADJUSTMENT": "DemographicsAdjustment",
+    "RETARGETING_ADJUSTMENT": "RetargetingAdjustment",
+    "REGIONAL_ADJUSTMENT": "RegionalAdjustment",
+    "VIDEO_ADJUSTMENT": "VideoAdjustment",
+    "SMART_AD_ADJUSTMENT": "SmartAdAdjustment",
+    "SERP_LAYOUT_ADJUSTMENT": "SerpLayoutAdjustment",
+    "INCOME_GRADE_ADJUSTMENT": "IncomeGradeAdjustment",
+    "AD_GROUP_ADJUSTMENT": "AdGroupAdjustment",
+}
+
+# Стало (plural-поля исправлены по WSDL BidModifierAddItem):
+_BIDMODIFIER_TYPE_TO_NESTED = {
+    "MOBILE_ADJUSTMENT": "MobileAdjustment",
+    "TABLET_ADJUSTMENT": "TabletAdjustment",
+    "DESKTOP_ADJUSTMENT": "DesktopAdjustment",
+    "DESKTOP_ONLY_ADJUSTMENT": "DesktopOnlyAdjustment",
+    "DEMOGRAPHICS_ADJUSTMENT": "DemographicsAdjustments",   # plural
+    "RETARGETING_ADJUSTMENT": "RetargetingAdjustments",     # plural
+    "REGIONAL_ADJUSTMENT": "RegionalAdjustments",           # plural
+    "VIDEO_ADJUSTMENT": "VideoAdjustment",
+    "SMART_AD_ADJUSTMENT": "SmartAdAdjustment",
+    "SERP_LAYOUT_ADJUSTMENT": "SerpLayoutAdjustments",      # plural
+    "INCOME_GRADE_ADJUSTMENT": "IncomeGradeAdjustments",    # plural
+    "AD_GROUP_ADJUSTMENT": "AdGroupAdjustment",
+}
+
+# Множество plural-ключей для формирования payload как списка:
+_PLURAL_NESTED_KEYS = {
+    "DemographicsAdjustments",
+    "RetargetingAdjustments",
+    "RegionalAdjustments",
+    "SerpLayoutAdjustments",
+    "IncomeGradeAdjustments",
+}
+```
+
+Затем в команде `add` найти место сборки `modifier_data` и добавить обработку plural:
+
+```python
+        nested_key = _BIDMODIFIER_TYPE_TO_NESTED[modifier_type.upper()]
+        nested = {"BidModifier": value}
+        if extra_json:
+            extra = json.loads(extra_json)
+            if not isinstance(extra, dict):
+                raise click.UsageError(
+                    "--json must be a JSON object (dict), "
+                    f"got {type(extra).__name__}"
+                )
+            nested.update(extra)
+
+        # Plural fields expect a list per WSDL BidModifierAddItem
+        if nested_key in _PLURAL_NESTED_KEYS:
+            modifier_data = {nested_key: [nested]}
+        else:
+            modifier_data = {nested_key: nested}
+```
+
+- [ ] **Step 5: Запустить тесты и убедиться что PASS**
+
+```bash
+.venv/bin/pytest tests/test_dry_run.py::TestBidModifiersAddPluralFields -v
+```
+
+Ожидается: все PASS.
+
+- [ ] **Step 6: Запустить полный unit-suite**
+
+```bash
+.venv/bin/pytest -m "not integration and not integration_write" -q
+```
+
+Ожидается: все PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add direct_cli/commands/bidmodifiers.py tests/test_dry_run.py
+git commit -m "fix(bidmodifiers add): use plural field names per WSDL BidModifierAddItem (Demographics/Retargeting/Regional/SerpLayout/IncomeGrade)"
+```
+
+---
+
+## Task 3: Добавить скрипт обновления WSDL-кэша
+
+Сейчас нет механизма обновить 27 кэшированных XML-файлов. Нужен скрипт `scripts/refresh_wsdl_cache.py`, который использует уже существующую функцию `refresh_all_caches()` из `wsdl_coverage.py`.
+
+**Files:**
+- Create: `scripts/refresh_wsdl_cache.py`
+
+- [ ] **Step 1: Создать `scripts/refresh_wsdl_cache.py`**
+
+```python
+#!/usr/bin/env python3
+"""Refresh cached WSDL files for all Yandex Direct API v5 services.
+
+Usage:
+    python scripts/refresh_wsdl_cache.py
+
+Fetches fresh WSDL XML from https://api.direct.yandex.com/v5/{service}?wsdl
+and overwrites files in tests/wsdl_cache/.
+
+Run periodically (e.g. monthly) or when suspecting the API has changed.
+"""
+
+import sys
+from pathlib import Path
+
+# Allow running from repo root without installing the package
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from direct_cli.wsdl_coverage import refresh_all_caches, CANONICAL_API_SERVICES
+
+
+def main():
+    print(f"Refreshing WSDL cache for {len(CANONICAL_API_SERVICES)} services...")
+    errors = refresh_all_caches()
+
+    if errors:
+        print("\nFailed services:")
+        for service, exc in sorted(errors.items()):
+            print(f"  {service}: {exc}")
+        print(f"\n{len(CANONICAL_API_SERVICES) - len(errors)} succeeded, {len(errors)} failed.")
+        sys.exit(1)
+    else:
+        print(f"All {len(CANONICAL_API_SERVICES)} services refreshed successfully.")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Убедиться что скрипт запускается без ошибок (dry check)**
+
+```bash
+python3 scripts/refresh_wsdl_cache.py --help 2>&1 || python3 -c "
+import sys; sys.path.insert(0, '.')
+from direct_cli.wsdl_coverage import refresh_all_caches, CANONICAL_API_SERVICES
+print('Import OK, services:', len(CANONICAL_API_SERVICES))
+"
+```
+
+Ожидается: `Import OK, services: 27` (без сетевых запросов).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/refresh_wsdl_cache.py
+git commit -m "chore: add scripts/refresh_wsdl_cache.py for updating WSDL cache"
+```
+
+---
+
+## Task 4: Закрыть issue и финальная проверка
+
+- [ ] **Step 1: Запустить все unit-тесты включая api_coverage**
+
+```bash
+.venv/bin/pytest -m "not integration and not integration_write" -v 2>&1 | tail -20
+```
+
+Ожидается: все PASS.
+
+- [ ] **Step 2: Убедиться что issue #32 можно закрыть — сверить требования**
+
+Требования из issue:
+- [x] Phase 1: тест покрытия методов по WSDL — реализован в PR #32
+- [x] Phase 2: обнаружение новых сервисов — реализован в PR #32
+- [x] advideos CLI — реализован в Task 1
+- [x] BidModifiers.add DemographicsAdjustments plural — исправлен в Task 2
+- [x] Скрипт обновления кэша — реализован в Task 3
+- [ ] Phase 3 (optional): payload schema validation — out of scope, отдельный issue если нужен
+
+- [ ] **Step 3: Закрыть issue на GitHub**
+
+```bash
+gh issue close 32 --repo axisrow/direct-cli --comment "Implemented: advideos command (get/add), fixed BidModifiers.add DemographicsAdjustments plural payload bug, added scripts/refresh_wsdl_cache.py. Phase 3 (payload schema validation) left as optional future work."
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
     "vcrpy>=6.0",
     "black>=22.0",
     "flake8>=4.0",
+    "requests>=2.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,4 +83,5 @@ markers = [
     "integration: marks tests as integration tests requiring a real API token (deselect with '-m \"not integration\"')",
     "integration_write: sandbox integration tests for write commands (replays VCR cassettes offline; --record-mode=rewrite needs YANDEX_DIRECT_TOKEN)",
     "sandbox_limitation: test skipped due to known Yandex Direct sandbox API limitation (not a CLI bug)",
+    "api_coverage: marks tests verifying CLI coverage against Yandex API WSDL (cached, no network required)",
 ]

--- a/scripts/build_api_coverage_report.py
+++ b/scripts/build_api_coverage_report.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Emit a machine-readable API coverage summary."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from direct_cli.wsdl_coverage import (
+    CLI_TO_API_SERVICE,
+    INTENTIONAL_EXTRA_METHODS,
+    get_api_coverage_policy,
+    fetch_wsdl,
+    get_cli_methods_for_service,
+    parse_wsdl_operations,
+)
+
+
+def main() -> int:
+    report = {
+        "policy": get_api_coverage_policy(),
+        "summary": {
+            "services_checked": 0,
+            "missing_service_methods": 0,
+            "unexpected_service_methods": 0,
+            "strict_parity_ok": True,
+        },
+        "canonical_services": sorted(CLI_TO_API_SERVICE.values()),
+        "aliases": get_api_coverage_policy()["cli_alias_groups"],
+        "non_wsdl_services": get_api_coverage_policy()["non_wsdl_services"],
+        "cli_helpers": {
+            f"{service}.{method}": reason
+            for (service, method), reason in sorted(INTENTIONAL_EXTRA_METHODS.items())
+        },
+        "services": [],
+    }
+
+    for cli_name, api_service in sorted(CLI_TO_API_SERVICE.items()):
+        api_methods = sorted(parse_wsdl_operations(fetch_wsdl(api_service)))
+        cli_methods = sorted(get_cli_methods_for_service(cli_name))
+        missing_methods = sorted(set(api_methods) - set(cli_methods))
+        extra_methods = sorted(
+            method
+            for method in (set(cli_methods) - set(api_methods))
+            if (cli_name, method) not in INTENTIONAL_EXTRA_METHODS
+        )
+        report["services"].append(
+            {
+                "cli_group": cli_name,
+                "api_service": api_service,
+                "api_methods": api_methods,
+                "cli_methods": cli_methods,
+                "missing_methods": missing_methods,
+                "extra_methods": extra_methods,
+                "allowed_extra_methods": {
+                    method: INTENTIONAL_EXTRA_METHODS[(cli_name, method)]
+                    for method in sorted(set(cli_methods) - set(api_methods))
+                    if (cli_name, method) in INTENTIONAL_EXTRA_METHODS
+                },
+            }
+        )
+        report["summary"]["services_checked"] += 1
+        report["summary"]["missing_service_methods"] += len(missing_methods)
+        report["summary"]["unexpected_service_methods"] += len(extra_methods)
+
+    report["summary"]["strict_parity_ok"] = (
+        report["summary"]["missing_service_methods"] == 0
+        and report["summary"]["unexpected_service_methods"] == 0
+    )
+
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_wsdl_drift.py
+++ b/scripts/check_wsdl_drift.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Compare cached WSDL files with the live Yandex Direct API."""
+
+from __future__ import annotations
+
+import difflib
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from direct_cli.wsdl_coverage import CANONICAL_API_SERVICES, CACHE_DIR, fetch_wsdl
+
+
+def main() -> int:
+    drift = []
+    missing_cache = []
+
+    for service in CANONICAL_API_SERVICES:
+        cache_file = CACHE_DIR / f"{service}.xml"
+        if not cache_file.exists():
+            missing_cache.append(
+                {
+                    "service": service,
+                    "cache_path": str(cache_file),
+                }
+            )
+            continue
+        cached = cache_file.read_text(encoding="utf-8")
+        live = fetch_wsdl(service, use_cache=False)
+        if cached != live:
+            diff = list(
+                difflib.unified_diff(
+                    cached.splitlines(),
+                    live.splitlines(),
+                    fromfile=f"cached/{service}.xml",
+                    tofile=f"live/{service}.xml",
+                    lineterm="",
+                )
+            )
+            drift.append(
+                {
+                    "service": service,
+                    "cache_path": str(cache_file),
+                    "diff_preview": diff[:50],
+                }
+            )
+
+    report = {
+        "services_checked": len(CANONICAL_API_SERVICES),
+        "missing_cache_count": len(missing_cache),
+        "missing_cache": missing_cache,
+        "drift_count": len(drift),
+        "drift": drift,
+    }
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+    return 1 if (drift or missing_cache) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/refresh_wsdl_cache.py
+++ b/scripts/refresh_wsdl_cache.py
@@ -7,7 +7,9 @@ Usage:
 Fetches fresh WSDL XML from https://api.direct.yandex.com/v5/{service}?wsdl
 and overwrites files in tests/wsdl_cache/.
 
-Run periodically (e.g. monthly) or when suspecting the API has changed.
+Run manually when refreshing the committed cache after the scheduled
+WSDL drift monitor reports a live API change, or when intentionally
+updating the cached fixtures.
 """
 
 import sys

--- a/scripts/refresh_wsdl_cache.py
+++ b/scripts/refresh_wsdl_cache.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Refresh cached WSDL files for all Yandex Direct API v5 services.
+
+Usage:
+    python scripts/refresh_wsdl_cache.py
+
+Fetches fresh WSDL XML from https://api.direct.yandex.com/v5/{service}?wsdl
+and overwrites files in tests/wsdl_cache/.
+
+Run periodically (e.g. monthly) or when suspecting the API has changed.
+"""
+
+import sys
+from pathlib import Path
+
+# Allow running from repo root without installing the package
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from direct_cli.wsdl_coverage import refresh_all_caches, CANONICAL_API_SERVICES
+
+
+def main():
+    print(f"Refreshing WSDL cache for {len(CANONICAL_API_SERVICES)} services...")
+    errors = refresh_all_caches()
+
+    if errors:
+        print("\nFailed services:")
+        for service, exc in sorted(errors.items()):
+            print(f"  {service}: {exc}")
+        print(f"\n{len(CANONICAL_API_SERVICES) - len(errors)} succeeded, {len(errors)} failed.")
+        sys.exit(1)
+    else:
+        print(f"All {len(CANONICAL_API_SERVICES)} services refreshed successfully.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -1,0 +1,124 @@
+"""
+API coverage tests — verify CLI coverage against Yandex Direct API v5 WSDL.
+
+Phase 1: For each CLI service, check that all WSDL operations are covered.
+Phase 2: Detect new API services not yet covered by the CLI.
+
+Uses cached WSDL files in tests/wsdl_cache/ — no network required in CI.
+"""
+
+import pytest
+
+from direct_cli.wsdl_coverage import (
+    CLI_TO_API_SERVICE,
+    CANONICAL_API_SERVICES,
+    KNOWN_MISSING_SERVICES,
+    fetch_wsdl,
+    get_cli_methods_for_service,
+    parse_wsdl_operations,
+)
+
+# API methods that exist in WSDL but the CLI does not implement.
+# When one is fixed, remove it from this set and the test will still pass.
+KNOWN_MISSING_METHODS = {
+    ("agencyclients", "addPassportOrganization"),
+    ("agencyclients", "addPassportOrganizationMember"),
+    ("agencyclients", "update"),
+    ("audiencetargets", "setBids"),
+    ("bids", "setAuto"),
+    ("creatives", "add"),
+    ("dictionaries", "getGeoRegions"),
+    ("dynamicads", "resume"),
+    ("dynamicads", "setBids"),
+    ("dynamicads", "suspend"),
+    ("keywordbids", "setAuto"),
+    ("retargeting", "update"),
+    ("smartadtargets", "resume"),
+    ("smartadtargets", "setBids"),
+    ("smartadtargets", "suspend"),
+}
+
+# CLI methods that have no WSDL counterpart but are intentionally present.
+ALLOWED_EXTRA_METHODS = {
+    ("bidmodifiers", "toggle"),  # JSON-only API method (not in WSDL)
+    ("agencyclients", "delete"),  # CLI-side guard that blocks with error
+}
+
+# CLI methods that have no WSDL counterpart and may indicate bugs.
+# keywords archive/unarchive: WSDL only exposes suspend/resume for keywords
+# dynamicads update: dynamictextadtargets WSDL has no update operation
+# keywordsresearch get: WSDL has no 'get' (only deduplicate, hasSearchVolume)
+KNOWN_EXTRA_CLI_METHODS = {
+    ("keywords", "archive"),
+    ("keywords", "unarchive"),
+    ("dynamicads", "update"),
+    ("keywordsresearch", "get"),
+}
+
+
+@pytest.mark.api_coverage
+class TestApiCoverage:
+    """Verify CLI coverage against Yandex Direct API v5 WSDL."""
+
+    def test_no_missing_services(self):
+        """Phase 2: every known API v5 service must be covered by the CLI.
+
+        Fails when Yandex adds a new service that direct-cli does not
+        yet implement.  Add a CLI command or update KNOWN_MISSING_SERVICES.
+        """
+        covered_services = set(CLI_TO_API_SERVICE.values())
+        all_known = set(CANONICAL_API_SERVICES)
+        missing = all_known - covered_services
+
+        # Remove services we already know about
+        unaccounted = missing - KNOWN_MISSING_SERVICES
+
+        assert unaccounted == set(), (
+            f"New API services detected (not in CLI and not in "
+            f"KNOWN_MISSING_SERVICES): {sorted(unaccounted)}. "
+            f"Add CLI commands or update KNOWN_MISSING_SERVICES."
+        )
+
+    def test_service_method_coverage(self):
+        """Phase 1: for each CLI service, verify method coverage vs WSDL."""
+        failures = []
+
+        for cli_name, api_service in sorted(CLI_TO_API_SERVICE.items()):
+            try:
+                wsdl_xml = fetch_wsdl(api_service)
+            except Exception as exc:
+                failures.append(
+                    f"{cli_name} -> {api_service}: WSDL fetch failed: {exc}"
+                )
+                continue
+
+            api_methods = set(parse_wsdl_operations(wsdl_xml))
+            cli_methods = get_cli_methods_for_service(cli_name)
+
+            missing = api_methods - cli_methods
+            extra = cli_methods - api_methods
+
+            # Subtract known gaps
+            real_missing = {
+                m for m in missing if (cli_name, m) not in KNOWN_MISSING_METHODS
+            }
+            real_extra = {
+                m
+                for m in extra
+                if (cli_name, m) not in ALLOWED_EXTRA_METHODS
+                and (cli_name, m) not in KNOWN_EXTRA_CLI_METHODS
+            }
+
+            if real_missing:
+                failures.append(
+                    f"{cli_name} -> {api_service}: MISSING API methods "
+                    f"(not in KNOWN_MISSING_METHODS): {sorted(real_missing)}"
+                )
+            if real_extra:
+                failures.append(
+                    f"{cli_name} -> {api_service}: EXTRA CLI methods "
+                    f"(not in ALLOWED_EXTRA_METHODS or "
+                    f"KNOWN_EXTRA_CLI_METHODS): {sorted(real_extra)}"
+                )
+
+        assert failures == [], "API coverage gaps detected:\n" + "\n".join(failures)

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -434,6 +434,11 @@ def _dry_run(*args: str) -> dict:
 
 
 def _assert_body_matches_wsdl(body: dict, service: str, operation: str):
+    # Coverage note: this validator checks top-level param names, required flags,
+    # and one level of inline-type fields. Nested validation does NOT cover types
+    # declared via <xsd:import> or fields inherited through xsd:extension — see
+    # `get_operation_request_schema` docstring for details. For those shapes,
+    # only the CLI-level dry-run command test guards correctness.
     schema = get_operation_request_schema(fetch_wsdl(service), operation)
     expected_fields = {field["name"] for field in schema["fields"]}
     required_fields = {

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -3,57 +3,480 @@ API coverage tests — verify CLI coverage against Yandex Direct API v5 WSDL.
 
 Phase 1: For each CLI service, check that all WSDL operations are covered.
 Phase 2: Detect new API services not yet covered by the CLI.
-
-Uses cached WSDL files in tests/wsdl_cache/ — no network required in CI.
+Phase 3: Validate dry-run payload shape against cached WSDL request schemas.
 """
 
-import pytest
+import json
+import importlib
+import subprocess
+import sys
 
+import pytest
+from click.testing import CliRunner
+
+from direct_cli.cli import cli
+from direct_cli.commands.reports import build_report_request
 from direct_cli.wsdl_coverage import (
+    CACHE_DIR,
     CLI_TO_API_SERVICE,
     CANONICAL_API_SERVICES,
+    CLI_ALIAS_GROUPS,
+    INTENTIONAL_EXTRA_METHODS,
     KNOWN_MISSING_SERVICES,
+    NON_WSDL_SERVICE_POLICIES,
     fetch_wsdl,
     get_cli_methods_for_service,
+    get_operation_request_schema,
     parse_wsdl_operations,
 )
 
-# API methods that exist in WSDL but the CLI does not implement.
-# When one is fixed, remove it from this set and the test will still pass.
-KNOWN_MISSING_METHODS = {
-    ("agencyclients", "addPassportOrganization"),
-    ("agencyclients", "addPassportOrganizationMember"),
-    ("agencyclients", "update"),
-    ("audiencetargets", "setBids"),
-    ("bids", "setAuto"),
-    ("creatives", "add"),
-    ("dictionaries", "getGeoRegions"),
-    ("dynamicads", "resume"),
-    ("dynamicads", "setBids"),
-    ("dynamicads", "suspend"),
-    ("keywordbids", "setAuto"),
-    ("retargeting", "update"),
-    ("smartadtargets", "resume"),
-    ("smartadtargets", "setBids"),
-    ("smartadtargets", "suspend"),
+ALLOWED_EXTRA_METHODS = set(INTENTIONAL_EXTRA_METHODS)
+
+DRY_RUN_PAYLOAD_EXCLUSIONS = {
+    "adextensions.add": "Requires verbose resource-specific JSON already covered by command-level dry-run tests.",
+    "adgroups.add": "Requires nested add payload fixtures; tracked separately from schema smoke coverage.",
+    "adgroups.update": "Requires nested update payload fixtures; tracked separately from schema smoke coverage.",
+    "adimages.add": "Requires file/image upload style JSON that is better covered by command tests.",
+    "ads.add": "Requires large heterogeneous ad payload variants; covered by focused dry-run tests.",
+    "ads.archive": "Lifecycle alias of the same request shape family as campaigns/keywords lifecycle commands.",
+    "ads.get": "Read path with rich field-selection options; payload contract differs from mutating coverage focus.",
+    "ads.list": "CLI alias of ads.get.",
+    "ads.resume": "Lifecycle alias in the same request-shape family as covered resume/delete actions.",
+    "ads.suspend": "Lifecycle alias in the same request-shape family as covered resume/delete actions.",
+    "ads.unarchive": "Lifecycle alias in the same request-shape family as covered resume/delete actions.",
+    "ads.update": "Requires large heterogeneous ad payload variants; covered by focused dry-run tests.",
+    "advideos.add": "Requires media payload fixture not worth duplicating in generic schema smoke coverage.",
+    "audiencetargets.resume": "Same simple Ids payload family as covered delete/set-bids actions.",
+    "audiencetargets.suspend": "Same simple Ids payload family as covered delete/set-bids actions.",
+    "bidmodifiers.add": "Requires modifier-type-specific nested payload fixtures.",
+    "bidmodifiers.delete": "Helper/legacy surface; not part of strict WSDL parity claim.",
+    "bidmodifiers.set": "Requires modifier-type-specific nested payload fixtures.",
+    "bidmodifiers.toggle": "Intentional CLI helper without matching WSDL method.",
+    "campaigns.add": "Requires campaign-type-specific payload variants; covered by focused dry-run tests.",
+    "campaigns.suspend": "Same lifecycle payload family as covered campaigns.delete/archive/resume.",
+    "campaigns.unarchive": "Same lifecycle payload family as covered campaigns.delete/archive/resume.",
+    "campaigns.update": "Requires campaign-type-specific payload variants; covered by focused dry-run tests.",
+    "dynamicads.add": "Requires dynamic ad payload fixture with nested asset fields.",
+    "dynamicads.resume": "Same simple Ids payload family as covered delete/set-bids actions.",
+    "dynamicads.suspend": "Same simple Ids payload family as covered delete/set-bids actions.",
+    "feeds.add": "Current WSDL schema parser treats feed source variants like required siblings; keep covered by command-level dry-run tests.",
+    "keywords.add": "Requires keyword/addition payload variants; covered by focused dry-run tests.",
+    "keywords.archive": "Legacy helper command preserved for compatibility.",
+    "keywords.resume": "Same simple Ids payload family as covered keywords.delete/suspend.",
+    "keywords.unarchive": "Legacy helper command preserved for compatibility.",
+    "keywords.update": "Requires keyword update payload variants; covered by focused dry-run tests.",
+    "retargeting.add": "Requires retargeting list payload fixture with nested rules.",
+    "smartadtargets.resume": "Same simple Ids payload family as covered delete/set-bids actions.",
+    "smartadtargets.suspend": "Same simple Ids payload family as covered delete/set-bids actions.",
+    "vcards.add": "Requires large contact-card payload fixture not needed for generic schema smoke coverage.",
 }
 
-# CLI methods that have no WSDL counterpart but are intentionally present.
-ALLOWED_EXTRA_METHODS = {
-    ("bidmodifiers", "toggle"),  # JSON-only API method (not in WSDL)
-    ("agencyclients", "delete"),  # CLI-side guard that blocks with error
-}
+PAYLOAD_CASES = [
+    (
+        "agencyclients",
+        "add",
+        [
+            "agencyclients",
+            "add",
+            "--json",
+            '{"Login":"client-login","FirstName":"Alice","LastName":"Smith","Currency":"RUB","Notification":{}}',
+        ],
+    ),
+    (
+        "agencyclients",
+        "addPassportOrganization",
+        [
+            "agencyclients",
+            "add-passport-organization",
+            "--name",
+            "Org",
+            "--currency",
+            "RUB",
+            "--notification-json",
+            '{}',
+        ],
+    ),
+    (
+        "agencyclients",
+        "addPassportOrganizationMember",
+        [
+            "agencyclients",
+            "add-passport-organization-member",
+            "--passport-organization-login",
+            "org-login",
+            "--role",
+            "CHIEF",
+            "--send-invite-to-json",
+            '{"Email":"user@example.com"}',
+        ],
+    ),
+    (
+        "agencyclients",
+        "update",
+        [
+            "agencyclients",
+            "update",
+            "--client-id",
+            "99",
+            "--json",
+            '{"Grants":[]}',
+        ],
+    ),
+    (
+        "audiencetargets",
+        "add",
+        [
+            "audiencetargets",
+            "add",
+            "--adgroup-id",
+            "100",
+            "--retargeting-list-id",
+            "200",
+            "--bid",
+            "12",
+        ],
+    ),
+    (
+        "audiencetargets",
+        "setBids",
+        [
+            "audiencetargets",
+            "set-bids",
+            "--id",
+            "10",
+            "--context-bid",
+            "5",
+        ],
+    ),
+    (
+        "bids",
+        "set",
+        [
+            "bids",
+            "set",
+            "--keyword-id",
+            "123",
+            "--bid",
+            "1.5",
+        ],
+    ),
+    (
+        "bids",
+        "setAuto",
+        [
+            "bids",
+            "set-auto",
+            "--keyword-id",
+            "123",
+            "--scope",
+            "SEARCH",
+        ],
+    ),
+    (
+        "clients",
+        "update",
+        [
+            "clients",
+            "update",
+            "--client-id",
+            "501",
+            "--json",
+            '{"Email":"user@example.com"}',
+        ],
+    ),
+    (
+        "creatives",
+        "add",
+        [
+            "creatives",
+            "add",
+            "--json",
+            '{"VideoExtensionCreative":{"VideoId":"video-id"}}',
+        ],
+    ),
+    (
+        "feeds",
+        "update",
+        [
+            "feeds",
+            "update",
+            "--id",
+            "18",
+            "--name",
+            "Renamed feed",
+        ],
+    ),
+    (
+        "dynamictextadtargets",
+        "setBids",
+        [
+            "dynamicads",
+            "set-bids",
+            "--id",
+            "10",
+            "--bid",
+            "3",
+            "--context-bid",
+            "2",
+        ],
+    ),
+    (
+        "keywordbids",
+        "set",
+        [
+            "keywordbids",
+            "set",
+            "--keyword-id",
+            "321",
+            "--search-bid",
+            "1.1",
+            "--network-bid",
+            "0.9",
+        ],
+    ),
+    (
+        "keywordbids",
+        "setAuto",
+        [
+            "keywordbids",
+            "set-auto",
+            "--keyword-id",
+            "321",
+            "--json",
+            '{"SearchByTrafficVolume":{"TargetTrafficVolume":100}}',
+        ],
+    ),
+    (
+        "negativekeywordsharedsets",
+        "add",
+        [
+            "negativekeywordsharedsets",
+            "add",
+            "--name",
+            "Shared negatives",
+            "--keywords",
+            "cheap,free",
+        ],
+    ),
+    (
+        "negativekeywordsharedsets",
+        "update",
+        [
+            "negativekeywordsharedsets",
+            "update",
+            "--id",
+            "19",
+            "--keywords",
+            "cheap,free",
+        ],
+    ),
+    (
+        "retargetinglists",
+        "update",
+        [
+            "retargeting",
+            "update",
+            "--id",
+            "55",
+            "--json",
+            '{"Name":"Renamed"}',
+        ],
+    ),
+    (
+        "sitelinks",
+        "add",
+        [
+            "sitelinks",
+            "add",
+            "--links",
+            '[{"Title":"Docs","Href":"https://example.com/docs"}]',
+        ],
+    ),
+    (
+        "smartadtargets",
+        "add",
+        [
+            "smartadtargets",
+            "add",
+            "--adgroup-id",
+            "77",
+            "--json",
+            '{"Name":"Audience A","Audience":"ALL_SEGMENTS"}',
+        ],
+    ),
+    (
+        "smartadtargets",
+        "update",
+        [
+            "smartadtargets",
+            "update",
+            "--id",
+            "66",
+            "--json",
+            '{"AverageCpc":1000000}',
+        ],
+    ),
+    (
+        "smartadtargets",
+        "setBids",
+        [
+            "smartadtargets",
+            "set-bids",
+            "--id",
+            "11",
+            "--average-cpc",
+            "1.5",
+        ],
+    ),
+    (
+        "campaigns",
+        "delete",
+        ["campaigns", "delete", "--id", "12"],
+    ),
+    (
+        "campaigns",
+        "archive",
+        ["campaigns", "archive", "--id", "12"],
+    ),
+    (
+        "campaigns",
+        "resume",
+        ["campaigns", "resume", "--id", "12"],
+    ),
+    (
+        "ads",
+        "delete",
+        ["ads", "delete", "--id", "7"],
+    ),
+    (
+        "ads",
+        "moderate",
+        ["ads", "moderate", "--id", "7"],
+    ),
+    (
+        "keywords",
+        "delete",
+        ["keywords", "delete", "--id", "8"],
+    ),
+    (
+        "keywords",
+        "suspend",
+        ["keywords", "suspend", "--id", "8"],
+    ),
+    (
+        "adgroups",
+        "delete",
+        ["adgroups", "delete", "--id", "14"],
+    ),
+    (
+        "adextensions",
+        "delete",
+        ["adextensions", "delete", "--id", "15"],
+    ),
+    (
+        "adimages",
+        "delete",
+        ["adimages", "delete", "--hash", "image-hash"],
+    ),
+    (
+        "audiencetargets",
+        "delete",
+        ["audiencetargets", "delete", "--id", "16"],
+    ),
+    (
+        "dynamictextadtargets",
+        "delete",
+        ["dynamicads", "delete", "--id", "17"],
+    ),
+    (
+        "feeds",
+        "delete",
+        ["feeds", "delete", "--id", "18"],
+    ),
+    (
+        "negativekeywordsharedsets",
+        "delete",
+        ["negativekeywordsharedsets", "delete", "--id", "19"],
+    ),
+    (
+        "retargetinglists",
+        "delete",
+        ["retargeting", "delete", "--id", "20"],
+    ),
+    (
+        "sitelinks",
+        "delete",
+        ["sitelinks", "delete", "--id", "21"],
+    ),
+    (
+        "smartadtargets",
+        "delete",
+        ["smartadtargets", "delete", "--id", "22"],
+    ),
+    (
+        "vcards",
+        "delete",
+        ["vcards", "delete", "--id", "23"],
+    ),
+]
 
-# CLI methods that have no WSDL counterpart and may indicate bugs.
-# keywords archive/unarchive: WSDL only exposes suspend/resume for keywords
-# dynamicads update: dynamictextadtargets WSDL has no update operation
-# keywordsresearch get: WSDL has no 'get' (only deduplicate, hasSearchVolume)
-KNOWN_EXTRA_CLI_METHODS = {
-    ("keywords", "archive"),
-    ("keywords", "unarchive"),
-    ("dynamicads", "update"),
-    ("keywordsresearch", "get"),
-}
+PAYLOAD_COVERED_COMMANDS = {f"{argv[0]}.{argv[1]}" for _, _, argv in PAYLOAD_CASES}
+
+
+def _dry_run(*args: str) -> dict:
+    result = CliRunner().invoke(cli, list(args) + ["--dry-run"])
+    assert result.exit_code == 0, (
+        f"command failed: direct {' '.join(args)} --dry-run\n"
+        f"output: {result.output}\n"
+        f"exception: {result.exception}"
+    )
+    return json.loads(result.output)
+
+
+def _assert_body_matches_wsdl(body: dict, service: str, operation: str):
+    schema = get_operation_request_schema(fetch_wsdl(service), operation)
+    expected_fields = {field["name"] for field in schema["fields"]}
+    required_fields = {
+        field["name"] for field in schema["fields"] if field["min_occurs"] > 0
+    }
+    actual_fields = set(body["params"])
+    assert actual_fields <= expected_fields, (
+        f"{service}.{operation}: unexpected top-level params "
+        f"{sorted(actual_fields - expected_fields)}"
+    )
+    assert required_fields <= actual_fields, (
+        f"{service}.{operation}: missing required top-level params "
+        f"{sorted(required_fields - actual_fields)}"
+    )
+
+    for field in schema["fields"]:
+        if field["name"] not in body["params"]:
+            continue
+        value = body["params"][field["name"]]
+        if field["max_occurs"] == "unbounded":
+            assert isinstance(value, list), (
+                f"{service}.{operation}.{field['name']} must be a list"
+            )
+            if value and field["item_fields"]:
+                required = {
+                    item["name"]
+                    for item in field["item_fields"]
+                    if item["min_occurs"] > 0
+                }
+                assert required <= set(value[0]), (
+                    f"{service}.{operation}.{field['name']} missing required item keys: "
+                    f"{sorted(required - set(value[0]))}"
+                )
+        elif field["item_fields"] and isinstance(value, dict):
+            required = {
+                item["name"]
+                for item in field["item_fields"]
+                if item["min_occurs"] > 0
+            }
+            assert required <= set(value), (
+                f"{service}.{operation}.{field['name']} missing required keys: "
+                f"{sorted(required - set(value))}"
+            )
 
 
 @pytest.mark.api_coverage
@@ -61,16 +484,9 @@ class TestApiCoverage:
     """Verify CLI coverage against Yandex Direct API v5 WSDL."""
 
     def test_no_missing_services(self):
-        """Phase 2: every known API v5 service must be covered by the CLI.
-
-        Fails when Yandex adds a new service that direct-cli does not
-        yet implement.  Add a CLI command or update KNOWN_MISSING_SERVICES.
-        """
         covered_services = set(CLI_TO_API_SERVICE.values())
         all_known = set(CANONICAL_API_SERVICES)
         missing = all_known - covered_services
-
-        # Remove services we already know about
         unaccounted = missing - KNOWN_MISSING_SERVICES
 
         assert unaccounted == set(), (
@@ -79,8 +495,35 @@ class TestApiCoverage:
             f"Add CLI commands or update KNOWN_MISSING_SERVICES."
         )
 
+    def test_wsdl_cache_matches_canonical_service_list(self):
+        cached = {
+            path.stem for path in CACHE_DIR.glob("*.xml") if path.is_file()
+        }
+        expected = set(CANONICAL_API_SERVICES)
+        assert cached == expected, (
+            "WSDL cache drift detected.\n"
+            f"Missing cache files: {sorted(expected - cached)}\n"
+            f"Unexpected cache files: {sorted(cached - expected)}"
+        )
+
+    def test_alias_groups_resolve_to_real_cli_groups(self):
+        for alias, target in sorted(CLI_ALIAS_GROUPS.items()):
+            assert alias in cli.commands, f"Missing CLI alias group: {alias}"
+            assert target in cli.commands, f"Missing target CLI group for alias: {target}"
+            assert cli.commands[alias] is cli.commands[target], (
+                f"Alias group {alias} does not resolve to the same Click group as {target}"
+            )
+
+    def test_non_wsdl_services_have_explicit_coverage_policy(self):
+        for service_name, policy in sorted(NON_WSDL_SERVICE_POLICIES.items()):
+            assert service_name in cli.commands, (
+                f"Non-WSDL service {service_name} is missing from the CLI"
+            )
+            assert policy["coverage"] == "contract-tests", (
+                f"Unexpected coverage policy for non-WSDL service {service_name}: {policy}"
+            )
+
     def test_service_method_coverage(self):
-        """Phase 1: for each CLI service, verify method coverage vs WSDL."""
         failures = []
 
         for cli_name, api_service in sorted(CLI_TO_API_SERVICE.items()):
@@ -96,29 +539,223 @@ class TestApiCoverage:
             cli_methods = get_cli_methods_for_service(cli_name)
 
             missing = api_methods - cli_methods
-            extra = cli_methods - api_methods
-
-            # Subtract known gaps
-            real_missing = {
-                m for m in missing if (cli_name, m) not in KNOWN_MISSING_METHODS
-            }
-            real_extra = {
-                m
-                for m in extra
-                if (cli_name, m) not in ALLOWED_EXTRA_METHODS
-                and (cli_name, m) not in KNOWN_EXTRA_CLI_METHODS
+            extra = {
+                method
+                for method in (cli_methods - api_methods)
+                if (cli_name, method) not in ALLOWED_EXTRA_METHODS
             }
 
-            if real_missing:
+            if missing:
                 failures.append(
-                    f"{cli_name} -> {api_service}: MISSING API methods "
-                    f"(not in KNOWN_MISSING_METHODS): {sorted(real_missing)}"
+                    f"{cli_name} -> {api_service}: missing API methods {sorted(missing)}"
                 )
-            if real_extra:
+            if extra:
                 failures.append(
-                    f"{cli_name} -> {api_service}: EXTRA CLI methods "
-                    f"(not in ALLOWED_EXTRA_METHODS or "
-                    f"KNOWN_EXTRA_CLI_METHODS): {sorted(real_extra)}"
+                    f"{cli_name} -> {api_service}: unexpected CLI methods {sorted(extra)}"
                 )
 
         assert failures == [], "API coverage gaps detected:\n" + "\n".join(failures)
+
+    @pytest.mark.parametrize(("service", "operation", "argv"), PAYLOAD_CASES)
+    def test_dry_run_payload_schema_coverage(self, service, operation, argv):
+        body = _dry_run(*argv)
+        assert body["method"] == operation
+        _assert_body_matches_wsdl(body, service, operation)
+
+    def test_all_canonical_dry_run_commands_have_payload_coverage_or_exclusion(self):
+        actual = set()
+        for group_name, group in sorted(cli.commands.items()):
+            if group_name in CLI_ALIAS_GROUPS or not hasattr(group, "commands"):
+                continue
+            for cmd_name, cmd in sorted(group.commands.items()):
+                if any(getattr(param, "name", None) == "dry_run" for param in cmd.params):
+                    actual.add(f"{group_name}.{cmd_name}")
+
+        accounted = PAYLOAD_COVERED_COMMANDS | set(DRY_RUN_PAYLOAD_EXCLUSIONS)
+        assert actual == accounted, (
+            "Canonical dry-run command registry is out of date.\n"
+            f"Missing accounting for: {sorted(actual - accounted)}\n"
+            f"Stale registry entries: {sorted(accounted - actual)}"
+        )
+
+    def test_reports_contract_coverage(self):
+        result = CliRunner().invoke(cli, ["reports", "list-types"])
+        assert result.exit_code == 0, result.output
+        report_types = json.loads(result.output)
+        assert report_types, "reports list-types returned no report types"
+        assert "CAMPAIGN_PERFORMANCE_REPORT" in report_types
+
+        body = CliRunner(
+            env={"YANDEX_DIRECT_TOKEN": "", "YANDEX_DIRECT_LOGIN": ""}
+        ).invoke(
+            cli,
+            [
+                "reports",
+                "get",
+                "--type",
+                "campaign_performance_report",
+                "--from",
+                "2026-01-01",
+                "--to",
+                "2026-01-31",
+                "--name",
+                "Coverage Report",
+                "--fields",
+                "Date,CampaignId",
+            ],
+        )
+        assert "Invalid value for '--type'" not in body.output
+
+    def test_reports_request_builder_contract(self):
+        request = build_report_request(
+            report_type="CAMPAIGN_PERFORMANCE_REPORT",
+            date_from="2026-01-01",
+            date_to="2026-01-31",
+            name="Coverage Report",
+            fields="Date,CampaignId",
+            campaign_ids="1,2",
+            output_format="csv",
+        )
+        assert request == {
+            "params": {
+                "SelectionCriteria": {
+                    "DateFrom": "2026-01-01",
+                    "DateTo": "2026-01-31",
+                    "Filter": [
+                        {
+                            "Field": "CampaignId",
+                            "Operator": "IN",
+                            "Values": ["1", "2"],
+                        }
+                    ],
+                },
+                "FieldNames": ["Date", "CampaignId"],
+                "ReportName": "Coverage Report",
+                "ReportType": "CAMPAIGN_PERFORMANCE_REPORT",
+                "DateRangeType": "CUSTOM_DATE",
+                "Format": "TSV",
+                "IncludeVAT": "YES",
+                "IncludeDiscount": "YES",
+            }
+        }
+
+    def test_reports_request_builder_adgroup_filter_and_field_normalization(self):
+        request = build_report_request(
+            report_type="ADGROUP_PERFORMANCE_REPORT",
+            date_from="2026-02-01",
+            date_to="2026-02-28",
+            name="Adgroup Coverage",
+            fields=" Date , AdGroupId , Clicks ",
+            adgroup_ids="10, 20 ,30",
+            output_format="json",
+        )
+        assert request["params"]["SelectionCriteria"]["Filter"] == [
+            {
+                "Field": "AdGroupId",
+                "Operator": "IN",
+                "Values": ["10", "20", "30"],
+            }
+        ]
+        assert request["params"]["FieldNames"] == ["Date", "AdGroupId", "Clicks"]
+        assert request["params"]["Format"] == "TSV"
+
+    def test_reports_request_builder_campaign_filter_takes_precedence(self):
+        request = build_report_request(
+            report_type="CUSTOM_REPORT",
+            date_from="2026-03-01",
+            date_to="2026-03-31",
+            name="Precedence Coverage",
+            fields="Date,CampaignId,AdGroupId",
+            campaign_ids="1,2",
+            adgroup_ids="99,100",
+            output_format="table",
+        )
+        assert request["params"]["SelectionCriteria"]["Filter"] == [
+            {
+                "Field": "CampaignId",
+                "Operator": "IN",
+                "Values": ["1", "2"],
+            }
+        ]
+        assert request["params"]["Format"] == "TSV"
+
+    @pytest.mark.parametrize("output_format", ["json", "table", "csv", "tsv"])
+    def test_reports_get_cli_path_sends_expected_request_body(
+        self, monkeypatch, output_format
+    ):
+        captured = {}
+        reports_module = importlib.import_module("direct_cli.commands.reports")
+
+        class _FakeResponse:
+            columns = ["Date", "CampaignId"]
+            data = [["2026-01-01", "1"]]
+
+            def __call__(self):
+                return self
+
+            def to_dicts(self):
+                return [{"Date": "2026-01-01", "CampaignId": "1"}]
+
+            def to_values(self):
+                return [["2026-01-01", "1"]]
+
+        class _FakeReports:
+            def post(self, data):
+                captured["body"] = data
+                return _FakeResponse()
+
+        class _FakeClient:
+            def reports(self):
+                return _FakeReports()
+
+        monkeypatch.setattr(reports_module, "create_client", lambda **_: _FakeClient())
+
+        result = CliRunner().invoke(
+            cli,
+            [
+                "reports",
+                "get",
+                "--type",
+                "campaign_performance_report",
+                "--from",
+                "2026-01-01",
+                "--to",
+                "2026-01-31",
+                "--name",
+                "Coverage Report",
+                "--fields",
+                " Date , CampaignId ",
+                "--campaign-ids",
+                "1, 2",
+                "--adgroup-ids",
+                "999",
+                "--format",
+                output_format,
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert captured["body"] == build_report_request(
+            report_type="CAMPAIGN_PERFORMANCE_REPORT",
+            date_from="2026-01-01",
+            date_to="2026-01-31",
+            name="Coverage Report",
+            fields=" Date , CampaignId ",
+            campaign_ids="1, 2",
+            adgroup_ids="999",
+            output_format=output_format,
+        )
+
+    def test_api_coverage_report_script_matches_strict_parity_contract(self):
+        result = subprocess.run(
+            [sys.executable, "scripts/build_api_coverage_report.py"],
+            cwd=CACHE_DIR.parent.parent,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        report = json.loads(result.stdout)
+        assert report["summary"]["strict_parity_ok"] is True
+        assert report["summary"]["missing_service_methods"] == 0
+        assert report["summary"]["unexpected_service_methods"] == 0
+        assert sorted(report["canonical_services"]) == CANONICAL_API_SERVICES

--- a/tests/test_comprehensive.py
+++ b/tests/test_comprehensive.py
@@ -45,6 +45,7 @@ class TestCommandsRegistered(unittest.TestCase):
         "retargeting",
         "creatives",
         "adimages",
+        "advideos",
         "adextensions",
         "sitelinks",
         "vcards",

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1271,3 +1271,23 @@ def test_clients_update_merges_extra_json_with_client_id():
     assert body["method"] == "update"
     client = body["params"]["Clients"][0]
     assert client == {"ClientId": 999, "Phone": "+70000000000"}
+
+
+class TestAdvideosDryRun:
+    def test_add_by_url(self):
+        body = _dry_run(
+            "advideos", "add",
+            "--url", "https://example.com/video.mp4",
+            "--name", "Test Video",
+        )
+        assert body["method"] == "add"
+        item = body["params"]["AdVideos"][0]
+        assert item["Url"] == "https://example.com/video.mp4"
+        assert item["Name"] == "Test Video"
+        assert "Type" not in item
+
+    def test_add_requires_url_or_data(self):
+        from click.testing import CliRunner
+        from direct_cli.cli import cli
+        result = CliRunner().invoke(cli, ["advideos", "add", "--dry-run"])
+        assert result.exit_code != 0

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1291,3 +1291,57 @@ class TestAdvideosDryRun:
         from direct_cli.cli import cli
         result = CliRunner().invoke(cli, ["advideos", "add", "--dry-run"])
         assert result.exit_code != 0
+
+
+class TestBidModifiersAddPluralFields:
+    """WSDL BidModifierAddItem uses plural array fields for 5 adjustment types."""
+
+    def test_demographics_plural(self):
+        body = _dry_run(
+            "bidmodifiers", "add",
+            "--campaign-id", "123",
+            "--type", "DEMOGRAPHICS_ADJUSTMENT",
+            "--value", "150",
+            "--json", '{"Gender": "GENDER_MALE", "Age": "AGE_25_34"}',
+        )
+        item = body["params"]["BidModifiers"][0]
+        assert "DemographicsAdjustments" in item, f"got keys: {list(item.keys())}"
+        assert "DemographicsAdjustment" not in item
+        assert isinstance(item["DemographicsAdjustments"], list)
+        assert item["DemographicsAdjustments"][0]["BidModifier"] == 150
+
+    def test_retargeting_plural(self):
+        body = _dry_run(
+            "bidmodifiers", "add",
+            "--campaign-id", "123",
+            "--type", "RETARGETING_ADJUSTMENT",
+            "--value", "120",
+            "--json", '{"RetargetingConditionId": 456}',
+        )
+        item = body["params"]["BidModifiers"][0]
+        assert "RetargetingAdjustments" in item, f"got keys: {list(item.keys())}"
+        assert isinstance(item["RetargetingAdjustments"], list)
+
+    def test_regional_plural(self):
+        body = _dry_run(
+            "bidmodifiers", "add",
+            "--campaign-id", "123",
+            "--type", "REGIONAL_ADJUSTMENT",
+            "--value", "110",
+            "--json", '{"RegionId": 1}',
+        )
+        item = body["params"]["BidModifiers"][0]
+        assert "RegionalAdjustments" in item, f"got keys: {list(item.keys())}"
+        assert isinstance(item["RegionalAdjustments"], list)
+
+    def test_mobile_singular(self):
+        """MobileAdjustment stays singular — regression guard."""
+        body = _dry_run(
+            "bidmodifiers", "add",
+            "--campaign-id", "123",
+            "--type", "MOBILE_ADJUSTMENT",
+            "--value", "130",
+        )
+        item = body["params"]["BidModifiers"][0]
+        assert "MobileAdjustment" in item
+        assert isinstance(item["MobileAdjustment"], dict)

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -38,12 +38,11 @@ that re-introducing the bug breaks CI immediately.
 Coverage scope
 --------------
 
-Only commands that already implement ``--dry-run`` are covered (this is
-all ``add`` / ``update`` / ``set`` / ``toggle`` write commands).
-Single-action state-change commands (``delete``, ``archive``,
-``unarchive``, ``suspend``, ``resume``, ``moderate``) currently don't
-expose ``--dry-run`` and only send a trivial ``SelectionCriteria``
-payload, so they're out of scope here.
+The suite covers both payload-building write commands (``add``,
+``update``, ``set``, ``toggle``) and the main single-action lifecycle
+commands that now expose ``--dry-run`` (``delete``, ``archive``,
+``unarchive``, ``suspend``, ``resume``, ``moderate``) so that trivial
+``SelectionCriteria`` regressions are also caught in CI.
 
 Part of axisrow/yandex-direct-mcp-plugin#61.
 """
@@ -869,7 +868,7 @@ def test_retargeting_add_unknown_type_is_rejected_by_choice():
 # ----------------------------------------------------------------------
 
 
-def test_audiencetargets_add_scales_bid_to_micro_units():
+def test_audiencetargets_add_scales_context_bid_to_micro_units():
     body = _dry_run(
         "audiencetargets",
         "add",
@@ -885,8 +884,22 @@ def test_audiencetargets_add_scales_bid_to_micro_units():
     assert target == {
         "AdGroupId": 100,
         "RetargetingListId": 200,
-        "Bid": 12_000_000,
+        "ContextBid": 12_000_000,
     }
+
+
+def test_audiencetargets_set_bids_uses_bids_array():
+    body = _dry_run(
+        "audiencetargets",
+        "set-bids",
+        "--id",
+        "101",
+        "--context-bid",
+        "7",
+    )
+    assert body["method"] == "setBids"
+    item = body["params"]["Bids"][0]
+    assert item == {"Id": 101, "ContextBid": 7_000_000}
 
 
 # ----------------------------------------------------------------------
@@ -1100,18 +1113,20 @@ def test_dynamicads_add_payload_uses_webpages_key():
     assert webpage["Conditions"] == target["Conditions"]
 
 
-def test_dynamicads_update_merges_extra_json():
+def test_dynamicads_set_bids_uses_bids_array():
     body = _dry_run(
         "dynamicads",
-        "update",
+        "set-bids",
         "--id",
         "44",
-        "--json",
-        json.dumps({"Name": "Renamed"}),
+        "--bid",
+        "3",
+        "--context-bid",
+        "2",
     )
-    assert body["method"] == "update"
-    webpage = body["params"]["Webpages"][0]
-    assert webpage == {"Id": 44, "Name": "Renamed"}
+    assert body["method"] == "setBids"
+    item = body["params"]["Bids"][0]
+    assert item == {"Id": 44, "Bid": 3_000_000, "ContextBid": 2_000_000}
 
 
 # ----------------------------------------------------------------------
@@ -1128,17 +1143,14 @@ def test_smartadtargets_add_payload_omits_type():
         "--type",
         "VIEWED_PRODUCT",
         "--json",
-        json.dumps({"TargetingId": "VIEWED_PRODUCT"}),
+        json.dumps({"Name": "Audience A", "Audience": "ALL_SEGMENTS"}),
     )
     assert body["method"] == "add"
     target = body["params"]["SmartAdTargets"][0]
-    # Regression guard: ``Type`` is not a field on
-    # ``SmartAdTargetAddItem``. The legacy ``--type`` CLI option is
-    # accepted for backward compatibility but no longer forwarded;
-    # callers must use --json to pass real fields like ``TargetingId``.
     assert "Type" not in target
     assert target["AdGroupId"] == 55
-    assert target["TargetingId"] == "VIEWED_PRODUCT"
+    assert target["Name"] == "Audience A"
+    assert target["Audience"] == "ALL_SEGMENTS"
 
 
 def test_smartadtargets_update_omits_type():
@@ -1148,12 +1160,12 @@ def test_smartadtargets_update_omits_type():
         "--id",
         "66",
         "--json",
-        json.dumps({"Bid": {"Deposit": 3_000_000, "Currency": "RUB"}}),
+        json.dumps({"AverageCpc": 3_000_000}),
     )
     target = body["params"]["SmartAdTargets"][0]
     assert "Type" not in target
     assert target["Id"] == 66
-    assert target["Bid"] == {"Deposit": 3_000_000, "Currency": "RUB"}
+    assert target["AverageCpc"] == 3_000_000
 
 
 def test_smartadtargets_add_type_is_now_optional():
@@ -1170,12 +1182,13 @@ def test_smartadtargets_add_type_is_now_optional():
         "--adgroup-id",
         "55",
         "--json",
-        json.dumps({"TargetingId": "VIEWED_PRODUCT"}),
+        json.dumps({"Name": "Audience A", "Audience": "ALL_SEGMENTS"}),
     )
     target = body["params"]["SmartAdTargets"][0]
     assert "Type" not in target
     assert target["AdGroupId"] == 55
-    assert target["TargetingId"] == "VIEWED_PRODUCT"
+    assert target["Name"] == "Audience A"
+    assert target["Audience"] == "ALL_SEGMENTS"
 
 
 def test_smartadtargets_add_without_fields_errors():
@@ -1200,7 +1213,7 @@ def test_smartadtargets_add_without_fields_errors():
     combined = (result.output or "") + (
         str(result.exception) if result.exception else ""
     )
-    assert "--json" in combined or "TargetingId" in combined
+    assert "--json" in combined or "Audience" in combined or "Name" in combined
 
 
 # ----------------------------------------------------------------------
@@ -1246,12 +1259,15 @@ def test_negativekeywordsharedsets_update_keywords():
 def test_agencyclients_add_passes_full_json_through():
     client_data = {
         "Login": "client-login",
+        "FirstName": "Alice",
+        "LastName": "Smith",
         "Currency": "RUB",
+        "Notification": {},
         "Grants": [],
     }
     body = _dry_run("agencyclients", "add", "--json", json.dumps(client_data))
     assert body["method"] == "add"
-    assert body["params"]["Clients"] == [client_data]
+    assert body["params"] == client_data
 
 
 # ----------------------------------------------------------------------
@@ -1345,3 +1361,197 @@ class TestBidModifiersAddPluralFields:
         item = body["params"]["BidModifiers"][0]
         assert "MobileAdjustment" in item
         assert isinstance(item["MobileAdjustment"], dict)
+
+
+# ----------------------------------------------------------------------
+# wsdl coverage gap closures
+# ----------------------------------------------------------------------
+
+
+def test_agencyclients_add_payload_uses_top_level_fields():
+    body = _dry_run(
+        "agencyclients",
+        "add",
+        "--json",
+        '{"Login":"client-login","FirstName":"Alice","LastName":"Smith","Currency":"RUB","Notification":{}}',
+    )
+    assert body["method"] == "add"
+    assert body["params"]["Login"] == "client-login"
+    assert "Notification" in body["params"]
+    assert "Clients" not in body["params"]
+
+
+def test_agencyclients_add_passport_organization_payload():
+    body = _dry_run(
+        "agencyclients",
+        "add-passport-organization",
+        "--name",
+        "Org",
+        "--currency",
+        "RUB",
+        "--notification-json",
+        '{}',
+    )
+    assert body["method"] == "addPassportOrganization"
+    assert body["params"] == {
+        "Name": "Org",
+        "Currency": "RUB",
+        "Notification": {},
+    }
+
+
+def test_agencyclients_add_passport_organization_member_payload():
+    body = _dry_run(
+        "agencyclients",
+        "add-passport-organization-member",
+        "--passport-organization-login",
+        "org-login",
+        "--role",
+        "CHIEF",
+        "--send-invite-to-json",
+        '{"Email":"user@example.com"}',
+    )
+    assert body["method"] == "addPassportOrganizationMember"
+    assert body["params"] == {
+        "PassportOrganizationLogin": "org-login",
+        "Role": "CHIEF",
+        "SendInviteTo": {"Email": "user@example.com"},
+    }
+
+
+def test_agencyclients_update_payload_uses_clients_array():
+    body = _dry_run(
+        "agencyclients",
+        "update",
+        "--client-id",
+        "42",
+        "--json",
+        '{"Grants":[]}',
+    )
+    item = body["params"]["Clients"][0]
+    assert item == {"ClientId": 42, "Grants": []}
+
+
+def test_bids_set_auto_requires_scope():
+    result = CliRunner().invoke(
+        cli,
+        ["bids", "set-auto", "--keyword-id", "1", "--dry-run"],
+    )
+    assert result.exit_code != 0
+    assert "Scope" in result.output or "scope" in result.output
+
+
+def test_bids_set_auto_payload_uses_bids_array():
+    body = _dry_run(
+        "bids",
+        "set-auto",
+        "--keyword-id",
+        "1",
+        "--scope",
+        "SEARCH",
+    )
+    item = body["params"]["Bids"][0]
+    assert item == {"KeywordId": 1, "Scope": ["SEARCH"]}
+
+
+def test_creatives_add_payload_uses_creatives_array():
+    body = _dry_run(
+        "creatives",
+        "add",
+        "--json",
+        '{"VideoExtensionCreative":{"VideoId":"video-id"}}',
+    )
+    assert body["method"] == "add"
+    assert body["params"]["Creatives"] == [
+        {"VideoExtensionCreative": {"VideoId": "video-id"}}
+    ]
+
+
+def test_keywordbids_set_auto_payload_uses_bidding_rule():
+    body = _dry_run(
+        "keywordbids",
+        "set-auto",
+        "--keyword-id",
+        "321",
+        "--json",
+        '{"SearchByTrafficVolume":{"TargetTrafficVolume":100}}',
+    )
+    item = body["params"]["KeywordBids"][0]
+    assert item == {
+        "KeywordId": 321,
+        "BiddingRule": {"SearchByTrafficVolume": {"TargetTrafficVolume": 100}},
+    }
+
+
+def test_retargeting_update_payload_uses_lists_array():
+    body = _dry_run(
+        "retargeting",
+        "update",
+        "--id",
+        "55",
+        "--json",
+        '{"Name":"Renamed"}',
+    )
+    assert body["method"] == "update"
+    assert body["params"]["RetargetingLists"][0] == {"Id": 55, "Name": "Renamed"}
+
+
+def test_smartadtargets_set_bids_payload_uses_average_cpc():
+    body = _dry_run(
+        "smartadtargets",
+        "set-bids",
+        "--id",
+        "11",
+        "--average-cpc",
+        "1.5",
+    )
+    assert body["method"] == "setBids"
+    assert body["params"]["Bids"][0] == {"Id": 11, "AverageCpc": 1_500_000}
+
+
+def test_campaigns_delete_dry_run_payload():
+    body = _dry_run("campaigns", "delete", "--id", "42")
+    assert body == {
+        "method": "delete",
+        "params": {"SelectionCriteria": {"Ids": [42]}},
+    }
+
+
+def test_ads_moderate_dry_run_payload():
+    body = _dry_run("ads", "moderate", "--id", "99")
+    assert body == {
+        "method": "moderate",
+        "params": {"SelectionCriteria": {"Ids": [99]}},
+    }
+
+
+def test_keywords_suspend_dry_run_payload():
+    body = _dry_run("keywords", "suspend", "--id", "77")
+    assert body == {
+        "method": "suspend",
+        "params": {"SelectionCriteria": {"Ids": [77]}},
+    }
+
+
+def test_adgroups_delete_dry_run_payload():
+    body = _dry_run("adgroups", "delete", "--id", "55")
+    assert body == {
+        "method": "delete",
+        "params": {"SelectionCriteria": {"Ids": [55]}},
+    }
+
+
+def test_adimages_delete_dry_run_payload():
+    body = _dry_run("adimages", "delete", "--hash", "image-hash")
+    assert body == {
+        "method": "delete",
+        "params": {"SelectionCriteria": {"AdImageHashes": ["image-hash"]}},
+    }
+
+
+def test_smartadtargets_delete_dry_run_payload():
+    body = _dry_run("smartadtargets", "delete", "--id", "88")
+    assert body == {
+        "method": "delete",
+        "params": {"SelectionCriteria": {"Ids": [88]}},
+    }

--- a/tests/test_integration_write.py
+++ b/tests/test_integration_write.py
@@ -48,7 +48,7 @@ Sandbox-limited (confirmed via live recording, ``@pytest.mark.sandbox_limitation
   - keywordbids set               — same
   - sitelinks add/delete          — sandbox service returns error 1000
   - adimages add/delete           — sandbox rejects valid 450x450 PNG uploads
-  - dynamicads add/update/delete  — sandbox does not support DYNAMIC_TEXT_CAMPAIGN creation
+  - dynamicads add/delete         — sandbox does not support DYNAMIC_TEXT_CAMPAIGN creation
   - audiencetargets add/delete    — sandbox does not persist adgroup/retargeting list
   - smartadtargets add            — sandbox does not support SMART_CAMPAIGN + SMART_AD_GROUP chain
 
@@ -769,15 +769,8 @@ class TestWriteDynamicAds:
             pytest.fail(f"API rejected dynamicads add (CLI bug?): {first['Errors']}")
 
         wid = first["Id"]
-        try:
-            r = _invoke(
-                "dynamicads", "update",
-                "--id", str(wid),
-                "--json", json.dumps({"Name": "Updated Webpage"}),
-            )
-            assert_success(r, "dynamicads update")
-        finally:
-            _invoke("dynamicads", "delete", "--id", str(wid))
+        r = _invoke("dynamicads", "delete", "--id", str(wid))
+        assert_success(r, "dynamicads delete")
 
 
 # ── smartadtargets ───────────────────────────────────────────────────────

--- a/tests/wsdl_cache/adextensions.xml
+++ b/tests/wsdl_cache/adextensions.xml
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:general="http://api.direct.yandex.com/v5/general"
+                  xmlns:ns="http://api.direct.yandex.com/v5/adextensions"
+                  xmlns:ext="http://api.direct.yandex.com/v5/adextensiontypes"
+                  name="AdExtensions"
+                  targetNamespace="http://api.direct.yandex.com/v5/adextensions">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://api.direct.yandex.com/v5/adextensions">
+            <xsd:import namespace="http://api.direct.yandex.com/v5/general" schemaLocation="https://soap.direct.yandex.ru/v5/general.xsd"/>
+            <xsd:import namespace="http://api.direct.yandex.com/v5/adextensiontypes" schemaLocation="https://soap.direct.yandex.ru/v5/adextensiontypes.xsd"/>
+            <xsd:simpleType name="AdExtensionFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Id"/>
+                    <xsd:enumeration value="Type"/>
+                    <xsd:enumeration value="State"/>
+                    <xsd:enumeration value="Status"/>
+                    <xsd:enumeration value="StatusClarification"/>
+                    <xsd:enumeration value="Associated"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="CalloutFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="CalloutText"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="AdExtensionGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ext:AdExtensionBase">
+                        <xsd:sequence>
+                            <xsd:element name="Id" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="Associated" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="AdExtensionAddItem">
+                <xsd:sequence>
+                    <xsd:element name="Callout" type="ext:Callout" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="AdExtensionsSelectionCriteria">
+                <xsd:sequence>
+                    <xsd:element name="Ids" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="Types" type="ext:AdExtensionTypeEnum" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="States" type="ext:AdExtensionStateSelectionEnum" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="Statuses" type="general:ExtensionStatusSelectionEnum" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="ModifiedSince" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="GetRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetRequestGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="SelectionCriteria" type="ns:AdExtensionsSelectionCriteria" minOccurs="1" maxOccurs="1"/>
+                                <xsd:element name="FieldNames" type="ns:AdExtensionFieldEnum" minOccurs="1" maxOccurs="unbounded"/>
+                                <xsd:element name="CalloutFieldNames" type="ns:CalloutFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetResponse">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetResponseGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="AdExtensions" type="ns:AdExtensionGetItem" minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="AdExtensions" type="ns:AdExtensionAddItem" minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="AddResults" type="general:ActionResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DeleteRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DeleteResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="DeleteResults" type="general:ActionResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="ApiException">
+        <wsdl:part element="general:FaultResponse" name="faultMessage"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationRequest">
+        <wsdl:part name="parameters" element="ns:AddRequest"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationResponse">
+        <wsdl:part name="parameters" element="ns:AddResponse"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationRequest">
+        <wsdl:part name="parameters" element="ns:GetRequest"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationResponse">
+        <wsdl:part name="parameters" element="ns:GetResponse"/>
+    </wsdl:message>
+    <wsdl:message name="DeleteOperationRequest">
+        <wsdl:part name="parameters" element="ns:DeleteRequest"/>
+    </wsdl:message>
+    <wsdl:message name="DeleteOperationResponse">
+        <wsdl:part name="parameters" element="ns:DeleteResponse"/>
+    </wsdl:message>
+    <wsdl:portType name="AdExtensionsPort">
+        <wsdl:operation name="add">
+            <wsdl:input name="addRequest" message="ns:AddOperationRequest"/>
+            <wsdl:output message="ns:AddOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="get">
+            <wsdl:input name="getRequest" message="ns:GetOperationRequest"/>
+            <wsdl:output message="ns:GetOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <wsdl:input name="deleteRequest" message="ns:DeleteOperationRequest"/>
+            <wsdl:output message="ns:DeleteOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="AdExtensionsSOAP" type="ns:AdExtensionsPort">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="add">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/adextensions/add"/>
+            <wsdl:input name="addRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="get">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/adextensions/get"/>
+            <wsdl:input name="getRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/adextensions/delete"/>
+            <wsdl:input name="deleteRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="AdExtensions">
+        <wsdl:port name="AdExtensionsSOAP" binding="ns:AdExtensionsSOAP">
+            <soap:address location="https://soap.direct.yandex.ru/v5/adextensions/"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/tests/wsdl_cache/adgroups.xml
+++ b/tests/wsdl_cache/adgroups.xml
@@ -1,0 +1,551 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+    xmlns:ns="http://api.direct.yandex.com/v5/adgroups" xmlns:general="http://api.direct.yandex.com/v5/general"
+    xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    name="AdGroups" targetNamespace="http://api.direct.yandex.com/v5/adgroups">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://api.direct.yandex.com/v5/adgroups">
+            <xsd:import namespace="http://api.direct.yandex.com/v5/general" schemaLocation="https://soap.direct.yandex.ru/v5/general.xsd"/>
+            <xsd:simpleType name="AdGroupFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Id"/>
+                    <xsd:enumeration value="CampaignId"/>
+                    <xsd:enumeration value="Status"/>
+                    <xsd:enumeration value="Name"/>
+                    <xsd:enumeration value="RegionIds"/>
+                    <xsd:enumeration value="RestrictedRegionIds"/>
+                    <xsd:enumeration value="NegativeKeywords"/>
+                    <xsd:enumeration value="NegativeKeywordSharedSetIds"/>
+                    <xsd:enumeration value="Type"/>
+                    <xsd:enumeration value="TrackingParams"/>
+                    <xsd:enumeration value="Subtype"/>
+                    <xsd:enumeration value="ServingStatus"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="MobileAppAdGroupFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="StoreUrl"/>
+                    <xsd:enumeration value="TargetDeviceType"/>
+                    <xsd:enumeration value="TargetCarrier"/>
+                    <xsd:enumeration value="TargetOperatingSystemVersion"/>
+                    <xsd:enumeration value="AppIconModeration"/>
+                    <xsd:enumeration value="AppAvailabilityStatus"/>
+                    <xsd:enumeration value="AppOperatingSystemType"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="DynamicTextAdGroupFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="AutotargetingCategories"/>
+                    <xsd:enumeration value="AutotargetingSettings"/>
+                    <xsd:enumeration value="DomainUrl"/>
+                    <xsd:enumeration value="DomainUrlProcessingStatus"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="DynamicTextFeedAdGroupFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="AutotargetingCategories"/>
+                    <xsd:enumeration value="AutotargetingSettings"/>
+                    <xsd:enumeration value="Source"/>
+                    <xsd:enumeration value="FeedId"/>
+                    <xsd:enumeration value="SourceType"/>
+                    <xsd:enumeration value="SourceProcessingStatus"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="SmartAdGroupFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="FeedId"/>
+                    <xsd:enumeration value="AdTitleSource"/>
+                    <xsd:enumeration value="AdBodySource"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="TextAdGroupFeedParamsFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="FeedId"/>
+                    <xsd:enumeration value="FeedCategoryIds"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="UnifiedAdGroupFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="OfferRetargeting"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="AdGroupSubtypeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="WEBPAGE"/>
+                    <xsd:enumeration value="FEED"/>
+                    <xsd:enumeration value="NONE"/>
+                    <xsd:enumeration value="KEYWORDS"/>
+                    <xsd:enumeration value="USER_PROFILE"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="AdGroupStatusSelectionEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="ACCEPTED"/>
+                    <xsd:enumeration value="DRAFT"/>
+                    <xsd:enumeration value="MODERATION"/>
+                    <xsd:enumeration value="REJECTED"/>
+                    <xsd:enumeration value="PREACCEPTED"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="AdGroupAppIconStatusSelectionEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="ACCEPTED"/>
+                    <xsd:enumeration value="MODERATION"/>
+                    <xsd:enumeration value="REJECTED"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="SourceProcessingStatusEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="EMPTY_RESULT"/>
+                    <xsd:enumeration value="PROCESSED"/>
+                    <xsd:enumeration value="UNKNOWN"/>
+                    <xsd:enumeration value="UNPROCESSED"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="SourceTypeGetEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="RETAIL_FEED"/>
+                    <xsd:enumeration value="UNKNOWN"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="AdGroupsSelectionCriteria">
+                <xsd:sequence>
+                    <xsd:element name="CampaignIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="Ids" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="Types" type="general:AdGroupTypesEnum" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="Statuses" type="ns:AdGroupStatusSelectionEnum" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="TagIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="Tags" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="AppIconStatuses" type="ns:AdGroupAppIconStatusSelectionEnum" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="ServingStatuses" type="general:ServingStatusEnum" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="NegativeKeywordSharedSetIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="AdGroupBase">
+                <xsd:sequence>
+                    <xsd:element name="RegionIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="NegativeKeywords" type="general:ArrayOfString" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="NegativeKeywordSharedSetIds" type="general:ArrayOfLong" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="TrackingParams" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="AdGroupAddItem">
+                <xsd:sequence>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="CampaignId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="RegionIds" type="xsd:long" minOccurs="1" maxOccurs="unbounded"/>
+                    <!--  not required, if specified but couldn't be empty  -->
+                    <xsd:element name="NegativeKeywords" type="general:ArrayOfString" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="NegativeKeywordSharedSetIds" type="general:ArrayOfLong" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="TrackingParams" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="MobileAppAdGroup" type="ns:MobileAppAdGroupAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="DynamicTextAdGroup" type="ns:DynamicTextAdGroup" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="DynamicTextFeedAdGroup" type="ns:DynamicTextFeedAdGroup" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CpmBannerKeywordsAdGroup" type="ns:CpmBannerKeywordsAdGroupAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CpmBannerUserProfileAdGroup" type="ns:CpmBannerUserProfileAdGroupAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CpmVideoAdGroup" type="ns:CpmVideoAdGroupAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="SmartAdGroup" type="ns:SmartAdGroupAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="UnifiedAdGroup" type="ns:UnifiedAdGroupAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="TextAdGroupFeedParams" type="ns:TextAdGroupFeedParamsAdd" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="AdGroupGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:AdGroupBase">
+                        <xsd:sequence>
+                            <xsd:element name="Id" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="Name" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="CampaignId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="Status" type="general:StatusEnum" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="Type" type="general:AdGroupTypesEnum" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="Subtype" type="ns:AdGroupSubtypeEnum" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="MobileAppAdGroup" type="ns:MobileAppAdGroupGet" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="DynamicTextAdGroup" type="ns:DynamicTextAdGroupGet" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="DynamicTextFeedAdGroup" type="ns:DynamicTextFeedAdGroupGet" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="SmartAdGroup" type="ns:SmartAdGroupGet" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="ServingStatus" type="general:ServingStatusEnum" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="RestrictedRegionIds" type="general:ArrayOfLong" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="TextAdGroupFeedParams" type="ns:TextAdGroupFeedParamsGet" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="UnifiedAdGroup" type="ns:UnifiedAdGroupGet" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:simpleType name="TargetDeviceTypeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="DEVICE_TYPE_MOBILE"/>
+                    <xsd:enumeration value="DEVICE_TYPE_TABLET"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="TargetCarrierEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="WI_FI_ONLY"/>
+                    <xsd:enumeration value="WI_FI_AND_CELLULAR"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="AppAvailabilityStatusEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="UNPROCESSED"/>
+                    <xsd:enumeration value="AVAILABLE"/>
+                    <xsd:enumeration value="NOT_AVAILABLE"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="MobileAppAdGroupGet">
+                <xsd:sequence>
+                    <xsd:element name="StoreUrl" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="TargetDeviceType" type="ns:TargetDeviceTypeEnum" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="TargetCarrier" type="ns:TargetCarrierEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="TargetOperatingSystemVersion" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AppIconModeration" type="general:ExtensionModeration" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="AppOperatingSystemType" type="general:MobileOperatingSystemTypeEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AppAvailabilityStatus" type="ns:AppAvailabilityStatusEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAppAdGroupUpdate">
+                <xsd:sequence>
+                    <xsd:element name="TargetDeviceType" type="ns:TargetDeviceTypeEnum" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="TargetCarrier" type="ns:TargetCarrierEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="TargetOperatingSystemVersion" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAppAdGroupAdd">
+                <xsd:sequence>
+                    <xsd:element name="StoreUrl" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="TargetDeviceType" type="ns:TargetDeviceTypeEnum" minOccurs="1" maxOccurs="unbounded"/>
+                    <xsd:element name="TargetCarrier" type="ns:TargetCarrierEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="TargetOperatingSystemVersion" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="DynamicAdGroup">
+                <xsd:sequence>
+                    <xsd:element name="AutotargetingCategories" type="general:AutotargetingCategory" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="AutotargetingSettings" type="general:AutotargetingSettings" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="DynamicAdGroupGet">
+                <xsd:sequence>
+                    <xsd:element name="AutotargetingCategories" type="general:AutotargetingCategoryArray" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AutotargetingSettings" type="general:AutotargetingSettings" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="DynamicTextAdGroup">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:DynamicAdGroup">
+                        <xsd:sequence>
+                            <xsd:element name="DomainUrl" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="DynamicTextAdGroupGet">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:DynamicAdGroupGet">
+                        <xsd:sequence>
+                            <xsd:element name="DomainUrl" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="DomainUrlProcessingStatus" type="ns:SourceProcessingStatusEnum" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="DynamicTextFeedAdGroup">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:DynamicAdGroup">
+                        <xsd:sequence>
+                            <xsd:element name="FeedId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="DynamicTextFeedAdGroupUpdate">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:DynamicAdGroup">
+                        <xsd:sequence>
+                            <xsd:element name="FeedId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="DynamicSourceGet">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:DynamicAdGroupGet">
+                        <xsd:sequence>
+                            <xsd:element name="Source" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="FeedId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="SourceType" type="ns:SourceTypeGetEnum" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="SourceProcessingStatus" type="ns:SourceProcessingStatusEnum" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="DynamicTextFeedAdGroupGet">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:DynamicSourceGet"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="TextAdGroupFeedParamsAdd">
+                <xsd:sequence>
+                    <xsd:element name="FeedId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="FeedCategoryIds" type="general:ArrayOfLong" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="TextAdGroupFeedParamsUpdate">
+                <xsd:sequence>
+                    <xsd:element name="FeedId" type="xsd:long" minOccurs="1" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="FeedCategoryIds" type="general:ArrayOfLong" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="TextAdGroupFeedParamsGet">
+                <xsd:sequence>
+                    <xsd:element name="FeedId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="FeedCategoryIds" type="general:ArrayOfLong" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="UnifiedAdGroupGet">
+                <xsd:sequence>
+                    <xsd:element name="OfferRetargeting" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="CpmBannerKeywordsAdGroupAdd">
+                <xsd:sequence/>
+            </xsd:complexType>
+            <xsd:complexType name="CpmBannerUserProfileAdGroupAdd">
+                <xsd:sequence/>
+            </xsd:complexType>
+            <xsd:complexType name="CpmVideoAdGroupAdd">
+                <xsd:sequence/>
+            </xsd:complexType>
+            <xsd:complexType name="UnifiedAdGroupAdd">
+                <xsd:sequence>
+                    <xsd:element name="OfferRetargeting" type="general:YesNoEnum" minOccurs="1" maxOccurs="1" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="UnifiedAdGroupUpdate">
+                <xsd:sequence>
+                    <xsd:element name="OfferRetargeting" type="general:YesNoEnum" minOccurs="0" maxOccurs="1" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SmartAdGroupAdd">
+                <xsd:sequence>
+                    <xsd:element name="FeedId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="AdTitleSource" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AdBodySource" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SmartAdGroupGet">
+                <xsd:sequence>
+                    <xsd:element name="FeedId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AdTitleSource" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="AdBodySource" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SmartAdGroupUpdate">
+                <xsd:sequence>
+                    <xsd:element name="AdTitleSource" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="AdBodySource" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="AdGroupUpdateItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:AdGroupBase">
+                        <xsd:sequence>
+                            <xsd:element name="Id" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="Name" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="MobileAppAdGroup" type="ns:MobileAppAdGroupUpdate" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="DynamicTextAdGroup" type="ns:DynamicTextAdGroup" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="DynamicTextFeedAdGroup" type="ns:DynamicTextFeedAdGroupUpdate" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="SmartAdGroup" type="ns:SmartAdGroupUpdate" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="TextAdGroupFeedParams" type="ns:TextAdGroupFeedParamsUpdate" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="UnifiedAdGroup" type="ns:UnifiedAdGroupUpdate" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <!--  Get operation in and our message types  -->
+            <xsd:element name="GetRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetRequestGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="SelectionCriteria" type="ns:AdGroupsSelectionCriteria" minOccurs="1" maxOccurs="1"/>
+                                <xsd:element name="FieldNames" type="ns:AdGroupFieldEnum" minOccurs="1" maxOccurs="unbounded"/>
+                                <xsd:element name="MobileAppAdGroupFieldNames" type="ns:MobileAppAdGroupFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="DynamicTextAdGroupFieldNames" type="ns:DynamicTextAdGroupFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="DynamicTextFeedAdGroupFieldNames" type="ns:DynamicTextFeedAdGroupFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="AutotargetingSettingsCategoriesFieldNames" type="general:AutotargetingCategoriesFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="AutotargetingSettingsBrandOptionsFieldNames" type="general:AutotargetingBrandOptionsFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="SmartAdGroupFieldNames" type="ns:SmartAdGroupFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="TextAdGroupFeedParamsFieldNames" type="ns:TextAdGroupFeedParamsFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="UnifiedAdGroupFieldNames" type="ns:UnifiedAdGroupFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetResponse">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetResponseGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="AdGroups" type="ns:AdGroupGetItem" minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <!--  / End of Get operation types  -->
+            <!--  Add operation types  -->
+            <xsd:element name="AddRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="AdGroups" type="ns:AdGroupAddItem" minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="AddResults" type="general:ActionResult" minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <!--  end of Add operation types  -->
+            <!--  Update operation types  -->
+            <xsd:element name="UpdateRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="AdGroups" type="ns:AdGroupUpdateItem" minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="UpdateResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="UpdateResults" type="general:ActionResult" minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <!--  end of Update operation types  -->
+            <!--  Delete operation types  -->
+            <xsd:element name="DeleteRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DeleteResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="DeleteResults" type="general:ActionResult" minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <!--  Delete operation types  -->
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="ApiException">
+        <wsdl:part element="general:FaultResponse" name="faultMessage"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationRequest">
+        <wsdl:part element="ns:GetRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationResponse">
+        <wsdl:part element="ns:GetResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationRequest">
+        <wsdl:part element="ns:AddRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationResponse">
+        <wsdl:part element="ns:AddResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="UpdateOperationRequest">
+        <wsdl:part element="ns:UpdateRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="UpdateOperationResponse">
+        <wsdl:part element="ns:UpdateResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="DeleteOperationRequest">
+        <wsdl:part element="ns:DeleteRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="DeleteOperationResponse">
+        <wsdl:part element="ns:DeleteResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:portType name="AdGroupsPort">
+        <wsdl:operation name="get">
+            <wsdl:input message="ns:GetOperationRequest" name="getRequest"/>
+            <wsdl:output message="ns:GetOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="add">
+            <wsdl:input message="ns:AddOperationRequest" name="addRequest"/>
+            <wsdl:output message="ns:AddOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="update">
+            <wsdl:input message="ns:UpdateOperationRequest" name="updateRequest"/>
+            <wsdl:output message="ns:UpdateOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <wsdl:input message="ns:DeleteOperationRequest" name="deleteRequest"/>
+            <wsdl:output message="ns:DeleteOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="AdGroupsSOAP" type="ns:AdGroupsPort">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="get">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/adgroups/get"/>
+            <wsdl:input name="getRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="add">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/adgroups/add"/>
+            <wsdl:input name="addRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="update">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/adgroups/update"/>
+            <wsdl:input name="updateRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/adgroups/delete"/>
+            <wsdl:input name="deleteRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="AdGroups">
+        <wsdl:port binding="ns:AdGroupsSOAP" name="AdGroupsSOAP">
+            <soap:address location="https://soap.direct.yandex.ru/v5/adgroups/"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/tests/wsdl_cache/adimages.xml
+++ b/tests/wsdl_cache/adimages.xml
@@ -1,0 +1,270 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:general="http://api.direct.yandex.com/v5/general"
+                  xmlns:ns="http://api.direct.yandex.com/v5/adimages"
+                  name="AdImages"
+                  targetNamespace="http://api.direct.yandex.com/v5/adimages">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://api.direct.yandex.com/v5/adimages">
+            <xsd:import namespace="http://api.direct.yandex.com/v5/general" schemaLocation="https://soap.direct.yandex.ru/v5/general.xsd" />
+            <xsd:simpleType name="AdImageFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="AdImageHash"/>
+                    <xsd:enumeration value="OriginalUrl"/>
+                    <xsd:enumeration value="PreviewUrl"/>
+                    <xsd:enumeration value="Name"/>
+                    <xsd:enumeration value="Type"/>
+                    <xsd:enumeration value="Subtype"/>
+                    <xsd:enumeration value="Associated"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="AdImageTypeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="SMALL"/>
+                    <xsd:enumeration value="REGULAR"/>
+                    <xsd:enumeration value="WIDE"/>
+                    <xsd:enumeration value="FIXED_IMAGE"/>
+                    <xsd:enumeration value="UNFIT"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="AdImageAddTypeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="REGULAR"/>
+                    <xsd:enumeration value="WIDE"/>
+                    <xsd:enumeration value="FIXED_IMAGE"/>
+                    <xsd:enumeration value="AUTO"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="AdImageSubtypeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="IMG_240_400"/>
+                    <xsd:enumeration value="IMG_300_250"/>
+                    <xsd:enumeration value="IMG_300_500"/>
+                    <xsd:enumeration value="IMG_300_600"/>
+                    <xsd:enumeration value="IMG_320_50"/>
+                    <xsd:enumeration value="IMG_320_100"/>
+                    <xsd:enumeration value="IMG_320_480"/>
+                    <xsd:enumeration value="IMG_336_280"/>
+                    <xsd:enumeration value="IMG_480_320"/>
+                    <xsd:enumeration value="IMG_728_90"/>
+                    <xsd:enumeration value="IMG_970_250"/>
+                    <xsd:enumeration value="IMG_516_272"/>
+                    <xsd:enumeration value="IMG_223_159"/>
+                    <xsd:enumeration value="IMG_480_800"/>
+                    <xsd:enumeration value="IMG_600_500"/>
+                    <xsd:enumeration value="IMG_600_1000"/>
+                    <xsd:enumeration value="IMG_600_1200"/>
+                    <xsd:enumeration value="IMG_640_100"/>
+                    <xsd:enumeration value="IMG_640_200"/>
+                    <xsd:enumeration value="IMG_640_960"/>
+                    <xsd:enumeration value="IMG_672_560"/>
+                    <xsd:enumeration value="IMG_960_640"/>
+                    <xsd:enumeration value="IMG_1456_180"/>
+                    <xsd:enumeration value="IMG_1940_500"/>
+                    <xsd:enumeration value="IMG_1032_544"/>
+		    <xsd:enumeration value="IMG_446_318"/>
+                    <xsd:enumeration value="IMG_720_1200"/>
+                    <xsd:enumeration value="IMG_900_750"/>
+                    <xsd:enumeration value="IMG_900_1500"/>
+                    <xsd:enumeration value="IMG_900_1800"/>
+                    <xsd:enumeration value="IMG_960_150"/>
+                    <xsd:enumeration value="IMG_960_300"/>
+                    <xsd:enumeration value="IMG_960_1440"/>
+                    <xsd:enumeration value="IMG_1008_840"/>
+                    <xsd:enumeration value="IMG_1440_960"/>
+                    <xsd:enumeration value="IMG_2184_270"/>
+                    <xsd:enumeration value="IMG_2910_750"/>
+                    <xsd:enumeration value="IMG_1548_816"/>
+		    <xsd:enumeration value="IMG_669_477"/>
+                    <xsd:enumeration value="IMG_960_1600"/>
+                    <xsd:enumeration value="IMG_1200_1000"/>
+                    <xsd:enumeration value="IMG_1200_2000"/>
+                    <xsd:enumeration value="IMG_1200_2400"/>
+                    <xsd:enumeration value="IMG_1280_200"/>
+                    <xsd:enumeration value="IMG_1280_400"/>
+                    <xsd:enumeration value="IMG_1280_1920"/>
+                    <xsd:enumeration value="IMG_1344_1120"/>
+                    <xsd:enumeration value="IMG_1920_1280"/>
+                    <xsd:enumeration value="IMG_2912_360"/>
+                    <xsd:enumeration value="IMG_3880_1000"/>
+                    <xsd:enumeration value="IMG_2064_1088"/>
+		    <xsd:enumeration value="IMG_892_636"/>
+                    <xsd:enumeration value="NONE"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="AdImageAddItem">
+                <xsd:sequence>
+                    <xsd:element name="ImageData" type="xsd:base64Binary" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Type" type="ns:AdImageAddTypeEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="AdImageGetItem">
+                <xsd:sequence>
+                    <xsd:element name="AdImageHash" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Associated" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Type" type="ns:AdImageTypeEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Subtype" type="ns:AdImageSubtypeEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="OriginalUrl" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true" />
+                    <xsd:element name="PreviewUrl" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="AdImageSelectionCriteria">
+                <xsd:sequence>
+                    <xsd:element name="AdImageHashes" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="Associated" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="AdImageHashesCriteria">
+                <xsd:sequence>
+                    <xsd:element name="AdImageHashes" type="xsd:string" minOccurs="1" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="AdImageActionResult">
+                <xsd:complexContent>
+                    <xsd:extension base="general:ActionResultBase">
+                        <xsd:sequence>
+                            <xsd:element name="AdImageHash" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:element name="GetRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetRequestGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="SelectionCriteria" type="ns:AdImageSelectionCriteria" minOccurs="0" maxOccurs="1"/>
+                                <xsd:element name="FieldNames" type="ns:AdImageFieldEnum" minOccurs="1" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetResponse">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetResponseGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="AdImages" type="ns:AdImageGetItem" minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="AdImages" type="ns:AdImageAddItem" minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="AddResults" type="ns:AdImageActionResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DeleteRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="ns:AdImageHashesCriteria" minOccurs="1" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DeleteResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="DeleteResults" type="ns:AdImageActionResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="ApiException">
+        <wsdl:part element="general:FaultResponse" name="faultMessage"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationRequest">
+        <wsdl:part name="parameters" element="ns:AddRequest"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationResponse">
+        <wsdl:part name="parameters" element="ns:AddResponse"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationRequest">
+        <wsdl:part name="parameters" element="ns:GetRequest"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationResponse">
+        <wsdl:part name="parameters" element="ns:GetResponse"/>
+    </wsdl:message>
+    <wsdl:message name="DeleteOperationRequest">
+        <wsdl:part name="parameters" element="ns:DeleteRequest"/>
+    </wsdl:message>
+    <wsdl:message name="DeleteOperationResponse">
+        <wsdl:part name="parameters" element="ns:DeleteResponse"/>
+    </wsdl:message>
+    <wsdl:portType name="AdImagesPort">
+        <wsdl:operation name="add">
+            <wsdl:input name="addRequest" message="ns:AddOperationRequest"/>
+            <wsdl:output message="ns:AddOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="get">
+            <wsdl:input name="getRequest" message="ns:GetOperationRequest"/>
+            <wsdl:output message="ns:GetOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <wsdl:input name="deleteRequest" message="ns:DeleteOperationRequest"/>
+            <wsdl:output message="ns:DeleteOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="AdImagesSOAP" type="ns:AdImagesPort">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="add">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/adimages/add"/>
+            <wsdl:input name="addRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="get">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/adimages/get"/>
+            <wsdl:input name="getRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/adimages/delete"/>
+            <wsdl:input name="deleteRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="AdImages">
+        <wsdl:port name="AdImagesSOAP" binding="ns:AdImagesSOAP">
+            <soap:address location="https://soap.direct.yandex.ru/v5/adimages"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/tests/wsdl_cache/ads.xml
+++ b/tests/wsdl_cache/ads.xml
@@ -1,0 +1,1622 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:ns="http://api.direct.yandex.com/v5/ads"
+                  xmlns:general="http://api.direct.yandex.com/v5/general"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema" name="Ads"
+                  xmlns:ext="http://api.direct.yandex.com/v5/adextensiontypes"
+                  targetNamespace="http://api.direct.yandex.com/v5/ads">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://api.direct.yandex.com/v5/ads">
+            <xsd:import namespace="http://api.direct.yandex.com/v5/general" schemaLocation="https://soap.direct.yandex.ru/v5/general.xsd" />
+            <xsd:import namespace="http://api.direct.yandex.com/v5/adextensiontypes" schemaLocation="https://soap.direct.yandex.ru/v5/adextensiontypes.xsd" />
+            <!-- ENUMERATES -->
+            <xsd:simpleType name="AdCategoryEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="ABORTION"/>
+                    <xsd:enumeration value="ALCOHOL"/>
+                    <xsd:enumeration value="BABY_FOOD"/>
+                    <xsd:enumeration value="DIETARY_SUPPLEMENTS"/>
+                    <xsd:enumeration value="MEDICINE"/>
+                    <xsd:enumeration value="PROJECT_DECLARATION"/>
+                    <xsd:enumeration value="PSEUDO_WEAPON"/>
+                    <xsd:enumeration value="TOBACCO"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="AgeLabelEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="MONTHS_0"/>
+                    <xsd:enumeration value="MONTHS_1"/>
+                    <xsd:enumeration value="MONTHS_2"/>
+                    <xsd:enumeration value="MONTHS_3"/>
+                    <xsd:enumeration value="MONTHS_4"/>
+                    <xsd:enumeration value="MONTHS_5"/>
+                    <xsd:enumeration value="MONTHS_6"/>
+                    <xsd:enumeration value="MONTHS_7"/>
+                    <xsd:enumeration value="MONTHS_8"/>
+                    <xsd:enumeration value="MONTHS_9"/>
+                    <xsd:enumeration value="MONTHS_10"/>
+                    <xsd:enumeration value="MONTHS_11"/>
+                    <xsd:enumeration value="MONTHS_12"/>
+                    <xsd:enumeration value="AGE_0"/>
+                    <xsd:enumeration value="AGE_6"/>
+                    <xsd:enumeration value="AGE_12"/>
+                    <xsd:enumeration value="AGE_16"/>
+                    <xsd:enumeration value="AGE_18"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="MobAppAgeLabelEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="AGE_0"/>
+                    <xsd:enumeration value="AGE_6"/>
+                    <xsd:enumeration value="AGE_12"/>
+                    <xsd:enumeration value="AGE_16"/>
+                    <xsd:enumeration value="AGE_18"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="AdFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="AdCategories"/>
+                    <xsd:enumeration value="AgeLabel"/>
+                    <xsd:enumeration value="AdGroupId"/>
+                    <xsd:enumeration value="CampaignId"/>
+                    <xsd:enumeration value="Id"/>
+                    <xsd:enumeration value="State"/>
+                    <xsd:enumeration value="Status"/>
+                    <xsd:enumeration value="StatusClarification"/>
+                    <xsd:enumeration value="Type"/>
+                    <xsd:enumeration value="Subtype"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="AdStateSelectionEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="OFF" />
+                    <xsd:enumeration value="ON" />
+                    <xsd:enumeration value="SUSPENDED" />
+                    <xsd:enumeration value="OFF_BY_MONITORING" />
+                    <xsd:enumeration value="ARCHIVED" />
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="AdStatusSelectionEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="DRAFT" />
+                    <xsd:enumeration value="MODERATION" />
+                    <xsd:enumeration value="PREACCEPTED" />
+                    <xsd:enumeration value="ACCEPTED" />
+                    <xsd:enumeration value="REJECTED" />
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="TextAdFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="AdImageHash"/>
+                    <xsd:enumeration value="DisplayDomain"/>
+                    <xsd:enumeration value="FinalUrl"/>
+                    <xsd:enumeration value="Href"/>
+                    <xsd:enumeration value="SitelinkSetId"/>
+                    <xsd:enumeration value="Text"/>
+                    <xsd:enumeration value="Title"/>
+                    <xsd:enumeration value="Title2"/>
+                    <xsd:enumeration value="Mobile"/>
+                    <xsd:enumeration value="VCardId"/>
+                    <xsd:enumeration value="DisplayUrlPath"/>
+                    <xsd:enumeration value="AdImageModeration"/>
+                    <xsd:enumeration value="SitelinksModeration"/>
+                    <xsd:enumeration value="VCardModeration"/>
+                    <xsd:enumeration value="AdExtensions"/>
+                    <xsd:enumeration value="DisplayUrlPathModeration"/>
+                    <xsd:enumeration value="VideoExtension"/>
+                    <xsd:enumeration value="TurboPageId"/>
+                    <xsd:enumeration value="TurboPageModeration"/>
+                    <xsd:enumeration value="BusinessId"/>
+                    <xsd:enumeration value="PreferVCardOverBusiness"/>
+                    <xsd:enumeration value="ErirAdDescription"/>
+                    <xsd:enumeration value="AutogeneratedErirAdDescription"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="TextAdPriceExtensionFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Price"/>
+                    <xsd:enumeration value="OldPrice"/>
+                    <xsd:enumeration value="PriceCurrency"/>
+                    <xsd:enumeration value="PriceQualifier"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="ResponsiveAdFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="AdImages"/>
+                    <xsd:enumeration value="DisplayDomain"/>
+                    <xsd:enumeration value="Href"/>
+                    <xsd:enumeration value="SitelinkSetId"/>
+                    <xsd:enumeration value="Texts"/>
+                    <xsd:enumeration value="Titles"/>
+                    <xsd:enumeration value="DisplayUrlPath"/>
+                    <xsd:enumeration value="SitelinksModeration"/>
+                    <xsd:enumeration value="AdExtensions"/>
+                    <xsd:enumeration value="DisplayUrlPathModeration"/>
+                    <xsd:enumeration value="PriceExtension"/>
+                    <xsd:enumeration value="VideoExtensions"/>
+                    <xsd:enumeration value="BusinessId"/>
+                    <xsd:enumeration value="ErirAdDescription"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="DynamicTextAdFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="AdImageHash"/>
+                    <xsd:enumeration value="SitelinkSetId"/>
+                    <xsd:enumeration value="Text"/>
+                    <xsd:enumeration value="VCardId"/>
+                    <xsd:enumeration value="AdImageModeration"/>
+                    <xsd:enumeration value="SitelinksModeration"/>
+                    <xsd:enumeration value="VCardModeration"/>
+                    <xsd:enumeration value="AdExtensions"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="MobileAppAdFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="AdImageHash"/>
+                    <xsd:enumeration value="Title" />
+                    <xsd:enumeration value="Text" />
+                    <xsd:enumeration value="Features" />
+                    <xsd:enumeration value="Action" />
+                    <xsd:enumeration value="TrackingUrl" />
+                    <xsd:enumeration value="AdImageModeration"/>
+                    <xsd:enumeration value="VideoExtension"/>
+                    <xsd:enumeration value="ErirAdDescription"/>
+                    <xsd:enumeration value="AutogeneratedErirAdDescription"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="TextImageAdFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="AdImageHash"/>
+                    <xsd:enumeration value="FinalUrl"/>
+                    <xsd:enumeration value="Href"/>
+                    <xsd:enumeration value="TurboPageId"/>
+                    <xsd:enumeration value="TurboPageModeration"/>
+                    <xsd:enumeration value="ErirAdDescription"/>
+                    <xsd:enumeration value="AutogeneratedErirAdDescription"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="MobileAppImageAdFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="AdImageHash"/>
+                    <xsd:enumeration value="TrackingUrl"/>
+                    <xsd:enumeration value="ErirAdDescription"/>
+                    <xsd:enumeration value="AutogeneratedErirAdDescription"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="TextAdBuilderAdFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Creative"/>
+                    <xsd:enumeration value="FinalUrl"/>
+                    <xsd:enumeration value="Href"/>
+                    <xsd:enumeration value="TurboPageId"/>
+                    <xsd:enumeration value="TurboPageModeration"/>
+                    <xsd:enumeration value="ErirAdDescription"/>
+                    <xsd:enumeration value="AutogeneratedErirAdDescription"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="MobileAppAdBuilderAdFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Creative"/>
+                    <xsd:enumeration value="TrackingUrl"/>
+                    <xsd:enumeration value="ErirAdDescription"/>
+                    <xsd:enumeration value="AutogeneratedErirAdDescription"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="MobileAppCpcVideoAdBuilderAdFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Creative"/>
+                    <xsd:enumeration value="TrackingUrl"/>
+                    <xsd:enumeration value="ErirAdDescription"/>
+                    <xsd:enumeration value="AutogeneratedErirAdDescription"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="CpmBannerAdBuilderAdFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Creative"/>
+                    <xsd:enumeration value="Href"/>
+                    <xsd:enumeration value="TrackingPixels"/>
+                    <xsd:enumeration value="TurboPageId"/>
+                    <xsd:enumeration value="TurboPageModeration"/>
+                    <xsd:enumeration value="ErirAdDescription"/>
+                    <xsd:enumeration value="AutogeneratedErirAdDescription"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="CpcVideoAdBuilderAdFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Creative"/>
+                    <xsd:enumeration value="Href"/>
+                    <xsd:enumeration value="TurboPageId"/>
+                    <xsd:enumeration value="TurboPageModeration"/>
+                    <xsd:enumeration value="ErirAdDescription"/>
+                    <xsd:enumeration value="AutogeneratedErirAdDescription"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="CpmVideoAdBuilderAdFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Creative"/>
+                    <xsd:enumeration value="Href"/>
+                    <xsd:enumeration value="TrackingPixels"/>
+                    <xsd:enumeration value="TurboPageId"/>
+                    <xsd:enumeration value="TurboPageModeration"/>
+                    <xsd:enumeration value="ErirAdDescription"/>
+                    <xsd:enumeration value="AutogeneratedErirAdDescription"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="SmartAdBuilderAdFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Creative"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="ShoppingAdFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="SitelinkSetId"/>
+                    <xsd:enumeration value="SitelinksModeration"/>
+                    <xsd:enumeration value="AdExtensions"/>
+                    <xsd:enumeration value="BusinessId"/>
+                    <xsd:enumeration value="FeedId"/>
+                    <xsd:enumeration value="FeedFilterConditions"/>
+                    <xsd:enumeration value="FeedProcessingStatus"/>
+                    <xsd:enumeration value="TitleSources"/>
+                    <xsd:enumeration value="TextSources"/>
+                    <xsd:enumeration value="DefaultTexts"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="ListingAdFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="SitelinkSetId"/>
+                    <xsd:enumeration value="SitelinksModeration"/>
+                    <xsd:enumeration value="AdExtensions"/>
+                    <xsd:enumeration value="BusinessId"/>
+                    <xsd:enumeration value="FeedId"/>
+                    <xsd:enumeration value="FeedFilterConditions"/>
+                    <xsd:enumeration value="FeedProcessingStatus"/>
+                    <xsd:enumeration value="TitleSources"/>
+                    <xsd:enumeration value="TextSources"/>
+                    <xsd:enumeration value="DefaultTexts"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="AdTypeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="TEXT_AD"/>
+                    <xsd:enumeration value="MOBILE_APP_AD"/>
+                    <xsd:enumeration value="DYNAMIC_TEXT_AD"/>
+                    <xsd:enumeration value="IMAGE_AD"/>
+                    <xsd:enumeration value="CPC_VIDEO_AD"/>
+                    <xsd:enumeration value="CPM_BANNER_AD"/>
+                    <xsd:enumeration value="CPM_VIDEO_AD"/>
+                    <xsd:enumeration value="SMART_AD"/>
+                    <xsd:enumeration value="SHOPPING_AD"/>
+                    <xsd:enumeration value="LISTING_AD"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="AdSubtypeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="MOBILE_APP_AD_BUILDER_AD"/>
+                    <xsd:enumeration value="MOBILE_APP_IMAGE_AD"/>
+                    <xsd:enumeration value="MOBILE_APP_CPC_VIDEO_AD_BUILDER_AD"/>
+                    <xsd:enumeration value="NONE"/>
+                    <xsd:enumeration value="TEXT_AD_BUILDER_AD"/>
+                    <xsd:enumeration value="TEXT_IMAGE_AD"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="MobileAppFeatureEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="PRICE" />
+                    <xsd:enumeration value="ICON" />
+                    <xsd:enumeration value="CUSTOMER_RATING" />
+                    <xsd:enumeration value="RATINGS" />
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="PriceCurrencyEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="RUB" />
+                    <xsd:enumeration value="UAH" />
+                    <xsd:enumeration value="BYN" />
+                    <xsd:enumeration value="USD" />
+                    <xsd:enumeration value="EUR" />
+                    <xsd:enumeration value="KZT" />
+                    <xsd:enumeration value="TRY" />
+                    <xsd:enumeration value="CHF" />
+                    <xsd:enumeration value="UZS" />
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="PriceQualifierEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="NONE" />
+                    <xsd:enumeration value="FROM" />
+                    <xsd:enumeration value="UP_TO" />
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="FeedProcessingStatusEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="EMPTY_RESULT"/>
+                    <xsd:enumeration value="PROCESSED"/>
+                    <xsd:enumeration value="UNKNOWN"/>
+                    <xsd:enumeration value="UNPROCESSED"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="ArrayOfAdCategoryEnum">
+                <xsd:sequence>
+                    <xsd:element name="Items" type="ns:AdCategoryEnum" minOccurs="1" maxOccurs="unbounded" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <!-- END ENUMERATES -->
+            <xsd:complexType name="AdExtensionAdGetItem">
+                <xsd:sequence>
+                    <xsd:element name="AdExtensionId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Type" type="ext:AdExtensionTypeEnum" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="TextGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="general:ExtensionModeration">
+                        <xsd:sequence>
+                            <xsd:element name="Text" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="TitleGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="general:ExtensionModeration">
+                        <xsd:sequence>
+                            <xsd:element name="Title" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="ArrayOfAdImageGet">
+                <xsd:sequence>
+                    <xsd:element name="Items" type="ns:AdImageGetItem" minOccurs="0" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="AdImageGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="general:ExtensionModeration">
+                        <xsd:sequence>
+                            <xsd:element name="ImageHash" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="ArrayOfVideoExtensionGet">
+                <xsd:sequence>
+                    <xsd:element name="Items" type="ns:VideoExtensionWithStatusClarificationGetItem" minOccurs="0"
+                                 maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="VideoExtensionWithStatusClarificationGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="general:ExtensionModeration">
+                        <xsd:sequence>
+                            <xsd:element name="CreativeId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="ThumbnailUrl" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="PreviewUrl" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="VideoExtensionGetItem">
+                <xsd:sequence>
+                    <xsd:element name="CreativeId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Status" type="general:StatusEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ThumbnailUrl" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="PreviewUrl" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="TrackingPixelGetItem">
+                <xsd:sequence>
+                    <xsd:element name="TrackingPixel" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Provider" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="TrackingPixelGetArray">
+                <xsd:sequence>
+                    <xsd:element name="Items" type="ns:TrackingPixelGetItem" minOccurs="0" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="VideoExtensionAddItem">
+                <xsd:sequence>
+                    <xsd:element name="CreativeId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="VideoExtensionUpdateItem">
+                <xsd:sequence>
+                    <xsd:element name="CreativeId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="PriceExtensionAddItem">
+                <xsd:sequence>
+                    <xsd:element name="Price" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="OldPrice" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PriceQualifier" type="ns:PriceQualifierEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="PriceCurrency" type="ns:PriceCurrencyEnum" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="PriceExtensionUpdateItem">
+                <xsd:sequence>
+                    <xsd:element name="Price" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="OldPrice" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="PriceQualifier" type="ns:PriceQualifierEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PriceCurrency" type="ns:PriceCurrencyEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="PriceExtensionGetItem">
+                <xsd:sequence>
+                    <xsd:element name="Price" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="OldPrice" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="PriceQualifier" type="ns:PriceQualifierEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PriceCurrency" type="ns:PriceCurrencyEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAppAdFeatureItem">
+                <xsd:sequence>
+                    <xsd:element name="Feature" type="ns:MobileAppFeatureEnum" minOccurs="1" maxOccurs="1" />
+                    <xsd:element name="Enabled" type="general:YesNoEnum" minOccurs="1" maxOccurs="1" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAppAdFeatureGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:MobileAppAdFeatureItem">
+                        <xsd:sequence>
+                            <xsd:element name="IsAvailable" type="general:YesNoUnknownEnum" minOccurs="1" maxOccurs="1" />
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="SmartAdBuilderAdAdd">
+                <xsd:sequence>
+                    <xsd:element name="LogoExtensionHash" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ShoppingAdAdd">
+                <xsd:sequence>
+                    <xsd:element name="SitelinkSetId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AdExtensionIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="BusinessId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="FeedId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="FeedFilterConditions" type="ns:FeedFilterConditionItem" minOccurs="0"
+                                 maxOccurs="unbounded"/>
+                    <xsd:element name="TitleSources" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="TextSources" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="DefaultTexts" type="xsd:string" minOccurs="1" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ListingAdAdd">
+                <xsd:sequence>
+                    <xsd:element name="SitelinkSetId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AdExtensionIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="BusinessId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="FeedId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="FeedFilterConditions" type="ns:FeedFilterConditionItem" minOccurs="0"
+                                 maxOccurs="unbounded"/>
+                    <xsd:element name="TitleSources" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="TextSources" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="DefaultTexts" type="xsd:string" minOccurs="1" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ArrayOfFeedFilterCondition">
+                <xsd:sequence>
+                    <xsd:element name="Items" type="ns:FeedFilterConditionItem" minOccurs="1" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="FeedFilterConditionItem">
+                <xsd:sequence>
+                    <xsd:element name="Operand" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Operator" type="general:StringConditionOperatorEnum" minOccurs="1"
+                                 maxOccurs="1"/>
+                    <xsd:element name="Arguments" type="xsd:string" minOccurs="1" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAppAdBase">
+                <xsd:sequence>
+                    <xsd:element name="Title" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Text" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="TrackingUrl" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="Action" type="general:MobileAppAdActionEnum" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="AdImageHash" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="ErirAdDescription" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SmartAdBuilderAdUpdate">
+                <xsd:sequence>
+                    <xsd:element name="LogoExtensionHash" type="xsd:string" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="ErirAdDescription" type="xsd:string" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ShoppingAdUpdate">
+                <xsd:sequence>
+                    <xsd:element name="SitelinkSetId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="CalloutSetting" type="ext:AdExtensionSetting" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="BusinessId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="FeedFilterConditions" type="ns:ArrayOfFeedFilterCondition" minOccurs="0"
+                                 maxOccurs="1" nillable="true"/>
+                    <xsd:element name="TitleSources" type="general:ArrayOfString" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="TextSources" type="general:ArrayOfString" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="DefaultTexts" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ListingAdUpdate">
+                <xsd:sequence>
+                    <xsd:element name="SitelinkSetId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="CalloutSetting" type="ext:AdExtensionSetting" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="BusinessId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="FeedFilterConditions" type="ns:ArrayOfFeedFilterCondition" minOccurs="0"
+                                 maxOccurs="1" nillable="true"/>
+                    <xsd:element name="TitleSources" type="general:ArrayOfString" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="TextSources" type="general:ArrayOfString" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="DefaultTexts" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <!-- Add Operation Types -->
+            <xsd:complexType name="AdAddItemBase">
+                <xsd:sequence>
+                    <xsd:element name="AdGroupId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="TextAdAddBase">
+                <xsd:sequence>
+                    <xsd:element name="VCardId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AdImageHash" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="SitelinkSetId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AdExtensionIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="AdAddItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:AdAddItemBase">
+                        <xsd:sequence>
+                            <!-- Choice: Required one of:  -->
+                            <xsd:element name="TextAd" type="ns:TextAdAdd" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="ResponsiveAd" type="ns:ResponsiveAdAdd" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="DynamicTextAd" type="ns:DynamicTextAdAdd" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="MobileAppAd" type="ns:MobileAppAdAdd" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="TextImageAd" type="ns:TextImageAdAdd" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="MobileAppImageAd" type="ns:MobileAppImageAdAdd" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="TextAdBuilderAd" type="ns:TextAdBuilderAdAdd" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="MobileAppAdBuilderAd" type="ns:MobileAppAdBuilderAdAdd" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="MobileAppCpcVideoAdBuilderAd" type="ns:MobileAppCpcVideoAdBuilderAdAdd" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="CpmBannerAdBuilderAd" type="ns:CpmBannerAdBuilderAdAdd" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="CpcVideoAdBuilderAd" type="ns:CpcVideoAdBuilderAdAdd" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="CpmVideoAdBuilderAd" type="ns:CpmVideoAdBuilderAdAdd" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="SmartAdBuilderAd" type="ns:SmartAdBuilderAdAdd" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="ShoppingAd" type="ns:ShoppingAdAdd" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="ListingAd" type="ns:ListingAdAdd" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="TextAdAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:TextAdAddBase">
+                        <xsd:sequence>
+                            <xsd:element name="Text" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="Title" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="Title2" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="FinalUrl" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="Href" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="Mobile" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="DisplayUrlPath" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="VideoExtension" type="ns:VideoExtensionAddItem" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="PriceExtension" type="ns:PriceExtensionAddItem" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="TurboPageId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="BusinessId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="PreferVCardOverBusiness" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="ErirAdDescription" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="ResponsiveAdAdd">
+                <xsd:sequence>
+                    <xsd:element name="Texts" type="xsd:string" minOccurs="1" maxOccurs="unbounded"/>
+                    <xsd:element name="Titles" type="xsd:string" minOccurs="1" maxOccurs="unbounded"/>
+                    <xsd:element name="AdImageHashes" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="VideoExtensionIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="Href" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AgeLabel" type="ns:AgeLabelEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="DisplayUrlPath" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="SitelinkSetId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AdExtensionIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="PriceExtension" type="ns:PriceExtensionAddItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="BusinessId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ErirAdDescription" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="DynamicTextAdAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:TextAdAddBase">
+                        <xsd:sequence>
+                            <xsd:element name="Text" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAppAdAdd">
+                <xsd:sequence>
+                    <xsd:element name="AdImageHash" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Text" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Title" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="TrackingUrl" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Action" type="general:MobileAppAdActionEnum" minOccurs="1" maxOccurs="1" />
+                    <xsd:element name="Features" type="ns:MobileAppAdFeatureItem" minOccurs="0" maxOccurs="unbounded" />
+                    <xsd:element name="AgeLabel" type="ns:MobAppAgeLabelEnum" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="VideoExtension" type="ns:VideoExtensionAddItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ErirAdDescription" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ImageAdAddBase">
+                <xsd:sequence>
+                    <xsd:element name="AdImageHash" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="ErirAdDescription" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="TextImageAdAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:ImageAdAddBase">
+                        <xsd:sequence>
+                            <xsd:element name="FinalUrl" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="Href" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="TurboPageId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAppImageAdAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:ImageAdAddBase">
+                        <xsd:sequence>
+                            <xsd:element name="TrackingUrl" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="AdBuilderAdAddItem">
+                <xsd:sequence>
+                    <xsd:element name="CreativeId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="AdBuilderAdAddBase">
+                <xsd:sequence>
+                    <xsd:element name="Creative" type="ns:AdBuilderAdAddItem" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="ErirAdDescription" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="TextAdBuilderAdAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:AdBuilderAdAddBase">
+                        <xsd:sequence>
+                            <xsd:element name="FinalUrl" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="Href" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="TurboPageId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAppAdBuilderAdAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:AdBuilderAdAddBase">
+                        <xsd:sequence>
+                            <xsd:element name="TrackingUrl" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAppCpcVideoAdBuilderAdAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:AdBuilderAdAddBase">
+                        <xsd:sequence>
+                            <xsd:element name="TrackingUrl" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="CpmBannerAdBuilderAdAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:AdBuilderAdAddBase">
+                        <xsd:sequence>
+                            <xsd:element name="Href" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="TrackingPixels" type="general:ArrayOfString" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="TurboPageId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="CpcVideoAdBuilderAdAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:AdBuilderAdAddBase">
+                        <xsd:sequence>
+                            <xsd:element name="Href" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="TurboPageId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="CpmVideoAdBuilderAdAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:AdBuilderAdAddBase">
+                        <xsd:sequence>
+                            <xsd:element name="Href" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="TrackingPixels" type="general:ArrayOfString" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="TurboPageId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <!-- Update Operation Types -->
+            <xsd:complexType name="AdUpdateItem">
+                <xsd:sequence>
+                    <xsd:element name="Id" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <!-- Choice: Required one of:  -->
+                    <xsd:element name="TextAd" type="ns:TextAdUpdate" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ResponsiveAd" type="ns:ResponsiveAdUpdate" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="DynamicTextAd" type="ns:DynamicTextAdUpdate" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="MobileAppAd" type="ns:MobileAppAdUpdate" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="TextImageAd" type="ns:TextImageAdUpdate" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="MobileAppImageAd" type="ns:MobileAppImageAdUpdate" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="MobileAppCpcVideoAdBuilderAd" type="ns:MobileAppCpcVideoAdBuilderAdUpdate" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="TextAdBuilderAd" type="ns:TextAdBuilderAdUpdate" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="MobileAppAdBuilderAd" type="ns:MobileAppAdBuilderAdUpdate" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CpcVideoAdBuilderAd" type="ns:CpcVideoAdBuilderAdUpdate" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CpmBannerAdBuilderAd" type="ns:CpmBannerAdBuilderAdUpdate" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CpmVideoAdBuilderAd" type="ns:CpmVideoAdBuilderAdUpdate" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="SmartAdBuilderAd" type="ns:SmartAdBuilderAdUpdate" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ShoppingAd" type="ns:ShoppingAdUpdate" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ListingAd" type="ns:ListingAdUpdate" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="TextAdUpdateBase">
+                <xsd:sequence>
+                    <xsd:element name="VCardId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="AdImageHash" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="SitelinkSetId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="CalloutSetting" type="ext:AdExtensionSetting" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="TextAdUpdate">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:TextAdUpdateBase">
+                        <xsd:sequence>
+                            <xsd:element name="Text" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="Title" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="Title2" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="FinalUrl" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="Href" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="AgeLabel" type="ns:AgeLabelEnum" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="DisplayUrlPath" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="VideoExtension" type="ns:VideoExtensionUpdateItem" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="PriceExtension" type="ns:PriceExtensionUpdateItem" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="TurboPageId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="BusinessId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="PreferVCardOverBusiness" type="general:YesNoEnum" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="ErirAdDescription" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="ResponsiveAdUpdate">
+                <xsd:sequence>
+                    <xsd:element name="Texts" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="Titles" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="AdImageHashes" type="general:ArrayOfString" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="VideoExtensionIds" type="general:ArrayOfLong" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="SitelinkSetId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="CalloutSetting" type="ext:AdExtensionSetting" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="Href" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="AgeLabel" type="ns:AgeLabelEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="DisplayUrlPath" type="xsd:string" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="PriceExtension" type="ns:PriceExtensionUpdateItem" minOccurs="0"
+                                 maxOccurs="1" nillable="true"/>
+                    <xsd:element name="BusinessId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="ErirAdDescription" type="xsd:string" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="DynamicTextAdUpdate">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:TextAdUpdateBase">
+                        <xsd:sequence>
+                            <xsd:element name="Text" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAppAdUpdate">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:MobileAppAdBase">
+                        <xsd:sequence>
+                            <xsd:element name="Features" type="ns:MobileAppAdFeatureItem" minOccurs="0" maxOccurs="unbounded"/>
+                            <xsd:element name="AgeLabel" type="ns:MobAppAgeLabelEnum" minOccurs="0" maxOccurs="1" />
+                            <xsd:element name="VideoExtension" type="ns:VideoExtensionUpdateItem" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="ImageAdUpdateBase">
+                <xsd:sequence>
+                    <xsd:element name="AdImageHash" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ErirAdDescription" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="TextImageAdUpdate">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:ImageAdUpdateBase">
+                        <xsd:sequence>
+                            <xsd:element name="FinalUrl" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="Href" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="TurboPageId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAppImageAdUpdate">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:ImageAdUpdateBase">
+                        <xsd:sequence>
+                            <xsd:element name="TrackingUrl" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="AdBuilderAdUpdateItem">
+                <xsd:sequence>
+                    <xsd:element name="CreativeId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="ErirAdDescription" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="AdBuilderAdUpdateBase">
+                <xsd:sequence>
+                    <xsd:element name="Creative" type="ns:AdBuilderAdUpdateItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ErirAdDescription" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="TextAdBuilderAdUpdate">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:AdBuilderAdUpdateBase">
+                        <xsd:sequence>
+                            <xsd:element name="FinalUrl" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="Href" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="TurboPageId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAppAdBuilderAdUpdate">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:AdBuilderAdUpdateBase">
+                        <xsd:sequence>
+                            <xsd:element name="TrackingUrl" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="CpmBannerAdBuilderAdUpdate">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:AdBuilderAdUpdateBase">
+                        <xsd:sequence>
+                            <xsd:element name="Href" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="TrackingPixels" type="general:ArrayOfString" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="TurboPageId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAppCpcVideoAdBuilderAdUpdate">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:AdBuilderAdUpdateBase">
+                        <xsd:sequence>
+                            <xsd:element name="TrackingUrl" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="CpcVideoAdBuilderAdUpdate">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:AdBuilderAdUpdateBase">
+                        <xsd:sequence>
+                            <xsd:element name="Href" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="TurboPageId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="CpmVideoAdBuilderAdUpdate">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:AdBuilderAdUpdateBase">
+                        <xsd:sequence>
+                            <xsd:element name="Href" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="TrackingPixels" type="general:ArrayOfString" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="TurboPageId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <!-- Get Operation Types -->
+            <xsd:complexType name="AdsSelectionCriteria">
+                <xsd:sequence>
+                    <xsd:element name="Ids" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="States" type="ns:AdStateSelectionEnum" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="Statuses" type="ns:AdStatusSelectionEnum" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="CampaignIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="AdGroupIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="Types" type="ns:AdTypeEnum" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="Mobile" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="VCardIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="SitelinkSetIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="AdImageHashes" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="VCardModerationStatuses" type="general:ExtensionStatusSelectionEnum" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="SitelinksModerationStatuses" type="general:ExtensionStatusSelectionEnum" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="AdImageModerationStatuses" type="general:ExtensionStatusSelectionEnum" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="AdExtensionIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="TextAdGetBase">
+                <xsd:sequence>
+                    <xsd:element name="VCardId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="AdImageHash" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="SitelinkSetId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="VCardModeration" type="general:ExtensionModeration" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="SitelinksModeration" type="general:ExtensionModeration" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="AdImageModeration" type="general:ExtensionModeration" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="AdExtensions" type="ns:AdExtensionAdGetItem" minOccurs="0" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="TextAdGet">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:TextAdGetBase">
+                        <xsd:sequence>
+                            <xsd:element name="Text" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="Title" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="Title2" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="FinalUrl" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="Href" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="Mobile" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="DisplayDomain" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="DisplayUrlPath" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="DisplayUrlPathModeration" type="general:ExtensionModeration" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="VideoExtension" type="ns:VideoExtensionGetItem" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="PriceExtension" type="ns:PriceExtensionGetItem" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="TurboPageId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="TurboPageModeration" type="general:ExtensionModeration" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="BusinessId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="PreferVCardOverBusiness" type="general:YesNoEnum" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="ErirAdDescription" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="AutogeneratedErirAdDescription" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="ResponsiveAdGet">
+                <xsd:sequence>
+                    <xsd:element name="Texts" type="ns:TextGetItem" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="Titles" type="ns:TitleGetItem" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="AdImages" type="ns:ArrayOfAdImageGet" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="VideoExtensions" type="ns:ArrayOfVideoExtensionGet" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="Href" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="DisplayDomain" type="xsd:string" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="DisplayUrlPath" type="xsd:string" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="DisplayUrlPathModeration" type="general:ExtensionModeration"
+                                 minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="PriceExtension" type="ns:PriceExtensionGetItem" minOccurs="0"
+                                 maxOccurs="1" nillable="true"/>
+                    <xsd:element name="BusinessId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="ErirAdDescription" type="xsd:string" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="SitelinkSetId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="SitelinksModeration" type="general:ExtensionModeration" minOccurs="0"
+                                 maxOccurs="1" nillable="true"/>
+                    <xsd:element name="AdExtensions" type="ns:AdExtensionAdGetItem" minOccurs="0"
+                                 maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SmartAdBuilderAdGet">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:AdBuilderAdGetBase">
+                        <xsd:sequence/>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="DynamicTextAdGet">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:TextAdGetBase">
+                        <xsd:sequence>
+                            <xsd:element name="Text" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAppAdGet">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:MobileAppAdBase">
+                        <xsd:sequence>
+                            <xsd:element name="Features" type="ns:MobileAppAdFeatureGetItem" minOccurs="0" maxOccurs="unbounded"/>
+                            <xsd:element name="AdImageModeration" type="general:ExtensionModeration" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="VideoExtension" type="ns:VideoExtensionGetItem" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="AutogeneratedErirAdDescription" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="ImageAdGetBase">
+                <xsd:sequence>
+                    <xsd:element name="AdImageHash" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ErirAdDescription" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="AutogeneratedErirAdDescription" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="TextImageAdGet">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:ImageAdGetBase">
+                        <xsd:sequence>
+                            <xsd:element name="FinalUrl" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="Href" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="TurboPageId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="TurboPageModeration" type="general:ExtensionModeration" minOccurs="0" maxOccurs="1" nillable="true"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAppImageAdGet">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:ImageAdGetBase">
+                        <xsd:sequence>
+                            <xsd:element name="TrackingUrl" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="AdBuilderAdGetItem">
+                <xsd:sequence>
+                    <xsd:element name="CreativeId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="ThumbnailUrl" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PreviewUrl" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="AdBuilderAdGetBase">
+                <xsd:sequence>
+                    <xsd:element name="Creative" type="ns:AdBuilderAdGetItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ErirAdDescription" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="AutogeneratedErirAdDescription" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="TextAdBuilderAdGet">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:AdBuilderAdGetBase">
+                        <xsd:sequence>
+                            <xsd:element name="FinalUrl" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="Href" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="TurboPageId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="TurboPageModeration" type="general:ExtensionModeration" minOccurs="0" maxOccurs="1" nillable="true"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAppAdBuilderAdGet">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:AdBuilderAdGetBase">
+                        <xsd:sequence>
+                            <xsd:element name="TrackingUrl" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="CpcVideoAdBuilderAdGet">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:AdBuilderAdGetBase">
+                        <xsd:sequence>
+                            <xsd:element name="Href" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="TurboPageId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="TurboPageModeration" type="general:ExtensionModeration" minOccurs="0" maxOccurs="1" nillable="true"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAppCpcVideoAdBuilderAdGet">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:AdBuilderAdGetBase">
+                        <xsd:sequence>
+                            <xsd:element name="TrackingUrl" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="CpmBannerAdBuilderAdGet">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:AdBuilderAdGetBase">
+                        <xsd:sequence>
+                            <xsd:element name="Href" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="TrackingPixels" type="ns:TrackingPixelGetArray" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="TurboPageId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="TurboPageModeration" type="general:ExtensionModeration" minOccurs="0" maxOccurs="1" nillable="true"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="CpmVideoAdBuilderAdGet">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:AdBuilderAdGetBase">
+                        <xsd:sequence>
+                            <xsd:element name="Href" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="TrackingPixels" type="ns:TrackingPixelGetArray" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="TurboPageId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="TurboPageModeration" type="general:ExtensionModeration" minOccurs="0" maxOccurs="1" nillable="true"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="ShoppingAdGet">
+                <xsd:sequence>
+                    <xsd:element name="SitelinkSetId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="SitelinksModeration" type="general:ExtensionModeration" minOccurs="0"
+                                 maxOccurs="1" nillable="true"/>
+                    <xsd:element name="AdExtensions" type="ns:AdExtensionAdGetItem" minOccurs="0"
+                                 maxOccurs="unbounded"/>
+                    <xsd:element name="BusinessId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="FeedId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="FeedFilterConditions" type="ns:ArrayOfFeedFilterCondition" minOccurs="0"
+                                 maxOccurs="1" nillable="true"/>
+                    <xsd:element name="FeedProcessingStatus" type="ns:FeedProcessingStatusEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="TitleSources" type="general:ArrayOfString" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="TextSources" type="general:ArrayOfString" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="DefaultTexts" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ListingAdGet">
+                <xsd:sequence>
+                    <xsd:element name="SitelinkSetId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="SitelinksModeration" type="general:ExtensionModeration" minOccurs="0"
+                                 maxOccurs="1" nillable="true"/>
+                    <xsd:element name="AdExtensions" type="ns:AdExtensionAdGetItem" minOccurs="0"
+                                 maxOccurs="unbounded"/>
+                    <xsd:element name="BusinessId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="FeedId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="FeedFilterConditions" type="ns:ArrayOfFeedFilterCondition" minOccurs="0"
+                                 maxOccurs="1" nillable="true"/>
+                    <xsd:element name="FeedProcessingStatus" type="ns:FeedProcessingStatusEnum" minOccurs="0"
+                                 maxOccurs="1"/>
+                    <xsd:element name="TitleSources" type="general:ArrayOfString" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="TextSources" type="general:ArrayOfString" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="DefaultTexts" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="AdGetItem">
+                <xsd:sequence>
+                    <xsd:element name="Id" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CampaignId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AdGroupId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Status" type="general:StatusEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="State" type="general:StateEnum" minOccurs="0" maxOccurs="1"/>
+                    <!-- Some description for status and state. If requested, can be empty
+                    nillable='true' -->
+                    <xsd:element name="StatusClarification" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <!-- Category, if requested can be empty nillable='true' -->
+                    <xsd:element name="AdCategories" type="ns:ArrayOfAdCategoryEnum" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <!-- AgeLabel, if requested can be empty nillable='true' -->
+                    <xsd:element name="AgeLabel" type="ns:AgeLabelEnum" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="Type" type="ns:AdTypeEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Subtype" type="ns:AdSubtypeEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="TextAd" type="ns:TextAdGet" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="DynamicTextAd" type="ns:DynamicTextAdGet" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="MobileAppAd" type="ns:MobileAppAdGet" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="TextImageAd" type="ns:TextImageAdGet" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="MobileAppImageAd" type="ns:MobileAppImageAdGet" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="TextAdBuilderAd" type="ns:TextAdBuilderAdGet" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="MobileAppAdBuilderAd" type="ns:MobileAppAdBuilderAdGet" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="MobileAppCpcVideoAdBuilderAd" type="ns:MobileAppCpcVideoAdBuilderAdGet" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CpmBannerAdBuilderAd" type="ns:CpmBannerAdBuilderAdGet" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CpcVideoAdBuilderAd" type="ns:CpcVideoAdBuilderAdGet" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CpmVideoAdBuilderAd" type="ns:CpmVideoAdBuilderAdGet" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="SmartAdBuilderAd" type="ns:SmartAdBuilderAdGet" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ShoppingAd" type="ns:ShoppingAdGet" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ListingAd" type="ns:ListingAdGet" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ResponsiveAd" type="ns:ResponsiveAdGet" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <!-- Methods -->
+            <xsd:element name="GetRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetRequestGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="SelectionCriteria" type="ns:AdsSelectionCriteria" minOccurs="1" maxOccurs="1"/>
+                                <xsd:element name="FieldNames" type="ns:AdFieldEnum" minOccurs="1" maxOccurs="unbounded"/>
+                                <xsd:element name="TextAdFieldNames" type="ns:TextAdFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="TextAdPriceExtensionFieldNames" type="ns:TextAdPriceExtensionFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="MobileAppAdFieldNames" type="ns:MobileAppAdFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="DynamicTextAdFieldNames" type="ns:DynamicTextAdFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="TextImageAdFieldNames" type="ns:TextImageAdFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="MobileAppImageAdFieldNames" type="ns:MobileAppImageAdFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="TextAdBuilderAdFieldNames" type="ns:TextAdBuilderAdFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="MobileAppAdBuilderAdFieldNames" type="ns:MobileAppAdBuilderAdFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="MobileAppCpcVideoAdBuilderAdFieldNames" type="ns:MobileAppCpcVideoAdBuilderAdFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="CpmBannerAdBuilderAdFieldNames" type="ns:CpmBannerAdBuilderAdFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="CpcVideoAdBuilderAdFieldNames" type="ns:CpcVideoAdBuilderAdFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="CpmVideoAdBuilderAdFieldNames" type="ns:CpmVideoAdBuilderAdFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="SmartAdBuilderAdFieldNames" type="ns:SmartAdBuilderAdFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="ShoppingAdFieldNames" type="ns:ShoppingAdFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="ListingAdFieldNames" type="ns:ListingAdFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="ResponsiveAdFieldNames" type="ns:ResponsiveAdFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetResponse">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetResponseGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="Ads" type="ns:AdGetItem" minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="Ads" type="ns:AdAddItem" minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="AddResults" type="general:ActionResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="UpdateRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="Ads" type="ns:AdUpdateItem" minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="UpdateResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="UpdateResults" type="general:ActionResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DeleteRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DeleteResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="DeleteResults" type="general:ActionResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="ArchiveRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="ArchiveResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="ArchiveResults" type="general:ActionResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="UnarchiveRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="UnarchiveResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="UnarchiveResults" type="general:ActionResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SuspendRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SuspendResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SuspendResults" type="general:ActionResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="ResumeRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="ResumeResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="ResumeResults" type="general:ActionResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="ModerateRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="ModerateResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="ModerateResults" type="general:ActionResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="ApiException">
+        <wsdl:part element="general:FaultResponse" name="faultMessage"/>
+    </wsdl:message>
+    <!-- ADD -->
+    <wsdl:message name="AddOperationRequest">
+        <wsdl:part element="ns:AddRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationResponse">
+        <wsdl:part name="parameters" element="ns:AddResponse"/>
+    </wsdl:message>
+    <!-- UPDATE -->
+    <wsdl:message name="UpdateOperationRequest">
+        <wsdl:part name="parameters" element="ns:UpdateRequest"/>
+    </wsdl:message>
+    <wsdl:message name="UpdateOperationResponse">
+        <wsdl:part name="parameters" element="ns:UpdateResponse"/>
+    </wsdl:message>
+    <!-- GET -->
+    <wsdl:message name="GetOperationRequest">
+        <wsdl:part name="parameters" element="ns:GetRequest"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationResponse">
+        <wsdl:part name="parameters" element="ns:GetResponse"/>
+    </wsdl:message>
+    <!-- DELETE -->
+    <wsdl:message name="DeleteOperationRequest">
+        <wsdl:part name="parameters" element="ns:DeleteRequest"/>
+    </wsdl:message>
+    <wsdl:message name="DeleteOperationResponse">
+        <wsdl:part name="parameters" element="ns:DeleteResponse"/>
+    </wsdl:message>
+    <!-- ARCHIVE -->
+    <wsdl:message name="ArchiveOperationRequest">
+        <wsdl:part name="parameters" element="ns:ArchiveRequest"/>
+    </wsdl:message>
+    <wsdl:message name="ArchiveOperationResponse">
+        <wsdl:part name="parameters" element="ns:ArchiveResponse"/>
+    </wsdl:message>
+    <!-- UNARCHIVE -->
+    <wsdl:message name="UnarchiveOperationRequest">
+        <wsdl:part name="parameters" element="ns:UnarchiveRequest"/>
+    </wsdl:message>
+    <wsdl:message name="UnarchiveOperationResponse">
+        <wsdl:part name="parameters" element="ns:UnarchiveResponse"/>
+    </wsdl:message>
+    <!-- SUSPEND -->
+    <wsdl:message name="SuspendOperationRequest">
+        <wsdl:part name="parameters" element="ns:SuspendRequest"/>
+    </wsdl:message>
+    <wsdl:message name="SuspendOperationResponse">
+        <wsdl:part name="parameters" element="ns:SuspendResponse"/>
+    </wsdl:message>
+    <!-- RESUME -->
+    <wsdl:message name="ResumeOperationRequest">
+        <wsdl:part name="parameters" element="ns:ResumeRequest"/>
+    </wsdl:message>
+    <wsdl:message name="ResumeOperationResponse">
+        <wsdl:part name="parameters" element="ns:ResumeResponse"/>
+    </wsdl:message>
+    <!-- MODERATE -->
+    <wsdl:message name="ModerateOperationRequest">
+        <wsdl:part name="parameters" element="ns:ModerateRequest"/>
+    </wsdl:message>
+    <wsdl:message name="ModerateOperationResponse">
+        <wsdl:part name="parameters" element="ns:ModerateResponse"/>
+    </wsdl:message>
+    <!-- PORT -->
+    <wsdl:portType name="AdsPort">
+        <wsdl:operation name="add">
+            <wsdl:input message="ns:AddOperationRequest" name="addRequest"/>
+            <wsdl:output message="ns:AddOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="update">
+            <wsdl:input message="ns:UpdateOperationRequest" name="updateRequest"/>
+            <wsdl:output message="ns:UpdateOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="get">
+            <wsdl:input message="ns:GetOperationRequest" name="getRequest"/>
+            <wsdl:output message="ns:GetOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <wsdl:input message="ns:DeleteOperationRequest" name="deleteRequest"/>
+            <wsdl:output message="ns:DeleteOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="archive">
+            <wsdl:input message="ns:ArchiveOperationRequest" name="archiveRequest"/>
+            <wsdl:output message="ns:ArchiveOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="unarchive">
+            <wsdl:input message="ns:UnarchiveOperationRequest" name="unarchiveRequest"/>
+            <wsdl:output message="ns:UnarchiveOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="suspend">
+            <wsdl:input message="ns:SuspendOperationRequest" name="suspendRequest"/>
+            <wsdl:output message="ns:SuspendOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="resume">
+            <wsdl:input message="ns:ResumeOperationRequest" name="resumeRequest"/>
+            <wsdl:output message="ns:ResumeOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="moderate">
+            <wsdl:input message="ns:ModerateOperationRequest" name="moderateRequest"/>
+            <wsdl:output message="ns:ModerateOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <!-- BINDING -->
+    <wsdl:binding name="AdsSOAP" type="ns:AdsPort">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="add">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/ads/add"/>
+            <wsdl:input name="addRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="update">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/ads/update"/>
+            <wsdl:input name="updateRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="get">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/ads/get"/>
+            <wsdl:input name="getRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/ads/delete"/>
+            <wsdl:input name="deleteRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="archive">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/ads/archive"/>
+            <wsdl:input name="archiveRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="unarchive">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/ads/unarchive"/>
+            <wsdl:input name="unarchiveRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="suspend">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/ads/suspend"/>
+            <wsdl:input name="suspendRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="resume">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/ads/resume"/>
+            <wsdl:input name="resumeRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="moderate">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/ads/moderate"/>
+            <wsdl:input name="moderateRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <!-- SERVICE -->
+    <wsdl:service name="Ads">
+        <wsdl:port binding="ns:AdsSOAP" name="AdsSOAP">
+            <soap:address location="https://soap.direct.yandex.ru/v5/ads"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/tests/wsdl_cache/advideos.xml
+++ b/tests/wsdl_cache/advideos.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:ns="http://api.direct.yandex.com/v5/advideos"
+                  xmlns:general="http://api.direct.yandex.com/v5/general"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema" name="AdVideos"
+                  targetNamespace="http://api.direct.yandex.com/v5/advideos">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://api.direct.yandex.com/v5/advideos">
+            <xsd:import namespace="http://api.direct.yandex.com/v5/general" schemaLocation="https://soap.direct.yandex.ru/v5/general.xsd"/>
+            <xsd:complexType name="AdVideoAddItem">
+                <xsd:sequence>
+                    <xsd:element name="Url" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="VideoData" type="xsd:base64Binary" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="AddRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="AdVideos" type="ns:AdVideoAddItem" minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:complexType name="VideoActionResult">
+                <xsd:complexContent>
+                    <xsd:extension base="general:ActionResultBase">
+                        <xsd:sequence>
+                            <xsd:element name="Id" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:element name="AddResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="AddResults" type="ns:VideoActionResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:complexType name="AdVideosSelectionCriteria">
+                <xsd:sequence>
+                    <xsd:element name="Ids" type="xsd:string" minOccurs="1" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:simpleType name="AdVideoFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Id"/>
+                    <xsd:enumeration value="Status"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:element name="GetRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetRequestGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="SelectionCriteria" type="ns:AdVideosSelectionCriteria" minOccurs="1"
+                                             maxOccurs="1"/>
+                                <xsd:element name="FieldNames" type="ns:AdVideoFieldEnum" minOccurs="1"
+                                             maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:simpleType name="StatusEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="READY"/>
+                    <xsd:enumeration value="ERROR"/>
+                    <xsd:enumeration value="CONVERTING"/>
+                    <xsd:enumeration value="NEW"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="AdVideoGetItem">
+                <xsd:sequence>
+                    <xsd:element name="Id" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Status" type="ns:StatusEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="GetResponse">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetResponseGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="AdVideos" type="ns:AdVideoGetItem" minOccurs="0"
+                                             maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="ApiException">
+        <wsdl:part element="general:FaultResponse" name="faultMessage"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationRequest">
+        <wsdl:part element="ns:AddRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationResponse">
+        <wsdl:part element="ns:AddResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationRequest">
+        <wsdl:part name="parameters" element="ns:GetRequest"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationResponse">
+        <wsdl:part name="parameters" element="ns:GetResponse"/>
+    </wsdl:message>
+    <wsdl:portType name="AdVideosPort">
+        <wsdl:operation name="add">
+            <wsdl:input message="ns:AddOperationRequest" name="addRequest"/>
+            <wsdl:output message="ns:AddOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="get">
+            <wsdl:input message="ns:GetOperationRequest" name="getRequest"/>
+            <wsdl:output message="ns:GetOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="AdVideosSOAP" type="ns:AdVideosPort">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="add">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/advideos/add"/>
+            <wsdl:input name="addRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="get">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/advideos/get"/>
+            <wsdl:input name="getRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="AdVideos">
+        <wsdl:port binding="ns:AdVideosSOAP" name="AdVideosSOAP">
+            <soap:address location="https://soap.direct.yandex.ru/v5/advideos"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/tests/wsdl_cache/agencyclients.xml
+++ b/tests/wsdl_cache/agencyclients.xml
@@ -1,0 +1,310 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<wsdl:definitions xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:general="http://api.direct.yandex.com/v5/general"
+                  xmlns:gc="http://api.direct.yandex.com/v5/generalclients"
+                  xmlns:ns="http://api.direct.yandex.com/v5/agencyclients"
+                  name="AgencyClients" targetNamespace="http://api.direct.yandex.com/v5/agencyclients">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://api.direct.yandex.com/v5/agencyclients">
+            <xsd:import namespace="http://api.direct.yandex.com/v5/general" schemaLocation="https://soap.direct.yandex.ru/v5/general.xsd" />
+            <xsd:import namespace="http://api.direct.yandex.com/v5/generalclients" schemaLocation="https://soap.direct.yandex.ru/v5/generalclients.xsd" />
+            <xsd:simpleType name="AgencyClientFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="AccountQuality"/>
+                    <xsd:enumeration value="Archived"/>
+                    <xsd:enumeration value="ClientId"/>
+                    <xsd:enumeration value="ClientInfo"/>
+                    <xsd:enumeration value="CountryId"/>
+                    <xsd:enumeration value="CreatedAt"/>
+                    <xsd:enumeration value="Currency"/>
+                    <xsd:enumeration value="Grants"/>
+                    <xsd:enumeration value="Bonuses"/>
+                    <xsd:enumeration value="Login"/>
+                    <xsd:enumeration value="Notification"/>
+                    <xsd:enumeration value="OverdraftSumAvailable"/>
+                    <xsd:enumeration value="Phone"/>
+                    <xsd:enumeration value="Representatives"/>
+                    <xsd:enumeration value="Restrictions"/>
+                    <xsd:enumeration value="Settings"/>
+                    <xsd:enumeration value="Type"/>
+                    <xsd:enumeration value="VatRate"/>
+                    <xsd:enumeration value="ForbiddenPlatform"/>
+                    <xsd:enumeration value="AvailableCampaignTypes"/>
+                    <xsd:enumeration value="AvailableAdGroupTypes"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="AgencyClientsSelectionCriteria">
+                <xsd:sequence>
+                    <xsd:element name="Logins" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="Archived" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="AgencyClientUpdateItem">
+                <xsd:complexContent>
+                    <xsd:extension base="gc:ClientUpdateItem">
+                        <xsd:sequence>
+                            <xsd:element name="ClientId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="Grants" type="gc:GrantItem" minOccurs="0" maxOccurs="unbounded"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="SendInviteTo">
+                <xsd:sequence>
+                    <xsd:element name="Phone" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Email" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="GetRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetRequestGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="SelectionCriteria" type="ns:AgencyClientsSelectionCriteria" minOccurs="1" maxOccurs="1"/>
+                                <xsd:element name="FieldNames" type="ns:AgencyClientFieldEnum" minOccurs="1"
+                                             maxOccurs="unbounded"/>
+                                <xsd:element name="TinInfoFieldNames" type="gc:TinInfoFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="OrganizationFieldNames" type="gc:OrgInfoFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="ContractFieldNames" type="gc:ContractInfoFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="ContragentFieldNames" type="gc:ContragentInfoFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="ContragentTinInfoFieldNames" type="gc:TinInfoFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetResponse">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetResponseGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="Clients" type="gc:ClientGetItem" minOccurs="0"
+                                             maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="Login" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                        <xsd:element name="FirstName" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                        <xsd:element name="LastName" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                        <xsd:element name="Currency" type="general:CurrencyEnum" minOccurs="1" maxOccurs="1"/>
+                        <xsd:element name="Notification" type="gc:NotificationAdd" minOccurs="1"
+                                     maxOccurs="1"/>
+                        <xsd:element name="Settings" type="gc:ClientSettingAddItem" minOccurs="0"
+                                     maxOccurs="unbounded"/>
+                        <xsd:element name="Grants" type="gc:GrantItem" minOccurs="0" maxOccurs="unbounded"/>
+                        <xsd:element name="TinInfo" type="gc:TinInfoAdd" minOccurs="0" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddResponse">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:ActionResultBase">
+                            <xsd:sequence>
+                                <xsd:element name="Login" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                                <xsd:element name="Password" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                                <xsd:element name="Email" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                                <xsd:element name="ClientId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddPassportOrganizationRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="Name" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                        <xsd:element name="Currency" type="general:CurrencyEnum" minOccurs="1" maxOccurs="1"/>
+                        <xsd:element name="Notification" type="gc:NotificationAdd" minOccurs="1"
+                                     maxOccurs="1"/>
+                        <xsd:element name="Settings" type="gc:ClientSettingAddItem" minOccurs="0"
+                                     maxOccurs="unbounded"/>
+                        <xsd:element name="Grants" type="gc:GrantItem" minOccurs="0" maxOccurs="unbounded"/>
+                        <xsd:element name="TinInfo" type="gc:TinInfoAdd" minOccurs="0" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddPassportOrganizationResponse">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:ActionResultBase">
+                            <xsd:sequence>
+                                <xsd:element name="Login" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                                <xsd:element name="ClientId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddPassportOrganizationMemberRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="PassportOrganizationLogin" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                        <xsd:element name="Role" type="general:RoleEnum" minOccurs="1" maxOccurs="1"/>
+                        <xsd:element name="SendInviteTo" type="ns:SendInviteTo" minOccurs="1" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddPassportOrganizationMemberResponse">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:ActionResultBase">
+                            <xsd:sequence>
+                                <xsd:element name="PassportOrganizationLogin" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="UpdateRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="Clients" type="ns:AgencyClientUpdateItem" minOccurs="1" maxOccurs="unbounded" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="UpdateResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="UpdateResults" type="general:ClientsActionResult" minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="ApiException">
+        <wsdl:part name="faultMessage" element="general:FaultResponse"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationRequest">
+        <wsdl:part name="parameters" element="ns:GetRequest"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationResponse">
+        <wsdl:part name="parameters" element="ns:GetResponse"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationRequest">
+        <wsdl:part name="parameters" element="ns:AddRequest"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationResponse">
+        <wsdl:part name="parameters" element="ns:AddResponse"/>
+    </wsdl:message>
+    <wsdl:message name="AddPassportOrganizationOperationRequest">
+        <wsdl:part name="parameters" element="ns:AddPassportOrganizationRequest"/>
+    </wsdl:message>
+    <wsdl:message name="AddPassportOrganizationOperationResponse">
+        <wsdl:part name="parameters" element="ns:AddPassportOrganizationResponse"/>
+    </wsdl:message>
+    <wsdl:message name="AddPassportOrganizationMemberOperationRequest">
+        <wsdl:part name="parameters" element="ns:AddPassportOrganizationMemberRequest"/>
+    </wsdl:message>
+    <wsdl:message name="AddPassportOrganizationMemberOperationResponse">
+        <wsdl:part name="parameters" element="ns:AddPassportOrganizationMemberResponse"/>
+    </wsdl:message>
+    <wsdl:message name="UpdateOperationRequest">
+        <wsdl:part name="parameters" element="ns:UpdateRequest"/>
+    </wsdl:message>
+    <wsdl:message name="UpdateOperationResponse">
+        <wsdl:part name="parameters" element="ns:UpdateResponse"/>
+    </wsdl:message>
+    <wsdl:portType name="AgencyClientsPort">
+        <wsdl:operation name="get">
+            <wsdl:input message="ns:GetOperationRequest"/>
+            <wsdl:output message="ns:GetOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="add">
+            <wsdl:input message="ns:AddOperationRequest"/>
+            <wsdl:output message="ns:AddOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="addPassportOrganization">
+            <wsdl:input message="ns:AddPassportOrganizationOperationRequest"/>
+            <wsdl:output message="ns:AddPassportOrganizationOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="addPassportOrganizationMember">
+            <wsdl:input message="ns:AddPassportOrganizationMemberOperationRequest"/>
+            <wsdl:output message="ns:AddPassportOrganizationMemberOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="update">
+            <wsdl:input  message="ns:UpdateOperationRequest"/>
+            <wsdl:output message="ns:UpdateOperationResponse"/>
+            <wsdl:fault  message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="AgencyClientsSOAP" type="ns:AgencyClientsPort">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="get">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/agencyclients/get"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="add">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/agencyclients/add"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="addPassportOrganization">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/agencyclients/addPassportOrganization"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="addPassportOrganizationMember">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/agencyclients/addPassportOrganizationMember"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="update">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/agencyclients/update"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="AgencyClients">
+        <wsdl:port binding="ns:AgencyClientsSOAP" name="AgencyClientsSOAP">
+            <soap:address location="https://soap.direct.yandex.ru/v5/agencyclients"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/tests/wsdl_cache/audiencetargets.xml
+++ b/tests/wsdl_cache/audiencetargets.xml
@@ -1,0 +1,339 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<wsdl:definitions xmlns:ns="http://api.direct.yandex.com/v5/audiencetargets"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:general="http://api.direct.yandex.com/v5/general"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  name="AudienceTargets"
+                  targetNamespace="http://api.direct.yandex.com/v5/audiencetargets">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://api.direct.yandex.com/v5/audiencetargets">
+            <xsd:import namespace="http://api.direct.yandex.com/v5/general" schemaLocation="https://soap.direct.yandex.ru/v5/general.xsd" />
+            <xsd:simpleType name="AudienceTargetStateEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="ON"/>
+                    <xsd:enumeration value="SUSPENDED"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="AudienceTargetFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Id" />
+                    <xsd:enumeration value="AdGroupId" />
+                    <xsd:enumeration value="CampaignId" />
+                    <xsd:enumeration value="RetargetingListId" />
+                    <xsd:enumeration value="InterestId" />
+                    <xsd:enumeration value="ContextBid" />
+                    <xsd:enumeration value="StrategyPriority" />
+                    <xsd:enumeration value="State" />
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="AudienceTargetSelectionCriteria">
+                <xsd:sequence>
+                    <xsd:element name="Ids" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="AdGroupIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="CampaignIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="RetargetingListIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="InterestIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="States" type="ns:AudienceTargetStateEnum" minOccurs="0" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="AudienceTargetBase">
+                <xsd:sequence>
+                    <xsd:element name="ContextBid" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="StrategyPriority" type="general:PriorityEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="AudienceTargetAddItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:AudienceTargetBase">
+                        <xsd:sequence>
+                            <xsd:element name="AdGroupId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="RetargetingListId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="InterestId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="AudienceTargetGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:AudienceTargetBase">
+                        <xsd:sequence>
+                            <xsd:element name="Id" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="AdGroupId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="CampaignId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="RetargetingListId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="InterestId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="State" type="general:StateEnum" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="AudienceTargetSetBidsItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:AudienceTargetBase">
+                        <xsd:sequence>
+                            <xsd:element name="Id" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="AdGroupId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="CampaignId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:element name="GetRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetRequestGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="SelectionCriteria" type="ns:AudienceTargetSelectionCriteria" minOccurs="1"
+                                     maxOccurs="1"/>
+                                <xsd:element name="FieldNames" type="ns:AudienceTargetFieldEnum" minOccurs="1" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetResponse">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetResponseGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="AudienceTargets" type="ns:AudienceTargetGetItem" minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="AudienceTargets" type="ns:AudienceTargetAddItem"
+                                     minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="AddResults" type="general:ActionResult"
+                                     minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DeleteRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1"
+                                     maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DeleteResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="DeleteResults" type="general:ActionResult"
+                                     minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SuspendRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1"
+                                     maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SuspendResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SuspendResults" type="general:ActionResult"
+                                     minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="ResumeRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1"
+                                     maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="ResumeResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="ResumeResults" type="general:ActionResult"
+                                     minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SetBidsRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="Bids" type="ns:AudienceTargetSetBidsItem"
+                                     minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SetBidsResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SetBidsResults" type="general:SetBidsActionResult"
+                                     minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="ApiException">
+        <wsdl:part element="general:FaultResponse" name="faultMessage"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationRequest">
+        <wsdl:part element="ns:GetRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationResponse">
+        <wsdl:part element="ns:GetResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationRequest">
+        <wsdl:part element="ns:AddRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationResponse">
+        <wsdl:part element="ns:AddResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="DeleteOperationRequest">
+        <wsdl:part element="ns:DeleteRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="DeleteOperationResponse">
+        <wsdl:part element="ns:DeleteResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="SuspendOperationRequest">
+        <wsdl:part element="ns:SuspendRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="SuspendOperationResponse">
+        <wsdl:part element="ns:SuspendResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="ResumeOperationRequest">
+        <wsdl:part element="ns:ResumeRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="ResumeOperationResponse">
+        <wsdl:part element="ns:ResumeResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="SetBidsOperationRequest">
+        <wsdl:part element="ns:SetBidsRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="SetBidsOperationResponse">
+        <wsdl:part element="ns:SetBidsResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:portType name="AudienceTargetsPort">
+        <wsdl:operation name="get">
+            <wsdl:input  message="ns:GetOperationRequest"/>
+            <wsdl:output message="ns:GetOperationResponse"/>
+            <wsdl:fault  message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="add">
+            <wsdl:input  message="ns:AddOperationRequest"/>
+            <wsdl:output message="ns:AddOperationResponse"/>
+            <wsdl:fault  message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <wsdl:input  message="ns:DeleteOperationRequest"/>
+            <wsdl:output message="ns:DeleteOperationResponse"/>
+            <wsdl:fault  message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="suspend">
+            <wsdl:input  message="ns:SuspendOperationRequest"/>
+            <wsdl:output message="ns:SuspendOperationResponse"/>
+            <wsdl:fault  message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="resume">
+            <wsdl:input  message="ns:ResumeOperationRequest"/>
+            <wsdl:output message="ns:ResumeOperationResponse"/>
+            <wsdl:fault  message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="setBids">
+            <wsdl:input  message="ns:SetBidsOperationRequest"/>
+            <wsdl:output message="ns:SetBidsOperationResponse"/>
+            <wsdl:fault  message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="AudienceTargetsSOAP" type="ns:AudienceTargetsPort">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="get">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/audiencetargets/get"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="add">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/audiencetargets/add"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/audiencetargets/delete"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="suspend">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/audiencetargets/suspend"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="resume">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/audiencetargets/resume"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="setBids">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/audiencetargets/setBids"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="AudienceTargets">
+        <wsdl:port binding="ns:AudienceTargetsSOAP" name="AudienceTargetsSOAP">
+            <soap:address location="https://soap.direct.yandex.ru/v5/audiencetargets"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/tests/wsdl_cache/bidmodifiers.xml
+++ b/tests/wsdl_cache/bidmodifiers.xml
@@ -1,0 +1,536 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:ns="http://api.direct.yandex.com/v5/bidmodifiers"
+                  xmlns:general="http://api.direct.yandex.com/v5/general"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema" name="BidModifiers"
+                  targetNamespace="http://api.direct.yandex.com/v5/bidmodifiers">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://api.direct.yandex.com/v5/bidmodifiers">
+            <xsd:import namespace="http://api.direct.yandex.com/v5/general" schemaLocation="https://soap.direct.yandex.ru/v5/general.xsd" />
+            <xsd:simpleType name="BidModifierTypeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="MOBILE_ADJUSTMENT"/>
+                    <xsd:enumeration value="DESKTOP_ADJUSTMENT"/>
+                    <xsd:enumeration value="SMART_TV_ADJUSTMENT"/>
+                    <xsd:enumeration value="TABLET_ADJUSTMENT"/>
+                    <xsd:enumeration value="DESKTOP_ONLY_ADJUSTMENT"/>
+                    <xsd:enumeration value="DEMOGRAPHICS_ADJUSTMENT"/>
+                    <xsd:enumeration value="RETARGETING_ADJUSTMENT"/>
+                    <xsd:enumeration value="REGIONAL_ADJUSTMENT"/>
+                    <xsd:enumeration value="VIDEO_ADJUSTMENT"/>
+                    <xsd:enumeration value="SMART_AD_ADJUSTMENT"/>
+                    <xsd:enumeration value="SERP_LAYOUT_ADJUSTMENT"/>
+                    <xsd:enumeration value="INCOME_GRADE_ADJUSTMENT"/>
+                    <xsd:enumeration value="AD_GROUP_ADJUSTMENT"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="BidModifierLevelEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="CAMPAIGN"/>
+                    <xsd:enumeration value="AD_GROUP"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="BidModifierFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Id"/>
+                    <xsd:enumeration value="CampaignId"/>
+                    <xsd:enumeration value="AdGroupId"/>
+                    <xsd:enumeration value="Level"/>
+                    <xsd:enumeration value="Type"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="MobileAdjustmentFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="BidModifier"/>
+                    <xsd:enumeration value="OperatingSystemType"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="DesktopAdjustmentFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="BidModifier"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="SmartTvAdjustmentFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="BidModifier"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="TabletAdjustmentFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="BidModifier"/>
+                    <xsd:enumeration value="OperatingSystemType"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="DesktopOnlyAdjustmentFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="BidModifier"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="DemographicsAdjustmentFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Gender"/>
+                    <xsd:enumeration value="Age"/>
+                    <xsd:enumeration value="BidModifier"/>
+                    <xsd:enumeration value="Enabled"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="RetargetingAdjustmentFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="RetargetingConditionId"/>
+                    <xsd:enumeration value="BidModifier"/>
+                    <xsd:enumeration value="Accessible"/>
+                    <xsd:enumeration value="Enabled"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="RegionalAdjustmentFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="RegionId"/>
+                    <xsd:enumeration value="BidModifier"/>
+                    <xsd:enumeration value="Enabled"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="VideoAdjustmentFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="BidModifier"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="SmartAdAdjustmentFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="BidModifier"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="SerpLayoutAdjustmentFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="SerpLayout"/>
+                    <xsd:enumeration value="BidModifier"/>
+                    <xsd:enumeration value="Enabled"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="OperatingSystemTypeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="IOS"/>
+                    <xsd:enumeration value="ANDROID"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="IncomeGradeAdjustmentFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Grade"/>
+                    <xsd:enumeration value="BidModifier"/>
+                    <xsd:enumeration value="Enabled"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="AdGroupAdjustmentFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="BidModifier"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="BidModifiersSelectionCriteria">
+                <xsd:sequence>
+                    <xsd:element name="CampaignIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="AdGroupIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="Ids" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="Types" type="ns:BidModifierTypeEnum" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="Levels" type="ns:BidModifierLevelEnum" minOccurs="1" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="BidModifierGetItem">
+                <xsd:sequence>
+                    <xsd:element name="CampaignId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AdGroupId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="Id" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Level" type="ns:BidModifierLevelEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Type" type="ns:BidModifierTypeEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="MobileAdjustment" type="ns:MobileAdjustmentGet" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="DesktopAdjustment" type="ns:DesktopAdjustmentGet" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="SmartTvAdjustment" type="ns:SmartTvAdjustmentGet" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="TabletAdjustment" type="ns:TabletAdjustmentGet" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="DesktopOnlyAdjustment" type="ns:DesktopOnlyAdjustmentGet" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="DemographicsAdjustment" type="ns:DemographicsAdjustmentGet" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="RetargetingAdjustment" type="ns:RetargetingAdjustmentGet" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="RegionalAdjustment" type="ns:RegionalAdjustmentGet" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="VideoAdjustment" type="ns:VideoAdjustmentGet" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="SmartAdAdjustment" type="ns:SmartAdAdjustmentGet" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="SerpLayoutAdjustment" type="ns:SerpLayoutAdjustmentGet" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="IncomeGradeAdjustment" type="ns:IncomeGradeAdjustmentGet" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AdGroupAdjustment" type="ns:AdGroupAdjustmentGet" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAdjustmentGet">
+                <xsd:sequence>
+                    <xsd:element name="BidModifier" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="OperatingSystemType" type="ns:OperatingSystemTypeEnum" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="DesktopAdjustmentGet">
+                <xsd:sequence>
+                    <xsd:element name="BidModifier" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SmartTvAdjustmentGet">
+                <xsd:sequence>
+                    <xsd:element name="BidModifier" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="TabletAdjustmentGet">
+                <xsd:sequence>
+                    <xsd:element name="BidModifier" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="OperatingSystemType" type="ns:OperatingSystemTypeEnum" minOccurs="0"
+                                 maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="DesktopOnlyAdjustmentGet">
+                <xsd:sequence>
+                    <xsd:element name="BidModifier" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="DemographicsAdjustmentGet">
+                <xsd:sequence>
+                    <xsd:element name="Gender" type="general:GenderEnum" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="Age" type="general:AgeRangeEnum" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="BidModifier" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Enabled" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="IncomeGradeAdjustmentGet">
+                <xsd:sequence>
+                    <xsd:element name="Grade" type="general:IncomeGradeEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="BidModifier" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Enabled" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="RetargetingAdjustmentGet">
+                <xsd:sequence>
+                    <xsd:element name="RetargetingConditionId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="BidModifier" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Accessible" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Enabled" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="RegionalAdjustmentGet">
+                <xsd:sequence>
+                    <xsd:element name="RegionId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="BidModifier" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Enabled" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="VideoAdjustmentGet">
+                <xsd:sequence>
+                    <xsd:element name="BidModifier" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SmartAdAdjustmentGet">
+                <xsd:sequence>
+                    <xsd:element name="BidModifier" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SerpLayoutAdjustmentGet">
+                <xsd:sequence>
+                    <xsd:element name="SerpLayout" type="general:SerpLayoutEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="BidModifier" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Enabled" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="AdGroupAdjustmentGet">
+                <xsd:sequence>
+                    <xsd:element name="BidModifier" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="BidModifierAddBase">
+                <xsd:sequence>
+                    <xsd:element name="CampaignId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AdGroupId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAdjustmentAdd">
+                <xsd:sequence>
+                    <xsd:element name="BidModifier" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="OperatingSystemType" type="ns:OperatingSystemTypeEnum" minOccurs="0"
+                                 maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="DesktopAdjustmentAdd">
+                <xsd:sequence>
+                    <xsd:element name="BidModifier" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SmartTvAdjustmentAdd">
+                <xsd:sequence>
+                    <xsd:element name="BidModifier" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="TabletAdjustmentAdd">
+                <xsd:sequence>
+                    <xsd:element name="BidModifier" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="OperatingSystemType" type="ns:OperatingSystemTypeEnum" minOccurs="0"
+                                 maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="DesktopOnlyAdjustmentAdd">
+                <xsd:sequence>
+                    <xsd:element name="BidModifier" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="DemographicsAdjustmentAdd">
+                <xsd:sequence>
+                    <xsd:element name="Gender" type="general:GenderEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Age" type="general:AgeRangeEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="BidModifier" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="RetargetingAdjustmentAdd">
+                <xsd:sequence>
+                    <xsd:element name="RetargetingConditionId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="BidModifier" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="RegionalAdjustmentAdd">
+                <xsd:sequence>
+                    <xsd:element name="RegionId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="BidModifier" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="VideoAdjustmentAdd">
+                <xsd:sequence>
+                    <xsd:element name="BidModifier" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SmartAdAdjustmentAdd">
+                <xsd:sequence>
+                    <xsd:element name="BidModifier" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="AdGroupAdjustmentAdd">
+                <xsd:sequence>
+                    <xsd:element name="BidModifier" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SerpLayoutAdjustmentAdd">
+                <xsd:sequence>
+                    <xsd:element name="SerpLayout" type="general:SerpLayoutEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="BidModifier" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="IncomeGradeAdjustmentAdd">
+                <xsd:sequence>
+                    <xsd:element name="Grade" type="general:IncomeGradeEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="BidModifier" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="BidModifierAddItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:BidModifierAddBase">
+                        <xsd:sequence>
+                            <xsd:element name="MobileAdjustment" type="ns:MobileAdjustmentAdd" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="DesktopAdjustment" type="ns:DesktopAdjustmentAdd" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="SmartTvAdjustment" type="ns:SmartTvAdjustmentAdd" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="TabletAdjustment" type="ns:TabletAdjustmentAdd" minOccurs="0"
+                                         maxOccurs="1"/>
+                            <xsd:element name="DesktopOnlyAdjustment" type="ns:DesktopOnlyAdjustmentAdd" minOccurs="0"
+                                         maxOccurs="1"/>
+                            <xsd:element name="DemographicsAdjustments" type="ns:DemographicsAdjustmentAdd" minOccurs="0" maxOccurs="unbounded"/>
+                            <xsd:element name="RetargetingAdjustments" type="ns:RetargetingAdjustmentAdd" minOccurs="0" maxOccurs="unbounded"/>
+                            <xsd:element name="RegionalAdjustments" type="ns:RegionalAdjustmentAdd" minOccurs="0" maxOccurs="unbounded"/>
+                            <xsd:element name="VideoAdjustment" type="ns:VideoAdjustmentAdd" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="SmartAdAdjustment" type="ns:SmartAdAdjustmentAdd" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="SerpLayoutAdjustments" type="ns:SerpLayoutAdjustmentAdd" minOccurs="0" maxOccurs="unbounded"/>
+                            <xsd:element name="IncomeGradeAdjustments" type="ns:IncomeGradeAdjustmentAdd" minOccurs="0" maxOccurs="unbounded"/>
+                            <xsd:element name="AdGroupAdjustment" type="ns:AdGroupAdjustmentAdd" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="BidModifierSetItem">
+                <xsd:sequence>
+                    <xsd:element name="Id" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="BidModifier" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="GetRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetRequestGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="SelectionCriteria" type="ns:BidModifiersSelectionCriteria" minOccurs="1" maxOccurs="1"/>
+                                <xsd:element name="FieldNames" type="ns:BidModifierFieldEnum" minOccurs="1" maxOccurs="unbounded"/>
+                                <xsd:element name="MobileAdjustmentFieldNames" type="ns:MobileAdjustmentFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="DesktopAdjustmentFieldNames" type="ns:DesktopAdjustmentFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="SmartTvAdjustmentFieldNames" type="ns:SmartTvAdjustmentFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="TabletAdjustmentFieldNames" type="ns:TabletAdjustmentFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="DesktopOnlyAdjustmentFieldNames" type="ns:DesktopOnlyAdjustmentFieldEnum"
+                                             minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="DemographicsAdjustmentFieldNames" type="ns:DemographicsAdjustmentFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="RetargetingAdjustmentFieldNames" type="ns:RetargetingAdjustmentFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="RegionalAdjustmentFieldNames" type="ns:RegionalAdjustmentFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="VideoAdjustmentFieldNames" type="ns:VideoAdjustmentFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="SmartAdAdjustmentFieldNames" type="ns:SmartAdAdjustmentFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="SerpLayoutAdjustmentFieldNames" type="ns:SerpLayoutAdjustmentFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="IncomeGradeAdjustmentFieldNames" type="ns:IncomeGradeAdjustmentFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="AdGroupAdjustmentFieldNames" type="ns:AdGroupAdjustmentFieldEnum"
+                                             minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetResponse">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetResponseGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="BidModifiers" type="ns:BidModifierGetItem" minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="BidModifiers" type="ns:BidModifierAddItem" minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="AddResults" type="general:MultiIdsActionResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SetRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="BidModifiers" type="ns:BidModifierSetItem" minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SetResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SetResults" type="general:ActionResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DeleteRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DeleteResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="DeleteResults" type="general:ActionResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="ApiException">
+        <wsdl:part element="general:FaultResponse" name="faultMessage"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationRequest">
+        <wsdl:part name="parameters" element="ns:GetRequest"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationResponse">
+        <wsdl:part name="parameters" element="ns:GetResponse"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationRequest">
+        <wsdl:part element="ns:AddRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationResponse">
+        <wsdl:part name="parameters" element="ns:AddResponse"/>
+    </wsdl:message>
+    <wsdl:message name="SetOperationRequest">
+        <wsdl:part name="parameters" element="ns:SetRequest"/>
+    </wsdl:message>
+    <wsdl:message name="SetOperationResponse">
+        <wsdl:part name="parameters" element="ns:SetResponse"/>
+    </wsdl:message>
+    <wsdl:message name="DeleteOperationRequest">
+        <wsdl:part name="parameters" element="ns:DeleteRequest"/>
+    </wsdl:message>
+    <wsdl:message name="DeleteOperationResponse">
+        <wsdl:part name="parameters" element="ns:DeleteResponse"/>
+    </wsdl:message>
+    <wsdl:portType name="BidModifiersPort">
+        <wsdl:operation name="get">
+            <wsdl:input message="ns:GetOperationRequest" name="getRequest"/>
+            <wsdl:output message="ns:GetOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="add">
+            <wsdl:input message="ns:AddOperationRequest" name="addRequest"/>
+            <wsdl:output message="ns:AddOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="set">
+            <wsdl:input message="ns:SetOperationRequest" name="setRequest"/>
+            <wsdl:output message="ns:SetOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <wsdl:input message="ns:DeleteOperationRequest" name="deleteRequest"/>
+            <wsdl:output message="ns:DeleteOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="BidModifiersSOAP" type="ns:BidModifiersPort">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="add">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/bidmodifiers/add"/>
+            <wsdl:input name="addRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="set">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/bidmodifiers/set"/>
+            <wsdl:input name="setRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="get">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/bidmodifiers/get"/>
+            <wsdl:input name="getRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/bidmodifiers/delete"/>
+            <wsdl:input name="deleteRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="BidModifiers">
+        <wsdl:port binding="ns:BidModifiersSOAP" name="BidModifiersSOAP">
+            <soap:address location="https://soap.direct.yandex.ru/v5/bidmodifiers"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/tests/wsdl_cache/bids.xml
+++ b/tests/wsdl_cache/bids.xml
@@ -1,0 +1,262 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<wsdl:definitions xmlns:ns="http://api.direct.yandex.com/v5/bids"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:general="http://api.direct.yandex.com/v5/general"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  name="Bids"
+                  targetNamespace="http://api.direct.yandex.com/v5/bids">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://api.direct.yandex.com/v5/bids">
+            <xsd:import namespace="http://api.direct.yandex.com/v5/general" schemaLocation="https://soap.direct.yandex.ru/v5/general.xsd" />
+            <xsd:simpleType name="BidFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="KeywordId" />
+                    <xsd:enumeration value="AdGroupId" />
+                    <xsd:enumeration value="CampaignId" />
+                    <xsd:enumeration value="Bid" />
+                    <xsd:enumeration value="AutotargetingSearchBidIsAuto" />
+                    <xsd:enumeration value="ContextBid" />
+                    <xsd:enumeration value="StrategyPriority" />
+                    <xsd:enumeration value="CompetitorsBids" />
+                    <xsd:enumeration value="SearchPrices" />
+                    <xsd:enumeration value="ContextCoverage" />
+                    <xsd:enumeration value="MinSearchPrice" />
+                    <xsd:enumeration value="CurrentSearchPrice" />
+                    <xsd:enumeration value="AuctionBids" />
+                    <xsd:enumeration value="ServingStatus" />
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="CalculateByEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="VALUE"/>
+                    <xsd:enumeration value="DIFF"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="BidsSelectionCriteria">
+                <xsd:sequence>
+                    <xsd:element name="CampaignIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="AdGroupIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="KeywordIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="ServingStatuses" type="general:ServingStatusEnum" minOccurs="0" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SearchPrices">
+                <xsd:sequence>
+                    <xsd:element name="Position" type="general:PositionEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Price" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ContextCoverage">
+                <xsd:sequence>
+                    <xsd:element name="Items" type="ns:ContextCoverageItem" minOccurs="0" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ContextCoverageItem">
+                <xsd:sequence>
+                    <xsd:element name="Probability" type="xsd:decimal" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Price" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="BidActionResult">
+                <xsd:complexContent>
+                    <xsd:extension base="general:ActionResultBase">
+                        <xsd:sequence>
+                            <xsd:element name="CampaignId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="AdGroupId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="KeywordId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="BidGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:BidActionResult">
+                        <xsd:sequence>
+                            <xsd:element name="Bid" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="AutotargetingSearchBidIsAuto" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="ContextBid" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="StrategyPriority" type="general:PriorityEnum" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="CompetitorsBids" type="xsd:long" minOccurs="0" maxOccurs="unbounded" />
+                            <xsd:element name="SearchPrices" type="ns:SearchPrices" minOccurs="0" maxOccurs="unbounded" />
+                            <xsd:element name="ContextCoverage" type="ns:ContextCoverage" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="MinSearchPrice" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="CurrentSearchPrice" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="AuctionBids" type="ns:AuctionBidItem" minOccurs="0" maxOccurs="unbounded" />
+                            <xsd:element name="ServingStatus" type="general:ServingStatusEnum" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="AuctionBidItem">
+                <xsd:sequence>
+                    <xsd:element name="Position" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Bid" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Price" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="BidSetItem">
+                <xsd:sequence>
+                    <xsd:element name="CampaignId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AdGroupId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="KeywordId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Bid" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ContextBid" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AutotargetingSearchBidIsAuto" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="StrategyPriority" type="general:PriorityEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="BidSetAutoItem">
+                <xsd:sequence>
+                    <xsd:element name="CampaignId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AdGroupId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="KeywordId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="MaxBid" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Position" type="general:PositionEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="IncreasePercent" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CalculateBy" type="ns:CalculateByEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ContextCoverage" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Scope" type="general:ScopeEnum" minOccurs="1" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="GetRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetRequestGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="SelectionCriteria" type="ns:BidsSelectionCriteria" minOccurs="1"
+                                             maxOccurs="1"/>
+                                <xsd:element name="FieldNames" type="ns:BidFieldEnum" minOccurs="1" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetResponse">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetResponseGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="Bids" type="ns:BidGetItem" minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SetRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="Bids" type="ns:BidSetItem"
+                                     minOccurs="1" maxOccurs="unbounded" nillable="false"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SetResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SetResults" type="ns:BidActionResult"
+                                     minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SetAutoRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="Bids" type="ns:BidSetAutoItem"
+                                     minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SetAutoResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SetAutoResults" type="ns:BidActionResult"
+                                     minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="ApiException">
+        <wsdl:part element="general:FaultResponse" name="faultMessage"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationRequest">
+        <wsdl:part element="ns:GetRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationResponse">
+        <wsdl:part element="ns:GetResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="SetOperationRequest">
+        <wsdl:part element="ns:SetRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="SetOperationResponse">
+        <wsdl:part element="ns:SetResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="SetAutoOperationRequest">
+        <wsdl:part element="ns:SetAutoRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="SetAutoOperationResponse">
+        <wsdl:part element="ns:SetAutoResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:portType name="BidsPort">
+        <wsdl:operation name="get">
+            <wsdl:input  message="ns:GetOperationRequest"/>
+            <wsdl:output message="ns:GetOperationResponse"/>
+            <wsdl:fault  message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="set">
+            <wsdl:input  message="ns:SetOperationRequest"/>
+            <wsdl:output message="ns:SetOperationResponse"/>
+            <wsdl:fault  message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="setAuto">
+            <wsdl:input  message="ns:SetAutoOperationRequest"/>
+            <wsdl:output message="ns:SetAutoOperationResponse"/>
+            <wsdl:fault  message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="BidsSOAP" type="ns:BidsPort">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="get">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/bids/get"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="set">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/bids/set"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="setAuto">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/bids/setAuto"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="Bids">
+        <wsdl:port binding="ns:BidsSOAP" name="BidsSOAP">
+            <soap:address location="https://soap.direct.yandex.ru/v5/bids"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/tests/wsdl_cache/businesses.xml
+++ b/tests/wsdl_cache/businesses.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:ns="http://api.direct.yandex.com/v5/businesses"
+                  xmlns:general="http://api.direct.yandex.com/v5/general"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  name="Businesses"
+                  targetNamespace="http://api.direct.yandex.com/v5/businesses">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://api.direct.yandex.com/v5/businesses">
+            <xsd:import namespace="http://api.direct.yandex.com/v5/general" schemaLocation="https://soap.direct.yandex.ru/v5/general.xsd"/>
+            <xsd:simpleType name="BusinessFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Id"/>
+                    <xsd:enumeration value="Name"/>
+                    <xsd:enumeration value="Address"/>
+                    <xsd:enumeration value="Phone"/>
+                    <xsd:enumeration value="ProfileUrl"/>
+                    <xsd:enumeration value="InternalUrl"/>
+                    <xsd:enumeration value="IsPublished"/>
+                    <xsd:enumeration value="MergedIds"/>
+                    <xsd:enumeration value="Rubric"/>
+                    <xsd:enumeration value="Urls"/>
+                    <xsd:enumeration value="HasOffice"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="BusinessGetItem">
+                <xsd:sequence>
+                    <xsd:element name="Id" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Address" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="Phone" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ProfileUrl" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="InternalUrl" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="IsPublished" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="MergedIds" type="general:ArrayOfLong" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="Rubric" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Urls" type="general:ArrayOfString" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="HasOffice" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="GetRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetRequestGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="0"
+                                             maxOccurs="1"/>
+                                <xsd:element name="FieldNames" type="ns:BusinessFieldEnum" minOccurs="1"
+                                             maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetResponse">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetResponseGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="Businesses" type="ns:BusinessGetItem" minOccurs="0"
+                                             maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="GetOperationRequest">
+        <wsdl:part name="parameters" element="ns:GetRequest"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationResponse">
+        <wsdl:part name="parameters" element="ns:GetResponse"/>
+    </wsdl:message>
+    <wsdl:message name="ApiException">
+        <wsdl:part name="faultMessage" element="general:FaultResponse"/>
+    </wsdl:message>
+    <wsdl:portType name="BusinessesPort">
+        <wsdl:operation name="get">
+            <wsdl:input message="ns:GetOperationRequest" name="getRequest"/>
+            <wsdl:output message="ns:GetOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="BusinessesSOAP" type="ns:BusinessesPort">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="get">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/businesses/get"/>
+            <wsdl:input name="getRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="Businesses">
+        <wsdl:port binding="ns:BusinessesSOAP" name="BusinessesSOAP">
+            <soap:address location="https://soap.direct.yandex.ru/v5/businesses"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/tests/wsdl_cache/campaigns.xml
+++ b/tests/wsdl_cache/campaigns.xml
@@ -1,0 +1,2809 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:ns="http://api.direct.yandex.com/v5/campaigns"
+                  xmlns:general="http://api.direct.yandex.com/v5/general"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  name="Campaigns" targetNamespace="http://api.direct.yandex.com/v5/campaigns">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://api.direct.yandex.com/v5/campaigns">
+           <xsd:import namespace="http://api.direct.yandex.com/v5/general" schemaLocation="https://soap.direct.yandex.ru/v5/general.xsd" />
+            <!-- ENUMERATES -->
+            <xsd:simpleType name="SmsEventsEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="MONITORING"/>
+                    <xsd:enumeration value="MODERATION"/>
+                    <xsd:enumeration value="MONEY_IN"/>
+                    <xsd:enumeration value="MONEY_OUT"/>
+                    <xsd:enumeration value="FINISHED"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="PlacementTypesEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="SEARCH_RESULTS"/>
+                    <xsd:enumeration value="PRODUCT_GALLERY"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="PlacementType">
+                <xsd:sequence>
+                    <xsd:element name="Type" type="ns:PlacementTypesEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Value" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="PlacementTypeArray">
+                <xsd:sequence>
+                    <xsd:element name="Items" type="ns:PlacementType" minOccurs="1" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:simpleType name="CampaignStatusSelectionEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="ACCEPTED"/>
+                    <xsd:enumeration value="DRAFT"/>
+                    <xsd:enumeration value="MODERATION"/>
+                    <xsd:enumeration value="REJECTED"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="CampaignStateEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="ARCHIVED" />
+                    <xsd:enumeration value="CONVERTED"/>
+                    <xsd:enumeration value="ENDED"/>
+                    <xsd:enumeration value="OFF"/>
+                    <xsd:enumeration value="ON"/>
+                    <xsd:enumeration value="SUSPENDED"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="CampaignStateGetEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="ARCHIVED" />
+                    <xsd:enumeration value="CONVERTED"/>
+                    <xsd:enumeration value="ENDED"/>
+                    <xsd:enumeration value="OFF"/>
+                    <xsd:enumeration value="ON"/>
+                    <xsd:enumeration value="SUSPENDED"/>
+                    <xsd:enumeration value="UNKNOWN" />
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="CampaignStatusPaymentEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="DISALLOWED"/>
+                    <xsd:enumeration value="ALLOWED"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="RelevantKeywordsModeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="MINIMUM"/>
+                    <xsd:enumeration value="OPTIMAL"/>
+                    <xsd:enumeration value="MAXIMUM"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="DailyBudgetModeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="STANDARD"/>
+                    <xsd:enumeration value="DISTRIBUTED"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="CampaignFundsEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="CAMPAIGN_FUNDS"/>
+                    <xsd:enumeration value="SHARED_ACCOUNT_FUNDS"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="CampaignTypeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="TEXT_CAMPAIGN"/>
+                    <xsd:enumeration value="MOBILE_APP_CAMPAIGN"/>
+                    <xsd:enumeration value="DYNAMIC_TEXT_CAMPAIGN"/>
+                    <xsd:enumeration value="CPM_BANNER_CAMPAIGN"/>
+                    <xsd:enumeration value="SMART_CAMPAIGN"/>
+                    <xsd:enumeration value="UNIFIED_CAMPAIGN"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="CampaignTypeGetEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="TEXT_CAMPAIGN"/>
+                    <xsd:enumeration value="MOBILE_APP_CAMPAIGN"/>
+                    <xsd:enumeration value="DYNAMIC_TEXT_CAMPAIGN"/>
+                    <xsd:enumeration value="CPM_BANNER_CAMPAIGN"/>
+                    <xsd:enumeration value="SMART_CAMPAIGN"/>
+                    <xsd:enumeration value="UNIFIED_CAMPAIGN"/>
+                    <xsd:enumeration value="UNKNOWN" />
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="CampaignFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="BlockedIps"/>
+                    <xsd:enumeration value="ExcludedSites"/>
+                    <xsd:enumeration value="Currency"/>
+                    <xsd:enumeration value="DailyBudget"/>
+                    <xsd:enumeration value="Notification"/>
+                    <xsd:enumeration value="EndDate"/>
+                    <xsd:enumeration value="Funds"/>
+                    <xsd:enumeration value="ClientInfo"/>
+                    <xsd:enumeration value="Id"/>
+                    <xsd:enumeration value="Name"/>
+                    <xsd:enumeration value="NegativeKeywords"/>
+                    <xsd:enumeration value="RepresentedBy"/>
+                    <xsd:enumeration value="StartDate"/>
+                    <xsd:enumeration value="Statistics"/>
+                    <xsd:enumeration value="State"/>
+                    <xsd:enumeration value="Status"/>
+                    <xsd:enumeration value="StatusPayment"/>
+                    <xsd:enumeration value="StatusClarification"/>
+                    <xsd:enumeration value="SourceId"/>
+                    <xsd:enumeration value="TimeTargeting"/>
+                    <xsd:enumeration value="TimeZone"/>
+                    <xsd:enumeration value="Type"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="TextCampaignFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="CounterIds"/>
+                    <xsd:enumeration value="RelevantKeywords"/>
+                    <xsd:enumeration value="Settings"/>
+                    <xsd:enumeration value="BiddingStrategy"/>
+                    <xsd:enumeration value="PriorityGoals"/>
+                    <xsd:enumeration value="TrackingParams"/>
+                    <xsd:enumeration value="AttributionModel"/>
+                    <xsd:enumeration value="PackageBiddingStrategy"/>
+                    <xsd:enumeration value="CanBeUsedAsPackageBiddingStrategySource"/>
+                    <xsd:enumeration value="NegativeKeywordSharedSetIds"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="TextCampaignSearchStrategyPlacementTypesFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="SearchResults"/>
+                    <xsd:enumeration value="ProductGallery"/>
+                    <xsd:enumeration value="DynamicPlaces"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="UnifiedCampaignFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="CounterIds"/>
+                    <xsd:enumeration value="Settings"/>
+                    <xsd:enumeration value="BiddingStrategy"/>
+                    <xsd:enumeration value="PriorityGoals"/>
+                    <xsd:enumeration value="TrackingParams"/>
+                    <xsd:enumeration value="AttributionModel"/>
+                    <xsd:enumeration value="PackageBiddingStrategy"/>
+                    <xsd:enumeration value="CanBeUsedAsPackageBiddingStrategySource"/>
+                    <xsd:enumeration value="NegativeKeywordSharedSetIds"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="UnifiedCampaignSearchStrategyPlacementTypesFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="SearchResults"/>
+                    <xsd:enumeration value="ProductGallery"/>
+                    <xsd:enumeration value="DynamicPlaces"/>
+                    <xsd:enumeration value="Maps"/>
+                    <xsd:enumeration value="SearchOrganizationList"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="UnifiedCampaignPackageBiddingStrategyPlatformsFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="SearchResult"/>
+                    <xsd:enumeration value="ProductGallery"/>
+                    <xsd:enumeration value="Maps"/>
+                    <xsd:enumeration value="SearchOrganizationList"/>
+                    <xsd:enumeration value="Network"/>
+                    <xsd:enumeration value="DynamicPlaces"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="MobileAppCampaignFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Settings"/>
+                    <xsd:enumeration value="BiddingStrategy"/>
+                    <xsd:enumeration value="PackageBiddingStrategy"/>
+                    <xsd:enumeration value="CanBeUsedAsPackageBiddingStrategySource"/>
+                    <xsd:enumeration value="NegativeKeywordSharedSetIds"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="DynamicTextCampaignFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="PlacementTypes"/>
+                    <xsd:enumeration value="CounterIds"/>
+                    <xsd:enumeration value="Settings"/>
+                    <xsd:enumeration value="BiddingStrategy"/>
+                    <xsd:enumeration value="PriorityGoals"/>
+                    <xsd:enumeration value="TrackingParams"/>
+                    <xsd:enumeration value="AttributionModel"/>
+                    <xsd:enumeration value="PackageBiddingStrategy"/>
+                    <xsd:enumeration value="CanBeUsedAsPackageBiddingStrategySource"/>
+                    <xsd:enumeration value="NegativeKeywordSharedSetIds"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="DynamicTextCampaignSearchStrategyPlacementTypesFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="SearchResults"/>
+                    <xsd:enumeration value="ProductGallery"/>
+                    <xsd:enumeration value="DynamicPlaces"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="CpmBannerCampaignFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="CounterIds"/>
+                    <xsd:enumeration value="FrequencyCap"/>
+                    <xsd:enumeration value="VideoTarget"/>
+                    <xsd:enumeration value="Settings"/>
+                    <xsd:enumeration value="BiddingStrategy"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="SmartCampaignFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="CounterId"/>
+                    <xsd:enumeration value="Settings"/>
+                    <xsd:enumeration value="BiddingStrategy"/>
+                    <xsd:enumeration value="PriorityGoals"/>
+                    <xsd:enumeration value="TrackingParams"/>
+                    <xsd:enumeration value="AttributionModel"/>
+                    <xsd:enumeration value="PackageBiddingStrategy"/>
+                    <xsd:enumeration value="CanBeUsedAsPackageBiddingStrategySource"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="TextCampaignSearchStrategyTypeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="AVERAGE_CPC"/>
+                    <xsd:enumeration value="AVERAGE_CPA"/>
+                    <xsd:enumeration value="PAY_FOR_CONVERSION"/>
+                    <xsd:enumeration value="WB_MAXIMUM_CONVERSION_RATE"/>
+                    <xsd:enumeration value="HIGHEST_POSITION"/>
+                    <xsd:enumeration value="IMPRESSIONS_BELOW_SEARCH"/>
+                    <xsd:enumeration value="SERVING_OFF"/>
+                    <xsd:enumeration value="UNKNOWN"/>
+                    <xsd:enumeration value="WB_MAXIMUM_CLICKS"/>
+                    <xsd:enumeration value="WEEKLY_CLICK_PACKAGE"/>
+                    <xsd:enumeration value="AVERAGE_ROI"/>
+                    <xsd:enumeration value="AVERAGE_CRR"/>
+                    <xsd:enumeration value="PAY_FOR_CONVERSION_CRR"/>
+                    <xsd:enumeration value="AVERAGE_CPA_MULTIPLE_GOALS"/>
+                    <xsd:enumeration value="PAY_FOR_CONVERSION_MULTIPLE_GOALS"/>
+                    <xsd:enumeration value="MAX_PROFIT"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="UnifiedCampaignSearchStrategyTypeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="AVERAGE_CPC"/>
+                    <xsd:enumeration value="AVERAGE_CPA"/>
+                    <xsd:enumeration value="PAY_FOR_CONVERSION"/>
+                    <xsd:enumeration value="WB_MAXIMUM_CONVERSION_RATE"/>
+                    <xsd:enumeration value="HIGHEST_POSITION"/>
+                    <xsd:enumeration value="SERVING_OFF"/>
+                    <xsd:enumeration value="UNKNOWN"/>
+                    <xsd:enumeration value="WB_MAXIMUM_CLICKS"/>
+                    <xsd:enumeration value="AVERAGE_CRR"/>
+                    <xsd:enumeration value="PAY_FOR_CONVERSION_CRR"/>
+                    <xsd:enumeration value="AVERAGE_CPA_MULTIPLE_GOALS"/>
+                    <xsd:enumeration value="PAY_FOR_CONVERSION_MULTIPLE_GOALS"/>
+                    <xsd:enumeration value="MAX_PROFIT"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="TextCampaignNetworkStrategyTypeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="AVERAGE_CPC"/>
+                    <xsd:enumeration value="AVERAGE_CPA"/>
+                    <xsd:enumeration value="PAY_FOR_CONVERSION"/>
+                    <xsd:enumeration value="WB_MAXIMUM_CONVERSION_RATE"/>
+                    <xsd:enumeration value="MAXIMUM_COVERAGE"/>
+                    <xsd:enumeration value="NETWORK_DEFAULT"/>
+                    <xsd:enumeration value="SERVING_OFF"/>
+                    <xsd:enumeration value="UNKNOWN"/>
+                    <xsd:enumeration value="WB_MAXIMUM_CLICKS"/>
+                    <xsd:enumeration value="WEEKLY_CLICK_PACKAGE"/>
+                    <xsd:enumeration value="AVERAGE_ROI"/>
+                    <xsd:enumeration value="AVERAGE_CRR"/>
+                    <xsd:enumeration value="PAY_FOR_CONVERSION_CRR"/>
+                    <xsd:enumeration value="AVERAGE_CPA_MULTIPLE_GOALS"/>
+                    <xsd:enumeration value="PAY_FOR_CONVERSION_MULTIPLE_GOALS"/>
+                    <xsd:enumeration value="MAX_PROFIT"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="UnifiedCampaignNetworkStrategyTypeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="AVERAGE_CPC"/>
+                    <xsd:enumeration value="AVERAGE_CPA"/>
+                    <xsd:enumeration value="PAY_FOR_CONVERSION"/>
+                    <xsd:enumeration value="WB_MAXIMUM_CONVERSION_RATE"/>
+                    <xsd:enumeration value="NETWORK_DEFAULT"/>
+                    <xsd:enumeration value="SERVING_OFF"/>
+                    <xsd:enumeration value="UNKNOWN"/>
+                    <xsd:enumeration value="WB_MAXIMUM_CLICKS"/>
+                    <xsd:enumeration value="AVERAGE_CRR"/>
+                    <xsd:enumeration value="PAY_FOR_CONVERSION_CRR"/>
+                    <xsd:enumeration value="AVERAGE_CPA_MULTIPLE_GOALS"/>
+                    <xsd:enumeration value="PAY_FOR_CONVERSION_MULTIPLE_GOALS"/>
+                    <xsd:enumeration value="MAX_PROFIT"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="MobileAppCampaignSearchStrategyTypeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="AVERAGE_CPC"/>
+                    <xsd:enumeration value="AVERAGE_CPI"/>
+                    <xsd:enumeration value="WB_MAXIMUM_APP_INSTALLS"/>
+                    <xsd:enumeration value="HIGHEST_POSITION"/>
+                    <xsd:enumeration value="IMPRESSIONS_BELOW_SEARCH"/>
+                    <xsd:enumeration value="SERVING_OFF"/>
+                    <xsd:enumeration value="UNKNOWN"/>
+                    <xsd:enumeration value="WB_MAXIMUM_CLICKS"/>
+                    <xsd:enumeration value="WEEKLY_CLICK_PACKAGE"/>
+                    <xsd:enumeration value="PAY_FOR_INSTALL"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="MobileAppCampaignNetworkStrategyTypeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="NETWORK_DEFAULT"/>
+                    <xsd:enumeration value="MAXIMUM_COVERAGE"/>
+                    <xsd:enumeration value="AVERAGE_CPC"/>
+                    <xsd:enumeration value="AVERAGE_CPI"/>
+                    <xsd:enumeration value="WB_MAXIMUM_APP_INSTALLS"/>
+                    <xsd:enumeration value="SERVING_OFF"/>
+                    <xsd:enumeration value="UNKNOWN"/>
+                    <xsd:enumeration value="WB_MAXIMUM_CLICKS"/>
+                    <xsd:enumeration value="WEEKLY_CLICK_PACKAGE"/>
+                    <xsd:enumeration value="PAY_FOR_INSTALL"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="DynamicTextCampaignSearchStrategyTypeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="AVERAGE_CPC"/>
+                    <xsd:enumeration value="AVERAGE_CPA"/>
+                    <xsd:enumeration value="PAY_FOR_CONVERSION"/>
+                    <xsd:enumeration value="WB_MAXIMUM_CONVERSION_RATE"/>
+                    <xsd:enumeration value="HIGHEST_POSITION"/>
+                    <xsd:enumeration value="IMPRESSIONS_BELOW_SEARCH"/>
+                    <xsd:enumeration value="UNKNOWN"/>
+                    <xsd:enumeration value="WB_MAXIMUM_CLICKS"/>
+                    <xsd:enumeration value="WEEKLY_CLICK_PACKAGE"/>
+                    <xsd:enumeration value="AVERAGE_ROI"/>
+                    <xsd:enumeration value="AVERAGE_CRR"/>
+                    <xsd:enumeration value="PAY_FOR_CONVERSION_CRR"/>
+                    <xsd:enumeration value="SERVING_OFF"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="DynamicTextCampaignNetworkStrategyTypeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="NETWORK_DEFAULT"/>
+                    <xsd:enumeration value="MAXIMUM_COVERAGE"/>
+                    <xsd:enumeration value="WB_MAXIMUM_CONVERSION_RATE"/>
+                    <xsd:enumeration value="WB_MAXIMUM_CLICKS"/>
+                    <xsd:enumeration value="AVERAGE_CPC"/>
+                    <xsd:enumeration value="AVERAGE_CPA"/>
+                    <xsd:enumeration value="PAY_FOR_CONVERSION"/>
+                    <xsd:enumeration value="AVERAGE_ROI"/>
+                    <xsd:enumeration value="AVERAGE_CRR"/>
+                    <xsd:enumeration value="PAY_FOR_CONVERSION_CRR"/>
+                    <xsd:enumeration value="WEEKLY_CLICK_PACKAGE"/>
+                    <xsd:enumeration value="SERVING_OFF"/>
+                    <xsd:enumeration value="UNKNOWN"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="CpmBannerCampaignSearchStrategyTypeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="SERVING_OFF"/>
+                    <xsd:enumeration value="UNKNOWN"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="CpmBannerCampaignNetworkStrategyTypeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="MANUAL_CPM"/>
+                    <xsd:enumeration value="WB_DECREASED_PRICE_FOR_REPEATED_IMPRESSIONS"/>
+                    <xsd:enumeration value="CP_DECREASED_PRICE_FOR_REPEATED_IMPRESSIONS"/>
+                    <xsd:enumeration value="WB_MAXIMUM_IMPRESSIONS"/>
+                    <xsd:enumeration value="CP_MAXIMUM_IMPRESSIONS"/>
+                    <xsd:enumeration value="WB_AVERAGE_CPV"/>
+                    <xsd:enumeration value="CP_AVERAGE_CPV"/>
+                    <xsd:enumeration value="UNKNOWN"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="SmartCampaignSearchStrategyTypeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="AVERAGE_CPC_PER_CAMPAIGN"/>
+                    <xsd:enumeration value="AVERAGE_CPC_PER_FILTER"/>
+                    <xsd:enumeration value="AVERAGE_CPA_PER_CAMPAIGN"/>
+                    <xsd:enumeration value="AVERAGE_CPA_PER_FILTER"/>
+                    <xsd:enumeration value="PAY_FOR_CONVERSION_PER_CAMPAIGN"/>
+                    <xsd:enumeration value="PAY_FOR_CONVERSION_PER_FILTER"/>
+                    <xsd:enumeration value="AVERAGE_ROI"/>
+                    <xsd:enumeration value="AVERAGE_CRR"/>
+                    <xsd:enumeration value="PAY_FOR_CONVERSION_CRR"/>
+                    <xsd:enumeration value="SERVING_OFF"/>
+                    <xsd:enumeration value="UNKNOWN"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="SmartCampaignNetworkStrategyTypeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="NETWORK_DEFAULT"/>
+                    <xsd:enumeration value="AVERAGE_CPC_PER_CAMPAIGN"/>
+                    <xsd:enumeration value="AVERAGE_CPC_PER_FILTER"/>
+                    <xsd:enumeration value="AVERAGE_CPA_PER_CAMPAIGN"/>
+                    <xsd:enumeration value="AVERAGE_CPA_PER_FILTER"/>
+                    <xsd:enumeration value="PAY_FOR_CONVERSION_PER_CAMPAIGN"/>
+                    <xsd:enumeration value="PAY_FOR_CONVERSION_PER_FILTER"/>
+                    <xsd:enumeration value="AVERAGE_ROI"/>
+                    <xsd:enumeration value="AVERAGE_CRR"/>
+                    <xsd:enumeration value="PAY_FOR_CONVERSION_CRR"/>
+                    <xsd:enumeration value="SERVING_OFF"/>
+                    <xsd:enumeration value="UNKNOWN"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <!-- CAMPAIGN FLAGS -->
+            <xsd:simpleType name="TextCampaignSettingsEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="EXCLUDE_PAUSED_COMPETING_ADS"/>
+                    <xsd:enumeration value="ADD_OPENSTAT_TAG"/>
+                    <xsd:enumeration value="ADD_METRICA_TAG"/>
+                    <xsd:enumeration value="ADD_TO_FAVORITES"/>
+                    <xsd:enumeration value="ENABLE_AREA_OF_INTEREST_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_CURRENT_AREA_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_REGULAR_AREA_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_SITE_MONITORING"/>
+                    <xsd:enumeration value="ENABLE_BEHAVIORAL_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_AUTOFOCUS"/>
+                    <xsd:enumeration value="REQUIRE_SERVICING"/>
+                    <xsd:enumeration value="ENABLE_RELATED_KEYWORDS"/>
+                    <xsd:enumeration value="ENABLE_EXTENDED_AD_TITLE"/>
+                    <xsd:enumeration value="MAINTAIN_NETWORK_CPC"/>
+                    <xsd:enumeration value="ENABLE_COMPANY_INFO"/>
+                    <xsd:enumeration value="CAMPAIGN_EXACT_PHRASE_MATCHING_ENABLED"/>
+                    <xsd:enumeration value="ALTERNATIVE_TEXTS_ENABLED"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="TextCampaignSettingsGetEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="EXCLUDE_PAUSED_COMPETING_ADS"/>
+                    <xsd:enumeration value="ADD_OPENSTAT_TAG"/>
+                    <xsd:enumeration value="ADD_METRICA_TAG"/>
+                    <xsd:enumeration value="ADD_TO_FAVORITES"/>
+                    <xsd:enumeration value="ENABLE_AREA_OF_INTEREST_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_CURRENT_AREA_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_REGULAR_AREA_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_SITE_MONITORING"/>
+                    <xsd:enumeration value="ENABLE_BEHAVIORAL_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_AUTOFOCUS"/>
+                    <xsd:enumeration value="REQUIRE_SERVICING"/>
+                    <xsd:enumeration value="ENABLE_RELATED_KEYWORDS"/>
+                    <xsd:enumeration value="ENABLE_EXTENDED_AD_TITLE"/>
+                    <xsd:enumeration value="MAINTAIN_NETWORK_CPC"/>
+                    <xsd:enumeration value="ENABLE_COMPANY_INFO"/>
+                    <xsd:enumeration value="SHARED_ACCOUNT_ENABLED"/>
+                    <xsd:enumeration value="DAILY_BUDGET_ALLOWED"/>
+                    <xsd:enumeration value="CAMPAIGN_EXACT_PHRASE_MATCHING_ENABLED"/>
+                    <xsd:enumeration value="ALTERNATIVE_TEXTS_ENABLED"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="UnifiedCampaignSettingsEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="ADD_METRICA_TAG"/>
+                    <xsd:enumeration value="ADD_TO_FAVORITES"/>
+                    <xsd:enumeration value="ENABLE_AREA_OF_INTEREST_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_SITE_MONITORING"/>
+                    <xsd:enumeration value="REQUIRE_SERVICING"/>
+                    <xsd:enumeration value="ENABLE_COMPANY_INFO"/>
+                    <xsd:enumeration value="CAMPAIGN_EXACT_PHRASE_MATCHING_ENABLED"/>
+                    <xsd:enumeration value="ALTERNATIVE_TEXTS_ENABLED"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="UnifiedCampaignSettingsGetEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="ADD_METRICA_TAG"/>
+                    <xsd:enumeration value="ADD_TO_FAVORITES"/>
+                    <xsd:enumeration value="ENABLE_AREA_OF_INTEREST_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_SITE_MONITORING"/>
+                    <xsd:enumeration value="REQUIRE_SERVICING"/>
+                    <xsd:enumeration value="ENABLE_COMPANY_INFO"/>
+                    <xsd:enumeration value="SHARED_ACCOUNT_ENABLED"/>
+                    <xsd:enumeration value="CAMPAIGN_EXACT_PHRASE_MATCHING_ENABLED"/>
+                    <xsd:enumeration value="ALTERNATIVE_TEXTS_ENABLED"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="MobileAppCampaignSettingsEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="ADD_TO_FAVORITES"/>
+                    <xsd:enumeration value="ENABLE_AREA_OF_INTEREST_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_CURRENT_AREA_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_REGULAR_AREA_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_BEHAVIORAL_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_AUTOFOCUS"/>
+                    <xsd:enumeration value="REQUIRE_SERVICING"/>
+                    <xsd:enumeration value="MAINTAIN_NETWORK_CPC"/>
+                    <xsd:enumeration value="CAMPAIGN_EXACT_PHRASE_MATCHING_ENABLED"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="MobileAppCampaignSettingsGetEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="ADD_TO_FAVORITES"/>
+                    <xsd:enumeration value="ENABLE_AREA_OF_INTEREST_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_CURRENT_AREA_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_REGULAR_AREA_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_BEHAVIORAL_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_AUTOFOCUS"/>
+                    <xsd:enumeration value="REQUIRE_SERVICING"/>
+                    <xsd:enumeration value="MAINTAIN_NETWORK_CPC"/>
+                    <xsd:enumeration value="SHARED_ACCOUNT_ENABLED"/>
+                    <xsd:enumeration value="DAILY_BUDGET_ALLOWED"/>
+                    <xsd:enumeration value="CAMPAIGN_EXACT_PHRASE_MATCHING_ENABLED"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="DynamicTextCampaignSettingsEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="ADD_OPENSTAT_TAG"/>
+                    <!-- External statistics, StatusOpenStat  -->
+                    <xsd:enumeration value="ADD_METRICA_TAG"/>
+                    <!--ClickTrackEnabled,  Tag links for Metrica -->
+                    <xsd:enumeration value="ADD_TO_FAVORITES"/>
+                    <xsd:enumeration value="ENABLE_AREA_OF_INTEREST_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_CURRENT_AREA_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_REGULAR_AREA_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_SITE_MONITORING"/>
+                    <!--  StatusMetricaControl  -->
+                    <xsd:enumeration value="ENABLE_BEHAVIORAL_TARGETING"/>
+                    <!-- StatusBehavior -->
+                    <!-- allow to create or pass campaigns to manager assistance, if applicable -->
+                    <xsd:enumeration value="REQUIRE_SERVICING"/>
+                    <xsd:enumeration value="ENABLE_EXTENDED_AD_TITLE"/>
+                    <xsd:enumeration value="ENABLE_COMPANY_INFO"/>
+                    <xsd:enumeration value="CAMPAIGN_EXACT_PHRASE_MATCHING_ENABLED"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="DynamicTextCampaignSettingsGetEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="ADD_OPENSTAT_TAG"/>
+                    <!-- External statistics, StatusOpenStat  -->
+                    <xsd:enumeration value="ADD_METRICA_TAG"/>
+                    <!--ClickTrackEnabled,  Tag links for Metrica -->
+                    <xsd:enumeration value="ADD_TO_FAVORITES"/>
+                    <xsd:enumeration value="ENABLE_AREA_OF_INTEREST_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_CURRENT_AREA_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_REGULAR_AREA_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_SITE_MONITORING"/>
+                    <!--  StatusMetricaControl  -->
+                    <xsd:enumeration value="ENABLE_BEHAVIORAL_TARGETING"/>
+                    <!-- StatusBehavior -->
+                    <!-- allow to create or pass campaigns to manager assistance, if applicable -->
+                    <xsd:enumeration value="REQUIRE_SERVICING"/>
+                    <xsd:enumeration value="ENABLE_EXTENDED_AD_TITLE"/>
+                    <xsd:enumeration value="ENABLE_COMPANY_INFO"/>
+                    <xsd:enumeration value="SHARED_ACCOUNT_ENABLED"/>
+                    <xsd:enumeration value="DAILY_BUDGET_ALLOWED"/>
+                    <xsd:enumeration value="CAMPAIGN_EXACT_PHRASE_MATCHING_ENABLED"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="CpmBannerCampaignSettingsEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="ADD_OPENSTAT_TAG"/>
+                    <xsd:enumeration value="ADD_METRICA_TAG"/>
+                    <xsd:enumeration value="ADD_TO_FAVORITES"/>
+                    <xsd:enumeration value="ENABLE_AREA_OF_INTEREST_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_CURRENT_AREA_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_REGULAR_AREA_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_SITE_MONITORING"/>
+                    <xsd:enumeration value="REQUIRE_SERVICING"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="CpmBannerCampaignSettingsGetEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="ADD_OPENSTAT_TAG"/>
+                    <xsd:enumeration value="ADD_METRICA_TAG"/>
+                    <xsd:enumeration value="ADD_TO_FAVORITES"/>
+                    <xsd:enumeration value="ENABLE_AREA_OF_INTEREST_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_CURRENT_AREA_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_REGULAR_AREA_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_SITE_MONITORING"/>
+                    <xsd:enumeration value="REQUIRE_SERVICING"/>
+                    <xsd:enumeration value="SHARED_ACCOUNT_ENABLED"/>
+                    <xsd:enumeration value="DAILY_BUDGET_ALLOWED"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="SmartCampaignSettingsEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="ADD_TO_FAVORITES"/>
+                    <xsd:enumeration value="ENABLE_AREA_OF_INTEREST_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_CURRENT_AREA_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_REGULAR_AREA_TARGETING"/>
+                    <xsd:enumeration value="REQUIRE_SERVICING"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="SmartCampaignSettingsGetEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="ADD_TO_FAVORITES"/>
+                    <xsd:enumeration value="ENABLE_AREA_OF_INTEREST_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_CURRENT_AREA_TARGETING"/>
+                    <xsd:enumeration value="ENABLE_REGULAR_AREA_TARGETING"/>
+                    <xsd:enumeration value="REQUIRE_SERVICING"/>
+                    <xsd:enumeration value="SHARED_ACCOUNT_ENABLED"/>
+                    <xsd:enumeration value="DAILY_BUDGET_ALLOWED"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="BudgetTypeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="WEEKLY_BUDGET"/>
+                    <xsd:enumeration value="CUSTOM_PERIOD_BUDGET"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="TextCampaignSearchStrategyPlacementTypes">
+                <xsd:sequence>
+                    <xsd:element name="SearchResults" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ProductGallery" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="DynamicPlaces" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="TextCampaignPlatforms">
+                <xsd:sequence>
+                    <xsd:element name="SearchResult" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="ProductGallery" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Network" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="DynamicPlaces" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="UnifiedCampaignSearchStrategyPlacementTypes">
+                <xsd:sequence>
+                    <xsd:element name="SearchResults" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ProductGallery" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="DynamicPlaces" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Maps" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="SearchOrganizationList" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="UnifiedCampaignPlatforms">
+                <xsd:sequence>
+                    <xsd:element name="SearchResult" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="ProductGallery" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Maps" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="SearchOrganizationList" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Network" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="DynamicPlaces" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SmartCampaignPlatforms">
+                <xsd:sequence>
+                    <xsd:element name="Search" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Network" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="PackageBiddingStrategyGetBase">
+                <xsd:sequence>
+                    <xsd:element name="StrategyId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="PackageBiddingStrategyAddBase">
+                <xsd:sequence>
+                    <xsd:element name="StrategyId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="StrategyFromCampaignId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="PackageBiddingStrategyUpdateBase">
+                <xsd:sequence>
+                    <xsd:element name="StrategyId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="StrategyFromCampaignId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="TextCampaignPackageBiddingStrategyGet">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:PackageBiddingStrategyGetBase">
+                        <xsd:sequence>
+                            <xsd:element name="Platforms" type="ns:TextCampaignPlatforms" minOccurs="1" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="UnifiedCampaignPackageBiddingStrategyGet">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:PackageBiddingStrategyGetBase">
+                        <xsd:sequence>
+                            <xsd:element name="Platforms" type="ns:UnifiedCampaignPlatforms" minOccurs="1" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="TextCampaignPackageBiddingStrategyAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:PackageBiddingStrategyAddBase">
+                        <xsd:sequence>
+                            <xsd:element name="Platforms" type="ns:TextCampaignPlatforms" minOccurs="1" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="UnifiedCampaignPackageBiddingStrategyAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:PackageBiddingStrategyAddBase">
+                        <xsd:sequence>
+                            <xsd:element name="Platforms" type="ns:UnifiedCampaignPlatforms" minOccurs="1" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="TextCampaignPackageBiddingStrategyUpdate">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:PackageBiddingStrategyUpdateBase">
+                        <xsd:sequence>
+                            <xsd:element name="Platforms" type="ns:TextCampaignPlatforms" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="UnifiedCampaignPackageBiddingStrategyUpdate">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:PackageBiddingStrategyUpdateBase">
+                        <xsd:sequence>
+                            <xsd:element name="Platforms" type="ns:UnifiedCampaignPlatforms" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="DynamicTextCampaignPackageBiddingStrategyGet">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:PackageBiddingStrategyGetBase"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="DynamicTextCampaignPackageBiddingStrategyAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:PackageBiddingStrategyAddBase"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="DynamicTextCampaignPackageBiddingStrategyUpdate">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:PackageBiddingStrategyUpdateBase"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="SmartCampaignPackageBiddingStrategyGet">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:PackageBiddingStrategyGetBase">
+                        <xsd:sequence>
+                            <xsd:element name="Platforms" type="ns:SmartCampaignPlatforms" minOccurs="1" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="SmartCampaignPackageBiddingStrategyAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:PackageBiddingStrategyAddBase">
+                        <xsd:sequence>
+                            <xsd:element name="Platforms" type="ns:SmartCampaignPlatforms" minOccurs="1" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="SmartCampaignPackageBiddingStrategyUpdate">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:PackageBiddingStrategyUpdateBase">
+                        <xsd:sequence>
+                            <xsd:element name="Platforms" type="ns:SmartCampaignPlatforms" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAppCampaignPackageBiddingStrategyGet">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:PackageBiddingStrategyGetBase"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <!-- END CAMPAIGN FLAGS -->
+            <!-- END ENUMERATES -->
+            <!-- STRATEGIES DEFINITION -->
+            <!-- START BIDDING STRATEGIES SETTINGS -->
+            <xsd:complexType name="StrategyWeeklyBudgetBase">
+                <xsd:sequence>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long"  minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyMaximumClicks">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyWeeklyBudgetBase">
+                        <xsd:sequence>
+                            <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1" nillable="true"/><xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyMaximumConversionRate">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyWeeklyBudgetBase">
+                        <xsd:sequence>
+                            <xsd:element name="GoalId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1" nillable="true"/><xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyMaximumAppInstalls">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyWeeklyBudgetBase"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpc">
+                <xsd:sequence>
+                    <xsd:element name="AverageCpc" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1" nillable="true"/><xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpa">
+                <xsd:sequence>
+                    <xsd:element name="AverageCpa" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="GoalId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="ExplorationBudget" type="ns:ExplorationBudget" minOccurs="0" maxOccurs="1" nillable="true"/><xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForConversion">
+                <xsd:sequence>
+                    <xsd:element name="Cpa" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="GoalId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1" nillable="true"/><xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpi">
+                <xsd:sequence>
+                    <xsd:element name="AverageCpi" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForInstall">
+            <xsd:sequence>
+                <xsd:element name="AverageCpi" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+            </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpaPerCampaign">
+            <xsd:sequence>
+                <xsd:element name="AverageCpa" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="GoalId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1" nillable="true"/>
+                <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                <xsd:element name="ExplorationBudget" type="ns:ExplorationBudget" minOccurs="0" maxOccurs="1" nillable="true"/><xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+            </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForConversionPerCampaign">
+            <xsd:sequence>
+                <xsd:element name="Cpa" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="GoalId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1" nillable="true"/><xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+            </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForConversionPerFilter">
+            <xsd:sequence>
+                <xsd:element name="Cpa" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="GoalId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1" nillable="true"/><xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+            </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpaPerFilter">
+            <xsd:sequence>
+                <xsd:element name="FilterAverageCpa" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="GoalId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1" nillable="true"/>
+                <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                <xsd:element name="ExplorationBudget" type="ns:ExplorationBudget" minOccurs="0" maxOccurs="1" nillable="true"/><xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+            </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpcPerCampaign">
+            <xsd:sequence>
+                <xsd:element name="AverageCpc" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1" nillable="true"/>
+                <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/><xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+            </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpcPerFilter">
+            <xsd:sequence>
+                <xsd:element name="FilterAverageCpc" type="xsd:long" nillable="true" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1" nillable="true"/>
+                <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/><xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+            </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageRoi">
+                <xsd:sequence>
+                    <xsd:element name="ReserveReturn" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="RoiCoef" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="GoalId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="Profitability" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="ExplorationBudget" type="ns:ExplorationBudget" minOccurs="0" maxOccurs="1" nillable="true"/><xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCrr">
+                <xsd:sequence>
+                    <xsd:element name="Crr" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="GoalId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="ExplorationBudget" type="ns:ExplorationBudget" minOccurs="0" maxOccurs="1" nillable="true"/><xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForConversionCrr">
+            <xsd:sequence>
+                <xsd:element name="Crr" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="GoalId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1" nillable="true"/><xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+            </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyWeeklyClickPackage">
+                <xsd:sequence>
+                    <xsd:element name="ClicksPerWeek" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpc" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyMaxProfit">
+                <xsd:sequence>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="ExplorationBudget" type="ns:ExplorationBudget" minOccurs="0" maxOccurs="1" nillable="true"/><xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpaMultipleGoals">
+            <xsd:sequence>
+                <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1" nillable="true"/>
+                <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                <xsd:element name="ExplorationBudget" type="ns:ExplorationBudget" minOccurs="0" maxOccurs="1" nillable="true"/><xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+            </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForConversionMultipleGoals">
+            <xsd:sequence>
+                <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1" nillable="true"/><xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+            </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyNetworkDefault">
+                <xsd:sequence>
+                    <xsd:element name="LimitPercent" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyMaximumImpressionsBase">
+                <xsd:sequence>
+                    <xsd:element name="AverageCpm" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="SpendLimit" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyWbMaximumImpressions">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyMaximumImpressionsBase"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyCpMaximumImpressions">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyMaximumImpressionsBase">
+                        <xsd:sequence>
+                            <xsd:element name="StartDate" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="EndDate" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="AutoContinue" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpvBase">
+                <xsd:sequence>
+                    <xsd:element name="AverageCpv" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="SpendLimit" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyWbAverageCpv">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyAverageCpvBase"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyCpAverageCpv">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyAverageCpvBase">
+                        <xsd:sequence>
+                            <xsd:element name="StartDate" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="EndDate" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="AutoContinue" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyDecreasedPriceForRepeatedImpressionsBase">
+                <xsd:sequence>
+                    <xsd:element name="AverageCpm" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="SpendLimit" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyWbDecreasedPriceForRepeatedImpressions">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyDecreasedPriceForRepeatedImpressionsBase"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyCpDecreasedPriceForRepeatedImpressions">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyDecreasedPriceForRepeatedImpressionsBase">
+                        <xsd:sequence>
+                            <xsd:element name="StartDate" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="EndDate" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="AutoContinue" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="TextCampaignStrategyBase">
+                <xsd:sequence>
+                    <xsd:element name="WbMaximumClicks"
+                                 type="ns:StrategyMaximumClicks" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WbMaximumConversionRate"
+                                 type="ns:StrategyMaximumConversionRate" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpc"
+                                 type="ns:StrategyAverageCpc" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpa"
+                                 type="ns:StrategyAverageCpa" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversion"
+                                 type="ns:StrategyPayForConversion" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WeeklyClickPackage"
+                                 type="ns:StrategyWeeklyClickPackage" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageRoi"
+                                 type="ns:StrategyAverageRoi" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCrr"
+                                 type="ns:StrategyAverageCrr" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversionCrr"
+                                 type="ns:StrategyPayForConversionCrr" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpaMultipleGoals"
+                                 type="ns:StrategyAverageCpaMultipleGoals" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversionMultipleGoals"
+                                 type="ns:StrategyPayForConversionMultipleGoals" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="MaxProfit"
+                                 type="ns:StrategyMaxProfit" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="TextCampaignNetworkStrategy">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:TextCampaignStrategyBase">
+                        <xsd:sequence>
+                            <xsd:element name="BiddingStrategyType"
+                                         type="ns:TextCampaignNetworkStrategyTypeEnum" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="NetworkDefault"
+                                         type="ns:StrategyNetworkDefault" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="TextCampaignSearchStrategy">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:TextCampaignStrategyBase">
+                        <xsd:sequence>
+                            <xsd:element name="BiddingStrategyType" type="ns:TextCampaignSearchStrategyTypeEnum" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="PlacementTypes" type="ns:TextCampaignSearchStrategyPlacementTypes" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="UnifiedCampaignStrategyBase">
+                <xsd:sequence>
+                    <xsd:element name="WbMaximumClicks"
+                                 type="ns:StrategyMaximumClicks" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WbMaximumConversionRate"
+                                 type="ns:StrategyMaximumConversionRate" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpc"
+                                 type="ns:StrategyAverageCpc" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpa"
+                                 type="ns:StrategyAverageCpa" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversion"
+                                 type="ns:StrategyPayForConversion" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCrr"
+                                 type="ns:StrategyAverageCrr" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversionCrr"
+                                 type="ns:StrategyPayForConversionCrr" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpaMultipleGoals"
+                                 type="ns:StrategyAverageCpaMultipleGoals" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversionMultipleGoals"
+                                 type="ns:StrategyPayForConversionMultipleGoals" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="MaxProfit"
+                                 type="ns:StrategyMaxProfit" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="UnifiedCampaignNetworkStrategy">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:UnifiedCampaignStrategyBase">
+                        <xsd:sequence>
+                            <xsd:element name="BiddingStrategyType"
+                                         type="ns:UnifiedCampaignNetworkStrategyTypeEnum" minOccurs="1" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="UnifiedCampaignSearchStrategy">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:UnifiedCampaignStrategyBase">
+                        <xsd:sequence>
+                            <xsd:element name="BiddingStrategyType" type="ns:UnifiedCampaignSearchStrategyTypeEnum" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="PlacementTypes" type="ns:UnifiedCampaignSearchStrategyPlacementTypes" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAppCampaignStrategyBase">
+                <xsd:sequence>
+                    <xsd:element name="WbMaximumClicks"
+                                 type="ns:StrategyMaximumClicks" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WbMaximumAppInstalls"
+                                 type="ns:StrategyMaximumAppInstalls" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpc"
+                                 type="ns:StrategyAverageCpc" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpi"
+                                 type="ns:StrategyAverageCpi" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WeeklyClickPackage"
+                                 type="ns:StrategyWeeklyClickPackage" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForInstall"
+                                 type="ns:StrategyPayForInstall" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAppCampaignSearchStrategy">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:MobileAppCampaignStrategyBase">
+                        <xsd:sequence>
+                            <xsd:element name="BiddingStrategyType" type="ns:MobileAppCampaignSearchStrategyTypeEnum" minOccurs="1" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAppCampaignNetworkStrategy">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:MobileAppCampaignStrategyBase">
+                        <xsd:sequence>
+                            <xsd:element name="BiddingStrategyType"
+                                         type="ns:MobileAppCampaignNetworkStrategyTypeEnum" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="NetworkDefault"
+                                         type="ns:StrategyNetworkDefault" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="DynamicTextCampaignStrategyBase">
+                <xsd:sequence>
+                    <xsd:element name="WbMaximumClicks"
+                                 type="ns:StrategyMaximumClicks" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WbMaximumConversionRate"
+                                 type="ns:StrategyMaximumConversionRate" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpc"
+                                 type="ns:StrategyAverageCpc" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpa"
+                                 type="ns:StrategyAverageCpa" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversion"
+                                 type="ns:StrategyPayForConversion" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WeeklyClickPackage"
+                                 type="ns:StrategyWeeklyClickPackage" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageRoi"
+                                 type="ns:StrategyAverageRoi" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCrr"
+                                 type="ns:StrategyAverageCrr" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversionCrr"
+                                 type="ns:StrategyPayForConversionCrr" minOccurs="0" maxOccurs="1"/>
+               </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="DynamicTextCampaignSearchStrategyPlacementTypes">
+                <xsd:sequence>
+                    <xsd:element name="SearchResults" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ProductGallery" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="DynamicPlaces" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="DynamicTextCampaignSearchStrategy">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:DynamicTextCampaignStrategyBase">
+                        <xsd:sequence>
+                            <xsd:element name="BiddingStrategyType"
+                                         type="ns:DynamicTextCampaignSearchStrategyTypeEnum" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="PlacementTypes"
+                                         type="ns:DynamicTextCampaignSearchStrategyPlacementTypes" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="DynamicTextCampaignNetworkStrategy">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:DynamicTextCampaignStrategyBase">
+                        <xsd:sequence>
+                            <xsd:element name="BiddingStrategyType"
+                                        type="ns:DynamicTextCampaignNetworkStrategyTypeEnum" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="NetworkDefault"
+                                        type="ns:StrategyNetworkDefault" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="CpmBannerCampaignSearchStrategy">
+                <xsd:sequence>
+                    <xsd:element name="BiddingStrategyType"
+                                 type="ns:CpmBannerCampaignSearchStrategyTypeEnum" minOccurs="1" maxOccurs="1"/>
+               </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="CpmBannerCampaignNetworkStrategy">
+                <xsd:sequence>
+                    <xsd:element name="BiddingStrategyType"
+                                 type="ns:CpmBannerCampaignNetworkStrategyTypeEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="WbMaximumImpressions"
+                                 type="ns:StrategyWbMaximumImpressions" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CpMaximumImpressions"
+                                 type="ns:StrategyCpMaximumImpressions" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WbDecreasedPriceForRepeatedImpressions"
+                                 type="ns:StrategyWbDecreasedPriceForRepeatedImpressions" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CpDecreasedPriceForRepeatedImpressions"
+                                 type="ns:StrategyCpDecreasedPriceForRepeatedImpressions" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WbAverageCpv"
+                                 type="ns:StrategyWbAverageCpv" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CpAverageCpv"
+                                 type="ns:StrategyCpAverageCpv" minOccurs="0" maxOccurs="1"/>
+               </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SmartCampaignStrategyBase">
+                <xsd:sequence>
+                    <xsd:element name="AverageCpcPerCampaign"
+                                 type="ns:StrategyAverageCpcPerCampaign" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpcPerFilter"
+                                 type="ns:StrategyAverageCpcPerFilter" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpaPerCampaign"
+                                 type="ns:StrategyAverageCpaPerCampaign" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversionPerCampaign"
+                                 type="ns:StrategyPayForConversionPerCampaign" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversionPerFilter"
+                                 type="ns:StrategyPayForConversionPerFilter" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpaPerFilter"
+                                 type="ns:StrategyAverageCpaPerFilter" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageRoi"
+                                 type="ns:StrategyAverageRoi" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCrr"
+                                 type="ns:StrategyAverageCrr" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversionCrr"
+                                 type="ns:StrategyPayForConversionCrr" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SmartCampaignSearchStrategy">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:SmartCampaignStrategyBase">
+                        <xsd:sequence>
+                            <xsd:element name="BiddingStrategyType"
+                                         type="ns:SmartCampaignSearchStrategyTypeEnum" minOccurs="1"
+                                         maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="SmartCampaignNetworkStrategy">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:SmartCampaignStrategyBase">
+                        <xsd:sequence>
+                            <xsd:element name="BiddingStrategyType"
+                                         type="ns:SmartCampaignNetworkStrategyTypeEnum" minOccurs="1"
+                                         maxOccurs="1"/>
+                            <xsd:element name="NetworkDefault"
+                                        type="ns:StrategyNetworkDefault" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="TextCampaignStrategy">
+                <xsd:sequence>
+                    <xsd:element name="Search"
+                                 type="ns:TextCampaignSearchStrategy" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Network"
+                                 type="ns:TextCampaignNetworkStrategy" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="UnifiedCampaignStrategy">
+                <xsd:sequence>
+                    <xsd:element name="Search"
+                                 type="ns:UnifiedCampaignSearchStrategy" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Network"
+                                 type="ns:UnifiedCampaignNetworkStrategy" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAppCampaignStrategy">
+                <xsd:sequence>
+                    <xsd:element name="Search"
+                                 type="ns:MobileAppCampaignSearchStrategy" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Network"
+                                 type="ns:MobileAppCampaignNetworkStrategy" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="DynamicTextCampaignStrategy">
+                <xsd:sequence>
+                    <xsd:element name="Search"
+                                 type="ns:DynamicTextCampaignSearchStrategy" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Network"
+                                 type="ns:DynamicTextCampaignNetworkStrategy" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="CpmBannerCampaignStrategy">
+                <xsd:sequence>
+                    <xsd:element name="Search"
+                                 type="ns:CpmBannerCampaignSearchStrategy" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Network"
+                                 type="ns:CpmBannerCampaignNetworkStrategy" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SmartCampaignStrategy">
+                <xsd:sequence>
+                    <xsd:element name="Search"
+                                 type="ns:SmartCampaignSearchStrategy" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Network"
+                                 type="ns:SmartCampaignNetworkStrategy" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyWeeklyBudgetAddBase">
+                <xsd:sequence>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long"  minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyMaximumClicksAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyWeeklyBudgetAddBase">
+                        <xsd:sequence>
+                            <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyMaximumConversionRateAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyWeeklyBudgetAddBase">
+                        <xsd:sequence>
+                            <xsd:element name="GoalId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyMaximumAppInstallsAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyWeeklyBudgetAddBase"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpcAdd">
+                <xsd:sequence>
+                    <xsd:element name="AverageCpc" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpaAdd">
+                <xsd:sequence>
+                    <xsd:element name="AverageCpa" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="GoalId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ExplorationBudget" type="ns:ExplorationBudget" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForConversionAdd">
+                <xsd:sequence>
+                    <xsd:element name="Cpa" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="GoalId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpiAdd">
+                <xsd:sequence>
+                    <xsd:element name="AverageCpi" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForInstallAdd">
+            <xsd:sequence>
+                <xsd:element name="AverageCpi" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+            </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpaPerCampaignAdd">
+            <xsd:sequence>
+                <xsd:element name="AverageCpa" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                <xsd:element name="GoalId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="ExplorationBudget" type="ns:ExplorationBudget" minOccurs="0" maxOccurs="1"/>
+            </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForConversionPerCampaignAdd">
+            <xsd:sequence>
+                <xsd:element name="Cpa" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                <xsd:element name="GoalId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+            </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForConversionPerFilterAdd">
+            <xsd:sequence>
+                <xsd:element name="Cpa" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                <xsd:element name="GoalId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+            </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpaPerFilterAdd">
+            <xsd:sequence>
+                <xsd:element name="FilterAverageCpa" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                <xsd:element name="GoalId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="ExplorationBudget" type="ns:ExplorationBudget" minOccurs="0" maxOccurs="1"/>
+            </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpcPerCampaignAdd">
+            <xsd:sequence>
+                <xsd:element name="AverageCpc" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+            </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpcPerFilterAdd">
+            <xsd:sequence>
+                <xsd:element name="FilterAverageCpc" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+            </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageRoiAdd">
+                <xsd:sequence>
+                    <xsd:element name="ReserveReturn" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="RoiCoef" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="GoalId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Profitability" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ExplorationBudget" type="ns:ExplorationBudget" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCrrAdd">
+                <xsd:sequence>
+                    <xsd:element name="Crr" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="GoalId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ExplorationBudget" type="ns:ExplorationBudget" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForConversionCrrAdd">
+            <xsd:sequence>
+                <xsd:element name="Crr" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+                <xsd:element name="GoalId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+            </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyWeeklyClickPackageAdd">
+                <xsd:sequence>
+                    <xsd:element name="ClicksPerWeek" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="AverageCpc" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyMaxProfitAdd">
+                <xsd:sequence>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ExplorationBudget" type="ns:ExplorationBudget" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpaMultipleGoalsAdd">
+            <xsd:sequence>
+                <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="ExplorationBudget" type="ns:ExplorationBudget" minOccurs="0" maxOccurs="1"/>
+            </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForConversionMultipleGoalsAdd">
+            <xsd:sequence>
+                <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+            </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyNetworkDefaultAdd">
+                <xsd:sequence>
+                    <xsd:element name="LimitPercent" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyMaximumImpressionsAddBase">
+                <xsd:sequence>
+                    <xsd:element name="AverageCpm" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="SpendLimit" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyWbMaximumImpressionsAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyMaximumImpressionsAddBase"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyCpMaximumImpressionsAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyMaximumImpressionsAddBase">
+                        <xsd:sequence>
+                            <xsd:element name="StartDate" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="EndDate" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="AutoContinue" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpvAddBase">
+                <xsd:sequence>
+                    <xsd:element name="AverageCpv" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="SpendLimit" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyWbAverageCpvAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyAverageCpvAddBase"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyCpAverageCpvAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyAverageCpvAddBase">
+                        <xsd:sequence>
+                            <xsd:element name="StartDate" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="EndDate" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="AutoContinue" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyDecreasedPriceForRepeatedImpressionsAddBase">
+                <xsd:sequence>
+                    <xsd:element name="AverageCpm" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="SpendLimit" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyWbDecreasedPriceForRepeatedImpressionsAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyDecreasedPriceForRepeatedImpressionsAddBase"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyCpDecreasedPriceForRepeatedImpressionsAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyDecreasedPriceForRepeatedImpressionsAddBase">
+                        <xsd:sequence>
+                            <xsd:element name="StartDate" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="EndDate" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="AutoContinue" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="TextCampaignStrategyAddBase">
+                <xsd:sequence>
+                    <xsd:element name="WbMaximumClicks"
+                                 type="ns:StrategyMaximumClicksAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WbMaximumConversionRate"
+                                 type="ns:StrategyMaximumConversionRateAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpc"
+                                 type="ns:StrategyAverageCpcAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpa"
+                                 type="ns:StrategyAverageCpaAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversion"
+                                 type="ns:StrategyPayForConversionAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WeeklyClickPackage"
+                                 type="ns:StrategyWeeklyClickPackageAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageRoi"
+                                 type="ns:StrategyAverageRoiAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCrr"
+                                 type="ns:StrategyAverageCrrAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversionCrr"
+                                 type="ns:StrategyPayForConversionCrrAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpaMultipleGoals"
+                                 type="ns:StrategyAverageCpaMultipleGoalsAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversionMultipleGoals"
+                                 type="ns:StrategyPayForConversionMultipleGoalsAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="MaxProfit"
+                                 type="ns:StrategyMaxProfitAdd" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="TextCampaignNetworkStrategyAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:TextCampaignStrategyAddBase">
+                        <xsd:sequence>
+                            <xsd:element name="BiddingStrategyType"
+                                         type="ns:TextCampaignNetworkStrategyTypeEnum" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="NetworkDefault"
+                                         type="ns:StrategyNetworkDefaultAdd" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="TextCampaignSearchStrategyAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:TextCampaignStrategyAddBase">
+                        <xsd:sequence>
+                            <xsd:element name="BiddingStrategyType" type="ns:TextCampaignSearchStrategyTypeEnum" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="PlacementTypes" type="ns:TextCampaignSearchStrategyPlacementTypes" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="UnifiedCampaignStrategyAddBase">
+                <xsd:sequence>
+                    <xsd:element name="WbMaximumClicks"
+                                 type="ns:StrategyMaximumClicksAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WbMaximumConversionRate"
+                                 type="ns:StrategyMaximumConversionRateAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpc"
+                                 type="ns:StrategyAverageCpcAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpa"
+                                 type="ns:StrategyAverageCpaAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversion"
+                                 type="ns:StrategyPayForConversionAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCrr"
+                                 type="ns:StrategyAverageCrrAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversionCrr"
+                                 type="ns:StrategyPayForConversionCrrAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpaMultipleGoals"
+                                 type="ns:StrategyAverageCpaMultipleGoalsAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversionMultipleGoals"
+                                 type="ns:StrategyPayForConversionMultipleGoalsAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="MaxProfit"
+                                 type="ns:StrategyMaxProfitAdd" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="UnifiedCampaignNetworkStrategyAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:UnifiedCampaignStrategyAddBase">
+                        <xsd:sequence>
+                            <xsd:element name="BiddingStrategyType"
+                                         type="ns:UnifiedCampaignNetworkStrategyTypeEnum" minOccurs="1" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="UnifiedCampaignSearchStrategyAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:UnifiedCampaignStrategyAddBase">
+                        <xsd:sequence>
+                            <xsd:element name="BiddingStrategyType" type="ns:UnifiedCampaignSearchStrategyTypeEnum" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="PlacementTypes" type="ns:UnifiedCampaignSearchStrategyPlacementTypes" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAppCampaignStrategyAddBase">
+                <xsd:sequence>
+                    <xsd:element name="WbMaximumClicks"
+                                 type="ns:StrategyMaximumClicksAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WbMaximumAppInstalls"
+                                 type="ns:StrategyMaximumAppInstallsAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpc"
+                                 type="ns:StrategyAverageCpcAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpi"
+                                 type="ns:StrategyAverageCpiAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WeeklyClickPackage"
+                                 type="ns:StrategyWeeklyClickPackageAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForInstall"
+                                 type="ns:StrategyPayForInstallAdd" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAppCampaignSearchStrategyAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:MobileAppCampaignStrategyAddBase">
+                        <xsd:sequence>
+                            <xsd:element name="BiddingStrategyType" type="ns:MobileAppCampaignSearchStrategyTypeEnum" minOccurs="1" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAppCampaignNetworkStrategyAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:MobileAppCampaignStrategyAddBase">
+                        <xsd:sequence>
+                            <xsd:element name="BiddingStrategyType"
+                                         type="ns:MobileAppCampaignNetworkStrategyTypeEnum" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="NetworkDefault"
+                                         type="ns:StrategyNetworkDefaultAdd" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="DynamicTextCampaignStrategyAddBase">
+                <xsd:sequence>
+                    <xsd:element name="WbMaximumClicks"
+                                 type="ns:StrategyMaximumClicksAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WbMaximumConversionRate"
+                                 type="ns:StrategyMaximumConversionRateAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpc"
+                                 type="ns:StrategyAverageCpcAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpa"
+                                 type="ns:StrategyAverageCpaAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversion"
+                                 type="ns:StrategyPayForConversionAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WeeklyClickPackage"
+                                 type="ns:StrategyWeeklyClickPackageAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageRoi"
+                                 type="ns:StrategyAverageRoiAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCrr"
+                                 type="ns:StrategyAverageCrrAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversionCrr"
+                                 type="ns:StrategyPayForConversionCrrAdd" minOccurs="0" maxOccurs="1"/>
+               </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="DynamicTextCampaignSearchStrategyPlacementTypesAdd">
+                <xsd:sequence>
+                    <xsd:element name="SearchResults" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ProductGallery" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="DynamicPlaces" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="DynamicTextCampaignSearchStrategyAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:DynamicTextCampaignStrategyAddBase">
+                        <xsd:sequence>
+                            <xsd:element name="BiddingStrategyType"
+                                         type="ns:DynamicTextCampaignSearchStrategyTypeEnum" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="PlacementTypes"
+                                         type="ns:DynamicTextCampaignSearchStrategyPlacementTypesAdd" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="DynamicTextCampaignNetworkStrategyAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:DynamicTextCampaignStrategyAddBase">
+                        <xsd:sequence>
+                            <xsd:element name="BiddingStrategyType"
+                                        type="ns:DynamicTextCampaignNetworkStrategyTypeEnum" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="NetworkDefault"
+                                        type="ns:StrategyNetworkDefaultAdd" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="CpmBannerCampaignSearchStrategyAdd">
+                <xsd:sequence>
+                    <xsd:element name="BiddingStrategyType"
+                                 type="ns:CpmBannerCampaignSearchStrategyTypeEnum" minOccurs="1" maxOccurs="1"/>
+               </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="CpmBannerCampaignNetworkStrategyAdd">
+                <xsd:sequence>
+                    <xsd:element name="BiddingStrategyType"
+                                 type="ns:CpmBannerCampaignNetworkStrategyTypeEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="WbMaximumImpressions"
+                                 type="ns:StrategyWbMaximumImpressionsAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CpMaximumImpressions"
+                                 type="ns:StrategyCpMaximumImpressionsAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WbDecreasedPriceForRepeatedImpressions"
+                                 type="ns:StrategyWbDecreasedPriceForRepeatedImpressionsAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CpDecreasedPriceForRepeatedImpressions"
+                                 type="ns:StrategyCpDecreasedPriceForRepeatedImpressionsAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WbAverageCpv"
+                                 type="ns:StrategyWbAverageCpvAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CpAverageCpv"
+                                 type="ns:StrategyCpAverageCpvAdd" minOccurs="0" maxOccurs="1"/>
+               </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SmartCampaignStrategyAddBase">
+                <xsd:sequence>
+                    <xsd:element name="AverageCpcPerCampaign"
+                                 type="ns:StrategyAverageCpcPerCampaignAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpcPerFilter"
+                                 type="ns:StrategyAverageCpcPerFilterAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpaPerCampaign"
+                                 type="ns:StrategyAverageCpaPerCampaignAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversionPerCampaign"
+                                 type="ns:StrategyPayForConversionPerCampaignAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversionPerFilter"
+                                 type="ns:StrategyPayForConversionPerFilterAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpaPerFilter"
+                                 type="ns:StrategyAverageCpaPerFilterAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageRoi"
+                                 type="ns:StrategyAverageRoiAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCrr"
+                                 type="ns:StrategyAverageCrrAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversionCrr"
+                                 type="ns:StrategyPayForConversionCrrAdd" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SmartCampaignSearchStrategyAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:SmartCampaignStrategyAddBase">
+                        <xsd:sequence>
+                            <xsd:element name="BiddingStrategyType"
+                                         type="ns:SmartCampaignSearchStrategyTypeEnum" minOccurs="1"
+                                         maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="SmartCampaignNetworkStrategyAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:SmartCampaignStrategyAddBase">
+                        <xsd:sequence>
+                            <xsd:element name="BiddingStrategyType"
+                                         type="ns:SmartCampaignNetworkStrategyTypeEnum" minOccurs="1"
+                                         maxOccurs="1"/>
+                            <xsd:element name="NetworkDefault"
+                                        type="ns:StrategyNetworkDefaultAdd" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="TextCampaignStrategyAdd">
+                <xsd:sequence>
+                    <xsd:element name="Search"
+                                 type="ns:TextCampaignSearchStrategyAdd" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Network"
+                                 type="ns:TextCampaignNetworkStrategyAdd" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="UnifiedCampaignStrategyAdd">
+                <xsd:sequence>
+                    <xsd:element name="Search"
+                                 type="ns:UnifiedCampaignSearchStrategyAdd" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Network"
+                                 type="ns:UnifiedCampaignNetworkStrategyAdd" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAppCampaignStrategyAdd">
+                <xsd:sequence>
+                    <xsd:element name="Search"
+                                 type="ns:MobileAppCampaignSearchStrategyAdd" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Network"
+                                 type="ns:MobileAppCampaignNetworkStrategyAdd" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="DynamicTextCampaignStrategyAdd">
+                <xsd:sequence>
+                    <xsd:element name="Search"
+                                 type="ns:DynamicTextCampaignSearchStrategyAdd" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Network"
+                                 type="ns:DynamicTextCampaignNetworkStrategyAdd" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="CpmBannerCampaignStrategyAdd">
+                <xsd:sequence>
+                    <xsd:element name="Search"
+                                 type="ns:CpmBannerCampaignSearchStrategyAdd" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Network"
+                                 type="ns:CpmBannerCampaignNetworkStrategyAdd" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SmartCampaignStrategyAdd">
+                <xsd:sequence>
+                    <xsd:element name="Search"
+                                 type="ns:SmartCampaignSearchStrategyAdd" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Network"
+                                 type="ns:SmartCampaignNetworkStrategyAdd" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <!-- STRATEGIES DEFINITION END -->
+            <xsd:complexType name="Notification">
+                <xsd:sequence>
+                    <xsd:element name="SmsSettings" type="ns:SmsSettings" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="EmailSettings" type="ns:EmailSettings" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SmsSettings">
+                <xsd:sequence>
+                    <xsd:element name="Events" type="ns:SmsEventsEnum" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="TimeFrom" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="TimeTo" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="EmailSettings">
+                <xsd:sequence>
+                    <xsd:element name="Email" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CheckPositionInterval" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WarningBalance" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="SendAccountNews" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="SendWarnings" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="TimeTargetingOnPublicHolidays">
+                <xsd:sequence>
+                    <xsd:element name="SuspendOnHolidays" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="BidPercent" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="StartHour" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="EndHour" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="RelevantKeywordsSettingAdd">
+                <xsd:sequence>
+                    <xsd:element name="BudgetPercent" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Mode" type="ns:RelevantKeywordsModeEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="OptimizeGoalId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="RelevantKeywordsSetting">
+                <xsd:sequence>
+                    <xsd:element name="BudgetPercent" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Mode" type="ns:RelevantKeywordsModeEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="OptimizeGoalId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="PriorityGoalsItem">
+                <xsd:sequence>
+                    <xsd:element name="GoalId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Value" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="IsMetrikaSourceOfValue" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="PriorityGoalsUpdateItem">
+                <xsd:sequence>
+                    <xsd:element name="GoalId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Value" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="IsMetrikaSourceOfValue" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Operation" type="general:OperationEnum" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="PriorityGoalsArray">
+                <xsd:sequence>
+                    <xsd:element name="Items" type="ns:PriorityGoalsItem" minOccurs="1" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="PriorityGoalsUpdateSetting">
+                <xsd:sequence>
+                    <xsd:element name="Items" type="ns:PriorityGoalsUpdateItem" minOccurs="1" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="FrequencyCapSetting">
+                <xsd:sequence>
+                    <xsd:element name="Impressions" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="PeriodDays" type="xsd:int" minOccurs="1" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="DailyBudget">
+                <xsd:sequence>
+                    <xsd:element name="Amount" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Mode" type="ns:DailyBudgetModeEnum" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="CustomPeriodBudget">
+                <xsd:sequence>
+                    <xsd:element name="SpendLimit" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="StartDate" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="EndDate" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="AutoContinue" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ExplorationBudget">
+                <xsd:sequence>
+                    <xsd:element name="MinimumExplorationBudget" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="IsMinimumExplorationBudgetCustom" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="TextCampaignSetting">
+                <xsd:sequence>
+                    <xsd:element name="Option" type="ns:TextCampaignSettingsEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Value" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="TextCampaignSettingGet">
+                <xsd:sequence>
+                    <xsd:element name="Option" type="ns:TextCampaignSettingsGetEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Value" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="UnifiedCampaignSetting">
+                <xsd:sequence>
+                    <xsd:element name="Option" type="ns:UnifiedCampaignSettingsEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Value" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="UnifiedCampaignSettingGet">
+                <xsd:sequence>
+                    <xsd:element name="Option" type="ns:UnifiedCampaignSettingsGetEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Value" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAppCampaignSetting">
+                <xsd:sequence>
+                    <xsd:element name="Option" type="ns:MobileAppCampaignSettingsEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Value" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAppCampaignSettingGet">
+                <xsd:sequence>
+                    <xsd:element name="Option" type="ns:MobileAppCampaignSettingsGetEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Value" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="DynamicTextCampaignSetting">
+                <xsd:sequence>
+                    <xsd:element name="Option" type="ns:DynamicTextCampaignSettingsEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Value" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+                </xsd:complexType>
+            <xsd:complexType name="DynamicTextCampaignSettingGet">
+                <xsd:sequence>
+                    <xsd:element name="Option" type="ns:DynamicTextCampaignSettingsGetEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Value" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="CpmBannerCampaignSetting">
+                <xsd:sequence>
+                    <xsd:element name="Option" type="ns:CpmBannerCampaignSettingsEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Value" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+                </xsd:complexType>
+            <xsd:complexType name="CpmBannerCampaignSettingGet">
+                <xsd:sequence>
+                    <xsd:element name="Option" type="ns:CpmBannerCampaignSettingsGetEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Value" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SmartCampaignSetting">
+                <xsd:sequence>
+                    <xsd:element name="Option" type="ns:SmartCampaignSettingsEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Value" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SmartCampaignSettingGet">
+                <xsd:sequence>
+                    <xsd:element name="Option" type="ns:SmartCampaignSettingsGetEnum" minOccurs="1"
+                                 maxOccurs="1"/>
+                    <xsd:element name="Value" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="CampaignFundsParam">
+                <xsd:sequence>
+                    <xsd:element name="Sum" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Balance" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <!-- bonus money for those who has discount and work in currency -->
+                    <xsd:element name="BalanceBonus" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="SumAvailableForTransfer" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SharedAccountFundsParam">
+                <xsd:sequence>
+                    <!-- if there are some money on campaign (some refund by statistic or other way, this is rest field  -->
+                    <xsd:element name="Refund" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <!-- total money spend by the campaign from the beginning - this is field sum -->
+                    <xsd:element name="Spend" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="FundsParam">
+                <xsd:sequence>
+                    <xsd:element name="Mode" type="ns:CampaignFundsEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="CampaignFunds" type="ns:CampaignFundsParam" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="SharedAccountFunds" type="ns:SharedAccountFundsParam" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="CampaignAssistant">
+                <xsd:sequence>
+                    <xsd:element name="Manager" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="Agency" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="TimeTargetingBase">
+                <xsd:sequence>
+                    <xsd:element name="Schedule" type="general:ArrayOfString" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ConsiderWorkingWeekends" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="TimeTargeting">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:TimeTargetingBase">
+                        <xsd:sequence>
+                            <xsd:element name="HolidaysSchedule" type="ns:TimeTargetingOnPublicHolidays" minOccurs="0" maxOccurs="1" nillable="true"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="TimeTargetingAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:TimeTargetingBase">
+                        <xsd:sequence>
+                            <xsd:element name="HolidaysSchedule" type="ns:TimeTargetingOnPublicHolidays" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="CampaignBase">
+                <xsd:sequence>
+                    <xsd:element name="ClientInfo" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Notification" type="ns:Notification" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="TimeZone" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="TextCampaignBase">
+                <xsd:sequence>
+                    <xsd:element name="CounterIds" type="general:ArrayOfInteger" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="RelevantKeywords" type="ns:RelevantKeywordsSetting" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="AttributionModel" type="general:AttributionModelEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="NegativeKeywordSharedSetIds" type="general:ArrayOfLong" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="UnifiedCampaignBase">
+                <xsd:sequence>
+                    <xsd:element name="CounterIds" type="general:ArrayOfInteger" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="AttributionModel" type="general:AttributionModelEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="NegativeKeywordSharedSetIds" type="general:ArrayOfLong" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="DynamicTextCampaignBase">
+                <xsd:sequence>
+                    <xsd:element name="CounterIds" type="general:ArrayOfInteger" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="AttributionModel" type="general:AttributionModelEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="NegativeKeywordSharedSetIds" type="general:ArrayOfLong" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="CpmBannerCampaignBase">
+                <xsd:sequence>
+                    <xsd:element name="CounterIds" type="general:ArrayOfInteger" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="FrequencyCap" type="ns:FrequencyCapSetting" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SmartCampaignBase">
+                <xsd:sequence>
+                    <xsd:element name="CounterId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AttributionModel" type="general:AttributionModelEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="TextCampaignAddItem">
+                <xsd:sequence>
+                    <xsd:element name="BiddingStrategy" type="ns:TextCampaignStrategyAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Settings" type="ns:TextCampaignSetting" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="CounterIds" type="general:ArrayOfInteger" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="RelevantKeywords" type="ns:RelevantKeywordsSettingAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PriorityGoals" type="ns:PriorityGoalsArray" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="TrackingParams" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AttributionModel" type="general:AttributionModelEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PackageBiddingStrategy" type="ns:TextCampaignPackageBiddingStrategyAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="NegativeKeywordSharedSetIds" type="general:ArrayOfLong" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="UnifiedCampaignAddItem">
+                <xsd:sequence>
+                    <xsd:element name="BiddingStrategy" type="ns:UnifiedCampaignStrategyAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Settings" type="ns:UnifiedCampaignSetting" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="CounterIds" type="general:ArrayOfInteger" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PriorityGoals" type="ns:PriorityGoalsArray" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="TrackingParams" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AttributionModel" type="general:AttributionModelEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PackageBiddingStrategy" type="ns:UnifiedCampaignPackageBiddingStrategyAdd"
+                                 minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="NegativeKeywordSharedSetIds" type="general:ArrayOfLong" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAppCampaignAddItem">
+                <xsd:sequence>
+                    <xsd:element name="BiddingStrategy" type="ns:MobileAppCampaignStrategyAdd" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Settings" type="ns:MobileAppCampaignSetting" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="NegativeKeywordSharedSetIds" type="general:ArrayOfLong" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="DynamicTextCampaignAddItem">
+                <xsd:sequence>
+                    <xsd:element name="BiddingStrategy" type="ns:DynamicTextCampaignStrategyAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Settings" type="ns:DynamicTextCampaignSetting" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="PlacementTypes" type="ns:PlacementType" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="CounterIds" type="general:ArrayOfInteger" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PriorityGoals" type="ns:PriorityGoalsArray" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="TrackingParams" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AttributionModel" type="general:AttributionModelEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PackageBiddingStrategy" type="ns:DynamicTextCampaignPackageBiddingStrategyAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="NegativeKeywordSharedSetIds" type="general:ArrayOfLong" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="CpmBannerCampaignAddItem">
+                <xsd:sequence>
+                    <xsd:element name="BiddingStrategy" type="ns:CpmBannerCampaignStrategyAdd" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Settings" type="ns:CpmBannerCampaignSetting" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="CounterIds" type="general:ArrayOfInteger" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="FrequencyCap" type="ns:FrequencyCapSetting" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="VideoTarget" type="general:VideoTargetEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SmartCampaignAddItem">
+                <xsd:sequence>
+                    <xsd:element name="BiddingStrategy" type="ns:SmartCampaignStrategyAdd" minOccurs="0"
+                                 maxOccurs="1"/>
+                    <xsd:element name="Settings" type="ns:SmartCampaignSetting" minOccurs="0"
+                                 maxOccurs="unbounded"/>
+                    <xsd:element name="CounterId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="PriorityGoals" type="ns:PriorityGoalsArray" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="TrackingParams" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AttributionModel" type="general:AttributionModelEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PackageBiddingStrategy" type="ns:SmartCampaignPackageBiddingStrategyAdd" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="CampaignAddItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:CampaignBase">
+                        <xsd:sequence>
+                            <xsd:element name="Name" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="StartDate" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="DailyBudget" type="ns:DailyBudget" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="EndDate" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="NegativeKeywords" type="general:ArrayOfString" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="BlockedIps" type="general:ArrayOfString" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="ExcludedSites" type="general:ArrayOfString" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="TextCampaign" type="ns:TextCampaignAddItem" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="UnifiedCampaign" type="ns:UnifiedCampaignAddItem" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="MobileAppCampaign" type="ns:MobileAppCampaignAddItem" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="DynamicTextCampaign" type="ns:DynamicTextCampaignAddItem" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="CpmBannerCampaign" type="ns:CpmBannerCampaignAddItem" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="SmartCampaign" type="ns:SmartCampaignAddItem" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="TimeTargeting" type="ns:TimeTargetingAdd" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="TextCampaignUpdateItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:TextCampaignBase">
+                        <xsd:sequence>
+                            <xsd:element name="BiddingStrategy"
+                                         type="ns:TextCampaignStrategy" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="Settings" type="ns:TextCampaignSetting" minOccurs="0" maxOccurs="unbounded"/>
+                            <xsd:element name="TrackingParams" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="PriorityGoals" type="ns:PriorityGoalsUpdateSetting" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="PackageBiddingStrategy" type="ns:TextCampaignPackageBiddingStrategyUpdate" minOccurs="0" maxOccurs="1" nillable="true"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="UnifiedCampaignUpdateItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:UnifiedCampaignBase">
+                        <xsd:sequence>
+                            <xsd:element name="BiddingStrategy"
+                                         type="ns:UnifiedCampaignStrategy" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="Settings" type="ns:UnifiedCampaignSetting" minOccurs="0" maxOccurs="unbounded"/>
+                            <xsd:element name="TrackingParams" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="PriorityGoals" type="ns:PriorityGoalsUpdateSetting" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="PackageBiddingStrategy"
+                                         type="ns:UnifiedCampaignPackageBiddingStrategyUpdate" minOccurs="0"
+                                         maxOccurs="1" nillable="true"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAppCampaignUpdateItem">
+                <xsd:sequence>
+                    <xsd:element name="BiddingStrategy"
+                                 type="ns:MobileAppCampaignStrategy" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Settings" type="ns:MobileAppCampaignSetting" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="NegativeKeywordSharedSetIds" type="general:ArrayOfLong" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="DynamicTextCampaignUpdateItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:DynamicTextCampaignBase">
+                        <xsd:sequence>
+                            <xsd:element name="BiddingStrategy"
+                                         type="ns:DynamicTextCampaignStrategy" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="Settings" type="ns:DynamicTextCampaignSetting" minOccurs="0" maxOccurs="unbounded"/>
+                            <xsd:element name="PlacementTypes" type="ns:PlacementType" minOccurs="0" maxOccurs="unbounded"/>
+                            <xsd:element name="TrackingParams" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="PriorityGoals" type="ns:PriorityGoalsUpdateSetting" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="PackageBiddingStrategy" type="ns:DynamicTextCampaignPackageBiddingStrategyUpdate" minOccurs="0" maxOccurs="1" nillable="true"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="CpmBannerCampaignUpdateItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:CpmBannerCampaignBase">
+                        <xsd:sequence>
+                            <xsd:element name="BiddingStrategy" type="ns:CpmBannerCampaignStrategy" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="Settings" type="ns:CpmBannerCampaignSetting" minOccurs="0" maxOccurs="unbounded"/>
+                            <xsd:element name="VideoTarget" type="general:VideoTargetEnum" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+             <xsd:complexType name="SmartCampaignUpdateItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:SmartCampaignBase">
+                        <xsd:sequence>
+                            <xsd:element name="BiddingStrategy" type="ns:SmartCampaignStrategy" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="Settings" type="ns:SmartCampaignSetting" minOccurs="0" maxOccurs="unbounded"/>
+                            <xsd:element name="TrackingParams" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="PriorityGoals" type="ns:PriorityGoalsUpdateSetting" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="PackageBiddingStrategy" type="ns:SmartCampaignPackageBiddingStrategyUpdate" minOccurs="0" maxOccurs="1" nillable="true"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="CampaignUpdateItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:CampaignBase">
+                        <xsd:sequence>
+                            <xsd:element name="Id" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="Name" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="StartDate" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="DailyBudget" type="ns:DailyBudget" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="EndDate" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="NegativeKeywords" type="general:ArrayOfString" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="BlockedIps" type="general:ArrayOfString" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="ExcludedSites" type="general:ArrayOfString" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="TextCampaign" type="ns:TextCampaignUpdateItem" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="UnifiedCampaign" type="ns:UnifiedCampaignUpdateItem" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="MobileAppCampaign" type="ns:MobileAppCampaignUpdateItem" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="DynamicTextCampaign" type="ns:DynamicTextCampaignUpdateItem" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="CpmBannerCampaign" type="ns:CpmBannerCampaignUpdateItem" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="SmartCampaign" type="ns:SmartCampaignUpdateItem" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="TimeTargeting" type="ns:TimeTargeting" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="TextCampaignGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:TextCampaignBase">
+                        <xsd:sequence>
+                            <xsd:element name="BiddingStrategy" type="ns:TextCampaignStrategy" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="Settings" type="ns:TextCampaignSettingGet" minOccurs="0" maxOccurs="unbounded"/>
+                            <xsd:element name="TrackingParams" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="PriorityGoals" type="ns:PriorityGoalsArray" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="PackageBiddingStrategy" type="ns:TextCampaignPackageBiddingStrategyGet" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="CanBeUsedAsPackageBiddingStrategySource" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="UnifiedCampaignGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:UnifiedCampaignBase">
+                        <xsd:sequence>
+                            <xsd:element name="BiddingStrategy" type="ns:UnifiedCampaignStrategy" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="Settings" type="ns:UnifiedCampaignSettingGet" minOccurs="0" maxOccurs="unbounded"/>
+                            <xsd:element name="TrackingParams" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="PriorityGoals" type="ns:PriorityGoalsArray" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="PackageBiddingStrategy" type="ns:UnifiedCampaignPackageBiddingStrategyGet" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="CanBeUsedAsPackageBiddingStrategySource" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="MobileAppCampaignGetItem">
+                <xsd:sequence>
+                    <xsd:element name="BiddingStrategy" type="ns:MobileAppCampaignStrategy" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Settings" type="ns:MobileAppCampaignSettingGet" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="PackageBiddingStrategy" type="ns:MobileAppCampaignPackageBiddingStrategyGet" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="CanBeUsedAsPackageBiddingStrategySource" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="NegativeKeywordSharedSetIds" type="general:ArrayOfLong" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="DynamicTextCampaignGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:DynamicTextCampaignBase">
+                        <xsd:sequence>
+                            <xsd:element name="BiddingStrategy" type="ns:DynamicTextCampaignStrategy" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="Settings" type="ns:DynamicTextCampaignSettingGet" minOccurs="0" maxOccurs="unbounded"/>
+                            <xsd:element name="PlacementTypes" type="ns:PlacementTypeArray" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="TrackingParams" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="PriorityGoals" type="ns:PriorityGoalsArray" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="PackageBiddingStrategy" type="ns:DynamicTextCampaignPackageBiddingStrategyGet" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="CanBeUsedAsPackageBiddingStrategySource" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="CpmBannerCampaignGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:CpmBannerCampaignBase">
+                        <xsd:sequence>
+                            <xsd:element name="BiddingStrategy" type="ns:CpmBannerCampaignStrategy" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="Settings" type="ns:CpmBannerCampaignSettingGet" minOccurs="0" maxOccurs="unbounded"/>
+                            <xsd:element name="VideoTarget" type="general:VideoTargetEnum" minOccurs="0" maxOccurs="1" nillable="true"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="SmartCampaignGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:SmartCampaignBase">
+                        <xsd:sequence>
+                            <xsd:element name="BiddingStrategy" type="ns:SmartCampaignStrategy" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="Settings" type="ns:SmartCampaignSettingGet" minOccurs="0" maxOccurs="unbounded"/>
+                            <xsd:element name="TrackingParams" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="PriorityGoals" type="ns:PriorityGoalsArray" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="PackageBiddingStrategy" type="ns:SmartCampaignPackageBiddingStrategyGet" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="CanBeUsedAsPackageBiddingStrategySource" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="CampaignGetItem">
+                <xsd:sequence>
+                    <xsd:element name="ClientInfo" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="Notification" type="ns:Notification" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="TimeZone" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Id" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="StartDate" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Type" type="ns:CampaignTypeGetEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Status" type="general:StatusEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="State" type="ns:CampaignStateGetEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="StatusPayment" type="ns:CampaignStatusPaymentEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="StatusClarification" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="SourceId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="Statistics" type="general:Statistics" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Currency" type="general:CurrencyEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Funds" type="ns:FundsParam" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="RepresentedBy" type="ns:CampaignAssistant" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="DailyBudget" type="ns:DailyBudget" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="EndDate" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="NegativeKeywords" type="general:ArrayOfString" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="BlockedIps" type="general:ArrayOfString" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="ExcludedSites" type="general:ArrayOfString" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="TextCampaign" type="ns:TextCampaignGetItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="UnifiedCampaign" type="ns:UnifiedCampaignGetItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="MobileAppCampaign" type="ns:MobileAppCampaignGetItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="DynamicTextCampaign" type="ns:DynamicTextCampaignGetItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CpmBannerCampaign" type="ns:CpmBannerCampaignGetItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="SmartCampaign" type="ns:SmartCampaignGetItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="TimeTargeting" type="ns:TimeTargeting" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <!-- Get Operation Types -->
+            <xsd:complexType name="CampaignsSelectionCriteria">
+                <xsd:sequence>
+                    <xsd:element name="Ids" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="Types" type="ns:CampaignTypeEnum" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="States" type="ns:CampaignStateEnum" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="Statuses" type="ns:CampaignStatusSelectionEnum" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="StatusesPayment" type="ns:CampaignStatusPaymentEnum" minOccurs="0" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <!-- Methods -->
+            <xsd:element name="GetRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetRequestGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="SelectionCriteria" type="ns:CampaignsSelectionCriteria" minOccurs="0" maxOccurs="1"/>
+                                <xsd:element name="FieldNames" type="ns:CampaignFieldEnum" minOccurs="1" maxOccurs="unbounded"/>
+                                <xsd:element name="TextCampaignFieldNames" type="ns:TextCampaignFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="TextCampaignSearchStrategyPlacementTypesFieldNames" type="ns:TextCampaignSearchStrategyPlacementTypesFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="MobileAppCampaignFieldNames" type="ns:MobileAppCampaignFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="DynamicTextCampaignFieldNames" type="ns:DynamicTextCampaignFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="DynamicTextCampaignSearchStrategyPlacementTypesFieldNames" type="ns:DynamicTextCampaignSearchStrategyPlacementTypesFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="CpmBannerCampaignFieldNames" type="ns:CpmBannerCampaignFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="SmartCampaignFieldNames" type="ns:SmartCampaignFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="UnifiedCampaignFieldNames" type="ns:UnifiedCampaignFieldEnum"
+                                             minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="UnifiedCampaignSearchStrategyPlacementTypesFieldNames"
+                                             type="ns:UnifiedCampaignSearchStrategyPlacementTypesFieldEnum" minOccurs="0"
+                                             maxOccurs="unbounded"/>
+                                <xsd:element name="UnifiedCampaignPackageBiddingStrategyPlatformsFieldNames"
+                                             type="ns:UnifiedCampaignPackageBiddingStrategyPlatformsFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetResponse">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetResponseGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="Campaigns" type="ns:CampaignGetItem" minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="Campaigns" type="ns:CampaignAddItem" minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="AddResults" type="general:ActionResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="UpdateRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="Campaigns" type="ns:CampaignUpdateItem" minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="UpdateResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="UpdateResults" type="general:ActionResult" minOccurs="0"
+                                     maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DeleteRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DeleteResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="DeleteResults" type="general:ActionResult" minOccurs="0"
+                                     maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="ArchiveRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="ArchiveResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="ArchiveResults" type="general:ActionResult" minOccurs="0"
+                                     maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="UnarchiveRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="UnarchiveResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="UnarchiveResults" type="general:ActionResult" minOccurs="0"
+                                     maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SuspendRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SuspendResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SuspendResults" type="general:ActionResult" minOccurs="0"
+                                     maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="ResumeRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="ResumeResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="ResumeResults" type="general:ActionResult" minOccurs="0"
+                                     maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="ApiException">
+        <wsdl:part element="general:FaultResponse" name="faultMessage"/>
+    </wsdl:message>
+    <!-- ADD -->
+    <wsdl:message name="AddOperationRequest">
+        <wsdl:part element="ns:AddRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationResponse">
+        <wsdl:part name="parameters" element="ns:AddResponse"/>
+    </wsdl:message>
+    <!-- UPDATE -->
+    <wsdl:message name="UpdateOperationRequest">
+        <wsdl:part name="parameters" element="ns:UpdateRequest"/>
+    </wsdl:message>
+    <wsdl:message name="UpdateOperationResponse">
+        <wsdl:part name="parameters" element="ns:UpdateResponse"/>
+    </wsdl:message>
+    <!-- GET -->
+    <wsdl:message name="GetOperationRequest">
+        <wsdl:part name="parameters" element="ns:GetRequest"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationResponse">
+        <wsdl:part name="parameters" element="ns:GetResponse"/>
+    </wsdl:message>
+    <!-- DELETE -->
+    <wsdl:message name="DeleteOperationRequest">
+        <wsdl:part name="parameters" element="ns:DeleteRequest"/>
+    </wsdl:message>
+    <wsdl:message name="DeleteOperationResponse">
+        <wsdl:part name="parameters" element="ns:DeleteResponse"/>
+    </wsdl:message>
+    <!-- ARCHIVE -->
+    <wsdl:message name="ArchiveOperationRequest">
+        <wsdl:part name="parameters" element="ns:ArchiveRequest"/>
+    </wsdl:message>
+    <wsdl:message name="ArchiveOperationResponse">
+        <wsdl:part name="parameters" element="ns:ArchiveResponse"/>
+    </wsdl:message>
+    <!-- UNARCHIVE -->
+    <wsdl:message name="UnarchiveOperationRequest">
+        <wsdl:part name="parameters" element="ns:UnarchiveRequest"/>
+    </wsdl:message>
+    <wsdl:message name="UnarchiveOperationResponse">
+        <wsdl:part name="parameters" element="ns:UnarchiveResponse"/>
+    </wsdl:message>
+    <!-- SUSPEND -->
+    <wsdl:message name="SuspendOperationRequest">
+        <wsdl:part name="parameters" element="ns:SuspendRequest"/>
+    </wsdl:message>
+    <wsdl:message name="SuspendOperationResponse">
+        <wsdl:part name="parameters" element="ns:SuspendResponse"/>
+    </wsdl:message>
+    <!-- RESUME -->
+    <wsdl:message name="ResumeOperationRequest">
+        <wsdl:part name="parameters" element="ns:ResumeRequest"/>
+    </wsdl:message>
+    <wsdl:message name="ResumeOperationResponse">
+        <wsdl:part name="parameters" element="ns:ResumeResponse"/>
+    </wsdl:message>
+    <!-- PORT -->
+    <wsdl:portType name="CampaignsPort">
+        <wsdl:operation name="add">
+            <wsdl:input message="ns:AddOperationRequest" name="addRequest"/>
+            <wsdl:output message="ns:AddOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="update">
+            <wsdl:input message="ns:UpdateOperationRequest" name="updateRequest"/>
+            <wsdl:output message="ns:UpdateOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="get">
+            <wsdl:input message="ns:GetOperationRequest" name="getRequest"/>
+            <wsdl:output message="ns:GetOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <wsdl:input message="ns:DeleteOperationRequest" name="deleteRequest"/>
+            <wsdl:output message="ns:DeleteOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="archive">
+            <wsdl:input message="ns:ArchiveOperationRequest" name="archiveRequest"/>
+            <wsdl:output message="ns:ArchiveOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="unarchive">
+            <wsdl:input message="ns:UnarchiveOperationRequest" name="unarchiveRequest"/>
+            <wsdl:output message="ns:UnarchiveOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="suspend">
+            <wsdl:input message="ns:SuspendOperationRequest" name="suspendRequest"/>
+            <wsdl:output message="ns:SuspendOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="resume">
+            <wsdl:input message="ns:ResumeOperationRequest" name="resumeRequest"/>
+            <wsdl:output message="ns:ResumeOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <!-- BINDING -->
+    <wsdl:binding name="CampaignsSOAP" type="ns:CampaignsPort">
+        <soap:binding style="document"
+                      transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="add">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/campaigns/add"/>
+            <wsdl:input name="addRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="update">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/campaigns/update"/>
+            <wsdl:input name="updateRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="get">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/campaigns/get"/>
+            <wsdl:input name="getRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/campaigns/delete"/>
+            <wsdl:input name="deleteRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="archive">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/campaigns/archive"/>
+            <wsdl:input name="archiveRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="unarchive">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/campaigns/unarchive"/>
+            <wsdl:input name="unarchiveRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="suspend">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/campaigns/suspend"/>
+            <wsdl:input name="suspendRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="resume">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/campaigns/resume"/>
+            <wsdl:input name="resumeRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <!-- SERVICE -->
+    <wsdl:service name="Campaigns">
+        <wsdl:port binding="ns:CampaignsSOAP" name="CampaignsSOAP">
+            <soap:address location="https://soap.direct.yandex.ru/v5/campaigns"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/tests/wsdl_cache/changes.xml
+++ b/tests/wsdl_cache/changes.xml
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<wsdl:definitions xmlns:ns="http://api.direct.yandex.com/v5/changes"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:general="http://api.direct.yandex.com/v5/general"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  name="Changes" targetNamespace="http://api.direct.yandex.com/v5/changes">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://api.direct.yandex.com/v5/changes">
+            <xsd:import namespace="http://api.direct.yandex.com/v5/general" schemaLocation="https://soap.direct.yandex.ru/v5/general.xsd" />
+            <xsd:element name="CheckDictionariesRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="Timestamp" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="CheckDictionariesResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="TimeZonesChanged" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                        <xsd:element name="RegionsChanged" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                        <xsd:element name="InterestsChanged" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                        <xsd:element name="Timestamp" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="CheckCampaignsRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="Timestamp" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:complexType name="CampaignChangesItem">
+                <xsd:sequence>
+                    <xsd:element name="CampaignId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="ChangesIn" type="ns:CampaignChangesInEnum" minOccurs="1" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:simpleType name="CampaignChangesInEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="SELF" />
+                    <xsd:enumeration value="CHILDREN" />
+                    <xsd:enumeration value="STAT" />
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:element name="CheckCampaignsResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="Campaigns" minOccurs="0" maxOccurs="unbounded" type="ns:CampaignChangesItem"/>
+                        <xsd:element name="Timestamp" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="CheckRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="CampaignIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                        <xsd:element name="AdGroupIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                        <xsd:element name="AdIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                        <xsd:element name="Timestamp" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                        <xsd:element name="FieldNames" minOccurs="1" maxOccurs="unbounded" type="ns:CheckFieldEnum"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:simpleType name="CheckFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="CampaignIds" />
+                    <xsd:enumeration value="AdGroupIds" />
+                    <xsd:enumeration value="AdIds" />
+                    <xsd:enumeration value="CampaignsStat" />
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:element name="CheckResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="Modified" type="ns:CheckResponseModified" minOccurs="0" maxOccurs="1"/>
+                        <xsd:element name="NotFound" type="ns:CheckResponseIds" minOccurs="0" maxOccurs="1"/>
+                        <xsd:element name="Unprocessed" type="ns:CheckResponseIds" minOccurs="0" maxOccurs="1"/>
+                        <xsd:element name="Timestamp" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:complexType name="CheckResponseModified">
+                <xsd:sequence>
+                    <xsd:element name="CampaignIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="AdGroupIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="AdIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="CampaignsStat" type="ns:CampaignStatItem" minOccurs="0" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="CampaignStatItem">
+                <xsd:sequence>
+                    <xsd:element name="CampaignId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="BorderDate" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="CheckResponseIds">
+                <xsd:sequence>
+                    <xsd:element name="CampaignIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="AdGroupIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="AdIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="ApiException">
+        <wsdl:part element="general:FaultResponse" name="faultMessage"/>
+    </wsdl:message>
+    <wsdl:message name="CheckDictionariesOperationRequest">
+        <wsdl:part element="ns:CheckDictionariesRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="CheckDictionariesOperationResponse">
+        <wsdl:part element="ns:CheckDictionariesResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="CheckCampaignsOperationRequest">
+        <wsdl:part element="ns:CheckCampaignsRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="CheckCampaignsOperationResponse">
+        <wsdl:part element="ns:CheckCampaignsResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="CheckOperationRequest">
+        <wsdl:part element="ns:CheckRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="CheckOperationResponse">
+        <wsdl:part element="ns:CheckResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:portType name="ChangesPort">
+        <wsdl:operation name="checkDictionaries">
+            <wsdl:input  message="ns:CheckDictionariesOperationRequest"/>
+            <wsdl:output message="ns:CheckDictionariesOperationResponse"/>
+            <wsdl:fault  message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="checkCampaigns">
+            <wsdl:input  message="ns:CheckCampaignsOperationRequest"/>
+            <wsdl:output message="ns:CheckCampaignsOperationResponse"/>
+            <wsdl:fault  message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="check">
+            <wsdl:input  message="ns:CheckOperationRequest"/>
+            <wsdl:output message="ns:CheckOperationResponse"/>
+            <wsdl:fault  message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="ChangesSOAP" type="ns:ChangesPort">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="checkDictionaries">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/changes/checkDictionaries"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="checkCampaigns">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/changes/checkCampaigns"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="check">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/changes/check"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="Changes">
+        <wsdl:port binding="ns:ChangesSOAP" name="ChangesSOAP">
+            <soap:address location="https://soap.direct.yandex.ru/v5/changes"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/tests/wsdl_cache/clients.xml
+++ b/tests/wsdl_cache/clients.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<wsdl:definitions xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:general="http://api.direct.yandex.com/v5/general"
+                  xmlns:gc="http://api.direct.yandex.com/v5/generalclients"
+                  xmlns:ns="http://api.direct.yandex.com/v5/clients"
+                  name="Clients" targetNamespace="http://api.direct.yandex.com/v5/clients">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://api.direct.yandex.com/v5/clients">
+            <xsd:import namespace="http://api.direct.yandex.com/v5/general" schemaLocation="https://soap.direct.yandex.ru/v5/general.xsd" />
+            <xsd:import namespace="http://api.direct.yandex.com/v5/generalclients" schemaLocation="https://soap.direct.yandex.ru/v5/generalclients.xsd" />
+            <xsd:simpleType name="ClientFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="AccountQuality"/>
+                    <xsd:enumeration value="Archived"/>
+                    <xsd:enumeration value="ClientId"/>
+                    <xsd:enumeration value="ClientInfo"/>
+                    <xsd:enumeration value="CountryId"/>
+                    <xsd:enumeration value="CreatedAt"/>
+                    <xsd:enumeration value="Currency"/>
+                    <xsd:enumeration value="Grants"/>
+                    <xsd:enumeration value="Bonuses"/>
+                    <xsd:enumeration value="Login"/>
+                    <xsd:enumeration value="Notification"/>
+                    <xsd:enumeration value="OverdraftSumAvailable"/>
+                    <xsd:enumeration value="Phone"/>
+                    <xsd:enumeration value="Representatives"/>
+                    <xsd:enumeration value="Restrictions"/>
+                    <xsd:enumeration value="Settings"/>
+                    <xsd:enumeration value="Type"/>
+                    <xsd:enumeration value="VatRate"/>
+                    <xsd:enumeration value="ForbiddenPlatform"/>
+                    <xsd:enumeration value="AvailableCampaignTypes"/>
+                    <xsd:enumeration value="AvailableAdGroupTypes"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:element name="GetRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="FieldNames" type="ns:ClientFieldEnum" minOccurs="1" maxOccurs="unbounded"/>
+                        <xsd:element name="TinInfoFieldNames" type="gc:TinInfoFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                        <xsd:element name="OrganizationFieldNames" type="gc:OrgInfoFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                        <xsd:element name="ContractFieldNames" type="gc:ContractInfoFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                        <xsd:element name="ContragentFieldNames" type="gc:ContragentInfoFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                        <xsd:element name="ContragentTinInfoFieldNames" type="gc:TinInfoFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="Clients" type="gc:ClientGetItem" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="UpdateRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="Clients" type="gc:ClientUpdateItem" minOccurs="1" maxOccurs="unbounded" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="UpdateResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="UpdateResults" type="general:ClientsActionResult" minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="GetOperationRequest">
+        <wsdl:part name="parameters" element="ns:GetRequest"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationResponse">
+        <wsdl:part name="parameters" element="ns:GetResponse"/>
+    </wsdl:message>
+    <wsdl:message name="ApiException">
+        <wsdl:part name="faultMessage" element="general:FaultResponse"/>
+    </wsdl:message>
+    <wsdl:message name="UpdateOperationRequest">
+        <wsdl:part name="parameters" element="ns:UpdateRequest"/>
+    </wsdl:message>
+    <wsdl:message name="UpdateOperationResponse">
+        <wsdl:part name="parameters" element="ns:UpdateResponse"/>
+    </wsdl:message>
+    <wsdl:portType name="ClientsPort">
+        <wsdl:operation name="get">
+            <wsdl:input  message="ns:GetOperationRequest"/>
+            <wsdl:output message="ns:GetOperationResponse"/>
+            <wsdl:fault  message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="update">
+            <wsdl:input  message="ns:UpdateOperationRequest"/>
+            <wsdl:output message="ns:UpdateOperationResponse"/>
+            <wsdl:fault  message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="ClientsSOAP" type="ns:ClientsPort">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="get">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/clients/get"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="update">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/clients/update"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="Clients">
+        <wsdl:port binding="ns:ClientsSOAP" name="ClientsSOAP">
+            <soap:address location="https://soap.direct.yandex.ru/v5/clients"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/tests/wsdl_cache/creatives.xml
+++ b/tests/wsdl_cache/creatives.xml
@@ -1,0 +1,239 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:ns="http://api.direct.yandex.com/v5/creatives"
+                  xmlns:general="http://api.direct.yandex.com/v5/general"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema" name="Creatives"
+                  targetNamespace="http://api.direct.yandex.com/v5/creatives">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://api.direct.yandex.com/v5/creatives">
+	    <xsd:import namespace="http://api.direct.yandex.com/v5/general" schemaLocation="https://soap.direct.yandex.ru/v5/general.xsd" />
+            <xsd:simpleType name="CreativeTypeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="IMAGE_CREATIVE"/>
+                    <xsd:enumeration value="HTML5_CREATIVE"/>
+                    <xsd:enumeration value="VIDEO_EXTENSION_CREATIVE"/>
+                    <xsd:enumeration value="CPC_VIDEO_CREATIVE"/>
+                    <xsd:enumeration value="CPM_VIDEO_CREATIVE"/>
+                    <xsd:enumeration value="SMART_CREATIVE"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="CreativeFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Id"/>
+                    <xsd:enumeration value="Type"/>
+                    <xsd:enumeration value="Name"/>
+                    <xsd:enumeration value="PreviewUrl"/>
+                    <xsd:enumeration value="Width"/>
+                    <xsd:enumeration value="Height"/>
+                    <xsd:enumeration value="ThumbnailUrl"/>
+                    <xsd:enumeration value="Associated"/>
+                    <xsd:enumeration value="IsAdaptive"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="BusinessTypeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="RETAIL"/>
+                    <xsd:enumeration value="HOTELS"/>
+                    <xsd:enumeration value="REALTY"/>
+                    <xsd:enumeration value="AUTOMOBILES"/>
+                    <xsd:enumeration value="FLIGHTS"/>
+                    <xsd:enumeration value="CLOTHES"/>
+                    <xsd:enumeration value="OTHER"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="VideoExtensionCreativeFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Duration"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="CpcVideoCreativeFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Duration"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="CpmVideoCreativeFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Duration"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="SmartCreativeFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="CreativeGroupId"/>
+                    <xsd:enumeration value="CreativeGroupName"/>
+                    <xsd:enumeration value="BusinessType"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="CreativesSelectionCriteria">
+                <xsd:sequence>
+                    <xsd:element name="Types" type="ns:CreativeTypeEnum" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="Ids" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="CreativeGetItem">
+                <xsd:sequence>
+                    <xsd:element name="Id" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Type" type="ns:CreativeTypeEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PreviewUrl" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Width" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Height" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ThumbnailUrl" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Associated" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="IsAdaptive" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="VideoExtensionCreative" type="ns:VideoExtensionCreativeGet" minOccurs="0"
+                                 maxOccurs="1"/>
+                    <xsd:element name="CpcVideoCreative" type="ns:CpcVideoCreativeGet" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CpmVideoCreative" type="ns:CpmVideoCreativeGet" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="SmartCreative" type="ns:SmartCreativeGet" minOccurs="0"
+                                 maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="VideoExtensionCreativeAddItem">
+                <xsd:sequence>
+                    <xsd:element name="VideoId" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="CreativeAddItem">
+                <xsd:sequence>
+                    <xsd:element name="VideoExtensionCreative" type="ns:VideoExtensionCreativeAddItem" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="AddRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="Creatives" type="ns:CreativeAddItem" minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="AddResults" type="general:ActionResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:complexType name="VideoCreativeGetBase">
+                <xsd:sequence>
+                    <xsd:element name="Duration" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="VideoExtensionCreativeGet">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:VideoCreativeGetBase"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="CpcVideoCreativeGet">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:VideoCreativeGetBase"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="CpmVideoCreativeGet">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:VideoCreativeGetBase"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="SmartCreativeGet">
+                <xsd:sequence>
+                    <xsd:element name="CreativeGroupId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CreativeGroupName" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="BusinessType" type="ns:BusinessTypeEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="GetRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetRequestGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="SelectionCriteria" type="ns:CreativesSelectionCriteria"
+                                             minOccurs="1" maxOccurs="1"/>
+                                <xsd:element name="FieldNames" type="ns:CreativeFieldEnum" minOccurs="1"
+                                             maxOccurs="unbounded"/>
+                                <xsd:element name="VideoExtensionCreativeFieldNames"
+                                             type="ns:VideoExtensionCreativeFieldEnum" minOccurs="0"
+                                             maxOccurs="unbounded"/>
+                                <xsd:element name="CpcVideoCreativeFieldNames" type="ns:CpcVideoCreativeFieldEnum"
+                                             minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="CpmVideoCreativeFieldNames" type="ns:CpmVideoCreativeFieldEnum"
+                                             minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="SmartCreativeFieldNames" type="ns:SmartCreativeFieldEnum"
+                                             minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetResponse">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetResponseGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="Creatives" type="ns:CreativeGetItem" minOccurs="0"
+                                             maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="ApiException">
+        <wsdl:part element="general:FaultResponse" name="faultMessage"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationRequest">
+        <wsdl:part element="ns:AddRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationResponse">
+        <wsdl:part element="ns:AddResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationRequest">
+        <wsdl:part name="parameters" element="ns:GetRequest"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationResponse">
+        <wsdl:part name="parameters" element="ns:GetResponse"/>
+    </wsdl:message>
+    <wsdl:portType name="CreativesPort">
+        <wsdl:operation name="add">
+            <wsdl:input message="ns:AddOperationRequest" name="addRequest"/>
+            <wsdl:output message="ns:AddOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="get">
+            <wsdl:input message="ns:GetOperationRequest" name="getRequest"/>
+            <wsdl:output message="ns:GetOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="CreativesSOAP" type="ns:CreativesPort">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="add">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/creatives/add"/>
+            <wsdl:input name="addRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="get">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/creatives/get"/>
+            <wsdl:input name="getRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="Creatives">
+        <wsdl:port binding="ns:CreativesSOAP" name="CreativesSOAP">
+            <soap:address location="https://soap.direct.yandex.ru/v5/creatives"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/tests/wsdl_cache/dictionaries.xml
+++ b/tests/wsdl_cache/dictionaries.xml
@@ -1,0 +1,327 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:ns="http://api.direct.yandex.com/v5/dictionaries"
+                  xmlns:general="http://api.direct.yandex.com/v5/general"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema" name="Dictionaries"
+                  targetNamespace="http://api.direct.yandex.com/v5/dictionaries">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://api.direct.yandex.com/v5/dictionaries">
+            <xsd:import namespace="http://api.direct.yandex.com/v5/general" schemaLocation="https://soap.direct.yandex.ru/v5/general.xsd" />
+            <xsd:simpleType name="DictionaryNameEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Currencies"/>
+                    <xsd:enumeration value="MetroStations"/>
+                    <xsd:enumeration value="GeoRegions"/>
+                    <xsd:enumeration value="GeoRegionNames"/>
+                    <xsd:enumeration value="TimeZones"/>
+                    <xsd:enumeration value="Constants"/>
+                    <xsd:enumeration value="AdCategories"/>
+                    <xsd:enumeration value="OperationSystemVersions"/>
+                    <xsd:enumeration value="ProductivityAssertions"/>
+                    <xsd:enumeration value="SupplySidePlatforms"/>
+                    <xsd:enumeration value="Interests"/>
+                    <xsd:enumeration value="AudienceCriteriaTypes"/>
+                    <xsd:enumeration value="AudienceDemographicProfiles"/>
+                    <xsd:enumeration value="AudienceInterests"/>
+                    <xsd:enumeration value="FilterSchemas"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="GeoRegionsSelectionCriteria">
+                <xsd:sequence>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="RegionIds" type="xsd:long" minOccurs="0"  maxOccurs="unbounded"/>
+                    <xsd:element name="ExactNames" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="CurrenciesItem">
+                <xsd:sequence>
+                    <xsd:element name="Currency" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Properties" type="ns:ConstantsItem" minOccurs="1" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="MetroStationsItem">
+                <xsd:sequence>
+                    <xsd:element name="GeoRegionId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="MetroStationId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="MetroStationName" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="GeoRegionsItem">
+                <xsd:sequence>
+                    <xsd:element name="GeoRegionId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="GeoRegionName" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="GeoRegionType" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="ParentId" type="xsd:long" minOccurs="1" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="GeoRegionNamesItem">
+                <xsd:sequence>
+                    <xsd:element name="GeoRegionId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="GeoRegionName" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="GeoRegionType" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="TimeZonesItem">
+                <xsd:sequence>
+                    <xsd:element name="TimeZone" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="TimeZoneName" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="UtcOffset" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ConstantsItem">
+                <xsd:sequence>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Value" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="AdCategoriesItem">
+                <xsd:sequence>
+                    <xsd:element name="AdCategory" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Description" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Message" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="OperationSystemVersionsItem">
+                <xsd:sequence>
+                    <xsd:element name="OsName" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="OsVersion" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ProductivityAssertionsItem">
+                <xsd:sequence>
+                    <xsd:element name="Reference" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Title" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Recommendation" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SupplySidePlatformsItem">
+                <xsd:sequence>
+                    <xsd:element name="Title" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="InterestsItem">
+                <xsd:sequence>
+                    <xsd:element name="InterestId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="ParentId" type="xsd:long" minOccurs="1" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="IsTargetable" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:simpleType name="CanSelectEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="ALL"/>
+                    <xsd:enumeration value="EXCEPT_ALL"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="InterestTypeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="SHORT_TERM"/>
+                    <xsd:enumeration value="LONG_TERM"/>
+                    <xsd:enumeration value="ANY"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="GeoRegionFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="GeoRegionId"/>
+                    <xsd:enumeration value="GeoRegionName"/>
+                    <xsd:enumeration value="ParentGeoRegionNames"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="AudienceCriteriaTypesItem">
+                <xsd:sequence>
+                    <xsd:element name="Type" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="BlockElement" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Description" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="CanSelect" type="ns:CanSelectEnum" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="AudienceDemographicProfilesItem">
+                <xsd:sequence>
+                    <xsd:element name="Id" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Type" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Description" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="AudienceInterestsItem">
+                <xsd:sequence>
+                    <xsd:element name="InterestKey" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Id" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="ParentId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Description" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="InterestType" type="ns:InterestTypeEnum" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="GeoRegionGetItem">
+                <xsd:sequence>
+                    <xsd:element name="GeoRegionId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="GeoRegionName" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ParentGeoRegionNames" type="general:ArrayOfString" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:simpleType name="FilterFieldType">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Enum"/>
+                    <xsd:enumeration value="Number"/>
+                    <xsd:enumeration value="String"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="EnumFilterFieldProps">
+                <xsd:sequence>
+                    <xsd:element name="Values" type="general:ArrayOfString" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="NumberFilterFieldProps">
+                <xsd:sequence>
+                    <xsd:element name="Min" type="xsd:decimal" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Max" type="xsd:decimal" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Precision" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StringFilterFieldProps">
+                <xsd:sequence>
+                    <xsd:element name="MaxLength" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="MinLength" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="FilterFieldOperator">
+                <xsd:sequence>
+                    <xsd:element name="MaxItems" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Type" type="general:StringConditionOperatorEnum" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="FilterFieldItem">
+                <xsd:sequence>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Type" type="ns:FilterFieldType" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="EnumProps" type="ns:EnumFilterFieldProps" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="NumberProps" type="ns:NumberFilterFieldProps" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="StringProps" type="ns:StringFilterFieldProps" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Operators" type="ns:FilterFieldOperator" minOccurs="1" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="FilterSchemasItem">
+                <xsd:sequence>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Fields" type="ns:FilterFieldItem" minOccurs="1" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="GetRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="DictionaryNames" type="ns:DictionaryNameEnum" minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="Currencies" type="ns:CurrenciesItem" minOccurs="0" maxOccurs="unbounded"/>
+                        <xsd:element name="MetroStations" type="ns:MetroStationsItem" minOccurs="0" maxOccurs="unbounded"/>
+                        <xsd:element name="GeoRegions" type="ns:GeoRegionsItem" minOccurs="0" maxOccurs="unbounded"/>
+                        <xsd:element name="GeoRegionNames" type="ns:GeoRegionNamesItem" minOccurs="0" maxOccurs="unbounded"/>
+                        <xsd:element name="TimeZones" type="ns:TimeZonesItem" minOccurs="0" maxOccurs="unbounded"/>
+                        <xsd:element name="Constants" type="ns:ConstantsItem" minOccurs="0" maxOccurs="unbounded"/>
+                        <xsd:element name="AdCategories" type="ns:AdCategoriesItem" minOccurs="0" maxOccurs="unbounded"/>
+                        <xsd:element name="OperationSystemVersions" type="ns:OperationSystemVersionsItem" minOccurs="0" maxOccurs="unbounded"/>
+                        <xsd:element name="ProductivityAssertions" type="ns:ProductivityAssertionsItem" minOccurs="0" maxOccurs="unbounded"/>
+                        <xsd:element name="SupplySidePlatforms" type="ns:SupplySidePlatformsItem" minOccurs="0" maxOccurs="unbounded"/>
+                        <xsd:element name="Interests" type="ns:InterestsItem" minOccurs="0" maxOccurs="unbounded"/>
+                        <xsd:element name="AudienceCriteriaTypes" type="ns:AudienceCriteriaTypesItem" minOccurs="0" maxOccurs="unbounded"/>
+                        <xsd:element name="AudienceDemographicProfiles" type="ns:AudienceDemographicProfilesItem" minOccurs="0" maxOccurs="unbounded"/>
+                        <xsd:element name="AudienceInterests" type="ns:AudienceInterestsItem" minOccurs="0" maxOccurs="unbounded"/>
+                        <xsd:element name="FilterSchemas" type="ns:FilterSchemasItem" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetGeoRegionsRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetRequestGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="SelectionCriteria" type="ns:GeoRegionsSelectionCriteria" minOccurs="1"
+                                             maxOccurs="1"/>
+                                <xsd:element name="FieldNames" type="ns:GeoRegionFieldEnum" minOccurs="1"
+                                             maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetGeoRegionsResponse">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetResponseGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="GeoRegions" type="ns:GeoRegionGetItem"
+                                             minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="ApiException">
+        <wsdl:part element="general:FaultResponse" name="faultMessage"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationRequest">
+        <wsdl:part name="parameters" element="ns:GetRequest"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationResponse">
+        <wsdl:part name="parameters" element="ns:GetResponse"/>
+    </wsdl:message>
+    <wsdl:message name="GetGeoRegionsOperationRequest">
+        <wsdl:part name="parameters" element="ns:GetGeoRegionsRequest"/>
+    </wsdl:message>
+    <wsdl:message name="GetGeoRegionsOperationResponse">
+        <wsdl:part name="parameters" element="ns:GetGeoRegionsResponse"/>
+    </wsdl:message>
+    <wsdl:portType name="DictionariesPort">
+        <wsdl:operation name="get">
+            <wsdl:input message="ns:GetOperationRequest" name="getRequest"/>
+            <wsdl:output message="ns:GetOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="getGeoRegions">
+            <wsdl:input message="ns:GetGeoRegionsOperationRequest" name="getGeoRegions"/>
+            <wsdl:output message="ns:GetGeoRegionsOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="DictionariesSOAP" type="ns:DictionariesPort">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="get">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/dictionaries/get"/>
+            <wsdl:input name="getRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="getGeoRegions">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/dictionaries/getGeoRegions"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="Dictionaries">
+        <wsdl:port binding="ns:DictionariesSOAP" name="DictionariesSOAP">
+            <soap:address location="https://soap.direct.yandex.ru/v5/dictionaries"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/tests/wsdl_cache/dynamictextadtargets.xml
+++ b/tests/wsdl_cache/dynamictextadtargets.xml
@@ -1,0 +1,338 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:general="http://api.direct.yandex.com/v5/general"
+                  xmlns:ns="http://api.direct.yandex.com/v5/dynamictextadtargets"
+                  name="DynamicTextAdTargets"
+                  targetNamespace="http://api.direct.yandex.com/v5/dynamictextadtargets">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://api.direct.yandex.com/v5/dynamictextadtargets">
+            <xsd:import namespace="http://api.direct.yandex.com/v5/general" schemaLocation="https://soap.direct.yandex.ru/v5/general.xsd" />
+            <xsd:simpleType name="WebpageFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="AdGroupId" />
+                    <xsd:enumeration value="Bid" />
+                    <xsd:enumeration value="CampaignId" />
+                    <xsd:enumeration value="Conditions" />
+                    <xsd:enumeration value="ConditionType" />
+                    <xsd:enumeration value="ContextBid" />
+                    <xsd:enumeration value="Id" />
+                    <xsd:enumeration value="Name" />
+                    <xsd:enumeration value="State" />
+                    <xsd:enumeration value="StatusClarification" />
+                    <xsd:enumeration value="StrategyPriority" />
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="WebpageConditionOperandEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="DOMAIN"/>
+                    <xsd:enumeration value="OFFERS_LIST_URL"/>
+                    <xsd:enumeration value="PAGE_CONTENT" />
+                    <xsd:enumeration value="PAGE_TITLE" />
+                    <xsd:enumeration value="URL"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="WebpageTypeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="PAGES_ALL" />
+                    <xsd:enumeration value="PAGES_SUBSET" />
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="StringConditionOperatorEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="EQUALS_ANY" />
+                    <xsd:enumeration value="NOT_EQUALS_ALL" />
+                    <xsd:enumeration value="CONTAINS_ANY" />
+                    <xsd:enumeration value="NOT_CONTAINS_ALL" />
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="WebpageAddItem">
+                <xsd:sequence>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="1" maxOccurs="1" />
+                    <xsd:element name="AdGroupId" type="xsd:long" minOccurs="1" maxOccurs="1" />
+                    <xsd:element name="Conditions" type="ns:WebpageCondition" minOccurs="0" maxOccurs="unbounded" />
+                    <xsd:element name="Bid" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ContextBid" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="StrategyPriority" type="general:PriorityEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="WebpageCondition">
+                <xsd:sequence>
+                    <xsd:element name="Operand" type="ns:WebpageConditionOperandEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Operator" type="ns:StringConditionOperatorEnum" minOccurs="1" maxOccurs="1" />
+                    <xsd:element name="Arguments" type="xsd:string" minOccurs="1" maxOccurs="unbounded" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="WebpageGetItem">
+                <xsd:sequence>
+                    <xsd:element name="Id" type="xsd:long" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="AdGroupId" type="xsd:long" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="CampaignId" type="xsd:long" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="Name" type="xsd:string" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="Bid" type="xsd:long" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="ContextBid" type="xsd:long" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="StrategyPriority" type="general:PriorityEnum" minOccurs="0" maxOccurs="1" nillable="true" />
+                    <xsd:element name="State" type="general:StateEnum" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="StatusClarification" type="xsd:string" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="Conditions" type="ns:WebpageCondition" minOccurs="0" maxOccurs="unbounded" />
+                    <xsd:element name="ConditionType" type="ns:WebpageTypeEnum" minOccurs="0" maxOccurs="1" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SetBidsItem">
+                <xsd:sequence>
+                    <xsd:element name="CampaignId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AdGroupId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Id" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Bid" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ContextBid" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="StrategyPriority" type="general:PriorityEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="AddRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="Webpages" type="ns:WebpageAddItem" minOccurs="1" maxOccurs="unbounded" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="AddResults" type="general:ActionResult" minOccurs="1" maxOccurs="unbounded" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetRequestGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="SelectionCriteria" type="general:AdTargetsSelectionCriteria" minOccurs="1" maxOccurs="1" />
+                                <xsd:element name="FieldNames" type="ns:WebpageFieldEnum" minOccurs="1" maxOccurs="unbounded" />
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetResponse">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetResponseGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="Webpages" type="ns:WebpageGetItem" minOccurs="0" maxOccurs="unbounded" />
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DeleteRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1" maxOccurs="1" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DeleteResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="DeleteResults" type="general:ActionResult" minOccurs="1" maxOccurs="unbounded" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SuspendRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1" maxOccurs="1" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SuspendResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SuspendResults" type="general:ActionResult" minOccurs="1" maxOccurs="unbounded" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="ResumeRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1" maxOccurs="1" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="ResumeResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="ResumeResults" type="general:ActionResult" minOccurs="1" maxOccurs="unbounded" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SetBidsRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="Bids" type="ns:SetBidsItem" minOccurs="1" maxOccurs="unbounded" nillable="false"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SetBidsResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SetBidsResults" type="general:SetBidsActionResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="AddOperationRequest">
+        <wsdl:part element="ns:AddRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationResponse">
+        <wsdl:part element="ns:AddResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationRequest">
+        <wsdl:part element="ns:GetRequest" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="GetOperationResponse">
+        <wsdl:part element="ns:GetResponse" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="DeleteOperationRequest">
+        <wsdl:part element="ns:DeleteRequest" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="DeleteOperationResponse">
+        <wsdl:part element="ns:DeleteResponse" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="SuspendOperationRequest">
+        <wsdl:part element="ns:SuspendRequest" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="SuspendOperationResponse">
+        <wsdl:part element="ns:SuspendResponse" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="ResumeOperationRequest">
+        <wsdl:part element="ns:ResumeRequest" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="ResumeOperationResponse">
+        <wsdl:part element="ns:ResumeResponse" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="SetBidsOperationRequest">
+        <wsdl:part element="ns:SetBidsRequest" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="SetBidsOperationResponse">
+        <wsdl:part element="ns:SetBidsResponse" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="ApiException">
+        <wsdl:part element="general:FaultResponse" name="faultMessage" />
+    </wsdl:message>
+    <wsdl:portType name="DynamicTextAdTargetsPort">
+        <wsdl:operation name="add">
+            <wsdl:input message="ns:AddOperationRequest" name="addRequest"/>
+            <wsdl:output message="ns:AddOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException" />
+        </wsdl:operation>
+        <wsdl:operation name="get">
+            <wsdl:input message="ns:GetOperationRequest" name="getRequest"/>
+            <wsdl:output message="ns:GetOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException" />
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <wsdl:input message="ns:DeleteOperationRequest" name="deleteRequest"/>
+            <wsdl:output message="ns:DeleteOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException" />
+        </wsdl:operation>
+        <wsdl:operation name="suspend">
+            <wsdl:input message="ns:SuspendOperationRequest" name="suspendRequest"/>
+            <wsdl:output message="ns:SuspendOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException" />
+        </wsdl:operation>
+        <wsdl:operation name="resume">
+            <wsdl:input message="ns:ResumeOperationRequest" name="resumeRequest"/>
+            <wsdl:output message="ns:ResumeOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException" />
+        </wsdl:operation>
+        <wsdl:operation name="setBids">
+            <wsdl:input message="ns:SetBidsOperationRequest" name="setBidsRequest"/>
+            <wsdl:output message="ns:SetBidsOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException" />
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="DynamicTextAdTargetsSOAP" type="ns:DynamicTextAdTargetsPort">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
+        <wsdl:operation name="add">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/dynamictextadtargets/add"/>
+            <wsdl:input name="addRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal" />
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="get">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/dynamictextadtargets/get"/>
+            <wsdl:input name="getRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal" />
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/dynamictextadtargets/delete"/>
+            <wsdl:input name="deleteRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal" />
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="suspend">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/dynamictextadtargets/suspend"/>
+            <wsdl:input name="suspendRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal" />
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="resume">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/dynamictextadtargets/resume"/>
+            <wsdl:input name="resumeRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal" />
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="setBids">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/dynamictextadtargets/setBids"/>
+            <wsdl:input name="setBidsRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal" />
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="DynamicTextAdTargets">
+        <wsdl:port binding="ns:DynamicTextAdTargetsSOAP" name="DynamicTextAdTargetsSOAP">
+            <soap:address location="https://soap.direct.yandex.ru/v5/dynamictextadtargets"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/tests/wsdl_cache/feeds.xml
+++ b/tests/wsdl_cache/feeds.xml
@@ -1,0 +1,339 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:general="http://api.direct.yandex.com/v5/general"
+                  xmlns:ns="http://api.direct.yandex.com/v5/feeds"
+                  name="Feeds"
+                  targetNamespace="http://api.direct.yandex.com/v5/feeds">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://api.direct.yandex.com/v5/feeds">
+            <xsd:import namespace="http://api.direct.yandex.com/v5/general" schemaLocation="https://soap.direct.yandex.ru/v5/general.xsd"/>
+            <xsd:simpleType name="BusinessTypeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="RETAIL"/>
+                    <xsd:enumeration value="HOTELS"/>
+                    <xsd:enumeration value="REALTY"/>
+                    <xsd:enumeration value="AUTOMOBILES"/>
+                    <xsd:enumeration value="FLIGHTS"/>
+                    <xsd:enumeration value="OTHER"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="SourceTypeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="URL"/>
+                    <xsd:enumeration value="FILE"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="FeedStatusEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="NEW"/>
+                    <xsd:enumeration value="UPDATING"/>
+                    <xsd:enumeration value="DONE"/>
+                    <xsd:enumeration value="ERROR"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="FeedFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Id"/>
+                    <xsd:enumeration value="Name"/>
+                    <xsd:enumeration value="BusinessType"/>
+                    <xsd:enumeration value="SourceType"/>
+                    <xsd:enumeration value="FilterSchema"/>
+                    <xsd:enumeration value="UpdatedAt"/>
+                    <xsd:enumeration value="CampaignIds"/>
+                    <xsd:enumeration value="NumberOfItems"/>
+                    <xsd:enumeration value="NumberOfListings"/>
+                    <xsd:enumeration value="Status"/>
+                    <xsd:enumeration value="TitleAndTextSources"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="FileFeedFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Filename"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="UrlFeedFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Login"/>
+                    <xsd:enumeration value="Url"/>
+                    <xsd:enumeration value="RemoveUtmTags"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="UrlFeedBase">
+                <xsd:sequence>
+                    <xsd:element name="RemoveUtmTags" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="UrlFeedAdd">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:UrlFeedBase">
+                        <xsd:sequence>
+                            <xsd:element name="Url" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                            <xsd:element name="Login" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="Password" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="UrlFeedGet">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:UrlFeedBase">
+                        <xsd:sequence>
+                            <xsd:element name="Url" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="Login" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="UrlFeedUpdate">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:UrlFeedBase">
+                        <xsd:sequence>
+                            <xsd:element name="Url" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="Login" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                            <xsd:element name="Password" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="FileFeedAdd">
+                <xsd:sequence>
+                    <xsd:element name="Data" type="xsd:base64Binary" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Filename" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="FileFeedUpdate">
+                <xsd:sequence>
+                    <xsd:element name="Data" type="xsd:base64Binary" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Filename" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="FileFeedGet">
+                <xsd:sequence>
+                    <xsd:element name="Filename" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="FeedsSelectionCriteria">
+                <xsd:sequence>
+                    <xsd:element name="Ids" type="xsd:long" minOccurs="1" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="FeedAddItem">
+                <xsd:sequence>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="BusinessType" type="ns:BusinessTypeEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="SourceType" type="ns:SourceTypeEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="UrlFeed" type="ns:UrlFeedAdd" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="FileFeed" type="ns:FileFeedAdd" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="FeedGetItem">
+                <xsd:sequence>
+                    <xsd:element name="Id" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="BusinessType" type="ns:BusinessTypeEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="SourceType" type="ns:SourceTypeEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="FilterSchema" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="UpdatedAt" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="CampaignIds" type="general:ArrayOfLong" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="FileFeed" type="ns:FileFeedGet" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="NumberOfItems" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="NumberOfListings" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="Status" type="ns:FeedStatusEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="UrlFeed" type="ns:UrlFeedGet" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="TitleAndTextSources" type="general:ArrayOfString" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="FeedUpdateItem">
+                <xsd:sequence>
+                    <xsd:element name="Id" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="UrlFeed" type="ns:UrlFeedUpdate" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="FileFeed" type="ns:FileFeedUpdate" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="AddRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="Feeds" type="ns:FeedAddItem" minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="AddResults" type="general:ActionResult" minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetRequestGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="FieldNames" type="ns:FeedFieldEnum" minOccurs="1"
+                                             maxOccurs="unbounded"/>
+                                <xsd:element name="FileFeedFieldNames" type="ns:FileFeedFieldEnum" minOccurs="0"
+                                             maxOccurs="unbounded"/>
+                                <xsd:element name="UrlFeedFieldNames" type="ns:UrlFeedFieldEnum" minOccurs="0"
+                                             maxOccurs="unbounded"/>
+                                <xsd:element name="SelectionCriteria" type="ns:FeedsSelectionCriteria" minOccurs="0"
+                                             maxOccurs="1"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetResponse">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetResponseGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="Feeds" type="ns:FeedGetItem" minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="UpdateRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="Feeds" type="ns:FeedUpdateItem" minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="UpdateResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="UpdateResults" type="general:ActionResult" minOccurs="1"
+                                     maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DeleteRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="ns:FeedsSelectionCriteria" minOccurs="1"
+                                     maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DeleteResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="DeleteResults" type="general:ActionResult" minOccurs="1"
+                                     maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="ApiException">
+        <wsdl:part element="general:FaultResponse" name="faultMessage"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationRequest">
+        <wsdl:part element="ns:AddRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationResponse">
+        <wsdl:part element="ns:AddResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationRequest">
+        <wsdl:part element="ns:GetRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationResponse">
+        <wsdl:part element="ns:GetResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="UpdateOperationRequest">
+        <wsdl:part element="ns:UpdateRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="UpdateOperationResponse">
+        <wsdl:part element="ns:UpdateResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="DeleteOperationRequest">
+        <wsdl:part element="ns:DeleteRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="DeleteOperationResponse">
+        <wsdl:part element="ns:DeleteResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:portType name="FeedsPort">
+        <wsdl:operation name="add">
+            <wsdl:input message="ns:AddOperationRequest" name="addRequest"/>
+            <wsdl:output message="ns:AddOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="get">
+            <wsdl:input message="ns:GetOperationRequest" name="getRequest"/>
+            <wsdl:output message="ns:GetOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="update">
+            <wsdl:input message="ns:UpdateOperationRequest" name="updateRequest"/>
+            <wsdl:output message="ns:UpdateOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <wsdl:input message="ns:DeleteOperationRequest" name="deleteRequest"/>
+            <wsdl:output message="ns:DeleteOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="FeedsSOAP" type="ns:FeedsPort">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="add">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/feeds/add"/>
+            <wsdl:input name="addRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="get">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/feeds/get"/>
+            <wsdl:input name="getRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="update">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/feeds/update"/>
+            <wsdl:input name="updateRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/feeds/delete"/>
+            <wsdl:input name="deleteRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="Feeds">
+        <wsdl:port binding="ns:FeedsSOAP" name="FeedsSOAP">
+            <soap:address location="https://soap.direct.yandex.ru/v5/feeds/"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/tests/wsdl_cache/keywordbids.xml
+++ b/tests/wsdl_cache/keywordbids.xml
@@ -1,0 +1,291 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<wsdl:definitions xmlns:ns="http://api.direct.yandex.com/v5/keywordbids"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:general="http://api.direct.yandex.com/v5/general"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  name="KeywordBids"
+                  targetNamespace="http://api.direct.yandex.com/v5/keywordbids">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://api.direct.yandex.com/v5/keywordbids">
+            <xsd:import namespace="http://api.direct.yandex.com/v5/general" schemaLocation="https://soap.direct.yandex.ru/v5/general.xsd" />
+            <xsd:simpleType name="KeywordBidFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="KeywordId"/>
+                    <xsd:enumeration value="AdGroupId"/>
+                    <xsd:enumeration value="CampaignId"/>
+                    <xsd:enumeration value="ServingStatus"/>
+                    <xsd:enumeration value="StrategyPriority"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="KeywordBidSearchFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Bid"/>
+                    <xsd:enumeration value="AutotargetingSearchBidIsAuto"/>
+                    <xsd:enumeration value="AuctionBids"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="KeywordBidNetworkFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Bid"/>
+                    <xsd:enumeration value="Coverage"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="KeywordBidsSelectionCriteria">
+                <xsd:sequence>
+                    <xsd:element name="CampaignIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="AdGroupIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="KeywordIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="ServingStatuses" type="general:ServingStatusEnum" minOccurs="0"
+                                 maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="Search">
+                <xsd:sequence>
+                    <xsd:element name="Bid" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AutotargetingSearchBidIsAuto" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AuctionBids" type="ns:AuctionBids" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="AuctionBids">
+                <xsd:sequence>
+                    <xsd:element name="AuctionBidItems" type="ns:AuctionBidItem" minOccurs="0" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="AuctionBidItem">
+                <xsd:sequence>
+                    <xsd:element name="TrafficVolume" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Bid" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Price" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="Network">
+                <xsd:sequence>
+                    <xsd:element name="Bid" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Coverage" type="ns:Coverage" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="Coverage">
+                <xsd:sequence>
+                    <xsd:element name="CoverageItems" type="ns:NetworkCoverageItem" minOccurs="0" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="NetworkCoverageItem">
+                <xsd:sequence>
+                    <xsd:element name="Probability" type="xsd:decimal" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Bid" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="KeywordBidActionResult">
+                <xsd:complexContent>
+                    <xsd:extension base="general:ActionResultBase">
+                        <xsd:sequence>
+                            <xsd:element name="CampaignId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="AdGroupId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="KeywordId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="KeywordBidGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:KeywordBidActionResult">
+                        <xsd:sequence>
+                            <xsd:element name="ServingStatus" type="general:ServingStatusEnum" minOccurs="0"
+                                         maxOccurs="1"/>
+                            <xsd:element name="StrategyPriority" type="general:PriorityEnum" minOccurs="0" maxOccurs="1"
+                                         nillable="true"/>
+                            <xsd:element name="Search" type="ns:Search" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="Network" type="ns:Network" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="KeywordBidSetItem">
+                <xsd:sequence>
+                    <xsd:element name="CampaignId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AdGroupId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="KeywordId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="SearchBid" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AutotargetingSearchBidIsAuto" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="NetworkBid" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="StrategyPriority" type="general:PriorityEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="KeywordBidSetAutoItem">
+                <xsd:sequence>
+                    <xsd:element name="CampaignId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AdGroupId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="KeywordId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="BiddingRule" type="ns:BiddingRule" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="BiddingRule">
+                <xsd:sequence>
+                    <xsd:element name="SearchByTrafficVolume" type="ns:SearchByTrafficVolume" minOccurs="0"
+                                 maxOccurs="1"/>
+                    <xsd:element name="NetworkByCoverage" type="ns:NetworkByCoverage" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SearchByTrafficVolume">
+                <xsd:sequence>
+                    <xsd:element name="TargetTrafficVolume" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="IncreasePercent" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="NetworkByCoverage">
+                <xsd:sequence>
+                    <xsd:element name="TargetCoverage" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="IncreasePercent" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="GetRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetRequestGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="SelectionCriteria" type="ns:KeywordBidsSelectionCriteria"
+                                             minOccurs="1"
+                                             maxOccurs="1"/>
+                                <xsd:element name="FieldNames" type="ns:KeywordBidFieldEnum" minOccurs="1"
+                                             maxOccurs="unbounded"/>
+                                <xsd:element name="SearchFieldNames" type="ns:KeywordBidSearchFieldEnum" minOccurs="0"
+                                             maxOccurs="unbounded"/>
+                                <xsd:element name="NetworkFieldNames" type="ns:KeywordBidNetworkFieldEnum" minOccurs="0"
+                                             maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetResponse">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetResponseGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="KeywordBids" type="ns:KeywordBidGetItem" minOccurs="0"
+                                             maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SetRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="KeywordBids" type="ns:KeywordBidSetItem"
+                                     minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SetResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SetResults" type="ns:KeywordBidActionResult"
+                                     minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SetAutoRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="KeywordBids" type="ns:KeywordBidSetAutoItem"
+                                     minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SetAutoResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SetAutoResults" type="ns:KeywordBidActionResult"
+                                     minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="ApiException">
+        <wsdl:part element="general:FaultResponse" name="faultMessage"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationRequest">
+        <wsdl:part element="ns:GetRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationResponse">
+        <wsdl:part element="ns:GetResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="SetOperationRequest">
+        <wsdl:part element="ns:SetRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="SetOperationResponse">
+        <wsdl:part element="ns:SetResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="SetAutoOperationRequest">
+        <wsdl:part element="ns:SetAutoRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="SetAutoOperationResponse">
+        <wsdl:part element="ns:SetAutoResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:portType name="KeywordBidsPort">
+        <wsdl:operation name="get">
+            <wsdl:input message="ns:GetOperationRequest"/>
+            <wsdl:output message="ns:GetOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="set">
+            <wsdl:input message="ns:SetOperationRequest"/>
+            <wsdl:output message="ns:SetOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="setAuto">
+            <wsdl:input message="ns:SetAutoOperationRequest"/>
+            <wsdl:output message="ns:SetAutoOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="KeywordBidsSOAP" type="ns:KeywordBidsPort">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="get">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/keywordbids/get"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="set">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/keywordbids/set"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="setAuto">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/keywordbids/setAuto"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="KeywordBids">
+        <wsdl:port binding="ns:KeywordBidsSOAP" name="KeywordBidsSOAP">
+            <soap:address location="https://soap.direct.yandex.ru/v5/keywordbids"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/tests/wsdl_cache/keywords.xml
+++ b/tests/wsdl_cache/keywords.xml
@@ -1,0 +1,362 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:general="http://api.direct.yandex.com/v5/general"
+                  xmlns:ns="http://api.direct.yandex.com/v5/keywords"
+                  name="Keywords"
+                  targetNamespace="http://api.direct.yandex.com/v5/keywords">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://api.direct.yandex.com/v5/keywords">
+            <xsd:import namespace="http://api.direct.yandex.com/v5/general" schemaLocation="https://soap.direct.yandex.ru/v5/general.xsd" />
+            <xsd:simpleType name="KeywordFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Id" />
+                    <xsd:enumeration value="Keyword" />
+                    <xsd:enumeration value="State" />
+                    <xsd:enumeration value="Status" />
+                    <xsd:enumeration value="AdGroupId" />
+                    <xsd:enumeration value="CampaignId" />
+                    <xsd:enumeration value="Bid" />
+                    <xsd:enumeration value="AutotargetingSearchBidIsAuto" />
+                    <xsd:enumeration value="ContextBid" />
+                    <xsd:enumeration value="StrategyPriority" />
+                    <xsd:enumeration value="UserParam1" />
+                    <xsd:enumeration value="UserParam2" />
+                    <xsd:enumeration value="Productivity" />
+                    <xsd:enumeration value="StatisticsSearch" />
+                    <xsd:enumeration value="StatisticsNetwork" />
+                    <xsd:enumeration value="ServingStatus" />
+                    <xsd:enumeration value="AutotargetingCategories" />
+                    <xsd:enumeration value="AutotargetingBrandOptions" />
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="KeywordStateSelectionEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="OFF" />
+                    <xsd:enumeration value="ON" />
+                    <xsd:enumeration value="SUSPENDED" />
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="KeywordStatusSelectionEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="DRAFT" />
+                    <xsd:enumeration value="ACCEPTED" />
+                    <xsd:enumeration value="REJECTED" />
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="KeywordsSelectionCriteria">
+                <xsd:sequence>
+                    <xsd:element name="Ids" type="xsd:long" minOccurs="0" maxOccurs="unbounded" />
+                    <xsd:element name="AdGroupIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded" />
+                    <xsd:element name="CampaignIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded" />
+                    <xsd:element name="States" type="ns:KeywordStateSelectionEnum" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="Statuses" type="ns:KeywordStatusSelectionEnum" minOccurs="0" maxOccurs="unbounded" />
+                    <xsd:element name="ModifiedSince" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ServingStatuses" type="general:ServingStatusEnum" minOccurs="0" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="KeywordAddItem">
+                <xsd:sequence>
+                    <xsd:element name="Keyword" type="xsd:string" minOccurs="1" maxOccurs="1" />
+                    <xsd:element name="AdGroupId" type="xsd:long" minOccurs="1" maxOccurs="1" />
+                    <xsd:element name="Bid" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AutotargetingSearchBidIsAuto" type="general:YesNoEnum" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="ContextBid" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="StrategyPriority" type="general:PriorityEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="UserParam1" type="xsd:string" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="UserParam2" type="xsd:string" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="AutotargetingCategories" type="general:AutotargetingCategory" minOccurs="0" maxOccurs="unbounded" />
+                    <xsd:element name="AutotargetingBrandOptions" type="general:AutotargetingBrandOption" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="AutotargetingSettings" type="general:AutotargetingSettings" minOccurs="0" maxOccurs="1" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="KeywordProductivity">
+                <xsd:sequence>
+                    <xsd:element name="Value" type="xsd:decimal" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="References" type="xsd:int" minOccurs="0" maxOccurs="unbounded" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="KeywordGetItem">
+                <xsd:sequence>
+                    <xsd:element name="Id" type="xsd:long" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="Keyword" type="xsd:string" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="AdGroupId" type="xsd:long" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="CampaignId" type="xsd:long" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="Bid" type="xsd:long" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="AutotargetingSearchBidIsAuto" type="general:YesNoEnum" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="ContextBid" type="xsd:long" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="StrategyPriority" type="general:PriorityEnum" minOccurs="0" maxOccurs="1" nillable="true" />
+                    <xsd:element name="State" type="general:StateEnum" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="Status" type="general:StatusEnum" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="UserParam1" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true" />
+                    <xsd:element name="UserParam2" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true" />
+                    <xsd:element name="Productivity" type="ns:KeywordProductivity" minOccurs="0" maxOccurs="1" nillable="true" />
+                    <xsd:element name="StatisticsSearch" type="general:Statistics" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="StatisticsNetwork" type="general:Statistics" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="ServingStatus" type="general:ServingStatusEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AutotargetingCategories" type="general:AutotargetingCategoryArray" minOccurs="0" maxOccurs="1" nillable="true" />
+                    <xsd:element name="AutotargetingBrandOptions" type="general:AutotargetingBrandOptionArray" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="AutotargetingSettings" type="general:AutotargetingSettings" minOccurs="0" maxOccurs="1" nillable="true" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="KeywordUpdateItem">
+                <xsd:sequence>
+                    <xsd:element name="Id" type="xsd:long" minOccurs="1" maxOccurs="1" />
+                    <xsd:element name="Keyword" type="xsd:string" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="UserParam1" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true" />
+                    <xsd:element name="UserParam2" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true" />
+                    <xsd:element name="AutotargetingCategories" type="general:AutotargetingCategory" minOccurs="0" maxOccurs="unbounded" />
+                    <xsd:element name="AutotargetingBrandOptions" type="general:AutotargetingBrandOption" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="AutotargetingSettings" type="general:AutotargetingSettings" minOccurs="0" maxOccurs="1" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="AddRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="Keywords" type="ns:KeywordAddItem" minOccurs="1" maxOccurs="unbounded" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="AddResults" type="general:ActionResult" minOccurs="1" maxOccurs="unbounded" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetRequestGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="SelectionCriteria" type="ns:KeywordsSelectionCriteria" minOccurs="1" maxOccurs="1" />
+                                <xsd:element name="FieldNames" type="ns:KeywordFieldEnum" minOccurs="1" maxOccurs="unbounded" />
+                                <xsd:element name="AutotargetingSettingsCategoriesFieldNames" type="general:AutotargetingCategoriesFieldEnum" minOccurs="0" maxOccurs="unbounded" />
+                                <xsd:element name="AutotargetingSettingsBrandOptionsFieldNames" type="general:AutotargetingBrandOptionsFieldEnum" minOccurs="0" maxOccurs="unbounded" />
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetResponse">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetResponseGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="Keywords" type="ns:KeywordGetItem" minOccurs="0" maxOccurs="unbounded" />
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="UpdateRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="Keywords" type="ns:KeywordUpdateItem" minOccurs="1" maxOccurs="unbounded" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="UpdateResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="UpdateResults" type="general:ActionResult" minOccurs="1" maxOccurs="unbounded" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DeleteRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1" maxOccurs="1" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DeleteResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="DeleteResults" type="general:ActionResult" minOccurs="1" maxOccurs="unbounded" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SuspendRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1" maxOccurs="1" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SuspendResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SuspendResults" type="general:ActionResult" minOccurs="1" maxOccurs="unbounded" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="ResumeRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1" maxOccurs="1" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="ResumeResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="ResumeResults" type="general:ActionResult" minOccurs="1" maxOccurs="unbounded" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="AddOperationRequest">
+        <wsdl:part element="ns:AddRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationResponse">
+        <wsdl:part element="ns:AddResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationRequest">
+        <wsdl:part element="ns:GetRequest" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="GetOperationResponse">
+        <wsdl:part element="ns:GetResponse" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="UpdateOperationRequest">
+        <wsdl:part element="ns:UpdateRequest" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="UpdateOperationResponse">
+        <wsdl:part element="ns:UpdateResponse" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="DeleteOperationRequest">
+        <wsdl:part element="ns:DeleteRequest" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="DeleteOperationResponse">
+        <wsdl:part element="ns:DeleteResponse" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="SuspendOperationRequest">
+        <wsdl:part element="ns:SuspendRequest" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="SuspendOperationResponse">
+        <wsdl:part element="ns:SuspendResponse" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="ResumeOperationRequest">
+        <wsdl:part element="ns:ResumeRequest" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="ResumeOperationResponse">
+        <wsdl:part element="ns:ResumeResponse" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="ApiException">
+        <wsdl:part element="general:FaultResponse" name="faultMessage" />
+    </wsdl:message>
+    <wsdl:portType name="KeywordsPort">
+        <wsdl:operation name="add">
+            <wsdl:input message="ns:AddOperationRequest" name="addRequest"/>
+            <wsdl:output message="ns:AddOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException" />
+        </wsdl:operation>
+        <wsdl:operation name="get">
+            <wsdl:input message="ns:GetOperationRequest" name="getRequest"/>
+            <wsdl:output message="ns:GetOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException" />
+        </wsdl:operation>
+        <wsdl:operation name="update">
+            <wsdl:input message="ns:UpdateOperationRequest" name="updateRequest"/>
+            <wsdl:output message="ns:UpdateOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException" />
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <wsdl:input message="ns:DeleteOperationRequest" name="deleteRequest"/>
+            <wsdl:output message="ns:DeleteOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException" />
+        </wsdl:operation>
+        <wsdl:operation name="suspend">
+            <wsdl:input message="ns:SuspendOperationRequest" name="suspendRequest"/>
+            <wsdl:output message="ns:SuspendOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException" />
+        </wsdl:operation>
+        <wsdl:operation name="resume">
+            <wsdl:input message="ns:ResumeOperationRequest" name="resumeRequest"/>
+            <wsdl:output message="ns:ResumeOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException" />
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="KeywordsSOAP" type="ns:KeywordsPort">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
+        <wsdl:operation name="add">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/keywords/add"/>
+            <wsdl:input name="addRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal" />
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="get">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/keywords/get"/>
+            <wsdl:input name="getRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal" />
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="update">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/keywords/update"/>
+            <wsdl:input name="updateRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal" />
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/keywords/delete"/>
+            <wsdl:input name="deleteRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal" />
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="suspend">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/keywords/suspend"/>
+            <wsdl:input name="suspendRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal" />
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="resume">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/keywords/resume"/>
+            <wsdl:input name="resumeRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal" />
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="Keywords">
+        <wsdl:port binding="ns:KeywordsSOAP" name="KeywordsSOAP">
+            <soap:address location="https://soap.direct.yandex.ru/v5/keywords/"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/tests/wsdl_cache/keywordsresearch.xml
+++ b/tests/wsdl_cache/keywordsresearch.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<wsdl:definitions xmlns:ns="http://api.direct.yandex.com/v5/keywordsresearch"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:general="http://api.direct.yandex.com/v5/general"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  name="KeywordsResearch"
+                  targetNamespace="http://api.direct.yandex.com/v5/keywordsresearch">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://api.direct.yandex.com/v5/keywordsresearch">
+            <xsd:import namespace="http://api.direct.yandex.com/v5/general" schemaLocation="https://soap.direct.yandex.ru/v5/general.xsd" />
+            <xsd:simpleType name="HasSearchVolumeFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Keyword" />
+                    <xsd:enumeration value="RegionIds" />
+                    <xsd:enumeration value="AllDevices" />
+                    <xsd:enumeration value="MobilePhones" />
+                    <xsd:enumeration value="Tablets" />
+                    <xsd:enumeration value="Desktops" />
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="HasSearchVolumeItem">
+                <xsd:sequence>
+                    <xsd:element name="Keyword" type="xsd:string" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="RegionIds" type="xsd:long" minOccurs="0" maxOccurs="unbounded" />
+                    <xsd:element name="AllDevices" type="general:YesNoEnum" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="MobilePhones" type="general:YesNoEnum" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="Tablets" type="general:YesNoEnum" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="Desktops" type="general:YesNoEnum" minOccurs="0" maxOccurs="1" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="HasSearchVolumeSelectionCriteria">
+                <xsd:sequence>
+                    <xsd:element name="RegionIds" type="xsd:long" minOccurs="1" maxOccurs="unbounded" />
+                    <xsd:element name="Keywords" type="xsd:string" minOccurs="1" maxOccurs="unbounded" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="HasSearchVolumeRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="ns:HasSearchVolumeSelectionCriteria"
+                                     minOccurs="1" maxOccurs="1" />
+                        <xsd:element name="FieldNames" type="ns:HasSearchVolumeFieldEnum"
+                                     minOccurs="1" maxOccurs="unbounded" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="HasSearchVolumeResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="HasSearchVolumeResults" type="ns:HasSearchVolumeItem"
+                                     minOccurs="1" maxOccurs="unbounded" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:complexType name="DeduplicateRequestItem">
+                <xsd:sequence>
+                    <xsd:element name="Id" type="xsd:long" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="Keyword" type="xsd:string" minOccurs="1" maxOccurs="1" />
+                    <xsd:element name="Weight" type="xsd:long" minOccurs="0" maxOccurs="1" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:simpleType name="DeduplicateOperationEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="MERGE_DUPLICATES" />
+                    <xsd:enumeration value="ELIMINATE_OVERLAPPING" />
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:element name="DeduplicateRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="Operation" type="ns:DeduplicateOperationEnum"
+                                     minOccurs="0" maxOccurs="unbounded" />
+                        <xsd:element name="Keywords" type="ns:DeduplicateRequestItem"
+                                     minOccurs="1" maxOccurs="unbounded" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:complexType name="DeduplicateErrorItem">
+                <xsd:complexContent>
+                    <xsd:extension base="general:ActionResult">
+                        <xsd:sequence>
+                            <xsd:element name="Position" type="xsd:long" minOccurs="1" maxOccurs="1" />
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="DeduplicateResponseAddItem">
+                <xsd:sequence>
+                    <xsd:element name="Keyword" type="xsd:string" minOccurs="1" maxOccurs="1" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="DeduplicateResponseUpdateItem">
+                <xsd:sequence>
+                    <xsd:element name="Id" type="xsd:long" minOccurs="1" maxOccurs="1" />
+                    <xsd:element name="Keyword" type="xsd:string" minOccurs="1" maxOccurs="1" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="DeduplicateResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="Add" type="ns:DeduplicateResponseAddItem"
+                                     minOccurs="0" maxOccurs="unbounded" />
+                        <xsd:element name="Update" type="ns:DeduplicateResponseUpdateItem"
+                                     minOccurs="0" maxOccurs="unbounded" />
+                        <xsd:element name="Delete" type="general:IdsCriteria"
+                                     minOccurs="0" maxOccurs="1" />
+                        <xsd:element name="Failure" type="ns:DeduplicateErrorItem"
+                                     minOccurs="0" maxOccurs="unbounded" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="ApiException">
+        <wsdl:part element="general:FaultResponse" name="faultMessage" />
+    </wsdl:message>
+    <wsdl:message name="HasSearchVolumeOperationRequest">
+        <wsdl:part element="ns:HasSearchVolumeRequest" name="parameters" />
+    </wsdl:message>
+    <wsdl:message name="HasSearchVolumeOperationResponse">
+        <wsdl:part element="ns:HasSearchVolumeResponse" name="parameters" />
+    </wsdl:message>
+    <wsdl:message name="DeduplicateOperationRequest">
+        <wsdl:part element="ns:DeduplicateRequest" name="parameters" />
+    </wsdl:message>
+    <wsdl:message name="DeduplicateOperationResponse">
+        <wsdl:part element="ns:DeduplicateResponse" name="parameters" />
+    </wsdl:message>
+    <wsdl:portType name="KeywordsResearchPort">
+        <wsdl:operation name="hasSearchVolume">
+            <wsdl:input message="ns:HasSearchVolumeOperationRequest" />
+            <wsdl:output message="ns:HasSearchVolumeOperationResponse" />
+            <wsdl:fault  message="ns:ApiException" name="ApiException" />
+        </wsdl:operation>
+        <wsdl:operation name="deduplicate">
+            <wsdl:input message="ns:DeduplicateOperationRequest" />
+            <wsdl:output message="ns:DeduplicateOperationResponse" />
+            <wsdl:fault  message="ns:ApiException" name="ApiException" />
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="KeywordsResearchSOAP" type="ns:KeywordsResearchPort">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
+        <wsdl:operation name="hasSearchVolume">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/keywordsresearch/hasSearchVolume" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal" />
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="deduplicate">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/keywordsresearch/deduplicate" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal" />
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="KeywordsResearch">
+        <wsdl:port binding="ns:KeywordsResearchSOAP" name="KeywordsResearchSOAP">
+            <soap:address location="https://soap.direct.yandex.ru/v5/keywordsresearch" />
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/tests/wsdl_cache/leads.xml
+++ b/tests/wsdl_cache/leads.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<wsdl:definitions xmlns:ns="http://api.direct.yandex.com/v5/leads"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:general="http://api.direct.yandex.com/v5/general"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  name="Leads"
+                  targetNamespace="http://api.direct.yandex.com/v5/leads">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://api.direct.yandex.com/v5/leads">
+            <xsd:import namespace="http://api.direct.yandex.com/v5/general" schemaLocation="https://soap.direct.yandex.ru/v5/general.xsd"/>
+            <xsd:simpleType name="LeadFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Id"/>
+                    <xsd:enumeration value="SubmittedAt"/>
+                    <xsd:enumeration value="TurboPageId"/>
+                    <xsd:enumeration value="TurboPageName"/>
+                    <xsd:enumeration value="Data"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="LeadsSelectionCriteria">
+                <xsd:sequence>
+                    <xsd:element name="TurboPageIds" type="xsd:long" minOccurs="1" maxOccurs="unbounded"/>
+                    <xsd:element name="DateTimeFrom" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="DateTimeTo" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="LeadDataItem">
+                <xsd:sequence>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Value" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="LeadGetItem">
+                <xsd:sequence>
+                    <xsd:element name="Id" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="SubmittedAt" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="TurboPageId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="TurboPageName" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Data" type="ns:LeadDataItem" minOccurs="0" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="GetRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetRequestGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="SelectionCriteria" type="ns:LeadsSelectionCriteria"
+                                             minOccurs="1" maxOccurs="1"/>
+                                <xsd:element name="FieldNames" type="ns:LeadFieldEnum"
+                                             minOccurs="1" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetResponse">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetResponseGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="Leads" type="ns:LeadGetItem"
+                                             minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="ApiException">
+        <wsdl:part element="general:FaultResponse" name="faultMessage"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationRequest">
+        <wsdl:part element="ns:GetRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationResponse">
+        <wsdl:part element="ns:GetResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:portType name="LeadsPort">
+        <wsdl:operation name="get">
+            <wsdl:input message="ns:GetOperationRequest"/>
+            <wsdl:output message="ns:GetOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="LeadsSOAP" type="ns:LeadsPort">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="get">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/leads/get"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="Leads">
+        <wsdl:port binding="ns:LeadsSOAP" name="LeadsSOAP">
+            <soap:address location="https://soap.direct.yandex.ru/v5/leads"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/tests/wsdl_cache/negativekeywordsharedsets.xml
+++ b/tests/wsdl_cache/negativekeywordsharedsets.xml
@@ -1,0 +1,232 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<wsdl:definitions xmlns:ns="http://api.direct.yandex.com/v5/negativekeywordsharedsets"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:general="http://api.direct.yandex.com/v5/general"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  name="NegativeKeywordSharedSets"
+                  targetNamespace="http://api.direct.yandex.com/v5/negativekeywordsharedsets">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://api.direct.yandex.com/v5/negativekeywordsharedsets">
+            <xsd:import namespace="http://api.direct.yandex.com/v5/general" schemaLocation="https://soap.direct.yandex.ru/v5/general.xsd"/>
+            <xsd:simpleType name="NegativeKeywordSharedSetFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Id"/>
+                    <xsd:enumeration value="Name"/>
+                    <xsd:enumeration value="NegativeKeywords"/>
+                    <xsd:enumeration value="Associated"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="NegativeKeywordSharedSetBase">
+                <xsd:sequence>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="NegativeKeywords" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="NegativeKeywordSharedSetGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:NegativeKeywordSharedSetBase">
+                        <xsd:sequence>
+                            <xsd:element name="Id" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="Associated" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="NegativeKeywordSharedSetUpdateItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:NegativeKeywordSharedSetBase">
+                        <xsd:sequence>
+                            <xsd:element name="Id" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="NegativeKeywordSharedSetAddItem">
+                <xsd:sequence>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="NegativeKeywords" type="xsd:string" minOccurs="1" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="GetRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetRequestGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="0"
+                                             maxOccurs="1"/>
+                                <xsd:element name="FieldNames" type="ns:NegativeKeywordSharedSetFieldEnum" minOccurs="1"
+                                             maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetResponse">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetResponseGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="NegativeKeywordSharedSets" type="ns:NegativeKeywordSharedSetGetItem"
+                                             minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="NegativeKeywordSharedSets" type="ns:NegativeKeywordSharedSetAddItem"
+                                     minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="AddResults" type="general:ActionResult"
+                                     minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="UpdateRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="NegativeKeywordSharedSets" type="ns:NegativeKeywordSharedSetUpdateItem"
+                                     minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="UpdateResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="UpdateResults" type="general:ActionResult"
+                                     minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DeleteRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1"
+                                     maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DeleteResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="DeleteResults" type="general:ActionResult"
+                                     minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="ApiException">
+        <wsdl:part element="general:FaultResponse" name="faultMessage"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationRequest">
+        <wsdl:part element="ns:GetRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationResponse">
+        <wsdl:part element="ns:GetResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationRequest">
+        <wsdl:part element="ns:AddRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationResponse">
+        <wsdl:part element="ns:AddResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="UpdateOperationRequest">
+        <wsdl:part element="ns:UpdateRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="UpdateOperationResponse">
+        <wsdl:part element="ns:UpdateResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="DeleteOperationRequest">
+        <wsdl:part element="ns:DeleteRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="DeleteOperationResponse">
+        <wsdl:part element="ns:DeleteResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:portType name="NegativeKeywordSharedSetsPort">
+        <wsdl:operation name="get">
+            <wsdl:input message="ns:GetOperationRequest"/>
+            <wsdl:output message="ns:GetOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="add">
+            <wsdl:input message="ns:AddOperationRequest"/>
+            <wsdl:output message="ns:AddOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="update">
+            <wsdl:input message="ns:UpdateOperationRequest"/>
+            <wsdl:output message="ns:UpdateOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <wsdl:input message="ns:DeleteOperationRequest"/>
+            <wsdl:output message="ns:DeleteOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="NegativeKeywordSharedSetsSOAP" type="ns:NegativeKeywordSharedSetsPort">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="get">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/negativekeywordsharedsets/get"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="add">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/negativekeywordsharedsets/add"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="update">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/negativekeywordsharedsets/update"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/negativekeywordsharedsets/delete"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="NegativeKeywordSharedSets">
+        <wsdl:port binding="ns:NegativeKeywordSharedSetsSOAP" name="NegativeKeywordSharedSetsSOAP">
+            <soap:address location="https://soap.direct.yandex.ru/v5/negativekeywordsharedsets"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/tests/wsdl_cache/retargetinglists.xml
+++ b/tests/wsdl_cache/retargetinglists.xml
@@ -1,0 +1,283 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<wsdl:definitions xmlns:ns="http://api.direct.yandex.com/v5/retargetinglists"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:general="http://api.direct.yandex.com/v5/general"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  name="RetargetingLists"
+                  targetNamespace="http://api.direct.yandex.com/v5/retargetinglists">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://api.direct.yandex.com/v5/retargetinglists">
+            <xsd:import namespace="http://api.direct.yandex.com/v5/general" schemaLocation="https://soap.direct.yandex.ru/v5/general.xsd" />
+            <xsd:simpleType name="RetargetingListFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Type" />
+                    <xsd:enumeration value="Id" />
+                    <xsd:enumeration value="Name" />
+                    <xsd:enumeration value="Description" />
+                    <xsd:enumeration value="Rules" />
+                    <xsd:enumeration value="IsAvailable" />
+                    <xsd:enumeration value="Scope" />
+                    <xsd:enumeration value="AvailableForTargetsInAdGroupTypes" />
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="RetargetingListScopeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="FOR_TARGETS_AND_ADJUSTMENTS"/>
+                    <xsd:enumeration value="FOR_ADJUSTMENTS_ONLY"/>
+                    <xsd:enumeration value="FOR_TARGETS_ONLY"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="RetargetingListRuleOperatorEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="ALL"/>
+                    <xsd:enumeration value="ANY"/>
+                    <xsd:enumeration value="NONE" />
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="RetargetingListTypeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="RETARGETING"/>
+                    <xsd:enumeration value="AUDIENCE"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="AvailableForTargetsInAdGroupTypesArray">
+                <xsd:sequence>
+                    <xsd:element name="Items" type="general:AdGroupTypesEnum" minOccurs="1" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="RetargetingListSelectionCriteria">
+                <xsd:sequence>
+                    <xsd:element name="Types" type="ns:RetargetingListTypeEnum" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="Ids" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="RetargetingListRuleArgumentItem">
+                <xsd:sequence>
+                    <xsd:element name="MembershipLifeSpan" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ExternalId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="RetargetingListRuleItem">
+                <xsd:sequence>
+                    <xsd:element name="Arguments" type="ns:RetargetingListRuleArgumentItem" minOccurs="1" maxOccurs="unbounded"/>
+                    <xsd:element name="Operator" type="ns:RetargetingListRuleOperatorEnum" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="RetargetingListBase">
+                <xsd:sequence>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="Description" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="Rules" type="ns:RetargetingListRuleItem" minOccurs="0" maxOccurs="unbounded" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="RetargetingListGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:RetargetingListBase">
+                        <xsd:sequence>
+                            <xsd:element name="Type" type="ns:RetargetingListTypeEnum" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="Id" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="IsAvailable" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="Scope" type="ns:RetargetingListScopeEnum" minOccurs="0" maxOccurs="1"/>
+                            <xsd:element name="AvailableForTargetsInAdGroupTypes" type="ns:AvailableForTargetsInAdGroupTypesArray" minOccurs="0" maxOccurs="1" nillable="true"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="RetargetingListUpdateItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:RetargetingListBase">
+                        <xsd:sequence>
+                            <xsd:element name="Id" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="RetargetingListAddItem">
+                <xsd:sequence>
+                    <xsd:element name="Type" type="ns:RetargetingListTypeEnum" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="Name" type="xsd:string" minOccurs="1" maxOccurs="1" />
+                    <xsd:element name="Description" type="xsd:string" minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="Rules" type="ns:RetargetingListRuleItem" minOccurs="1" maxOccurs="unbounded" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="GetRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetRequestGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="SelectionCriteria" type="ns:RetargetingListSelectionCriteria" minOccurs="0"
+                                     maxOccurs="1"/>
+                                <xsd:element name="FieldNames" type="ns:RetargetingListFieldEnum" minOccurs="1" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetResponse">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetResponseGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="RetargetingLists" type="ns:RetargetingListGetItem" minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="RetargetingLists" type="ns:RetargetingListAddItem"
+                                     minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="AddResults" type="general:ActionResult"
+                                     minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="UpdateRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="RetargetingLists" type="ns:RetargetingListUpdateItem"
+                                     minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="UpdateResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="UpdateResults" type="general:ActionResult"
+                                     minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DeleteRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1"
+                                     maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DeleteResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="DeleteResults" type="general:ActionResult"
+                                     minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="ApiException">
+        <wsdl:part element="general:FaultResponse" name="faultMessage"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationRequest">
+        <wsdl:part element="ns:GetRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationResponse">
+        <wsdl:part element="ns:GetResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationRequest">
+        <wsdl:part element="ns:AddRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationResponse">
+        <wsdl:part element="ns:AddResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="UpdateOperationRequest">
+        <wsdl:part element="ns:UpdateRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="UpdateOperationResponse">
+        <wsdl:part element="ns:UpdateResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="DeleteOperationRequest">
+        <wsdl:part element="ns:DeleteRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="DeleteOperationResponse">
+        <wsdl:part element="ns:DeleteResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:portType name="RetargetingListsPort">
+        <wsdl:operation name="get">
+            <wsdl:input  message="ns:GetOperationRequest"/>
+            <wsdl:output message="ns:GetOperationResponse"/>
+            <wsdl:fault  message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="add">
+            <wsdl:input  message="ns:AddOperationRequest"/>
+            <wsdl:output message="ns:AddOperationResponse"/>
+            <wsdl:fault  message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="update">
+            <wsdl:input  message="ns:UpdateOperationRequest"/>
+            <wsdl:output message="ns:UpdateOperationResponse"/>
+            <wsdl:fault  message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <wsdl:input  message="ns:DeleteOperationRequest"/>
+            <wsdl:output message="ns:DeleteOperationResponse"/>
+            <wsdl:fault  message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="RetargetingListsSOAP" type="ns:RetargetingListsPort">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="get">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/retargetinglists/get"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="add">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/retargetinglists/add"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="update">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/retargetinglists/update"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/retargetinglists/delete"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="RetargetingLists">
+        <wsdl:port binding="ns:RetargetingListsSOAP" name="RetargetingListsSOAP">
+            <soap:address location="https://soap.direct.yandex.ru/v5/retargetinglists"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/tests/wsdl_cache/sitelinks.xml
+++ b/tests/wsdl_cache/sitelinks.xml
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:general="http://api.direct.yandex.com/v5/general"
+                  xmlns:ns="http://api.direct.yandex.com/v5/sitelinks"
+                  name="Sitelinks"
+                  targetNamespace="http://api.direct.yandex.com/v5/sitelinks">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://api.direct.yandex.com/v5/sitelinks">
+            <xsd:import namespace="http://api.direct.yandex.com/v5/general" schemaLocation="https://soap.direct.yandex.ru/v5/general.xsd" />
+            <xsd:simpleType name="SitelinksSetFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Id"/>
+                    <xsd:enumeration value="Sitelinks"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="SitelinkAddItem">
+                <xsd:sequence>
+                    <xsd:element name="Title" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Href" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Description" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="TurboPageId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SitelinkGetItem">
+                <xsd:sequence>
+                    <xsd:element name="Title" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Href" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="Description" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="TurboPageId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SitelinksSetAddItem">
+                <xsd:sequence>
+                    <xsd:element name="Sitelinks" type="ns:SitelinkAddItem" minOccurs="1" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SitelinksSetGetItem">
+                <xsd:sequence>
+                    <xsd:element name="Id" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Sitelinks" type="ns:SitelinkGetItem" minOccurs="0" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="AddRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SitelinksSets" type="ns:SitelinksSetAddItem" minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="AddResults" type="general:ActionResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:simpleType name="SitelinkFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Title"/>
+                    <xsd:enumeration value="Href"/>
+                    <xsd:enumeration value="Description"/>
+                    <xsd:enumeration value="TurboPageId"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:element name="GetRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetRequestGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="0" maxOccurs="1"/>
+                                <xsd:element name="FieldNames" type="ns:SitelinksSetFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="SitelinkFieldNames" type="ns:SitelinkFieldEnum" minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetResponse">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetResponseGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="SitelinksSets" type="ns:SitelinksSetGetItem" minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DeleteRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DeleteResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="DeleteResults" type="general:ActionResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="ApiException">
+        <wsdl:part element="general:FaultResponse" name="faultMessage"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationRequest">
+        <wsdl:part name="parameters" element="ns:AddRequest"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationResponse">
+        <wsdl:part name="parameters" element="ns:AddResponse"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationRequest">
+        <wsdl:part name="parameters" element="ns:GetRequest"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationResponse">
+        <wsdl:part name="parameters" element="ns:GetResponse"/>
+    </wsdl:message>
+    <wsdl:message name="DeleteOperationRequest">
+        <wsdl:part name="parameters" element="ns:DeleteRequest"/>
+    </wsdl:message>
+    <wsdl:message name="DeleteOperationResponse">
+        <wsdl:part name="parameters" element="ns:DeleteResponse"/>
+    </wsdl:message>
+    <wsdl:portType name="SitelinksPort">
+        <wsdl:operation name="add">
+            <wsdl:input name="addRequest" message="ns:AddOperationRequest"/>
+            <wsdl:output message="ns:AddOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="get">
+            <wsdl:input name="getRequest" message="ns:GetOperationRequest"/>
+            <wsdl:output message="ns:GetOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <wsdl:input name="deleteRequest" message="ns:DeleteOperationRequest"/>
+            <wsdl:output message="ns:DeleteOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="SitelinksSOAP" type="ns:SitelinksPort">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="add">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/sitelinks/add"/>
+            <wsdl:input name="addRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="get">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/sitelinks/get"/>
+            <wsdl:input name="getRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/sitelinks/delete"/>
+            <wsdl:input name="deleteRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="Sitelinks">
+        <wsdl:port name="SitelinksSOAP" binding="ns:SitelinksSOAP">
+            <soap:address location="https://soap.direct.yandex.ru/v5/sitelinks/"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/tests/wsdl_cache/smartadtargets.xml
+++ b/tests/wsdl_cache/smartadtargets.xml
@@ -1,0 +1,395 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:general="http://api.direct.yandex.com/v5/general"
+                  xmlns:ns="http://api.direct.yandex.com/v5/smartadtargets"
+                  name="SmartAdTargets"
+                  targetNamespace="http://api.direct.yandex.com/v5/smartadtargets">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://api.direct.yandex.com/v5/smartadtargets">
+            <xsd:import namespace="http://api.direct.yandex.com/v5/general"
+                        schemaLocation="https://soap.direct.yandex.ru/v5/general.xsd"/>
+            <xsd:simpleType name="SmartAdTargetFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Id"/>
+                    <xsd:enumeration value="AdGroupId"/>
+                    <xsd:enumeration value="CampaignId"/>
+                    <xsd:enumeration value="Name"/>
+                    <xsd:enumeration value="AverageCpc"/>
+                    <xsd:enumeration value="AverageCpa"/>
+                    <xsd:enumeration value="StrategyPriority"/>
+                    <xsd:enumeration value="Conditions"/>
+                    <xsd:enumeration value="ConditionType"/>
+                    <xsd:enumeration value="State"/>
+                    <xsd:enumeration value="Audience"/>
+                    <xsd:enumeration value="AvailableItemsOnly"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="AudienceEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="INTERESTED_IN_SIMILAR_PRODUCTS"/>
+                    <xsd:enumeration value="VISITED_PRODUCT_PAGE"/>
+                    <xsd:enumeration value="ALL_SEGMENTS"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="ConditionsArray">
+                <xsd:sequence>
+                    <xsd:element name="Items" type="ns:ConditionsItem" minOccurs="1" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ConditionsItem">
+                <xsd:sequence>
+                    <xsd:element name="Operand" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Operator" type="general:StringConditionOperatorEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Arguments" type="xsd:string" minOccurs="1" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SmartAdTargetAddItem">
+                <xsd:sequence>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="AdGroupId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="AverageCpc" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpa" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="StrategyPriority" type="general:PriorityEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Audience" type="ns:AudienceEnum" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Conditions" type="ns:ConditionsArray" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AvailableItemsOnly" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SmartAdTargetGetItem">
+                <xsd:sequence>
+                    <xsd:element name="Id" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AdGroupId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CampaignId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpc" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="AverageCpa" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="StrategyPriority" type="general:PriorityEnum" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="State" type="general:StateEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Audience" type="ns:AudienceEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Conditions" type="ns:ConditionsArray" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="ConditionType" type="general:ConditionTypeEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AvailableItemsOnly" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SmartAdTargetUpdateItem">
+                <xsd:sequence>
+                    <xsd:element name="Id" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpc" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="AverageCpa" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="StrategyPriority" type="general:PriorityEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Audience" type="ns:AudienceEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Conditions" type="ns:ConditionsArray" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AvailableItemsOnly" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SetBidsItem">
+                <xsd:sequence>
+                    <xsd:element name="CampaignId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AdGroupId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Id" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpc" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="AverageCpa" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="StrategyPriority" type="general:PriorityEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="AddRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SmartAdTargets" type="ns:SmartAdTargetAddItem" minOccurs="1"
+                                     maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="AddResults" type="general:ActionResult" minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetRequestGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="SelectionCriteria" type="general:AdTargetsSelectionCriteria"
+                                             minOccurs="1"
+                                             maxOccurs="1"/>
+                                <xsd:element name="FieldNames" type="ns:SmartAdTargetFieldEnum" minOccurs="1"
+                                             maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetResponse">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetResponseGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="SmartAdTargets" type="ns:SmartAdTargetGetItem" minOccurs="0"
+                                             maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="UpdateRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SmartAdTargets" type="ns:SmartAdTargetUpdateItem" minOccurs="1"
+                                     maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="UpdateResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="UpdateResults" type="general:ActionResult" minOccurs="1"
+                                     maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DeleteRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DeleteResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="DeleteResults" type="general:ActionResult" minOccurs="1"
+                                     maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SuspendRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SuspendResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SuspendResults" type="general:ActionResult" minOccurs="1"
+                                     maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="ResumeRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="ResumeResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="ResumeResults" type="general:ActionResult" minOccurs="1"
+                                     maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SetBidsRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="Bids" type="ns:SetBidsItem" minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SetBidsResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SetBidsResults" type="general:SetBidsActionResult" minOccurs="0"
+                                     maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="AddOperationRequest">
+        <wsdl:part element="ns:AddRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationResponse">
+        <wsdl:part element="ns:AddResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationRequest">
+        <wsdl:part element="ns:GetRequest" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="GetOperationResponse">
+        <wsdl:part element="ns:GetResponse" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="UpdateOperationRequest">
+        <wsdl:part element="ns:UpdateRequest" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="UpdateOperationResponse">
+        <wsdl:part element="ns:UpdateResponse" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="DeleteOperationRequest">
+        <wsdl:part element="ns:DeleteRequest" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="DeleteOperationResponse">
+        <wsdl:part element="ns:DeleteResponse" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="SuspendOperationRequest">
+        <wsdl:part element="ns:SuspendRequest" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="SuspendOperationResponse">
+        <wsdl:part element="ns:SuspendResponse" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="ResumeOperationRequest">
+        <wsdl:part element="ns:ResumeRequest" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="ResumeOperationResponse">
+        <wsdl:part element="ns:ResumeResponse" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="SetBidsOperationRequest">
+        <wsdl:part element="ns:SetBidsRequest" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="SetBidsOperationResponse">
+        <wsdl:part element="ns:SetBidsResponse" name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="ApiException">
+        <wsdl:part element="general:FaultResponse" name="faultMessage"/>
+    </wsdl:message>
+    <wsdl:portType name="SmartAdTargetsPort">
+        <wsdl:operation name="add">
+            <wsdl:input message="ns:AddOperationRequest" name="addRequest"/>
+            <wsdl:output message="ns:AddOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="get">
+            <wsdl:input message="ns:GetOperationRequest" name="getRequest"/>
+            <wsdl:output message="ns:GetOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="update">
+            <wsdl:input message="ns:UpdateOperationRequest" name="updateRequest"/>
+            <wsdl:output message="ns:UpdateOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <wsdl:input message="ns:DeleteOperationRequest" name="deleteRequest"/>
+            <wsdl:output message="ns:DeleteOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="suspend">
+            <wsdl:input message="ns:SuspendOperationRequest" name="suspendRequest"/>
+            <wsdl:output message="ns:SuspendOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="resume">
+            <wsdl:input message="ns:ResumeOperationRequest" name="resumeRequest"/>
+            <wsdl:output message="ns:ResumeOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="setBids">
+            <wsdl:input message="ns:SetBidsOperationRequest" name="setBidsRequest"/>
+            <wsdl:output message="ns:SetBidsOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="SmartAdTargetsSOAP" type="ns:SmartAdTargetsPort">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="add">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/smartadtargets/add"/>
+            <wsdl:input name="addRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="get">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/smartadtargets/get"/>
+            <wsdl:input name="getRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="update">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/smartadtargets/update"/>
+            <wsdl:input name="updateRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/smartadtargets/delete"/>
+            <wsdl:input name="deleteRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="suspend">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/smartadtargets/suspend"/>
+            <wsdl:input name="suspendRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="resume">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/smartadtargets/resume"/>
+            <wsdl:input name="resumeRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="setBids">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/smartadtargets/setBids"/>
+            <wsdl:input name="setBidsRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="SmartAdTargets">
+        <wsdl:port binding="ns:SmartAdTargetsSOAP" name="SmartAdTargetsSOAP">
+            <soap:address location="https://soap.direct.yandex.ru/v5/smartadtargets"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/tests/wsdl_cache/turbopages.xml
+++ b/tests/wsdl_cache/turbopages.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:general="http://api.direct.yandex.com/v5/general"
+                  xmlns:ns="http://api.direct.yandex.com/v5/turbopages"
+                  name="TurboPages"
+                  targetNamespace="http://api.direct.yandex.com/v5/turbopages">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://api.direct.yandex.com/v5/turbopages">
+            <xsd:import namespace="http://api.direct.yandex.com/v5/general" schemaLocation="https://soap.direct.yandex.ru/v5/general.xsd"/>
+            <xsd:simpleType name="TurboPageFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Id"/>
+                    <xsd:enumeration value="Name"/>
+                    <xsd:enumeration value="Href"/>
+                    <xsd:enumeration value="PreviewHref"/>
+                    <xsd:enumeration value="TurboSiteHref"/>
+                    <xsd:enumeration value="BoundWithHref"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="TurboPagesSelectionCriteria">
+                <xsd:sequence>
+                    <xsd:element name="Ids" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="BoundWithHrefs" type="xsd:string" minOccurs="0"
+                                 maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="TurboPageGetItem">
+                <xsd:sequence>
+                    <xsd:element name="Id" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Href" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PreviewHref" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="TurboSiteHref" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="BoundWithHref" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="GetRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetRequestGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="SelectionCriteria" type="ns:TurboPagesSelectionCriteria" minOccurs="0"
+                                             maxOccurs="1"/>
+                                <xsd:element name="FieldNames" type="ns:TurboPageFieldEnum" minOccurs="1"
+                                             maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetResponse">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetResponseGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="TurboPages" type="ns:TurboPageGetItem" minOccurs="0"
+                                             maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="ApiException">
+        <wsdl:part element="general:FaultResponse" name="faultMessage"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationRequest">
+        <wsdl:part name="parameters" element="ns:GetRequest"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationResponse">
+        <wsdl:part name="parameters" element="ns:GetResponse"/>
+    </wsdl:message>
+    <wsdl:portType name="TurboPagesPort">
+        <wsdl:operation name="get">
+            <wsdl:input name="getRequest" message="ns:GetOperationRequest"/>
+            <wsdl:output message="ns:GetOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="TurboPagesSOAP" type="ns:TurboPagesPort">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="get">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/turbopages/get"/>
+            <wsdl:input name="getRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="TurboPages">
+        <wsdl:port name="TurboPagesSOAP" binding="ns:TurboPagesSOAP">
+            <soap:address location="https://soap.direct.yandex.ru/v5/turbopages/"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/tests/wsdl_cache/vcards.xml
+++ b/tests/wsdl_cache/vcards.xml
@@ -1,0 +1,238 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:general="http://api.direct.yandex.com/v5/general"
+                  xmlns:ns="http://api.direct.yandex.com/v5/vcards"
+                  name="VCards"
+                  targetNamespace="http://api.direct.yandex.com/v5/vcards">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://api.direct.yandex.com/v5/vcards">
+            <xsd:import namespace="http://api.direct.yandex.com/v5/general" schemaLocation="https://soap.direct.yandex.ru/v5/general.xsd" />
+            <xsd:simpleType name="VCardFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Id"/>
+                    <xsd:enumeration value="Country"/>
+                    <xsd:enumeration value="City"/>
+                    <xsd:enumeration value="Street"/>
+                    <xsd:enumeration value="House"/>
+                    <xsd:enumeration value="Building"/>
+                    <xsd:enumeration value="Apartment"/>
+                    <xsd:enumeration value="CompanyName"/>
+                    <xsd:enumeration value="ExtraMessage"/>
+                    <xsd:enumeration value="ContactPerson"/>
+                    <xsd:enumeration value="ContactEmail"/>
+                    <xsd:enumeration value="MetroStationId"/>
+                    <xsd:enumeration value="CampaignId"/>
+                    <xsd:enumeration value="Ogrn"/>
+                    <xsd:enumeration value="WorkTime"/>
+                    <xsd:enumeration value="InstantMessenger"/>
+                    <xsd:enumeration value="Phone"/>
+                    <xsd:enumeration value="PointOnMap"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="Phone">
+                <xsd:sequence>
+                    <xsd:element name="CountryCode" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="CityCode" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="PhoneNumber" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Extension" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="InstantMessenger">
+                <xsd:sequence>
+                    <xsd:element name="MessengerClient" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="MessengerLogin" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="MapPoint">
+                <xsd:sequence>
+                    <xsd:element name="X" type="xsd:decimal" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Y" type="xsd:decimal" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="X1" type="xsd:decimal" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Y1" type="xsd:decimal" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="X2" type="xsd:decimal" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Y2" type="xsd:decimal" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="VCardAddItem">
+                <xsd:sequence>
+                    <xsd:element name="CampaignId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Country" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="City" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="CompanyName" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="WorkTime" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Phone" type="ns:Phone" minOccurs="1" maxOccurs="1"/>
+                    <!-- This part of parameters is not required for creation -->
+                    <xsd:element name="Street" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="House" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Building" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Apartment" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="InstantMessenger" type="ns:InstantMessenger" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ExtraMessage" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ContactEmail" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Ogrn" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="MetroStationId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PointOnMap" type="ns:MapPoint" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ContactPerson" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="VCardGetItem">
+                <xsd:sequence>
+                    <xsd:element name="Id" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CampaignId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Country" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="City" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WorkTime" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Phone" type="ns:Phone" minOccurs="0" maxOccurs="1"/>
+                    <!-- This part of parameters can be nillable and has no data-->
+                    <xsd:element name="Street" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="House" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="Building" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="Apartment" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="InstantMessenger" type="ns:InstantMessenger" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="CompanyName" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="ExtraMessage" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="ContactEmail" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="Ogrn" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="MetroStationId" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="PointOnMap" type="ns:MapPoint" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="ContactPerson" type="xsd:string" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="GetRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetRequestGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="0" maxOccurs="1"/>
+                                <xsd:element name="FieldNames" type="ns:VCardFieldEnum" minOccurs="1" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetResponse">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetResponseGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="VCards" type="ns:VCardGetItem" minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="VCards" type="ns:VCardAddItem" minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="AddResults" type="general:ActionResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DeleteRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DeleteResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="DeleteResults" type="general:ActionResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="ApiException">
+        <wsdl:part element="general:FaultResponse" name="faultMessage"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationRequest">
+        <wsdl:part name="parameters" element="ns:AddRequest"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationResponse">
+        <wsdl:part name="parameters" element="ns:AddResponse"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationRequest">
+        <wsdl:part name="parameters" element="ns:GetRequest"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationResponse">
+        <wsdl:part name="parameters" element="ns:GetResponse"/>
+    </wsdl:message>
+    <wsdl:message name="DeleteOperationRequest">
+        <wsdl:part name="parameters" element="ns:DeleteRequest"/>
+    </wsdl:message>
+    <wsdl:message name="DeleteOperationResponse">
+        <wsdl:part name="parameters" element="ns:DeleteResponse"/>
+    </wsdl:message>
+    <wsdl:portType name="VCardsPort">
+        <wsdl:operation name="add">
+            <wsdl:input name="addRequest" message="ns:AddOperationRequest"/>
+            <wsdl:output message="ns:AddOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="get">
+            <wsdl:input name="getRequest" message="ns:GetOperationRequest"/>
+            <wsdl:output message="ns:GetOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <wsdl:input name="deleteRequest" message="ns:DeleteOperationRequest"/>
+            <wsdl:output message="ns:DeleteOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="VCardsSOAP" type="ns:VCardsPort">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="add">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/vcards/add"/>
+            <wsdl:input name="addRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="get">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/vcards/get"/>
+            <wsdl:input name="getRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <soap:operation soapAction="https://api.direct.yandex.com/v5/vcards/delete"/>
+            <wsdl:input name="deleteRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="VCards">
+        <wsdl:port name="VCardsSOAP" binding="ns:VCardsSOAP">
+            <soap:address location="https://soap.direct.yandex.ru/v5/vcards"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
## Summary

- Add WSDL-based coverage tests that detect missing CLI commands and methods by comparing against Yandex Direct API v5 service definitions (closes #32)
- `direct_cli/wsdl_coverage.py`: WSDL fetching, parsing, CLI↔API service/method mapping with cached XML files for offline CI
- `tests/test_api_coverage.py`: Phase 1 (method coverage per service) and Phase 2 (new service discovery) tests
- 27 cached WSDL XML files in `tests/wsdl_cache/`
- `api_coverage` pytest marker added to `pyproject.toml`

**Detected gaps (tracked in `KNOWN_*` constants):**
- Missing service: `advideos`
- 15 missing API methods (setAuto, setBids, getGeoRegions, etc.)
- 4 extra CLI methods without WSDL counterpart (keywords archive/unarchive, dynamicads update, keywordsresearch get)

## Test plan

- [x] `pytest tests/test_api_coverage.py -v` — 2/2 passed (offline, from cache)
- [x] `pytest -m api_coverage -v` — marker filtering works
- [x] Full suite `pytest` — 120 passed, no regressions
- [x] `black --check` / `flake8` — clean
- [ ] Remove an entry from `KNOWN_MISSING_METHODS` → test fails with clear message
- [ ] Add a fake service to `CANONICAL_API_SERVICES` → `test_no_missing_services` fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)