### PR TITLE
fix: patch vendored tapi imports during update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ coverage.xml
 .venv
 
 # IDE
+.claude/
 .vscode/
 .idea/
 *.swp

--- a/scripts/patch_vendor_imports.py
+++ b/scripts/patch_vendor_imports.py
@@ -19,6 +19,14 @@ FROM_SUBMODULE_RE = re.compile(
 )
 
 
+def _validate_captured(captured: str, path: Path, line_number: int, line: str) -> None:
+    """Raise ValueError if the captured import group indicates a multi-line form."""
+    if captured.startswith("(") or captured.rstrip() in ("\\", ""):
+        raise ValueError(
+            f"{path}:{line_number}: multi-line import not supported: {line!r}"
+        )
+
+
 def patch_line(line: str, path: Path, line_number: int) -> str:
     """
     Rewrite a single import line if it references the upstream package.
@@ -37,19 +45,13 @@ def patch_line(line: str, path: Path, line_number: int) -> str:
     match = FROM_PACKAGE_RE.match(line)
     if match:
         captured = match.group(1)
-        if captured.startswith("("):
-            raise ValueError(
-                f"{path}:{line_number}: multi-line import not supported: {line!r}"
-            )
+        _validate_captured(captured, path, line_number, line)
         return f"from . import {captured}"
 
     match = FROM_SUBMODULE_RE.match(line)
     if match:
         captured = match.group(2)
-        if captured.startswith("("):
-            raise ValueError(
-                f"{path}:{line_number}: multi-line import not supported: {line!r}"
-            )
+        _validate_captured(captured, path, line_number, line)
         return f"from .{match.group(1)} import {captured}"
 
     if line.startswith("import tapi_yandex_direct"):

--- a/scripts/patch_vendor_imports.py
+++ b/scripts/patch_vendor_imports.py
@@ -36,11 +36,21 @@ def patch_line(line: str, path: Path, line_number: int) -> str:
     """
     match = FROM_PACKAGE_RE.match(line)
     if match:
-        return f"from . import {match.group(1)}"
+        captured = match.group(1)
+        if captured.startswith("("):
+            raise ValueError(
+                f"{path}:{line_number}: multi-line import not supported: {line!r}"
+            )
+        return f"from . import {captured}"
 
     match = FROM_SUBMODULE_RE.match(line)
     if match:
-        return f"from .{match.group(1)} import {match.group(2)}"
+        captured = match.group(2)
+        if captured.startswith("("):
+            raise ValueError(
+                f"{path}:{line_number}: multi-line import not supported: {line!r}"
+            )
+        return f"from .{match.group(1)} import {captured}"
 
     if line.startswith("import tapi_yandex_direct"):
         raise ValueError(f"{path}:{line_number}: unsupported absolute import: {line}")
@@ -48,15 +58,18 @@ def patch_line(line: str, path: Path, line_number: int) -> str:
     return line
 
 
-def patch_file(path: Path) -> bool:
+def _compute_patch(path: Path) -> str | None:
     """
-    Patch all supported upstream absolute imports in a Python file.
+    Compute patched content for a file, without writing.
 
     Args:
         path: Python source file to patch.
 
     Returns:
-        True when the file content changed.
+        Patched content string, or None if no changes are needed.
+
+    Raises:
+        ValueError: If an unsupported import form is found.
     """
     original = path.read_text(encoding="utf-8")
     has_trailing_newline = original.endswith("\n")
@@ -69,15 +82,17 @@ def patch_file(path: Path) -> bool:
         patched += "\n"
 
     if patched == original:
-        return False
+        return None
 
-    path.write_text(patched, encoding="utf-8")
-    return True
+    return patched
 
 
 def patch_vendor_dir(vendor_dir: Path) -> int:
     """
     Patch all Python files under a vendored tapi_yandex_direct directory.
+
+    Computes all patches before writing any files so that a ValueError on
+    any file prevents partial (broken) writes.
 
     Args:
         vendor_dir: Path to the vendored package directory.
@@ -87,15 +102,21 @@ def patch_vendor_dir(vendor_dir: Path) -> int:
 
     Raises:
         FileNotFoundError: If the vendor directory does not exist.
+        ValueError: If an unsupported import form is found.
     """
     if not vendor_dir.is_dir():
         raise FileNotFoundError(f"Vendor directory not found: {vendor_dir}")
 
-    changed = 0
+    patches: dict[Path, str] = {}
     for path in sorted(vendor_dir.rglob("*.py")):
-        if patch_file(path):
-            changed += 1
-    return changed
+        patched = _compute_patch(path)
+        if patched is not None:
+            patches[path] = patched
+
+    for path, content in patches.items():
+        path.write_text(content, encoding="utf-8")
+
+    return len(patches)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/patch_vendor_imports.py
+++ b/scripts/patch_vendor_imports.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+Patch vendored tapi_yandex_direct imports after copying upstream files.
+
+The upstream package imports itself as ``tapi_yandex_direct``.  Direct CLI
+embeds it under ``direct_cli._vendor``, so those imports must be relative.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+FROM_PACKAGE_RE = re.compile(r"^from tapi_yandex_direct import (.+)$")
+FROM_SUBMODULE_RE = re.compile(
+    r"^from tapi_yandex_direct\.([A-Za-z0-9_\.]+) import (.+)$"
+)
+
+
+def patch_line(line: str, path: Path, line_number: int) -> str:
+    """
+    Rewrite a single import line if it references the upstream package.
+
+    Args:
+        line: Source line without its trailing newline.
+        path: File path used in error messages.
+        line_number: One-based line number used in error messages.
+
+    Returns:
+        The original or rewritten line.
+
+    Raises:
+        ValueError: If an unsupported absolute import form is found.
+    """
+    match = FROM_PACKAGE_RE.match(line)
+    if match:
+        return f"from . import {match.group(1)}"
+
+    match = FROM_SUBMODULE_RE.match(line)
+    if match:
+        return f"from .{match.group(1)} import {match.group(2)}"
+
+    if line.startswith("import tapi_yandex_direct"):
+        raise ValueError(f"{path}:{line_number}: unsupported absolute import: {line}")
+
+    return line
+
+
+def patch_file(path: Path) -> bool:
+    """
+    Patch all supported upstream absolute imports in a Python file.
+
+    Args:
+        path: Python source file to patch.
+
+    Returns:
+        True when the file content changed.
+    """
+    original = path.read_text(encoding="utf-8")
+    has_trailing_newline = original.endswith("\n")
+    patched_lines = [
+        patch_line(line, path, line_number)
+        for line_number, line in enumerate(original.splitlines(), 1)
+    ]
+    patched = "\n".join(patched_lines)
+    if has_trailing_newline:
+        patched += "\n"
+
+    if patched == original:
+        return False
+
+    path.write_text(patched, encoding="utf-8")
+    return True
+
+
+def patch_vendor_dir(vendor_dir: Path) -> int:
+    """
+    Patch all Python files under a vendored tapi_yandex_direct directory.
+
+    Args:
+        vendor_dir: Path to the vendored package directory.
+
+    Returns:
+        Number of files changed.
+
+    Raises:
+        FileNotFoundError: If the vendor directory does not exist.
+    """
+    if not vendor_dir.is_dir():
+        raise FileNotFoundError(f"Vendor directory not found: {vendor_dir}")
+
+    changed = 0
+    for path in sorted(vendor_dir.rglob("*.py")):
+        if patch_file(path):
+            changed += 1
+    return changed
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Patch vendored tapi_yandex_direct absolute imports."
+    )
+    parser.add_argument("vendor_dir", type=Path)
+    args = parser.parse_args(argv)
+
+    try:
+        changed = patch_vendor_dir(args.vendor_dir)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Patched vendor imports in {changed} file(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/update_vendor.sh
+++ b/scripts/update_vendor.sh
@@ -10,6 +10,13 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 VENDOR_DIR="${ROOT_DIR}/direct_cli/_vendor/tapi_yandex_direct"
 VENDOR_INIT="${VENDOR_DIR}/__init__.py"
 
+smoke_vendor_import() {
+  (
+    cd "${ROOT_DIR}"
+    python3 -c "from direct_cli._vendor.tapi_yandex_direct import YandexDirect; YandexDirect(access_token='test-token')"
+  )
+}
+
 # --- Read current vendored version ---
 if [[ ! -f "${VENDOR_INIT}" ]]; then
   echo "ERROR: Vendor directory not found: ${VENDOR_DIR}"
@@ -31,6 +38,7 @@ echo "Fork version: ${FORK_VERSION}"
 # --- Compare ---
 if [[ "${CURRENT_VERSION}" == "${FORK_VERSION}" ]]; then
   echo "Vendor up to date (${CURRENT_VERSION}), nothing to do."
+  smoke_vendor_import
   exit 0
 fi
 
@@ -41,6 +49,9 @@ cp "${TMP_DIR}/fork/tapi_yandex_direct/__init__.py"        "${VENDOR_DIR}/"
 cp "${TMP_DIR}/fork/tapi_yandex_direct/tapi_yandex_direct.py" "${VENDOR_DIR}/"
 cp "${TMP_DIR}/fork/tapi_yandex_direct/resource_mapping.py" "${VENDOR_DIR}/"
 cp "${TMP_DIR}/fork/tapi_yandex_direct/exceptions.py"       "${VENDOR_DIR}/"
+
+python3 "${ROOT_DIR}/scripts/patch_vendor_imports.py" "${VENDOR_DIR}"
+smoke_vendor_import
 
 # --- Commit ---
 cd "${ROOT_DIR}"

--- a/tests/test_vendor_imports.py
+++ b/tests/test_vendor_imports.py
@@ -1,0 +1,86 @@
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+PATCH_SCRIPT = ROOT_DIR / "scripts/patch_vendor_imports.py"
+VENDOR_DIR = ROOT_DIR / "direct_cli/_vendor/tapi_yandex_direct"
+
+
+def test_patch_vendor_imports_rewrites_absolute_imports(tmp_path):
+    vendor_dir = tmp_path / "tapi_yandex_direct"
+    vendor_dir.mkdir()
+    module = vendor_dir / "tapi_yandex_direct.py"
+    init_file = vendor_dir / "__init__.py"
+
+    module.write_text(
+        "\n".join(
+            [
+                "from tapi_yandex_direct import exceptions",
+                "from tapi_yandex_direct.resource_mapping import RESOURCE_MAPPING_V5",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    init_file.write_text(
+        "from tapi_yandex_direct.tapi_yandex_direct import YandexDirect\n",
+        encoding="utf-8",
+    )
+
+    subprocess.run(
+        [sys.executable, str(PATCH_SCRIPT), str(vendor_dir)],
+        check=True,
+        cwd=ROOT_DIR,
+    )
+    first_module = module.read_text(encoding="utf-8")
+    first_init = init_file.read_text(encoding="utf-8")
+
+    subprocess.run(
+        [sys.executable, str(PATCH_SCRIPT), str(vendor_dir)],
+        check=True,
+        cwd=ROOT_DIR,
+    )
+
+    assert first_module == module.read_text(encoding="utf-8")
+    assert first_init == init_file.read_text(encoding="utf-8")
+    assert first_module == "\n".join(
+        [
+            "from . import exceptions",
+            "from .resource_mapping import RESOURCE_MAPPING_V5",
+            "",
+        ]
+    )
+    assert first_init == "from .tapi_yandex_direct import YandexDirect\n"
+
+
+def test_patch_vendor_imports_rejects_plain_absolute_import(tmp_path):
+    vendor_dir = tmp_path / "tapi_yandex_direct"
+    vendor_dir.mkdir()
+    module = vendor_dir / "tapi_yandex_direct.py"
+    module.write_text("import tapi_yandex_direct\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, str(PATCH_SCRIPT), str(vendor_dir)],
+        cwd=ROOT_DIR,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "unsupported absolute import" in result.stderr
+
+
+def test_vendored_tapi_yandex_direct_uses_relative_imports():
+    offenders = []
+    for path in VENDOR_DIR.rglob("*.py"):
+        for line_number, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), 1
+        ):
+            stripped = line.strip()
+            if stripped.startswith(
+                ("from tapi_yandex_direct", "import tapi_yandex_direct")
+            ):
+                offenders.append(f"{path.relative_to(ROOT_DIR)}:{line_number}: {line}")
+
+    assert offenders == []

--- a/tests/test_vendor_imports.py
+++ b/tests/test_vendor_imports.py
@@ -90,6 +90,25 @@ def test_patch_vendor_imports_rejects_multiline_import(tmp_path):
     assert module.read_text(encoding="utf-8") == "from tapi_yandex_direct import (\n"
 
 
+def test_patch_vendor_imports_rejects_backslash_continuation(tmp_path):
+    vendor_dir = tmp_path / "tapi_yandex_direct"
+    vendor_dir.mkdir()
+    module = vendor_dir / "tapi_yandex_direct.py"
+    module.write_text("from tapi_yandex_direct import \\\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, str(PATCH_SCRIPT), str(vendor_dir)],
+        cwd=ROOT_DIR,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "multi-line import not supported" in result.stderr
+    # File must not be written (atomic patching)
+    assert module.read_text(encoding="utf-8") == "from tapi_yandex_direct import \\\n"
+
+
 def test_patch_vendor_imports_atomic_on_unsupported_import(tmp_path):
     """Verify no files are written when a later file has an unsupported import."""
     vendor_dir = tmp_path / "tapi_yandex_direct"

--- a/tests/test_vendor_imports.py
+++ b/tests/test_vendor_imports.py
@@ -71,6 +71,51 @@ def test_patch_vendor_imports_rejects_plain_absolute_import(tmp_path):
     assert "unsupported absolute import" in result.stderr
 
 
+def test_patch_vendor_imports_rejects_multiline_import(tmp_path):
+    vendor_dir = tmp_path / "tapi_yandex_direct"
+    vendor_dir.mkdir()
+    module = vendor_dir / "tapi_yandex_direct.py"
+    module.write_text("from tapi_yandex_direct import (\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, str(PATCH_SCRIPT), str(vendor_dir)],
+        cwd=ROOT_DIR,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "multi-line import not supported" in result.stderr
+    # File must not be written (atomic patching)
+    assert module.read_text(encoding="utf-8") == "from tapi_yandex_direct import (\n"
+
+
+def test_patch_vendor_imports_atomic_on_unsupported_import(tmp_path):
+    """Verify no files are written when a later file has an unsupported import."""
+    vendor_dir = tmp_path / "tapi_yandex_direct"
+    vendor_dir.mkdir()
+    good_file = vendor_dir / "good.py"
+    bad_file = vendor_dir / "zzz_bad.py"
+
+    good_file.write_text(
+        "from tapi_yandex_direct import exceptions\n", encoding="utf-8"
+    )
+    bad_file.write_text("import tapi_yandex_direct\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, str(PATCH_SCRIPT), str(vendor_dir)],
+        cwd=ROOT_DIR,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    # good.py must remain unpatched (atomic)
+    assert good_file.read_text(encoding="utf-8") == (
+        "from tapi_yandex_direct import exceptions\n"
+    )
+
+
 def test_vendored_tapi_yandex_direct_uses_relative_imports():
     offenders = []
     for path in VENDOR_DIR.rglob("*.py"):


### PR DESCRIPTION
## Summary
- add a vendor import patch helper for upstream tapi_yandex_direct absolute imports
- run the helper and a YandexDirect smoke import from scripts/update_vendor.sh
- add regression tests for rewrite/idempotence/error handling and real vendor import scanning

Closes #93

## Test Plan
- bash -n scripts/update_vendor.sh
- python3 scripts/patch_vendor_imports.py direct_cli/_vendor/tapi_yandex_direct
- python3 -c "from direct_cli._vendor.tapi_yandex_direct import YandexDirect; YandexDirect(access_token='test-token')"
- python3 -m pytest tests/test_transport_contract.py tests/test_vendor_imports.py -q
- python3 -m pytest tests/test_api_coverage.py tests/test_auth_bw.py tests/test_auth_oauth.py tests/test_auth_op.py tests/test_cli.py tests/test_comprehensive.py tests/test_dry_run.py tests/test_reports_drift.py tests/test_transport_contract.py tests/test_vendor_imports.py -q
- python3 -m black --check scripts/patch_vendor_imports.py tests/test_vendor_imports.py

## Notes
- Full python3 -m pytest was also run and hit 7 existing live/read-only integration failures unrelated to this vendor patch path.