### PR TITLE
feat: add V4 Live goals commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ direct balance --logins client-login --dry-run
 | `--profile` | Credential profile name |
 | `--sandbox` | Use sandbox API |
 
+### V4 Live Goals
+
+```bash
+direct v4goals get-stat-goals --campaign-ids 123,456
+direct v4goals get-retargeting-goals --campaign-ids 123,456 --format table
+direct v4goals get-stat-goals --campaign-ids 123 --dry-run
+```
+
 ### CLI Convention
 
 The current CLI convention is defined as follows.

--- a/direct_cli/_vendor/tapi_yandex_direct/v4/adapter.py
+++ b/direct_cli/_vendor/tapi_yandex_direct/v4/adapter.py
@@ -45,8 +45,8 @@ class V4LiveClientAdapter(JSONAdapterMixin, TapiAdapter):
 
         # Enrich the JSON body with token / locale. format_data_to_request does
         # not see api_params, so we do this after super() has serialised the
-        # user data. V4 Live login placement is method-specific, so callers
-        # must pass any method-level login value explicitly in the body.
+        # user data. Agency/client selection is transport-level
+        # (Client-Login header); method params must stay schema-shaped.
         raw = params.get("data")
         if raw:
             if isinstance(raw, (bytes, bytearray)):
@@ -71,6 +71,10 @@ class V4LiveClientAdapter(JSONAdapterMixin, TapiAdapter):
 
         if token:
             params["headers"]["Authorization"] = "Bearer {}".format(token)
+
+        login = api_params.get("login")
+        if login:
+            params["headers"]["Client-Login"] = login
 
         return params
 

--- a/direct_cli/cli.py
+++ b/direct_cli/cli.py
@@ -47,10 +47,10 @@ from .commands.v4shells import (
     v4events,
     v4finance,
     v4forecast,
-    v4goals,
     v4meta,
     v4wordstat,
 )
+from .commands.v4goals import v4goals
 
 # Load .env file
 load_dotenv()

--- a/direct_cli/commands/v4goals.py
+++ b/direct_cli/commands/v4goals.py
@@ -1,0 +1,98 @@
+"""Yandex Direct v4 Live goals commands."""
+
+import click
+
+from ..api import create_v4_client
+from ..output import format_output, print_error
+from ..utils import parse_ids
+from ..v4 import build_v4_body, call_v4
+from .v4shells import V4_EPILOG
+
+
+def _campaign_ids_param(campaign_ids: str) -> dict:
+    """Build the v4 Live CampaignIDInfo parameter."""
+    try:
+        ids = parse_ids(campaign_ids)
+    except ValueError as exc:
+        raise click.UsageError(str(exc))
+    return {"CampaignIDS": ids}
+
+
+def _run_goals_command(
+    ctx,
+    method: str,
+    campaign_ids: str,
+    output_format: str,
+    output: str,
+    dry_run: bool,
+) -> None:
+    param = _campaign_ids_param(campaign_ids)
+    if dry_run:
+        format_output(build_v4_body(method, param), "json", None)
+        return
+
+    try:
+        client = create_v4_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            profile=ctx.obj.get("profile"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+        data = call_v4(client, method, param)
+        format_output(data, output_format, output)
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@click.group(epilog=V4_EPILOG)
+def v4goals():
+    """Yandex Direct v4 Live goals commands."""
+
+
+@v4goals.command(name="get-stat-goals")
+@click.option("--campaign-ids", required=True, help="Comma-separated campaign IDs")
+@click.option(
+    "--format",
+    "output_format",
+    default="json",
+    type=click.Choice(["json", "table", "csv", "tsv"]),
+    help="Output format",
+)
+@click.option("--output", help="Output file")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def get_stat_goals(ctx, campaign_ids, output_format, output, dry_run):
+    """Get Yandex Metrica goals available for campaigns."""
+    _run_goals_command(
+        ctx,
+        "GetStatGoals",
+        campaign_ids,
+        output_format,
+        output,
+        dry_run,
+    )
+
+
+@v4goals.command(name="get-retargeting-goals")
+@click.option("--campaign-ids", required=True, help="Comma-separated campaign IDs")
+@click.option(
+    "--format",
+    "output_format",
+    default="json",
+    type=click.Choice(["json", "table", "csv", "tsv"]),
+    help="Output format",
+)
+@click.option("--output", help="Output file")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def get_retargeting_goals(ctx, campaign_ids, output_format, output, dry_run):
+    """Get retargeting goals for campaigns."""
+    _run_goals_command(
+        ctx,
+        "GetRetargetingGoals",
+        campaign_ids,
+        output_format,
+        output,
+        dry_run,
+    )

--- a/direct_cli/commands/v4goals.py
+++ b/direct_cli/commands/v4goals.py
@@ -6,6 +6,7 @@ from ..api import create_v4_client
 from ..output import format_output, print_error
 from ..utils import parse_ids
 from ..v4 import build_v4_body, call_v4
+from ..v4_contracts import v4_method_contract
 from .v4shells import V4_EPILOG
 
 
@@ -50,6 +51,7 @@ def v4goals():
     """Yandex Direct v4 Live goals commands."""
 
 
+@v4_method_contract("GetStatGoals")
 @v4goals.command(name="get-stat-goals")
 @click.option("--campaign-ids", required=True, help="Comma-separated campaign IDs")
 @click.option(
@@ -74,6 +76,7 @@ def get_stat_goals(ctx, campaign_ids, output_format, output, dry_run):
     )
 
 
+@v4_method_contract("GetRetargetingGoals")
 @v4goals.command(name="get-retargeting-goals")
 @click.option("--campaign-ids", required=True, help="Comma-separated campaign IDs")
 @click.option(

--- a/direct_cli/commands/v4shells.py
+++ b/direct_cli/commands/v4shells.py
@@ -21,11 +21,6 @@ def v4account():
 
 
 @click.group(epilog=V4_EPILOG)
-def v4goals():
-    """Yandex Direct v4 Live goals commands."""
-
-
-@click.group(epilog=V4_EPILOG)
 def v4events():
     """Yandex Direct v4 Live events commands."""
 

--- a/direct_cli/smoke_matrix.py
+++ b/direct_cli/smoke_matrix.py
@@ -57,6 +57,8 @@ SMOKE_MATRIX = {
         "smartadtargets.get",
         "strategies.get",
         "turbopages.get",
+        "v4goals.get-retargeting-goals",
+        "v4goals.get-stat-goals",
         "vcards.get",
     ],
     WRITE_SANDBOX: [

--- a/direct_cli/v4_contracts.py
+++ b/direct_cli/v4_contracts.py
@@ -109,7 +109,10 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
         method="AccountManagement",
         group="shared_account",
         param_shape=PARAM_OBJECT,
-        login_placement="optional SelectionCriteria.Logins for agency/client selection",
+        login_placement=(
+            "param contains only documented method fields; global --login uses "
+            "Client-Login header"
+        ),
         safety=SAFETY_MIXED,
         source_status=SOURCE_CONFIRMED_LIVE,
         live_probe_allowed=True,
@@ -138,7 +141,10 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
         method="GetStatGoals",
         group="goals",
         param_shape=PARAM_OBJECT,
-        login_placement="optional param.login accepted; not injected by transport",
+        login_placement=(
+            "param contains only documented method fields; global --login uses "
+            "Client-Login header"
+        ),
         safety=SAFETY_READ,
         source_status=SOURCE_CONFIRMED_LIVE,
         live_probe_allowed=True,
@@ -149,7 +155,10 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
         method="GetRetargetingGoals",
         group="goals",
         param_shape=PARAM_OBJECT,
-        login_placement="CampaignIDS works; Logins also accepted by live API",
+        login_placement=(
+            "param contains only documented method fields; global --login uses "
+            "Client-Login header"
+        ),
         safety=SAFETY_READ,
         source_status=SOURCE_CONFIRMED_LIVE,
         live_probe_allowed=True,

--- a/tests/api_coverage_payloads.py
+++ b/tests/api_coverage_payloads.py
@@ -44,6 +44,8 @@ DRY_RUN_PAYLOAD_EXCLUSIONS = {
     "smartadtargets.suspend": "Same simple Ids payload family as covered delete/set-bids actions.",
     "vcards.add": "Requires large contact-card payload fixture not needed for generic schema smoke coverage.",
     "reports.get": "Reports API uses a custom TSV endpoint; payload contract is covered by test_reports_request_builder_contract.",
+    "v4goals.get-retargeting-goals": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
+    "v4goals.get-stat-goals": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
 }
 
 PAYLOAD_CASES = [

--- a/tests/test_smoke_matrix.py
+++ b/tests/test_smoke_matrix.py
@@ -60,9 +60,9 @@ def test_smoke_matrix_covers_every_cli_subcommand_once():
 def test_smoke_matrix_counts_match_current_cli_surface():
     summary = smoke_summary()
 
-    assert summary["total_cli_groups"] == 39
-    assert summary["total_cli_subcommands"] == 121
-    assert summary["api_cli_subcommands"] == 117
+    assert summary["total_cli_groups"] == 40
+    assert summary["total_cli_subcommands"] == 123
+    assert summary["api_cli_subcommands"] == 119
     assert summary["wsdl_services"] == 29
     assert summary["non_wsdl_services"] == sorted(NON_WSDL_SERVICES)
     assert summary["api_services_total"] == 30

--- a/tests/test_smoke_matrix.py
+++ b/tests/test_smoke_matrix.py
@@ -60,7 +60,7 @@ def test_smoke_matrix_covers_every_cli_subcommand_once():
 def test_smoke_matrix_counts_match_current_cli_surface():
     summary = smoke_summary()
 
-    assert summary["total_cli_groups"] == 40
+    assert summary["total_cli_groups"] == 39
     assert summary["total_cli_subcommands"] == 123
     assert summary["api_cli_subcommands"] == 119
     assert summary["wsdl_services"] == 29

--- a/tests/test_v4_contracts.py
+++ b/tests/test_v4_contracts.py
@@ -85,7 +85,7 @@ def test_v4_call_helper_preserves_non_dict_params():
     assert result == [{"Login": "x", "UnitsRest": 1}]
 
 
-def test_v4_adapter_does_not_inject_param_login():
+def test_v4_adapter_sends_login_as_header_without_mutating_param():
     from direct_cli._vendor.tapi_yandex_direct.v4.adapter import V4LiveClientAdapter
 
     adapter = V4LiveClientAdapter()
@@ -105,6 +105,19 @@ def test_v4_adapter_does_not_inject_param_login():
     assert body["param"] == {"CampaignIDS": [123]}
     assert body["token"] == "token"
     assert body["locale"] == "en"
+    assert request["headers"]["Client-Login"] == "client-login"
+
+
+def test_v4_goal_contracts_keep_global_login_at_transport_level():
+    for method in ("GetStatGoals", "GetRetargetingGoals"):
+        contract = get_v4_contract(method)
+
+        assert "Client-Login header" in contract.login_placement
+        assert contract.example_param == {"CampaignIDS": [123]}
+        assert build_v4_body(method, contract.example_param) == {
+            "method": method,
+            "param": {"CampaignIDS": [123]},
+        }
 
 
 def test_v4_method_contract_decorator_attaches_known_contract():

--- a/tests/test_v4goals.py
+++ b/tests/test_v4goals.py
@@ -83,6 +83,37 @@ def test_get_stat_goals_formats_mocked_response_as_json():
     )
 
 
+def test_get_stat_goals_with_login_keeps_method_param_schema():
+    with patch("direct_cli.commands.v4goals.create_v4_client") as create_client:
+        with patch(
+            "direct_cli.commands.v4goals.call_v4",
+            return_value=[{"CampaignID": 1, "GoalID": 10, "Name": "Lead"}],
+        ) as call:
+            result = _invoke(
+                "--token",
+                "token",
+                "--login",
+                "client-login",
+                "v4goals",
+                "get-stat-goals",
+                "--campaign-ids",
+                "1",
+            )
+
+    assert result.exit_code == 0
+    create_client.assert_called_once_with(
+        token="token",
+        login="client-login",
+        profile=None,
+        sandbox=False,
+    )
+    call.assert_called_once_with(
+        create_client.return_value,
+        "GetStatGoals",
+        {"CampaignIDS": [1]},
+    )
+
+
 def test_get_retargeting_goals_formats_mocked_response_as_table():
     with patch("direct_cli.commands.v4goals.create_v4_client") as create_client:
         with patch(

--- a/tests/test_v4goals.py
+++ b/tests/test_v4goals.py
@@ -1,0 +1,121 @@
+import json
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from direct_cli.cli import cli
+
+
+def _invoke(*args: str):
+    return CliRunner().invoke(cli, list(args))
+
+
+def test_get_stat_goals_dry_run_uses_campaign_ids_param():
+    result = _invoke(
+        "v4goals",
+        "get-stat-goals",
+        "--campaign-ids",
+        "1,2,3",
+        "--dry-run",
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "method": "GetStatGoals",
+        "param": {"CampaignIDS": [1, 2, 3]},
+    }
+
+
+def test_get_retargeting_goals_dry_run_uses_campaign_ids_param():
+    result = _invoke(
+        "v4goals",
+        "get-retargeting-goals",
+        "--campaign-ids",
+        "1,2,3",
+        "--dry-run",
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "method": "GetRetargetingGoals",
+        "param": {"CampaignIDS": [1, 2, 3]},
+    }
+
+
+def test_get_stat_goals_missing_campaign_ids_fails_with_usage_error():
+    result = _invoke("v4goals", "get-stat-goals", "--dry-run")
+
+    assert result.exit_code != 0
+    assert "Missing option '--campaign-ids'" in result.output
+
+
+def test_get_retargeting_goals_missing_campaign_ids_fails_with_usage_error():
+    result = _invoke("v4goals", "get-retargeting-goals", "--dry-run")
+
+    assert result.exit_code != 0
+    assert "Missing option '--campaign-ids'" in result.output
+
+
+def test_get_stat_goals_formats_mocked_response_as_json():
+    with patch("direct_cli.commands.v4goals.create_v4_client") as create_client:
+        with patch(
+            "direct_cli.commands.v4goals.call_v4",
+            return_value=[{"CampaignID": 1, "GoalID": 10, "Name": "Lead"}],
+        ) as call:
+            result = _invoke(
+                "--token",
+                "token",
+                "v4goals",
+                "get-stat-goals",
+                "--campaign-ids",
+                "1",
+            )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == [
+        {"CampaignID": 1, "GoalID": 10, "Name": "Lead"}
+    ]
+    call.assert_called_once_with(
+        create_client.return_value,
+        "GetStatGoals",
+        {"CampaignIDS": [1]},
+    )
+
+
+def test_get_retargeting_goals_formats_mocked_response_as_table():
+    with patch("direct_cli.commands.v4goals.create_v4_client") as create_client:
+        with patch(
+            "direct_cli.commands.v4goals.call_v4",
+            return_value=[{"CampaignID": 1, "GoalID": 10, "Name": "Lead"}],
+        ) as call:
+            result = _invoke(
+                "--token",
+                "token",
+                "v4goals",
+                "get-retargeting-goals",
+                "--campaign-ids",
+                "1",
+                "--format",
+                "table",
+            )
+
+    assert result.exit_code == 0
+    assert "CampaignID" in result.output
+    assert "GoalID" in result.output
+    assert "Lead" in result.output
+    call.assert_called_once_with(
+        create_client.return_value,
+        "GetRetargetingGoals",
+        {"CampaignIDS": [1]},
+    )
+
+
+def test_v4goals_help_contains_no_json_input_flag():
+    for args in [
+        ("v4goals", "--help"),
+        ("v4goals", "get-stat-goals", "--help"),
+        ("v4goals", "get-retargeting-goals", "--help"),
+    ]:
+        result = _invoke(*args)
+        assert result.exit_code == 0
+        assert "--json" not in result.output

--- a/tests/test_v4goals.py
+++ b/tests/test_v4goals.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from click.testing import CliRunner
 
 from direct_cli.cli import cli
+from direct_cli.v4_contracts import get_v4_contract
 
 
 def _invoke(*args: str):
@@ -119,3 +120,14 @@ def test_v4goals_help_contains_no_json_input_flag():
         result = _invoke(*args)
         assert result.exit_code == 0
         assert "--json" not in result.output
+
+
+def test_v4goals_commands_declare_v4_contracts():
+    commands = cli.commands["v4goals"].commands
+
+    assert commands["get-stat-goals"].v4_method == "GetStatGoals"
+    assert commands["get-stat-goals"].v4_contract == get_v4_contract("GetStatGoals")
+    assert commands["get-retargeting-goals"].v4_method == "GetRetargetingGoals"
+    assert commands["get-retargeting-goals"].v4_contract == get_v4_contract(
+        "GetRetargetingGoals"
+    )


### PR DESCRIPTION
Closes #130

## Summary
- implement `direct v4goals get-stat-goals --campaign-ids ...`
- implement `direct v4goals get-retargeting-goals --campaign-ids ...`
- add dry-run coverage, smoke matrix entries, and README examples

## V4 Live parameter note
- Official Yandex Direct GetStatGoals Live docs say multiple campaign IDs are passed in `CampaignIDS`: https://yandex.com/dev/direct/doc/dg-v4/en/live/GetStatGoals
- The GetRetargetingGoals Live method is referenced from the current RetargetingList docs, but a standalone method page was not discoverable in the public index during implementation. This PR follows issue #130's typed `--campaign-ids` contract and uses the same `CampaignIDS` wire parameter for both commands.

## Tests
- pytest -q tests/test_v4goals.py tests/test_smoke_matrix.py tests/test_comprehensive.py
- pytest -q tests/test_api_coverage.py tests/test_cli.py tests/test_dry_run.py