### PR TITLE
test: add read-only integration tests for 5 uncovered commands (#59 phase 1)

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -271,58 +271,147 @@ class TestReadOnlyDictionaries(unittest.TestCase):
 class TestReadOnlyReports(unittest.TestCase):
     def test_get_campaign_performance_report(self):
         result = invoke_get(
-            "reports", "get",
-            "--type", "campaign_performance_report",
-            "--from", "2026-01-01",
-            "--to", "2026-01-31",
-            "--name", "Integration Test Report",
-            "--fields", "Date,CampaignId,Clicks,Impressions",
-            "--format", "json",
+            "reports",
+            "get",
+            "--type",
+            "campaign_performance_report",
+            "--from",
+            "2026-01-01",
+            "--to",
+            "2026-01-31",
+            "--name",
+            "Integration Test Report",
+            "--fields",
+            "Date,CampaignId,Clicks,Impressions",
+            "--format",
+            "json",
         )
         assert_success(result, "reports get campaign_performance_report")
 
     def test_get_report_with_filter(self):
         result = invoke_get(
-            "reports", "get",
-            "--type", "campaign_performance_report",
-            "--from", "2026-01-01",
-            "--to", "2026-01-31",
-            "--name", "Filtered Report",
-            "--fields", "Date,CampaignId,Clicks",
-            "--filter", "Clicks:GREATER_THAN:0",
-            "--format", "json",
+            "reports",
+            "get",
+            "--type",
+            "campaign_performance_report",
+            "--from",
+            "2026-01-01",
+            "--to",
+            "2026-01-31",
+            "--name",
+            "Filtered Report",
+            "--fields",
+            "Date,CampaignId,Clicks",
+            "--filter",
+            "Clicks:GREATER_THAN:0",
+            "--format",
+            "json",
         )
         assert_success(result, "reports get with --filter")
 
     def test_get_report_with_order_by(self):
         result = invoke_get(
-            "reports", "get",
-            "--type", "campaign_performance_report",
-            "--from", "2026-01-01",
-            "--to", "2026-01-31",
-            "--name", "Ordered Report",
-            "--fields", "Date,CampaignId,Clicks",
-            "--order-by", "Clicks",
-            "--format", "json",
+            "reports",
+            "get",
+            "--type",
+            "campaign_performance_report",
+            "--from",
+            "2026-01-01",
+            "--to",
+            "2026-01-31",
+            "--name",
+            "Ordered Report",
+            "--fields",
+            "Date,CampaignId,Clicks",
+            "--order-by",
+            "Clicks",
+            "--format",
+            "json",
         )
         assert_success(result, "reports get with --order-by Clicks")
 
     def test_get_report_formats(self):
         for output_format in ["json", "table", "csv", "tsv"]:
             result = invoke_get(
-                "reports", "get",
-                "--type", "campaign_performance_report",
-                "--from", "2026-01-01",
-                "--to", "2026-01-31",
-                "--name", f"Format Test {output_format}",
-                "--fields", "Date,CampaignId",
-                "--format", output_format,
+                "reports",
+                "get",
+                "--type",
+                "campaign_performance_report",
+                "--from",
+                "2026-01-01",
+                "--to",
+                "2026-01-31",
+                "--name",
+                f"Format Test {output_format}",
+                "--fields",
+                "Date,CampaignId",
+                "--format",
+                output_format,
             )
             assert result.exit_code == 0, (
                 f"[reports get --format {output_format}] exit_code={result.exit_code}\n"
                 f"output: {result.output}\n"
                 f"exception: {result.exception}"
             )
+
+
+@pytest.mark.integration
+@skip_if_no_token
+class TestReadOnlyLeads(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.campaign_id = get_first_campaign_id()
+
+    def test_get_leads(self):
+        if not self.campaign_id:
+            self.skipTest("No campaigns found in account")
+        result = invoke_get(
+            "leads",
+            "get",
+            "--campaign-ids",
+            str(self.campaign_id),
+            "--limit",
+            "1",
+            "--format",
+            "json",
+        )
+        assert_success(result, "leads get")
+
+
+@pytest.mark.integration
+@skip_if_no_token
+class TestReadOnlyTurbopages(unittest.TestCase):
+    def test_get_turbopages(self):
+        result = invoke_get("turbopages", "get", "--limit", "1", "--format", "json")
+        assert_success(result, "turbopages get")
+
+
+@pytest.mark.integration
+@skip_if_no_token
+class TestReadOnlyBusinesses(unittest.TestCase):
+    def test_get_businesses(self):
+        result = invoke_get("businesses", "get", "--limit", "1", "--format", "json")
+        assert_success(result, "businesses get")
+
+
+@pytest.mark.integration
+@skip_if_no_token
+class TestReadOnlyAdVideos(unittest.TestCase):
+    def test_get_advideos(self):
+        result = invoke_get("advideos", "get", "--limit", "1", "--format", "json")
+        assert_success(result, "advideos get")
+
+
+@pytest.mark.integration
+@skip_if_no_token
+class TestReadOnlyAgencyClients(unittest.TestCase):
+    def test_get_agencyclients(self):
+        result = invoke_get("agencyclients", "get", "--limit", "1", "--format", "json")
+        if result.exit_code != 0 and (
+            "403" in result.output or "Access denied" in result.output
+        ):
+            self.skipTest("agencyclients returned 403 — not an agency account")
+        assert_success(result, "agencyclients get")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add 5 read-only integration test classes for commands that were implemented but never exercised against live API:
  - `TestReadOnlyLeads` — `leads get` (skip if no campaigns)
  - `TestReadOnlyTurbopages` — `turbopages get`
  - `TestReadOnlyBusinesses` — `businesses get`
  - `TestReadOnlyAdVideos` — `advideos get`
  - `TestReadOnlyAgencyClients` — `agencyclients get` (skip on 403 — non-agency accounts)

- Zero risk — all tests are GET-only, auto-skipped without `YANDEX_DIRECT_TOKEN`

## Test plan

- [x] `pytest tests/test_comprehensive.py tests/test_cli.py` — 42 passed, 0 failed
- [x] `black --check` + `flake8` — clean
- [ ] `pytest -m integration -v` — requires `YANDEX_DIRECT_TOKEN` (manual verification)

Part of #59 (Phase 1 of 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)