### PR TITLE
fix: close #108 with single source of truth for default FieldNames

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Click group-of-groups. Each Yandex Direct API resource = one file in `direct_cli
 
 **Error handling:** All commands wrap API calls in `try/except Exception` → `print_error(str(e))` + `raise click.Abort()`.
 
-**Default fields:** `COMMON_FIELDS` in `utils.py` maps resource names to `FieldNames`. Not all fields are valid for all resources (e.g., `adimages` uses `AdImageHash`, not `Id`).
+**Default fields:** `COMMON_FIELDS` in `utils.py` maps resource names to default `*FieldNames`. Most entries are `list[str]`; multi-`*FieldNames` resources use `dict[str, list[str]]` keyed by WSDL request param (for example `FieldNames`, `TextAdFieldNames`, `SearchFieldNames`). Not all fields are valid for all resources (e.g., `adimages` uses `AdImageHash`, not `Id`).
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ direct dictionaries get-geo-regions --name Moscow --region-ids 225,187 --exact-n
 direct clients get --fields ClientId,Login,Currency
 
 # Changes
-direct changes check --campaign-ids 1,2,3 --timestamp 2026-04-14T00:00:00
+direct changes check --campaign-ids 1,2,3 --timestamp 2026-04-14T00:00:00 --fields CampaignIds,AdGroupIds,AdIds,CampaignsStat
 direct changes check-campaigns --timestamp 2026-04-14T00:00:00
 direct changes check-dictionaries
 
@@ -313,15 +313,18 @@ direct retargeting add --name "List A" --type AUDIENCE --rule "ALL:12345:30|6789
 direct retargeting update --id 55 --name "Renamed" --rule "ANY:12345:30" --dry-run
 
 # Bids and modifiers
+direct bids get --campaign-ids 123 --fields CampaignId,AdGroupId,KeywordId,Bid
 direct bids set --keyword-id 123 --bid 15000000
 direct bids set-auto --keyword-id 123 --max-bid 20000000 --position PREMIUMBLOCK --scope SEARCH --dry-run
 direct keywordbids set --keyword-id 321 --search-bid 8000000 --network-bid 3000000
 direct keywordbids set-auto --keyword-id 321 --target-traffic-volume 100 --increase-percent 10 --bid-ceiling 12500000 --dry-run
+direct bidmodifiers get --campaign-ids 123 --fields Id,CampaignId,AdGroupId,Level,Type
 direct bidmodifiers add --campaign-id 123 --type DEMOGRAPHICS_ADJUSTMENT --value 150 --gender GENDER_MALE --age AGE_25_34 --dry-run
 direct bidmodifiers set --id 99 --value 130 --dry-run
 
 # Canonical multiword groups
 direct negativekeywordsharedsets update --id 123 --keywords "foo,bar"
+direct audiencetargets get --campaign-ids 123 --fields Id,AdGroupId,RetargetingListId,State,ContextBid
 direct audiencetargets add --adgroup-id 100 --retargeting-list-id 200 --bid 12000000 --priority HIGH --dry-run
 direct audiencetargets set-bids --id 101 --context-bid 7000000 --priority LOW --dry-run
 direct dynamicads add --adgroup-id 33 --name "Webpage A" --condition "URL:CONTAINS_ANY:test|shop" --condition "PAGE_CONTENT:CONTAINS:baz" --bid 3000000 --context-bid 2000000 --priority HIGH --dry-run
@@ -920,7 +923,7 @@ direct dictionaries get-geo-regions --name Москва --region-ids 225,187 --e
 direct clients get --fields ClientId,Login,Currency
 
 # Изменения
-direct changes check --campaign-ids 1,2,3 --timestamp 2026-04-14T00:00:00
+direct changes check --campaign-ids 1,2,3 --timestamp 2026-04-14T00:00:00 --fields CampaignIds,AdGroupIds,AdIds,CampaignsStat
 direct changes check-campaigns --timestamp 2026-04-14T00:00:00
 direct changes check-dictionaries
 
@@ -930,15 +933,18 @@ direct retargeting add --name "Список A" --type AUDIENCE --rule "ALL:12345
 direct retargeting update --id 55 --name "Переименованный список" --rule "ANY:12345:30" --dry-run
 
 # Ставки и модификаторы
+direct bids get --campaign-ids 123 --fields CampaignId,AdGroupId,KeywordId,Bid
 direct bids set --keyword-id 123 --bid 15000000
 direct bids set-auto --keyword-id 123 --max-bid 20000000 --position PREMIUMBLOCK --scope SEARCH --dry-run
 direct keywordbids set --keyword-id 321 --search-bid 8000000 --network-bid 3000000
 direct keywordbids set-auto --keyword-id 321 --target-traffic-volume 100 --increase-percent 10 --bid-ceiling 12500000 --dry-run
+direct bidmodifiers get --campaign-ids 123 --fields Id,CampaignId,AdGroupId,Level,Type
 direct bidmodifiers add --campaign-id 123 --type DEMOGRAPHICS_ADJUSTMENT --value 150 --gender GENDER_MALE --age AGE_25_34 --dry-run
 direct bidmodifiers set --id 99 --value 130 --dry-run
 
 # Канонические многословные группы
 direct negativekeywordsharedsets update --id 123 --keywords "foo,bar"
+direct audiencetargets get --campaign-ids 123 --fields Id,AdGroupId,RetargetingListId,State,ContextBid
 direct audiencetargets add --adgroup-id 100 --retargeting-list-id 200 --bid 12000000 --priority HIGH --dry-run
 direct audiencetargets set-bids --id 101 --context-bid 7000000 --priority LOW --dry-run
 direct dynamicads add --adgroup-id 33 --name "Webpage A" --condition "URL:CONTAINS_ANY:test|shop" --condition "PAGE_CONTENT:CONTAINS:baz" --bid 3000000 --context-bid 2000000 --priority HIGH --dry-run

--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import create_client
 from ..output import format_output, print_error
-from ..utils import parse_ids
+from ..utils import get_default_fields, parse_ids
 
 
 @click.group()
@@ -46,15 +46,13 @@ def get(
     """Get ads"""
     try:
         field_names = (
-            fields.split(",")
-            if fields
-            else ["Id", "CampaignId", "AdGroupId", "Status", "State", "Type"]
+            fields.split(",") if fields else get_default_fields("ads", "FieldNames")
         )
 
         text_ad_field_names = (
             text_ad_fields.split(",")
             if text_ad_fields
-            else ["Title", "Title2", "Text", "Href"]
+            else get_default_fields("ads", "TextAdFieldNames")
         )
 
         criteria = {}

--- a/direct_cli/commands/agencyclients.py
+++ b/direct_cli/commands/agencyclients.py
@@ -71,7 +71,9 @@ def get(ctx, logins, archived, limit, fetch_all, output_format, output, fields):
             sandbox=ctx.obj.get("sandbox"),
         )
 
-        field_names = fields.split(",") if fields else get_default_fields("clients")
+        field_names = (
+            fields.split(",") if fields else get_default_fields("agencyclients")
+        )
 
         criteria = {"Archived": archived}
         if logins:
@@ -227,7 +229,9 @@ def add_passport_organization(
 
 
 @agencyclients.command(name="add-passport-organization-member")
-@click.option("--passport-organization-login", required=True, help="Passport organization login")
+@click.option(
+    "--passport-organization-login", required=True, help="Passport organization login"
+)
 @click.option("--role", required=True, help="Organization member role")
 @click.option("--invite-email", help="Invitation email")
 @click.option("--invite-phone", help="Invitation phone")

--- a/direct_cli/commands/audiencetargets.py
+++ b/direct_cli/commands/audiencetargets.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import create_client
 from ..output import format_output, print_error
-from ..utils import parse_ids, MICRO_RUBLES
+from ..utils import get_default_fields, parse_ids, MICRO_RUBLES
 
 
 @click.group()
@@ -22,8 +22,19 @@ def audiencetargets():
 @click.option("--fetch-all", is_flag=True, help="Fetch all pages")
 @click.option("--format", "output_format", default="json", help="Output format")
 @click.option("--output", help="Output file")
+@click.option("--fields", help="Comma-separated field names")
 @click.pass_context
-def get(ctx, ids, adgroup_ids, campaign_ids, limit, fetch_all, output_format, output):
+def get(
+    ctx,
+    ids,
+    adgroup_ids,
+    campaign_ids,
+    limit,
+    fetch_all,
+    output_format,
+    output,
+    fields,
+):
     """Get audience targets"""
     try:
         client = create_client(
@@ -40,15 +51,12 @@ def get(ctx, ids, adgroup_ids, campaign_ids, limit, fetch_all, output_format, ou
         if campaign_ids:
             criteria["CampaignIds"] = parse_ids(campaign_ids)
 
+        field_names = (
+            fields.split(",") if fields else get_default_fields("audiencetargets")
+        )
         params = {
             "SelectionCriteria": criteria,
-            "FieldNames": [
-                "Id",
-                "AdGroupId",
-                "RetargetingListId",
-                "State",
-                "ContextBid",
-            ],
+            "FieldNames": field_names,
         }
 
         if limit:
@@ -152,11 +160,7 @@ def set_bids(ctx, target_id, adgroup_id, campaign_id, context_bid, priority, dry
             bid_data["ContextBid"] = context_bid
         if priority:
             bid_data["StrategyPriority"] = priority
-        bid_fields = {
-            k
-            for k in ("ContextBid", "StrategyPriority")
-            if k in bid_data
-        }
+        bid_fields = {k for k in ("ContextBid", "StrategyPriority") if k in bid_data}
         if not bid_data:
             raise click.UsageError(
                 "Provide target selection and bid fields for set-bids"
@@ -194,7 +198,10 @@ def set_bids(ctx, target_id, adgroup_id, campaign_id, context_bid, priority, dry
 def delete(ctx, target_id, dry_run):
     """Delete audience target"""
     try:
-        body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [target_id]}}}
+        body = {
+            "method": "delete",
+            "params": {"SelectionCriteria": {"Ids": [target_id]}},
+        }
 
         if dry_run:
             format_output(body, "json", None)
@@ -221,7 +228,10 @@ def delete(ctx, target_id, dry_run):
 def suspend(ctx, target_id, dry_run):
     """Suspend audience target"""
     try:
-        body = {"method": "suspend", "params": {"SelectionCriteria": {"Ids": [target_id]}}}
+        body = {
+            "method": "suspend",
+            "params": {"SelectionCriteria": {"Ids": [target_id]}},
+        }
 
         if dry_run:
             format_output(body, "json", None)
@@ -248,7 +258,10 @@ def suspend(ctx, target_id, dry_run):
 def resume(ctx, target_id, dry_run):
     """Resume audience target"""
     try:
-        body = {"method": "resume", "params": {"SelectionCriteria": {"Ids": [target_id]}}}
+        body = {
+            "method": "resume",
+            "params": {"SelectionCriteria": {"Ids": [target_id]}},
+        }
 
         if dry_run:
             format_output(body, "json", None)

--- a/direct_cli/commands/bidmodifiers.py
+++ b/direct_cli/commands/bidmodifiers.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import create_client
 from ..output import format_output, print_error
-from ..utils import parse_ids
+from ..utils import get_default_fields, parse_ids
 
 
 @click.group()
@@ -29,9 +29,18 @@ def bidmodifiers():
 @click.option("--fetch-all", is_flag=True, help="Fetch all pages")
 @click.option("--format", "output_format", default="json", help="Output format")
 @click.option("--output", help="Output file")
+@click.option("--fields", help="Comma-separated field names")
 @click.pass_context
 def get(
-    ctx, campaign_ids, adgroup_ids, levels, limit, fetch_all, output_format, output
+    ctx,
+    campaign_ids,
+    adgroup_ids,
+    levels,
+    limit,
+    fetch_all,
+    output_format,
+    output,
+    fields,
 ):
     """Get bid modifiers"""
     try:
@@ -47,9 +56,12 @@ def get(
         if adgroup_ids:
             criteria["AdGroupIds"] = parse_ids(adgroup_ids)
 
+        field_names = (
+            fields.split(",") if fields else get_default_fields("bidmodifiers")
+        )
         params = {
             "SelectionCriteria": criteria,
-            "FieldNames": ["Id", "CampaignId", "AdGroupId", "Level", "Type"],
+            "FieldNames": field_names,
         }
 
         if limit:

--- a/direct_cli/commands/bids.py
+++ b/direct_cli/commands/bids.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import create_client
 from ..output import format_output, print_error
-from ..utils import parse_ids, MICRO_RUBLES
+from ..utils import get_default_fields, parse_ids, MICRO_RUBLES
 
 
 @click.group()
@@ -22,8 +22,19 @@ def bids():
 @click.option("--fetch-all", is_flag=True, help="Fetch all pages")
 @click.option("--format", "output_format", default="json", help="Output format")
 @click.option("--output", help="Output file")
+@click.option("--fields", help="Comma-separated field names")
 @click.pass_context
-def get(ctx, campaign_ids, adgroup_ids, keyword_ids, limit, fetch_all, output_format, output):
+def get(
+    ctx,
+    campaign_ids,
+    adgroup_ids,
+    keyword_ids,
+    limit,
+    fetch_all,
+    output_format,
+    output,
+    fields,
+):
     """Get bids"""
     try:
         client = create_client(
@@ -40,9 +51,10 @@ def get(ctx, campaign_ids, adgroup_ids, keyword_ids, limit, fetch_all, output_fo
         if keyword_ids:
             criteria["KeywordIds"] = parse_ids(keyword_ids)
 
+        field_names = fields.split(",") if fields else get_default_fields("bids")
         params = {
             "SelectionCriteria": criteria,
-            "FieldNames": ["CampaignId", "AdGroupId", "KeywordId", "Bid"],
+            "FieldNames": field_names,
         }
 
         if limit:

--- a/direct_cli/commands/changes.py
+++ b/direct_cli/commands/changes.py
@@ -18,6 +18,7 @@ def changes():
 @click.option("--campaign-ids", required=True, help="Comma-separated campaign IDs")
 @click.option(
     "--timestamp",
+    required=True,
     help="Timestamp for changes check (YYYY-MM-DDTHH:MM:SS)",
 )
 @click.option("--fields", help="Comma-separated field names")
@@ -36,10 +37,9 @@ def check(ctx, campaign_ids, timestamp, fields, output_format, output):
         field_names = fields.split(",") if fields else get_default_fields("changes")
         params = {
             "CampaignIds": parse_ids(campaign_ids),
+            "Timestamp": parse_datetime(timestamp),
             "FieldNames": field_names,
         }
-        if timestamp:
-            params["Timestamp"] = parse_datetime(timestamp)
 
         body = {"method": "check", "params": params}
 

--- a/direct_cli/commands/changes.py
+++ b/direct_cli/commands/changes.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import create_client
 from ..output import format_output, print_error
-from ..utils import parse_datetime, parse_ids
+from ..utils import get_default_fields, parse_datetime, parse_ids
 
 
 @click.group()
@@ -16,11 +16,15 @@ def changes():
 
 @changes.command()
 @click.option("--campaign-ids", required=True, help="Comma-separated campaign IDs")
-@click.option("--timestamp", help="Timestamp for changes check (YYYY-MM-DDTHH:MM:SS)")
+@click.option(
+    "--timestamp",
+    help="Timestamp for changes check (YYYY-MM-DDTHH:MM:SS)",
+)
+@click.option("--fields", help="Comma-separated field names")
 @click.option("--format", "output_format", default="json", help="Output format")
 @click.option("--output", help="Output file")
 @click.pass_context
-def check(ctx, campaign_ids, timestamp, output_format, output):
+def check(ctx, campaign_ids, timestamp, fields, output_format, output):
     """Check changes for campaigns"""
     try:
         client = create_client(
@@ -29,8 +33,11 @@ def check(ctx, campaign_ids, timestamp, output_format, output):
             sandbox=ctx.obj.get("sandbox"),
         )
 
-        params = {"CampaignIds": parse_ids(campaign_ids)}
-
+        field_names = fields.split(",") if fields else get_default_fields("changes")
+        params = {
+            "CampaignIds": parse_ids(campaign_ids),
+            "FieldNames": field_names,
+        }
         if timestamp:
             params["Timestamp"] = parse_datetime(timestamp)
 

--- a/direct_cli/commands/creatives.py
+++ b/direct_cli/commands/creatives.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import create_client
 from ..output import format_output, print_error
-from ..utils import parse_ids
+from ..utils import get_default_fields, parse_ids
 
 
 @click.group()
@@ -31,9 +31,7 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields):
             sandbox=ctx.obj.get("sandbox"),
         )
 
-        field_names = (
-            fields.split(",") if fields else ["Id", "Name", "Type"]
-        )
+        field_names = fields.split(",") if fields else get_default_fields("creatives")
 
         criteria = {}
         if ids:

--- a/direct_cli/commands/dynamicads.py
+++ b/direct_cli/commands/dynamicads.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import create_client
 from ..output import format_output, print_error
-from ..utils import parse_condition_specs, parse_ids, MICRO_RUBLES
+from ..utils import get_default_fields, parse_condition_specs, parse_ids, MICRO_RUBLES
 
 
 @click.group()
@@ -32,7 +32,7 @@ def get(ctx, ids, adgroup_ids, limit, fetch_all, output_format, output, fields):
             sandbox=ctx.obj.get("sandbox"),
         )
 
-        field_names = fields.split(",") if fields else ["Id", "AdGroupId", "Conditions", "Bid"]
+        field_names = fields.split(",") if fields else get_default_fields("dynamicads")
 
         criteria = {}
         if ids:
@@ -123,7 +123,10 @@ def add(ctx, adgroup_id, name, conditions, bid, context_bid, priority, dry_run):
 def delete(ctx, target_id, dry_run):
     """Delete dynamic ad target"""
     try:
-        body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [target_id]}}}
+        body = {
+            "method": "delete",
+            "params": {"SelectionCriteria": {"Ids": [target_id]}},
+        }
 
         if dry_run:
             format_output(body, "json", None)
@@ -150,7 +153,10 @@ def delete(ctx, target_id, dry_run):
 def suspend(ctx, target_id, dry_run):
     """Suspend dynamic ad target"""
     try:
-        body = {"method": "suspend", "params": {"SelectionCriteria": {"Ids": [target_id]}}}
+        body = {
+            "method": "suspend",
+            "params": {"SelectionCriteria": {"Ids": [target_id]}},
+        }
 
         if dry_run:
             format_output(body, "json", None)
@@ -176,7 +182,10 @@ def suspend(ctx, target_id, dry_run):
 def resume(ctx, target_id, dry_run):
     """Resume dynamic ad target"""
     try:
-        body = {"method": "resume", "params": {"SelectionCriteria": {"Ids": [target_id]}}}
+        body = {
+            "method": "resume",
+            "params": {"SelectionCriteria": {"Ids": [target_id]}},
+        }
 
         if dry_run:
             format_output(body, "json", None)
@@ -204,7 +213,9 @@ def resume(ctx, target_id, dry_run):
 @click.option("--priority", help="Strategy priority")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def set_bids(ctx, target_id, adgroup_id, campaign_id, bid, context_bid, priority, dry_run):
+def set_bids(
+    ctx, target_id, adgroup_id, campaign_id, bid, context_bid, priority, dry_run
+):
     """Set dynamic ad target bids"""
     try:
         bid_data = {}
@@ -221,9 +232,7 @@ def set_bids(ctx, target_id, adgroup_id, campaign_id, bid, context_bid, priority
         if priority:
             bid_data["StrategyPriority"] = priority
         bid_fields = {
-            k
-            for k in ("Bid", "ContextBid", "StrategyPriority")
-            if k in bid_data
+            k for k in ("Bid", "ContextBid", "StrategyPriority") if k in bid_data
         }
         if not bid_data:
             raise click.UsageError(

--- a/direct_cli/commands/dynamicfeedadtargets.py
+++ b/direct_cli/commands/dynamicfeedadtargets.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import create_client
 from ..output import format_output, print_error
-from ..utils import parse_condition_specs, parse_ids, MICRO_RUBLES
+from ..utils import get_default_fields, parse_condition_specs, parse_ids, MICRO_RUBLES
 
 
 @click.group()
@@ -36,9 +36,7 @@ def get(
         )
 
         field_names = (
-            fields.split(",")
-            if fields
-            else ["Id", "AdGroupId", "CampaignId", "Name", "Bid", "ContextBid"]
+            fields.split(",") if fields else get_default_fields("dynamicfeedadtargets")
         )
 
         criteria = {}

--- a/direct_cli/commands/keywordbids.py
+++ b/direct_cli/commands/keywordbids.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import create_client
 from ..output import format_output, print_error
-from ..utils import parse_ids, MICRO_RUBLES
+from ..utils import get_default_fields, parse_ids, MICRO_RUBLES
 
 
 @click.group()
@@ -44,15 +44,9 @@ def get(
 
         params = {
             "SelectionCriteria": criteria,
-            "FieldNames": [
-                "KeywordId",
-                "AdGroupId",
-                "CampaignId",
-                "ServingStatus",
-                "StrategyPriority",
-            ],
-            "SearchFieldNames": ["Bid"],
-            "NetworkFieldNames": ["Bid"],
+            "FieldNames": get_default_fields("keywordbids", "FieldNames"),
+            "SearchFieldNames": get_default_fields("keywordbids", "SearchFieldNames"),
+            "NetworkFieldNames": get_default_fields("keywordbids", "NetworkFieldNames"),
         }
 
         if limit:
@@ -126,7 +120,9 @@ def set(ctx, keyword_id, search_bid, network_bid, dry_run):
     help="NetworkByCoverage.TargetCoverage value",
 )
 @click.option("--increase-percent", type=int, help="Bidding rule IncreasePercent")
-@click.option("--bid-ceiling", type=MICRO_RUBLES, help="Bidding rule bid ceiling in micro-rubles")
+@click.option(
+    "--bid-ceiling", type=MICRO_RUBLES, help="Bidding rule bid ceiling in micro-rubles"
+)
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
 def set_auto(

--- a/direct_cli/commands/keywordsresearch.py
+++ b/direct_cli/commands/keywordsresearch.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import create_client
 from ..output import format_output, print_error
-from ..utils import parse_ids
+from ..utils import get_default_fields, parse_ids
 
 
 @click.group()
@@ -37,7 +37,7 @@ def has_search_volume(ctx, keywords, region_ids, fields, output_format, output):
         field_names = (
             [f.strip() for f in fields.split(",")]
             if fields
-            else ["Keyword", "AllDevices"]
+            else get_default_fields("keywordsresearch")
         )
 
         body = {

--- a/direct_cli/commands/leads.py
+++ b/direct_cli/commands/leads.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import create_client
 from ..output import format_output, print_error
-from ..utils import parse_ids
+from ..utils import get_default_fields, parse_ids
 
 
 @click.group()
@@ -35,11 +35,7 @@ def get(ctx, turbo_page_ids, limit, fetch_all, output_format, output, fields):
             sandbox=ctx.obj.get("sandbox"),
         )
 
-        field_names = (
-            fields.split(",")
-            if fields
-            else ["Id", "SubmittedAt", "TurboPageId", "TurboPageName"]
-        )
+        field_names = fields.split(",") if fields else get_default_fields("leads")
 
         criteria = {"TurboPageIds": parse_ids(turbo_page_ids)}
 

--- a/direct_cli/commands/negativekeywordsharedsets.py
+++ b/direct_cli/commands/negativekeywordsharedsets.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import create_client
 from ..output import format_output, print_error
-from ..utils import parse_ids
+from ..utils import get_default_fields, parse_ids
 
 
 @click.group()
@@ -32,7 +32,9 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields):
         )
 
         field_names = (
-            fields.split(",") if fields else ["Id", "Name", "NegativeKeywords"]
+            fields.split(",")
+            if fields
+            else get_default_fields("negativekeywordsharedsets")
         )
 
         criteria = {}

--- a/direct_cli/commands/sitelinks.py
+++ b/direct_cli/commands/sitelinks.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import create_client
 from ..output import format_output, print_error
-from ..utils import parse_ids, parse_sitelink_specs
+from ..utils import get_default_fields, parse_ids, parse_sitelink_specs
 
 
 @click.group()
@@ -31,7 +31,7 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields):
             sandbox=ctx.obj.get("sandbox"),
         )
 
-        field_names = fields.split(",") if fields else ["Id", "Sitelinks"]
+        field_names = fields.split(",") if fields else get_default_fields("sitelinks")
 
         criteria = {}
         if ids:

--- a/direct_cli/commands/strategies.py
+++ b/direct_cli/commands/strategies.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import create_client
 from ..output import format_output, print_error
-from ..utils import parse_ids, parse_json
+from ..utils import get_default_fields, parse_ids, parse_json
 
 STRATEGY_TYPES = [
     "WbMaximumClicks",
@@ -59,9 +59,7 @@ def get(ctx, ids, types, is_archived, limit, fetch_all, output_format, output, f
             sandbox=ctx.obj.get("sandbox"),
         )
 
-        field_names = (
-            fields.split(",") if fields else ["Id", "Name", "Type", "StatusArchived"]
-        )
+        field_names = fields.split(",") if fields else get_default_fields("strategies")
 
         criteria = {}
         if ids:
@@ -133,7 +131,9 @@ def add(
         if strategy_params:
             parsed = parse_json(strategy_params)
             if not isinstance(parsed, dict):
-                raise click.UsageError("--params must be a JSON object, not an array or scalar")
+                raise click.UsageError(
+                    "--params must be a JSON object, not an array or scalar"
+                )
             strategy_data[strategy_type] = parsed
         if counter_ids:
             strategy_data["CounterIds"] = {
@@ -212,7 +212,9 @@ def update(
             if strategy_params:
                 parsed = parse_json(strategy_params)
                 if not isinstance(parsed, dict):
-                    raise click.UsageError("--params must be a JSON object, not an array or scalar")
+                    raise click.UsageError(
+                        "--params must be a JSON object, not an array or scalar"
+                    )
                 strategy_data[strategy_type] = parsed
             else:
                 strategy_data[strategy_type] = {}

--- a/direct_cli/commands/turbopages.py
+++ b/direct_cli/commands/turbopages.py
@@ -11,7 +11,7 @@ import click
 
 from ..api import create_client
 from ..output import format_output, print_error
-from ..utils import parse_ids
+from ..utils import get_default_fields, parse_ids
 
 
 @click.group()
@@ -36,7 +36,7 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields):
             sandbox=ctx.obj.get("sandbox"),
         )
 
-        field_names = fields.split(",") if fields else ["Id", "Name", "Href", "TurboSiteHref", "PreviewHref", "BoundWithHref"]
+        field_names = fields.split(",") if fields else get_default_fields("turbopages")
 
         criteria = {}
         if ids:

--- a/direct_cli/commands/vcards.py
+++ b/direct_cli/commands/vcards.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import create_client
 from ..output import format_output, print_error
-from ..utils import parse_ids
+from ..utils import get_default_fields, parse_ids
 
 
 @click.group()
@@ -31,11 +31,7 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields):
             sandbox=ctx.obj.get("sandbox"),
         )
 
-        field_names = (
-            fields.split(",")
-            if fields
-            else ["Id", "CampaignId", "Country", "City", "CompanyName"]
-        )
+        field_names = fields.split(",") if fields else get_default_fields("vcards")
 
         criteria = {}
         if ids:

--- a/direct_cli/utils.py
+++ b/direct_cli/utils.py
@@ -5,7 +5,7 @@ Utilities for Direct CLI
 import base64
 import json
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import click
 
@@ -247,7 +247,7 @@ def parse_sitelink_specs(specs: Optional[List[str]]) -> Optional[List[Dict[str, 
     return sitelinks
 
 
-COMMON_FIELDS = {
+COMMON_FIELDS: Dict[str, Union[List[str], Dict[str, List[str]]]] = {
     "campaigns": [
         "Id",
         "Name",
@@ -260,7 +260,10 @@ COMMON_FIELDS = {
         "ClientInfo",
     ],
     "adgroups": ["Id", "Name", "CampaignId", "Status", "Type", "RegionIds"],
-    "ads": ["Id", "CampaignId", "AdGroupId", "Status", "State", "Type", "TextAd"],
+    "ads": {
+        "FieldNames": ["Id", "CampaignId", "AdGroupId", "Status", "State", "Type"],
+        "TextAdFieldNames": ["Title", "Title2", "Text", "Href"],
+    },
     "keywords": [
         "Id",
         "Keyword",
@@ -275,6 +278,7 @@ COMMON_FIELDS = {
     "creatives": ["Id", "Name", "Type"],
     "adimages": ["AdImageHash", "Name"],
     "adextensions": ["Id", "Type", "State", "Status"],
+    "negativekeywordsharedsets": ["Id", "Name", "NegativeKeywords"],
     "sitelinks": ["Id", "Sitelinks"],
     "vcards": ["Id", "CampaignId", "Country", "City", "CompanyName"],
     "leads": ["Id", "SubmittedAt", "TurboPageId", "TurboPageName"],
@@ -291,12 +295,56 @@ COMMON_FIELDS = {
     "businesses": ["Id", "Name", "Address", "Phone", "ProfileUrl"],
     "retargetinglists": ["Id", "Name", "Type", "Scope"],
     "advideos": ["Id", "Status"],
+    "bids": ["CampaignId", "AdGroupId", "KeywordId", "Bid"],
+    "bidmodifiers": ["Id", "CampaignId", "AdGroupId", "Level", "Type"],
+    "audiencetargets": [
+        "Id",
+        "AdGroupId",
+        "RetargetingListId",
+        "State",
+        "ContextBid",
+    ],
+    "dynamicads": ["Id", "AdGroupId", "Conditions", "Bid"],
+    "strategies": ["Id", "Name", "Type", "StatusArchived"],
+    "dynamicfeedadtargets": [
+        "Id",
+        "AdGroupId",
+        "CampaignId",
+        "Name",
+        "Bid",
+        "ContextBid",
+    ],
+    # Multi-FieldNames resources: WSDL exposes more than one ``*FieldNames``
+    # request param (e.g. SearchFieldNames + NetworkFieldNames). Each key is
+    # the WSDL request-field name; values are the default enum-validated lists.
+    "keywordbids": {
+        "FieldNames": [
+            "KeywordId",
+            "AdGroupId",
+            "CampaignId",
+            "ServingStatus",
+            "StrategyPriority",
+        ],
+        "SearchFieldNames": ["Bid"],
+        "NetworkFieldNames": ["Bid"],
+    },
 }
 
 
-def get_default_fields(resource: str) -> List[str]:
-    """Get default field names for resource"""
-    return COMMON_FIELDS.get(resource, ["Id", "Name"])
+def get_default_fields(resource: str, request_field: str = "FieldNames") -> List[str]:
+    """Return default field names for a resource's WSDL request param.
+
+    For single-FieldNames resources, ``COMMON_FIELDS[resource]`` is a list and
+    ``request_field`` is ignored. For multi-FieldNames resources (like
+    ``keywordbids`` with ``SearchFieldNames``/``NetworkFieldNames``), the
+    value is a dict keyed by request-field name.
+    """
+    entry = COMMON_FIELDS.get(resource)
+    if entry is None:
+        return ["Id", "Name"]
+    if isinstance(entry, dict):
+        return entry.get(request_field, ["Id", "Name"])
+    return entry
 
 
 def get_docs_url(service: str) -> Optional[str]:

--- a/direct_cli/utils.py
+++ b/direct_cli/utils.py
@@ -275,6 +275,7 @@ COMMON_FIELDS: Dict[str, Union[List[str], Dict[str, List[str]]]] = {
         "ContextBid",
     ],
     "clients": ["ClientId", "Login", "CountryId", "Currency"],
+    "agencyclients": ["ClientId", "Login", "CountryId", "Currency"],
     "creatives": ["Id", "Name", "Type"],
     "adimages": ["AdImageHash", "Name"],
     "adextensions": ["Id", "Type", "State", "Status"],
@@ -293,6 +294,7 @@ COMMON_FIELDS: Dict[str, Union[List[str], Dict[str, List[str]]]] = {
     "feeds": ["Id", "Name", "BusinessType", "SourceType", "Status"],
     "smartadtargets": ["Id", "CampaignId", "AdGroupId", "State"],
     "businesses": ["Id", "Name", "Address", "Phone", "ProfileUrl"],
+    "changes": ["CampaignIds", "AdGroupIds", "AdIds", "CampaignsStat"],
     "retargetinglists": ["Id", "Name", "Type", "Scope"],
     "advideos": ["Id", "Status"],
     "bids": ["CampaignId", "AdGroupId", "KeywordId", "Bid"],
@@ -328,6 +330,7 @@ COMMON_FIELDS: Dict[str, Union[List[str], Dict[str, List[str]]]] = {
         "SearchFieldNames": ["Bid"],
         "NetworkFieldNames": ["Bid"],
     },
+    "keywordsresearch": ["Keyword", "AllDevices"],
 }
 
 

--- a/scripts/build_api_coverage_checklist.py
+++ b/scripts/build_api_coverage_checklist.py
@@ -301,7 +301,7 @@ Version `0.3.0` cannot ship until command/API coverage is 100% across the suppor
 - `scripts/build_api_coverage_report.py` reports `summary.live_model_parity_ok == true` (✅ already true on `main`)
 - `model_gaps.live_discovered_missing_services == []` (✅)
 - `model_gaps.live_discovered_missing_methods == 0` (✅)
-- Schema-level gate `summary.schema_parity_ok == true` ({schema_status}) — every `get` default `FieldNames` payload and `COMMON_FIELDS` default is a subset of the corresponding WSDL `*FieldEnum`, and required default `*FieldNames` params are present
+- Schema-level gate `summary.schema_parity_ok == true` ({schema_status}) — every enum-backed default `*FieldNames` command declares defaults in `COMMON_FIELDS`, every default `FieldNames` payload and `COMMON_FIELDS` default is a subset of the corresponding WSDL `*FieldEnum`, and required default `*FieldNames` params are present
 - Every canonical CLI command in the per-service status below shows ✅ on all four checkboxes (or has a documented `n/a` rationale)
 - Every mutating command has dry-run payload coverage or a documented exclusion
 - Wire method names are validated wherever command aliases or kebab-case map to Yandex camelCase
@@ -344,9 +344,10 @@ Current gate status from `scripts/build_api_coverage_report.py`: `summary.schema
 The gate parses every `*FieldEnum` from `tests/wsdl_cache/*.xml` and asserts that:
 
 1. Each default `*FieldNames` value from `direct_cli/utils.py:COMMON_FIELDS` is a member of the corresponding WSDL enum.
-2. Each captured default `get` payload sends enum-valid `*FieldNames` values.
+2. Each captured default payload for WSDL operations with `*FieldNames` sends enum-valid `*FieldNames` values.
 3. Each multi-field default declared in `COMMON_FIELDS` sends all required default `*FieldNames` request params.
-4. New `get` groups are either covered by the gate or explicitly waived with rationale.
+4. Each enum-backed command with default `*FieldNames` has a `COMMON_FIELDS` entry as the single source of truth for defaults.
+5. New WSDL `*FieldNames` operations are either covered by the gate or explicitly waived with rationale.
 
 ---
 

--- a/scripts/build_api_coverage_checklist.py
+++ b/scripts/build_api_coverage_checklist.py
@@ -17,7 +17,9 @@ from __future__ import annotations
 import sys
 from collections import defaultdict
 from pathlib import Path
+from typing import Optional
 
+from build_api_coverage_report import build_report
 from direct_cli.cli import cli
 from direct_cli.smoke_matrix import SMOKE_MATRIX
 from direct_cli.wsdl_coverage import (
@@ -31,20 +33,11 @@ from direct_cli.wsdl_coverage import (
 
 API_TO_CLI = {v: k for k, v in CLI_TO_API_SERVICE.items()}
 SMOKE_OF = {cmd: cat for cat, cmds in SMOKE_MATRIX.items() for cmd in cmds}
+_COVERAGE_REPORT: Optional[dict] = None
 
-# Known schema-level issues (FieldNames vs WSDL FieldEnum, SelectionCriteria
-# defaults, integration-test correctness). Source: issue #108 + audit on
-# 2026-04-25.
+# Known schema-level issues (SelectionCriteria defaults and integration-test
+# correctness). Source: API coverage audit on 2026-04-25.
 KNOWN_ISSUES: dict[tuple[str, str], list[str]] = {
-    ("smartadtargets", "get"): [
-        "FieldNames mismatch: shipping `Status`, `ServingStatus` — only `State` exists in WSDL FieldEnum (#108)",
-    ],
-    ("adextensions", "get"): [
-        "FieldNames mismatch: missing `State` (defined in WSDL FieldEnum, dropped from response) (#108)",
-    ],
-    ("businesses", "get"): [
-        "Default FieldNames may include `Type` which is not in WSDL FieldEnum (#108 audit pending)",
-    ],
     ("leads", "get"): [
         "SelectionCriteria requires `TurboPageIds`; integration test currently passes `--campaign-ids` (no such option) → exit_code=2",
     ],
@@ -55,7 +48,7 @@ KNOWN_ISSUES: dict[tuple[str, str], list[str]] = {
         "Integration test (`tests/test_integration.py::TestReadOnlyAgencyClients`) skips on HTTP 403 / `Access denied` for non-agency accounts; live coverage therefore depends on an agency token",
     ],
     ("bidmodifiers", "get"): [
-        "WSDL requires `Levels` (e.g. `[\"CAMPAIGN\"]`) in SelectionCriteria",
+        'WSDL requires `Levels` (e.g. `["CAMPAIGN"]`) in SelectionCriteria',
     ],
     ("keywordsresearch", "has-search-volume"): [
         "WSDL requires both `Keywords` and `RegionIds`",
@@ -64,6 +57,14 @@ KNOWN_ISSUES: dict[tuple[str, str], list[str]] = {
         "WSDL marks `Ids` as `minOccurs=1`",
     ],
 }
+
+
+def coverage_report() -> dict:
+    """Return the machine-readable coverage report once per checklist run."""
+    global _COVERAGE_REPORT
+    if _COVERAGE_REPORT is None:
+        _COVERAGE_REPORT = build_report()
+    return _COVERAGE_REPORT
 
 
 def emoji_for_method(cli_group: str, cli_name: str) -> str:
@@ -107,7 +108,9 @@ def build_method_rows(api_service: str) -> list[dict]:
         wsdl_to_cli[wsdl_op].append(cli_name)
 
     rows = []
-    for wsdl_op in sorted(parse_wsdl_operations(fetch_wsdl(api_service, use_cache=True))):
+    for wsdl_op in sorted(
+        parse_wsdl_operations(fetch_wsdl(api_service, use_cache=True))
+    ):
         cli_names = sorted(wsdl_to_cli.get(wsdl_op, []))
         # Pick the "primary" CLI name. Prefer exact match, otherwise first alpha.
         if wsdl_op in cli_names:
@@ -120,7 +123,9 @@ def build_method_rows(api_service: str) -> list[dict]:
             {
                 "wsdl_op": wsdl_op,
                 "cli_name": primary,
-                "cli_aliases": [c for c in cli_names if c != primary] if primary else [],
+                "cli_aliases": (
+                    [c for c in cli_names if c != primary] if primary else []
+                ),
                 "smoke": SMOKE_OF.get(f"{cli_group}.{primary}") if primary else None,
             }
         )
@@ -171,11 +176,14 @@ def render_method(cli_group: str, row: dict) -> str:
         title += f" · CLI helper aliases: {alias_list}"
 
     is_get = wsdl == "get"
+    schema_ok = coverage_report()["summary"]["schema_parity_ok"]
     fieldnames_check = (
-        "[ ] Default FieldNames validated against WSDL FieldEnum (#108)"
+        "[x] Default FieldNames validated against WSDL FieldEnum"
         if is_get
         else "[n/a] FieldNames validation"
     )
+    if is_get and not schema_ok:
+        fieldnames_check = "[ ] Default FieldNames validated against WSDL FieldEnum"
     # SelectionCriteria check only applies where the WSDL request schema actually
     # contains a SelectionCriteria element. `checkCampaigns` and `deduplicate`
     # have top-level required inputs (Timestamp / Operation+Keywords) but no
@@ -190,9 +198,9 @@ def render_method(cli_group: str, row: dict) -> str:
         # Mark FieldNames or selection unchecked depending on issue type
         joined = " ".join(issues)
         if "FieldNames" in joined and is_get:
-            fieldnames_check = "[ ] ⚠️ Default FieldNames — known issue (see #108)"
+            fieldnames_check = "[ ] ⚠️ Default FieldNames — known issue"
         if "SelectionCriteria" in joined:
-            selection_check = "[ ] ⚠️ SelectionCriteria — known issue (see #108)"
+            selection_check = "[ ] ⚠️ SelectionCriteria — known issue"
     issue_lines = "\n".join(f"  - ⚠️ {note}" for note in issues)
     cli_status = "[x]" if cli_name else "[ ]"
     integration_status = (
@@ -217,7 +225,9 @@ def render_service(api_service: str, idx: int, total: int) -> str:
     method_count = len([r for r in rows if r["wsdl_op"] is not None])
     extras = [r for r in rows if r["wsdl_op"] is None]
     extra_note = f" + {len(extras)} CLI-only guard" if extras else ""
-    svc_emoji = emoji_for_service(cli_group, [r for r in rows if r["wsdl_op"] is not None])
+    svc_emoji = emoji_for_service(
+        cli_group, [r for r in rows if r["wsdl_op"] is not None]
+    )
     label = f"### {idx}/{total}. `{api_service}` {svc_emoji}"
     sub = f"_API service: `{api_service}` · CLI group: `{cli_group}` · WSDL ops: {method_count}{extra_note}_"
     methods_md = "\n".join(render_method(cli_group, row) for row in rows)
@@ -243,6 +253,9 @@ def render_reports_section(idx: int, total: int) -> str:
 
 
 def render_summary() -> str:
+    report = coverage_report()
+    schema_ok = report["summary"]["schema_parity_ok"]
+    schema_status = "✅ `true`" if schema_ok else "🟡 `false`"
     total_wsdl_methods = sum(
         len(parse_wsdl_operations(fetch_wsdl(s, use_cache=True)))
         for s in CANONICAL_API_SERVICES
@@ -258,13 +271,16 @@ def render_summary() -> str:
         "- `summary.live_model_parity_ok`: ✅ `true`\n"
         "- `model_gaps.live_discovered_missing_services`: `[]`\n"
         "- `model_gaps.live_discovered_missing_methods`: `0`\n"
-        "- Schema-level validation gate (FieldNames + SelectionCriteria): "
-        "🟡 partial — see #108 and per-service status below"
+        f"- `summary.schema_parity_ok`: {schema_status}"
     )
 
 
 def render_body() -> str:
     summary = render_summary()
+    report = coverage_report()
+    schema_ok = report["summary"]["schema_parity_ok"]
+    schema_checkbox = "[x]" if schema_ok else "[ ]"
+    schema_status = "✅ `true`" if schema_ok else "🟡 `false`"
     total = len(CANONICAL_API_SERVICES) + 1  # + reports
     services_md = "\n\n".join(
         render_service(api, i + 1, total)
@@ -285,7 +301,7 @@ Version `0.3.0` cannot ship until command/API coverage is 100% across the suppor
 - `scripts/build_api_coverage_report.py` reports `summary.live_model_parity_ok == true` (✅ already true on `main`)
 - `model_gaps.live_discovered_missing_services == []` (✅)
 - `model_gaps.live_discovered_missing_methods == 0` (✅)
-- A new schema-level gate `summary.schema_parity_ok == true` (🟡 introduced by #108) — every `get`-method's default `FieldNames` is a subset of the corresponding WSDL `*FieldEnum`, and every `SelectionCriteria` default satisfies `minOccurs=1`
+- Schema-level gate `summary.schema_parity_ok == true` ({schema_status}) — every `get` default `FieldNames` payload and `COMMON_FIELDS` default is a subset of the corresponding WSDL `*FieldEnum`, and required default `*FieldNames` params are present
 - Every canonical CLI command in the per-service status below shows ✅ on all four checkboxes (or has a documented `n/a` rationale)
 - Every mutating command has dry-run payload coverage or a documented exclusion
 - Wire method names are validated wherever command aliases or kebab-case map to Yandex camelCase
@@ -321,19 +337,16 @@ Service-level emoji rollup:
 
 ---
 
-## Schema validation gate (driven by #108)
+## Schema validation gate
 
-Before this issue can be closed, #108 must be merged so that the `tests/test_api_coverage.py::test_default_fieldnames_match_wsdl_enum` test exists and passes for **all** services. The test parses every `*FieldEnum` from `tests/wsdl_cache/*.xml` and asserts that:
+Current gate status from `scripts/build_api_coverage_report.py`: `summary.schema_parity_ok == {str(schema_ok).lower()}`.
 
-1. Each default `FieldNames` value (from `direct_cli/utils.py:COMMON_FIELDS` and from any hard-coded value inside `direct_cli/commands/*.py`) is a member of the corresponding WSDL enum.
-2. Each `get`-method that has `minOccurs=1` `SelectionCriteria` fields in WSDL refuses to build a payload without them (no silent empty-`SelectionCriteria` requests).
+The gate parses every `*FieldEnum` from `tests/wsdl_cache/*.xml` and asserts that:
 
-Confirmed remaining schema-level work after #107 (driven by #108):
-
-- [ ] `smartadtargets` — drop `Status`, `ServingStatus` from default fields, add `State`.
-- [ ] `adextensions` — add `State` to default fields.
-- [ ] `businesses` — drop `Type` from `COMMON_FIELDS` (not in WSDL enum).
-- [ ] Add the `test_default_fieldnames_match_wsdl_enum` test in `tests/test_api_coverage.py`.
+1. Each default `*FieldNames` value from `direct_cli/utils.py:COMMON_FIELDS` is a member of the corresponding WSDL enum.
+2. Each captured default `get` payload sends enum-valid `*FieldNames` values.
+3. Each multi-field default declared in `COMMON_FIELDS` sends all required default `*FieldNames` request params.
+4. New `get` groups are either covered by the gate or explicitly waived with rationale.
 
 ---
 
@@ -402,7 +415,7 @@ Originally tracked the `dynamicfeedadtargets` (×6 methods) and `strategies` (×
 - [x] `python3 scripts/build_api_coverage_report.py` reports `live_model_parity_ok: true`
 - [x] `model_gaps.live_discovered_missing_services` is empty
 - [x] `model_gaps.live_discovered_missing_methods` is `0`
-- [ ] **NEW:** `summary.schema_parity_ok == true` after #108 merges
+- {schema_checkbox} `summary.schema_parity_ok == true`
 - [ ] Every WSDL service block above shows ✅ at the service-level rollup
 - [ ] `tests/API_COVERAGE.md` lists every canonical command with classification
 - [ ] README API coverage and CLI contract match the CLI surface
@@ -420,7 +433,7 @@ Worked example: `bidmodifiers.toggle` is deprecated since 2025-11-13; live WSDL 
 
 ## Related issues
 
-- #108 — driver of the schema validation gate (FieldNames vs WSDL FieldEnum).
+- #108 — implemented schema validation gate (FieldNames vs WSDL FieldEnum).
 - #107 — fixed default FieldNames for `strategies`, `turbopages`, `businesses`.
 - #102 — removed `keywords archive/unarchive` (API method does not exist).
 - #98 — auto-resolve login after OAuth, fix test isolation.

--- a/scripts/build_api_coverage_report.py
+++ b/scripts/build_api_coverage_report.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 import importlib
 import sys
@@ -118,14 +119,37 @@ def _operation_requires_common_fields(cli_group: str, operation: str) -> bool:
     return not _command_option_is_required(cli_group, cli_command, "fields")
 
 
+def _capture_func_accepts_operation(capture_func) -> bool:
+    """Whether the capture callable accepts a second positional ``operation``."""
+    try:
+        signature = inspect.signature(capture_func)
+    except (TypeError, ValueError):
+        return True
+    positional = [
+        param
+        for param in signature.parameters.values()
+        if param.kind
+        in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.VAR_POSITIONAL,
+        )
+    ]
+    if any(p.kind is inspect.Parameter.VAR_POSITIONAL for p in positional):
+        return True
+    return len(positional) >= 2
+
+
 def _capture_operation_body(capture_func, cli_group: str, operation: str) -> dict:
     """Call a capture function that may accept either group or group+operation."""
-    try:
+    if _capture_func_accepts_operation(capture_func):
         return capture_func(cli_group, operation)
-    except TypeError:
-        if operation != "get":
-            raise
-        return capture_func(cli_group)
+    if operation != "get":
+        raise TypeError(
+            f"capture_func does not accept operation argument; "
+            f"cannot capture {cli_group}.{operation}"
+        )
+    return capture_func(cli_group)
 
 
 def _common_field_resource_targets() -> dict[str, tuple[str, str]]:
@@ -140,6 +164,16 @@ def _common_field_resource_targets() -> dict[str, tuple[str, str]]:
         elif resource in api_to_cli:
             targets[resource] = (api_to_cli[resource], resource)
     return targets
+
+
+def _orphan_common_fields_keys() -> list[str]:
+    """Return ``COMMON_FIELDS`` keys that match no CLI group or API service.
+
+    Catches typos like ``"dynamicfeedadtarget"`` (singular) — silently skipped
+    by ``_common_field_resource_targets`` and therefore never validated.
+    """
+    targets = _common_field_resource_targets()
+    return sorted(set(COMMON_FIELDS) - set(targets))
 
 
 def _validate_common_field_defaults(fetch_wsdl_func) -> tuple[list[dict], list[dict]]:
@@ -320,7 +354,8 @@ def _build_model_gaps(report: dict, live_fetch_wsdl_func) -> dict:
 class _CapturedResponse:
     """Minimal tapi-like response object for CLI request capture."""
 
-    data = {}
+    def __init__(self):
+        self.data = {}
 
     def __call__(self):
         return self
@@ -419,12 +454,13 @@ def capture_cli_get_request_body(cli_group: str) -> dict:
 def build_schema_gate(fetch_wsdl_func=fetch_wsdl, capture_get_body_func=None) -> dict:
     """Validate default CLI ``*FieldNames`` values against WSDL ``*FieldEnum``.
 
-    Returns a result dict with six failure modes that all flip
+    Returns a result dict with seven failure modes that all flip
     ``schema_parity_ok`` to ``False``:
 
     - ``field_name_mismatches`` — values sent by the CLI that are not in the
       corresponding WSDL ``*FieldEnum``, plus invalid values in
-      ``COMMON_FIELDS`` itself.
+      ``COMMON_FIELDS`` itself. Wire-payload entries that duplicate a
+      ``COMMON_FIELDS``-source mismatch for the same value are skipped.
     - ``capture_errors`` — wire-capture failed (missing required option, etc.).
     - ``uncovered_get_groups`` — CLI ``get`` commands whose WSDL has no
       enum-backed validation path and no ``SCHEMA_GATE_WAIVERS`` entry. This
@@ -434,11 +470,26 @@ def build_schema_gate(fetch_wsdl_func=fetch_wsdl, capture_get_body_func=None) ->
       ``*FieldNames`` request param, but the command default payload omits it.
     - ``missing_common_fields`` — enum-backed CLI ``get`` commands that do not
       declare default ``*FieldNames`` in ``COMMON_FIELDS``.
+    - ``orphan_common_fields`` — ``COMMON_FIELDS`` keys that match neither a
+      CLI group nor an API service (typically typos), so they would never be
+      validated against any WSDL enum.
     """
     if capture_get_body_func is None:
         capture_get_body_func = capture_cli_request_body
 
     mismatches, capture_errors = _validate_common_field_defaults(fetch_wsdl_func)
+    # Index COMMON_FIELDS-source mismatches by (cli_group, operation,
+    # request_field, invalid_value) so the wire-payload pass below can skip
+    # values already flagged at the COMMON_FIELDS layer. Without this dedup,
+    # any default that flows through both validators would yield duplicate
+    # entries in field_name_mismatches, breaking single-issue assertions.
+    common_fields_flagged = {
+        (m["cli_group"], m["operation"], m["request_field"], value)
+        for m in mismatches
+        if m["source"] == "COMMON_FIELDS"
+        for value in m["invalid_values"]
+    }
+    orphan_common_fields = _orphan_common_fields_keys()
     missing_field_name_params = []
     missing_common_fields = []
     validated_groups = set()
@@ -531,7 +582,11 @@ def build_schema_gate(fetch_wsdl_func=fetch_wsdl, capture_get_body_func=None) ->
 
                 allowed_values = set(spec["values"])
                 invalid_values = sorted(
-                    value for value in actual_values if value not in allowed_values
+                    value
+                    for value in actual_values
+                    if value not in allowed_values
+                    and (cli_name, operation, request_field, value)
+                    not in common_fields_flagged
                 )
                 if invalid_values:
                     mismatches.append(
@@ -574,6 +629,7 @@ def build_schema_gate(fetch_wsdl_func=fetch_wsdl, capture_get_body_func=None) ->
         "capture_errors": capture_errors,
         "missing_field_name_params": missing_field_name_params,
         "missing_common_fields": missing_common_fields,
+        "orphan_common_fields": orphan_common_fields,
         "uncovered_get_groups": uncovered_get_groups,
         "waiver_misuse": waiver_misuse,
         "schema_parity_ok": (
@@ -581,6 +637,7 @@ def build_schema_gate(fetch_wsdl_func=fetch_wsdl, capture_get_body_func=None) ->
             and not capture_errors
             and not missing_field_name_params
             and not missing_common_fields
+            and not orphan_common_fields
             and not uncovered_get_groups
             and not waiver_misuse
         ),
@@ -692,6 +749,7 @@ def build_report(fetch_wsdl_func=fetch_wsdl, live_fetch_wsdl_func=None) -> dict:
         "capture_errors": schema_gate["capture_errors"],
         "missing_field_name_params": schema_gate["missing_field_name_params"],
         "missing_common_fields": schema_gate["missing_common_fields"],
+        "orphan_common_fields": schema_gate["orphan_common_fields"],
         "uncovered_get_groups": schema_gate["uncovered_get_groups"],
         "waiver_misuse": schema_gate["waiver_misuse"],
     }

--- a/scripts/build_api_coverage_report.py
+++ b/scripts/build_api_coverage_report.py
@@ -19,6 +19,7 @@ from direct_cli.wsdl_coverage import (
     CLI_TO_API_SERVICE,
     INTENTIONAL_EXTRA_METHODS,
     LIVE_DISCOVERED_API_SERVICES,
+    METHOD_NAME_OVERRIDES,
     get_api_coverage_policy,
     fetch_wsdl,
     fetch_live_wsdl,
@@ -27,20 +28,37 @@ from direct_cli.wsdl_coverage import (
     parse_wsdl_operations,
 )
 
-GET_CAPTURE_OPTION_FIXTURES = {
-    "dynamicfeedadtargets": ["--ids", "1"],
-    "leads": ["--turbo-page-ids", "1"],
+FIELD_OPERATION_CAPTURE_OPTION_FIXTURES = {
+    ("changes", "check"): [
+        "--campaign-ids",
+        "1",
+        "--timestamp",
+        "2026-04-14T00:00:00",
+    ],
+    ("dictionaries", "getGeoRegions"): ["--fields", "GeoRegionId"],
+    ("dynamicfeedadtargets", "get"): ["--ids", "1"],
+    ("keywordsresearch", "hasSearchVolume"): [
+        "--keywords",
+        "buy laptop",
+        "--region-ids",
+        "213",
+    ],
+    ("leads", "get"): ["--turbo-page-ids", "1"],
 }
 
-# Explicit allow-list for CLI ``get`` groups whose WSDL has no ``*FieldEnum``
-# request param — there's nothing for the schema gate to validate. Each entry
-# must justify why FieldNames validation is not applicable; any new ``get``
-# command not covered by the gate AND not waived here will fail the build.
+# Explicit allow-list for CLI ``get`` groups whose ``get`` operation has no
+# ``*FieldEnum`` request param. Each entry must justify why default FieldNames
+# validation is not applicable; any new uncovered ``get`` command not waived
+# here will fail the build.
 SCHEMA_GATE_WAIVERS = {
     "dictionaries": (
         "WSDL has no FieldEnum for get; FieldNames is a free-form list of "
         "dictionary names provided by the user."
     ),
+}
+
+CLI_COMMAND_BY_WSDL_OPERATION = {
+    wsdl_name: cli_name for cli_name, wsdl_name in METHOD_NAME_OVERRIDES.items()
 }
 
 
@@ -58,11 +76,62 @@ def _common_default_field_params(
     return {"FieldNames": list(entry)}
 
 
+def _field_name_operations(fetch_wsdl_func, api_service: str) -> dict[str, dict]:
+    """Return WSDL operations that declare enum-backed ``*FieldNames``."""
+    wsdl_xml = _fetch_wsdl(fetch_wsdl_func, api_service)
+    return {
+        operation: get_operation_field_name_enums(wsdl_xml, operation)
+        for operation in parse_wsdl_operations(wsdl_xml)
+        if get_operation_field_name_enums(wsdl_xml, operation)
+    }
+
+
+def _default_common_field_operation(field_operations: dict[str, dict]) -> Optional[str]:
+    """Return the operation whose defaults should be validated from COMMON_FIELDS."""
+    if "get" in field_operations:
+        return "get"
+    if len(field_operations) == 1:
+        return next(iter(field_operations))
+    return None
+
+
+def _cli_command_name_for_operation(operation: str) -> str:
+    """Return Click command name for a WSDL operation."""
+    if operation == "get":
+        return "get"
+    return CLI_COMMAND_BY_WSDL_OPERATION.get(operation, operation)
+
+
+def _cli_command_exists(group_name: str, command_name: str) -> bool:
+    """Return whether a Click command exists."""
+    group = cli.commands.get(group_name)
+    return group is not None and command_name in group.commands
+
+
+def _operation_requires_common_fields(cli_group: str, operation: str) -> bool:
+    """Return whether operation defaults should be sourced from COMMON_FIELDS."""
+    cli_command = _cli_command_name_for_operation(operation)
+    if not _cli_command_exists(cli_group, cli_command):
+        return True
+    if not _command_supports_option(cli_group, cli_command, "fields"):
+        return operation != "get"
+    return not _command_option_is_required(cli_group, cli_command, "fields")
+
+
+def _capture_operation_body(capture_func, cli_group: str, operation: str) -> dict:
+    """Call a capture function that may accept either group or group+operation."""
+    try:
+        return capture_func(cli_group, operation)
+    except TypeError:
+        if operation != "get":
+            raise
+        return capture_func(cli_group)
+
+
 def _common_field_resource_targets() -> dict[str, tuple[str, str]]:
     """Return ``COMMON_FIELDS`` resource -> (cli_group, api_service)."""
     api_to_cli = {
-        api_service: cli_group
-        for cli_group, api_service in CLI_TO_API_SERVICE.items()
+        api_service: cli_group for cli_group, api_service in CLI_TO_API_SERVICE.items()
     }
     targets = {}
     for resource in COMMON_FIELDS:
@@ -81,12 +150,10 @@ def _validate_common_field_defaults(fetch_wsdl_func) -> tuple[list[dict], list[d
     for resource, (cli_name, api_service) in sorted(
         _common_field_resource_targets().items()
     ):
-        if "get" not in get_cli_methods_for_service(cli_name):
-            continue
-
         try:
-            wsdl_xml = _fetch_wsdl(fetch_wsdl_func, api_service)
-            field_specs = get_operation_field_name_enums(wsdl_xml, "get")
+            field_operations = _field_name_operations(fetch_wsdl_func, api_service)
+            operation = _default_common_field_operation(field_operations)
+            field_specs = field_operations.get(operation, {}) if operation else {}
         except Exception as exc:
             capture_errors.append(
                 {
@@ -99,6 +166,11 @@ def _validate_common_field_defaults(fetch_wsdl_func) -> tuple[list[dict], list[d
             )
             continue
 
+        if operation is None:
+            continue
+        if operation not in get_cli_methods_for_service(cli_name):
+            continue
+
         for request_field, actual_values in sorted(
             _common_default_field_params(resource).items()
         ):
@@ -108,7 +180,7 @@ def _validate_common_field_defaults(fetch_wsdl_func) -> tuple[list[dict], list[d
                     {
                         "cli_group": cli_name,
                         "api_service": api_service,
-                        "operation": "get",
+                        "operation": operation,
                         "request_field": request_field,
                         "enum_type": None,
                         "invalid_values": list(actual_values),
@@ -128,7 +200,7 @@ def _validate_common_field_defaults(fetch_wsdl_func) -> tuple[list[dict], list[d
                     {
                         "cli_group": cli_name,
                         "api_service": api_service,
-                        "operation": "get",
+                        "operation": operation,
                         "request_field": request_field,
                         "enum_type": spec["enum_type"],
                         "invalid_values": invalid_values,
@@ -248,6 +320,8 @@ def _build_model_gaps(report: dict, live_fetch_wsdl_func) -> dict:
 class _CapturedResponse:
     """Minimal tapi-like response object for CLI request capture."""
 
+    data = {}
+
     def __call__(self):
         return self
 
@@ -283,23 +357,43 @@ def _command_supports_option(
     group_name: str, command_name: str, param_name: str
 ) -> bool:
     """Return whether a Click command exposes a parameter by internal name."""
-    command = cli.commands[group_name].commands[command_name]
+    group = cli.commands.get(group_name)
+    if group is None or command_name not in group.commands:
+        return False
+    command = group.commands[command_name]
     return any(getattr(param, "name", None) == param_name for param in command.params)
 
 
-def capture_cli_get_request_body(cli_group: str) -> dict:
-    """Invoke ``direct <group> get`` with a fake client and return the body."""
+def _command_option_is_required(
+    group_name: str, command_name: str, param_name: str
+) -> bool:
+    """Return whether a Click command option is required."""
+    group = cli.commands.get(group_name)
+    if group is None or command_name not in group.commands:
+        return False
+    command = group.commands[command_name]
+    for param in command.params:
+        if getattr(param, "name", None) == param_name:
+            return bool(getattr(param, "required", False))
+    return False
+
+
+def capture_cli_request_body(cli_group: str, operation: str = "get") -> dict:
+    """Invoke a CLI command with a fake client and return the request body."""
     module = importlib.import_module(f"direct_cli.commands.{cli_group}")
     original_create_client = module.create_client
     captured = {}
+    cli_command = _cli_command_name_for_operation(operation)
 
     try:
         module.create_client = lambda **_: _CapturedClient(captured)
-        argv = [cli_group, "get"]
-        argv.extend(GET_CAPTURE_OPTION_FIXTURES.get(cli_group, []))
-        if _command_supports_option(cli_group, "get", "limit"):
+        argv = [cli_group, cli_command]
+        argv.extend(
+            FIELD_OPERATION_CAPTURE_OPTION_FIXTURES.get((cli_group, operation), [])
+        )
+        if _command_supports_option(cli_group, cli_command, "limit"):
             argv.extend(["--limit", "1"])
-        if _command_supports_option(cli_group, "get", "output_format"):
+        if _command_supports_option(cli_group, cli_command, "output_format"):
             argv.extend(["--format", "json"])
 
         result = CliRunner().invoke(cli, argv)
@@ -317,29 +411,36 @@ def capture_cli_get_request_body(cli_group: str) -> dict:
     return captured["body"]
 
 
+def capture_cli_get_request_body(cli_group: str) -> dict:
+    """Invoke ``direct <group> get`` with a fake client and return the body."""
+    return capture_cli_request_body(cli_group, "get")
+
+
 def build_schema_gate(fetch_wsdl_func=fetch_wsdl, capture_get_body_func=None) -> dict:
     """Validate default CLI ``*FieldNames`` values against WSDL ``*FieldEnum``.
 
-    Returns a result dict with five failure modes that all flip
+    Returns a result dict with six failure modes that all flip
     ``schema_parity_ok`` to ``False``:
 
     - ``field_name_mismatches`` — values sent by the CLI that are not in the
       corresponding WSDL ``*FieldEnum``, plus invalid values in
       ``COMMON_FIELDS`` itself.
     - ``capture_errors`` — wire-capture failed (missing required option, etc.).
-    - ``uncovered_get_groups`` — CLI ``get`` commands whose WSDL declares a
-      ``*FieldEnum`` but whose actual request did not exercise it (and no
-      ``SCHEMA_GATE_WAIVERS`` entry justifies skipping). This catches new
-      ``get`` commands added without registration in the gate.
+    - ``uncovered_get_groups`` — CLI ``get`` commands whose WSDL has no
+      enum-backed validation path and no ``SCHEMA_GATE_WAIVERS`` entry. This
+      catches new ``get`` commands added without registration in the gate.
     - ``waiver_misuse`` — waivers that no longer point at a no-enum group.
     - ``missing_field_name_params`` — ``COMMON_FIELDS`` declares a default
       ``*FieldNames`` request param, but the command default payload omits it.
+    - ``missing_common_fields`` — enum-backed CLI ``get`` commands that do not
+      declare default ``*FieldNames`` in ``COMMON_FIELDS``.
     """
     if capture_get_body_func is None:
-        capture_get_body_func = capture_cli_get_request_body
+        capture_get_body_func = capture_cli_request_body
 
     mismatches, capture_errors = _validate_common_field_defaults(fetch_wsdl_func)
     missing_field_name_params = []
+    missing_common_fields = []
     validated_groups = set()
     waived_no_enum_groups = set()
 
@@ -348,83 +449,106 @@ def build_schema_gate(fetch_wsdl_func=fetch_wsdl, capture_get_body_func=None) ->
             continue
 
         try:
-            wsdl_xml = _fetch_wsdl(fetch_wsdl_func, api_service)
-            field_specs = get_operation_field_name_enums(wsdl_xml, "get")
+            field_operations = _field_name_operations(fetch_wsdl_func, api_service)
         except Exception as exc:
             capture_errors.append(
                 {
                     "cli_group": cli_name,
                     "api_service": api_service,
-                    "operation": "get",
+                    "operation": "*",
                     "error": str(exc),
                 }
             )
             continue
 
-        if not field_specs:
+        if not field_operations:
             waived_no_enum_groups.add(cli_name)
             continue
+        if (
+            "get" in get_cli_methods_for_service(cli_name)
+            and "get" not in field_operations
+        ):
+            waived_no_enum_groups.add(cli_name)
 
-        expected_field_params = _common_default_field_params(cli_name, api_service)
-
-        try:
-            body = capture_get_body_func(cli_name)
-        except Exception as exc:
-            capture_errors.append(
-                {
-                    "cli_group": cli_name,
-                    "api_service": api_service,
-                    "operation": "get",
-                    "error": str(exc),
-                }
-            )
-            continue
-
-        params = body.get("params", {})
-        missing_params = sorted(
-            request_field
-            for request_field in expected_field_params
-            if request_field not in params
-        )
-        if missing_params:
-            missing_field_name_params.append(
-                {
-                    "cli_group": cli_name,
-                    "api_service": api_service,
-                    "operation": "get",
-                    "missing_params": missing_params,
-                }
-            )
-
-        validated_any_field = False
-        for request_field, spec in sorted(field_specs.items()):
-            if request_field not in params:
+        for operation, field_specs in sorted(field_operations.items()):
+            if operation not in get_cli_methods_for_service(cli_name):
                 continue
-            validated_any_field = True
 
-            actual_values = params[request_field]
-            if not isinstance(actual_values, list):
-                actual_values = [actual_values]
-
-            allowed_values = set(spec["values"])
-            invalid_values = sorted(
-                value for value in actual_values if value not in allowed_values
-            )
-            if invalid_values:
-                mismatches.append(
+            expected_field_params = _common_default_field_params(cli_name, api_service)
+            if (
+                _operation_requires_common_fields(cli_name, operation)
+                and not expected_field_params
+            ):
+                missing_common_fields.append(
                     {
                         "cli_group": cli_name,
                         "api_service": api_service,
-                        "operation": "get",
-                        "request_field": request_field,
-                        "enum_type": spec["enum_type"],
-                        "invalid_values": invalid_values,
-                        "actual_values": actual_values,
-                        "source": "wire_payload",
+                        "operation": operation,
+                        "expected_request_fields": sorted(field_specs),
                     }
                 )
-        if validated_any_field:
-            validated_groups.add(cli_name)
+
+            try:
+                body = _capture_operation_body(
+                    capture_get_body_func, cli_name, operation
+                )
+            except Exception as exc:
+                capture_errors.append(
+                    {
+                        "cli_group": cli_name,
+                        "api_service": api_service,
+                        "operation": operation,
+                        "error": str(exc),
+                    }
+                )
+                continue
+
+            params = body.get("params", {})
+            missing_params = sorted(
+                request_field
+                for request_field in expected_field_params
+                if request_field not in params
+            )
+            if missing_params:
+                missing_field_name_params.append(
+                    {
+                        "cli_group": cli_name,
+                        "api_service": api_service,
+                        "operation": operation,
+                        "missing_params": missing_params,
+                    }
+                )
+
+            validated_any_field = False
+            for request_field, spec in sorted(field_specs.items()):
+                if request_field not in params:
+                    continue
+                validated_any_field = True
+
+                actual_values = params[request_field]
+                if not isinstance(actual_values, list):
+                    actual_values = [actual_values]
+
+                allowed_values = set(spec["values"])
+                invalid_values = sorted(
+                    value for value in actual_values if value not in allowed_values
+                )
+                if invalid_values:
+                    mismatches.append(
+                        {
+                            "cli_group": cli_name,
+                            "api_service": api_service,
+                            "operation": operation,
+                            "request_field": request_field,
+                            "enum_type": spec["enum_type"],
+                            "invalid_values": invalid_values,
+                            "actual_values": actual_values,
+                            "source": "wire_payload",
+                            "resource": cli_name,
+                        }
+                    )
+            if validated_any_field:
+                validated_groups.add(cli_name)
 
     expected_groups = {
         cli_name
@@ -449,12 +573,14 @@ def build_schema_gate(fetch_wsdl_func=fetch_wsdl, capture_get_body_func=None) ->
         "field_name_mismatches": mismatches,
         "capture_errors": capture_errors,
         "missing_field_name_params": missing_field_name_params,
+        "missing_common_fields": missing_common_fields,
         "uncovered_get_groups": uncovered_get_groups,
         "waiver_misuse": waiver_misuse,
         "schema_parity_ok": (
             not mismatches
             and not capture_errors
             and not missing_field_name_params
+            and not missing_common_fields
             and not uncovered_get_groups
             and not waiver_misuse
         ),
@@ -565,6 +691,7 @@ def build_report(fetch_wsdl_func=fetch_wsdl, live_fetch_wsdl_func=None) -> dict:
         "field_name_mismatches": schema_gate["field_name_mismatches"],
         "capture_errors": schema_gate["capture_errors"],
         "missing_field_name_params": schema_gate["missing_field_name_params"],
+        "missing_common_fields": schema_gate["missing_common_fields"],
         "uncovered_get_groups": schema_gate["uncovered_get_groups"],
         "waiver_misuse": schema_gate["waiver_misuse"],
     }

--- a/scripts/build_api_coverage_report.py
+++ b/scripts/build_api_coverage_report.py
@@ -508,6 +508,7 @@ def build_schema_gate(fetch_wsdl_func=fetch_wsdl, capture_get_body_func=None) ->
                     "api_service": api_service,
                     "operation": "*",
                     "error": str(exc),
+                    "source": "wsdl_fetch",
                 }
             )
             continue
@@ -550,6 +551,7 @@ def build_schema_gate(fetch_wsdl_func=fetch_wsdl, capture_get_body_func=None) ->
                         "api_service": api_service,
                         "operation": operation,
                         "error": str(exc),
+                        "source": "wire_payload",
                     }
                 )
                 continue

--- a/scripts/build_api_coverage_report.py
+++ b/scripts/build_api_coverage_report.py
@@ -7,12 +7,14 @@ import json
 import importlib
 import sys
 from pathlib import Path
+from typing import Optional
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from click.testing import CliRunner
 
 from direct_cli.cli import cli
+from direct_cli.utils import COMMON_FIELDS
 from direct_cli.wsdl_coverage import (
     CLI_TO_API_SERVICE,
     INTENTIONAL_EXTRA_METHODS,
@@ -29,6 +31,114 @@ GET_CAPTURE_OPTION_FIXTURES = {
     "dynamicfeedadtargets": ["--ids", "1"],
     "leads": ["--turbo-page-ids", "1"],
 }
+
+# Explicit allow-list for CLI ``get`` groups whose WSDL has no ``*FieldEnum``
+# request param — there's nothing for the schema gate to validate. Each entry
+# must justify why FieldNames validation is not applicable; any new ``get``
+# command not covered by the gate AND not waived here will fail the build.
+SCHEMA_GATE_WAIVERS = {
+    "dictionaries": (
+        "WSDL has no FieldEnum for get; FieldNames is a free-form list of "
+        "dictionary names provided by the user."
+    ),
+}
+
+
+def _common_default_field_params(
+    cli_group: str, api_service: Optional[str] = None
+) -> dict[str, list[str]]:
+    """Return ``COMMON_FIELDS`` defaults keyed by WSDL request param."""
+    entry = COMMON_FIELDS.get(cli_group)
+    if entry is None and api_service is not None:
+        entry = COMMON_FIELDS.get(api_service)
+    if entry is None:
+        return {}
+    if isinstance(entry, dict):
+        return {field_name: list(values) for field_name, values in entry.items()}
+    return {"FieldNames": list(entry)}
+
+
+def _common_field_resource_targets() -> dict[str, tuple[str, str]]:
+    """Return ``COMMON_FIELDS`` resource -> (cli_group, api_service)."""
+    api_to_cli = {
+        api_service: cli_group
+        for cli_group, api_service in CLI_TO_API_SERVICE.items()
+    }
+    targets = {}
+    for resource in COMMON_FIELDS:
+        if resource in CLI_TO_API_SERVICE:
+            targets[resource] = (resource, CLI_TO_API_SERVICE[resource])
+        elif resource in api_to_cli:
+            targets[resource] = (api_to_cli[resource], resource)
+    return targets
+
+
+def _validate_common_field_defaults(fetch_wsdl_func) -> tuple[list[dict], list[dict]]:
+    """Validate every ``COMMON_FIELDS`` entry against its WSDL enum."""
+    mismatches = []
+    capture_errors = []
+
+    for resource, (cli_name, api_service) in sorted(
+        _common_field_resource_targets().items()
+    ):
+        if "get" not in get_cli_methods_for_service(cli_name):
+            continue
+
+        try:
+            wsdl_xml = _fetch_wsdl(fetch_wsdl_func, api_service)
+            field_specs = get_operation_field_name_enums(wsdl_xml, "get")
+        except Exception as exc:
+            capture_errors.append(
+                {
+                    "cli_group": cli_name,
+                    "api_service": api_service,
+                    "operation": "get",
+                    "error": str(exc),
+                    "source": "COMMON_FIELDS",
+                }
+            )
+            continue
+
+        for request_field, actual_values in sorted(
+            _common_default_field_params(resource).items()
+        ):
+            spec = field_specs.get(request_field)
+            if spec is None:
+                mismatches.append(
+                    {
+                        "cli_group": cli_name,
+                        "api_service": api_service,
+                        "operation": "get",
+                        "request_field": request_field,
+                        "enum_type": None,
+                        "invalid_values": list(actual_values),
+                        "actual_values": list(actual_values),
+                        "source": "COMMON_FIELDS",
+                        "resource": resource,
+                    }
+                )
+                continue
+
+            allowed_values = set(spec["values"])
+            invalid_values = sorted(
+                value for value in actual_values if value not in allowed_values
+            )
+            if invalid_values:
+                mismatches.append(
+                    {
+                        "cli_group": cli_name,
+                        "api_service": api_service,
+                        "operation": "get",
+                        "request_field": request_field,
+                        "enum_type": spec["enum_type"],
+                        "invalid_values": invalid_values,
+                        "actual_values": list(actual_values),
+                        "source": "COMMON_FIELDS",
+                        "resource": resource,
+                    }
+                )
+
+    return mismatches, capture_errors
 
 
 def _fetch_wsdl(fetch_func, service: str) -> str:
@@ -208,12 +318,30 @@ def capture_cli_get_request_body(cli_group: str) -> dict:
 
 
 def build_schema_gate(fetch_wsdl_func=fetch_wsdl, capture_get_body_func=None) -> dict:
-    """Validate default CLI ``*FieldNames`` values against WSDL ``*FieldEnum``."""
+    """Validate default CLI ``*FieldNames`` values against WSDL ``*FieldEnum``.
+
+    Returns a result dict with five failure modes that all flip
+    ``schema_parity_ok`` to ``False``:
+
+    - ``field_name_mismatches`` — values sent by the CLI that are not in the
+      corresponding WSDL ``*FieldEnum``, plus invalid values in
+      ``COMMON_FIELDS`` itself.
+    - ``capture_errors`` — wire-capture failed (missing required option, etc.).
+    - ``uncovered_get_groups`` — CLI ``get`` commands whose WSDL declares a
+      ``*FieldEnum`` but whose actual request did not exercise it (and no
+      ``SCHEMA_GATE_WAIVERS`` entry justifies skipping). This catches new
+      ``get`` commands added without registration in the gate.
+    - ``waiver_misuse`` — waivers that no longer point at a no-enum group.
+    - ``missing_field_name_params`` — ``COMMON_FIELDS`` declares a default
+      ``*FieldNames`` request param, but the command default payload omits it.
+    """
     if capture_get_body_func is None:
         capture_get_body_func = capture_cli_get_request_body
 
-    mismatches = []
-    capture_errors = []
+    mismatches, capture_errors = _validate_common_field_defaults(fetch_wsdl_func)
+    missing_field_name_params = []
+    validated_groups = set()
+    waived_no_enum_groups = set()
 
     for cli_name, api_service in sorted(CLI_TO_API_SERVICE.items()):
         if "get" not in get_cli_methods_for_service(cli_name):
@@ -234,7 +362,10 @@ def build_schema_gate(fetch_wsdl_func=fetch_wsdl, capture_get_body_func=None) ->
             continue
 
         if not field_specs:
+            waived_no_enum_groups.add(cli_name)
             continue
+
+        expected_field_params = _common_default_field_params(cli_name, api_service)
 
         try:
             body = capture_get_body_func(cli_name)
@@ -250,9 +381,26 @@ def build_schema_gate(fetch_wsdl_func=fetch_wsdl, capture_get_body_func=None) ->
             continue
 
         params = body.get("params", {})
+        missing_params = sorted(
+            request_field
+            for request_field in expected_field_params
+            if request_field not in params
+        )
+        if missing_params:
+            missing_field_name_params.append(
+                {
+                    "cli_group": cli_name,
+                    "api_service": api_service,
+                    "operation": "get",
+                    "missing_params": missing_params,
+                }
+            )
+
+        validated_any_field = False
         for request_field, spec in sorted(field_specs.items()):
             if request_field not in params:
                 continue
+            validated_any_field = True
 
             actual_values = params[request_field]
             if not isinstance(actual_values, list):
@@ -272,13 +420,44 @@ def build_schema_gate(fetch_wsdl_func=fetch_wsdl, capture_get_body_func=None) ->
                         "enum_type": spec["enum_type"],
                         "invalid_values": invalid_values,
                         "actual_values": actual_values,
+                        "source": "wire_payload",
                     }
                 )
+        if validated_any_field:
+            validated_groups.add(cli_name)
+
+    expected_groups = {
+        cli_name
+        for cli_name in CLI_TO_API_SERVICE
+        if "get" in get_cli_methods_for_service(cli_name)
+    }
+    error_groups = {entry["cli_group"] for entry in capture_errors}
+    uncovered_get_groups = sorted(
+        expected_groups
+        - validated_groups
+        - error_groups
+        - (waived_no_enum_groups & set(SCHEMA_GATE_WAIVERS))
+    )
+
+    waiver_misuse = sorted(
+        cli_name
+        for cli_name in SCHEMA_GATE_WAIVERS
+        if cli_name not in waived_no_enum_groups
+    )
 
     return {
         "field_name_mismatches": mismatches,
         "capture_errors": capture_errors,
-        "schema_parity_ok": not mismatches and not capture_errors,
+        "missing_field_name_params": missing_field_name_params,
+        "uncovered_get_groups": uncovered_get_groups,
+        "waiver_misuse": waiver_misuse,
+        "schema_parity_ok": (
+            not mismatches
+            and not capture_errors
+            and not missing_field_name_params
+            and not uncovered_get_groups
+            and not waiver_misuse
+        ),
     }
 
 
@@ -385,6 +564,9 @@ def build_report(fetch_wsdl_func=fetch_wsdl, live_fetch_wsdl_func=None) -> dict:
     report["schema"] = {
         "field_name_mismatches": schema_gate["field_name_mismatches"],
         "capture_errors": schema_gate["capture_errors"],
+        "missing_field_name_params": schema_gate["missing_field_name_params"],
+        "uncovered_get_groups": schema_gate["uncovered_get_groups"],
+        "waiver_misuse": schema_gate["waiver_misuse"],
     }
     report["summary"]["schema_parity_ok"] = schema_gate["schema_parity_ok"]
 

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -988,6 +988,7 @@ class TestApiCoverage:
         assert report["schema"]["field_name_mismatches"] == []
         assert report["schema"]["capture_errors"] == []
         assert report["schema"]["missing_field_name_params"] == []
+        assert report["schema"]["missing_common_fields"] == []
         assert report["schema"]["uncovered_get_groups"] == []
         assert report["schema"]["waiver_misuse"] == []
 
@@ -1024,13 +1025,18 @@ class TestApiCoverage:
         assert schema_gate["field_name_mismatches"] == []
         assert schema_gate["capture_errors"] == []
         assert schema_gate["missing_field_name_params"] == []
+        assert schema_gate["missing_common_fields"] == []
         assert schema_gate["uncovered_get_groups"] == []
         assert schema_gate["waiver_misuse"] == []
 
     def test_schema_gate_flags_uncovered_get_command(self, monkeypatch):
         """A new ``get`` command without coverage and without waiver fails."""
         report_script = _load_coverage_report_script()
-        monkeypatch.setattr(report_script, "CLI_TO_API_SERVICE", {"fake": "fake"})
+        monkeypatch.setattr(
+            report_script,
+            "CLI_TO_API_SERVICE",
+            {"fake": "fake"},
+        )
         monkeypatch.setattr(
             report_script,
             "get_cli_methods_for_service",
@@ -1050,6 +1056,86 @@ class TestApiCoverage:
         assert schema_gate["uncovered_get_groups"] == ["fake"]
         assert schema_gate["field_name_mismatches"] == []
         assert schema_gate["missing_field_name_params"] == []
+
+    def test_schema_gate_flags_missing_common_fields_for_valid_inline_payload(
+        self, monkeypatch
+    ):
+        """Enum-backed ``get`` commands must declare defaults in COMMON_FIELDS."""
+        report_script = _load_coverage_report_script()
+        monkeypatch.setattr(
+            report_script,
+            "CLI_TO_API_SERVICE",
+            {"fake": "fake"},
+        )
+        monkeypatch.setattr(
+            report_script,
+            "get_cli_methods_for_service",
+            lambda cli_name: {"get"},
+        )
+        monkeypatch.setattr(report_script, "COMMON_FIELDS", {})
+        monkeypatch.setattr(report_script, "SCHEMA_GATE_WAIVERS", {})
+
+        schema_gate = report_script.build_schema_gate(
+            fetch_wsdl_func=lambda service: _wsdl_with_get_field_enum("Id", "Name"),
+            capture_get_body_func=lambda cli_name: {
+                "method": "get",
+                "params": {"FieldNames": ["Id", "Name"]},
+            },
+        )
+
+        assert schema_gate["schema_parity_ok"] is False
+        assert schema_gate["field_name_mismatches"] == []
+        assert schema_gate["missing_field_name_params"] == []
+        assert schema_gate["uncovered_get_groups"] == []
+        assert schema_gate["missing_common_fields"] == [
+            {
+                "cli_group": "fake",
+                "api_service": "fake",
+                "operation": "get",
+                "expected_request_fields": ["FieldNames"],
+            }
+        ]
+
+    def test_schema_gate_validates_non_get_fieldname_operation(self, monkeypatch):
+        """FieldNames validation is not limited to ``get`` operations."""
+        report_script = _load_coverage_report_script()
+        monkeypatch.setattr(
+            report_script,
+            "CLI_TO_API_SERVICE",
+            {"keywordsresearch": "keywordsresearch"},
+        )
+        monkeypatch.setattr(
+            report_script,
+            "get_cli_methods_for_service",
+            lambda cli_name: {"hasSearchVolume"},
+        )
+        monkeypatch.setattr(
+            report_script,
+            "COMMON_FIELDS",
+            {"keywordsresearch": ["Keyword", "Bogus"]},
+        )
+
+        schema_gate = report_script.build_schema_gate(
+            capture_get_body_func=lambda cli_name, operation: {
+                "method": operation,
+                "params": {"FieldNames": ["Keyword"]},
+            },
+        )
+
+        assert schema_gate["schema_parity_ok"] is False
+        assert schema_gate["field_name_mismatches"] == [
+            {
+                "cli_group": "keywordsresearch",
+                "api_service": "keywordsresearch",
+                "operation": "hasSearchVolume",
+                "request_field": "FieldNames",
+                "enum_type": "HasSearchVolumeFieldEnum",
+                "invalid_values": ["Bogus"],
+                "actual_values": ["Keyword", "Bogus"],
+                "source": "COMMON_FIELDS",
+                "resource": "keywordsresearch",
+            }
+        ]
 
     def test_schema_gate_waiver_required_when_no_field_enum(self, monkeypatch):
         """Service with no FieldEnum in WSDL must be explicitly waived."""
@@ -1267,6 +1353,7 @@ class TestApiCoverage:
                 "invalid_values": ["Bogus"],
                 "actual_values": ["Id", "Bogus"],
                 "source": "wire_payload",
+                "resource": "fake",
             }
         ]
 

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -989,6 +989,7 @@ class TestApiCoverage:
         assert report["schema"]["capture_errors"] == []
         assert report["schema"]["missing_field_name_params"] == []
         assert report["schema"]["missing_common_fields"] == []
+        assert report["schema"]["orphan_common_fields"] == []
         assert report["schema"]["uncovered_get_groups"] == []
         assert report["schema"]["waiver_misuse"] == []
 
@@ -1026,6 +1027,7 @@ class TestApiCoverage:
         assert schema_gate["capture_errors"] == []
         assert schema_gate["missing_field_name_params"] == []
         assert schema_gate["missing_common_fields"] == []
+        assert schema_gate["orphan_common_fields"] == []
         assert schema_gate["uncovered_get_groups"] == []
         assert schema_gate["waiver_misuse"] == []
 
@@ -1149,6 +1151,7 @@ class TestApiCoverage:
             "get_cli_methods_for_service",
             lambda cli_name: {"get"},
         )
+        monkeypatch.setattr(report_script, "COMMON_FIELDS", {})
 
         # Without waiver → uncovered
         monkeypatch.setattr(report_script, "SCHEMA_GATE_WAIVERS", {})
@@ -1175,6 +1178,7 @@ class TestApiCoverage:
             "get_cli_methods_for_service",
             lambda cli_name: {"get"},
         )
+        monkeypatch.setattr(report_script, "COMMON_FIELDS", {})
         monkeypatch.setattr(report_script, "SCHEMA_GATE_WAIVERS", {"fake": "stale"})
 
         schema_gate = report_script.build_schema_gate(
@@ -1324,6 +1328,100 @@ class TestApiCoverage:
             }
         ]
 
+    def test_schema_gate_flags_orphan_common_fields_keys(self, monkeypatch):
+        """Typo in COMMON_FIELDS key fails the gate as orphan."""
+        report_script = _load_coverage_report_script()
+        monkeypatch.setattr(report_script, "CLI_TO_API_SERVICE", {"fake": "fake"})
+        monkeypatch.setattr(
+            report_script,
+            "get_cli_methods_for_service",
+            lambda cli_name: {"get"},
+        )
+        # 'fake' matches CLI group; 'typoed_resource' matches nothing.
+        monkeypatch.setattr(
+            report_script,
+            "COMMON_FIELDS",
+            {"fake": ["Id"], "typoed_resource": ["Whatever"]},
+        )
+
+        schema_gate = report_script.build_schema_gate(
+            fetch_wsdl_func=lambda service: _wsdl_with_get_field_enum("Id", "Name"),
+            capture_get_body_func=lambda cli_name, operation: {
+                "method": operation,
+                "params": {"FieldNames": ["Id"]},
+            },
+        )
+
+        assert schema_gate["schema_parity_ok"] is False
+        assert schema_gate["orphan_common_fields"] == ["typoed_resource"]
+        assert schema_gate["field_name_mismatches"] == []
+
+    def test_schema_gate_dedupes_common_fields_and_wire_payload_mismatches(
+        self, monkeypatch
+    ):
+        """Invalid value flagged in COMMON_FIELDS is not also reported from wire."""
+        report_script = _load_coverage_report_script()
+        monkeypatch.setattr(report_script, "CLI_TO_API_SERVICE", {"fake": "fake"})
+        monkeypatch.setattr(
+            report_script,
+            "get_cli_methods_for_service",
+            lambda cli_name: {"get"},
+        )
+        monkeypatch.setattr(
+            report_script,
+            "COMMON_FIELDS",
+            {"fake": ["Id", "Bogus"]},
+        )
+
+        schema_gate = report_script.build_schema_gate(
+            fetch_wsdl_func=lambda service: _wsdl_with_get_field_enum("Id", "Name"),
+            # Wire payload echoes the invalid COMMON_FIELDS value.
+            capture_get_body_func=lambda cli_name, operation: {
+                "method": operation,
+                "params": {"FieldNames": ["Id", "Bogus"]},
+            },
+        )
+
+        assert schema_gate["schema_parity_ok"] is False
+        assert len(schema_gate["field_name_mismatches"]) == 1
+        assert schema_gate["field_name_mismatches"][0]["source"] == "COMMON_FIELDS"
+        assert schema_gate["field_name_mismatches"][0]["invalid_values"] == ["Bogus"]
+
+    def test_capture_operation_body_does_not_swallow_internal_typeerror(self):
+        """Internal TypeError must surface, not be retried as arity mismatch."""
+        report_script = _load_coverage_report_script()
+        call_count = {"two_arg": 0, "one_arg": 0}
+
+        def bad_two_arg_capture(cli_name, operation):
+            call_count["two_arg"] += 1
+            raise TypeError("boom from inside")
+
+        def bad_one_arg_capture(cli_name):
+            call_count["one_arg"] += 1
+            raise TypeError("boom from inside one-arg")
+
+        # Two-arg signature → arity check passes, no fallback re-call.
+        with pytest.raises(TypeError, match="boom from inside"):
+            report_script._capture_operation_body(
+                bad_two_arg_capture, "fake", "get"
+            )
+        assert call_count["two_arg"] == 1  # exactly one call, no silent retry
+
+        # One-arg signature on non-get operation must raise, not silently fall
+        # back to one-arg call (which would lose the operation context).
+        with pytest.raises(TypeError):
+            report_script._capture_operation_body(
+                bad_one_arg_capture, "fake", "set"
+            )
+
+        # One-arg on get → falls back to single-arg call (legacy compat).
+        call_count["one_arg"] = 0
+        with pytest.raises(TypeError, match="one-arg"):
+            report_script._capture_operation_body(
+                bad_one_arg_capture, "fake", "get"
+            )
+        assert call_count["one_arg"] == 1
+
     def test_schema_gate_reports_invalid_default_fieldname(self, monkeypatch):
         report_script = _load_coverage_report_script()
         monkeypatch.setattr(report_script, "CLI_TO_API_SERVICE", {"fake": "fake"})
@@ -1332,6 +1430,7 @@ class TestApiCoverage:
             "get_cli_methods_for_service",
             lambda cli_name: {"get"},
         )
+        monkeypatch.setattr(report_script, "COMMON_FIELDS", {})
 
         schema_gate = report_script.build_schema_gate(
             fetch_wsdl_func=lambda service: _wsdl_with_get_field_enum("Id", "Name"),

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -98,6 +98,54 @@ def _wsdl_with_get_field_enum(*values):
     )
 
 
+def _wsdl_with_get_field_enums(field_values):
+    """Build a minimal WSDL get request with several ``*FieldNames`` enums."""
+    simple_types = []
+    elements = []
+    for field_name, values in field_values.items():
+        enum_stem = field_name.removesuffix("Names")
+        enum_type = f"Fake{enum_stem}Enum"
+        enum_values = "\n".join(
+            f'                <xsd:enumeration value="{value}" />' for value in values
+        )
+        simple_types.append(
+            f'        <xsd:simpleType name="{enum_type}">\n'
+            '            <xsd:restriction base="xsd:string">\n'
+            f"{enum_values}\n"
+            "            </xsd:restriction>\n"
+            "        </xsd:simpleType>"
+        )
+        elements.append(
+            f'                    <xsd:element name="{field_name}" '
+            f'type="tns:{enum_type}" minOccurs="0" maxOccurs="unbounded" />'
+        )
+
+    return (
+        '<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" '
+        'xmlns:xsd="http://www.w3.org/2001/XMLSchema" '
+        'xmlns:tns="http://api.direct.yandex.com/v5/fake">\n'
+        '    <wsdl:message name="getRequest">\n'
+        '        <wsdl:part name="parameters" element="tns:get" />\n'
+        "    </wsdl:message>\n"
+        "    <wsdl:portType>\n"
+        '        <wsdl:operation name="get">\n'
+        '            <wsdl:input message="tns:getRequest" />\n'
+        "        </wsdl:operation>\n"
+        "    </wsdl:portType>\n"
+        '    <xsd:schema targetNamespace="http://api.direct.yandex.com/v5/fake">\n'
+        f"{chr(10).join(simple_types)}\n"
+        '        <xsd:element name="get">\n'
+        "            <xsd:complexType>\n"
+        "                <xsd:sequence>\n"
+        f"{chr(10).join(elements)}\n"
+        "                </xsd:sequence>\n"
+        "            </xsd:complexType>\n"
+        "        </xsd:element>\n"
+        "    </xsd:schema>\n"
+        "</wsdl:definitions>\n"
+    )
+
+
 DRY_RUN_PAYLOAD_EXCLUSIONS = {
     "adextensions.add": "Callout-only add; covered by command-level dry-run tests.",
     "adgroups.add": "Requires group-type-specific typed payload fixtures; tracked separately from schema smoke coverage.",
@@ -939,6 +987,9 @@ class TestApiCoverage:
         assert report["model_gaps"]["live_discovered_missing_services"] == []
         assert report["schema"]["field_name_mismatches"] == []
         assert report["schema"]["capture_errors"] == []
+        assert report["schema"]["missing_field_name_params"] == []
+        assert report["schema"]["uncovered_get_groups"] == []
+        assert report["schema"]["waiver_misuse"] == []
 
     def test_real_wsdl_field_enum_parser_for_108_services(self):
         expected = {
@@ -972,6 +1023,220 @@ class TestApiCoverage:
         assert schema_gate["schema_parity_ok"] is True
         assert schema_gate["field_name_mismatches"] == []
         assert schema_gate["capture_errors"] == []
+        assert schema_gate["missing_field_name_params"] == []
+        assert schema_gate["uncovered_get_groups"] == []
+        assert schema_gate["waiver_misuse"] == []
+
+    def test_schema_gate_flags_uncovered_get_command(self, monkeypatch):
+        """A new ``get`` command without coverage and without waiver fails."""
+        report_script = _load_coverage_report_script()
+        monkeypatch.setattr(report_script, "CLI_TO_API_SERVICE", {"fake": "fake"})
+        monkeypatch.setattr(
+            report_script,
+            "get_cli_methods_for_service",
+            lambda cli_name: {"get"},
+        )
+        monkeypatch.setattr(report_script, "SCHEMA_GATE_WAIVERS", {})
+
+        schema_gate = report_script.build_schema_gate(
+            fetch_wsdl_func=lambda service: _wsdl_with_get_field_enum("Id", "Name"),
+            capture_get_body_func=lambda cli_name: {
+                "method": "get",
+                "params": {},  # never sends FieldNames → not exercised
+            },
+        )
+
+        assert schema_gate["schema_parity_ok"] is False
+        assert schema_gate["uncovered_get_groups"] == ["fake"]
+        assert schema_gate["field_name_mismatches"] == []
+        assert schema_gate["missing_field_name_params"] == []
+
+    def test_schema_gate_waiver_required_when_no_field_enum(self, monkeypatch):
+        """Service with no FieldEnum in WSDL must be explicitly waived."""
+        report_script = _load_coverage_report_script()
+        # Use real dictionaries WSDL: it has a get operation but no *FieldEnum.
+        monkeypatch.setattr(
+            report_script, "CLI_TO_API_SERVICE", {"fake": "dictionaries"}
+        )
+        monkeypatch.setattr(
+            report_script,
+            "get_cli_methods_for_service",
+            lambda cli_name: {"get"},
+        )
+
+        # Without waiver → uncovered
+        monkeypatch.setattr(report_script, "SCHEMA_GATE_WAIVERS", {})
+        gate_no_waiver = report_script.build_schema_gate(
+            capture_get_body_func=lambda cli: {"method": "get", "params": {}},
+        )
+        assert gate_no_waiver["schema_parity_ok"] is False
+        assert "fake" in gate_no_waiver["uncovered_get_groups"]
+
+        # With waiver → passes
+        monkeypatch.setattr(report_script, "SCHEMA_GATE_WAIVERS", {"fake": "no enum"})
+        gate_waived = report_script.build_schema_gate(
+            capture_get_body_func=lambda cli: {"method": "get", "params": {}},
+        )
+        assert gate_waived["schema_parity_ok"] is True
+        assert gate_waived["uncovered_get_groups"] == []
+
+    def test_schema_gate_flags_stale_waiver(self, monkeypatch):
+        """A waiver for a service that DOES have FieldEnum is misuse."""
+        report_script = _load_coverage_report_script()
+        monkeypatch.setattr(report_script, "CLI_TO_API_SERVICE", {"fake": "fake"})
+        monkeypatch.setattr(
+            report_script,
+            "get_cli_methods_for_service",
+            lambda cli_name: {"get"},
+        )
+        monkeypatch.setattr(report_script, "SCHEMA_GATE_WAIVERS", {"fake": "stale"})
+
+        schema_gate = report_script.build_schema_gate(
+            fetch_wsdl_func=lambda s: _wsdl_with_get_field_enum("Id", "Name"),
+            capture_get_body_func=lambda cli: {
+                "method": "get",
+                "params": {"FieldNames": ["Id"]},
+            },
+        )
+        assert schema_gate["schema_parity_ok"] is False
+        assert schema_gate["waiver_misuse"] == ["fake"]
+
+    def test_schema_gate_flags_missing_common_field_name_params(self, monkeypatch):
+        """Multi-FieldNames defaults must all appear in the command payload."""
+        report_script = _load_coverage_report_script()
+        monkeypatch.setattr(report_script, "CLI_TO_API_SERVICE", {"fake": "fake"})
+        monkeypatch.setattr(
+            report_script,
+            "get_cli_methods_for_service",
+            lambda cli_name: {"get"},
+        )
+        monkeypatch.setattr(
+            report_script,
+            "COMMON_FIELDS",
+            {
+                "fake": {
+                    "FieldNames": ["Id"],
+                    "SearchFieldNames": ["Bid"],
+                    "NetworkFieldNames": ["Bid"],
+                }
+            },
+        )
+
+        schema_gate = report_script.build_schema_gate(
+            fetch_wsdl_func=lambda service: _wsdl_with_get_field_enums(
+                {
+                    "FieldNames": ["Id"],
+                    "SearchFieldNames": ["Bid"],
+                    "NetworkFieldNames": ["Bid"],
+                }
+            ),
+            capture_get_body_func=lambda cli_name: {
+                "method": "get",
+                "params": {"FieldNames": ["Id"]},
+            },
+        )
+
+        assert schema_gate["schema_parity_ok"] is False
+        assert schema_gate["field_name_mismatches"] == []
+        assert schema_gate["missing_field_name_params"] == [
+            {
+                "cli_group": "fake",
+                "api_service": "fake",
+                "operation": "get",
+                "missing_params": ["NetworkFieldNames", "SearchFieldNames"],
+            }
+        ]
+
+    def test_schema_gate_validates_common_fields_even_when_payload_is_valid(
+        self, monkeypatch
+    ):
+        """Invalid ``COMMON_FIELDS`` values fail even if captured wire is clean."""
+        report_script = _load_coverage_report_script()
+        monkeypatch.setattr(report_script, "CLI_TO_API_SERVICE", {"fake": "fake"})
+        monkeypatch.setattr(
+            report_script,
+            "get_cli_methods_for_service",
+            lambda cli_name: {"get"},
+        )
+        monkeypatch.setattr(
+            report_script,
+            "COMMON_FIELDS",
+            {"fake": {"FieldNames": ["Id", "Bogus"], "TextAdFieldNames": ["Title"]}},
+        )
+
+        schema_gate = report_script.build_schema_gate(
+            fetch_wsdl_func=lambda service: _wsdl_with_get_field_enums(
+                {
+                    "FieldNames": ["Id"],
+                    "TextAdFieldNames": ["Title"],
+                }
+            ),
+            capture_get_body_func=lambda cli_name: {
+                "method": "get",
+                "params": {
+                    "FieldNames": ["Id"],
+                    "TextAdFieldNames": ["Title"],
+                },
+            },
+        )
+
+        assert schema_gate["schema_parity_ok"] is False
+        assert schema_gate["missing_field_name_params"] == []
+        assert schema_gate["field_name_mismatches"] == [
+            {
+                "cli_group": "fake",
+                "api_service": "fake",
+                "operation": "get",
+                "request_field": "FieldNames",
+                "enum_type": "FakeFieldEnum",
+                "invalid_values": ["Bogus"],
+                "actual_values": ["Id", "Bogus"],
+                "source": "COMMON_FIELDS",
+                "resource": "fake",
+            }
+        ]
+
+    def test_schema_gate_validates_api_service_keyed_common_fields(self, monkeypatch):
+        """``COMMON_FIELDS`` entries keyed by API service are validated too."""
+        report_script = _load_coverage_report_script()
+        monkeypatch.setattr(
+            report_script,
+            "CLI_TO_API_SERVICE",
+            {"retargeting": "retargetinglists"},
+        )
+        monkeypatch.setattr(
+            report_script,
+            "get_cli_methods_for_service",
+            lambda cli_name: {"get"},
+        )
+        monkeypatch.setattr(
+            report_script,
+            "COMMON_FIELDS",
+            {"retargetinglists": ["Id", "Bogus"]},
+        )
+
+        schema_gate = report_script.build_schema_gate(
+            fetch_wsdl_func=lambda service: _wsdl_with_get_field_enum("Id", "Name"),
+            capture_get_body_func=lambda cli_name: {
+                "method": "get",
+                "params": {"FieldNames": ["Id"]},
+            },
+        )
+
+        assert schema_gate["schema_parity_ok"] is False
+        assert schema_gate["field_name_mismatches"] == [
+            {
+                "cli_group": "retargeting",
+                "api_service": "retargetinglists",
+                "operation": "get",
+                "request_field": "FieldNames",
+                "enum_type": "FakeFieldEnum",
+                "invalid_values": ["Bogus"],
+                "actual_values": ["Id", "Bogus"],
+                "source": "COMMON_FIELDS",
+                "resource": "retargetinglists",
+            }
+        ]
 
     def test_schema_gate_reports_invalid_default_fieldname(self, monkeypatch):
         report_script = _load_coverage_report_script()
@@ -1001,6 +1266,7 @@ class TestApiCoverage:
                 "enum_type": "FakeFieldEnum",
                 "invalid_values": ["Bogus"],
                 "actual_values": ["Id", "Bogus"],
+                "source": "wire_payload",
             }
         ]
 

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -54,6 +54,7 @@ from unittest.mock import patch
 from click.testing import CliRunner
 
 from direct_cli.cli import cli
+from direct_cli.utils import get_default_fields
 
 
 def _dry_run(*args: str) -> dict:
@@ -239,15 +240,10 @@ def test_ads_get_default_fieldnames():
     """Default FieldNames includes basic top-level fields, plus TextAdFieldNames."""
     body = _dry_run("ads", "get", "--campaign-ids", "12345")
     assert body["method"] == "get"
-    assert body["params"]["FieldNames"] == [
-        "Id",
-        "CampaignId",
-        "AdGroupId",
-        "Status",
-        "State",
-        "Type",
-    ]
-    assert body["params"]["TextAdFieldNames"] == ["Title", "Title2", "Text", "Href"]
+    assert body["params"]["FieldNames"] == get_default_fields("ads", "FieldNames")
+    assert body["params"]["TextAdFieldNames"] == get_default_fields(
+        "ads", "TextAdFieldNames"
+    )
 
 
 def test_ads_get_with_fields_overrides_defaults():


### PR DESCRIPTION
## Summary

Closes #108 by eliminating the architectural causes of WSDL FieldName regressions, not just the latest symptoms.

- **One source of truth**: every default `FieldNames` now flows through `COMMON_FIELDS` + `get_default_fields()`. No inline literals remain in `direct_cli/commands/` (except `dictionaries`, where the list is required CLI input).
- **Multi-FieldNames support**: `COMMON_FIELDS` entries can be dicts keyed by WSDL request param. Used for `ads` (`FieldNames` + `TextAdFieldNames`) and `keywordbids` (`FieldNames` + `SearchFieldNames` + `NetworkFieldNames`).
- **Hardened schema gate**: `build_schema_gate` now validates `COMMON_FIELDS` directly against WSDL `*FieldEnum` (not only wire payload), and exposes five failure buckets — `field_name_mismatches`, `capture_errors`, `uncovered_get_groups`, `waiver_misuse`, `missing_field_name_params`. Any non-empty bucket flips `schema_parity_ok` to `false`.
- **Explicit waivers**: `SCHEMA_GATE_WAIVERS` requires a justification string for any `get` command without WSDL `*FieldEnum` (currently only `dictionaries`). Stale waivers (where Yandex later adds an enum) fail the gate as `waiver_misuse`.
- **Regression tests** prove the gate catches: invalid values in `COMMON_FIELDS`, uncovered new commands, missing waivers, stale waivers, and incomplete multi-FieldNames coverage.

Why this closes #108 permanently: there is no longer a way to add a new `get` resource that bypasses validation. Adding a command without a `COMMON_FIELDS` entry (or explicit waiver) fails CI.

## Test plan

- [x] `pytest -q` — 89 passed in test_api_coverage.py, full suite green
- [x] `python3 scripts/build_api_coverage_report.py` — `schema_parity_ok: true`, all 5 schema buckets empty
- [x] `python3 scripts/check_wsdl_drift.py` — 29 services, 0 drift
- [x] Live read-only smoke on 7 migrated commands (`bids`, `bidmodifiers`, `audiencetargets`, `keywordbids`, `dynamicads`, `strategies`, `dynamicfeedadtargets`) — no `error_code=8000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)