### PR TITLE
fix: enforce direct-only executable contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ direct --token YOUR_TOKEN --login YOUR_LOGIN campaigns get
 ```
 
 Install with `pip install direct-cli`, then run commands with `direct`.
+Invoking the deprecated `direct-cli` entrypoint exits with
+`use direct instead of direct-cli`.
 
 ### Global Options
 
@@ -64,9 +66,10 @@ Naming rules:
   - multiword commands use kebab-case
   - examples: `get`, `set-bids`, `check-campaigns`, `has-search-volume`
 
-direct-cli owns the public naming contract. `tapi-yandex-direct` may
-influence the internal transport layer, but it does not define canonical CLI
-names.
+The `direct` executable defines the public naming contract. The
+`direct-cli` package name and deprecated shim do not define canonical CLI
+names. `tapi-yandex-direct` may influence the internal transport layer, but it
+does not define canonical CLI names.
 
 The current policy is canonical-only. Historical aliases are not preserved in
 the runtime CLI by default. If compatibility is ever needed, an alias must be
@@ -464,7 +467,9 @@ YANDEX_DIRECT_LOGIN=ваш_логин_на_яндексе
 direct --token ВАШ_ТОКЕН --login ВАШ_ЛОГИН campaigns get
 ```
 
-Установка остаётся через `pip install direct-cli`, а запуск команд теперь идет через `direct`.
+Установка остаётся через `pip install direct-cli`, а запуск команд теперь идет
+через `direct`. Вызов deprecated entrypoint `direct-cli` завершается ошибкой с
+подсказкой `use direct instead of direct-cli`.
 
 ### Глобальные опции
 
@@ -493,17 +498,20 @@ Command naming rules:
 - в документации и примерах каноническими считаются `get`,
   `check-dictionaries` и `has-search-volume`
 
-`direct-cli` владеет публичным naming contract. `tapi-yandex-direct` может
-влиять на внутренний transport layer, но не определяет канонические CLI-имена.
+Публичный naming contract задаёт исполняемый файл `direct`. Имя пакета
+`direct-cli` и deprecated shim не определяют канонические CLI-имена.
+`tapi-yandex-direct` может влиять на внутренний transport layer, но не
+определяет канонические CLI-имена.
 
 Текущая политика — canonical-only. Исторические aliases по умолчанию не
 сохраняются в runtime CLI. Если совместимость когда-нибудь понадобится, alias
 должен быть добавлен как явное exception-правило с конкретным legacy syntax из
 `tapi-yandex-direct`, который действительно нужно поддержать.
 
-`direct-cli` — это транспортный слой над API Яндекс Директа. Канонические
-имена CLI-групп следуют нормализованным Python-именам из
-`tapi-yandex-direct`, а имена подкоманд — это kebab-case проекции API-методов.
+`direct` — это канонический transport entrypoint над API Яндекс Директа,
+устанавливаемый пакетом `direct-cli`. Канонические имена CLI-групп следуют
+нормализованным Python-именам из `tapi-yandex-direct`, а имена подкоманд —
+это kebab-case проекции API-методов.
 
 Базовые соответствия:
 
@@ -538,8 +546,10 @@ Naming rules:
   - multiword commands use kebab-case
   - examples: `get`, `set-bids`, `check-campaigns`, `has-search-volume`
 
-`direct-cli` владеет публичным naming contract. `tapi-yandex-direct` может
-влиять на внутренний transport layer, но не определяет канонические CLI-имена.
+Публичный naming contract задаёт исполняемый файл `direct`. Имя пакета
+`direct-cli` и deprecated shim не определяют канонические CLI-имена.
+`tapi-yandex-direct` может влиять на внутренний transport layer, но не
+определяет канонические CLI-имена.
 
 Текущая политика — canonical-only. Исторические aliases по умолчанию не
 сохраняются в runtime CLI. Если совместимость когда-нибудь понадобится, alias

--- a/direct_cli/_deprecated.py
+++ b/direct_cli/_deprecated.py
@@ -1,0 +1,11 @@
+import click
+
+DEPRECATED_ENTRYPOINT_MESSAGE = (
+    "direct-cli is deprecated; use direct instead of direct-cli."
+)
+
+
+def deprecated_main() -> None:
+    """Fail fast for the deprecated `direct-cli` entrypoint."""
+    click.echo(f"Error: {DEPRECATED_ENTRYPOINT_MESSAGE}", err=True)
+    raise SystemExit(2)

--- a/direct_cli/cli.py
+++ b/direct_cli/cli.py
@@ -40,10 +40,6 @@ from .commands.advideos import advideos
 # Load .env file
 load_dotenv()
 
-DEPRECATED_ENTRYPOINT_MESSAGE = (
-    "`direct-cli` is deprecated; use direct instead of direct-cli."
-)
-
 
 @click.group(name="direct")
 @click.option("--token", envvar="YANDEX_DIRECT_TOKEN", help="API access token")
@@ -108,12 +104,6 @@ def cli(
     else:
         ctx.obj["token"] = token
         ctx.obj["login"] = login
-
-
-def deprecated_main() -> None:
-    """Fail fast for the deprecated `direct-cli` entrypoint."""
-    click.echo(f"Error: {DEPRECATED_ENTRYPOINT_MESSAGE}", err=True)
-    raise SystemExit(2)
 
 
 # Register all commands

--- a/direct_cli/cli.py
+++ b/direct_cli/cli.py
@@ -40,6 +40,10 @@ from .commands.advideos import advideos
 # Load .env file
 load_dotenv()
 
+DEPRECATED_ENTRYPOINT_MESSAGE = (
+    "`direct-cli` is deprecated; use direct instead of direct-cli."
+)
+
 
 @click.group(name="direct")
 @click.option("--token", envvar="YANDEX_DIRECT_TOKEN", help="API access token")
@@ -104,6 +108,12 @@ def cli(
     else:
         ctx.obj["token"] = token
         ctx.obj["login"] = login
+
+
+def deprecated_main() -> None:
+    """Fail fast for the deprecated `direct-cli` entrypoint."""
+    click.echo(f"Error: {DEPRECATED_ENTRYPOINT_MESSAGE}", err=True)
+    raise SystemExit(2)
 
 
 # Register all commands

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dev = [
 
 [project.scripts]
 direct = "direct_cli.cli:cli"
-direct-cli = "direct_cli.cli:deprecated_main"
+direct-cli = "direct_cli._deprecated:deprecated_main"
 
 [project.urls]
 Homepage = "https://github.com/axisrow/direct-cli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dev = [
 
 [project.scripts]
 direct = "direct_cli.cli:cli"
-direct-cli = "direct_cli.cli:cli"
+direct-cli = "direct_cli.cli:deprecated_main"
 
 [project.urls]
 Homepage = "https://github.com/axisrow/direct-cli"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,12 +2,14 @@
 Tests for Direct CLI
 """
 
+import io
 import os
 import unittest
+from contextlib import redirect_stderr
 from pathlib import Path
 from unittest.mock import patch
 from click.testing import CliRunner
-from direct_cli.cli import cli
+from direct_cli.cli import DEPRECATED_ENTRYPOINT_MESSAGE, cli, deprecated_main
 
 
 class TestCLI(unittest.TestCase):
@@ -112,6 +114,14 @@ class TestCLI(unittest.TestCase):
             self.assertNotIn("--notification-json", result.output)
             self.assertNotIn("--send-invite-to-json", result.output)
 
+    def test_deprecated_direct_cli_entrypoint_exits_with_hint(self):
+        stderr = io.StringIO()
+        with self.assertRaises(SystemExit) as context:
+            with redirect_stderr(stderr):
+                deprecated_main()
+        self.assertEqual(context.exception.code, 2)
+        self.assertIn(DEPRECATED_ENTRYPOINT_MESSAGE, stderr.getvalue())
+
 
 class TestAuth(unittest.TestCase):
     """Test authentication"""
@@ -146,7 +156,8 @@ class TestReadmeContract(unittest.TestCase):
         self.assertIn("direct <group> <command> [flags]", self.content)
         self.assertIn("Group naming rules", self.content)
         self.assertIn("Command naming rules", self.content)
-        self.assertIn("direct-cli owns the public naming contract", self.content)
+        self.assertIn("The `direct` executable defines the public naming contract", self.content)
+        self.assertIn("use direct instead of direct-cli", self.content)
 
     def test_readme_contains_canonical_command_examples(self):
         """README must include canonical examples for renamed commands."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,8 @@ from contextlib import redirect_stderr
 from pathlib import Path
 from unittest.mock import patch
 from click.testing import CliRunner
-from direct_cli.cli import DEPRECATED_ENTRYPOINT_MESSAGE, cli, deprecated_main
+from direct_cli.cli import cli
+from direct_cli._deprecated import DEPRECATED_ENTRYPOINT_MESSAGE, deprecated_main
 
 
 class TestCLI(unittest.TestCase):
@@ -156,7 +157,10 @@ class TestReadmeContract(unittest.TestCase):
         self.assertIn("direct <group> <command> [flags]", self.content)
         self.assertIn("Group naming rules", self.content)
         self.assertIn("Command naming rules", self.content)
-        self.assertIn("The `direct` executable defines the public naming contract", self.content)
+        self.assertIn(
+            "The `direct` executable defines the public naming contract",
+            self.content,
+        )
         self.assertIn("use direct instead of direct-cli", self.content)
 
     def test_readme_contains_canonical_command_examples(self):


### PR DESCRIPTION
## Summary

- enforce `direct` as the only supported executable contract
- turn the deprecated `direct-cli` entrypoint into a failing shim with the hint `use direct instead of direct-cli`
- update README and contract tests to document and lock the new behavior

## Testing

- `pytest -q`

## Notes

- companion MCP migration tracking issue: axisrow/yandex-direct-mcp-plugin#72
