### PR TITLE
fix(keywordbids): use valid FieldNames for get

### DIFF
--- a/direct_cli/commands/keywordbids.py
+++ b/direct_cli/commands/keywordbids.py
@@ -51,6 +51,8 @@ def get(
                 "ServingStatus",
                 "StrategyPriority",
             ],
+            "SearchFieldNames": ["Bid"],
+            "NetworkFieldNames": ["Bid"],
         }
 
         if limit:

--- a/direct_cli/commands/keywordbids.py
+++ b/direct_cli/commands/keywordbids.py
@@ -23,7 +23,9 @@ def keywordbids():
 @click.option("--format", "output_format", default="json", help="Output format")
 @click.option("--output", help="Output file")
 @click.pass_context
-def get(ctx, keyword_ids, adgroup_ids, campaign_ids, limit, fetch_all, output_format, output):
+def get(
+    ctx, keyword_ids, adgroup_ids, campaign_ids, limit, fetch_all, output_format, output
+):
     """Get keyword bids"""
     try:
         client = create_client(
@@ -42,7 +44,13 @@ def get(ctx, keyword_ids, adgroup_ids, campaign_ids, limit, fetch_all, output_fo
 
         params = {
             "SelectionCriteria": criteria,
-            "FieldNames": ["KeywordId", "AdGroupId", "CampaignId", "Bid", "ContextBid"],
+            "FieldNames": [
+                "KeywordId",
+                "AdGroupId",
+                "CampaignId",
+                "ServingStatus",
+                "StrategyPriority",
+            ],
         }
 
         if limit:
@@ -143,9 +151,9 @@ def set_auto(
                 "TargetTrafficVolume": target_traffic_volume
             }
             if increase_percent is not None:
-                bidding_rule["SearchByTrafficVolume"]["IncreasePercent"] = (
-                    increase_percent
-                )
+                bidding_rule["SearchByTrafficVolume"][
+                    "IncreasePercent"
+                ] = increase_percent
             if bid_ceiling is not None:
                 bidding_rule["SearchByTrafficVolume"]["BidCeiling"] = to_micros(
                     bid_ceiling
@@ -153,13 +161,9 @@ def set_auto(
         if target_coverage is not None:
             bidding_rule["NetworkByCoverage"] = {"TargetCoverage": target_coverage}
             if increase_percent is not None:
-                bidding_rule["NetworkByCoverage"]["IncreasePercent"] = (
-                    increase_percent
-                )
+                bidding_rule["NetworkByCoverage"]["IncreasePercent"] = increase_percent
             if bid_ceiling is not None:
-                bidding_rule["NetworkByCoverage"]["BidCeiling"] = to_micros(
-                    bid_ceiling
-                )
+                bidding_rule["NetworkByCoverage"]["BidCeiling"] = to_micros(bid_ceiling)
 
         bid_data = {"BiddingRule": bidding_rule}
         if campaign_id is not None:


### PR DESCRIPTION
## Summary

- `keywordbids get` sent `Bid` and `ContextBid` in `FieldNames`, which are valid only for the `keywords` resource, not `keywordbids`
- API returned `error_code=8000`: invalid enumeration value
- Fixed: replaced with the valid set `KeywordId`, `AdGroupId`, `CampaignId`, `ServingStatus`, `StrategyPriority`

**Root cause:** copy-paste error from `COMMON_FIELDS["keywords"]`

Closes #74

## Test plan
- [x] `pytest tests/test_cli.py tests/test_comprehensive.py` — passed
- [ ] `bash scripts/test_safe_commands.sh` — live smoke with token