### PR TITLE
fix(keywordsresearch): wrap Keywords in SelectionCriteria

### DIFF
--- a/direct_cli/commands/keywordsresearch.py
+++ b/direct_cli/commands/keywordsresearch.py
@@ -29,7 +29,11 @@ def has_search_volume(ctx, keywords, output_format, output):
 
         body = {
             "method": "hasSearchVolume",
-            "params": {"Keywords": [k.strip() for k in keywords.split(",")]},
+            "params": {
+                "SelectionCriteria": {
+                    "Keywords": [k.strip() for k in keywords.split(",")]
+                }
+            },
         }
 
         result = client.keywordsresearch().post(data=body)
@@ -56,7 +60,11 @@ def deduplicate(ctx, keywords, output_format, output):
 
         body = {
             "method": "deduplicate",
-            "params": {"Keywords": [k.strip() for k in keywords.split(",")]},
+            "params": {
+                "SelectionCriteria": {
+                    "Keywords": [k.strip() for k in keywords.split(",")]
+                }
+            },
         }
 
         result = client.keywordsresearch().post(data=body)


### PR DESCRIPTION
## Summary

- `keywordsresearch has-search-volume` and `deduplicate` failed with `error_code=8000: Omitted required parameter SelectionCriteria`
- Both methods require keywords nested inside `SelectionCriteria`, not at the top level of `params`
- Fixed the request body structure in both commands

**Root cause:** copy-paste error — `Keywords` was placed directly in `params` instead of inside `params.SelectionCriteria`

Closes #77

## Test plan
- [x] `pytest tests/test_cli.py tests/test_comprehensive.py` — passed
- [ ] `bash scripts/test_safe_commands.sh` — live smoke with token