### PR TITLE
test: add V4 Live contract registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ Install with `pip install direct-cli`, then run commands with `direct`.
 Invoking the deprecated `direct-cli` entrypoint exits with
 `use direct instead of direct-cli`.
 
+### Quick Start: Check Balance
+
+Yandex removed the legacy v4 `GetBalance` method. Direct CLI uses the v4 Live
+`AccountManagement` method with `Action=Get` for `direct balance`, returning
+money fields such as `Amount`, `AmountAvailableForTransfer`, and `Currency`.
+
+```bash
+direct balance
+direct balance --logins client-login,other-client --format table
+direct balance --logins client-login --dry-run
+```
+
 ### Global Options
 
 | Option | Description |

--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ direct balance --logins client-login --dry-run
 | `--profile` | Credential profile name |
 | `--sandbox` | Use sandbox API |
 
+### V4 Live Goals
+
+```bash
+direct v4goals get-stat-goals --campaign-ids 123,456
+direct v4goals get-retargeting-goals --campaign-ids 123,456 --format table
+direct v4goals get-stat-goals --campaign-ids 123 --dry-run
+```
+
 ### CLI Convention
 
 The current CLI convention is defined as follows.

--- a/direct_cli/_vendor/tapi_yandex_direct/v4/adapter.py
+++ b/direct_cli/_vendor/tapi_yandex_direct/v4/adapter.py
@@ -41,12 +41,12 @@ class V4LiveClientAdapter(JSONAdapterMixin, TapiAdapter):
         params = super().get_request_kwargs(api_params, *args, **kwargs)
 
         token = api_params.get("access_token")
-        login = api_params.get("login")
         language = api_params.get("language", "en")
 
-        # Enrich the JSON body with token / locale / login (param.login for
-        # agent calls). format_data_to_request does not see api_params, so we
-        # do this here, after super() has already serialised the user data.
+        # Enrich the JSON body with token / locale. format_data_to_request does
+        # not see api_params, so we do this after super() has serialised the
+        # user data. V4 Live login placement is method-specific, so callers
+        # must pass any method-level login value explicitly in the body.
         raw = params.get("data")
         if raw:
             if isinstance(raw, (bytes, bytearray)):
@@ -66,8 +66,6 @@ class V4LiveClientAdapter(JSONAdapterMixin, TapiAdapter):
                 body.setdefault("token", token)
             if language:
                 body.setdefault("locale", language)
-            if login and isinstance(body.get("param"), dict):
-                body["param"].setdefault("login", login)
 
             params["data"] = orjson.dumps(body)
 
@@ -98,7 +96,9 @@ class V4LiveClientAdapter(JSONAdapterMixin, TapiAdapter):
                 data = None
         return data
 
-    def process_response(self, response: Response, request_kwargs: dict, **kwargs) -> dict:
+    def process_response(
+        self, response: Response, request_kwargs: dict, **kwargs
+    ) -> dict:
         # Mirror the v5 behaviour: turn the serialised body back into a dict so
         # downstream hooks (extract, retry) can read it.
         if isinstance(request_kwargs.get("data"), (bytes, bytearray, str)):
@@ -178,8 +178,13 @@ class V4LiveClientAdapter(JSONAdapterMixin, TapiAdapter):
 
         return False
 
-    def extract(self, data, response: Optional[Response] = None,
-                request_kwargs: Optional[dict] = None, **kwargs):
+    def extract(
+        self,
+        data,
+        response: Optional[Response] = None,
+        request_kwargs: Optional[dict] = None,
+        **kwargs,
+    ):
         # v4 Live always nests payload under "data". For methods returning a
         # bare scalar (TransferMoney → 1), the scalar comes through unchanged.
         # response / request_kwargs are accepted but unused — they are kept

--- a/direct_cli/_vendor/tapi_yandex_direct/v4/adapter.py
+++ b/direct_cli/_vendor/tapi_yandex_direct/v4/adapter.py
@@ -45,8 +45,8 @@ class V4LiveClientAdapter(JSONAdapterMixin, TapiAdapter):
 
         # Enrich the JSON body with token / locale. format_data_to_request does
         # not see api_params, so we do this after super() has serialised the
-        # user data. V4 Live login placement is method-specific, so callers
-        # must pass any method-level login value explicitly in the body.
+        # user data. Agency/client selection is transport-level
+        # (Client-Login header); method params must stay schema-shaped.
         raw = params.get("data")
         if raw:
             if isinstance(raw, (bytes, bytearray)):
@@ -71,6 +71,10 @@ class V4LiveClientAdapter(JSONAdapterMixin, TapiAdapter):
 
         if token:
             params["headers"]["Authorization"] = "Bearer {}".format(token)
+
+        login = api_params.get("login")
+        if login:
+            params["headers"]["Client-Login"] = login
 
         return params
 

--- a/direct_cli/cli.py
+++ b/direct_cli/cli.py
@@ -47,10 +47,10 @@ from .commands.v4shells import (
     v4events,
     v4finance,
     v4forecast,
-    v4goals,
     v4meta,
     v4wordstat,
 )
+from .commands.v4goals import v4goals
 
 # Load .env file
 load_dotenv()

--- a/direct_cli/cli.py
+++ b/direct_cli/cli.py
@@ -41,6 +41,7 @@ from .commands.advideos import advideos
 from .commands.dynamicfeedadtargets import dynamicfeedadtargets
 from .commands.strategies import strategies
 from .commands.auth import auth
+from .commands.balance import balance
 from .commands.v4shells import (
     v4account,
     v4events,
@@ -182,6 +183,7 @@ for command in (
     advideos,
     dynamicfeedadtargets,
     strategies,
+    balance,
     v4finance,
     v4account,
     v4goals,

--- a/direct_cli/commands/balance.py
+++ b/direct_cli/commands/balance.py
@@ -1,0 +1,55 @@
+"""Money balance command backed by Yandex Direct v4 Live."""
+
+import click
+
+from ..api import create_v4_client
+from ..output import format_output, print_error
+from ..utils import parse_csv_strings
+from ..v4 import build_v4_body, call_v4
+from ..v4_contracts import v4_method_contract
+
+
+@v4_method_contract("AccountManagement")
+@click.command()
+@click.option("--logins", help="Comma-separated client logins")
+@click.option(
+    "--format",
+    "output_format",
+    default="json",
+    type=click.Choice(["json", "table", "csv", "tsv"]),
+    help="Output format",
+)
+@click.option("--output", help="Output file")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def balance(ctx, logins, output_format, output, dry_run):
+    """Check account money balance."""
+    login_list = parse_csv_strings(logins)
+    configured_login = ctx.obj.get("login")
+    if not login_list and configured_login:
+        login_list = [configured_login]
+
+    param = {
+        "Action": "Get",
+    }
+    if login_list:
+        param["SelectionCriteria"] = {"Logins": login_list}
+    elif ctx.obj.get("sandbox"):
+        raise click.UsageError("Provide --logins or configure YANDEX_DIRECT_LOGIN")
+
+    if dry_run:
+        format_output(build_v4_body("AccountManagement", param), "json", None)
+        return
+
+    try:
+        client = create_v4_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            profile=ctx.obj.get("profile"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+        data = call_v4(client, "AccountManagement", param)
+        format_output(data, output_format, output)
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()

--- a/direct_cli/commands/v4goals.py
+++ b/direct_cli/commands/v4goals.py
@@ -16,6 +16,8 @@ def _campaign_ids_param(campaign_ids: str) -> dict:
         ids = parse_ids(campaign_ids)
     except ValueError as exc:
         raise click.UsageError(str(exc))
+    if not ids:
+        raise click.UsageError("--campaign-ids must not be empty")
     return {"CampaignIDS": ids}
 
 

--- a/direct_cli/commands/v4goals.py
+++ b/direct_cli/commands/v4goals.py
@@ -1,0 +1,101 @@
+"""Yandex Direct v4 Live goals commands."""
+
+import click
+
+from ..api import create_v4_client
+from ..output import format_output, print_error
+from ..utils import parse_ids
+from ..v4 import build_v4_body, call_v4
+from ..v4_contracts import v4_method_contract
+from .v4shells import V4_EPILOG
+
+
+def _campaign_ids_param(campaign_ids: str) -> dict:
+    """Build the v4 Live CampaignIDInfo parameter."""
+    try:
+        ids = parse_ids(campaign_ids)
+    except ValueError as exc:
+        raise click.UsageError(str(exc))
+    return {"CampaignIDS": ids}
+
+
+def _run_goals_command(
+    ctx,
+    method: str,
+    campaign_ids: str,
+    output_format: str,
+    output: str,
+    dry_run: bool,
+) -> None:
+    param = _campaign_ids_param(campaign_ids)
+    if dry_run:
+        format_output(build_v4_body(method, param), "json", None)
+        return
+
+    try:
+        client = create_v4_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            profile=ctx.obj.get("profile"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+        data = call_v4(client, method, param)
+        format_output(data, output_format, output)
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@click.group(epilog=V4_EPILOG)
+def v4goals():
+    """Yandex Direct v4 Live goals commands."""
+
+
+@v4_method_contract("GetStatGoals")
+@v4goals.command(name="get-stat-goals")
+@click.option("--campaign-ids", required=True, help="Comma-separated campaign IDs")
+@click.option(
+    "--format",
+    "output_format",
+    default="json",
+    type=click.Choice(["json", "table", "csv", "tsv"]),
+    help="Output format",
+)
+@click.option("--output", help="Output file")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def get_stat_goals(ctx, campaign_ids, output_format, output, dry_run):
+    """Get Yandex Metrica goals available for campaigns."""
+    _run_goals_command(
+        ctx,
+        "GetStatGoals",
+        campaign_ids,
+        output_format,
+        output,
+        dry_run,
+    )
+
+
+@v4_method_contract("GetRetargetingGoals")
+@v4goals.command(name="get-retargeting-goals")
+@click.option("--campaign-ids", required=True, help="Comma-separated campaign IDs")
+@click.option(
+    "--format",
+    "output_format",
+    default="json",
+    type=click.Choice(["json", "table", "csv", "tsv"]),
+    help="Output format",
+)
+@click.option("--output", help="Output file")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def get_retargeting_goals(ctx, campaign_ids, output_format, output, dry_run):
+    """Get retargeting goals for campaigns."""
+    _run_goals_command(
+        ctx,
+        "GetRetargetingGoals",
+        campaign_ids,
+        output_format,
+        output,
+        dry_run,
+    )

--- a/direct_cli/commands/v4shells.py
+++ b/direct_cli/commands/v4shells.py
@@ -21,11 +21,6 @@ def v4account():
 
 
 @click.group(epilog=V4_EPILOG)
-def v4goals():
-    """Yandex Direct v4 Live goals commands."""
-
-
-@click.group(epilog=V4_EPILOG)
 def v4events():
     """Yandex Direct v4 Live events commands."""
 

--- a/direct_cli/smoke_matrix.py
+++ b/direct_cli/smoke_matrix.py
@@ -19,6 +19,7 @@ DANGEROUS = "DANGEROUS"
 
 SMOKE_MATRIX = {
     SAFE: [
+        "balance",
         "adextensions.get",
         "adgroups.get",
         "adimages.get",
@@ -190,11 +191,14 @@ def commands_for_category(category: str) -> list[str]:
 def _registered_cli_commands() -> set[str]:
     from direct_cli.cli import cli
 
-    return {
-        command_key(group_name, command_name)
-        for group_name, group in cli.commands.items()
-        for command_name in getattr(group, "commands", {})
-    }
+    registered = set()
+    for group_name, group in cli.commands.items():
+        if hasattr(group, "commands"):
+            for command_name in group.commands:
+                registered.add(command_key(group_name, command_name))
+        else:
+            registered.add(group_name)
+    return registered
 
 
 def _wsdl_operations_count() -> int:

--- a/direct_cli/smoke_matrix.py
+++ b/direct_cli/smoke_matrix.py
@@ -57,6 +57,8 @@ SMOKE_MATRIX = {
         "smartadtargets.get",
         "strategies.get",
         "turbopages.get",
+        "v4goals.get-retargeting-goals",
+        "v4goals.get-stat-goals",
         "vcards.get",
     ],
     WRITE_SANDBOX: [

--- a/direct_cli/v4.py
+++ b/direct_cli/v4.py
@@ -3,7 +3,7 @@
 from typing import Any, Optional
 
 
-def build_v4_body(method: str, param: Optional[dict] = None) -> dict:
+def build_v4_body(method: str, param: Optional[Any] = None) -> dict:
     """Build a v4 Live request body."""
     body = {"method": method}
     if param is not None:
@@ -11,7 +11,7 @@ def build_v4_body(method: str, param: Optional[dict] = None) -> dict:
     return body
 
 
-def call_v4(client: Any, method: str, param: Optional[dict] = None) -> Any:
+def call_v4(client: Any, method: str, param: Optional[Any] = None) -> Any:
     """Call one v4 Live method and return the extracted response payload."""
     result = client.v4live().post(data=build_v4_body(method, param))
     return result().extract()

--- a/direct_cli/v4_contracts.py
+++ b/direct_cli/v4_contracts.py
@@ -109,7 +109,10 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
         method="AccountManagement",
         group="shared_account",
         param_shape=PARAM_OBJECT,
-        login_placement="optional SelectionCriteria.Logins for agency/client selection",
+        login_placement=(
+            "param contains only documented method fields; global --login uses "
+            "Client-Login header"
+        ),
         safety=SAFETY_MIXED,
         source_status=SOURCE_CONFIRMED_LIVE,
         live_probe_allowed=True,
@@ -138,7 +141,10 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
         method="GetStatGoals",
         group="goals",
         param_shape=PARAM_OBJECT,
-        login_placement="optional param.login accepted; not injected by transport",
+        login_placement=(
+            "param contains only documented method fields; global --login uses "
+            "Client-Login header"
+        ),
         safety=SAFETY_READ,
         source_status=SOURCE_CONFIRMED_LIVE,
         live_probe_allowed=True,
@@ -149,7 +155,10 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
         method="GetRetargetingGoals",
         group="goals",
         param_shape=PARAM_OBJECT,
-        login_placement="CampaignIDS works; Logins also accepted by live API",
+        login_placement=(
+            "param contains only documented method fields; global --login uses "
+            "Client-Login header"
+        ),
         safety=SAFETY_READ,
         source_status=SOURCE_CONFIRMED_LIVE,
         live_probe_allowed=True,

--- a/direct_cli/v4_contracts.py
+++ b/direct_cli/v4_contracts.py
@@ -1,0 +1,406 @@
+"""Contract registry for Yandex Direct v4 Live methods."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from direct_cli._vendor.tapi_yandex_direct.v4 import SUPPORTED_V4_METHODS
+
+PARAM_ARRAY = "array"
+PARAM_OBJECT = "object"
+PARAM_OPTIONAL_OBJECT = "optional-object"
+PARAM_SCALAR = "scalar"
+PARAM_UNDOCUMENTED = "undocumented"
+
+SAFETY_READ = "read"
+SAFETY_WRITE = "write"
+SAFETY_DANGEROUS = "dangerous"
+SAFETY_ASYNC = "async"
+
+SOURCE_CONFIRMED_LIVE = "confirmed-live"
+SOURCE_DOCS = "docs"
+SOURCE_UNDOCUMENTED = "undocumented"
+
+
+@dataclass(frozen=True)
+class V4MethodContract:
+    """A known v4 Live method contract."""
+
+    method: str
+    group: str
+    param_shape: str
+    login_placement: str
+    safety: str
+    source_status: str
+    live_probe_allowed: bool
+    example_param: Any = None
+    notes: str = ""
+
+
+V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
+    "GetClientsUnits": V4MethodContract(
+        method="GetClientsUnits",
+        group="finance",
+        param_shape=PARAM_ARRAY,
+        login_placement="param is a list of client logins",
+        safety=SAFETY_READ,
+        source_status=SOURCE_CONFIRMED_LIVE,
+        live_probe_allowed=True,
+        example_param=["client-login"],
+        notes="Live rejects object params with error_code=9; pass the login array directly.",
+    ),
+    "GetCreditLimits": V4MethodContract(
+        method="GetCreditLimits",
+        group="finance",
+        param_shape=PARAM_UNDOCUMENTED,
+        login_placement="unknown",
+        safety=SAFETY_READ,
+        source_status=SOURCE_UNDOCUMENTED,
+        live_probe_allowed=False,
+    ),
+    "TransferMoney": V4MethodContract(
+        method="TransferMoney",
+        group="finance",
+        param_shape=PARAM_UNDOCUMENTED,
+        login_placement="unknown",
+        safety=SAFETY_DANGEROUS,
+        source_status=SOURCE_UNDOCUMENTED,
+        live_probe_allowed=False,
+    ),
+    "PayCampaigns": V4MethodContract(
+        method="PayCampaigns",
+        group="finance",
+        param_shape=PARAM_UNDOCUMENTED,
+        login_placement="unknown",
+        safety=SAFETY_DANGEROUS,
+        source_status=SOURCE_UNDOCUMENTED,
+        live_probe_allowed=False,
+    ),
+    "PayCampaignsByCard": V4MethodContract(
+        method="PayCampaignsByCard",
+        group="finance",
+        param_shape=PARAM_UNDOCUMENTED,
+        login_placement="unknown",
+        safety=SAFETY_DANGEROUS,
+        source_status=SOURCE_UNDOCUMENTED,
+        live_probe_allowed=False,
+    ),
+    "CheckPayment": V4MethodContract(
+        method="CheckPayment",
+        group="finance",
+        param_shape=PARAM_UNDOCUMENTED,
+        login_placement="unknown",
+        safety=SAFETY_READ,
+        source_status=SOURCE_UNDOCUMENTED,
+        live_probe_allowed=False,
+    ),
+    "CreateInvoice": V4MethodContract(
+        method="CreateInvoice",
+        group="finance",
+        param_shape=PARAM_UNDOCUMENTED,
+        login_placement="unknown",
+        safety=SAFETY_WRITE,
+        source_status=SOURCE_UNDOCUMENTED,
+        live_probe_allowed=False,
+    ),
+    "AccountManagement": V4MethodContract(
+        method="AccountManagement",
+        group="shared_account",
+        param_shape=PARAM_UNDOCUMENTED,
+        login_placement="unknown",
+        safety=SAFETY_WRITE,
+        source_status=SOURCE_UNDOCUMENTED,
+        live_probe_allowed=False,
+    ),
+    "EnableSharedAccount": V4MethodContract(
+        method="EnableSharedAccount",
+        group="shared_account",
+        param_shape=PARAM_UNDOCUMENTED,
+        login_placement="unknown",
+        safety=SAFETY_WRITE,
+        source_status=SOURCE_UNDOCUMENTED,
+        live_probe_allowed=False,
+    ),
+    "GetEventsLog": V4MethodContract(
+        method="GetEventsLog",
+        group="events",
+        param_shape=PARAM_UNDOCUMENTED,
+        login_placement="unknown",
+        safety=SAFETY_READ,
+        source_status=SOURCE_UNDOCUMENTED,
+        live_probe_allowed=False,
+    ),
+    "GetStatGoals": V4MethodContract(
+        method="GetStatGoals",
+        group="goals",
+        param_shape=PARAM_OBJECT,
+        login_placement="optional param.login accepted; not injected by transport",
+        safety=SAFETY_READ,
+        source_status=SOURCE_CONFIRMED_LIVE,
+        live_probe_allowed=True,
+        example_param={"CampaignIDS": [123]},
+        notes="Official docs and live probe confirm CampaignIDS.",
+    ),
+    "GetRetargetingGoals": V4MethodContract(
+        method="GetRetargetingGoals",
+        group="goals",
+        param_shape=PARAM_OBJECT,
+        login_placement="CampaignIDS works; Logins also accepted by live API",
+        safety=SAFETY_READ,
+        source_status=SOURCE_CONFIRMED_LIVE,
+        live_probe_allowed=True,
+        example_param={"CampaignIDS": [123]},
+        notes="Standalone public method page was not discoverable; live probe confirms CampaignIDS.",
+    ),
+    "CreateNewWordstatReport": V4MethodContract(
+        method="CreateNewWordstatReport",
+        group="wordstat",
+        param_shape=PARAM_UNDOCUMENTED,
+        login_placement="unknown",
+        safety=SAFETY_ASYNC,
+        source_status=SOURCE_UNDOCUMENTED,
+        live_probe_allowed=False,
+    ),
+    "GetWordstatReportList": V4MethodContract(
+        method="GetWordstatReportList",
+        group="wordstat",
+        param_shape=PARAM_UNDOCUMENTED,
+        login_placement="unknown",
+        safety=SAFETY_READ,
+        source_status=SOURCE_UNDOCUMENTED,
+        live_probe_allowed=False,
+    ),
+    "GetWordstatReport": V4MethodContract(
+        method="GetWordstatReport",
+        group="wordstat",
+        param_shape=PARAM_UNDOCUMENTED,
+        login_placement="unknown",
+        safety=SAFETY_READ,
+        source_status=SOURCE_UNDOCUMENTED,
+        live_probe_allowed=False,
+    ),
+    "DeleteWordstatReport": V4MethodContract(
+        method="DeleteWordstatReport",
+        group="wordstat",
+        param_shape=PARAM_UNDOCUMENTED,
+        login_placement="unknown",
+        safety=SAFETY_WRITE,
+        source_status=SOURCE_UNDOCUMENTED,
+        live_probe_allowed=False,
+    ),
+    "CreateNewForecast": V4MethodContract(
+        method="CreateNewForecast",
+        group="forecast",
+        param_shape=PARAM_UNDOCUMENTED,
+        login_placement="unknown",
+        safety=SAFETY_ASYNC,
+        source_status=SOURCE_UNDOCUMENTED,
+        live_probe_allowed=False,
+    ),
+    "GetForecastList": V4MethodContract(
+        method="GetForecastList",
+        group="forecast",
+        param_shape=PARAM_UNDOCUMENTED,
+        login_placement="unknown",
+        safety=SAFETY_READ,
+        source_status=SOURCE_UNDOCUMENTED,
+        live_probe_allowed=False,
+    ),
+    "GetForecast": V4MethodContract(
+        method="GetForecast",
+        group="forecast",
+        param_shape=PARAM_UNDOCUMENTED,
+        login_placement="unknown",
+        safety=SAFETY_READ,
+        source_status=SOURCE_UNDOCUMENTED,
+        live_probe_allowed=False,
+    ),
+    "DeleteForecastReport": V4MethodContract(
+        method="DeleteForecastReport",
+        group="forecast",
+        param_shape=PARAM_UNDOCUMENTED,
+        login_placement="unknown",
+        safety=SAFETY_WRITE,
+        source_status=SOURCE_UNDOCUMENTED,
+        live_probe_allowed=False,
+    ),
+    "DeleteOfflineReport": V4MethodContract(
+        method="DeleteOfflineReport",
+        group="offline_reports",
+        param_shape=PARAM_UNDOCUMENTED,
+        login_placement="unknown",
+        safety=SAFETY_WRITE,
+        source_status=SOURCE_UNDOCUMENTED,
+        live_probe_allowed=False,
+    ),
+    "DeleteReport": V4MethodContract(
+        method="DeleteReport",
+        group="offline_reports",
+        param_shape=PARAM_UNDOCUMENTED,
+        login_placement="unknown",
+        safety=SAFETY_WRITE,
+        source_status=SOURCE_UNDOCUMENTED,
+        live_probe_allowed=False,
+    ),
+    "GetBannersTags": V4MethodContract(
+        method="GetBannersTags",
+        group="tags",
+        param_shape=PARAM_UNDOCUMENTED,
+        login_placement="unknown",
+        safety=SAFETY_READ,
+        source_status=SOURCE_UNDOCUMENTED,
+        live_probe_allowed=False,
+    ),
+    "GetCampaignsTags": V4MethodContract(
+        method="GetCampaignsTags",
+        group="tags",
+        param_shape=PARAM_UNDOCUMENTED,
+        login_placement="unknown",
+        safety=SAFETY_READ,
+        source_status=SOURCE_UNDOCUMENTED,
+        live_probe_allowed=False,
+    ),
+    "UpdateBannersTags": V4MethodContract(
+        method="UpdateBannersTags",
+        group="tags",
+        param_shape=PARAM_UNDOCUMENTED,
+        login_placement="unknown",
+        safety=SAFETY_WRITE,
+        source_status=SOURCE_UNDOCUMENTED,
+        live_probe_allowed=False,
+    ),
+    "UpdateCampaignsTags": V4MethodContract(
+        method="UpdateCampaignsTags",
+        group="tags",
+        param_shape=PARAM_UNDOCUMENTED,
+        login_placement="unknown",
+        safety=SAFETY_WRITE,
+        source_status=SOURCE_UNDOCUMENTED,
+        live_probe_allowed=False,
+    ),
+    "AdImageAssociation": V4MethodContract(
+        method="AdImageAssociation",
+        group="ad_image",
+        param_shape=PARAM_UNDOCUMENTED,
+        login_placement="unknown",
+        safety=SAFETY_WRITE,
+        source_status=SOURCE_UNDOCUMENTED,
+        live_probe_allowed=False,
+    ),
+    "GetKeywordsSuggestion": V4MethodContract(
+        method="GetKeywordsSuggestion",
+        group="keywords",
+        param_shape=PARAM_UNDOCUMENTED,
+        login_placement="unknown",
+        safety=SAFETY_READ,
+        source_status=SOURCE_UNDOCUMENTED,
+        live_probe_allowed=False,
+    ),
+    "PingAPI": V4MethodContract(
+        method="PingAPI",
+        group="meta",
+        param_shape=PARAM_OPTIONAL_OBJECT,
+        login_placement="none",
+        safety=SAFETY_READ,
+        source_status=SOURCE_UNDOCUMENTED,
+        live_probe_allowed=False,
+    ),
+    "PingAPI_X": V4MethodContract(
+        method="PingAPI_X",
+        group="meta",
+        param_shape=PARAM_OPTIONAL_OBJECT,
+        login_placement="none",
+        safety=SAFETY_READ,
+        source_status=SOURCE_UNDOCUMENTED,
+        live_probe_allowed=False,
+    ),
+    "GetVersion": V4MethodContract(
+        method="GetVersion",
+        group="meta",
+        param_shape=PARAM_OPTIONAL_OBJECT,
+        login_placement="none",
+        safety=SAFETY_READ,
+        source_status=SOURCE_UNDOCUMENTED,
+        live_probe_allowed=False,
+    ),
+    "GetAvailableVersions": V4MethodContract(
+        method="GetAvailableVersions",
+        group="meta",
+        param_shape=PARAM_OPTIONAL_OBJECT,
+        login_placement="none",
+        safety=SAFETY_READ,
+        source_status=SOURCE_UNDOCUMENTED,
+        live_probe_allowed=False,
+    ),
+}
+
+
+def get_v4_contract(method: str) -> V4MethodContract:
+    """Return the known contract for one v4 Live method."""
+    return V4_METHOD_CONTRACTS[method]
+
+
+def v4_method_contract(method: str):
+    """Attach a v4 Live method contract to a Click command."""
+    contract = get_v4_contract(method)
+
+    def decorator(command):
+        command.v4_method = method
+        command.v4_contract = contract
+        return command
+
+    return decorator
+
+
+def validate_v4_contract_registry() -> list[str]:
+    """Return registry consistency errors."""
+    errors = []
+
+    supported = set(SUPPORTED_V4_METHODS)
+    registered = set(V4_METHOD_CONTRACTS)
+    missing = sorted(supported - registered)
+    stale = sorted(registered - supported)
+    if missing:
+        errors.append(f"Missing v4 contract entries: {missing}")
+    if stale:
+        errors.append(f"Stale v4 contract entries: {stale}")
+
+    valid_shapes = {
+        PARAM_ARRAY,
+        PARAM_OBJECT,
+        PARAM_OPTIONAL_OBJECT,
+        PARAM_SCALAR,
+        PARAM_UNDOCUMENTED,
+    }
+    valid_safety = {SAFETY_READ, SAFETY_WRITE, SAFETY_DANGEROUS, SAFETY_ASYNC}
+    valid_sources = {
+        SOURCE_CONFIRMED_LIVE,
+        SOURCE_DOCS,
+        SOURCE_UNDOCUMENTED,
+    }
+
+    for method, contract in sorted(V4_METHOD_CONTRACTS.items()):
+        expected_group = SUPPORTED_V4_METHODS.get(method, {}).get("group")
+        if expected_group and contract.group != expected_group:
+            errors.append(
+                f"{method} group mismatch: {contract.group!r} != {expected_group!r}"
+            )
+        if contract.method != method:
+            errors.append(f"{method} contract.method mismatch: {contract.method!r}")
+        if contract.param_shape not in valid_shapes:
+            errors.append(f"{method} has invalid param_shape: {contract.param_shape}")
+        if contract.safety not in valid_safety:
+            errors.append(f"{method} has invalid safety: {contract.safety}")
+        if contract.source_status not in valid_sources:
+            errors.append(
+                f"{method} has invalid source_status: {contract.source_status}"
+            )
+        if not contract.login_placement:
+            errors.append(f"{method} missing login_placement")
+        if contract.live_probe_allowed and contract.safety != SAFETY_READ:
+            errors.append(f"{method} live probe allowed for non-read safety")
+        if contract.live_probe_allowed and contract.example_param is None:
+            errors.append(f"{method} live probe missing example_param")
+
+    return errors

--- a/direct_cli/v4_contracts.py
+++ b/direct_cli/v4_contracts.py
@@ -350,7 +350,13 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
 
 def get_v4_contract(method: str) -> V4MethodContract:
     """Return the known contract for one v4 Live method."""
-    return V4_METHOD_CONTRACTS[method]
+    try:
+        return V4_METHOD_CONTRACTS[method]
+    except KeyError as exc:
+        valid_methods = ", ".join(sorted(V4_METHOD_CONTRACTS))
+        raise ValueError(
+            f"Unknown v4 Live method {method!r}. Valid methods: {valid_methods}"
+        ) from exc
 
 
 def v4_method_contract(method: str):

--- a/direct_cli/v4_contracts.py
+++ b/direct_cli/v4_contracts.py
@@ -17,6 +17,7 @@ SAFETY_READ = "read"
 SAFETY_WRITE = "write"
 SAFETY_DANGEROUS = "dangerous"
 SAFETY_ASYNC = "async"
+SAFETY_MIXED = "mixed"
 
 SOURCE_CONFIRMED_LIVE = "confirmed-live"
 SOURCE_DOCS = "docs"
@@ -107,11 +108,13 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
     "AccountManagement": V4MethodContract(
         method="AccountManagement",
         group="shared_account",
-        param_shape=PARAM_UNDOCUMENTED,
-        login_placement="unknown",
-        safety=SAFETY_WRITE,
-        source_status=SOURCE_UNDOCUMENTED,
-        live_probe_allowed=False,
+        param_shape=PARAM_OBJECT,
+        login_placement="optional SelectionCriteria.Logins for agency/client selection",
+        safety=SAFETY_MIXED,
+        source_status=SOURCE_CONFIRMED_LIVE,
+        live_probe_allowed=True,
+        example_param={"Action": "Get"},
+        notes="Action=Get is read-only and returns Accounts[].Amount/Currency.",
     ),
     "EnableSharedAccount": V4MethodContract(
         method="EnableSharedAccount",
@@ -373,7 +376,13 @@ def validate_v4_contract_registry() -> list[str]:
         PARAM_SCALAR,
         PARAM_UNDOCUMENTED,
     }
-    valid_safety = {SAFETY_READ, SAFETY_WRITE, SAFETY_DANGEROUS, SAFETY_ASYNC}
+    valid_safety = {
+        SAFETY_READ,
+        SAFETY_WRITE,
+        SAFETY_DANGEROUS,
+        SAFETY_ASYNC,
+        SAFETY_MIXED,
+    }
     valid_sources = {
         SOURCE_CONFIRMED_LIVE,
         SOURCE_DOCS,
@@ -398,8 +407,11 @@ def validate_v4_contract_registry() -> list[str]:
             )
         if not contract.login_placement:
             errors.append(f"{method} missing login_placement")
-        if contract.live_probe_allowed and contract.safety != SAFETY_READ:
-            errors.append(f"{method} live probe allowed for non-read safety")
+        if contract.live_probe_allowed and contract.safety not in {
+            SAFETY_READ,
+            SAFETY_MIXED,
+        }:
+            errors.append(f"{method} live probe allowed for unsafe safety")
         if contract.live_probe_allowed and contract.example_param is None:
             errors.append(f"{method} live probe missing example_param")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ markers = [
     "integration: marks tests as integration tests requiring a real API token (deselect with '-m \"not integration\"')",
     "integration_write: sandbox integration tests for write commands (replays VCR cassettes offline; --record-mode=rewrite needs YANDEX_DIRECT_TOKEN)",
     "integration_live_write: manual production API write tests limited to disposable draft resources (requires YANDEX_DIRECT_TOKEN and YANDEX_DIRECT_LIVE_WRITE=1)",
+    "v4_live_read: manual read-only v4 Live tests (requires YANDEX_DIRECT_TOKEN, YANDEX_DIRECT_LOGIN, and YANDEX_DIRECT_V4_LIVE_READ=1)",
     "sandbox_limitation(reason, category): test skipped due to known Yandex Direct sandbox API limitation (not a CLI bug). category is optional: 'disabled' = supported in live but disabled/broken in sandbox (codes 8800/1000/5004); 'unsupported' = resource type architecturally missing from sandbox (code 3500)",
     "api_coverage: marks tests verifying CLI coverage against Yandex API WSDL (cached, no network required)",
 ]

--- a/scripts/test_safe_commands.sh
+++ b/scripts/test_safe_commands.sh
@@ -239,12 +239,15 @@ run_test "dictionaries list-names (env auth)"      direct dictionaries list-name
 run_test "changes check-dictionaries (env auth)"   direct changes check-dictionaries
 run_test "reports list-types (env auth)"           direct reports list-types
 run_test "reports get (env auth)"                  direct reports get --type campaign_performance_report --from 2026-01-01 --to 2026-01-01 --name "Smoke Safe Report" --fields Date,CampaignId
+run_test "balance (env auth)"                      direct balance
 
 if [ -n "$CAMPAIGN_ID" ]; then
   run_test "changes check-campaigns (env auth)"    direct changes check-campaigns --timestamp 2026-04-23T00:00:00
   run_test "dynamicads get (env auth)"             direct dynamicads get --adgroup-ids "${ADGROUP_ID:-0}"
+  run_test "v4goals get-stat-goals (env auth)"     direct v4goals get-stat-goals --campaign-ids "$CAMPAIGN_ID"
+  run_test "v4goals get-retargeting-goals (env auth)" direct v4goals get-retargeting-goals --campaign-ids "$CAMPAIGN_ID"
 else
-  echo -e "  ${YELLOW}[SKIP]${RESET} changes check-campaigns / dynamicads get — нет campaign ID"
+  echo -e "  ${YELLOW}[SKIP]${RESET} changes check-campaigns / dynamicads get / v4goals — нет campaign ID"
 fi
 
 run_test "keywordsresearch has-search-volume (env auth)" direct keywordsresearch has-search-volume --keywords "купить велосипед" --region-ids 213

--- a/tests/api_coverage_payloads.py
+++ b/tests/api_coverage_payloads.py
@@ -44,6 +44,8 @@ DRY_RUN_PAYLOAD_EXCLUSIONS = {
     "smartadtargets.suspend": "Same simple Ids payload family as covered delete/set-bids actions.",
     "vcards.add": "Requires large contact-card payload fixture not needed for generic schema smoke coverage.",
     "reports.get": "Reports API uses a custom TSV endpoint; payload contract is covered by test_reports_request_builder_contract.",
+    "v4goals.get-retargeting-goals": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
+    "v4goals.get-stat-goals": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
 }
 
 PAYLOAD_CASES = [

--- a/tests/test_balance.py
+++ b/tests/test_balance.py
@@ -1,0 +1,137 @@
+import json
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from direct_cli.cli import cli
+from direct_cli.v4_contracts import get_v4_contract
+
+
+def test_balance_dry_run_with_logins_emits_v4_request_body():
+    result = CliRunner().invoke(cli, ["balance", "--logins", "a,b,c", "--dry-run"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "method": "AccountManagement",
+        "param": {
+            "Action": "Get",
+            "SelectionCriteria": {"Logins": ["a", "b", "c"]},
+        },
+    }
+
+
+def test_balance_omitted_logins_uses_configured_login():
+    result = CliRunner(env={"YANDEX_DIRECT_LOGIN": "client-login"}).invoke(
+        cli, ["balance", "--dry-run"]
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "method": "AccountManagement",
+        "param": {
+            "Action": "Get",
+            "SelectionCriteria": {"Logins": ["client-login"]},
+        },
+    }
+
+
+def test_balance_omitted_logins_without_login_uses_token_account():
+    with patch("direct_cli.cli.get_active_profile", return_value=None):
+        result = CliRunner(env={"YANDEX_DIRECT_LOGIN": ""}).invoke(
+            cli, ["--token", "token", "balance", "--dry-run"]
+        )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "method": "AccountManagement",
+        "param": {"Action": "Get"},
+    }
+
+
+def test_balance_omitted_logins_without_login_fails_for_sandbox_before_api_call():
+    with patch("direct_cli.cli.get_active_profile", return_value=None):
+        with patch("direct_cli.commands.balance.create_v4_client") as create_client:
+            result = CliRunner(env={"YANDEX_DIRECT_LOGIN": ""}).invoke(
+                cli, ["--sandbox", "--token", "token", "balance"]
+            )
+
+    assert result.exit_code != 0
+    assert "Provide --logins or configure YANDEX_DIRECT_LOGIN" in result.output
+    create_client.assert_not_called()
+
+
+def test_balance_formats_mocked_v4_response_as_json():
+    with patch("direct_cli.commands.balance.create_v4_client") as create_client:
+        with patch(
+            "direct_cli.commands.balance.call_v4",
+            return_value={
+                "ActionsResult": [],
+                "Accounts": [{"Login": "a", "Amount": "10.50", "Currency": "RUB"}],
+            },
+        ) as call:
+            result = CliRunner().invoke(
+                cli,
+                [
+                    "--token",
+                    "token",
+                    "balance",
+                    "--logins",
+                    "a",
+                ],
+            )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "ActionsResult": [],
+        "Accounts": [{"Login": "a", "Amount": "10.50", "Currency": "RUB"}],
+    }
+    create_client.assert_called_once()
+    call.assert_called_once_with(
+        create_client.return_value,
+        "AccountManagement",
+        {"Action": "Get", "SelectionCriteria": {"Logins": ["a"]}},
+    )
+
+
+def test_balance_formats_mocked_v4_response_as_table():
+    with patch("direct_cli.commands.balance.create_v4_client") as create_client:
+        with patch(
+            "direct_cli.commands.balance.call_v4",
+            return_value={
+                "ActionsResult": [],
+                "Accounts": [{"Login": "a", "Amount": "10.50", "Currency": "RUB"}],
+            },
+        ):
+            result = CliRunner().invoke(
+                cli,
+                [
+                    "--token",
+                    "token",
+                    "balance",
+                    "--logins",
+                    "a",
+                    "--format",
+                    "table",
+                ],
+            )
+
+    assert result.exit_code == 0
+    assert "Login" in result.output
+    assert "Amount" in result.output
+    assert "Currency" in result.output
+    assert "a" in result.output
+    create_client.assert_called_once()
+
+
+def test_balance_help_contains_no_json_input_flag():
+    result = CliRunner().invoke(cli, ["balance", "--help"])
+
+    assert result.exit_code == 0
+    assert "--json" not in result.output
+
+
+def test_balance_command_declares_v4_contract():
+    command = cli.commands["balance"]
+
+    assert command.v4_method == "AccountManagement"
+    assert command.v4_contract == get_v4_contract("AccountManagement")

--- a/tests/test_comprehensive.py
+++ b/tests/test_comprehensive.py
@@ -64,6 +64,7 @@ class TestCommandsRegistered(unittest.TestCase):
         "dynamicads",
         "dynamicfeedadtargets",
         "strategies",
+        "balance",
         "v4finance",
         "v4account",
         "v4goals",

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -51,7 +51,7 @@ Part of axisrow/yandex-direct-mcp-plugin#61.
 import json
 from unittest.mock import patch
 
-from click.testing import CliRunner
+from click.testing import CliRunner, Result
 
 from direct_cli.cli import cli
 from direct_cli.utils import get_default_fields
@@ -2182,7 +2182,7 @@ def test_strategies_unarchive_payload():
 # ----------------------------------------------------------------------
 
 
-def _failing_run(*args: str) -> "CliRunner.invoke result":
+def _failing_run(*args: str) -> Result:
     """Invoke a CLI command expected to fail, returning the result."""
     return CliRunner().invoke(cli, list(args))
 

--- a/tests/test_smoke_matrix.py
+++ b/tests/test_smoke_matrix.py
@@ -122,6 +122,16 @@ def test_safe_smoke_script_runs_agencyclients_sandbox_get():
     assert "BUG #73" not in contents
 
 
+def test_safe_smoke_script_runs_v4_safe_commands():
+    script = ROOT_DIR / "scripts" / "test_safe_commands.sh"
+    contents = script.read_text()
+
+    assert 'run_test "balance (env auth)"' in contents
+    assert 'v4goals get-stat-goals --campaign-ids "$CAMPAIGN_ID"' in contents
+    assert 'v4goals get-retargeting-goals (env auth)"' in contents
+    assert 'v4goals get-retargeting-goals --campaign-ids "$CAMPAIGN_ID"' in contents
+
+
 def test_sandbox_write_live_runner_covers_write_sandbox_matrix():
     module = _load_sandbox_runner_module()
 

--- a/tests/test_smoke_matrix.py
+++ b/tests/test_smoke_matrix.py
@@ -61,8 +61,8 @@ def test_smoke_matrix_counts_match_current_cli_surface():
     summary = smoke_summary()
 
     assert summary["total_cli_groups"] == 39
-    assert summary["total_cli_subcommands"] == 121
-    assert summary["api_cli_subcommands"] == 117
+    assert summary["total_cli_subcommands"] == 123
+    assert summary["api_cli_subcommands"] == 119
     assert summary["wsdl_services"] == 29
     assert summary["non_wsdl_services"] == sorted(NON_WSDL_SERVICES)
     assert summary["api_services_total"] == 30

--- a/tests/test_smoke_matrix.py
+++ b/tests/test_smoke_matrix.py
@@ -36,11 +36,14 @@ def _load_sandbox_runner_module():
 
 
 def _registered_cli_commands() -> set[str]:
-    return {
-        command_key(group_name, command_name)
-        for group_name, group in cli.commands.items()
-        for command_name in getattr(group, "commands", {})
-    }
+    registered = set()
+    for group_name, group in cli.commands.items():
+        if hasattr(group, "commands"):
+            for command_name in group.commands:
+                registered.add(command_key(group_name, command_name))
+        else:
+            registered.add(group_name)
+    return registered
 
 
 def test_smoke_matrix_covers_every_cli_subcommand_once():
@@ -57,9 +60,9 @@ def test_smoke_matrix_covers_every_cli_subcommand_once():
 def test_smoke_matrix_counts_match_current_cli_surface():
     summary = smoke_summary()
 
-    assert summary["total_cli_groups"] == 38
-    assert summary["total_cli_subcommands"] == 120
-    assert summary["api_cli_subcommands"] == 116
+    assert summary["total_cli_groups"] == 39
+    assert summary["total_cli_subcommands"] == 121
+    assert summary["api_cli_subcommands"] == 117
     assert summary["wsdl_services"] == 29
     assert summary["non_wsdl_services"] == sorted(NON_WSDL_SERVICES)
     assert summary["api_services_total"] == 30

--- a/tests/test_v4_contracts.py
+++ b/tests/test_v4_contracts.py
@@ -5,7 +5,6 @@ from direct_cli._vendor.tapi_yandex_direct.v4 import SUPPORTED_V4_METHODS
 from direct_cli.v4 import build_v4_body, call_v4
 from direct_cli.v4_contracts import (
     PARAM_UNDOCUMENTED,
-    SAFETY_READ,
     SOURCE_CONFIRMED_LIVE,
     V4_METHOD_CONTRACTS,
     get_v4_contract,
@@ -128,3 +127,15 @@ def test_v4_method_contract_decorator_attaches_known_contract():
     assert decorated is command
     assert command.v4_method == "GetClientsUnits"
     assert command.v4_contract == get_v4_contract("GetClientsUnits")
+
+
+def test_get_v4_contract_rejects_unknown_method_with_helpful_error():
+    try:
+        get_v4_contract("WrongMethod")
+    except ValueError as exc:
+        message = str(exc)
+    else:
+        raise AssertionError("Expected ValueError for unknown v4 method")
+
+    assert "Unknown v4 Live method 'WrongMethod'" in message
+    assert "GetClientsUnits" in message

--- a/tests/test_v4_contracts.py
+++ b/tests/test_v4_contracts.py
@@ -85,7 +85,7 @@ def test_v4_call_helper_preserves_non_dict_params():
     assert result == [{"Login": "x", "UnitsRest": 1}]
 
 
-def test_v4_adapter_does_not_inject_param_login():
+def test_v4_adapter_sends_login_as_header_without_mutating_param():
     from direct_cli._vendor.tapi_yandex_direct.v4.adapter import V4LiveClientAdapter
 
     adapter = V4LiveClientAdapter()
@@ -105,6 +105,19 @@ def test_v4_adapter_does_not_inject_param_login():
     assert body["param"] == {"CampaignIDS": [123]}
     assert body["token"] == "token"
     assert body["locale"] == "en"
+    assert request["headers"]["Client-Login"] == "client-login"
+
+
+def test_v4_goal_contracts_keep_global_login_at_transport_level():
+    for method in ("GetStatGoals", "GetRetargetingGoals"):
+        contract = get_v4_contract(method)
+
+        assert "Client-Login header" in contract.login_placement
+        assert contract.example_param == {"CampaignIDS": [123]}
+        assert build_v4_body(method, contract.example_param) == {
+            "method": method,
+            "param": {"CampaignIDS": [123]},
+        }
 
 
 def test_v4_method_contract_decorator_attaches_known_contract():

--- a/tests/test_v4_contracts.py
+++ b/tests/test_v4_contracts.py
@@ -1,0 +1,107 @@
+import json
+from unittest.mock import Mock
+
+from direct_cli._vendor.tapi_yandex_direct.v4 import SUPPORTED_V4_METHODS
+from direct_cli.v4 import build_v4_body, call_v4
+from direct_cli.v4_contracts import (
+    PARAM_UNDOCUMENTED,
+    SAFETY_READ,
+    SOURCE_CONFIRMED_LIVE,
+    V4_METHOD_CONTRACTS,
+    get_v4_contract,
+    v4_method_contract,
+    validate_v4_contract_registry,
+)
+
+
+def test_v4_contract_registry_covers_supported_methods_exactly():
+    assert validate_v4_contract_registry() == []
+    assert set(V4_METHOD_CONTRACTS) == set(SUPPORTED_V4_METHODS)
+
+
+def test_v4_contract_registry_has_explicit_policy_for_every_method():
+    for method, contract in V4_METHOD_CONTRACTS.items():
+        assert contract.method == method
+        assert contract.group == SUPPORTED_V4_METHODS[method]["group"]
+        assert contract.param_shape
+        assert contract.login_placement
+        assert contract.safety
+        assert contract.source_status
+        assert isinstance(contract.live_probe_allowed, bool)
+
+
+def test_confirmed_contracts_are_not_undocumented():
+    confirmed = [
+        contract
+        for contract in V4_METHOD_CONTRACTS.values()
+        if contract.source_status == SOURCE_CONFIRMED_LIVE
+    ]
+
+    assert {contract.method for contract in confirmed} == {
+        "GetClientsUnits",
+        "GetStatGoals",
+        "GetRetargetingGoals",
+    }
+    for contract in confirmed:
+        assert contract.param_shape != PARAM_UNDOCUMENTED
+        assert contract.safety == SAFETY_READ
+        assert contract.live_probe_allowed
+        assert contract.example_param is not None
+
+
+def test_get_clients_units_contract_uses_array_param():
+    contract = get_v4_contract("GetClientsUnits")
+
+    assert contract.example_param == ["client-login"]
+    assert build_v4_body("GetClientsUnits", ["client-login"]) == {
+        "method": "GetClientsUnits",
+        "param": ["client-login"],
+    }
+
+
+def test_v4_call_helper_preserves_non_dict_params():
+    response = Mock()
+    response.return_value.extract.return_value = [{"Login": "x", "UnitsRest": 1}]
+    resource = Mock()
+    resource.post.return_value = response
+    client = Mock()
+    client.v4live.return_value = resource
+
+    result = call_v4(client, "GetClientsUnits", ["x"])
+
+    resource.post.assert_called_once_with(
+        data={"method": "GetClientsUnits", "param": ["x"]}
+    )
+    assert result == [{"Login": "x", "UnitsRest": 1}]
+
+
+def test_v4_adapter_does_not_inject_param_login():
+    from direct_cli._vendor.tapi_yandex_direct.v4.adapter import V4LiveClientAdapter
+
+    adapter = V4LiveClientAdapter()
+    api_params = {
+        "access_token": "token",
+        "login": "client-login",
+        "language": "en",
+        "is_sandbox": False,
+    }
+
+    request = adapter.get_request_kwargs(
+        api_params,
+        data={"method": "GetStatGoals", "param": {"CampaignIDS": [123]}},
+    )
+    body = json.loads(request["data"])
+
+    assert body["param"] == {"CampaignIDS": [123]}
+    assert body["token"] == "token"
+    assert body["locale"] == "en"
+
+
+def test_v4_method_contract_decorator_attaches_known_contract():
+    command = Mock()
+
+    decorated = v4_method_contract("GetClientsUnits")(command)
+
+    assert decorated is command
+    assert command.v4_method == "GetClientsUnits"
+    assert command.v4_contract == get_v4_contract("GetClientsUnits")

--- a/tests/test_v4_contracts.py
+++ b/tests/test_v4_contracts.py
@@ -38,13 +38,13 @@ def test_confirmed_contracts_are_not_undocumented():
     ]
 
     assert {contract.method for contract in confirmed} == {
+        "AccountManagement",
         "GetClientsUnits",
         "GetStatGoals",
         "GetRetargetingGoals",
     }
     for contract in confirmed:
         assert contract.param_shape != PARAM_UNDOCUMENTED
-        assert contract.safety == SAFETY_READ
         assert contract.live_probe_allowed
         assert contract.example_param is not None
 
@@ -56,6 +56,16 @@ def test_get_clients_units_contract_uses_array_param():
     assert build_v4_body("GetClientsUnits", ["client-login"]) == {
         "method": "GetClientsUnits",
         "param": ["client-login"],
+    }
+
+
+def test_account_management_get_contract_returns_money_balance():
+    contract = get_v4_contract("AccountManagement")
+
+    assert contract.example_param == {"Action": "Get"}
+    assert build_v4_body("AccountManagement", {"Action": "Get"}) == {
+        "method": "AccountManagement",
+        "param": {"Action": "Get"},
     }
 
 

--- a/tests/test_v4_foundation.py
+++ b/tests/test_v4_foundation.py
@@ -35,9 +35,9 @@ def test_create_v4_client_passes_resolved_credentials():
 
 
 def test_build_v4_body_with_param():
-    assert build_v4_body("GetClientsUnits", {"Logins": ["x"]}) == {
+    assert build_v4_body("GetClientsUnits", ["x"]) == {
         "method": "GetClientsUnits",
-        "param": {"Logins": ["x"]},
+        "param": ["x"],
     }
 
 
@@ -49,10 +49,10 @@ def test_call_v4_posts_body_and_returns_extracted_payload():
     client = Mock()
     client.v4live.return_value = resource
 
-    result = call_v4(client, "GetClientsUnits", {"Logins": ["x"]})
+    result = call_v4(client, "GetClientsUnits", ["x"])
 
     resource.post.assert_called_once_with(
-        data={"method": "GetClientsUnits", "param": {"Logins": ["x"]}}
+        data={"method": "GetClientsUnits", "param": ["x"]}
     )
     response.return_value.extract.assert_called_once_with()
     assert result == [{"Login": "x", "Units": 100}]

--- a/tests/test_v4_live_contracts.py
+++ b/tests/test_v4_live_contracts.py
@@ -53,6 +53,18 @@ def test_v4_live_get_clients_units_contract():
     assert {"Login", "UnitsRest"} <= set(data[0])
 
 
+def test_v4_live_account_management_get_contract():
+    token, login = _credentials()
+    client = create_v4_client(token=token, login=login, language="ru")
+
+    data = call_v4(client, "AccountManagement", {"Action": "Get"})
+
+    assert isinstance(data, dict)
+    assert isinstance(data.get("Accounts"), list)
+    assert data["Accounts"]
+    assert {"Login", "Amount", "Currency"} <= set(data["Accounts"][0])
+
+
 def test_v4_live_goals_contracts():
     token, login = _credentials()
     campaign_id = _campaign_id(token, login)

--- a/tests/test_v4_live_contracts.py
+++ b/tests/test_v4_live_contracts.py
@@ -1,0 +1,73 @@
+import os
+
+import pytest
+from dotenv import load_dotenv
+
+from direct_cli.api import create_client, create_v4_client
+from direct_cli.v4 import call_v4
+
+load_dotenv()
+
+
+pytestmark = [
+    pytest.mark.v4_live_read,
+    pytest.mark.skipif(
+        os.getenv("YANDEX_DIRECT_V4_LIVE_READ") != "1",
+        reason="Set YANDEX_DIRECT_V4_LIVE_READ=1 to run v4 live read probes",
+    ),
+]
+
+
+def _credentials():
+    token = os.getenv("YANDEX_DIRECT_TOKEN")
+    login = os.getenv("YANDEX_DIRECT_LOGIN")
+    if not token or not login:
+        pytest.skip("YANDEX_DIRECT_TOKEN and YANDEX_DIRECT_LOGIN are required")
+    return token, login
+
+
+def _campaign_id(token: str, login: str) -> int:
+    client = create_client(token=token, login=login)
+    body = {
+        "method": "get",
+        "params": {
+            "FieldNames": ["Id"],
+            "Page": {"Limit": 1},
+        },
+    }
+    data = client.campaigns().post(data=body)().extract()
+    campaigns = data.get("Campaigns", []) if isinstance(data, dict) else data
+    if not campaigns:
+        pytest.skip("No campaign available for v4 goals live probes")
+    return campaigns[0]["Id"]
+
+
+def test_v4_live_get_clients_units_contract():
+    token, login = _credentials()
+    client = create_v4_client(token=token, login=login)
+
+    data = call_v4(client, "GetClientsUnits", [login])
+
+    assert isinstance(data, list)
+    assert data
+    assert {"Login", "UnitsRest"} <= set(data[0])
+
+
+def test_v4_live_goals_contracts():
+    token, login = _credentials()
+    campaign_id = _campaign_id(token, login)
+    client = create_v4_client(token=token, login=login)
+
+    stat_goals = call_v4(client, "GetStatGoals", {"CampaignIDS": [campaign_id]})
+    retargeting_goals = call_v4(
+        client,
+        "GetRetargetingGoals",
+        {"CampaignIDS": [campaign_id]},
+    )
+
+    assert isinstance(stat_goals, list)
+    assert isinstance(retargeting_goals, list)
+    if stat_goals:
+        assert {"CampaignID", "GoalID", "Name"} <= set(stat_goals[0])
+    if retargeting_goals:
+        assert {"GoalID", "Name"} <= set(retargeting_goals[0])

--- a/tests/test_v4goals.py
+++ b/tests/test_v4goals.py
@@ -57,6 +57,32 @@ def test_get_retargeting_goals_missing_campaign_ids_fails_with_usage_error():
     assert "Missing option '--campaign-ids'" in result.output
 
 
+def test_get_stat_goals_empty_campaign_ids_fails_with_usage_error():
+    result = _invoke(
+        "v4goals",
+        "get-stat-goals",
+        "--campaign-ids",
+        "",
+        "--dry-run",
+    )
+
+    assert result.exit_code != 0
+    assert "--campaign-ids must not be empty" in result.output
+
+
+def test_get_retargeting_goals_empty_campaign_ids_fails_with_usage_error():
+    result = _invoke(
+        "v4goals",
+        "get-retargeting-goals",
+        "--campaign-ids",
+        "",
+        "--dry-run",
+    )
+
+    assert result.exit_code != 0
+    assert "--campaign-ids must not be empty" in result.output
+
+
 def test_get_stat_goals_formats_mocked_response_as_json():
     with patch("direct_cli.commands.v4goals.create_v4_client") as create_client:
         with patch(

--- a/tests/test_v4goals.py
+++ b/tests/test_v4goals.py
@@ -1,0 +1,164 @@
+import json
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from direct_cli.cli import cli
+from direct_cli.v4_contracts import get_v4_contract
+
+
+def _invoke(*args: str):
+    return CliRunner().invoke(cli, list(args))
+
+
+def test_get_stat_goals_dry_run_uses_campaign_ids_param():
+    result = _invoke(
+        "v4goals",
+        "get-stat-goals",
+        "--campaign-ids",
+        "1,2,3",
+        "--dry-run",
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "method": "GetStatGoals",
+        "param": {"CampaignIDS": [1, 2, 3]},
+    }
+
+
+def test_get_retargeting_goals_dry_run_uses_campaign_ids_param():
+    result = _invoke(
+        "v4goals",
+        "get-retargeting-goals",
+        "--campaign-ids",
+        "1,2,3",
+        "--dry-run",
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "method": "GetRetargetingGoals",
+        "param": {"CampaignIDS": [1, 2, 3]},
+    }
+
+
+def test_get_stat_goals_missing_campaign_ids_fails_with_usage_error():
+    result = _invoke("v4goals", "get-stat-goals", "--dry-run")
+
+    assert result.exit_code != 0
+    assert "Missing option '--campaign-ids'" in result.output
+
+
+def test_get_retargeting_goals_missing_campaign_ids_fails_with_usage_error():
+    result = _invoke("v4goals", "get-retargeting-goals", "--dry-run")
+
+    assert result.exit_code != 0
+    assert "Missing option '--campaign-ids'" in result.output
+
+
+def test_get_stat_goals_formats_mocked_response_as_json():
+    with patch("direct_cli.commands.v4goals.create_v4_client") as create_client:
+        with patch(
+            "direct_cli.commands.v4goals.call_v4",
+            return_value=[{"CampaignID": 1, "GoalID": 10, "Name": "Lead"}],
+        ) as call:
+            result = _invoke(
+                "--token",
+                "token",
+                "v4goals",
+                "get-stat-goals",
+                "--campaign-ids",
+                "1",
+            )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == [
+        {"CampaignID": 1, "GoalID": 10, "Name": "Lead"}
+    ]
+    call.assert_called_once_with(
+        create_client.return_value,
+        "GetStatGoals",
+        {"CampaignIDS": [1]},
+    )
+
+
+def test_get_stat_goals_with_login_keeps_method_param_schema():
+    with patch("direct_cli.commands.v4goals.create_v4_client") as create_client:
+        with patch(
+            "direct_cli.commands.v4goals.call_v4",
+            return_value=[{"CampaignID": 1, "GoalID": 10, "Name": "Lead"}],
+        ) as call:
+            result = _invoke(
+                "--token",
+                "token",
+                "--login",
+                "client-login",
+                "v4goals",
+                "get-stat-goals",
+                "--campaign-ids",
+                "1",
+            )
+
+    assert result.exit_code == 0
+    create_client.assert_called_once_with(
+        token="token",
+        login="client-login",
+        profile=None,
+        sandbox=False,
+    )
+    call.assert_called_once_with(
+        create_client.return_value,
+        "GetStatGoals",
+        {"CampaignIDS": [1]},
+    )
+
+
+def test_get_retargeting_goals_formats_mocked_response_as_table():
+    with patch("direct_cli.commands.v4goals.create_v4_client") as create_client:
+        with patch(
+            "direct_cli.commands.v4goals.call_v4",
+            return_value=[{"CampaignID": 1, "GoalID": 10, "Name": "Lead"}],
+        ) as call:
+            result = _invoke(
+                "--token",
+                "token",
+                "v4goals",
+                "get-retargeting-goals",
+                "--campaign-ids",
+                "1",
+                "--format",
+                "table",
+            )
+
+    assert result.exit_code == 0
+    assert "CampaignID" in result.output
+    assert "GoalID" in result.output
+    assert "Lead" in result.output
+    call.assert_called_once_with(
+        create_client.return_value,
+        "GetRetargetingGoals",
+        {"CampaignIDS": [1]},
+    )
+
+
+def test_v4goals_help_contains_no_json_input_flag():
+    for args in [
+        ("v4goals", "--help"),
+        ("v4goals", "get-stat-goals", "--help"),
+        ("v4goals", "get-retargeting-goals", "--help"),
+    ]:
+        result = _invoke(*args)
+        assert result.exit_code == 0
+        assert "--json" not in result.output
+
+
+def test_v4goals_commands_declare_v4_contracts():
+    commands = cli.commands["v4goals"].commands
+
+    assert commands["get-stat-goals"].v4_method == "GetStatGoals"
+    assert commands["get-stat-goals"].v4_contract == get_v4_contract("GetStatGoals")
+    assert commands["get-retargeting-goals"].v4_method == "GetRetargetingGoals"
+    assert commands["get-retargeting-goals"].v4_contract == get_v4_contract(
+        "GetRetargetingGoals"
+    )


### PR DESCRIPTION
## Summary
- add a full V4 Live method contract registry covering every vendored `SUPPORTED_V4_METHODS` entry
- lock transport invariants: V4 params may be arrays/scalars/objects and the adapter no longer injects method-level `param.login`
- add skipped-by-default read-only live probes for confirmed contracts

## Confirmed contracts
- `GetClientsUnits` uses `param` as a login array, e.g. `["client-login"]`
- `GetStatGoals` uses `param.CampaignIDS`
- `GetRetargetingGoals` works with `param.CampaignIDS`; live probing also showed `Logins` is accepted for future agency-oriented commands

## Tests
- `pytest -q tests/test_v4_contracts.py tests/test_v4_foundation.py tests/test_v4_live_contracts.py`
- `pytest -q tests/test_api_coverage.py tests/test_cli.py tests/test_dry_run.py tests/test_comprehensive.py tests/test_smoke_matrix.py`
- `YANDEX_DIRECT_V4_LIVE_READ=1 pytest -q tests/test_v4_live_contracts.py`

## Notes
This is the base PR for rebasing #140 and #141 before adding additional V4 commands.

## Transport note
V4 global `--login`/client login selection is intentionally sent as the documented `Client-Login` request header. The adapter does not inject undocumented `param.login` into method payloads, so V4 `param` stays limited to documented method fields. Future V4 command implementations should expose method-specific login-like fields explicitly only when the official method contract documents them.


## Smoke matrix note
`balance` is a standalone Click command rather than a command group, so the smoke matrix registration check now explicitly includes standalone commands as well as group subcommands. This prevents future SAFE commands with no subcommands from being silently omitted from coverage.
