### PR TITLE
feat(utils): add get_docs_url() helper for tapi resource_mapping docs URLs

### DIFF
--- a/direct_cli/utils.py
+++ b/direct_cli/utils.py
@@ -7,6 +7,10 @@ import json
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
+from direct_cli._vendor.tapi_yandex_direct.resource_mapping import (
+    RESOURCE_MAPPING_V5,
+)
+
 
 def parse_ids(ids_str: Optional[str]) -> Optional[List[int]]:
     """Parse comma-separated IDs"""
@@ -263,3 +267,9 @@ COMMON_FIELDS = {
 def get_default_fields(resource: str) -> List[str]:
     """Get default field names for resource"""
     return COMMON_FIELDS.get(resource, ["Id", "Name"])
+
+
+def get_docs_url(service: str) -> Optional[str]:
+    """Return documentation URL for a service from tapi resource mapping."""
+    entry = RESOURCE_MAPPING_V5.get(service)
+    return entry.get("docs") if entry else None


### PR DESCRIPTION
## Summary
- Add `get_docs_url(service)` helper that reads documentation URLs from vendored `RESOURCE_MAPPING_V5`
- Avoids hardcoding/duplicating docs URLs in direct-cli codebase
- Prerequisite for issue #103 (replace hardcoded URLs in reports_coverage.py)

## Test plan
- [x] `ruff check` passes
- [x] All 288 tests pass
- [ ] Downstream: when tapi-yandex-direct adds `docs_pages` (issue axisrow/tapi-yandex-direct#10), update reports_coverage.py to use this helper

Related: axisrow/tapi-yandex-direct#10, #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)