### PR TITLE
feat: add V4 Live balance command

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ Invoking the deprecated `direct-cli` entrypoint exits with
 ### Quick Start: Check Balance
 
 Yandex removed the legacy v4 `GetBalance` method. Direct CLI uses the v4 Live
-`GetClientsUnits` method for `direct balance`.
+`AccountManagement` method with `Action=Get` for `direct balance`, returning
+money fields such as `Amount`, `AmountAvailableForTransfer`, and `Currency`.
 
 ```bash
 direct balance

--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ Install with `pip install direct-cli`, then run commands with `direct`.
 Invoking the deprecated `direct-cli` entrypoint exits with
 `use direct instead of direct-cli`.
 
+### Quick Start: Check Balance
+
+Yandex removed the legacy v4 `GetBalance` method. Direct CLI uses the v4 Live
+`GetClientsUnits` method for `direct balance`.
+
+```bash
+direct balance
+direct balance --logins client-login,other-client --format table
+direct balance --logins client-login --dry-run
+```
+
 ### Global Options
 
 | Option | Description |

--- a/direct_cli/cli.py
+++ b/direct_cli/cli.py
@@ -41,6 +41,7 @@ from .commands.advideos import advideos
 from .commands.dynamicfeedadtargets import dynamicfeedadtargets
 from .commands.strategies import strategies
 from .commands.auth import auth
+from .commands.balance import balance
 from .commands.v4shells import (
     v4account,
     v4events,
@@ -182,6 +183,7 @@ for command in (
     advideos,
     dynamicfeedadtargets,
     strategies,
+    balance,
     v4finance,
     v4account,
     v4goals,

--- a/direct_cli/commands/balance.py
+++ b/direct_cli/commands/balance.py
@@ -25,16 +25,18 @@ from ..v4_contracts import v4_method_contract
 def balance(ctx, logins, output_format, output, dry_run):
     """Check account money balance."""
     login_list = parse_csv_strings(logins)
-    if not login_list:
-        configured_login = ctx.obj.get("login")
-        if not configured_login:
-            raise click.UsageError("Provide --logins or configure YANDEX_DIRECT_LOGIN")
+    configured_login = ctx.obj.get("login")
+    if not login_list and configured_login:
         login_list = [configured_login]
 
     param = {
         "Action": "Get",
-        "SelectionCriteria": {"Logins": login_list},
     }
+    if login_list:
+        param["SelectionCriteria"] = {"Logins": login_list}
+    elif ctx.obj.get("sandbox"):
+        raise click.UsageError("Provide --logins or configure YANDEX_DIRECT_LOGIN")
+
     if dry_run:
         format_output(build_v4_body("AccountManagement", param), "json", None)
         return
@@ -47,7 +49,7 @@ def balance(ctx, logins, output_format, output, dry_run):
             sandbox=ctx.obj.get("sandbox"),
         )
         data = call_v4(client, "AccountManagement", param)
-        format_output(data.get("Accounts", data), output_format, output)
+        format_output(data, output_format, output)
     except Exception as e:
         print_error(str(e))
         raise click.Abort()

--- a/direct_cli/commands/balance.py
+++ b/direct_cli/commands/balance.py
@@ -6,8 +6,10 @@ from ..api import create_v4_client
 from ..output import format_output, print_error
 from ..utils import parse_csv_strings
 from ..v4 import build_v4_body, call_v4
+from ..v4_contracts import v4_method_contract
 
 
+@v4_method_contract("GetClientsUnits")
 @click.command()
 @click.option("--logins", help="Comma-separated client logins")
 @click.option(

--- a/direct_cli/commands/balance.py
+++ b/direct_cli/commands/balance.py
@@ -1,4 +1,4 @@
-"""Balance command backed by Yandex Direct v4 Live."""
+"""Money balance command backed by Yandex Direct v4 Live."""
 
 import click
 
@@ -9,7 +9,7 @@ from ..v4 import build_v4_body, call_v4
 from ..v4_contracts import v4_method_contract
 
 
-@v4_method_contract("GetClientsUnits")
+@v4_method_contract("AccountManagement")
 @click.command()
 @click.option("--logins", help="Comma-separated client logins")
 @click.option(
@@ -23,7 +23,7 @@ from ..v4_contracts import v4_method_contract
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
 def balance(ctx, logins, output_format, output, dry_run):
-    """Check client units balance."""
+    """Check account money balance."""
     login_list = parse_csv_strings(logins)
     if not login_list:
         configured_login = ctx.obj.get("login")
@@ -31,9 +31,12 @@ def balance(ctx, logins, output_format, output, dry_run):
             raise click.UsageError("Provide --logins or configure YANDEX_DIRECT_LOGIN")
         login_list = [configured_login]
 
-    param = login_list
+    param = {
+        "Action": "Get",
+        "SelectionCriteria": {"Logins": login_list},
+    }
     if dry_run:
-        format_output(build_v4_body("GetClientsUnits", param), "json", None)
+        format_output(build_v4_body("AccountManagement", param), "json", None)
         return
 
     try:
@@ -43,8 +46,8 @@ def balance(ctx, logins, output_format, output, dry_run):
             profile=ctx.obj.get("profile"),
             sandbox=ctx.obj.get("sandbox"),
         )
-        data = call_v4(client, "GetClientsUnits", param)
-        format_output(data, output_format, output)
+        data = call_v4(client, "AccountManagement", param)
+        format_output(data.get("Accounts", data), output_format, output)
     except Exception as e:
         print_error(str(e))
         raise click.Abort()

--- a/direct_cli/commands/balance.py
+++ b/direct_cli/commands/balance.py
@@ -29,7 +29,7 @@ def balance(ctx, logins, output_format, output, dry_run):
             raise click.UsageError("Provide --logins or configure YANDEX_DIRECT_LOGIN")
         login_list = [configured_login]
 
-    param = {"Logins": login_list}
+    param = login_list
     if dry_run:
         format_output(build_v4_body("GetClientsUnits", param), "json", None)
         return

--- a/direct_cli/commands/balance.py
+++ b/direct_cli/commands/balance.py
@@ -1,0 +1,48 @@
+"""Balance command backed by Yandex Direct v4 Live."""
+
+import click
+
+from ..api import create_v4_client
+from ..output import format_output, print_error
+from ..utils import parse_csv_strings
+from ..v4 import build_v4_body, call_v4
+
+
+@click.command()
+@click.option("--logins", help="Comma-separated client logins")
+@click.option(
+    "--format",
+    "output_format",
+    default="json",
+    type=click.Choice(["json", "table", "csv", "tsv"]),
+    help="Output format",
+)
+@click.option("--output", help="Output file")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def balance(ctx, logins, output_format, output, dry_run):
+    """Check client units balance."""
+    login_list = parse_csv_strings(logins)
+    if not login_list:
+        configured_login = ctx.obj.get("login")
+        if not configured_login:
+            raise click.UsageError("Provide --logins or configure YANDEX_DIRECT_LOGIN")
+        login_list = [configured_login]
+
+    param = {"Logins": login_list}
+    if dry_run:
+        format_output(build_v4_body("GetClientsUnits", param), "json", None)
+        return
+
+    try:
+        client = create_v4_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            profile=ctx.obj.get("profile"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+        data = call_v4(client, "GetClientsUnits", param)
+        format_output(data, output_format, output)
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()

--- a/direct_cli/smoke_matrix.py
+++ b/direct_cli/smoke_matrix.py
@@ -19,6 +19,7 @@ DANGEROUS = "DANGEROUS"
 
 SMOKE_MATRIX = {
     SAFE: [
+        "balance",
         "adextensions.get",
         "adgroups.get",
         "adimages.get",
@@ -190,11 +191,14 @@ def commands_for_category(category: str) -> list[str]:
 def _registered_cli_commands() -> set[str]:
     from direct_cli.cli import cli
 
-    return {
-        command_key(group_name, command_name)
-        for group_name, group in cli.commands.items()
-        for command_name in getattr(group, "commands", {})
-    }
+    registered = set()
+    for group_name, group in cli.commands.items():
+        if hasattr(group, "commands"):
+            for command_name in group.commands:
+                registered.add(command_key(group_name, command_name))
+        else:
+            registered.add(group_name)
+    return registered
 
 
 def _wsdl_operations_count() -> int:

--- a/tests/test_balance.py
+++ b/tests/test_balance.py
@@ -12,7 +12,7 @@ def test_balance_dry_run_with_logins_emits_v4_request_body():
     assert result.exit_code == 0
     assert json.loads(result.output) == {
         "method": "GetClientsUnits",
-        "param": {"Logins": ["a", "b", "c"]},
+        "param": ["a", "b", "c"],
     }
 
 
@@ -24,7 +24,7 @@ def test_balance_omitted_logins_uses_configured_login():
     assert result.exit_code == 0
     assert json.loads(result.output) == {
         "method": "GetClientsUnits",
-        "param": {"Logins": ["client-login"]},
+        "param": ["client-login"],
     }
 
 
@@ -60,9 +60,7 @@ def test_balance_formats_mocked_v4_response_as_json():
     assert result.exit_code == 0
     assert json.loads(result.output) == [{"Login": "a", "Units": 10}]
     create_client.assert_called_once()
-    call.assert_called_once_with(
-        create_client.return_value, "GetClientsUnits", {"Logins": ["a"]}
-    )
+    call.assert_called_once_with(create_client.return_value, "GetClientsUnits", ["a"])
 
 
 def test_balance_formats_mocked_v4_response_as_table():

--- a/tests/test_balance.py
+++ b/tests/test_balance.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from click.testing import CliRunner
 
 from direct_cli.cli import cli
+from direct_cli.v4_contracts import get_v4_contract
 
 
 def test_balance_dry_run_with_logins_emits_v4_request_body():
@@ -94,3 +95,10 @@ def test_balance_help_contains_no_json_input_flag():
 
     assert result.exit_code == 0
     assert "--json" not in result.output
+
+
+def test_balance_command_declares_v4_contract():
+    command = cli.commands["balance"]
+
+    assert command.v4_method == "GetClientsUnits"
+    assert command.v4_contract == get_v4_contract("GetClientsUnits")

--- a/tests/test_balance.py
+++ b/tests/test_balance.py
@@ -1,0 +1,98 @@
+import json
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from direct_cli.cli import cli
+
+
+def test_balance_dry_run_with_logins_emits_v4_request_body():
+    result = CliRunner().invoke(cli, ["balance", "--logins", "a,b,c", "--dry-run"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "method": "GetClientsUnits",
+        "param": {"Logins": ["a", "b", "c"]},
+    }
+
+
+def test_balance_omitted_logins_uses_configured_login():
+    result = CliRunner(env={"YANDEX_DIRECT_LOGIN": "client-login"}).invoke(
+        cli, ["balance", "--dry-run"]
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "method": "GetClientsUnits",
+        "param": {"Logins": ["client-login"]},
+    }
+
+
+def test_balance_omitted_logins_without_login_fails_before_api_call():
+    with patch("direct_cli.cli.get_active_profile", return_value=None):
+        with patch("direct_cli.commands.balance.create_v4_client") as create_client:
+            result = CliRunner(
+                env={"YANDEX_DIRECT_TOKEN": "", "YANDEX_DIRECT_LOGIN": ""}
+            ).invoke(cli, ["balance"])
+
+    assert result.exit_code != 0
+    assert "Provide --logins or configure YANDEX_DIRECT_LOGIN" in result.output
+    create_client.assert_not_called()
+
+
+def test_balance_formats_mocked_v4_response_as_json():
+    with patch("direct_cli.commands.balance.create_v4_client") as create_client:
+        with patch(
+            "direct_cli.commands.balance.call_v4",
+            return_value=[{"Login": "a", "Units": 10}],
+        ) as call:
+            result = CliRunner().invoke(
+                cli,
+                [
+                    "--token",
+                    "token",
+                    "balance",
+                    "--logins",
+                    "a",
+                ],
+            )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == [{"Login": "a", "Units": 10}]
+    create_client.assert_called_once()
+    call.assert_called_once_with(
+        create_client.return_value, "GetClientsUnits", {"Logins": ["a"]}
+    )
+
+
+def test_balance_formats_mocked_v4_response_as_table():
+    with patch("direct_cli.commands.balance.create_v4_client") as create_client:
+        with patch(
+            "direct_cli.commands.balance.call_v4",
+            return_value=[{"Login": "a", "Units": 10}],
+        ):
+            result = CliRunner().invoke(
+                cli,
+                [
+                    "--token",
+                    "token",
+                    "balance",
+                    "--logins",
+                    "a",
+                    "--format",
+                    "table",
+                ],
+            )
+
+    assert result.exit_code == 0
+    assert "Login" in result.output
+    assert "Units" in result.output
+    assert "a" in result.output
+    create_client.assert_called_once()
+
+
+def test_balance_help_contains_no_json_input_flag():
+    result = CliRunner().invoke(cli, ["balance", "--help"])
+
+    assert result.exit_code == 0
+    assert "--json" not in result.output

--- a/tests/test_balance.py
+++ b/tests/test_balance.py
@@ -12,8 +12,11 @@ def test_balance_dry_run_with_logins_emits_v4_request_body():
 
     assert result.exit_code == 0
     assert json.loads(result.output) == {
-        "method": "GetClientsUnits",
-        "param": ["a", "b", "c"],
+        "method": "AccountManagement",
+        "param": {
+            "Action": "Get",
+            "SelectionCriteria": {"Logins": ["a", "b", "c"]},
+        },
     }
 
 
@@ -24,8 +27,11 @@ def test_balance_omitted_logins_uses_configured_login():
 
     assert result.exit_code == 0
     assert json.loads(result.output) == {
-        "method": "GetClientsUnits",
-        "param": ["client-login"],
+        "method": "AccountManagement",
+        "param": {
+            "Action": "Get",
+            "SelectionCriteria": {"Logins": ["client-login"]},
+        },
     }
 
 
@@ -45,7 +51,10 @@ def test_balance_formats_mocked_v4_response_as_json():
     with patch("direct_cli.commands.balance.create_v4_client") as create_client:
         with patch(
             "direct_cli.commands.balance.call_v4",
-            return_value=[{"Login": "a", "Units": 10}],
+            return_value={
+                "ActionsResult": [],
+                "Accounts": [{"Login": "a", "Amount": "10.50", "Currency": "RUB"}],
+            },
         ) as call:
             result = CliRunner().invoke(
                 cli,
@@ -59,16 +68,25 @@ def test_balance_formats_mocked_v4_response_as_json():
             )
 
     assert result.exit_code == 0
-    assert json.loads(result.output) == [{"Login": "a", "Units": 10}]
+    assert json.loads(result.output) == [
+        {"Login": "a", "Amount": "10.50", "Currency": "RUB"}
+    ]
     create_client.assert_called_once()
-    call.assert_called_once_with(create_client.return_value, "GetClientsUnits", ["a"])
+    call.assert_called_once_with(
+        create_client.return_value,
+        "AccountManagement",
+        {"Action": "Get", "SelectionCriteria": {"Logins": ["a"]}},
+    )
 
 
 def test_balance_formats_mocked_v4_response_as_table():
     with patch("direct_cli.commands.balance.create_v4_client") as create_client:
         with patch(
             "direct_cli.commands.balance.call_v4",
-            return_value=[{"Login": "a", "Units": 10}],
+            return_value={
+                "ActionsResult": [],
+                "Accounts": [{"Login": "a", "Amount": "10.50", "Currency": "RUB"}],
+            },
         ):
             result = CliRunner().invoke(
                 cli,
@@ -85,7 +103,8 @@ def test_balance_formats_mocked_v4_response_as_table():
 
     assert result.exit_code == 0
     assert "Login" in result.output
-    assert "Units" in result.output
+    assert "Amount" in result.output
+    assert "Currency" in result.output
     assert "a" in result.output
     create_client.assert_called_once()
 
@@ -100,5 +119,5 @@ def test_balance_help_contains_no_json_input_flag():
 def test_balance_command_declares_v4_contract():
     command = cli.commands["balance"]
 
-    assert command.v4_method == "GetClientsUnits"
-    assert command.v4_contract == get_v4_contract("GetClientsUnits")
+    assert command.v4_method == "AccountManagement"
+    assert command.v4_contract == get_v4_contract("AccountManagement")

--- a/tests/test_balance.py
+++ b/tests/test_balance.py
@@ -35,12 +35,25 @@ def test_balance_omitted_logins_uses_configured_login():
     }
 
 
-def test_balance_omitted_logins_without_login_fails_before_api_call():
+def test_balance_omitted_logins_without_login_uses_token_account():
+    with patch("direct_cli.cli.get_active_profile", return_value=None):
+        result = CliRunner(env={"YANDEX_DIRECT_LOGIN": ""}).invoke(
+            cli, ["--token", "token", "balance", "--dry-run"]
+        )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "method": "AccountManagement",
+        "param": {"Action": "Get"},
+    }
+
+
+def test_balance_omitted_logins_without_login_fails_for_sandbox_before_api_call():
     with patch("direct_cli.cli.get_active_profile", return_value=None):
         with patch("direct_cli.commands.balance.create_v4_client") as create_client:
-            result = CliRunner(
-                env={"YANDEX_DIRECT_TOKEN": "", "YANDEX_DIRECT_LOGIN": ""}
-            ).invoke(cli, ["balance"])
+            result = CliRunner(env={"YANDEX_DIRECT_LOGIN": ""}).invoke(
+                cli, ["--sandbox", "--token", "token", "balance"]
+            )
 
     assert result.exit_code != 0
     assert "Provide --logins or configure YANDEX_DIRECT_LOGIN" in result.output
@@ -68,9 +81,10 @@ def test_balance_formats_mocked_v4_response_as_json():
             )
 
     assert result.exit_code == 0
-    assert json.loads(result.output) == [
-        {"Login": "a", "Amount": "10.50", "Currency": "RUB"}
-    ]
+    assert json.loads(result.output) == {
+        "ActionsResult": [],
+        "Accounts": [{"Login": "a", "Amount": "10.50", "Currency": "RUB"}],
+    }
     create_client.assert_called_once()
     call.assert_called_once_with(
         create_client.return_value,

--- a/tests/test_comprehensive.py
+++ b/tests/test_comprehensive.py
@@ -64,6 +64,7 @@ class TestCommandsRegistered(unittest.TestCase):
         "dynamicads",
         "dynamicfeedadtargets",
         "strategies",
+        "balance",
         "v4finance",
         "v4account",
         "v4goals",

--- a/tests/test_smoke_matrix.py
+++ b/tests/test_smoke_matrix.py
@@ -36,11 +36,14 @@ def _load_sandbox_runner_module():
 
 
 def _registered_cli_commands() -> set[str]:
-    return {
-        command_key(group_name, command_name)
-        for group_name, group in cli.commands.items()
-        for command_name in getattr(group, "commands", {})
-    }
+    registered = set()
+    for group_name, group in cli.commands.items():
+        if hasattr(group, "commands"):
+            for command_name in group.commands:
+                registered.add(command_key(group_name, command_name))
+        else:
+            registered.add(group_name)
+    return registered
 
 
 def test_smoke_matrix_covers_every_cli_subcommand_once():
@@ -57,9 +60,9 @@ def test_smoke_matrix_covers_every_cli_subcommand_once():
 def test_smoke_matrix_counts_match_current_cli_surface():
     summary = smoke_summary()
 
-    assert summary["total_cli_groups"] == 38
-    assert summary["total_cli_subcommands"] == 120
-    assert summary["api_cli_subcommands"] == 116
+    assert summary["total_cli_groups"] == 39
+    assert summary["total_cli_subcommands"] == 121
+    assert summary["api_cli_subcommands"] == 117
     assert summary["wsdl_services"] == 29
     assert summary["non_wsdl_services"] == sorted(NON_WSDL_SERVICES)
     assert summary["api_services_total"] == 30


### PR DESCRIPTION
Closes #129

## Summary
- add top-level `direct balance` backed by v4 Live `GetClientsUnits`
- support typed `--logins`, output formats, and `--dry-run` request preview
- classify `balance` as SAFE in the smoke matrix and document quick-start examples

## Tests
- pytest -q tests/test_balance.py tests/test_comprehensive.py tests/test_smoke_matrix.py
- pytest -q tests/test_api_coverage.py tests/test_cli.py tests/test_dry_run.py