### PR TITLE
Bump to 0.3.0 and update smoke script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "direct-cli"
-version = "0.2.11"
+version = "0.3.0"
 description = "Command-line interface for Yandex Direct API"
 readme = "README.md"
 license = {text = "MIT"}

--- a/scripts/test_safe_commands.sh
+++ b/scripts/test_safe_commands.sh
@@ -88,17 +88,25 @@ run_agencyclients_sandbox_get() {
   local output exit_code
   local args=(direct --sandbox)
   local has_dedicated_token=0
+  local agency_login_provided=0
 
   if [ -n "${YANDEX_DIRECT_AGENCY_TOKEN:-}" ]; then
     has_dedicated_token=1
     args+=(--token "$YANDEX_DIRECT_AGENCY_TOKEN")
     if [ -n "${YANDEX_DIRECT_AGENCY_LOGIN:-}" ]; then
       args+=(--login "$YANDEX_DIRECT_AGENCY_LOGIN")
+      agency_login_provided=1
     fi
   fi
 
   args+=(agencyclients get --archived NO --limit 1 --format json)
-  output=$("${args[@]}" 2>&1) && exit_code=0 || exit_code=$?
+  if [ "$has_dedicated_token" -eq 1 ] && [ "$agency_login_provided" -eq 0 ]; then
+    # Prevent the agency token from inheriting the regular YANDEX_DIRECT_LOGIN
+    # from .env — that mismatch would trigger a real API error and a false FAIL.
+    output=$(env -u YANDEX_DIRECT_LOGIN "${args[@]}" 2>&1) && exit_code=0 || exit_code=$?
+  else
+    output=$("${args[@]}" 2>&1) && exit_code=0 || exit_code=$?
+  fi
 
   if [ "$exit_code" -eq 0 ]; then
     echo -e "  ${GREEN}[PASS]${RESET} $name"

--- a/scripts/test_safe_commands.sh
+++ b/scripts/test_safe_commands.sh
@@ -11,7 +11,6 @@ ENV_FILE="$ROOT_DIR/.env"
 
 PASS=0
 FAIL=0
-KNOWN=0
 CAMPAIGN_ID=""
 ADGROUP_ID=""
 
@@ -19,7 +18,6 @@ ADGROUP_ID=""
 GREEN='\033[0;32m'
 RED='\033[0;31m'
 YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
 BOLD='\033[1m'
 RESET='\033[0m'
 
@@ -80,12 +78,38 @@ run_test() {
   fi
 }
 
-# Known-bug skip: prints [BUG #N] and counts separately, does not affect FAIL
-skip_bug() {
-  local issue="$1"
-  local name="$2"
-  echo -e "  ${CYAN}[BUG #$issue]${RESET} $name — см. github.com/axisrow/direct-cli/issues/$issue"
-  ((KNOWN++)) || true
+is_agency_access_denied() {
+  local output="$1"
+  grep -Eiq "403|error_code=54|Access denied|No rights to access the agency service" <<<"$output"
+}
+
+run_agencyclients_sandbox_get() {
+  local name="agencyclients get --sandbox"
+  local output exit_code
+  local args=(direct --sandbox)
+  local has_dedicated_token=0
+
+  if [ -n "${YANDEX_DIRECT_AGENCY_TOKEN:-}" ]; then
+    has_dedicated_token=1
+    args+=(--token "$YANDEX_DIRECT_AGENCY_TOKEN")
+    if [ -n "${YANDEX_DIRECT_AGENCY_LOGIN:-}" ]; then
+      args+=(--login "$YANDEX_DIRECT_AGENCY_LOGIN")
+    fi
+  fi
+
+  args+=(agencyclients get --archived NO --limit 1 --format json)
+  output=$("${args[@]}" 2>&1) && exit_code=0 || exit_code=$?
+
+  if [ "$exit_code" -eq 0 ]; then
+    echo -e "  ${GREEN}[PASS]${RESET} $name"
+    ((PASS++)) || true
+  elif [ "$has_dedicated_token" -eq 0 ] && is_agency_access_denied "$output"; then
+    echo -e "  ${YELLOW}[SKIP]${RESET} $name — no agency sandbox credentials"
+  else
+    echo -e "  ${RED}[FAIL]${RESET} $name"
+    echo "$output" | head -3 | sed 's/^/         /'
+    ((FAIL++)) || true
+  fi
 }
 
 # ─── Section A: Auth via env variables (no CLI flags) ────────────────────────
@@ -165,7 +189,7 @@ run_test "sitelinks get --ids (env auth)"          direct sitelinks get --ids 1
 run_test "vcards get --ids (env auth)"             direct vcards get --ids 1
 run_test "leads get --turbo-page-ids (env auth)" direct leads get --turbo-page-ids 1 --limit 1
 run_test "clients get (env auth)"                  direct clients get
-skip_bug 73 "agencyclients get — требует агентский аккаунт (sandbox)"
+run_agencyclients_sandbox_get
 run_test "feeds get --ids (env auth)"          direct feeds get --ids 1
 run_test "creatives get (env auth)"                direct creatives get
 # businesses requires Ids/Name/Url in SelectionCriteria
@@ -222,9 +246,6 @@ if [ "$FAIL" -eq 0 ]; then
   echo -e "${GREEN}Результаты: $PASS/$TOTAL PASS${RESET}"
 else
   echo -e "${RED}Результаты: $PASS PASS, $FAIL FAIL (из $TOTAL)${RESET}"
-fi
-if [ "$KNOWN" -gt 0 ]; then
-  echo -e "${CYAN}Пропущено (known bugs): $KNOWN${RESET}"
 fi
 echo -e "${BOLD}=========================================${RESET}"
 

--- a/tests/test_smoke_matrix.py
+++ b/tests/test_smoke_matrix.py
@@ -109,6 +109,16 @@ def test_sandbox_write_script_is_live_runner_not_cassette_replay():
     )
 
 
+def test_safe_smoke_script_runs_agencyclients_sandbox_get():
+    script = ROOT_DIR / "scripts" / "test_safe_commands.sh"
+    contents = script.read_text()
+
+    assert "agencyclients get" in contents
+    assert "--sandbox" in contents
+    assert "YANDEX_DIRECT_AGENCY_TOKEN" in contents
+    assert "BUG #73" not in contents
+
+
 def test_sandbox_write_live_runner_covers_write_sandbox_matrix():
     module = _load_sandbox_runner_module()
 


### PR DESCRIPTION
Bump project version to 0.3.0. Replace the old skip_bug flow in scripts/test_safe_commands.sh with a dedicated run_agencyclients_sandbox_get function that runs `agencyclients get --sandbox`, supports dedicated agency token/login, detects access-denied to emit a SKIP, and updates PASS/FAIL accounting. Remove the KNOWN counter, related cyan color var and known-bug summary. Update tests/test_smoke_matrix.py to assert the new agencyclients sandbox behavior (checks for 'agencyclients get', '--sandbox', 'YANDEX_DIRECT_AGENCY_TOKEN') and the removal of the old BUG #73 marker.

Fixes #73
