### PR TITLE
[codex] Replace hardcoded docs URLs from resource mapping

### DIFF
--- a/direct_cli/cli.py
+++ b/direct_cli/cli.py
@@ -8,6 +8,7 @@ from dotenv import load_dotenv
 
 from . import __version__
 from .auth import get_active_profile, get_credentials
+from .utils import get_docs_url
 
 from .commands.campaigns import campaigns
 from .commands.adgroups import adgroups
@@ -129,38 +130,52 @@ def cli(
         ctx.obj["login"] = login
 
 
+def _register_command(command: click.Command) -> None:
+    """Register a command and append mapped documentation URL to group help."""
+    docs_url = get_docs_url(command.name or "")
+    if docs_url:
+        docs_line = f"\b\nDocumentation: {docs_url}"
+        command.epilog = (
+            f"{command.epilog}\n\n{docs_line}" if command.epilog else docs_line
+        )
+    cli.add_command(command)
+
+
 # Register all commands
-cli.add_command(campaigns)
-cli.add_command(adgroups)
-cli.add_command(ads)
-cli.add_command(keywords)
-cli.add_command(keywordbids)
-cli.add_command(bids)
-cli.add_command(bidmodifiers)
-cli.add_command(audiencetargets)
-cli.add_command(retargeting)
-cli.add_command(creatives)
-cli.add_command(adimages)
-cli.add_command(adextensions)
-cli.add_command(sitelinks)
-cli.add_command(vcards)
-cli.add_command(leads)
-cli.add_command(clients)
-cli.add_command(agencyclients)
-cli.add_command(dictionaries)
-cli.add_command(changes)
-cli.add_command(reports)
-cli.add_command(turbopages)
-cli.add_command(negativekeywordsharedsets)
-cli.add_command(feeds)
-cli.add_command(smartadtargets)
-cli.add_command(businesses)
-cli.add_command(keywordsresearch)
-cli.add_command(dynamicads)
-cli.add_command(advideos)
-cli.add_command(dynamicfeedadtargets)
-cli.add_command(strategies)
-cli.add_command(auth)
+for command in (
+    campaigns,
+    adgroups,
+    ads,
+    keywords,
+    keywordbids,
+    bids,
+    bidmodifiers,
+    audiencetargets,
+    retargeting,
+    creatives,
+    adimages,
+    adextensions,
+    sitelinks,
+    vcards,
+    leads,
+    clients,
+    agencyclients,
+    dictionaries,
+    changes,
+    reports,
+    turbopages,
+    negativekeywordsharedsets,
+    feeds,
+    smartadtargets,
+    businesses,
+    keywordsresearch,
+    dynamicads,
+    advideos,
+    dynamicfeedadtargets,
+    strategies,
+    auth,
+):
+    _register_command(command)
 
 
 if __name__ == "__main__":

--- a/direct_cli/reports_coverage.py
+++ b/direct_cli/reports_coverage.py
@@ -15,6 +15,13 @@ from .utils import get_docs_pages
 
 
 _REPORTS_DOCS_PAGES = get_docs_pages("reports")
+_REQUIRED_DOCS_KEYS = ("type", "period", "fields-list", "headers")
+_missing_docs_keys = [k for k in _REQUIRED_DOCS_KEYS if k not in _REPORTS_DOCS_PAGES]
+if _missing_docs_keys:
+    raise RuntimeError(
+        "reports docs_pages mapping missing required keys "
+        f"{_missing_docs_keys}; vendored resource_mapping.py is out of sync"
+    )
 REPORTS_SPEC_URLS: dict[str, str] = {
     "type": _REPORTS_DOCS_PAGES["type"],
     "spec": _REPORTS_DOCS_PAGES["period"],

--- a/direct_cli/reports_coverage.py
+++ b/direct_cli/reports_coverage.py
@@ -11,12 +11,15 @@ import json
 import re
 from pathlib import Path
 
-# Real working URLs (yandex.ru, static HTML with content in page text)
+from .utils import get_docs_pages
+
+
+_REPORTS_DOCS_PAGES = get_docs_pages("reports")
 REPORTS_SPEC_URLS: dict[str, str] = {
-    "type": "https://yandex.ru/dev/direct/doc/reports/type.html",
-    "spec": "https://yandex.ru/dev/direct/doc/reports/period.html",
-    "fields-list": "https://yandex.ru/dev/direct/doc/reports/fields-list.html",
-    "headers": "https://yandex.ru/dev/direct/doc/reports/headers.html",
+    "type": _REPORTS_DOCS_PAGES["type"],
+    "spec": _REPORTS_DOCS_PAGES["period"],
+    "fields-list": _REPORTS_DOCS_PAGES["fields-list"],
+    "headers": _REPORTS_DOCS_PAGES["headers"],
 }
 
 REPORTS_CACHE_DIR = Path(__file__).resolve().parent.parent / "tests" / "reports_cache"

--- a/direct_cli/utils.py
+++ b/direct_cli/utils.py
@@ -296,3 +296,10 @@ def get_docs_url(service: str) -> Optional[str]:
     """Return documentation URL for a service from tapi resource mapping."""
     entry = RESOURCE_MAPPING_V5.get(service)
     return entry.get("docs") if entry else None
+
+
+def get_docs_pages(service: str) -> Dict[str, str]:
+    """Return documentation page URLs for a service from tapi resource mapping."""
+    entry = RESOURCE_MAPPING_V5.get(service)
+    docs_pages = entry.get("docs_pages") if entry else None
+    return dict(docs_pages) if docs_pages else {}

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -1119,6 +1119,22 @@ class TestApiCoverage:
 class TestReportsCoverage:
     """Tests for Reports API spec snapshot and CLI parity."""
 
+    def test_reports_spec_urls_come_from_resource_mapping(self):
+        """Reports docs URLs must be derived from the vendored resource mapping."""
+        from direct_cli._vendor.tapi_yandex_direct.resource_mapping import (
+            RESOURCE_MAPPING_V5,
+        )
+        from direct_cli.reports_coverage import REPORTS_SPEC_URLS
+
+        docs_pages = RESOURCE_MAPPING_V5["reports"]["docs_pages"]
+        assert REPORTS_SPEC_URLS == {
+            "type": docs_pages["type"],
+            "spec": docs_pages["period"],
+            "fields-list": docs_pages["fields-list"],
+            "headers": docs_pages["headers"],
+        }
+        assert all(not url.endswith(".html") for url in REPORTS_SPEC_URLS.values())
+
     def test_reports_cache_files_exist(self):
         """All 4 raw HTML files and spec.json must be committed."""
         from direct_cli.reports_coverage import REPORTS_CACHE_DIR

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,8 +12,10 @@ from unittest.mock import patch
 
 from click.testing import CliRunner
 
-from direct_cli.cli import cli
+from direct_cli._vendor.tapi_yandex_direct.resource_mapping import RESOURCE_MAPPING_V5
 from direct_cli._deprecated import DEPRECATED_ENTRYPOINT_MESSAGE, deprecated_main
+from direct_cli.cli import cli
+from direct_cli.utils import get_docs_url
 
 
 class TestCLI(unittest.TestCase):
@@ -42,6 +44,7 @@ class TestCLI(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertIn("Manage campaigns", result.output)
         self.assertIn("Usage: direct campaigns", result.output)
+        self.assertIn(f"Documentation: {get_docs_url('campaigns')}", result.output)
 
     def test_adgroups_help(self):
         """Test adgroups help"""
@@ -60,6 +63,26 @@ class TestCLI(unittest.TestCase):
         result = self.runner.invoke(cli, ["reports", "--help"])
         self.assertEqual(result.exit_code, 0)
         self.assertIn("Generate and manage reports", result.output)
+        self.assertIn(f"Documentation: {get_docs_url('reports')}", result.output)
+
+    def test_registered_mapped_groups_show_docs_url(self):
+        """Registered groups from resource mapping show their documentation URL."""
+        mapped_groups = sorted(set(cli.commands) & set(RESOURCE_MAPPING_V5))
+        self.assertTrue(mapped_groups)
+        for group in mapped_groups:
+            with self.subTest(group=group):
+                result = self.runner.invoke(cli, [group, "--help"])
+                self.assertEqual(result.exit_code, 0)
+                self.assertIn(
+                    f"Documentation: {get_docs_url(group)}",
+                    result.output,
+                )
+
+    def test_auth_help_has_no_docs_url(self):
+        """Auth is not a Yandex Direct API resource and has no docs epilog."""
+        result = self.runner.invoke(cli, ["auth", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertNotIn("Documentation:", result.output)
 
     def test_canonical_groups_in_help(self):
         """Test canonical transport groups"""


### PR DESCRIPTION
Closes #103.

## Summary
- derive Reports docs subpage URLs from vendored RESOURCE_MAPPING_V5 docs_pages
- add mapped Documentation epilogs to registered CLI group help
- cover mapped help output, auth exclusion, and reports URL mapping in tests

## Validation
- python3 -m pytest tests/test_cli.py tests/test_api_coverage.py::TestReportsCoverage tests/test_reports_drift.py -q
- rg -n "https://yandex.ru/dev/direct/doc" direct_cli scripts --glob '!direct_cli/_vendor/tapi_yandex_direct/resource_mapping.py'
