### PR TITLE
fix(keywordsresearch): fix deduplicate request structure

### DIFF
--- a/direct_cli/commands/keywordsresearch.py
+++ b/direct_cli/commands/keywordsresearch.py
@@ -61,9 +61,7 @@ def deduplicate(ctx, keywords, output_format, output):
         body = {
             "method": "deduplicate",
             "params": {
-                "SelectionCriteria": {
-                    "Keywords": [k.strip() for k in keywords.split(",")]
-                }
+                "Keywords": [{"Keyword": k.strip()} for k in keywords.split(",")]
             },
         }
 


### PR DESCRIPTION
## Summary
- Revert incorrect `SelectionCriteria` wrapper applied to `deduplicate` in PR #83
- Per WSDL `DeduplicateRequest`, the correct structure is `params.Keywords = [{Keyword: "..."}]` (array of objects), not `params.SelectionCriteria.Keywords`
- `has-search-volume` already uses `SelectionCriteria` correctly — this fix is only for `deduplicate`

Closes #87

## Test plan
- [x] `pytest tests/test_cli.py tests/test_comprehensive.py` — passes
- [x] Live: `direct keywordsresearch deduplicate --keywords "купить велосипед,велосипед купить"` returns `{"result": {"Add": [...]}}` without error