### PR TITLE
feat: add V4 Live CLI foundation

### DIFF
--- a/direct_cli/api.py
+++ b/direct_cli/api.py
@@ -5,6 +5,7 @@ API client wrapper for Direct CLI
 from typing import Optional, Dict, Any, List
 
 from direct_cli._vendor.tapi_yandex_direct import YandexDirect
+from direct_cli._vendor.tapi_yandex_direct.v4 import YandexDirectV4Live
 from .auth import get_credentials
 
 
@@ -64,6 +65,58 @@ def create_client(
         skip_column_header=skip_column_header,
         skip_report_summary=skip_report_summary,
         language=language,
+    )
+
+
+def create_v4_client(
+    token: Optional[str] = None,
+    login: Optional[str] = None,
+    profile: Optional[str] = None,
+    sandbox: bool = False,
+    op_token_ref: Optional[str] = None,
+    op_login_ref: Optional[str] = None,
+    bw_token_ref: Optional[str] = None,
+    bw_login_ref: Optional[str] = None,
+    language: Optional[str] = None,
+    retry_if_exceeded_limit: bool = True,
+    retries_if_server_error: int = 5,
+) -> YandexDirectV4Live:
+    """
+    Create YandexDirect v4 Live client.
+
+    Args:
+        token: API access token
+        login: Client login (for agency accounts)
+        profile: Credential profile name
+        sandbox: Use sandbox API
+        op_token_ref: 1Password secret reference for token
+        op_login_ref: 1Password secret reference for login
+        bw_token_ref: Bitwarden item name/ID for token
+        bw_login_ref: Bitwarden item name/ID for login
+        language: API locale
+        retry_if_exceeded_limit: Retry when the API limit is exceeded
+        retries_if_server_error: Number of retries for server errors
+
+    Returns:
+        YandexDirect v4 Live client instance
+    """
+    final_token, final_login = get_credentials(
+        token,
+        login,
+        profile=profile,
+        op_token_ref=op_token_ref,
+        op_login_ref=op_login_ref,
+        bw_token_ref=bw_token_ref,
+        bw_login_ref=bw_login_ref,
+    )
+
+    return YandexDirectV4Live(
+        access_token=final_token,
+        login=final_login,
+        is_sandbox=sandbox,
+        language=language or "en",
+        retry_if_exceeded_limit=retry_if_exceeded_limit,
+        retries_if_server_error=retries_if_server_error,
     )
 
 

--- a/direct_cli/cli.py
+++ b/direct_cli/cli.py
@@ -41,6 +41,15 @@ from .commands.advideos import advideos
 from .commands.dynamicfeedadtargets import dynamicfeedadtargets
 from .commands.strategies import strategies
 from .commands.auth import auth
+from .commands.v4shells import (
+    v4account,
+    v4events,
+    v4finance,
+    v4forecast,
+    v4goals,
+    v4meta,
+    v4wordstat,
+)
 
 # Load .env file
 load_dotenv()
@@ -173,6 +182,13 @@ for command in (
     advideos,
     dynamicfeedadtargets,
     strategies,
+    v4finance,
+    v4account,
+    v4goals,
+    v4events,
+    v4wordstat,
+    v4forecast,
+    v4meta,
     auth,
 ):
     _register_command(command)

--- a/direct_cli/commands/v4shells.py
+++ b/direct_cli/commands/v4shells.py
@@ -5,7 +5,8 @@ import click
 V4_EPILOG = (
     "\b\n"
     "V4 Live commands use typed flags only. Supported methods are listed in "
-    "direct_cli/_vendor/tapi_yandex_direct/v4/resource_mapping.py."
+    "the Yandex Direct v4 Live documentation: "
+    "https://yandex.com/dev/direct/doc/dg-v4/en/live/concepts"
 )
 
 

--- a/direct_cli/commands/v4shells.py
+++ b/direct_cli/commands/v4shells.py
@@ -1,0 +1,44 @@
+"""Shell command groups for Yandex Direct v4 Live command families."""
+
+import click
+
+V4_EPILOG = (
+    "\b\n"
+    "V4 Live commands use typed flags only. Supported methods are listed in "
+    "direct_cli/_vendor/tapi_yandex_direct/v4/resource_mapping.py."
+)
+
+
+@click.group(epilog=V4_EPILOG)
+def v4finance():
+    """Yandex Direct v4 Live finance commands."""
+
+
+@click.group(epilog=V4_EPILOG)
+def v4account():
+    """Yandex Direct v4 Live account commands."""
+
+
+@click.group(epilog=V4_EPILOG)
+def v4goals():
+    """Yandex Direct v4 Live goals commands."""
+
+
+@click.group(epilog=V4_EPILOG)
+def v4events():
+    """Yandex Direct v4 Live events commands."""
+
+
+@click.group(epilog=V4_EPILOG)
+def v4wordstat():
+    """Yandex Direct v4 Live wordstat commands."""
+
+
+@click.group(epilog=V4_EPILOG)
+def v4forecast():
+    """Yandex Direct v4 Live forecast commands."""
+
+
+@click.group(epilog=V4_EPILOG)
+def v4meta():
+    """Yandex Direct v4 Live metadata commands."""

--- a/direct_cli/v4.py
+++ b/direct_cli/v4.py
@@ -1,0 +1,17 @@
+"""Shared helpers for Yandex Direct v4 Live commands."""
+
+from typing import Any, Optional
+
+
+def build_v4_body(method: str, param: Optional[dict] = None) -> dict:
+    """Build a v4 Live request body."""
+    body = {"method": method}
+    if param is not None:
+        body["param"] = param
+    return body
+
+
+def call_v4(client: Any, method: str, param: Optional[dict] = None) -> Any:
+    """Call one v4 Live method and return the extracted response payload."""
+    result = client.v4live().post(data=build_v4_body(method, param))
+    return result().extract()

--- a/tests/test_comprehensive.py
+++ b/tests/test_comprehensive.py
@@ -64,6 +64,13 @@ class TestCommandsRegistered(unittest.TestCase):
         "dynamicads",
         "dynamicfeedadtargets",
         "strategies",
+        "v4finance",
+        "v4account",
+        "v4goals",
+        "v4events",
+        "v4wordstat",
+        "v4forecast",
+        "v4meta",
         "auth",
     ]
 

--- a/tests/test_smoke_matrix.py
+++ b/tests/test_smoke_matrix.py
@@ -57,7 +57,7 @@ def test_smoke_matrix_covers_every_cli_subcommand_once():
 def test_smoke_matrix_counts_match_current_cli_surface():
     summary = smoke_summary()
 
-    assert summary["total_cli_groups"] == 31
+    assert summary["total_cli_groups"] == 38
     assert summary["total_cli_subcommands"] == 120
     assert summary["api_cli_subcommands"] == 116
     assert summary["wsdl_services"] == 29

--- a/tests/test_v4_foundation.py
+++ b/tests/test_v4_foundation.py
@@ -1,10 +1,10 @@
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from click.testing import CliRunner
 
 from direct_cli.api import create_v4_client
 from direct_cli.cli import cli
-from direct_cli.v4 import build_v4_body
+from direct_cli.v4 import build_v4_body, call_v4
 
 
 def test_create_v4_client_passes_resolved_credentials():
@@ -39,6 +39,23 @@ def test_build_v4_body_with_param():
         "method": "GetClientsUnits",
         "param": {"Logins": ["x"]},
     }
+
+
+def test_call_v4_posts_body_and_returns_extracted_payload():
+    response = Mock()
+    response.return_value.extract.return_value = [{"Login": "x", "Units": 100}]
+    resource = Mock()
+    resource.post.return_value = response
+    client = Mock()
+    client.v4live.return_value = resource
+
+    result = call_v4(client, "GetClientsUnits", {"Logins": ["x"]})
+
+    resource.post.assert_called_once_with(
+        data={"method": "GetClientsUnits", "param": {"Logins": ["x"]}}
+    )
+    response.return_value.extract.assert_called_once_with()
+    assert result == [{"Login": "x", "Units": 100}]
 
 
 def test_v4_groups_appear_in_root_help():

--- a/tests/test_v4_foundation.py
+++ b/tests/test_v4_foundation.py
@@ -1,0 +1,74 @@
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from direct_cli.api import create_v4_client
+from direct_cli.cli import cli
+from direct_cli.v4 import build_v4_body
+
+
+def test_create_v4_client_passes_resolved_credentials():
+    with patch("direct_cli.api.get_credentials", return_value=("token", "login")):
+        with patch("direct_cli.api.YandexDirectV4Live") as client_class:
+            create_v4_client(
+                token="raw-token",
+                login="raw-login",
+                profile="prod",
+                sandbox=True,
+                op_token_ref="op://vault/item/token",
+                op_login_ref="op://vault/item/login",
+                bw_token_ref="bw-token",
+                bw_login_ref="bw-login",
+                language="ru",
+                retry_if_exceeded_limit=False,
+                retries_if_server_error=2,
+            )
+
+    client_class.assert_called_once_with(
+        access_token="token",
+        login="login",
+        is_sandbox=True,
+        language="ru",
+        retry_if_exceeded_limit=False,
+        retries_if_server_error=2,
+    )
+
+
+def test_build_v4_body_with_param():
+    assert build_v4_body("GetClientsUnits", {"Logins": ["x"]}) == {
+        "method": "GetClientsUnits",
+        "param": {"Logins": ["x"]},
+    }
+
+
+def test_v4_groups_appear_in_root_help():
+    result = CliRunner().invoke(cli, ["--help"])
+
+    assert result.exit_code == 0
+    for group in [
+        "v4finance",
+        "v4account",
+        "v4goals",
+        "v4events",
+        "v4wordstat",
+        "v4forecast",
+        "v4meta",
+    ]:
+        assert group in result.output
+
+
+def test_v4_group_help_does_not_mention_json_input():
+    runner = CliRunner()
+
+    for group in [
+        "v4finance",
+        "v4account",
+        "v4goals",
+        "v4events",
+        "v4wordstat",
+        "v4forecast",
+        "v4meta",
+    ]:
+        result = runner.invoke(cli, [group, "--help"])
+        assert result.exit_code == 0
+        assert "--json" not in result.output


### PR DESCRIPTION
Closes #124

## Summary
- add a v4 Live client factory and shared request helpers
- register empty v4 command-family groups for future typed commands
- cover v4 helper/client wiring and CLI registration in tests

## Tests
- pytest -q tests/test_v4_foundation.py tests/test_comprehensive.py tests/test_smoke_matrix.py
- pytest -q tests/test_api_coverage.py tests/test_cli.py