### PR TITLE
fix(feeds): use valid FieldNames for get (SourceType, not Source)

### DIFF
--- a/direct_cli/_vendor/tapi_yandex_direct/tapi_yandex_direct.py
+++ b/direct_cli/_vendor/tapi_yandex_direct/tapi_yandex_direct.py
@@ -8,8 +8,8 @@ from requests import Response
 from tapi2 import TapiAdapter, generate_wrapper_from_adapter, JSONAdapterMixin
 from tapi2.exceptions import ResponseProcessException, ClientError, TapiException
 
-from tapi_yandex_direct import exceptions
-from tapi_yandex_direct.resource_mapping import RESOURCE_MAPPING_V5
+from . import exceptions
+from .resource_mapping import RESOURCE_MAPPING_V5
 
 logger = logging.getLogger(__name__)
 

--- a/direct_cli/commands/feeds.py
+++ b/direct_cli/commands/feeds.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import create_client
 from ..output import format_output, print_error
-from ..utils import parse_ids
+from ..utils import get_default_fields, parse_ids
 
 
 @click.group()
@@ -31,9 +31,7 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields):
             sandbox=ctx.obj.get("sandbox"),
         )
 
-        field_names = (
-            fields.split(",") if fields else ["Id", "Name", "Source", "Status"]
-        )
+        field_names = fields.split(",") if fields else get_default_fields("feeds")
 
         criteria = {}
         if ids:
@@ -68,8 +66,7 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields):
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
 def add(ctx, name, url, dry_run):
-    """Add feed
-    """
+    """Add feed"""
     try:
         feed_data = {
             "Name": name,

--- a/direct_cli/utils.py
+++ b/direct_cli/utils.py
@@ -94,8 +94,7 @@ def parse_datetime(datetime_str: str) -> str:
         return f"{datetime_str}Z"
     except ValueError:
         raise ValueError(
-            "Invalid datetime format: "
-            f"{datetime_str}. Expected: YYYY-MM-DDTHH:MM:SS"
+            "Invalid datetime format: " f"{datetime_str}. Expected: YYYY-MM-DDTHH:MM:SS"
         )
 
 
@@ -253,7 +252,7 @@ COMMON_FIELDS = {
     "vcards": ["Id", "CampaignId", "Country", "City", "CompanyName"],
     "leads": ["Date", "LeadId", "CampaignId", "AdGroupId", "AdId"],
     "turbopages": ["Id", "Name", "Status", "Href"],
-    "feeds": ["Id", "Name", "Source", "Status"],
+    "feeds": ["Id", "Name", "BusinessType", "SourceType", "Status"],
     "smartadtargets": ["Id", "CampaignId", "AdGroupId", "Status", "ServingStatus"],
     "businesses": ["Id", "Name", "Url"],
     "retargetinglists": ["Id", "Name", "Type", "Scope"],


### PR DESCRIPTION
## Summary

- `feeds get` failed with `error_code=8000: invalid enumeration value` — `Source` is not a valid field for `feeds/get`
- Valid fields include: `Id`, `Name`, `BusinessType`, `SourceType`, `FilterSchema`, `UpdatedAt`, `CampaignIds`, `NumberOfItems`, `NumberOfListings`, `Status`, `TitleAndTextSources`, `Fields`
- Fixed `COMMON_FIELDS["feeds"]` in `utils.py` (single source of truth)
- `feeds.py` now uses `get_default_fields("feeds")` instead of an inline hardcoded list

**Root cause:** `Source` was used instead of `SourceType`, and the default was hardcoded inline in the command rather than read from `COMMON_FIELDS`, so the two were not kept in sync

Closes #79 (part 1 — `feeds get`)

## Test plan
- [x] `pytest tests/test_cli.py tests/test_comprehensive.py` — passed
- [ ] `bash scripts/test_safe_commands.sh` — live smoke with token