### PR TITLE
[codex] Fix integration discovery for Direct resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,23 @@ Notes:
 - Authorization is performed via `direct auth login`.
 - Alias `auth_login` is not supported.
 
+Credential resolution priority:
+
+| Priority | Source | Example |
+|----------|--------|---------|
+| 1 | Explicit CLI options | `direct --token TOKEN --login LOGIN campaigns get` |
+| 2 | OAuth profile storage | `direct --profile agency1 campaigns get` |
+| 3 | Profile-specific env vars | `YANDEX_DIRECT_TOKEN_AGENCY1`, `YANDEX_DIRECT_LOGIN_AGENCY1` |
+| 4 | Base env vars or project `.env` | `YANDEX_DIRECT_TOKEN`, `YANDEX_DIRECT_LOGIN` |
+| 5 | 1Password references | `--op-token-ref`, `YANDEX_DIRECT_OP_TOKEN_REF` |
+| 6 | Bitwarden references | `--bw-token-ref`, `YANDEX_DIRECT_BW_TOKEN_REF` |
+
+The project `.env` file is loaded automatically. If a profile is selected
+with `--profile` or `direct auth use --profile NAME`, Direct CLI does not
+fall back to base `YANDEX_DIRECT_LOGIN`; this prevents mixing a profile token
+with a login from the project `.env`. For multi-account setups, prefer OAuth
+profiles or profile-specific env vars instead of base credentials.
+
 Install with `pip install direct-cli`, then run commands with `direct`.
 Invoking the deprecated `direct-cli` entrypoint exits with
 `use direct instead of direct-cli`.
@@ -595,6 +612,45 @@ YANDEX_DIRECT_LOGIN=ваш_логин_на_яндексе
 direct --token ВАШ_ТОКЕН --login ВАШ_ЛОГИН campaigns get
 ```
 
+Используйте профильные credentials из `.env`:
+
+```env
+YANDEX_DIRECT_TOKEN_AGENCY1=token-1
+YANDEX_DIRECT_LOGIN_AGENCY1=client-login-1
+YANDEX_DIRECT_TOKEN_AGENCY2=token-2
+YANDEX_DIRECT_LOGIN_AGENCY2=client-login-2
+```
+
+OAuth и profile-команды:
+
+```bash
+direct auth login
+direct auth login --profile agency1
+direct auth login --code abc123 --profile agency1
+direct auth login --oauth-token y0_example --profile agency1
+direct auth list
+direct auth use --profile agency1
+direct auth status --profile agency1
+direct --profile agency1 campaigns get
+```
+
+Порядок выбора credentials:
+
+| Приоритет | Источник | Пример |
+|-----------|----------|--------|
+| 1 | Явные CLI-опции | `direct --token TOKEN --login LOGIN campaigns get` |
+| 2 | OAuth profile storage | `direct --profile agency1 campaigns get` |
+| 3 | Профильные env vars | `YANDEX_DIRECT_TOKEN_AGENCY1`, `YANDEX_DIRECT_LOGIN_AGENCY1` |
+| 4 | Базовые env vars или project `.env` | `YANDEX_DIRECT_TOKEN`, `YANDEX_DIRECT_LOGIN` |
+| 5 | 1Password references | `--op-token-ref`, `YANDEX_DIRECT_OP_TOKEN_REF` |
+| 6 | Bitwarden references | `--bw-token-ref`, `YANDEX_DIRECT_BW_TOKEN_REF` |
+
+Файл `.env` в проекте загружается автоматически. Если профиль выбран через
+`--profile` или `direct auth use --profile NAME`, Direct CLI не подставляет
+base `YANDEX_DIRECT_LOGIN`; это защищает от смешивания токена из профиля с
+логином из project `.env`. Для нескольких аккаунтов используйте OAuth profiles
+или профильные env vars, а не базовые credentials.
+
 Установка остаётся через `pip install direct-cli`, а запуск команд теперь идет
 через `direct`. Вызов deprecated entrypoint `direct-cli` завершается ошибкой с
 подсказкой `use direct instead of direct-cli`.
@@ -605,6 +661,7 @@ direct --token ВАШ_ТОКЕН --login ВАШ_ЛОГИН campaigns get
 |-------|----------|
 | `--token` | OAuth-токен доступа к API |
 | `--login` | Direct client login |
+| `--profile` | Имя credential profile |
 | `--sandbox` | Использовать тестовое API (песочница) |
 
 ### Использование

--- a/direct_cli/commands/agencyclients.py
+++ b/direct_cli/commands/agencyclients.py
@@ -22,16 +22,23 @@ def _build_notification(
     if notification_lang:
         notification["Lang"] = notification_lang
     if notification_email:
-        notification["EmailSubscriptions"] = [
-            {
-                "Option": "RECEIVE_RECOMMENDATIONS",
-                "Value": "YES" if send_account_news else "NO",
-            },
-            {
-                "Option": "TRACK_POSITION_CHANGES",
-                "Value": "YES" if send_warnings else "NO",
-            },
-        ]
+        subscriptions = []
+        if send_account_news is not None:
+            subscriptions.append(
+                {
+                    "Option": "RECEIVE_RECOMMENDATIONS",
+                    "Value": "YES" if send_account_news else "NO",
+                }
+            )
+        if send_warnings is not None:
+            subscriptions.append(
+                {
+                    "Option": "TRACK_POSITION_CHANGES",
+                    "Value": "YES" if send_warnings else "NO",
+                }
+            )
+        if subscriptions:
+            notification["EmailSubscriptions"] = subscriptions
     return notification
 
 

--- a/direct_cli/commands/agencyclients.py
+++ b/direct_cli/commands/agencyclients.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import create_client
 from ..output import format_output, print_error
-from ..utils import get_default_fields, parse_ids
+from ..utils import get_default_fields
 
 
 def _build_notification(
@@ -21,10 +21,17 @@ def _build_notification(
         notification["Email"] = notification_email
     if notification_lang:
         notification["Lang"] = notification_lang
-    if send_account_news is not None:
-        notification["SendAccountNews"] = "YES" if send_account_news else "NO"
-    if send_warnings is not None:
-        notification["SendWarnings"] = "YES" if send_warnings else "NO"
+    if notification_email:
+        notification["EmailSubscriptions"] = [
+            {
+                "Option": "RECEIVE_RECOMMENDATIONS",
+                "Value": "YES" if send_account_news else "NO",
+            },
+            {
+                "Option": "TRACK_POSITION_CHANGES",
+                "Value": "YES" if send_warnings else "NO",
+            },
+        ]
     return notification
 
 
@@ -34,14 +41,21 @@ def agencyclients():
 
 
 @agencyclients.command()
-@click.option("--ids", help="Comma-separated client IDs")
+@click.option("--logins", help="Comma-separated client logins")
+@click.option(
+    "--archived",
+    type=click.Choice(["YES", "NO"]),
+    default="NO",
+    show_default=True,
+    help="Filter archived clients",
+)
 @click.option("--limit", type=int, help="Limit number of results")
 @click.option("--fetch-all", is_flag=True, help="Fetch all pages")
 @click.option("--format", "output_format", default="json", help="Output format")
 @click.option("--output", help="Output file")
 @click.option("--fields", help="Comma-separated field names")
 @click.pass_context
-def get(ctx, ids, limit, fetch_all, output_format, output, fields):
+def get(ctx, logins, archived, limit, fetch_all, output_format, output, fields):
     """Get agency clients"""
     try:
         client = create_client(
@@ -52,14 +66,11 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields):
 
         field_names = fields.split(",") if fields else get_default_fields("clients")
 
-        criteria = {}
-        if ids:
-            criteria["ClientIds"] = parse_ids(ids)
+        criteria = {"Archived": archived}
+        if logins:
+            criteria["Logins"] = [login.strip() for login in logins.split(",")]
 
-        params = {"FieldNames": field_names}
-
-        if criteria:
-            params["SelectionCriteria"] = criteria
+        params = {"SelectionCriteria": criteria, "FieldNames": field_names}
 
         if limit:
             params["Page"] = {"Limit": limit}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "direct-cli"
-version = "0.2.10"
+version = "0.2.11"
 description = "Command-line interface for Yandex Direct API"
 readme = "README.md"
 license = {text = "MIT"}

--- a/scripts/test_safe_commands.sh
+++ b/scripts/test_safe_commands.sh
@@ -80,6 +80,42 @@ run_test() {
   fi
 }
 
+is_agency_access_denied() {
+  local output="$1"
+  local pattern='(^|[^0-9])403([^0-9]|$)|error_code=54|Access denied|No rights to access the agency service'
+  grep -Eiq "$pattern" <<<"$output"
+}
+
+run_agencyclients_sandbox_get() {
+  local name="agencyclients get --sandbox"
+  local output exit_code has_dedicated_token
+  local -a cmd
+
+  has_dedicated_token=0
+  if [ -n "${YANDEX_DIRECT_AGENCY_TOKEN:-}" ]; then
+    has_dedicated_token=1
+    cmd=(direct --sandbox --token "$YANDEX_DIRECT_AGENCY_TOKEN")
+    if [ -n "${YANDEX_DIRECT_AGENCY_LOGIN:-}" ]; then
+      cmd+=(--login "$YANDEX_DIRECT_AGENCY_LOGIN")
+    fi
+    cmd+=(agencyclients get --limit 1 --format json)
+  else
+    cmd=(direct --sandbox agencyclients get --limit 1 --format json)
+  fi
+
+  output=$("${cmd[@]}" 2>&1) && exit_code=0 || exit_code=$?
+  if [ "$exit_code" -eq 0 ]; then
+    echo -e "  ${GREEN}[PASS]${RESET} $name"
+    ((PASS++)) || true
+  elif [ "$has_dedicated_token" -eq 0 ] && is_agency_access_denied "$output"; then
+    echo -e "  ${YELLOW}[SKIP]${RESET} $name — no agency sandbox credentials"
+  else
+    echo -e "  ${RED}[FAIL]${RESET} $name"
+    echo "$output" | head -3 | sed 's/^/         /'
+    ((FAIL++)) || true
+  fi
+}
+
 # Known-bug skip: prints [BUG #N] and counts separately, does not affect FAIL
 skip_bug() {
   local issue="$1"
@@ -165,9 +201,7 @@ run_test "sitelinks get --ids (env auth)"          direct sitelinks get --ids 1
 run_test "vcards get --ids (env auth)"             direct vcards get --ids 1
 run_test "leads get --turbo-page-ids (env auth)" direct leads get --turbo-page-ids 1 --limit 1
 run_test "clients get (env auth)"                  direct clients get
-# agencyclients requires agency account — tracked in #73
-echo -e "  ${CYAN}[BUG #73]${RESET} agencyclients get — требует агентский аккаунт (sandbox)"
-((KNOWN++)) || true
+run_agencyclients_sandbox_get
 run_test "feeds get --ids (env auth)"          direct feeds get --ids 1
 run_test "creatives get (env auth)"                direct creatives get
 # businesses requires Ids/Name/Url in SelectionCriteria

--- a/tests/API_COVERAGE.md
+++ b/tests/API_COVERAGE.md
@@ -105,6 +105,20 @@ Sandbox re-check is not useful — this is an account-tier limitation.
 Testing strategy: manual-only on an account where DYNAMIC_TEXT_CAMPAIGN and
 SMART_CAMPAIGN are enabled. See `tests/MANUAL_COVERAGE.md`.
 
+### Category C — account-permission limited (code 3001)
+
+The endpoint is available, but the current sandbox agency account does not
+have rights to create agency clients. This differs from read-only
+`agencyclients get`, which is covered against sandbox.
+
+| Scenario | Symptom | Error code | Test class |
+|---|---|---|---|
+| agencyclients add-passport-organization | no rights to create clients | 3001 | manual-only |
+
+Testing strategy: keep `agencyclients get` in read-only integration coverage;
+keep agency-client creation manual-only unless a sandbox agency account with
+client-creation rights is available.
+
 Originally classified in
 [#28 issuecomment-4275359621](https://github.com/axisrow/direct-cli/issues/28#issuecomment-4275359621)
 and

--- a/tests/MANUAL_COVERAGE.md
+++ b/tests/MANUAL_COVERAGE.md
@@ -14,9 +14,12 @@ account requirements, or external dependencies.
 ## Account-Scoped Operations
 
 - **agencyclients add/update/delete** — requires an agency-type account.
-  Non-agency accounts receive 403.
+  Non-agency accounts receive 403. The current sandbox agency account can
+  read agency clients, but creation returns error 3001: "No rights to create
+  clients".
 - **agencyclients add-passport-organization** — creates a real Passport
-  organization linked to the account.
+  organization linked to the account. The current sandbox agency account is
+  sandbox-limited for this operation with error 3001.
 - **agencyclients add-passport-organization-member** — sends an invitation
   email to an external user.
 
@@ -64,8 +67,8 @@ Live tests skip gracefully when the API returns error 3500.
 |---|---|---|
 | ads moderate | Irreversible | Moderate |
 | campaigns/ads suspend/resume (live) | Traffic impact | High |
-| agencyclients add/update/delete | Account type | None (403) |
-| agencyclients add-passport-organization* | External state | Moderate |
+| agencyclients add/update/delete | Account type / sandbox rights (403 or 3001) | None (skip) |
+| agencyclients add-passport-organization* | External state / sandbox rights (3001) | Moderate |
 | bids/keywordbids/bidmodifiers set | Financial | High |
 | dynamicads (all) | Account type (3500) | None (skip) |
 | smartadtargets (all) | Account type (3500) | None (skip) |

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1378,8 +1378,10 @@ def test_agencyclients_add_builds_notification_from_typed_flags():
         "Notification": {
             "Email": "ops@example.com",
             "Lang": "RU",
-            "SendAccountNews": "YES",
-            "SendWarnings": "NO",
+            "EmailSubscriptions": [
+                {"Option": "RECEIVE_RECOMMENDATIONS", "Value": "YES"},
+                {"Option": "TRACK_POSITION_CHANGES", "Value": "NO"},
+            ],
         },
     }
     body = _dry_run(
@@ -1584,8 +1586,10 @@ def test_agencyclients_add_passport_organization_payload():
         "Notification": {
             "Email": "ops@example.com",
             "Lang": "EN",
-            "SendAccountNews": "NO",
-            "SendWarnings": "YES",
+            "EmailSubscriptions": [
+                {"Option": "RECEIVE_RECOMMENDATIONS", "Value": "NO"},
+                {"Option": "TRACK_POSITION_CHANGES", "Value": "YES"},
+            ],
         },
     }
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -194,7 +194,8 @@ def get_first_advideo_probe_id() -> str | None:
             "--format",
             "json",
         )
-        if parse_json_output(probe_result) is not None:
+        probe_data = parse_json_output(probe_result)
+        if isinstance(probe_data, list) and probe_data:
             return str(candidate)
     return None
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -58,15 +58,154 @@ def assert_success(result, cmd_label: str):
         pytest.fail(f"[{cmd_label}] output is not valid JSON:\n{result.output[:500]}")
 
 
+def parse_json_output(result):
+    """Return decoded JSON output, or None if the command did not return JSON."""
+    if result.exit_code != 0:
+        return None
+    try:
+        return json.loads(result.output)
+    except json.JSONDecodeError:
+        return None
+
+
 def get_first_campaign_id() -> int | None:
     """Return the first available campaign ID, or None if no campaigns exist."""
     result = invoke_get("campaigns", "get", "--limit", "1", "--format", "json")
-    if result.exit_code != 0:
-        return None
-    data = json.loads(result.output)
+    data = parse_json_output(result)
     if isinstance(data, list) and data:
         return data[0].get("Id")
     return None
+
+
+def get_first_turbopage_id() -> int | None:
+    """Return the first available turbo page ID, or None if none exist."""
+    result = invoke_get("turbopages", "get", "--limit", "1", "--format", "json")
+    data = parse_json_output(result)
+    if isinstance(data, list) and data:
+        return data[0].get("Id")
+    return None
+
+
+def get_first_leads_turbopage_id() -> int | None:
+    """
+    Return a turbo page ID that can be used for leads.get, or None if no
+    read-only probe is accepted by the API.
+    """
+    turbo_page_id = get_first_turbopage_id()
+    if turbo_page_id:
+        return turbo_page_id
+
+    result = invoke_get(
+        "leads",
+        "get",
+        "--turbo-page-ids",
+        "0",
+        "--limit",
+        "1",
+        "--format",
+        "json",
+    )
+    if parse_json_output(result) is not None:
+        return 0
+    return None
+
+
+def get_first_business_id() -> int | None:
+    """Return a validated business ID, or None if discovery is unavailable."""
+    env_id = os.getenv("YANDEX_DIRECT_TEST_BUSINESS_ID")
+    if env_id:
+        env_result = invoke_get(
+            "businesses",
+            "get",
+            "--ids",
+            env_id,
+            "--limit",
+            "1",
+            "--format",
+            "json",
+        )
+        env_data = parse_json_output(env_result)
+        if isinstance(env_data, list) and env_data:
+            return env_data[0].get("Id")
+
+    probe_result = invoke_get(
+        "businesses",
+        "get",
+        "--ids",
+        "0",
+        "--limit",
+        "1",
+        "--format",
+        "json",
+    )
+    data = parse_json_output(probe_result)
+    if isinstance(data, list) and data:
+        return data[0].get("Id")
+    return None
+
+
+def get_first_advideo_probe_id() -> str | None:
+    """Return a creative/video ID accepted by advideos.get, or None."""
+    env_id = os.getenv("YANDEX_DIRECT_TEST_ADVIDEO_ID")
+    if env_id:
+        env_result = invoke_get(
+            "advideos",
+            "get",
+            "--ids",
+            env_id,
+            "--limit",
+            "1",
+            "--format",
+            "json",
+        )
+        env_data = parse_json_output(env_result)
+        if isinstance(env_data, list) and env_data:
+            return env_id
+
+    result = invoke_get(
+        "creatives",
+        "get",
+        "--fields",
+        "Id,Name,Type",
+        "--limit",
+        "20",
+        "--format",
+        "json",
+    )
+    data = parse_json_output(result)
+    if not isinstance(data, list):
+        return None
+
+    video_creative_types = {"VIDEO_EXTENSION_CREATIVE", "CPM_VIDEO_CREATIVE"}
+    for creative in data:
+        if creative.get("Type") not in video_creative_types:
+            continue
+        candidate = creative.get("Id")
+        if not candidate:
+            continue
+        probe_result = invoke_get(
+            "advideos",
+            "get",
+            "--ids",
+            str(candidate),
+            "--limit",
+            "1",
+            "--format",
+            "json",
+        )
+        if parse_json_output(probe_result) is not None:
+            return str(candidate)
+    return None
+
+
+def is_agency_access_denied(result) -> bool:
+    """Return True if agencyclients is unavailable for the current account."""
+    return result.exit_code != 0 and (
+        "403" in result.output
+        or "Access denied" in result.output
+        or "error_code=54" in result.output
+        or "No rights to access the agency service" in result.output
+    )
 
 
 @pytest.mark.integration
@@ -385,16 +524,16 @@ class TestReadOnlyDynamicFeedAdTargets(unittest.TestCase):
 class TestReadOnlyLeads(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.campaign_id = get_first_campaign_id()
+        cls.turbo_page_id = get_first_leads_turbopage_id()
 
     def test_get_leads(self):
-        if not self.campaign_id:
-            self.skipTest("No campaigns found in account")
+        if self.turbo_page_id is None:
+            self.skipTest("No turbo page ID or accepted leads probe available")
         result = invoke_get(
             "leads",
             "get",
-            "--campaign-ids",
-            str(self.campaign_id),
+            "--turbo-page-ids",
+            str(self.turbo_page_id),
             "--limit",
             "1",
             "--format",
@@ -414,16 +553,46 @@ class TestReadOnlyTurbopages(unittest.TestCase):
 @pytest.mark.integration
 @skip_if_no_token
 class TestReadOnlyBusinesses(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.business_id = get_first_business_id()
+
     def test_get_businesses(self):
-        result = invoke_get("businesses", "get", "--limit", "1", "--format", "json")
+        if self.business_id is None:
+            self.skipTest("No business ID or accepted businesses probe available")
+        result = invoke_get(
+            "businesses",
+            "get",
+            "--ids",
+            str(self.business_id),
+            "--limit",
+            "1",
+            "--format",
+            "json",
+        )
         assert_success(result, "businesses get")
 
 
 @pytest.mark.integration
 @skip_if_no_token
 class TestReadOnlyAdVideos(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.advideo_id = get_first_advideo_probe_id()
+
     def test_get_advideos(self):
-        result = invoke_get("advideos", "get", "--limit", "1", "--format", "json")
+        if self.advideo_id is None:
+            self.skipTest("No video creative ID accepted by advideos get")
+        result = invoke_get(
+            "advideos",
+            "get",
+            "--ids",
+            str(self.advideo_id),
+            "--limit",
+            "1",
+            "--format",
+            "json",
+        )
         assert_success(result, "advideos get")
 
 
@@ -431,12 +600,33 @@ class TestReadOnlyAdVideos(unittest.TestCase):
 @skip_if_no_token
 class TestReadOnlyAgencyClients(unittest.TestCase):
     def test_get_agencyclients(self):
-        result = invoke_get("agencyclients", "get", "--limit", "1", "--format", "json")
-        if result.exit_code != 0 and (
-            "403" in result.output or "Access denied" in result.output
-        ):
-            self.skipTest("agencyclients returned 403 — not an agency account")
-        assert_success(result, "agencyclients get")
+        sandbox_result = invoke_get(
+            "--sandbox",
+            "agencyclients",
+            "get",
+            "--limit",
+            "1",
+            "--format",
+            "json",
+        )
+        if sandbox_result.exit_code == 0:
+            assert_success(sandbox_result, "agencyclients get --sandbox")
+            return
+
+        live_result = invoke_get(
+            "agencyclients",
+            "get",
+            "--limit",
+            "1",
+            "--format",
+            "json",
+        )
+        if is_agency_access_denied(live_result):
+            self.skipTest(
+                "agencyclients is unavailable in sandbox and current live "
+                "account is not an agency account"
+            )
+        assert_success(live_result, "agencyclients get")
 
 
 if __name__ == "__main__":

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -105,7 +105,8 @@ def get_first_leads_turbopage_id() -> int | None:
         "--format",
         "json",
     )
-    if parse_json_output(result) is not None:
+    data = parse_json_output(result)
+    if isinstance(data, list) and data:
         return 0
     return None
 

--- a/tests/test_integration_write.py
+++ b/tests/test_integration_write.py
@@ -56,6 +56,10 @@ Sandbox-limited (confirmed via live recording, ``@pytest.mark.sandbox_limitation
   - dynamicads add/delete         — sandbox does not support DYNAMIC_TEXT_CAMPAIGN creation
   - smartadtargets add/update/delete — sandbox does not support SMART_CAMPAIGN + SMART_AD_GROUP chain
 
+  Category C — account-permission limited in sandbox (code 3001):
+  - agencyclients add-passport-organization — current sandbox agency account can read
+    agency clients but cannot create them ("No rights to create clients")
+
 Part of axisrow/yandex-direct-mcp-plugin#61 (Etap 3).
 """
 

--- a/tests/test_smoke_matrix.py
+++ b/tests/test_smoke_matrix.py
@@ -109,6 +109,16 @@ def test_sandbox_write_script_is_live_runner_not_cassette_replay():
     )
 
 
+def test_safe_script_exercises_agencyclients_get_with_sandbox():
+    script = ROOT_DIR / "scripts" / "test_safe_commands.sh"
+    contents = script.read_text()
+
+    assert "agencyclients get" in contents
+    assert "--sandbox" in contents
+    assert "YANDEX_DIRECT_AGENCY_TOKEN" in contents
+    assert "BUG #73" not in contents
+
+
 def test_sandbox_write_live_runner_covers_write_sandbox_matrix():
     module = _load_sandbox_runner_module()
 


### PR DESCRIPTION
## Summary

- Replace brittle integration defaults for leads, businesses, and advideos with discovery/probe helpers.
- Fix `agencyclients get` to use WSDL-backed `Logins` / `Archived` selection criteria instead of non-existent client ID criteria.
- Update agency client notification dry-run payloads to use `EmailSubscriptions`, matching the live API requirement.

## Root Cause

The read-only integration tests relied on magic IDs or adjacent-resource IDs, so missing fixtures could be hidden by permissive API responses. Separately, `agencyclients` had payload and selector drift from the WSDL/live API: nested imported fields were not covered deeply enough, and runtime validation rejected the old notification shape.

## Validation

- `python3 -m pytest tests/test_dry_run.py -k agencyclients -q`
- `python3 -m pytest tests/test_integration.py -k "leads or businesses or advideos or agencyclients" -v`
- `python3 -m pytest tests/test_integration.py::TestReadOnlyAgencyClients::test_get_agencyclients -v`

Tracked follow-up audit: https://github.com/axisrow/direct-cli/issues/112
