### PR TITLE
fix(changes): make --timestamp required for check-campaigns

### DIFF
--- a/direct_cli/commands/changes.py
+++ b/direct_cli/commands/changes.py
@@ -16,9 +16,7 @@ def changes():
 
 @changes.command()
 @click.option("--campaign-ids", required=True, help="Comma-separated campaign IDs")
-@click.option(
-    "--timestamp", help="Timestamp for changes check (YYYY-MM-DDTHH:MM:SS)"
-)
+@click.option("--timestamp", help="Timestamp for changes check (YYYY-MM-DDTHH:MM:SS)")
 @click.option("--format", "output_format", default="json", help="Output format")
 @click.option("--output", help="Output file")
 @click.pass_context
@@ -48,7 +46,9 @@ def check(ctx, campaign_ids, timestamp, output_format, output):
 
 @changes.command()
 @click.option(
-    "--timestamp", help="Timestamp for changes check (YYYY-MM-DDTHH:MM:SS)"
+    "--timestamp",
+    required=True,
+    help="Timestamp for changes check (YYYY-MM-DDTHH:MM:SS)",
 )
 @click.option("--format", "output_format", default="json", help="Output format")
 @click.option("--output", help="Output file")
@@ -62,10 +62,7 @@ def check_campaigns(ctx, timestamp, output_format, output):
             sandbox=ctx.obj.get("sandbox"),
         )
 
-        params = {}
-
-        if timestamp:
-            params["Timestamp"] = parse_datetime(timestamp)
+        params = {"Timestamp": parse_datetime(timestamp)}
 
         body = {"method": "checkCampaigns", "params": params}
 


### PR DESCRIPTION
## Summary

- `changes check-campaigns` without `--timestamp` sent an empty `params: {}` to the API, causing `error_code=8000`
- The `checkCampaigns` API requires `Timestamp` — it is not optional
- Made `--timestamp` required in Click; removed the conditional branch that was only needed when it was optional

**Note on `--campaign-ids`:** intentionally not added. The `checkCampaigns` API method does not accept `CampaignIds` — that parameter belongs to the separate `check` method, already exposed as `direct changes check`. Adding it would violate the project's 1-to-1 CLI↔API convention (README.md line 597).

Closes #79 (part 2 — `changes check-campaigns`)

## Test plan
- [x] `pytest tests/test_cli.py tests/test_comprehensive.py` — passed
- [ ] `bash scripts/test_safe_commands.sh` — live smoke with token