### PR TITLE
fix(tests): use get_credentials() instead of os.getenv for test auth

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,8 +27,23 @@ from direct_cli.cli import cli
 
 load_dotenv()
 
-_REAL_TOKEN = os.getenv("YANDEX_DIRECT_TOKEN")
-_REAL_LOGIN = os.getenv("YANDEX_DIRECT_LOGIN")
+
+def _resolve_test_credentials():
+    """Resolve real API credentials using the full auth priority chain.
+
+    Walks the same resolution as the CLI: direct args → OAuth profile →
+    env vars → .env → 1Password → Bitwarden.  Returns (None, None) when
+    no credentials are available (e.g. CI with VCR replay only).
+    """
+    from direct_cli.auth import get_credentials
+
+    try:
+        return get_credentials()
+    except (ValueError, RuntimeError):
+        return None, None
+
+
+_REAL_TOKEN, _REAL_LOGIN = _resolve_test_credentials()
 
 # A dummy token is fine in replay mode — VCR intercepts the request before
 # it touches the network.  In rewrite/record mode the real token from the
@@ -37,7 +52,7 @@ TOKEN = _REAL_TOKEN or "REPLAY_DUMMY_TOKEN"
 
 skip_if_no_token = pytest.mark.skipif(
     not _REAL_TOKEN,
-    reason="YANDEX_DIRECT_TOKEN is not set — skipping integration tests",
+    reason="No API credentials found — skipping integration tests",
 )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,6 @@ before committing.
 """
 
 import json
-import os
 import re
 
 import pytest
@@ -39,7 +38,7 @@ def _resolve_test_credentials():
 
     try:
         return get_credentials()
-    except (ValueError, RuntimeError):
+    except ValueError:
         return None, None
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -24,22 +24,16 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 import unittest
 
 import pytest
 from click.testing import CliRunner
-from dotenv import load_dotenv
 
 from direct_cli.cli import cli
 
-load_dotenv()
-
-TOKEN = os.getenv("YANDEX_DIRECT_TOKEN")
-
-skip_if_no_token = pytest.mark.skipif(
-    not TOKEN,
-    reason="YANDEX_DIRECT_TOKEN is not set — skipping integration tests",
-)
+sys.path.insert(0, os.path.dirname(__file__))
+from conftest import skip_if_no_token  # noqa: E402
 
 
 def make_runner():

--- a/tests/test_integration_live_write.py
+++ b/tests/test_integration_live_write.py
@@ -122,12 +122,11 @@ pytestmark = [
 
 def _invoke_live(*args: str):
     """Invoke a CLI command against production API with live credentials."""
-    token, login = _resolve_test_credentials()
-    assert token, "API credentials required for live draft write tests"
+    assert _LIVE_TOKEN, "API credentials required for live draft write tests"
 
-    all_args = ["--token", token]
-    if login:
-        all_args.extend(["--login", login])
+    all_args = ["--token", _LIVE_TOKEN]
+    if _LIVE_LOGIN:
+        all_args.extend(["--login", _LIVE_LOGIN])
     all_args.extend(args)
 
     return CliRunner().invoke(cli, all_args)

--- a/tests/test_integration_live_write.py
+++ b/tests/test_integration_live_write.py
@@ -36,15 +36,16 @@ Coverage status (issue #59):
 
 import json
 import os
+import sys
 from typing import Any, Dict, List, Optional
 
 import pytest
 from click.testing import CliRunner
-from dotenv import load_dotenv
 
 from direct_cli.cli import cli
 
-load_dotenv()
+sys.path.insert(0, os.path.dirname(__file__))
+from conftest import _resolve_test_credentials  # noqa: E402
 
 LIVE_WRITE_ENV = "YANDEX_DIRECT_LIVE_WRITE"
 TEST_CAMPAIGN_NAME = "direct-cli-live-draft-test-cassette"
@@ -101,6 +102,8 @@ _DRAFT_STATE_PATTERNS = (
 )
 
 
+_LIVE_TOKEN, _LIVE_LOGIN = _resolve_test_credentials()
+
 pytestmark = [
     pytest.mark.integration_live_write,
     pytest.mark.skipif(
@@ -108,8 +111,8 @@ pytestmark = [
         reason=f"{LIVE_WRITE_ENV}=1 is required for live draft write tests",
     ),
     pytest.mark.skipif(
-        not os.getenv("YANDEX_DIRECT_TOKEN"),
-        reason="YANDEX_DIRECT_TOKEN is required for live draft write tests",
+        not _LIVE_TOKEN,
+        reason="No API credentials found for live draft write tests",
     ),
 ]
 
@@ -119,11 +122,10 @@ pytestmark = [
 
 def _invoke_live(*args: str):
     """Invoke a CLI command against production API with live credentials."""
-    token = os.getenv("YANDEX_DIRECT_TOKEN")
-    assert token, "YANDEX_DIRECT_TOKEN is required for live draft write tests"
+    token, login = _resolve_test_credentials()
+    assert token, "API credentials required for live draft write tests"
 
     all_args = ["--token", token]
-    login = os.getenv("YANDEX_DIRECT_LOGIN")
     if login:
         all_args.extend(["--login", login])
     all_args.extend(args)


### PR DESCRIPTION
## Summary
- Integration tests (`conftest.py`, `test_integration.py`, `test_integration_live_write.py`) used `os.getenv("YANDEX_DIRECT_TOKEN")` directly, bypassing the standard auth priority chain in `auth.py:get_credentials()`
- Users with valid OAuth profiles (stored in `~/.direct-cli/auth.json`) but without `YANDEX_DIRECT_TOKEN` env var got all 24 integration tests **SKIPPED** despite having valid credentials
- Adds `_resolve_test_credentials()` helper in `conftest.py` that calls `get_credentials()` with the full priority chain: direct args → OAuth profile → env vars → .env → 1Password → Bitwarden
- `test_integration.py` now imports `skip_if_no_token` from conftest (eliminates duplication)
- `test_integration_live_write.py` now uses `_resolve_test_credentials()` in both `pytestmark` skipif and `_invoke_live()`

## Test plan
- [x] `pytest tests/ -m "not integration and not integration_write and not integration_live_write" -v` — 278 passed, no regressions
- [x] `pytest tests/test_integration_write.py -v` — 10 passed, 9 skipped (VCR replay unchanged)
- [x] `pytest tests/test_integration.py -v` — **18 passed** (previously 24 skipped with OAuth profile)