### PR TITLE
feat: implement strategies and dynamicfeedadtargets CLI groups (issue #59 Phase 6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,17 @@ direct smartadtargets update --id 456 --priority HIGH
 direct smartadtargets set-bids --id 456 --average-cpc 10.5 --average-cpa 15 --priority HIGH
 direct dynamicads set-bids --id 789 --bid 12.5 --context-bid 9 --priority HIGH
 
+# Shared bidding strategies
+direct strategies get --limit 5
+direct strategies add --name "Shared Clicks" --type WbMaximumClicks --params '{"SpendLimit":1000000000,"AverageCpc":30000000}' --dry-run
+direct strategies update --id 42 --params '{"AverageCpc":35000000}' --dry-run
+direct strategies archive --id 42 --dry-run
+
+# Dynamic feed ad targets
+direct dynamicfeedadtargets get --adgroup-ids 123 --limit 5
+direct dynamicfeedadtargets add --adgroup-id 33 --name "Feed slice A" --condition "CATEGORY:EQUALS:shoes" --bid 5 --dry-run
+direct dynamicfeedadtargets set-bids --id 789 --bid 6.5 --context-bid 4 --dry-run
+
 # Extensions, assets, feeds, and clients
 direct sitelinks add --sitelink "Docs|https://example.com/docs" --sitelink "Help|https://example.com/help|Desk" --dry-run
 direct vcards add --campaign-id 555 --country "Russia" --city "Moscow" --company-name "Acme" --work-time 1#5#9#0#18#0 --phone-country-code +7 --phone-city-code 495 --phone-number 1234567 --dry-run
@@ -786,6 +797,17 @@ direct smartadtargets add --adgroup-id 55 --name "Audience A" --audience ALL_SEG
 direct smartadtargets update --id 456 --priority HIGH
 direct smartadtargets set-bids --id 456 --average-cpc 10.5 --average-cpa 15 --priority HIGH
 direct dynamicads set-bids --id 789 --bid 12.5 --context-bid 9 --priority HIGH
+
+# Общие стратегии ставок
+direct strategies get --limit 5
+direct strategies add --name "Общая стратегия" --type WbMaximumClicks --params '{"SpendLimit":1000000000,"AverageCpc":30000000}' --dry-run
+direct strategies update --id 42 --params '{"AverageCpc":35000000}' --dry-run
+direct strategies archive --id 42 --dry-run
+
+# Динамические таргеты по фиду
+direct dynamicfeedadtargets get --adgroup-ids 123 --limit 5
+direct dynamicfeedadtargets add --adgroup-id 33 --name "Срез фида А" --condition "CATEGORY:EQUALS:shoes" --bid 5 --dry-run
+direct dynamicfeedadtargets set-bids --id 789 --bid 6.5 --context-bid 4 --dry-run
 
 # Расширения, ассеты, фиды и клиенты
 direct sitelinks add --sitelink "Docs|https://example.com/docs" --sitelink "Help|https://example.com/help|Desk" --dry-run

--- a/direct_cli/cli.py
+++ b/direct_cli/cli.py
@@ -37,6 +37,8 @@ from .commands.businesses import businesses
 from .commands.keywordsresearch import keywordsresearch
 from .commands.dynamicads import dynamicads
 from .commands.advideos import advideos
+from .commands.dynamicfeedadtargets import dynamicfeedadtargets
+from .commands.strategies import strategies
 
 # Load .env file
 load_dotenv()
@@ -137,6 +139,8 @@ cli.add_command(businesses)
 cli.add_command(keywordsresearch)
 cli.add_command(dynamicads)
 cli.add_command(advideos)
+cli.add_command(dynamicfeedadtargets)
+cli.add_command(strategies)
 
 
 if __name__ == "__main__":

--- a/direct_cli/commands/dynamicfeedadtargets.py
+++ b/direct_cli/commands/dynamicfeedadtargets.py
@@ -1,0 +1,273 @@
+"""
+DynamicFeedAdTargets commands
+"""
+
+import click
+
+from ..api import create_client
+from ..output import format_output, print_error
+from ..utils import parse_condition_specs, parse_ids, to_micros
+
+
+@click.group()
+def dynamicfeedadtargets():
+    """Manage dynamic feed ad targets"""
+
+
+@dynamicfeedadtargets.command()
+@click.option("--ids", help="Comma-separated target IDs")
+@click.option("--adgroup-ids", help="Comma-separated ad group IDs")
+@click.option("--campaign-ids", help="Comma-separated campaign IDs")
+@click.option("--limit", type=int, help="Limit number of results")
+@click.option("--fetch-all", is_flag=True, help="Fetch all pages")
+@click.option("--format", "output_format", default="json", help="Output format")
+@click.option("--output", help="Output file")
+@click.option("--fields", help="Comma-separated field names")
+@click.pass_context
+def get(
+    ctx, ids, adgroup_ids, campaign_ids, limit, fetch_all, output_format, output, fields
+):
+    """Get dynamic feed ad targets"""
+    try:
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
+        field_names = (
+            fields.split(",")
+            if fields
+            else ["Id", "AdGroupId", "CampaignId", "Name", "Bid", "ContextBid"]
+        )
+
+        criteria = {}
+        if ids:
+            criteria["Ids"] = parse_ids(ids)
+        if adgroup_ids:
+            criteria["AdGroupIds"] = parse_ids(adgroup_ids)
+        if campaign_ids:
+            criteria["CampaignIds"] = parse_ids(campaign_ids)
+
+        params = {"SelectionCriteria": criteria, "FieldNames": field_names}
+
+        if limit:
+            params["Page"] = {"Limit": limit}
+
+        body = {"method": "get", "params": params}
+
+        result = client.dynamicfeedadtargets().post(data=body)
+
+        if fetch_all:
+            items = []
+            for item in result().iter_items():
+                items.append(item)
+            format_output(items, output_format, output)
+        else:
+            data = result().extract()
+            format_output(data, output_format, output)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@dynamicfeedadtargets.command()
+@click.option("--adgroup-id", required=True, type=int, help="Ad group ID")
+@click.option("--name", required=True, help="Target name")
+@click.option(
+    "--condition",
+    "conditions",
+    multiple=True,
+    help="Condition spec: OPERAND:OPERATOR:ARG1|ARG2",
+)
+@click.option("--bid", type=float, help="Search bid")
+@click.option("--context-bid", type=float, help="Context bid")
+@click.option(
+    "--available-items-only",
+    type=click.Choice(["YES", "NO"], case_sensitive=False),
+    help="Restrict to currently available feed items",
+)
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def add(
+    ctx, adgroup_id, name, conditions, bid, context_bid, available_items_only, dry_run
+):
+    """Add dynamic feed ad target"""
+    try:
+        target_data = {
+            "AdGroupId": adgroup_id,
+            "Name": name,
+        }
+        parsed_conditions = (
+            parse_condition_specs(list(conditions)) if conditions else None
+        )
+        if parsed_conditions:
+            target_data["Conditions"] = parsed_conditions
+        if bid is not None:
+            target_data["Bid"] = to_micros(bid)
+        if context_bid is not None:
+            target_data["ContextBid"] = to_micros(context_bid)
+        if available_items_only:
+            target_data["AvailableItemsOnly"] = available_items_only.upper()
+
+        body = {"method": "add", "params": {"DynamicFeedAdTargets": [target_data]}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+        result = client.dynamicfeedadtargets().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except click.UsageError:
+        raise
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@dynamicfeedadtargets.command()
+@click.option("--id", "target_id", required=True, type=int, help="Target ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def delete(ctx, target_id, dry_run):
+    """Delete dynamic feed ad target"""
+    try:
+        body = {
+            "method": "delete",
+            "params": {"SelectionCriteria": {"Ids": [target_id]}},
+        }
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
+        result = client.dynamicfeedadtargets().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@dynamicfeedadtargets.command()
+@click.option("--id", "target_id", required=True, type=int, help="Target ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def suspend(ctx, target_id, dry_run):
+    """Suspend dynamic feed ad target"""
+    try:
+        body = {
+            "method": "suspend",
+            "params": {"SelectionCriteria": {"Ids": [target_id]}},
+        }
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+        result = client.dynamicfeedadtargets().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@dynamicfeedadtargets.command()
+@click.option("--id", "target_id", required=True, type=int, help="Target ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def resume(ctx, target_id, dry_run):
+    """Resume dynamic feed ad target"""
+    try:
+        body = {
+            "method": "resume",
+            "params": {"SelectionCriteria": {"Ids": [target_id]}},
+        }
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+        result = client.dynamicfeedadtargets().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@dynamicfeedadtargets.command(name="set-bids")
+@click.option("--id", "target_id", type=int, help="Target ID")
+@click.option("--adgroup-id", type=int, help="Ad group ID")
+@click.option("--campaign-id", type=int, help="Campaign ID")
+@click.option("--bid", type=float, help="Search bid")
+@click.option("--context-bid", type=float, help="Context bid")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def set_bids(ctx, target_id, adgroup_id, campaign_id, bid, context_bid, dry_run):
+    """Set dynamic feed ad target bids"""
+    try:
+        bid_data = {}
+        if target_id is not None:
+            bid_data["Id"] = target_id
+        if adgroup_id is not None:
+            bid_data["AdGroupId"] = adgroup_id
+        if campaign_id is not None:
+            bid_data["CampaignId"] = campaign_id
+        if bid is not None:
+            bid_data["Bid"] = to_micros(bid)
+        if context_bid is not None:
+            bid_data["ContextBid"] = to_micros(context_bid)
+
+        has_selector = any(k in bid_data for k in ("Id", "AdGroupId", "CampaignId"))
+        has_bid = any(k in bid_data for k in ("Bid", "ContextBid"))
+        if not has_selector:
+            raise click.UsageError(
+                "Provide a target selector (--id, --adgroup-id, or --campaign-id)"
+            )
+        if not has_bid:
+            raise click.UsageError("Provide at least one bid (--bid or --context-bid)")
+
+        body = {"method": "setBids", "params": {"Bids": [bid_data]}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+        result = client.dynamicfeedadtargets().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except click.UsageError:
+        raise
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()

--- a/direct_cli/commands/dynamicfeedadtargets.py
+++ b/direct_cli/commands/dynamicfeedadtargets.py
@@ -49,6 +49,11 @@ def get(
         if campaign_ids:
             criteria["CampaignIds"] = parse_ids(campaign_ids)
 
+        if not criteria:
+            raise click.UsageError(
+                "Provide at least one filter: --ids, --adgroup-ids, or --campaign-ids"
+            )
+
         params = {"SelectionCriteria": criteria, "FieldNames": field_names}
 
         if limit:

--- a/direct_cli/commands/dynamicfeedadtargets.py
+++ b/direct_cli/commands/dynamicfeedadtargets.py
@@ -72,6 +72,8 @@ def get(
             data = result().extract()
             format_output(data, output_format, output)
 
+    except click.UsageError:
+        raise
     except Exception as e:
         print_error(str(e))
         raise click.Abort()

--- a/direct_cli/commands/strategies.py
+++ b/direct_cli/commands/strategies.py
@@ -131,7 +131,10 @@ def add(
     try:
         strategy_data = {"Name": name, strategy_type: {}}
         if strategy_params:
-            strategy_data[strategy_type] = parse_json(strategy_params)
+            parsed = parse_json(strategy_params)
+            if not isinstance(parsed, dict):
+                raise click.UsageError("--params must be a JSON object, not an array or scalar")
+            strategy_data[strategy_type] = parsed
         if counter_ids:
             strategy_data["CounterIds"] = {
                 "Items": [int(x.strip()) for x in counter_ids.split(",")]
@@ -203,9 +206,13 @@ def update(
         if name:
             strategy_data["Name"] = name
         if strategy_type:
-            strategy_data[strategy_type] = (
-                parse_json(strategy_params) if strategy_params else {}
-            )
+            if strategy_params:
+                parsed = parse_json(strategy_params)
+                if not isinstance(parsed, dict):
+                    raise click.UsageError("--params must be a JSON object, not an array or scalar")
+                strategy_data[strategy_type] = parsed
+            else:
+                strategy_data[strategy_type] = {}
         if counter_ids:
             strategy_data["CounterIds"] = {
                 "Items": [int(x.strip()) for x in counter_ids.split(",")]

--- a/direct_cli/commands/strategies.py
+++ b/direct_cli/commands/strategies.py
@@ -1,0 +1,294 @@
+"""
+Strategies commands
+"""
+
+import click
+
+from ..api import create_client
+from ..output import format_output, print_error
+from ..utils import parse_ids, parse_json
+
+STRATEGY_TYPES = [
+    "WbMaximumClicks",
+    "WbMaximumClicksPerBid",
+    "WbMaximumConversionRate",
+    "WbMaximumConversionRatePerBid",
+    "AverageCpc",
+    "AverageCpa",
+    "AverageCpaPerFilter",
+    "AverageCpaPerCampaign",
+    "AverageCrr",
+    "AverageCrrPerCampaign",
+    "MaxProfit",
+    "MaxProfitPerFilter",
+    "MaxProfitPerCampaign",
+    "PayForConversion",
+    "PayForConversionPerFilter",
+    "PayForConversionPerCampaign",
+]
+
+
+@click.group()
+def strategies():
+    """Manage strategies"""
+
+
+@strategies.command()
+@click.option("--ids", help="Comma-separated strategy IDs")
+@click.option(
+    "--types",
+    help="Comma-separated strategy types",
+)
+@click.option(
+    "--is-archived",
+    type=click.Choice(["YES", "NO"], case_sensitive=False),
+    help="Filter by archived status",
+)
+@click.option("--limit", type=int, help="Limit number of results")
+@click.option("--fetch-all", is_flag=True, help="Fetch all pages")
+@click.option("--format", "output_format", default="json", help="Output format")
+@click.option("--output", help="Output file")
+@click.option("--fields", help="Comma-separated field names")
+@click.pass_context
+def get(ctx, ids, types, is_archived, limit, fetch_all, output_format, output, fields):
+    """Get strategies"""
+    try:
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
+        field_names = (
+            fields.split(",") if fields else ["Id", "Name", "Type", "IsArchived"]
+        )
+
+        criteria = {}
+        if ids:
+            criteria["Ids"] = parse_ids(ids)
+        if types:
+            criteria["Types"] = [t.strip() for t in types.split(",")]
+        if is_archived:
+            criteria["IsArchived"] = is_archived.upper()
+
+        params = {"SelectionCriteria": criteria, "FieldNames": field_names}
+        if limit:
+            params["Page"] = {"Limit": limit}
+
+        body = {"method": "get", "params": params}
+        result = client.strategies().post(data=body)
+
+        if fetch_all:
+            items = []
+            for item in result().iter_items():
+                items.append(item)
+            format_output(items, output_format, output)
+        else:
+            format_output(result().extract(), output_format, output)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@strategies.command()
+@click.option("--name", required=True, help="Strategy name")
+@click.option(
+    "--type",
+    "strategy_type",
+    required=True,
+    type=click.Choice(STRATEGY_TYPES, case_sensitive=True),
+    help="Strategy type",
+)
+@click.option(
+    "--params",
+    "strategy_params",
+    help="Strategy type-specific parameters as JSON",
+)
+@click.option("--counter-ids", help="Comma-separated Metrica counter IDs")
+@click.option("--priority-goals", help="Priority goals as JSON list")
+@click.option(
+    "--attribution-model",
+    type=click.Choice(
+        ["LYDC", "FC", "LC", "LSC", "LYDC_WEIGHT", "CROSSTDEVICE"],
+        case_sensitive=True,
+    ),
+    help="Attribution model",
+)
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def add(
+    ctx,
+    name,
+    strategy_type,
+    strategy_params,
+    counter_ids,
+    priority_goals,
+    attribution_model,
+    dry_run,
+):
+    """Add a strategy"""
+    try:
+        strategy_data = {"Name": name, strategy_type: {}}
+        if strategy_params:
+            strategy_data[strategy_type] = parse_json(strategy_params)
+        if counter_ids:
+            strategy_data["CounterIds"] = {
+                "Items": [int(x.strip()) for x in counter_ids.split(",")]
+            }
+        if priority_goals:
+            strategy_data["PriorityGoals"] = {"Items": parse_json(priority_goals)}
+        if attribution_model:
+            strategy_data["AttributionModel"] = attribution_model
+
+        body = {"method": "add", "params": {"Strategies": [strategy_data]}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+        result = client.strategies().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except click.UsageError:
+        raise
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@strategies.command()
+@click.option("--id", "strategy_id", required=True, type=int, help="Strategy ID")
+@click.option("--name", help="New strategy name")
+@click.option(
+    "--type",
+    "strategy_type",
+    type=click.Choice(STRATEGY_TYPES, case_sensitive=True),
+    help="Strategy type to update",
+)
+@click.option(
+    "--params", "strategy_params", help="Strategy type-specific fields as JSON"
+)
+@click.option("--counter-ids", help="Comma-separated Metrica counter IDs")
+@click.option("--priority-goals", help="Priority goals as JSON list")
+@click.option(
+    "--attribution-model",
+    type=click.Choice(
+        ["LYDC", "FC", "LC", "LSC", "LYDC_WEIGHT", "CROSSTDEVICE"],
+        case_sensitive=True,
+    ),
+    help="Attribution model",
+)
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def update(
+    ctx,
+    strategy_id,
+    name,
+    strategy_type,
+    strategy_params,
+    counter_ids,
+    priority_goals,
+    attribution_model,
+    dry_run,
+):
+    """Update a strategy"""
+    try:
+        strategy_data = {"Id": strategy_id}
+        if name:
+            strategy_data["Name"] = name
+        if strategy_type:
+            strategy_data[strategy_type] = (
+                parse_json(strategy_params) if strategy_params else {}
+            )
+        if counter_ids:
+            strategy_data["CounterIds"] = {
+                "Items": [int(x.strip()) for x in counter_ids.split(",")]
+            }
+        if priority_goals:
+            strategy_data["PriorityGoals"] = {"Items": parse_json(priority_goals)}
+        if attribution_model:
+            strategy_data["AttributionModel"] = attribution_model
+
+        body = {"method": "update", "params": {"Strategies": [strategy_data]}}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+        result = client.strategies().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except click.UsageError:
+        raise
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@strategies.command()
+@click.option("--id", "strategy_id", required=True, type=int, help="Strategy ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def archive(ctx, strategy_id, dry_run):
+    """Archive a strategy"""
+    try:
+        body = {
+            "method": "archive",
+            "params": {"SelectionCriteria": {"Ids": [strategy_id]}},
+        }
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+        result = client.strategies().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@strategies.command()
+@click.option("--id", "strategy_id", required=True, type=int, help="Strategy ID")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def unarchive(ctx, strategy_id, dry_run):
+    """Unarchive a strategy"""
+    try:
+        body = {
+            "method": "unarchive",
+            "params": {"SelectionCriteria": {"Ids": [strategy_id]}},
+        }
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+        result = client.strategies().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()

--- a/direct_cli/commands/strategies.py
+++ b/direct_cli/commands/strategies.py
@@ -140,7 +140,10 @@ def add(
                 "Items": [int(x.strip()) for x in counter_ids.split(",")]
             }
         if priority_goals:
-            strategy_data["PriorityGoals"] = {"Items": parse_json(priority_goals)}
+            parsed_goals = parse_json(priority_goals)
+            if not isinstance(parsed_goals, list):
+                raise click.UsageError("--priority-goals must be a JSON array")
+            strategy_data["PriorityGoals"] = {"Items": parsed_goals}
         if attribution_model:
             strategy_data["AttributionModel"] = attribution_model
 
@@ -218,7 +221,10 @@ def update(
                 "Items": [int(x.strip()) for x in counter_ids.split(",")]
             }
         if priority_goals:
-            strategy_data["PriorityGoals"] = {"Items": parse_json(priority_goals)}
+            parsed_goals = parse_json(priority_goals)
+            if not isinstance(parsed_goals, list):
+                raise click.UsageError("--priority-goals must be a JSON array")
+            strategy_data["PriorityGoals"] = {"Items": parsed_goals}
         if attribution_model:
             strategy_data["AttributionModel"] = attribution_model
 

--- a/direct_cli/wsdl_coverage.py
+++ b/direct_cli/wsdl_coverage.py
@@ -45,6 +45,8 @@ CLI_TO_API_SERVICE = {
     "businesses": "businesses",
     "keywordsresearch": "keywordsresearch",
     "dynamicads": "dynamictextadtargets",
+    "dynamicfeedadtargets": "dynamicfeedadtargets",
+    "strategies": "strategies",
     # reports excluded — uses JSON API, not WSDL
 }
 
@@ -85,6 +87,7 @@ CANONICAL_API_SERVICES = sorted(
         "clients",
         "creatives",
         "dictionaries",
+        "dynamicfeedadtargets",
         "dynamictextadtargets",
         "feeds",
         "keywordbids",
@@ -95,6 +98,7 @@ CANONICAL_API_SERVICES = sorted(
         "retargetinglists",
         "sitelinks",
         "smartadtargets",
+        "strategies",
         "turbopages",
         "vcards",
     ]
@@ -104,13 +108,7 @@ CANONICAL_API_SERVICES = sorted(
 # declared canonical coverage model. Keep this list conservative and sourced
 # from live WSDL/API reference audits so CI does not depend on brittle doc
 # navigation scraping.
-LIVE_DISCOVERED_API_SERVICES = sorted(
-    set(CANONICAL_API_SERVICES)
-    | {
-        "dynamicfeedadtargets",
-        "strategies",
-    }
-)
+LIVE_DISCOVERED_API_SERVICES = sorted(set(CANONICAL_API_SERVICES))
 
 KNOWN_MISSING_SERVICES = set()
 

--- a/tests/API_COVERAGE.md
+++ b/tests/API_COVERAGE.md
@@ -17,23 +17,18 @@ API model. It does not prove that the declared model includes every live
 Yandex Direct API service. Live service omissions are reported separately in
 `model_gaps`.
 
-## Current Live-Discovered Gaps
+## Current Coverage Metrics
 
-| API service | Missing CLI group | WSDL methods |
-|---|---|---|
-| `dynamicfeedadtargets` | `dynamicfeedadtargets` | `add`, `delete`, `get`, `resume`, `setBids`, `suspend` |
-| `strategies` | `strategies` | `add`, `archive`, `get`, `unarchive`, `update` |
-
-The current coverage report should therefore show:
+All previously live-discovered gaps (`dynamicfeedadtargets`, `strategies`) are
+now implemented and included in the canonical model. The expected coverage
+report values:
 
 | Metric | Expected current value |
 |---|---:|
-| Declared WSDL services | 27 |
-| Declared WSDL methods | 101 |
+| Declared WSDL services | 29 |
 | Live-discovered services | 29 |
-| Live-discovered methods | 112 |
-| Live-discovered missing services | 2 |
-| Live-discovered missing methods | 11 |
+| Live-discovered missing services | 0 |
+| Live-discovered missing methods | 0 |
 
 ## Maintenance Rules
 
@@ -78,14 +73,17 @@ Testing strategy: guarded live-write tier via `tests/test_integration_live_write
 ### Category B — unsupported (code 3500)
 
 Sandbox architecturally does not support these campaign/group types.
-Sandbox re-check is not useful — this is a design limitation, not a transient failure.
+Live API also rejects them on standard advertiser accounts — creation returns
+`3500 Not supported`. A dedicated agency or pilot account is required.
+Sandbox re-check is not useful — this is an account-tier limitation.
 
 | Scenario | Symptom | Error code | Test class |
 |---|---|---|---|
 | dynamicads | `DYNAMIC_TEXT_CAMPAIGN` creation rejected | 3500 | `TestWriteDynamicAds` |
 | smartadtargets | `SMART_CAMPAIGN` creation rejected | 3500 | `TestWriteSmartAdTargets` |
 
-Testing strategy: live-write tier is the only path to coverage for these resource types.
+Testing strategy: manual-only on an account where DYNAMIC_TEXT_CAMPAIGN and
+SMART_CAMPAIGN are enabled. See `tests/MANUAL_COVERAGE.md`.
 
 Originally classified in
 [#28 issuecomment-4275359621](https://github.com/axisrow/direct-cli/issues/28#issuecomment-4275359621)

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -86,6 +86,15 @@ DRY_RUN_PAYLOAD_EXCLUSIONS = {
     "dynamicads.add": "Requires condition-spec payload fixtures with optional bid fields.",
     "dynamicads.resume": "Same simple Ids payload family as covered delete/set-bids actions.",
     "dynamicads.suspend": "Same simple Ids payload family as covered delete/set-bids actions.",
+    "dynamicfeedadtargets.add": "Covered by test_dry_run.py::test_dynamicfeedadtargets_add_payload.",
+    "dynamicfeedadtargets.delete": "Covered by test_dry_run.py::test_dynamicfeedadtargets_delete_payload.",
+    "dynamicfeedadtargets.resume": "Covered by test_dry_run.py::test_dynamicfeedadtargets_resume_payload.",
+    "dynamicfeedadtargets.set-bids": "Covered by test_dry_run.py::test_dynamicfeedadtargets_set_bids_payload.",
+    "dynamicfeedadtargets.suspend": "Covered by test_dry_run.py::test_dynamicfeedadtargets_suspend_payload.",
+    "strategies.add": "Covered by test_dry_run.py::test_strategies_add_payload.",
+    "strategies.archive": "Covered by test_dry_run.py::test_strategies_archive_payload.",
+    "strategies.unarchive": "Covered by test_dry_run.py::test_strategies_unarchive_payload.",
+    "strategies.update": "Covered by test_dry_run.py::test_strategies_update_payload.",
     "feeds.add": "Current WSDL schema parser treats feed source variants like required siblings; keep covered by command-level dry-run tests.",
     "keywords.add": "Requires keyword/addition payload variants; covered by focused dry-run tests.",
     "keywords.archive": "Legacy helper command preserved for compatibility.",
@@ -886,15 +895,12 @@ class TestApiCoverage:
         )
         report = json.loads(result.stdout)
         assert report["summary"]["strict_parity_ok"] is True
-        assert report["summary"]["live_model_parity_ok"] is False
+        assert report["summary"]["live_model_parity_ok"] is True
         assert report["summary"]["missing_service_methods"] == 0
         assert report["summary"]["unexpected_service_methods"] == 0
         assert sorted(report["canonical_services"]) == CANONICAL_API_SERVICES
-        assert report["model_gaps"]["live_model_gap_count"] == 2
-        assert {
-            item["api_service"]
-            for item in report["model_gaps"]["live_discovered_missing_services"]
-        } == {"dynamicfeedadtargets", "strategies"}
+        assert report["model_gaps"]["live_model_gap_count"] == 0
+        assert report["model_gaps"]["live_discovered_missing_services"] == []
 
     def test_api_coverage_report_exposes_live_model_gaps(self, monkeypatch):
         """Report must distinguish declared parity from live-discovered gaps."""

--- a/tests/test_comprehensive.py
+++ b/tests/test_comprehensive.py
@@ -62,6 +62,8 @@ class TestCommandsRegistered(unittest.TestCase):
         "businesses",
         "keywordsresearch",
         "dynamicads",
+        "dynamicfeedadtargets",
+        "strategies",
     ]
 
     def test_all_expected_commands_registered(self):

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1837,3 +1837,115 @@ def test_reports_get_dry_run_outputs_request():
     assert body_params["ReportType"] == "CAMPAIGN_PERFORMANCE_REPORT"
     assert body_params["DateRangeType"] == "CUSTOM_DATE"
     assert "SelectionCriteria" in body_params
+
+
+# ----------------------------------------------------------------------
+# dynamicfeedadtargets
+# ----------------------------------------------------------------------
+
+
+def test_dynamicfeedadtargets_add_payload():
+    body = _dry_run(
+        "dynamicfeedadtargets", "add",
+        "--adgroup-id", "123",
+        "--name", "Test Target",
+        "--bid", "1.5",
+    )
+    assert body["method"] == "add"
+    target = body["params"]["DynamicFeedAdTargets"][0]
+    assert target["AdGroupId"] == 123
+    assert target["Name"] == "Test Target"
+    assert target["Bid"] == 1_500_000
+
+
+def test_dynamicfeedadtargets_delete_payload():
+    body = _dry_run("dynamicfeedadtargets", "delete", "--id", "42")
+    assert body == {
+        "method": "delete",
+        "params": {"SelectionCriteria": {"Ids": [42]}},
+    }
+
+
+def test_dynamicfeedadtargets_suspend_payload():
+    body = _dry_run("dynamicfeedadtargets", "suspend", "--id", "42")
+    assert body == {
+        "method": "suspend",
+        "params": {"SelectionCriteria": {"Ids": [42]}},
+    }
+
+
+def test_dynamicfeedadtargets_resume_payload():
+    body = _dry_run("dynamicfeedadtargets", "resume", "--id", "42")
+    assert body == {
+        "method": "resume",
+        "params": {"SelectionCriteria": {"Ids": [42]}},
+    }
+
+
+def test_dynamicfeedadtargets_set_bids_payload():
+    body = _dry_run(
+        "dynamicfeedadtargets", "set-bids",
+        "--id", "55",
+        "--bid", "2.0",
+    )
+    assert body["method"] == "setBids"
+    bid = body["params"]["Bids"][0]
+    assert bid["Id"] == 55
+    assert bid["Bid"] == 2_000_000
+
+
+# ----------------------------------------------------------------------
+# strategies
+# ----------------------------------------------------------------------
+
+
+def test_strategies_add_payload():
+    body = _dry_run(
+        "strategies", "add",
+        "--name", "My Strategy",
+        "--type", "AverageCpc",
+        "--params", '{"AverageCpc": 1000000}',
+    )
+    assert body["method"] == "add"
+    s = body["params"]["Strategies"][0]
+    assert s["Name"] == "My Strategy"
+    assert "AverageCpc" in s
+
+
+def test_strategies_add_no_type_key_at_root():
+    body = _dry_run(
+        "strategies", "add",
+        "--name", "My Strategy",
+        "--type", "WbMaximumClicks",
+    )
+    s = body["params"]["Strategies"][0]
+    assert "Type" not in s
+    assert "WbMaximumClicks" in s
+
+
+def test_strategies_update_payload():
+    body = _dry_run(
+        "strategies", "update",
+        "--id", "77",
+        "--name", "Updated",
+    )
+    assert body["method"] == "update"
+    s = body["params"]["Strategies"][0]
+    assert s["Id"] == 77
+    assert s["Name"] == "Updated"
+
+
+def test_strategies_archive_payload():
+    body = _dry_run("strategies", "archive", "--id", "10")
+    assert body == {
+        "method": "archive",
+        "params": {"SelectionCriteria": {"Ids": [10]}},
+    }
+
+
+def test_strategies_unarchive_payload():
+    body = _dry_run("strategies", "unarchive", "--id", "10")
+    assert body == {
+        "method": "unarchive",
+        "params": {"SelectionCriteria": {"Ids": [10]}},
+    }

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -271,58 +271,119 @@ class TestReadOnlyDictionaries(unittest.TestCase):
 class TestReadOnlyReports(unittest.TestCase):
     def test_get_campaign_performance_report(self):
         result = invoke_get(
-            "reports", "get",
-            "--type", "campaign_performance_report",
-            "--from", "2026-01-01",
-            "--to", "2026-01-31",
-            "--name", "Integration Test Report",
-            "--fields", "Date,CampaignId,Clicks,Impressions",
-            "--format", "json",
+            "reports",
+            "get",
+            "--type",
+            "campaign_performance_report",
+            "--from",
+            "2026-01-01",
+            "--to",
+            "2026-01-31",
+            "--name",
+            "Integration Test Report",
+            "--fields",
+            "Date,CampaignId,Clicks,Impressions",
+            "--format",
+            "json",
         )
         assert_success(result, "reports get campaign_performance_report")
 
     def test_get_report_with_filter(self):
         result = invoke_get(
-            "reports", "get",
-            "--type", "campaign_performance_report",
-            "--from", "2026-01-01",
-            "--to", "2026-01-31",
-            "--name", "Filtered Report",
-            "--fields", "Date,CampaignId,Clicks",
-            "--filter", "Clicks:GREATER_THAN:0",
-            "--format", "json",
+            "reports",
+            "get",
+            "--type",
+            "campaign_performance_report",
+            "--from",
+            "2026-01-01",
+            "--to",
+            "2026-01-31",
+            "--name",
+            "Filtered Report",
+            "--fields",
+            "Date,CampaignId,Clicks",
+            "--filter",
+            "Clicks:GREATER_THAN:0",
+            "--format",
+            "json",
         )
         assert_success(result, "reports get with --filter")
 
     def test_get_report_with_order_by(self):
         result = invoke_get(
-            "reports", "get",
-            "--type", "campaign_performance_report",
-            "--from", "2026-01-01",
-            "--to", "2026-01-31",
-            "--name", "Ordered Report",
-            "--fields", "Date,CampaignId,Clicks",
-            "--order-by", "Clicks",
-            "--format", "json",
+            "reports",
+            "get",
+            "--type",
+            "campaign_performance_report",
+            "--from",
+            "2026-01-01",
+            "--to",
+            "2026-01-31",
+            "--name",
+            "Ordered Report",
+            "--fields",
+            "Date,CampaignId,Clicks",
+            "--order-by",
+            "Clicks",
+            "--format",
+            "json",
         )
         assert_success(result, "reports get with --order-by Clicks")
 
     def test_get_report_formats(self):
         for output_format in ["json", "table", "csv", "tsv"]:
             result = invoke_get(
-                "reports", "get",
-                "--type", "campaign_performance_report",
-                "--from", "2026-01-01",
-                "--to", "2026-01-31",
-                "--name", f"Format Test {output_format}",
-                "--fields", "Date,CampaignId",
-                "--format", output_format,
+                "reports",
+                "get",
+                "--type",
+                "campaign_performance_report",
+                "--from",
+                "2026-01-01",
+                "--to",
+                "2026-01-31",
+                "--name",
+                f"Format Test {output_format}",
+                "--fields",
+                "Date,CampaignId",
+                "--format",
+                output_format,
             )
             assert result.exit_code == 0, (
                 f"[reports get --format {output_format}] exit_code={result.exit_code}\n"
                 f"output: {result.output}\n"
                 f"exception: {result.exception}"
             )
+
+
+@pytest.mark.integration
+@skip_if_no_token
+class TestReadOnlyStrategies(unittest.TestCase):
+    def test_get_strategies(self):
+        result = invoke_get("strategies", "get", "--limit", "1", "--format", "json")
+        assert_success(result, "strategies get")
+
+
+@pytest.mark.integration
+@skip_if_no_token
+class TestReadOnlyDynamicFeedAdTargets(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.campaign_id = get_first_campaign_id()
+
+    def test_get_dynamic_feed_ad_targets(self):
+        if not self.campaign_id:
+            self.skipTest("No campaigns found in account")
+        result = invoke_get(
+            "dynamicfeedadtargets",
+            "get",
+            "--campaign-ids",
+            str(self.campaign_id),
+            "--limit",
+            "1",
+            "--format",
+            "json",
+        )
+        assert_success(result, "dynamicfeedadtargets get")
 
 
 if __name__ == "__main__":

--- a/tests/wsdl_cache/dynamicfeedadtargets.xml
+++ b/tests/wsdl_cache/dynamicfeedadtargets.xml
@@ -1,0 +1,328 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:general="http://api.direct.yandex.com/v5/general"
+                  xmlns:ns="http://api.direct.yandex.com/v5/dynamicfeedadtargets"
+                  name="DynamicFeedAdTargets"
+                  targetNamespace="http://api.direct.yandex.com/v5/dynamicfeedadtargets">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://api.direct.yandex.com/v5/dynamicfeedadtargets">
+            <xsd:import namespace="http://api.direct.yandex.com/v5/general"
+                        schemaLocation="https://soap.direct.yandex.ru/v5/general.xsd"/>
+            <xsd:simpleType name="DynamicFeedAdTargetFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Id"/>
+                    <xsd:enumeration value="AdGroupId"/>
+                    <xsd:enumeration value="CampaignId"/>
+                    <xsd:enumeration value="Name"/>
+                    <xsd:enumeration value="Bid"/>
+                    <xsd:enumeration value="ContextBid"/>
+                    <xsd:enumeration value="Conditions"/>
+                    <xsd:enumeration value="ConditionType"/>
+                    <xsd:enumeration value="State"/>
+                    <xsd:enumeration value="AvailableItemsOnly"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="FeedCondition">
+                <xsd:sequence>
+                    <xsd:element name="Operand" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Operator" type="general:StringConditionOperatorEnum" minOccurs="1"
+                                 maxOccurs="1"/>
+                    <xsd:element name="Arguments" type="xsd:string" minOccurs="1" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ConditionsArray">
+                <xsd:sequence>
+                    <xsd:element name="Items" type="ns:FeedCondition" minOccurs="1" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="DynamicFeedAdTargetGetItem">
+                <xsd:sequence>
+                    <xsd:element name="Id" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AdGroupId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CampaignId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Bid" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ContextBid" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="State" type="general:StateEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Conditions" type="ns:ConditionsArray" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="ConditionType" type="general:ConditionTypeEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AvailableItemsOnly" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="DynamicFeedAdTargetAddItem">
+                <xsd:sequence>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="AdGroupId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Bid" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ContextBid" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Conditions" type="ns:ConditionsArray" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AvailableItemsOnly" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="SetBidsItem">
+                <xsd:sequence>
+                    <xsd:element name="CampaignId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AdGroupId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Id" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="Bid" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ContextBid" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="AddRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="DynamicFeedAdTargets" type="ns:DynamicFeedAdTargetAddItem" minOccurs="1"
+                                     maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="AddResults" type="general:ActionResult" minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetRequestGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="SelectionCriteria" type="general:AdTargetsSelectionCriteria"
+                                             minOccurs="1" maxOccurs="1"/>
+                                <xsd:element name="FieldNames" type="ns:DynamicFeedAdTargetFieldEnum" minOccurs="1"
+                                             maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetResponse">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetResponseGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="DynamicFeedAdTargets" type="ns:DynamicFeedAdTargetGetItem"
+                                             minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DeleteRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DeleteResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="DeleteResults" type="general:ActionResult" minOccurs="1"
+                                     maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SuspendRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SuspendResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SuspendResults" type="general:ActionResult" minOccurs="1"
+                                     maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="ResumeRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="ResumeResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="ResumeResults" type="general:ActionResult" minOccurs="1"
+                                     maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SetBidsRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="Bids" type="ns:SetBidsItem" minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SetBidsResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SetBidsResults" type="general:SetBidsActionResult" minOccurs="0"
+                                     maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="AddOperationRequest">
+        <wsdl:part element="ns:AddRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationResponse">
+        <wsdl:part element="ns:AddResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationRequest">
+        <wsdl:part element="ns:GetRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationResponse">
+        <wsdl:part element="ns:GetResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="DeleteOperationRequest">
+        <wsdl:part element="ns:DeleteRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="DeleteOperationResponse">
+        <wsdl:part element="ns:DeleteResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="SuspendOperationRequest">
+        <wsdl:part element="ns:SuspendRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="SuspendOperationResponse">
+        <wsdl:part element="ns:SuspendResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="ResumeOperationRequest">
+        <wsdl:part element="ns:ResumeRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="ResumeOperationResponse">
+        <wsdl:part element="ns:ResumeResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="SetBidsOperationRequest">
+        <wsdl:part element="ns:SetBidsRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="SetBidsOperationResponse">
+        <wsdl:part element="ns:SetBidsResponse" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="ApiException">
+        <wsdl:part element="general:FaultResponse" name="faultMessage"/>
+    </wsdl:message>
+    <wsdl:portType name="DynamicFeedAdTargetsPort">
+        <wsdl:operation name="add">
+            <wsdl:input message="ns:AddOperationRequest" name="addRequest"/>
+            <wsdl:output message="ns:AddOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="get">
+            <wsdl:input message="ns:GetOperationRequest" name="getRequest"/>
+            <wsdl:output message="ns:GetOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <wsdl:input message="ns:DeleteOperationRequest" name="deleteRequest"/>
+            <wsdl:output message="ns:DeleteOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="suspend">
+            <wsdl:input message="ns:SuspendOperationRequest" name="suspendRequest"/>
+            <wsdl:output message="ns:SuspendOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="resume">
+            <wsdl:input message="ns:ResumeOperationRequest" name="resumeRequest"/>
+            <wsdl:output message="ns:ResumeOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="setBids">
+            <wsdl:input message="ns:SetBidsOperationRequest" name="setBidsRequest"/>
+            <wsdl:output message="ns:SetBidsOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="DynamicFeedAdTargetsSOAP" type="ns:DynamicFeedAdTargetsPort">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="add">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/dynamicfeedadtargets/add"/>
+            <wsdl:input name="addRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="get">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/dynamicfeedadtargets/get"/>
+            <wsdl:input name="getRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="delete">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/dynamicfeedadtargets/delete"/>
+            <wsdl:input name="deleteRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="suspend">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/dynamicfeedadtargets/suspend"/>
+            <wsdl:input name="suspendRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="resume">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/dynamicfeedadtargets/resume"/>
+            <wsdl:input name="resumeRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="setBids">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/dynamicfeedadtargets/setBids"/>
+            <wsdl:input name="setBidsRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="DynamicFeedAdTargets">
+        <wsdl:port binding="ns:DynamicFeedAdTargetsSOAP" name="DynamicFeedAdTargetsSOAP">
+            <soap:address location="https://soap.direct.yandex.ru/v5/dynamicfeedadtargets"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/tests/wsdl_cache/strategies.xml
+++ b/tests/wsdl_cache/strategies.xml
@@ -1,0 +1,1100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions
+        xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+        xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+        xmlns:ns="http://api.direct.yandex.com/v5/strategies"
+        xmlns:general="http://api.direct.yandex.com/v5/general"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        name="Strategies"
+        targetNamespace="http://api.direct.yandex.com/v5/strategies">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://api.direct.yandex.com/v5/strategies">
+            <xsd:import namespace="http://api.direct.yandex.com/v5/general" schemaLocation="https://soap.direct.yandex.ru/v5/general.xsd"/>
+            <xsd:simpleType name="StrategyFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Id"/>
+                    <xsd:enumeration value="AttributionModel"/>
+                    <xsd:enumeration value="CounterIds"/>
+                    <xsd:enumeration value="PriorityGoals"/>
+                    <xsd:enumeration value="Type"/>
+                    <xsd:enumeration value="Name"/>
+                    <xsd:enumeration value="StatusArchived"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="StrategyMaximumClicksFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="WeeklySpendLimit"/>
+                    <xsd:enumeration value="CustomPeriodBudget"/>
+                    <xsd:enumeration value="BudgetType"/>
+                    <xsd:enumeration value="BidCeiling"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="StrategyMaximumConversionRateFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="WeeklySpendLimit"/>
+                    <xsd:enumeration value="CustomPeriodBudget"/>
+                    <xsd:enumeration value="BudgetType"/>
+                    <xsd:enumeration value="BidCeiling"/>
+                    <xsd:enumeration value="GoalId"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="StrategyAverageCpcFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="AverageCpc"/>
+                    <xsd:enumeration value="WeeklySpendLimit"/>
+                    <xsd:enumeration value="CustomPeriodBudget"/>
+                    <xsd:enumeration value="BudgetType"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="StrategyAverageCpaFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="AverageCpa"/>
+                    <xsd:enumeration value="GoalId"/>
+                    <xsd:enumeration value="WeeklySpendLimit"/>
+                    <xsd:enumeration value="CustomPeriodBudget"/>
+                    <xsd:enumeration value="BudgetType"/>
+                    <xsd:enumeration value="BidCeiling"/>
+                    <xsd:enumeration value="ExplorationBudget"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="StrategyMaxProfitFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="WeeklySpendLimit"/>
+                    <xsd:enumeration value="CustomPeriodBudget"/>
+                    <xsd:enumeration value="BudgetType"/>
+                    <xsd:enumeration value="ExplorationBudget"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="StrategyPayForConversionFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Cpa"/>
+                    <xsd:enumeration value="GoalId"/>
+                    <xsd:enumeration value="WeeklySpendLimit"/>
+                    <xsd:enumeration value="CustomPeriodBudget"/>
+                    <xsd:enumeration value="BudgetType"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="StrategyAverageCpaPerCampaignFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="AverageCpa"/>
+                    <xsd:enumeration value="GoalId"/>
+                    <xsd:enumeration value="WeeklySpendLimit"/>
+                    <xsd:enumeration value="CustomPeriodBudget"/>
+                    <xsd:enumeration value="BudgetType"/>
+                    <xsd:enumeration value="BidCeiling"/>
+                    <xsd:enumeration value="ExplorationBudget"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="StrategyPayForConversionPerCampaignFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Cpa"/>
+                    <xsd:enumeration value="GoalId"/>
+                    <xsd:enumeration value="WeeklySpendLimit"/>
+                    <xsd:enumeration value="CustomPeriodBudget"/>
+                    <xsd:enumeration value="BudgetType"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="StrategyPayForConversionPerFilterFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Cpa"/>
+                    <xsd:enumeration value="GoalId"/>
+                    <xsd:enumeration value="WeeklySpendLimit"/>
+                    <xsd:enumeration value="CustomPeriodBudget"/>
+                    <xsd:enumeration value="BudgetType"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="StrategyAverageCpaPerFilterFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="FilterAverageCpa"/>
+                    <xsd:enumeration value="GoalId"/>
+                    <xsd:enumeration value="WeeklySpendLimit"/>
+                    <xsd:enumeration value="CustomPeriodBudget"/>
+                    <xsd:enumeration value="BudgetType"/>
+                    <xsd:enumeration value="BidCeiling"/>
+                    <xsd:enumeration value="ExplorationBudget"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="StrategyAverageCpcPerCampaignFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="AverageCpc"/>
+                    <xsd:enumeration value="WeeklySpendLimit"/>
+                    <xsd:enumeration value="CustomPeriodBudget"/>
+                    <xsd:enumeration value="BudgetType"/>
+                    <xsd:enumeration value="BidCeiling"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="StrategyAverageCpcPerFilterFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="FilterAverageCpc"/>
+                    <xsd:enumeration value="WeeklySpendLimit"/>
+                    <xsd:enumeration value="CustomPeriodBudget"/>
+                    <xsd:enumeration value="BudgetType"/>
+                    <xsd:enumeration value="BidCeiling"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="StrategyAverageCrrFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Crr"/>
+                    <xsd:enumeration value="GoalId"/>
+                    <xsd:enumeration value="WeeklySpendLimit"/>
+                    <xsd:enumeration value="CustomPeriodBudget"/>
+                    <xsd:enumeration value="BudgetType"/>
+                    <xsd:enumeration value="ExplorationBudget"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="StrategyPayForConversionCrrFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="Crr"/>
+                    <xsd:enumeration value="GoalId"/>
+                    <xsd:enumeration value="WeeklySpendLimit"/>
+                    <xsd:enumeration value="CustomPeriodBudget"/>
+                    <xsd:enumeration value="BudgetType"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="StrategyAverageCpaMultipleGoalsFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="WeeklySpendLimit"/>
+                    <xsd:enumeration value="CustomPeriodBudget"/>
+                    <xsd:enumeration value="BudgetType"/>
+                    <xsd:enumeration value="ExplorationBudget"/>
+                    <xsd:enumeration value="BidCeiling"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="StrategyPayForConversionMultipleGoalsFieldEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="WeeklySpendLimit"/>
+                    <xsd:enumeration value="CustomPeriodBudget"/>
+                    <xsd:enumeration value="BudgetType"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="StrategyType">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="AVERAGE_CPC"/> <!--+-->
+                    <xsd:enumeration value="AVERAGE_CPA"/> <!--+-->
+                    <xsd:enumeration value="PAY_FOR_CONVERSION"/> <!--+-->
+                    <xsd:enumeration value="WB_MAXIMUM_CONVERSION_RATE"/> <!--+-->
+                    <xsd:enumeration value="WB_MAXIMUM_CLICKS"/> <!--+-->
+                    <xsd:enumeration value="AVERAGE_CRR"/> <!--+-->
+                    <xsd:enumeration value="PAY_FOR_CONVERSION_CRR"/> <!--+-->
+                    <xsd:enumeration value="AVERAGE_CPC_PER_CAMPAIGN"/> <!--+-->
+                    <xsd:enumeration value="AVERAGE_CPC_PER_FILTER"/> <!--+-->
+                    <xsd:enumeration value="AVERAGE_CPA_PER_CAMPAIGN"/> <!--+-->
+                    <xsd:enumeration value="AVERAGE_CPA_PER_FILTER"/> <!--+-->
+                    <xsd:enumeration value="PAY_FOR_CONVERSION_PER_CAMPAIGN"/> <!--+-->
+                    <xsd:enumeration value="PAY_FOR_CONVERSION_PER_FILTER"/> <!--+-->
+                    <xsd:enumeration value="MAX_PROFIT"/> <!--+-->
+                    <xsd:enumeration value="AVERAGE_CPA_MULTIPLE_GOALS"/> <!--+-->
+                    <xsd:enumeration value="PAY_FOR_CONVERSION_MULTIPLE_GOALS"/> <!--+-->
+                    <xsd:enumeration value="UNKNOWN"/> <!--+-->
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="BudgetTypeEnum">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="WEEKLY_BUDGET"/>
+                    <xsd:enumeration value="CUSTOM_PERIOD_BUDGET"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:complexType name="ExplorationBudget">
+                <xsd:sequence>
+                    <xsd:element name="MinimumExplorationBudget" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="IsMinimumExplorationBudgetCustom" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="CustomPeriodBudget">
+                <xsd:sequence>
+                    <xsd:element name="SpendLimit" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="StartDate" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="EndDate" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="AutoContinue" type="general:YesNoEnum" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyMaximumClicksAddItem">
+                <xsd:sequence>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyMaximumConversionRateAddItem">
+                <xsd:sequence>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="GoalId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpcAddItem">
+                <xsd:sequence>
+                    <xsd:element name="AverageCpc" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpaAddItem">
+                <xsd:sequence>
+                    <xsd:element name="AverageCpa" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="GoalId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ExplorationBudget" type="ns:ExplorationBudget" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyMaxProfitAddItem">
+                <xsd:sequence>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ExplorationBudget" type="ns:ExplorationBudget" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForConversionAddItem">
+                <xsd:sequence>
+                    <xsd:element name="Cpa" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="GoalId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpaPerCampaignAddItem">
+                <xsd:sequence>
+                    <xsd:element name="AverageCpa" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="GoalId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ExplorationBudget" type="ns:ExplorationBudget" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForConversionPerCampaignAddItem">
+                <xsd:sequence>
+                    <xsd:element name="Cpa" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="GoalId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForConversionPerFilterAddItem">
+                <xsd:sequence>
+                    <xsd:element name="Cpa" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="GoalId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpaPerFilterAddItem">
+                <xsd:sequence>
+                    <xsd:element name="FilterAverageCpa" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="GoalId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ExplorationBudget" type="ns:ExplorationBudget" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpcPerCampaignAddItem">
+                <xsd:sequence>
+                    <xsd:element name="AverageCpc" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpcPerFilterAddItem">
+                <xsd:sequence>
+                    <xsd:element name="FilterAverageCpc" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCrrAddItem">
+                <xsd:sequence>
+                    <xsd:element name="Crr" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="GoalId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ExplorationBudget" type="ns:ExplorationBudget" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForConversionCrrAddItem">
+                <xsd:sequence>
+                    <xsd:element name="Crr" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="GoalId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpaMultipleGoalsAddItem">
+                <xsd:sequence>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="ExplorationBudget" type="ns:ExplorationBudget" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForConversionMultipleGoalsAddItem">
+                <xsd:sequence>
+                    <xsd:element name="GoalId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyMaximumClicksBase">
+                <xsd:sequence>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyMaximumConversionRateBase">
+                <xsd:sequence>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="GoalId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpcBase">
+                <xsd:sequence>
+                    <xsd:element name="AverageCpc" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpaBase">
+                <xsd:sequence>
+                    <xsd:element name="AverageCpa" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="GoalId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="ExplorationBudget" type="ns:ExplorationBudget" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyMaxProfitBase">
+                <xsd:sequence>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="ExplorationBudget" type="ns:ExplorationBudget" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForConversionBase">
+                <xsd:sequence>
+                    <xsd:element name="Cpa" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="GoalId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpaPerCampaignBase">
+                <xsd:sequence>
+                    <xsd:element name="AverageCpa" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="GoalId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="ExplorationBudget" type="ns:ExplorationBudget" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForConversionPerCampaignBase">
+                <xsd:sequence>
+                    <xsd:element name="Cpa" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="GoalId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForConversionPerFilterBase">
+                <xsd:sequence>
+                    <xsd:element name="Cpa" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="GoalId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpaPerFilterBase">
+                <xsd:sequence>
+                    <xsd:element name="FilterAverageCpa" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="GoalId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="ExplorationBudget" type="ns:ExplorationBudget" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpcPerCampaignBase">
+                <xsd:sequence>
+                    <xsd:element name="AverageCpc" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpcPerFilterBase">
+                <xsd:sequence>
+                    <xsd:element name="FilterAverageCpc" type="xsd:long" nillable="true" minOccurs="0"
+                                 maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCrrBase">
+                <xsd:sequence>
+                    <xsd:element name="Crr" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="GoalId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="ExplorationBudget" type="ns:ExplorationBudget" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForConversionCrrBase">
+                <xsd:sequence>
+                    <xsd:element name="Crr" type="xsd:int" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="GoalId" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpaMultipleGoalsBase">
+                <xsd:sequence>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="ExplorationBudget" type="ns:ExplorationBudget" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="BidCeiling" type="xsd:long" minOccurs="0" maxOccurs="1" nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForConversionMultipleGoalsBase">
+                <xsd:sequence>
+                    <xsd:element name="WeeklySpendLimit" type="xsd:long" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                    <xsd:element name="CustomPeriodBudget" type="ns:CustomPeriodBudget" minOccurs="0" maxOccurs="1"
+                                 nillable="true"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="PriorityGoalsItem">
+                <xsd:sequence>
+                    <xsd:element name="GoalId" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="Value" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="IsMetrikaSourceOfValue" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="PriorityGoalsArray">
+                <xsd:sequence>
+                    <xsd:element name="Items" type="ns:PriorityGoalsItem" minOccurs="1" maxOccurs="unbounded"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAddItem">
+                <xsd:sequence>
+                    <xsd:element name="AttributionModel" type="general:AttributionModelEnum" minOccurs="0"
+                                 maxOccurs="1"/>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="CounterIds" type="general:ArrayOfLong" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PriorityGoals" type="ns:PriorityGoalsArray" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WbMaximumClicks" type="ns:StrategyMaximumClicksAddItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WbMaximumConversionRate" type="ns:StrategyMaximumConversionRateAddItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpc" type="ns:StrategyAverageCpcAddItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpa" type="ns:StrategyAverageCpaAddItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="MaxProfit" type="ns:StrategyMaxProfitAddItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversion" type="ns:StrategyPayForConversionAddItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpaPerCampaign" type="ns:StrategyAverageCpaPerCampaignAddItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversionPerCampaign" type="ns:StrategyPayForConversionPerCampaignAddItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversionPerFilter" type="ns:StrategyPayForConversionPerFilterAddItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpaPerFilter" type="ns:StrategyAverageCpaPerFilterAddItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpcPerCampaign" type="ns:StrategyAverageCpcPerCampaignAddItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpcPerFilter" type="ns:StrategyAverageCpcPerFilterAddItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCrr" type="ns:StrategyAverageCrrAddItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversionCrr" type="ns:StrategyPayForConversionCrrAddItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpaMultipleGoals" type="ns:StrategyAverageCpaMultipleGoalsAddItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversionMultipleGoals" type="ns:StrategyPayForConversionMultipleGoalsAddItem" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyMaximumClicksGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyMaximumClicksBase">
+                        <xsd:sequence>
+                            <xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyMaximumConversionRateGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyMaximumConversionRateBase">
+                        <xsd:sequence>
+                            <xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpcGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyAverageCpcBase">
+                        <xsd:sequence>
+                            <xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpaGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyAverageCpaBase">
+                        <xsd:sequence>
+                            <xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyMaxProfitGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyMaxProfitBase">
+                        <xsd:sequence>
+                            <xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForConversionGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyPayForConversionBase">
+                        <xsd:sequence>
+                            <xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpaPerCampaignGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyAverageCpaPerCampaignBase">
+                        <xsd:sequence>
+                            <xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForConversionPerCampaignGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyPayForConversionPerCampaignBase">
+                        <xsd:sequence>
+                            <xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForConversionPerFilterGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyPayForConversionPerFilterBase">
+                        <xsd:sequence>
+                            <xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpaPerFilterGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyAverageCpaPerFilterBase">
+                        <xsd:sequence>
+                            <xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpcPerCampaignGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyAverageCpcPerCampaignBase">
+                        <xsd:sequence>
+                            <xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpcPerFilterGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyAverageCpcPerFilterBase">
+                        <xsd:sequence>
+                            <xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCrrGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyAverageCrrBase">
+                        <xsd:sequence>
+                            <xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForConversionCrrGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyPayForConversionCrrBase">
+                        <xsd:sequence>
+                            <xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpaMultipleGoalsGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyAverageCpaMultipleGoalsBase">
+                        <xsd:sequence>
+                            <xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForConversionMultipleGoalsGetItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyPayForConversionMultipleGoalsBase">
+                        <xsd:sequence>
+                            <xsd:element name="BudgetType" type="ns:BudgetTypeEnum" minOccurs="0" maxOccurs="1"/>
+                        </xsd:sequence>
+                    </xsd:extension>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyGetItem">
+                <xsd:sequence>
+                    <xsd:element name="Id" type="xsd:long" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AttributionModel" type="general:AttributionModelEnum" minOccurs="0"
+                                 maxOccurs="1"/>
+                    <xsd:element name="Type" type="ns:StrategyType" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PriorityGoals" type="ns:PriorityGoalsArray" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="CounterIds" type="general:ArrayOfLong" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="StatusArchived" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WbMaximumClicks" type="ns:StrategyMaximumClicksGetItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WbMaximumConversionRate" type="ns:StrategyMaximumConversionRateGetItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpc" type="ns:StrategyAverageCpcGetItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpa" type="ns:StrategyAverageCpaGetItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="MaxProfit" type="ns:StrategyMaxProfitGetItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversion" type="ns:StrategyPayForConversionGetItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpaPerCampaign" type="ns:StrategyAverageCpaPerCampaignGetItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversionPerCampaign" type="ns:StrategyPayForConversionPerCampaignGetItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversionPerFilter" type="ns:StrategyPayForConversionPerFilterGetItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpaPerFilter" type="ns:StrategyAverageCpaPerFilterGetItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpcPerCampaign" type="ns:StrategyAverageCpcPerCampaignGetItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpcPerFilter" type="ns:StrategyAverageCpcPerFilterGetItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCrr" type="ns:StrategyAverageCrrGetItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversionCrr" type="ns:StrategyPayForConversionCrrGetItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpaMultipleGoals" type="ns:StrategyAverageCpaMultipleGoalsGetItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversionMultipleGoals" type="ns:StrategyPayForConversionMultipleGoalsGetItem" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="StrategiesSelectionCriteria">
+                <xsd:sequence>
+                    <xsd:element name="Ids" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="Types" type="ns:StrategyType" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="IsArchived" type="general:YesNoEnum" minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="GetRequest">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetRequestGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="SelectionCriteria" type="ns:StrategiesSelectionCriteria"
+                                             minOccurs="1" maxOccurs="1"/>
+                                <xsd:element name="FieldNames" type="ns:StrategyFieldEnum" minOccurs="1"
+                                             maxOccurs="unbounded"/>
+                                <xsd:element name="StrategyMaximumClicksFieldNames"
+                                             type="ns:StrategyMaximumClicksFieldEnum" minOccurs="0"
+                                             maxOccurs="unbounded"/>
+                                <xsd:element name="StrategyMaximumConversionRateFieldNames"
+                                             type="ns:StrategyMaximumConversionRateFieldEnum" minOccurs="0"
+                                             maxOccurs="unbounded"/>
+                                <xsd:element name="StrategyAverageCpcFieldNames" type="ns:StrategyAverageCpcFieldEnum"
+                                             minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="StrategyAverageCpaFieldNames" type="ns:StrategyAverageCpaFieldEnum"
+                                             minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="StrategyMaxProfitFieldNames" type="ns:StrategyMaxProfitFieldEnum"
+                                             minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="StrategyPayForConversionFieldNames"
+                                             type="ns:StrategyPayForConversionFieldEnum" minOccurs="0"
+                                             maxOccurs="unbounded"/>
+                                <xsd:element name="StrategyAverageCpaPerCampaignFieldNames"
+                                             type="ns:StrategyAverageCpaPerCampaignFieldEnum" minOccurs="0"
+                                             maxOccurs="unbounded"/>
+                                <xsd:element name="StrategyPayForConversionPerCampaignFieldNames"
+                                             type="ns:StrategyPayForConversionPerCampaignFieldEnum" minOccurs="0"
+                                             maxOccurs="unbounded"/>
+                                <xsd:element name="StrategyPayForConversionPerFilterFieldNames"
+                                             type="ns:StrategyPayForConversionPerFilterFieldEnum" minOccurs="0"
+                                             maxOccurs="unbounded"/>
+                                <xsd:element name="StrategyAverageCpaPerFilterFieldNames"
+                                             type="ns:StrategyAverageCpaPerFilterFieldEnum" minOccurs="0"
+                                             maxOccurs="unbounded"/>
+                                <xsd:element name="StrategyAverageCpcPerCampaignFieldNames"
+                                             type="ns:StrategyAverageCpcPerCampaignFieldEnum" minOccurs="0"
+                                             maxOccurs="unbounded"/>
+                                <xsd:element name="StrategyAverageCpcPerFilterFieldNames"
+                                             type="ns:StrategyAverageCpcPerFilterFieldEnum" minOccurs="0"
+                                             maxOccurs="unbounded"/>
+                                <xsd:element name="StrategyAverageCrrFieldNames" type="ns:StrategyAverageCrrFieldEnum"
+                                             minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="StrategyPayForConversionCrrFieldNames"
+                                             type="ns:StrategyPayForConversionCrrFieldEnum" minOccurs="0"
+                                             maxOccurs="unbounded"/>
+                                <xsd:element name="StrategyAverageCpaMultipleGoalsFieldNames" type="ns:StrategyAverageCpaMultipleGoalsFieldEnum"
+                                             minOccurs="0" maxOccurs="unbounded"/>
+                                <xsd:element name="StrategyPayForConversionMultipleGoalsFieldNames"
+                                             type="ns:StrategyPayForConversionMultipleGoalsFieldEnum" minOccurs="0"
+                                             maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:complexType name="StrategyMaximumClicksUpdateItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyMaximumClicksBase"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyMaximumConversionRateUpdateItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyMaximumConversionRateBase"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpcUpdateItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyAverageCpcBase"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpaUpdateItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyAverageCpaBase"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyMaxProfitUpdateItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyMaxProfitBase"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForConversionUpdateItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyPayForConversionBase"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpaPerCampaignUpdateItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyAverageCpaPerCampaignBase"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForConversionPerCampaignUpdateItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyPayForConversionPerCampaignBase"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForConversionPerFilterUpdateItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyPayForConversionPerFilterBase"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpaPerFilterUpdateItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyAverageCpaPerFilterBase"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpcPerCampaignUpdateItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyAverageCpcPerCampaignBase"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpcPerFilterUpdateItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyAverageCpcPerFilterBase"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCrrUpdateItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyAverageCrrBase"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForConversionCrrUpdateItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyPayForConversionCrrBase"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyAverageCpaMultipleGoalsUpdateItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyAverageCpaMultipleGoalsBase"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyPayForConversionMultipleGoalsUpdateItem">
+                <xsd:complexContent>
+                    <xsd:extension base="ns:StrategyPayForConversionMultipleGoalsBase"/>
+                </xsd:complexContent>
+            </xsd:complexType>
+            <xsd:complexType name="StrategyUpdateItem">
+                <xsd:sequence>
+                    <xsd:element name="Id" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element name="AttributionModel" type="general:AttributionModelEnum" minOccurs="0"
+                                 maxOccurs="1"/>
+                    <xsd:element name="Name" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="CounterIds" type="general:ArrayOfLong" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="PriorityGoals" type="ns:PriorityGoalsArray" minOccurs="0" maxOccurs="1" nillable="true"/>
+                    <xsd:element name="WbMaximumClicks" type="ns:StrategyMaximumClicksUpdateItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="WbMaximumConversionRate" type="ns:StrategyMaximumConversionRateUpdateItem"
+                                 minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpc" type="ns:StrategyAverageCpcUpdateItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpa" type="ns:StrategyAverageCpaUpdateItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="MaxProfit" type="ns:StrategyMaxProfitUpdateItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversion" type="ns:StrategyPayForConversionUpdateItem" minOccurs="0"
+                                 maxOccurs="1"/>
+                    <xsd:element name="AverageCpaPerCampaign" type="ns:StrategyAverageCpaPerCampaignUpdateItem"
+                                 minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversionPerCampaign"
+                                 type="ns:StrategyPayForConversionPerCampaignUpdateItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversionPerFilter" type="ns:StrategyPayForConversionPerFilterUpdateItem"
+                                 minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpaPerFilter" type="ns:StrategyAverageCpaPerFilterUpdateItem"
+                                 minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpcPerCampaign" type="ns:StrategyAverageCpcPerCampaignUpdateItem"
+                                 minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpcPerFilter" type="ns:StrategyAverageCpcPerFilterUpdateItem"
+                                 minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCrr" type="ns:StrategyAverageCrrUpdateItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversionCrr" type="ns:StrategyPayForConversionCrrUpdateItem"
+                                 minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="AverageCpaMultipleGoals" type="ns:StrategyAverageCpaMultipleGoalsUpdateItem" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="PayForConversionMultipleGoals" type="ns:StrategyPayForConversionMultipleGoalsUpdateItem"
+                                 minOccurs="0" maxOccurs="1"/>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:element name="AddRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="Strategies" type="ns:StrategyAddItem" minOccurs="1" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="AddResults" type="general:ActionResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetResponse">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="general:GetResponseGeneral">
+                            <xsd:sequence>
+                                <xsd:element name="Strategies" type="ns:StrategyGetItem" minOccurs="0"
+                                             maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:extension>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="UpdateRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="Strategies" type="ns:StrategyUpdateItem" minOccurs="1"
+                                     maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="UpdateResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="UpdateResults" type="general:ActionResult" minOccurs="0"
+                                     maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="ArchiveRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="ArchiveResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="ArchiveResults" type="general:ActionResult" minOccurs="0"
+                                     maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="UnarchiveRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="SelectionCriteria" type="general:IdsCriteria" minOccurs="1" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="UnarchiveResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="UnarchiveResults" type="general:ActionResult" minOccurs="0"
+                                     maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="ApiException">
+        <wsdl:part element="general:FaultResponse" name="faultMessage"/>
+    </wsdl:message>
+    <!-- ADD -->
+    <wsdl:message name="AddOperationRequest">
+        <wsdl:part element="ns:AddRequest" name="parameters"/>
+    </wsdl:message>
+    <wsdl:message name="AddOperationResponse">
+        <wsdl:part name="parameters" element="ns:AddResponse"/>
+    </wsdl:message>
+    <!-- UPDATE -->
+    <wsdl:message name="UpdateOperationRequest">
+        <wsdl:part name="parameters" element="ns:UpdateRequest"/>
+    </wsdl:message>
+    <wsdl:message name="UpdateOperationResponse">
+        <wsdl:part name="parameters" element="ns:UpdateResponse"/>
+    </wsdl:message>
+    <!-- GET -->
+    <wsdl:message name="GetOperationRequest">
+        <wsdl:part name="parameters" element="ns:GetRequest"/>
+    </wsdl:message>
+    <wsdl:message name="GetOperationResponse">
+        <wsdl:part name="parameters" element="ns:GetResponse"/>
+    </wsdl:message>
+    <!-- ARCHIVE -->
+    <wsdl:message name="ArchiveOperationRequest">
+        <wsdl:part name="parameters" element="ns:ArchiveRequest"/>
+    </wsdl:message>
+    <wsdl:message name="ArchiveOperationResponse">
+        <wsdl:part name="parameters" element="ns:ArchiveResponse"/>
+    </wsdl:message>
+    <!-- UNARCHIVE -->
+    <wsdl:message name="UnarchiveOperationRequest">
+        <wsdl:part name="parameters" element="ns:UnarchiveRequest"/>
+    </wsdl:message>
+    <wsdl:message name="UnarchiveOperationResponse">
+        <wsdl:part name="parameters" element="ns:UnarchiveResponse"/>
+    </wsdl:message>
+    <wsdl:portType name="StrategiesPort">
+        <wsdl:operation name="add">
+            <wsdl:input message="ns:AddOperationRequest" name="addRequest"/>
+            <wsdl:output message="ns:AddOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="update">
+            <wsdl:input message="ns:UpdateOperationRequest" name="updateRequest"/>
+            <wsdl:output message="ns:UpdateOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="get">
+            <wsdl:input message="ns:GetOperationRequest" name="getRequest"/>
+            <wsdl:output message="ns:GetOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="archive">
+            <wsdl:input message="ns:ArchiveOperationRequest" name="archiveRequest"/>
+            <wsdl:output message="ns:ArchiveOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+        <wsdl:operation name="unarchive">
+            <wsdl:input message="ns:UnarchiveOperationRequest" name="unarchiveRequest"/>
+            <wsdl:output message="ns:UnarchiveOperationResponse"/>
+            <wsdl:fault message="ns:ApiException" name="ApiException"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="StrategiesSOAP" type="ns:StrategiesPort">
+        <soap:binding style="document"
+                      transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="add">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/strategies/add"/>
+            <wsdl:input name="addRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="update">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/strategies/update"/>
+            <wsdl:input name="updateRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="get">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/strategies/get"/>
+            <wsdl:input name="getRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="archive">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/strategies/archive"/>
+            <wsdl:input name="archiveRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="unarchive">
+            <soap:operation soapAction="http://api.direct.yandex.com/v5/strategies/unarchive"/>
+            <wsdl:input name="unarchiveRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+            <wsdl:fault name="ApiException">
+                <soap:fault name="ApiException" use="literal"/>
+            </wsdl:fault>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="Strategies">
+        <wsdl:port binding="ns:StrategiesSOAP" name="StrategiesSOAP">
+            <soap:address location="https://soap.direct.yandex.ru/v5/strategies"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
## Summary

- Implements `direct strategies` (add/archive/get/unarchive/update) — closes live-discovered gap from issue #54
- Implements `direct dynamicfeedadtargets` (add/delete/get/resume/set-bids/suspend)
- `live_model_parity_ok` flips to `True`; zero model gaps remaining
- 10 new dry-run payload tests; WSDL cache files for both services

Closes issue #59 Phase 6. Relates to #54.

## Test plan

- [x] 243 unit tests pass (`pytest -q`)
- [x] `test_api_coverage.py` contract tests pass, `live_model_gap_count == 0`
- [x] `direct strategies add --name "T" --type WbMaximumClicks --dry-run` ✓
- [x] `direct dynamicfeedadtargets add --adgroup-id 123 --name "t" --dry-run` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)