### PR TITLE
feat: migrate CLI to typed flags contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,8 +242,7 @@ direct dictionaries get-geo-regions --name Moscow --region-ids 225,187 --exact-n
 # Client info
 direct clients get --fields ClientId,Login,Currency
 
-# Changes feed
-direct changes get --campaign-ids 1,2,3
+# Changes
 direct changes check --campaign-ids 1,2,3 --timestamp 2026-04-14T00:00:00
 direct changes check-campaigns --timestamp 2026-04-14T00:00:00
 direct changes check-dictionaries
@@ -713,8 +712,7 @@ direct dictionaries get-geo-regions --name Москва --region-ids 225,187 --e
 # Информация о клиенте
 direct clients get --fields ClientId,Login,Currency
 
-# Лента изменений
-direct changes get --campaign-ids 1,2,3
+# Изменения
 direct changes check --campaign-ids 1,2,3 --timestamp 2026-04-14T00:00:00
 direct changes check-campaigns --timestamp 2026-04-14T00:00:00
 direct changes check-dictionaries


### PR DESCRIPTION
## Summary

- Migrate all CLI commands from raw `--json` input to typed CLI flags
- Codify CLI naming convention (kebab-case commands, lowercase groups, no `--json` in public contract)
- Add shared utilities: `to_micros()`, `parse_kv()`, `parse_conditions()`, `parse_sitelinks()`
- Fix validation gaps: `UsageError` re-raise in keywordbids, retargeting, campaigns
- Fix `bidmodifiers set --value` to use int type
- Migrate keywords bid conversion to shared `to_micros` helper
- Merge main into branch (resolve documentation conflicts)

## Test plan

- [x] `pytest` — unit/dry-run tests pass
- [x] `pytest -m integration` — read-only integration tests
- [x] `pytest -m integration_write` — VCR cassette replay tests
- [x] Dry-run smoke tests for new typed-flag commands
- [ ] Manual smoke test with sandbox API

🤖 Generated with [Claude Code](https://claude.com/claude-code)