### PR TITLE
fix(bidmodifiers): fix Levels location, AD_GROUP enum value, and FieldNames

### DIFF
--- a/direct_cli/commands/bidmodifiers.py
+++ b/direct_cli/commands/bidmodifiers.py
@@ -19,9 +19,9 @@ def bidmodifiers():
 @click.option("--adgroup-ids", help="Comma-separated ad group IDs")
 @click.option(
     "--levels",
-    type=click.Choice(["CAMPAIGN", "ADGROUP"], case_sensitive=False),
+    type=click.Choice(["CAMPAIGN", "AD_GROUP"], case_sensitive=False),
     multiple=True,
-    default=("CAMPAIGN", "ADGROUP"),
+    default=("CAMPAIGN", "AD_GROUP"),
     show_default=True,
     help="Bid modifier levels to retrieve",
 )
@@ -41,7 +41,7 @@ def get(
             sandbox=ctx.obj.get("sandbox"),
         )
 
-        criteria = {}
+        criteria = {"Levels": [lv.upper() for lv in levels]}
         if campaign_ids:
             criteria["CampaignIds"] = parse_ids(campaign_ids)
         if adgroup_ids:
@@ -49,8 +49,7 @@ def get(
 
         params = {
             "SelectionCriteria": criteria,
-            "Levels": [lv.upper() for lv in levels],
-            "FieldNames": ["Id", "CampaignId", "AdGroupId", "Type", "ModifierValue"],
+            "FieldNames": ["Id", "CampaignId", "AdGroupId", "Level", "Type"],
         }
 
         if limit:


### PR DESCRIPTION
## Summary

Three bugs introduced in PR #81 (all discovered via live API testing):

1. **`Levels` in wrong location**: must be inside `SelectionCriteria` per WSDL `BidModifiersSelectionCriteria`, not at top-level `params`
2. **Wrong enum value**: `ADGROUP` → `AD_GROUP` (with underscore, per `BidModifierLevelEnum`)
3. **Invalid `FieldNames`**: `ModifierValue` doesn't exist → replaced with `Level` (valid per `BidModifierFieldEnum`: `Id`, `CampaignId`, `AdGroupId`, `Level`, `Type`)

Closes #90

## Test plan
- [x] `pytest tests/test_cli.py tests/test_comprehensive.py` — passes
- [x] Live: `direct bidmodifiers get --campaign-ids <ID>` returns `[]` without error (no modifiers in test account, but request accepted)