### PR TITLE
feat(auth): auto-resolve login after OAuth, fix test isolation

### DIFF
--- a/direct_cli/auth.py
+++ b/direct_cli/auth.py
@@ -10,6 +10,7 @@ import secrets
 import shutil
 import subprocess
 import tempfile
+import logging
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -273,6 +274,7 @@ def list_profiles(path: Optional[Path] = None) -> List[Dict[str, Any]]:
             "source": "env",
             "has_token": True,
             "has_login": bool(login),
+            "login": login or None,
             "active": profile_name == active_profile,
         }
 
@@ -361,7 +363,8 @@ def resolve_login(token: str) -> Optional[str]:
         with urllib.request.urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
             return data.get("login")
-    except Exception:
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError, json.JSONDecodeError) as exc:
+        logging.debug("resolve_login failed: %s", exc)
         return None
 
 

--- a/direct_cli/auth.py
+++ b/direct_cli/auth.py
@@ -268,6 +268,7 @@ def list_profiles(path: Optional[Path] = None) -> List[Dict[str, Any]]:
         if existing:
             existing["source"] = "oauth+env"
             existing["has_login"] = bool(existing["has_login"] or login)
+            existing["login"] = existing["login"] or login
             continue
         profiles[profile_name] = {
             "profile": profile_name,

--- a/direct_cli/auth.py
+++ b/direct_cli/auth.py
@@ -249,6 +249,7 @@ def list_profiles(path: Optional[Path] = None) -> List[Dict[str, Any]]:
             "source": "oauth",
             "has_token": True,
             "has_login": bool(login),
+            "login": login,
             "active": profile_name == active_profile,
         }
 
@@ -348,6 +349,20 @@ def exchange_oauth_code(
         raise RuntimeError("OAuth token response does not contain access_token")
     # TODO: Persist refresh_token/expires_in and refresh automatically.
     return access_token
+
+
+def resolve_login(token: str) -> Optional[str]:
+    """Resolve Yandex login from OAuth token via Passport API."""
+    request = urllib.request.Request(
+        "https://login.yandex.ru/info",
+        headers={"Authorization": f"OAuth {token}"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            return data.get("login")
+    except Exception:
+        return None
 
 
 def get_credentials(

--- a/direct_cli/commands/auth.py
+++ b/direct_cli/commands/auth.py
@@ -118,6 +118,9 @@ def status(profile):
     if oauth_profile:
         source = "oauth"
         login_value = oauth_profile.get("login")
+        if not login_value and env_login:
+            login_value = env_login
+            source = "oauth+env"
     elif env_token:
         source = "env"
         login_value = env_login

--- a/direct_cli/commands/auth.py
+++ b/direct_cli/commands/auth.py
@@ -11,6 +11,7 @@ from ..auth import (
     get_env_profile,
     get_oauth_profile,
     list_profiles,
+    resolve_login,
     save_oauth_profile,
     set_active_profile,
 )
@@ -35,6 +36,8 @@ def login(profile, code, oauth_token, client_id, client_secret, login):
 
     token = oauth_token
     if token:
+        if not login:
+            login = resolve_login(token)
         save_oauth_profile(profile=profile, token=token, login=login)
         print_success(f"Profile '{profile}' is saved and active.")
         return
@@ -64,6 +67,8 @@ def login(profile, code, oauth_token, client_id, client_secret, login):
     except RuntimeError as error:
         raise click.ClickException(str(error))
 
+    if not login:
+        login = resolve_login(token)
     save_oauth_profile(profile=profile, token=token, login=login)
     print_success(f"Profile '{profile}' is saved and active.")
 
@@ -78,9 +83,9 @@ def list_command():
 
     for item in profiles:
         marker = "*" if item["active"] else " "
-        login_state = "yes" if item["has_login"] else "no"
+        login_display = item.get("login") or "(not set)"
         click.echo(
-            f"{marker} {item['profile']}  source={item['source']}  login={login_state}"
+            f"{marker} {item['profile']}  source={item['source']}  login={login_display}"
         )
 
 
@@ -112,14 +117,17 @@ def status(profile):
 
     if oauth_profile:
         source = "oauth"
-        has_login = bool(oauth_profile.get("login"))
+        login_value = oauth_profile.get("login")
     elif env_token:
         source = "env"
-        has_login = bool(env_login)
+        login_value = env_login
     else:
         raise click.ClickException(f"Profile '{selected}' is not configured.")
 
     click.echo(f"profile={selected}")
     click.echo(f"source={source}")
     click.echo("has_token=yes")
-    click.echo(f"has_login={'yes' if has_login else 'no'}")
+    if login_value:
+        click.echo(f"login={login_value}")
+    else:
+        click.echo("login=(not set)")

--- a/scripts/test_safe_commands.sh
+++ b/scripts/test_safe_commands.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Test all read-only (safe) direct-cli commands against the real Yandex Direct API.
 # Usage: ./scripts/test_safe_commands.sh
-# Requires .env with YANDEX_DIRECT_TOKEN and YANDEX_DIRECT_LOGIN in project root.
+# Credentials: loads .env if present, otherwise uses auth profile from direct auth login.
 
 set -euo pipefail
 
@@ -23,23 +23,40 @@ CYAN='\033[0;36m'
 BOLD='\033[1m'
 RESET='\033[0m'
 
-# ─── Load .env ────────────────────────────────────────────────────────────────
+# ─── Credentials ──────────────────────────────────────────────────────────────
+AUTH_SOURCE=""
+
 if [ -f "$ENV_FILE" ]; then
   set +u
   # shellcheck disable=SC2046
   export $(grep -v '^#' "$ENV_FILE" | grep -v '^$' | xargs)
   set -u
+  AUTH_SOURCE="env"
 fi
 
-if [ -z "${YANDEX_DIRECT_TOKEN:-}" ] || [ -z "${YANDEX_DIRECT_LOGIN:-}" ]; then
-  echo -e "${RED}ERROR:${RESET} YANDEX_DIRECT_TOKEN and YANDEX_DIRECT_LOGIN must be set."
-  echo "       Put them in .env or export them before running this script."
-  exit 1
+# Fallback: if .env didn't provide credentials, try auth profile
+if [ -z "${YANDEX_DIRECT_TOKEN:-}" ]; then
+  if direct auth status >/dev/null 2>&1; then
+    AUTH_SOURCE="profile"
+  else
+    echo -e "${RED}ERROR:${RESET} No credentials found."
+    echo "       Use 'direct auth login', put .env, or export YANDEX_DIRECT_TOKEN."
+    exit 1
+  fi
+fi
+
+if [ "$AUTH_SOURCE" = "profile" ]; then
+  AUTH_LOGIN=$(direct auth status 2>&1 | grep '^login=' | cut -d= -f2)
+  AUTH_TOKEN_HINT=$(direct auth status 2>&1 | head -1 | cut -d= -f2)
+else
+  AUTH_LOGIN="${YANDEX_DIRECT_LOGIN:-}"
+  AUTH_TOKEN_HINT="${YANDEX_DIRECT_TOKEN:0:8}..."
 fi
 
 echo -e "${BOLD}direct-cli safe commands test${RESET}"
-echo "Login: $YANDEX_DIRECT_LOGIN"
-echo "Token: ${YANDEX_DIRECT_TOKEN:0:8}..."
+echo "Source: $AUTH_SOURCE"
+echo "Login: $AUTH_LOGIN"
+echo "Token: $AUTH_TOKEN_HINT"
 python3 - <<'PY'
 from direct_cli.smoke_matrix import SAFE, commands_for_category
 
@@ -182,16 +199,20 @@ echo ""
 echo -e "${BOLD}=== B. Аутентификация через CLI-флаги ===${RESET}"
 echo ""
 
-T="$YANDEX_DIRECT_TOKEN"
-L="$YANDEX_DIRECT_LOGIN"
+if [ -n "${YANDEX_DIRECT_TOKEN:-}" ]; then
+  T="$YANDEX_DIRECT_TOKEN"
+  L="${YANDEX_DIRECT_LOGIN:-}"
 
-run_test "campaigns get (flag auth)"          direct --token "$T" --login "$L" campaigns get
-run_test "clients get (flag auth)"            direct --token "$T" --login "$L" clients get
-run_test "dictionaries list-names (flag auth)" direct --token "$T" --login "$L" dictionaries list-names
-run_test "reports list-types (flag auth)"     direct --token "$T" --login "$L" reports list-types
+  run_test "campaigns get (flag auth)"          direct --token "$T" --login "$L" campaigns get
+  run_test "clients get (flag auth)"            direct --token "$T" --login "$L" clients get
+  run_test "dictionaries list-names (flag auth)" direct --token "$T" --login "$L" dictionaries list-names
+  run_test "reports list-types (flag auth)"     direct --token "$T" --login "$L" reports list-types
 
-if [ -n "$CAMPAIGN_ID" ]; then
-  run_test "adgroups get (flag auth)"         direct --token "$T" --login "$L" adgroups get --campaign-ids "$CAMPAIGN_ID"
+  if [ -n "$CAMPAIGN_ID" ]; then
+    run_test "adgroups get (flag auth)"         direct --token "$T" --login "$L" adgroups get --campaign-ids "$CAMPAIGN_ID"
+  fi
+else
+  echo -e "  ${YELLOW}[SKIP]${RESET} Секция B — нет YANDEX_DIRECT_TOKEN в env (используется auth profile)"
 fi
 
 echo ""

--- a/scripts/test_safe_commands.sh
+++ b/scripts/test_safe_commands.sh
@@ -47,7 +47,7 @@ fi
 
 if [ "$AUTH_SOURCE" = "profile" ]; then
   AUTH_LOGIN=$(direct auth status 2>&1 | grep '^login=' | cut -d= -f2)
-  AUTH_TOKEN_HINT=$(direct auth status 2>&1 | head -1 | cut -d= -f2)
+  AUTH_TOKEN_HINT="(auth profile)"
 else
   AUTH_LOGIN="${YANDEX_DIRECT_LOGIN:-}"
   AUTH_TOKEN_HINT="${YANDEX_DIRECT_TOKEN:0:8}..."

--- a/tests/test_auth_bw.py
+++ b/tests/test_auth_bw.py
@@ -76,8 +76,9 @@ class TestGetCredentialsBw:
     """Tests for Bitwarden fallback in get_credentials"""
 
     @patch("direct_cli.auth.load_env_file")
+    @patch("direct_cli.auth.get_active_profile", return_value=None)
     @patch("direct_cli.auth.bw_read", return_value="bw-token-value")
-    def test_get_credentials_bw_fallback(self, mock_bw_read, mock_load, monkeypatch):
+    def test_get_credentials_bw_fallback(self, mock_bw_read, mock_profile, mock_load, monkeypatch):
         monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
         monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
         monkeypatch.delenv("YANDEX_DIRECT_OP_TOKEN_REF", raising=False)
@@ -90,9 +91,10 @@ class TestGetCredentialsBw:
         mock_bw_read.assert_called_once_with("yandex-direct-item", "password")
 
     @patch("direct_cli.auth.load_env_file")
+    @patch("direct_cli.auth.get_active_profile", return_value=None)
     @patch("direct_cli.auth.bw_read")
     def test_get_credentials_env_takes_priority_over_bw(
-        self, mock_bw_read, mock_load, monkeypatch
+        self, mock_bw_read, mock_profile, mock_load, monkeypatch
     ):
         monkeypatch.setenv("YANDEX_DIRECT_TOKEN", "env-token")
         monkeypatch.setenv("YANDEX_DIRECT_BW_TOKEN_REF", "yandex-direct-item")
@@ -102,9 +104,10 @@ class TestGetCredentialsBw:
         mock_bw_read.assert_not_called()
 
     @patch("direct_cli.auth.load_env_file")
+    @patch("direct_cli.auth.get_active_profile", return_value=None)
     @patch("direct_cli.auth.bw_read", return_value="bw-login-value")
     def test_get_credentials_bw_login_fallback(
-        self, mock_bw_read, mock_load, monkeypatch
+        self, mock_bw_read, mock_profile, mock_load, monkeypatch
     ):
         monkeypatch.setenv("YANDEX_DIRECT_TOKEN", "some-token")
         monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
@@ -116,9 +119,10 @@ class TestGetCredentialsBw:
         mock_bw_read.assert_called_once_with("yandex-direct-item", "username")
 
     @patch("direct_cli.auth.load_env_file")
+    @patch("direct_cli.auth.get_active_profile", return_value=None)
     @patch("direct_cli.auth.bw_read", return_value="bw-token-value")
     def test_get_credentials_explicit_bw_ref_param(
-        self, mock_bw_read, mock_load, monkeypatch
+        self, mock_bw_read, mock_profile, mock_load, monkeypatch
     ):
         monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
         monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
@@ -132,10 +136,11 @@ class TestGetCredentialsBw:
         mock_bw_read.assert_called_once_with("yandex-direct-item", "password")
 
     @patch("direct_cli.auth.load_env_file")
+    @patch("direct_cli.auth.get_active_profile", return_value=None)
     @patch("direct_cli.auth.op_read", return_value="op-token-value")
     @patch("direct_cli.auth.bw_read")
     def test_op_takes_priority_over_bw(
-        self, mock_bw_read, mock_op_read, mock_load, monkeypatch
+        self, mock_bw_read, mock_op_read, mock_profile, mock_load, monkeypatch
     ):
         monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
         monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
@@ -159,9 +164,10 @@ class TestCLIBwOptions:
         assert "--bw-login-ref" in result.output
 
     @patch("direct_cli.auth.load_env_file")
+    @patch("direct_cli.auth.get_active_profile", return_value=None)
     @patch("direct_cli.auth.bw_read", return_value="resolved-bw-token")
     def test_bw_token_ref_resolves_via_cli_flag(
-        self, mock_bw_read, mock_load, monkeypatch
+        self, mock_bw_read, mock_profile, mock_load, monkeypatch
     ):
         monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
         monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
@@ -183,12 +189,13 @@ class TestCLIBwOptions:
         mock_bw_read.assert_called_once_with("yandex-direct-item", "password")
 
     @patch("direct_cli.auth.load_env_file")
+    @patch("direct_cli.auth.get_active_profile", return_value=None)
     @patch(
         "direct_cli.auth.bw_read",
         side_effect=RuntimeError("Bitwarden CLI (bw) not found"),
     )
     def test_bw_token_ref_error_surfaces_cleanly(
-        self, mock_bw_read, mock_load, monkeypatch
+        self, mock_bw_read, mock_profile, mock_load, monkeypatch
     ):
         monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
         monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)

--- a/tests/test_auth_op.py
+++ b/tests/test_auth_op.py
@@ -55,8 +55,9 @@ class TestGetCredentialsOp:
     """Tests for 1Password fallback in get_credentials"""
 
     @patch("direct_cli.auth.load_env_file")
+    @patch("direct_cli.auth.get_active_profile", return_value=None)
     @patch("direct_cli.auth.op_read", return_value="op-token-value")
-    def test_get_credentials_op_fallback(self, mock_op_read, mock_load, monkeypatch):
+    def test_get_credentials_op_fallback(self, mock_op_read, mock_profile, mock_load, monkeypatch):
         monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
         monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
         monkeypatch.setenv("YANDEX_DIRECT_OP_TOKEN_REF", "op://vault/item/token")
@@ -66,9 +67,10 @@ class TestGetCredentialsOp:
         mock_op_read.assert_called_once_with("op://vault/item/token")
 
     @patch("direct_cli.auth.load_env_file")
+    @patch("direct_cli.auth.get_active_profile", return_value=None)
     @patch("direct_cli.auth.op_read")
     def test_get_credentials_env_takes_priority_over_op(
-        self, mock_op_read, mock_load, monkeypatch
+        self, mock_op_read, mock_profile, mock_load, monkeypatch
     ):
         monkeypatch.setenv("YANDEX_DIRECT_TOKEN", "env-token")
         monkeypatch.setenv("YANDEX_DIRECT_OP_TOKEN_REF", "op://vault/item/token")
@@ -78,9 +80,10 @@ class TestGetCredentialsOp:
         mock_op_read.assert_not_called()
 
     @patch("direct_cli.auth.load_env_file")
+    @patch("direct_cli.auth.get_active_profile", return_value=None)
     @patch("direct_cli.auth.op_read", return_value="op-login-value")
     def test_get_credentials_op_login_fallback(
-        self, mock_op_read, mock_load, monkeypatch
+        self, mock_op_read, mock_profile, mock_load, monkeypatch
     ):
         monkeypatch.setenv("YANDEX_DIRECT_TOKEN", "some-token")
         monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
@@ -91,9 +94,10 @@ class TestGetCredentialsOp:
         mock_op_read.assert_called_once_with("op://vault/item/login")
 
     @patch("direct_cli.auth.load_env_file")
+    @patch("direct_cli.auth.get_active_profile", return_value=None)
     @patch("direct_cli.auth.op_read", return_value="op-token-value")
     def test_get_credentials_explicit_op_ref_param(
-        self, mock_op_read, mock_load, monkeypatch
+        self, mock_op_read, mock_profile, mock_load, monkeypatch
     ):
         monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
         monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
@@ -114,9 +118,10 @@ class TestCLIOpOptions:
         assert "--op-login-ref" in result.output
 
     @patch("direct_cli.auth.load_env_file")
+    @patch("direct_cli.auth.get_active_profile", return_value=None)
     @patch("direct_cli.auth.op_read", return_value="resolved-op-token")
     def test_op_token_ref_resolves_via_cli_flag(
-        self, mock_op_read, mock_load, monkeypatch
+        self, mock_op_read, mock_profile, mock_load, monkeypatch
     ):
         monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
         monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
@@ -129,12 +134,13 @@ class TestCLIOpOptions:
         mock_op_read.assert_called_once_with("op://vault/item/token")
 
     @patch("direct_cli.auth.load_env_file")
+    @patch("direct_cli.auth.get_active_profile", return_value=None)
     @patch(
         "direct_cli.auth.op_read",
         side_effect=RuntimeError("1Password CLI (op) not found"),
     )
     def test_op_token_ref_error_surfaces_cleanly(
-        self, mock_op_read, mock_load, monkeypatch
+        self, mock_op_read, mock_profile, mock_load, monkeypatch
     ):
         monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
         monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -149,8 +149,9 @@ class TestAuth(unittest.TestCase):
 
         with patch.dict(os.environ, {}, clear=True):
             with patch("direct_cli.auth.load_env_file"):
-                with self.assertRaises(ValueError) as context:
-                    get_credentials(token=None, login=None)
+                with patch("direct_cli.auth.get_active_profile", return_value=None):
+                    with self.assertRaises(ValueError) as context:
+                        get_credentials(token=None, login=None)
 
         self.assertIn("API token required", str(context.exception))
 

--- a/tests/test_comprehensive.py
+++ b/tests/test_comprehensive.py
@@ -153,8 +153,9 @@ class TestAuth(unittest.TestCase):
         """Raises ValueError when no token is available anywhere"""
         with patch.dict(os.environ, {}, clear=True):
             with patch("direct_cli.auth.load_env_file"):
-                with self.assertRaises(ValueError) as ctx:
-                    auth.get_credentials(token=None, login=None)
+                with patch("direct_cli.auth.get_active_profile", return_value=None):
+                    with self.assertRaises(ValueError) as ctx:
+                        auth.get_credentials(token=None, login=None)
         self.assertIn("API token required", str(ctx.exception))
 
     def test_token_from_argument(self):
@@ -165,7 +166,8 @@ class TestAuth(unittest.TestCase):
     def test_token_from_env(self):
         with patch.dict(os.environ, {"YANDEX_DIRECT_TOKEN": "env_token"}, clear=True):
             with patch("direct_cli.auth.load_env_file"):
-                token, login = auth.get_credentials(token=None, login=None)
+                with patch("direct_cli.auth.get_active_profile", return_value=None):
+                    token, login = auth.get_credentials(token=None, login=None)
         self.assertEqual(token, "env_token")
 
     def test_argument_takes_priority_over_env(self):
@@ -181,7 +183,8 @@ class TestErrorHandling(unittest.TestCase):
         """Command must fail when no token is provided"""
         runner = CliRunner(env={"YANDEX_DIRECT_TOKEN": "", "YANDEX_DIRECT_LOGIN": ""})
         with patch("direct_cli.auth.load_env_file"):
-            result = runner.invoke(cli, ["campaigns", "get"])
+            with patch("direct_cli.auth.get_active_profile", return_value=None):
+                result = runner.invoke(cli, ["campaigns", "get"])
         self.assertNotEqual(result.exit_code, 0)
 
 

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -48,6 +48,7 @@ Part of axisrow/yandex-direct-mcp-plugin#61.
 """
 
 import json
+from unittest.mock import patch
 
 from click.testing import CliRunner
 
@@ -1077,25 +1078,26 @@ def test_reports_get_type_is_case_insensitive():
     click.Choice(..., case_sensitive=False) on REPORT_TYPES normalizes
     the input — users can type ``campaign_performance_report``.
     """
-    result = CliRunner(
-        env={"YANDEX_DIRECT_TOKEN": "", "YANDEX_DIRECT_LOGIN": ""},
-    ).invoke(
-        cli,
-        [
-            "reports",
-            "get",
-            "--type",
-            "campaign_performance_report",
-            "--from",
-            "2026-01-01",
-            "--to",
-            "2026-01-31",
-            "--name",
-            "X",
-            "--fields",
-            "Date",
-        ],
-    )
+    with patch("direct_cli.auth.get_active_profile", return_value=None):
+        result = CliRunner(
+            env={"YANDEX_DIRECT_TOKEN": "", "YANDEX_DIRECT_LOGIN": ""},
+        ).invoke(
+            cli,
+            [
+                "reports",
+                "get",
+                "--type",
+                "campaign_performance_report",
+                "--from",
+                "2026-01-01",
+                "--to",
+                "2026-01-31",
+                "--name",
+                "X",
+                "--fields",
+                "Date",
+            ],
+        )
     # Force a missing-token failure so this unit test cannot make a real
     # reports request when a developer/CI environment has credentials set.
     # What we care about is that Click's parameter parser did NOT reject


### PR DESCRIPTION
## Summary
- **Auto-resolve login**: After `direct auth login`, the CLI now queries Yandex Passport API (`login.yandex.ru/info`) to automatically resolve and save the login alongside the token — no need to pass `--login` manually
- **Show login in auth commands**: `direct auth list` and `direct auth status` now display the actual login value (e.g. `login=axisrow`) instead of just `has_login=yes`
- **Fix test isolation**: Mock `get_active_profile()` in all tests that call `get_credentials()` to prevent real `~/.direct-cli/auth.json` from leaking token/profile data into test runs (5 test files)
- **Auth profile fallback in safe test script**: `scripts/test_safe_commands.sh` now works without `.env` — falls back to the configured auth profile via `direct auth status`

## Test plan
- [x] `pytest` passes with real `auth.json` present (test isolation verified)
- [x] `direct auth login --oauth-token TOKEN` auto-resolves login
- [x] `direct auth status` shows `login=axisrow`
- [x] `direct auth list` shows actual login value
- [x] `scripts/test_safe_commands.sh` works with auth profile (no .env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)