### PR TITLE
[codex] add v4 finance and events commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,24 @@ direct v4goals get-retargeting-goals --campaign-ids 123,456 --format table
 direct v4goals get-stat-goals --campaign-ids 123 --dry-run
 ```
 
+### V4 Live Events
+
+```bash
+direct v4events get-events-log --from 2026-04-14T00:00:00 --to 2026-04-15T00:00:00
+direct v4events get-events-log --from 2026-04-14T00:00:00 --to 2026-04-15T00:00:00 --currency RUB --limit 100 --offset 0 --format table
+```
+
+### V4 Live Finance
+
+`get-credit-limits` requires a financial token and operation number. Pass them
+with `--finance-token` and `--operation-num`, or set
+`YANDEX_DIRECT_FINANCE_TOKEN` and `YANDEX_DIRECT_OPERATION_NUM`.
+
+```bash
+direct v4finance get-credit-limits --logins client-login --finance-token FINANCE_TOKEN --operation-num 123
+direct v4finance get-credit-limits --logins client-login,other-client --format table
+```
+
 ### CLI Convention
 
 The current CLI convention is defined as follows.

--- a/direct_cli/_vendor/tapi_yandex_direct/v4/adapter.py
+++ b/direct_cli/_vendor/tapi_yandex_direct/v4/adapter.py
@@ -43,11 +43,14 @@ class V4LiveClientAdapter(JSONAdapterMixin, TapiAdapter):
         token = api_params.get("access_token")
         login = api_params.get("login")
         language = api_params.get("language", "en")
+        finance_token = api_params.get("finance_token")
+        operation_num = api_params.get("operation_num")
 
-        # Enrich the JSON body with token / locale. format_data_to_request does
-        # not see api_params, so we do this here, after super() has already
-        # serialised the user data. Agency/client selection is transport-level
-        # (Client-Login header); method params must stay schema-shaped.
+        # Enrich the JSON body with top-level v4 Live fields.
+        # format_data_to_request does not see api_params, so we do this here,
+        # after super() has already serialised the user data. Agency/client
+        # selection is transport-level (Client-Login header); method params
+        # must stay schema-shaped.
         raw = params.get("data")
         if raw:
             if isinstance(raw, (bytes, bytearray)):
@@ -67,6 +70,10 @@ class V4LiveClientAdapter(JSONAdapterMixin, TapiAdapter):
                 body.setdefault("token", token)
             if language:
                 body.setdefault("locale", language)
+            if finance_token:
+                body.setdefault("finance_token", finance_token)
+            if operation_num is not None:
+                body.setdefault("operation_num", operation_num)
 
             params["data"] = orjson.dumps(body)
 

--- a/direct_cli/_vendor/tapi_yandex_direct/v4/adapter.pyi
+++ b/direct_cli/_vendor/tapi_yandex_direct/v4/adapter.pyi
@@ -49,6 +49,8 @@ class YandexDirectV4Live:
         language: str = "en",
         retry_if_exceeded_limit: bool = True,
         retries_if_server_error: int = 5,
+        finance_token: Optional[str] = None,
+        operation_num: Optional[int] = None,
     ) -> None: ...
 
     def v4live(self) -> V4LiveExecutor: ...

--- a/direct_cli/api.py
+++ b/direct_cli/api.py
@@ -80,6 +80,8 @@ def create_v4_client(
     language: Optional[str] = None,
     retry_if_exceeded_limit: bool = True,
     retries_if_server_error: int = 5,
+    finance_token: Optional[str] = None,
+    operation_num: Optional[int] = None,
 ) -> YandexDirectV4Live:
     """
     Create YandexDirect v4 Live client.
@@ -96,6 +98,8 @@ def create_v4_client(
         language: API locale
         retry_if_exceeded_limit: Retry when the API limit is exceeded
         retries_if_server_error: Number of retries for server errors
+        finance_token: Financial token for v4 Live finance methods
+        operation_num: Financial operation number for v4 Live finance methods
 
     Returns:
         YandexDirect v4 Live client instance
@@ -117,6 +121,8 @@ def create_v4_client(
         language=language or "en",
         retry_if_exceeded_limit=retry_if_exceeded_limit,
         retries_if_server_error=retries_if_server_error,
+        finance_token=finance_token,
+        operation_num=operation_num,
     )
 
 

--- a/direct_cli/cli.py
+++ b/direct_cli/cli.py
@@ -42,10 +42,10 @@ from .commands.dynamicfeedadtargets import dynamicfeedadtargets
 from .commands.strategies import strategies
 from .commands.auth import auth
 from .commands.balance import balance
+from .commands.v4events import v4events
+from .commands.v4finance import v4finance
 from .commands.v4shells import (
     v4account,
-    v4events,
-    v4finance,
     v4forecast,
     v4meta,
     v4wordstat,

--- a/direct_cli/commands/v4events.py
+++ b/direct_cli/commands/v4events.py
@@ -1,0 +1,118 @@
+"""Yandex Direct v4 Live events commands."""
+
+import re
+from datetime import datetime
+from typing import Optional
+
+import click
+
+from ..api import create_v4_client
+from ..output import format_output, print_error
+from ..v4 import build_v4_body, call_v4
+from ..v4_contracts import v4_method_contract
+from .v4shells import V4_EPILOG
+
+V4_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S"
+V4_DATETIME_RE = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}")
+
+
+def _parse_v4_datetime(value: str, option_name: str) -> datetime:
+    """Parse a strict v4 Live CLI datetime token."""
+    if not V4_DATETIME_RE.fullmatch(value):
+        raise click.UsageError(
+            f"Invalid {option_name}: {value}. Expected YYYY-MM-DDTHH:MM:SS"
+        )
+    try:
+        return datetime.strptime(value, V4_DATETIME_FORMAT)
+    except ValueError:
+        raise click.UsageError(
+            f"Invalid {option_name}: {value}. Expected YYYY-MM-DDTHH:MM:SS"
+        )
+
+
+def _events_log_param(
+    timestamp_from: str,
+    timestamp_to: str,
+    currency: str,
+    limit: Optional[int],
+    offset: Optional[int],
+) -> dict:
+    """Build the v4 Live GetEventsLog parameter."""
+    from_dt = _parse_v4_datetime(timestamp_from, "--from")
+    to_dt = _parse_v4_datetime(timestamp_to, "--to")
+    if from_dt > to_dt:
+        raise click.UsageError("--from must be earlier than or equal to --to")
+
+    param = {
+        "TimestampFrom": timestamp_from,
+        "TimestampTo": timestamp_to,
+        "Currency": currency,
+    }
+    if limit is not None:
+        param["Limit"] = limit
+    if offset is not None:
+        param["Offset"] = offset
+    return param
+
+
+@click.group(epilog=V4_EPILOG)
+def v4events():
+    """Yandex Direct v4 Live events commands."""
+
+
+@v4_method_contract("GetEventsLog")
+@v4events.command(name="get-events-log")
+@click.option(
+    "--from",
+    "timestamp_from",
+    required=True,
+    help="Start timestamp in YYYY-MM-DDTHH:MM:SS format",
+)
+@click.option(
+    "--to",
+    "timestamp_to",
+    required=True,
+    help="End timestamp in YYYY-MM-DDTHH:MM:SS format",
+)
+@click.option("--currency", default="RUB", show_default=True, help="Currency")
+@click.option("--limit", type=click.IntRange(min=0), help="Result limit")
+@click.option("--offset", type=click.IntRange(min=0), help="Result offset")
+@click.option(
+    "--format",
+    "output_format",
+    default="json",
+    type=click.Choice(["json", "table", "csv", "tsv"]),
+    help="Output format",
+)
+@click.option("--output", help="Output file")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def get_events_log(
+    ctx,
+    timestamp_from,
+    timestamp_to,
+    currency,
+    limit,
+    offset,
+    output_format,
+    output,
+    dry_run,
+):
+    """Get v4 Live events log entries."""
+    param = _events_log_param(timestamp_from, timestamp_to, currency, limit, offset)
+    if dry_run:
+        format_output(build_v4_body("GetEventsLog", param), "json", None)
+        return
+
+    try:
+        client = create_v4_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            profile=ctx.obj.get("profile"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+        data = call_v4(client, "GetEventsLog", param)
+        format_output(data, output_format, output)
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()

--- a/direct_cli/commands/v4finance.py
+++ b/direct_cli/commands/v4finance.py
@@ -22,17 +22,21 @@ def _logins_param(logins: str) -> list[str]:
     return login_list
 
 
-def _require_finance_credentials(
+def _finance_credentials(
     finance_token: Optional[str],
     operation_num: Optional[int],
-) -> None:
-    """Validate finance credentials before any v4 Live API call."""
-    if finance_token and operation_num is not None:
-        return
-    raise click.UsageError(
-        "Provide --finance-token and --operation-num, or set "
-        "YANDEX_DIRECT_FINANCE_TOKEN and YANDEX_DIRECT_OPERATION_NUM"
-    )
+) -> tuple[str, int]:
+    """Validate and normalize finance credentials before any v4 Live API call."""
+    normalized_token = (finance_token or "").strip()
+    if normalized_token and operation_num is not None:
+        return normalized_token, operation_num
+    raise click.UsageError(_FINANCE_CREDENTIALS_ERROR)
+
+
+_FINANCE_CREDENTIALS_ERROR = (
+    "Provide --finance-token and --operation-num, or set "
+    "YANDEX_DIRECT_FINANCE_TOKEN and YANDEX_DIRECT_OPERATION_NUM"
+)
 
 
 def _masked_finance_body(method: str, param: list[str], operation_num: int) -> dict:
@@ -83,7 +87,7 @@ def get_credit_limits(
 ):
     """Get client credit limits."""
     login_list = _logins_param(logins)
-    _require_finance_credentials(finance_token, operation_num)
+    finance_token, operation_num = _finance_credentials(finance_token, operation_num)
 
     if dry_run:
         format_output(

--- a/direct_cli/commands/v4finance.py
+++ b/direct_cli/commands/v4finance.py
@@ -1,0 +1,109 @@
+"""Yandex Direct v4 Live finance commands."""
+
+from typing import Optional
+
+import click
+
+from ..api import create_v4_client
+from ..output import format_output, print_error
+from ..utils import parse_csv_strings
+from ..v4 import build_v4_body, call_v4
+from ..v4_contracts import v4_method_contract
+from .v4shells import V4_EPILOG
+
+FINANCE_TOKEN_MASK = "<redacted>"
+
+
+def _logins_param(logins: str) -> list[str]:
+    """Build the v4 Live login list parameter."""
+    login_list = parse_csv_strings(logins)
+    if not login_list:
+        raise click.UsageError("--logins must not be empty")
+    return login_list
+
+
+def _require_finance_credentials(
+    finance_token: Optional[str],
+    operation_num: Optional[int],
+) -> None:
+    """Validate finance credentials before any v4 Live API call."""
+    if finance_token and operation_num is not None:
+        return
+    raise click.UsageError(
+        "Provide --finance-token and --operation-num, or set "
+        "YANDEX_DIRECT_FINANCE_TOKEN and YANDEX_DIRECT_OPERATION_NUM"
+    )
+
+
+def _masked_finance_body(method: str, param: list[str], operation_num: int) -> dict:
+    """Build a dry-run body without exposing the financial token."""
+    body = build_v4_body(method, param)
+    body["finance_token"] = FINANCE_TOKEN_MASK
+    body["operation_num"] = operation_num
+    return body
+
+
+@click.group(epilog=V4_EPILOG)
+def v4finance():
+    """Yandex Direct v4 Live finance commands."""
+
+
+@v4_method_contract("GetCreditLimits")
+@v4finance.command(name="get-credit-limits")
+@click.option("--logins", required=True, help="Comma-separated client logins")
+@click.option(
+    "--finance-token",
+    envvar="YANDEX_DIRECT_FINANCE_TOKEN",
+    help="Financial token",
+)
+@click.option(
+    "--operation-num",
+    type=click.IntRange(min=0),
+    envvar="YANDEX_DIRECT_OPERATION_NUM",
+    help="Financial operation number",
+)
+@click.option(
+    "--format",
+    "output_format",
+    default="json",
+    type=click.Choice(["json", "table", "csv", "tsv"]),
+    help="Output format",
+)
+@click.option("--output", help="Output file")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def get_credit_limits(
+    ctx,
+    logins,
+    finance_token,
+    operation_num,
+    output_format,
+    output,
+    dry_run,
+):
+    """Get client credit limits."""
+    login_list = _logins_param(logins)
+    _require_finance_credentials(finance_token, operation_num)
+
+    if dry_run:
+        format_output(
+            _masked_finance_body("GetCreditLimits", login_list, operation_num),
+            "json",
+            None,
+        )
+        return
+
+    try:
+        client = create_v4_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            profile=ctx.obj.get("profile"),
+            sandbox=ctx.obj.get("sandbox"),
+            finance_token=finance_token,
+            operation_num=operation_num,
+        )
+        data = call_v4(client, "GetCreditLimits", login_list)
+        format_output(data, output_format, output)
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()

--- a/direct_cli/commands/v4shells.py
+++ b/direct_cli/commands/v4shells.py
@@ -11,18 +11,8 @@ V4_EPILOG = (
 
 
 @click.group(epilog=V4_EPILOG)
-def v4finance():
-    """Yandex Direct v4 Live finance commands."""
-
-
-@click.group(epilog=V4_EPILOG)
 def v4account():
     """Yandex Direct v4 Live account commands."""
-
-
-@click.group(epilog=V4_EPILOG)
-def v4events():
-    """Yandex Direct v4 Live events commands."""
 
 
 @click.group(epilog=V4_EPILOG)

--- a/direct_cli/smoke_matrix.py
+++ b/direct_cli/smoke_matrix.py
@@ -57,6 +57,8 @@ SMOKE_MATRIX = {
         "smartadtargets.get",
         "strategies.get",
         "turbopages.get",
+        "v4events.get-events-log",
+        "v4finance.get-credit-limits",
         "v4goals.get-retargeting-goals",
         "v4goals.get-stat-goals",
         "vcards.get",

--- a/direct_cli/v4_contracts.py
+++ b/direct_cli/v4_contracts.py
@@ -54,11 +54,19 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
     "GetCreditLimits": V4MethodContract(
         method="GetCreditLimits",
         group="finance",
-        param_shape=PARAM_UNDOCUMENTED,
-        login_placement="unknown",
+        param_shape=PARAM_ARRAY,
+        login_placement=(
+            "param is a list of client logins; finance_token and "
+            "operation_num are top-level v4 Live body fields"
+        ),
         safety=SAFETY_READ,
-        source_status=SOURCE_UNDOCUMENTED,
+        source_status=SOURCE_CONFIRMED_LIVE,
         live_probe_allowed=False,
+        example_param=["client-login"],
+        notes=(
+            "Requires finance_token and operation_num at the top level. "
+            "Live probe without them returns error_code=350."
+        ),
     ),
     "TransferMoney": V4MethodContract(
         method="TransferMoney",
@@ -131,11 +139,20 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
     "GetEventsLog": V4MethodContract(
         method="GetEventsLog",
         group="events",
-        param_shape=PARAM_UNDOCUMENTED,
-        login_placement="unknown",
+        param_shape=PARAM_OBJECT,
+        login_placement=(
+            "param contains timestamps, Currency, and optional Limit/Offset; "
+            "global --login uses Client-Login header"
+        ),
         safety=SAFETY_READ,
-        source_status=SOURCE_UNDOCUMENTED,
-        live_probe_allowed=False,
+        source_status=SOURCE_CONFIRMED_LIVE,
+        live_probe_allowed=True,
+        example_param={
+            "TimestampFrom": "2026-04-14T00:00:00",
+            "TimestampTo": "2026-04-14T01:00:00",
+            "Currency": "RUB",
+        },
+        notes="Currency is required by live API; omitting it returns error_code=245.",
     ),
     "GetStatGoals": V4MethodContract(
         method="GetStatGoals",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "direct-cli"
-version = "0.3.0"
+version = "0.3.2"
 description = "Command-line interface for Yandex Direct API"
 readme = "README.md"
 license = {text = "MIT"}
@@ -91,7 +91,7 @@ markers = [
     "integration: marks tests as integration tests requiring a real API token (deselect with '-m \"not integration\"')",
     "integration_write: sandbox integration tests for write commands (replays VCR cassettes offline; --record-mode=rewrite needs YANDEX_DIRECT_TOKEN)",
     "integration_live_write: manual production API write tests limited to disposable draft resources (requires YANDEX_DIRECT_TOKEN and YANDEX_DIRECT_LIVE_WRITE=1)",
-    "v4_live_read: manual read-only v4 Live tests (requires YANDEX_DIRECT_TOKEN, YANDEX_DIRECT_LOGIN, and YANDEX_DIRECT_V4_LIVE_READ=1)",
+    "v4_live_read: manual read-only v4 Live tests (requires YANDEX_DIRECT_TOKEN and YANDEX_DIRECT_LOGIN)",
     "sandbox_limitation(reason, category): test skipped due to known Yandex Direct sandbox API limitation (not a CLI bug). category is optional: 'disabled' = supported in live but disabled/broken in sandbox (codes 8800/1000/5004); 'unsupported' = resource type architecturally missing from sandbox (code 3500)",
     "api_coverage: marks tests verifying CLI coverage against Yandex API WSDL (cached, no network required)",
 ]

--- a/scripts/test_safe_commands.sh
+++ b/scripts/test_safe_commands.sh
@@ -261,7 +261,9 @@ run_test "changes check-dictionaries (env auth)"   direct changes check-dictiona
 run_test "reports list-types (env auth)"           direct reports list-types
 run_test "reports get (env auth)"                  direct reports get --type campaign_performance_report --from 2026-01-01 --to 2026-01-01 --name "Smoke Safe Report" --fields Date,CampaignId
 run_test "balance (env auth)"                      direct balance
-run_test "v4events get-events-log (env auth)"      direct v4events get-events-log --from 2026-04-14T00:00:00 --to 2026-04-15T00:00:00 --limit 1
+EVENTS_FROM=$(date -u -d 'yesterday' '+%Y-%m-%dT00:00:00' 2>/dev/null || date -u -v-1d '+%Y-%m-%dT00:00:00')
+EVENTS_TO=$(date -u '+%Y-%m-%dT00:00:00')
+run_test "v4events get-events-log (env auth)"      direct v4events get-events-log --from "$EVENTS_FROM" --to "$EVENTS_TO" --limit 1
 run_v4finance_get_credit_limits
 
 if [ -n "$CAMPAIGN_ID" ]; then

--- a/scripts/test_safe_commands.sh
+++ b/scripts/test_safe_commands.sh
@@ -15,6 +15,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 ENV_FILE="$ROOT_DIR/.env"
 
+export PYTHONPATH="$ROOT_DIR${PYTHONPATH:+:$PYTHONPATH}"
+
+direct() {
+  python3 -m direct_cli.cli "$@"
+}
+
 PASS=0
 FAIL=0
 CAMPAIGN_ID=""
@@ -147,6 +153,21 @@ run_advideos_probe_get() {
   fi
 }
 
+run_v4finance_get_credit_limits() {
+  local name="v4finance get-credit-limits (env auth)"
+
+  if [ -z "${YANDEX_DIRECT_FINANCE_TOKEN:-}" ] || [ -z "${YANDEX_DIRECT_OPERATION_NUM:-}" ]; then
+    echo -e "  ${YELLOW}[SKIP]${RESET} $name - no finance credentials"
+    return
+  fi
+  if [ -z "${AUTH_LOGIN:-}" ]; then
+    echo -e "  ${YELLOW}[SKIP]${RESET} $name - no login"
+    return
+  fi
+
+  run_test "$name" direct v4finance get-credit-limits --logins "$AUTH_LOGIN"
+}
+
 # ─── Section A: Auth via env variables (no CLI flags) ────────────────────────
 echo -e "${BOLD}=== A. Аутентификация через env-переменные ===${RESET}"
 echo ""
@@ -240,6 +261,8 @@ run_test "changes check-dictionaries (env auth)"   direct changes check-dictiona
 run_test "reports list-types (env auth)"           direct reports list-types
 run_test "reports get (env auth)"                  direct reports get --type campaign_performance_report --from 2026-01-01 --to 2026-01-01 --name "Smoke Safe Report" --fields Date,CampaignId
 run_test "balance (env auth)"                      direct balance
+run_test "v4events get-events-log (env auth)"      direct v4events get-events-log --from 2026-04-14T00:00:00 --to 2026-04-15T00:00:00 --limit 1
+run_v4finance_get_credit_limits
 
 if [ -n "$CAMPAIGN_ID" ]; then
   run_test "changes check-campaigns (env auth)"    direct changes check-campaigns --timestamp 2026-04-23T00:00:00

--- a/tests/api_coverage_payloads.py
+++ b/tests/api_coverage_payloads.py
@@ -44,6 +44,8 @@ DRY_RUN_PAYLOAD_EXCLUSIONS = {
     "smartadtargets.suspend": "Same simple Ids payload family as covered delete/set-bids actions.",
     "vcards.add": "Requires large contact-card payload fixture not needed for generic schema smoke coverage.",
     "reports.get": "Reports API uses a custom TSV endpoint; payload contract is covered by test_reports_request_builder_contract.",
+    "v4events.get-events-log": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
+    "v4finance.get-credit-limits": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
     "v4goals.get-retargeting-goals": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
     "v4goals.get-stat-goals": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
 }

--- a/tests/test_smoke_matrix.py
+++ b/tests/test_smoke_matrix.py
@@ -127,7 +127,8 @@ def test_safe_smoke_script_runs_v4_safe_commands():
     contents = script.read_text()
 
     assert 'run_test "balance (env auth)"' in contents
-    assert 'v4events get-events-log --from 2026-04-14T00:00:00 --to 2026-04-15T00:00:00 --limit 1' in contents
+    assert "EVENTS_FROM=" in contents
+    assert 'v4events get-events-log --from "$EVENTS_FROM" --to "$EVENTS_TO"' in contents
     assert 'run_v4finance_get_credit_limits' in contents
     assert 'v4goals get-stat-goals --campaign-ids "$CAMPAIGN_ID"' in contents
     assert 'v4goals get-retargeting-goals (env auth)"' in contents

--- a/tests/test_smoke_matrix.py
+++ b/tests/test_smoke_matrix.py
@@ -61,8 +61,8 @@ def test_smoke_matrix_counts_match_current_cli_surface():
     summary = smoke_summary()
 
     assert summary["total_cli_groups"] == 39
-    assert summary["total_cli_subcommands"] == 123
-    assert summary["api_cli_subcommands"] == 119
+    assert summary["total_cli_subcommands"] == 125
+    assert summary["api_cli_subcommands"] == 121
     assert summary["wsdl_services"] == 29
     assert summary["non_wsdl_services"] == sorted(NON_WSDL_SERVICES)
     assert summary["api_services_total"] == 30
@@ -127,6 +127,8 @@ def test_safe_smoke_script_runs_v4_safe_commands():
     contents = script.read_text()
 
     assert 'run_test "balance (env auth)"' in contents
+    assert 'v4events get-events-log --from 2026-04-14T00:00:00 --to 2026-04-15T00:00:00 --limit 1' in contents
+    assert 'run_v4finance_get_credit_limits' in contents
     assert 'v4goals get-stat-goals --campaign-ids "$CAMPAIGN_ID"' in contents
     assert 'v4goals get-retargeting-goals (env auth)"' in contents
     assert 'v4goals get-retargeting-goals --campaign-ids "$CAMPAIGN_ID"' in contents

--- a/tests/test_v4_contracts.py
+++ b/tests/test_v4_contracts.py
@@ -4,6 +4,8 @@ from unittest.mock import Mock
 from direct_cli._vendor.tapi_yandex_direct.v4 import SUPPORTED_V4_METHODS
 from direct_cli.v4 import build_v4_body, call_v4
 from direct_cli.v4_contracts import (
+    PARAM_ARRAY,
+    PARAM_OBJECT,
     PARAM_UNDOCUMENTED,
     SOURCE_CONFIRMED_LIVE,
     V4_METHOD_CONTRACTS,
@@ -39,13 +41,24 @@ def test_confirmed_contracts_are_not_undocumented():
     assert {contract.method for contract in confirmed} == {
         "AccountManagement",
         "GetClientsUnits",
+        "GetCreditLimits",
+        "GetEventsLog",
         "GetStatGoals",
         "GetRetargetingGoals",
     }
     for contract in confirmed:
         assert contract.param_shape != PARAM_UNDOCUMENTED
-        assert contract.live_probe_allowed
         assert contract.example_param is not None
+
+    assert {
+        contract.method for contract in confirmed if contract.live_probe_allowed
+    } == {
+        "AccountManagement",
+        "GetClientsUnits",
+        "GetEventsLog",
+        "GetStatGoals",
+        "GetRetargetingGoals",
+    }
 
 
 def test_get_clients_units_contract_uses_array_param():
@@ -65,6 +78,33 @@ def test_account_management_get_contract_returns_money_balance():
     assert build_v4_body("AccountManagement", {"Action": "Get"}) == {
         "method": "AccountManagement",
         "param": {"Action": "Get"},
+    }
+
+
+def test_get_credit_limits_contract_uses_login_array_and_finance_top_level():
+    contract = get_v4_contract("GetCreditLimits")
+
+    assert contract.param_shape == PARAM_ARRAY
+    assert contract.example_param == ["client-login"]
+    assert "finance_token" in contract.login_placement
+    assert build_v4_body("GetCreditLimits", ["client-login"]) == {
+        "method": "GetCreditLimits",
+        "param": ["client-login"],
+    }
+
+
+def test_get_events_log_contract_uses_timestamp_object_with_currency():
+    contract = get_v4_contract("GetEventsLog")
+
+    assert contract.param_shape == PARAM_OBJECT
+    assert contract.example_param == {
+        "TimestampFrom": "2026-04-14T00:00:00",
+        "TimestampTo": "2026-04-14T01:00:00",
+        "Currency": "RUB",
+    }
+    assert build_v4_body("GetEventsLog", contract.example_param) == {
+        "method": "GetEventsLog",
+        "param": contract.example_param,
     }
 
 
@@ -105,6 +145,33 @@ def test_v4_adapter_sends_login_as_header_without_mutating_param():
     assert body["token"] == "token"
     assert body["locale"] == "en"
     assert request["headers"]["Client-Login"] == "client-login"
+
+
+def test_v4_adapter_sends_finance_credentials_as_top_level_body_fields():
+    from direct_cli._vendor.tapi_yandex_direct.v4.adapter import V4LiveClientAdapter
+
+    adapter = V4LiveClientAdapter()
+    api_params = {
+        "access_token": "token",
+        "login": "agency-login",
+        "language": "en",
+        "is_sandbox": False,
+        "finance_token": "finance-token",
+        "operation_num": 42,
+    }
+
+    request = adapter.get_request_kwargs(
+        api_params,
+        data={"method": "GetCreditLimits", "param": ["client-login"]},
+    )
+    body = json.loads(request["data"])
+
+    assert body["param"] == ["client-login"]
+    assert body["finance_token"] == "finance-token"
+    assert body["operation_num"] == 42
+    assert body["token"] == "token"
+    assert body["locale"] == "en"
+    assert request["headers"]["Client-Login"] == "agency-login"
 
 
 def test_v4_goal_contracts_keep_global_login_at_transport_level():

--- a/tests/test_v4_foundation.py
+++ b/tests/test_v4_foundation.py
@@ -22,6 +22,8 @@ def test_create_v4_client_passes_resolved_credentials():
                 language="ru",
                 retry_if_exceeded_limit=False,
                 retries_if_server_error=2,
+                finance_token="finance-token",
+                operation_num=42,
             )
 
     client_class.assert_called_once_with(
@@ -31,6 +33,8 @@ def test_create_v4_client_passes_resolved_credentials():
         language="ru",
         retry_if_exceeded_limit=False,
         retries_if_server_error=2,
+        finance_token="finance-token",
+        operation_num=42,
     )
 
 

--- a/tests/test_v4_live_contracts.py
+++ b/tests/test_v4_live_contracts.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from dotenv import load_dotenv
@@ -34,6 +35,30 @@ def _campaign_id(token: str, login: str) -> int:
     if not campaigns:
         pytest.skip("No campaign available for v4 goals live probes")
     return campaigns[0]["Id"]
+
+
+def _finance_credentials():
+    finance_token = os.getenv("YANDEX_DIRECT_FINANCE_TOKEN")
+    operation_num = os.getenv("YANDEX_DIRECT_OPERATION_NUM")
+    if not finance_token or not operation_num:
+        pytest.skip(
+            "YANDEX_DIRECT_FINANCE_TOKEN and YANDEX_DIRECT_OPERATION_NUM are required"
+        )
+    try:
+        return finance_token, int(operation_num)
+    except ValueError:
+        pytest.skip("YANDEX_DIRECT_OPERATION_NUM must be an integer")
+
+
+def _events_window() -> tuple[str, str]:
+    timestamp_to = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(
+        days=1
+    )
+    timestamp_from = timestamp_to - timedelta(hours=1)
+    return (
+        timestamp_from.strftime("%Y-%m-%dT%H:%M:%S"),
+        timestamp_to.strftime("%Y-%m-%dT%H:%M:%S"),
+    )
 
 
 def test_v4_live_get_clients_units_contract():
@@ -77,3 +102,37 @@ def test_v4_live_goals_contracts():
         assert {"CampaignID", "GoalID", "Name"} <= set(stat_goals[0])
     if retargeting_goals:
         assert {"GoalID", "Name"} <= set(retargeting_goals[0])
+
+
+def test_v4_live_get_events_log_contract():
+    token, login = _credentials()
+    timestamp_from, timestamp_to = _events_window()
+    client = create_v4_client(token=token, login=login)
+
+    data = call_v4(
+        client,
+        "GetEventsLog",
+        {
+            "TimestampFrom": timestamp_from,
+            "TimestampTo": timestamp_to,
+            "Currency": "RUB",
+            "Limit": 1,
+        },
+    )
+
+    assert data is not None
+
+
+def test_v4_live_get_credit_limits_contract():
+    token, login = _credentials()
+    finance_token, operation_num = _finance_credentials()
+    client = create_v4_client(
+        token=token,
+        login=login,
+        finance_token=finance_token,
+        operation_num=operation_num,
+    )
+
+    data = call_v4(client, "GetCreditLimits", [login])
+
+    assert data is not None

--- a/tests/test_v4events.py
+++ b/tests/test_v4events.py
@@ -1,0 +1,162 @@
+import json
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from direct_cli.cli import cli
+from direct_cli.v4_contracts import get_v4_contract
+
+
+def _invoke(*args: str):
+    env = {"YANDEX_DIRECT_TOKEN": "", "YANDEX_DIRECT_LOGIN": ""}
+    with patch("direct_cli.cli.get_active_profile", return_value=None):
+        return CliRunner(env=env).invoke(cli, list(args))
+
+
+def test_get_events_log_dry_run_uses_canonical_body_with_default_currency():
+    result = _invoke(
+        "v4events",
+        "get-events-log",
+        "--from",
+        "2026-04-14T00:00:00",
+        "--to",
+        "2026-04-14T01:00:00",
+        "--dry-run",
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "method": "GetEventsLog",
+        "param": {
+            "TimestampFrom": "2026-04-14T00:00:00",
+            "TimestampTo": "2026-04-14T01:00:00",
+            "Currency": "RUB",
+        },
+    }
+
+
+def test_get_events_log_dry_run_adds_optional_pagination_when_passed():
+    result = _invoke(
+        "v4events",
+        "get-events-log",
+        "--from",
+        "2026-04-14T00:00:00",
+        "--to",
+        "2026-04-14T01:00:00",
+        "--currency",
+        "USD",
+        "--limit",
+        "100",
+        "--offset",
+        "20",
+        "--dry-run",
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "method": "GetEventsLog",
+        "param": {
+            "TimestampFrom": "2026-04-14T00:00:00",
+            "TimestampTo": "2026-04-14T01:00:00",
+            "Currency": "USD",
+            "Limit": 100,
+            "Offset": 20,
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "timestamp",
+    [
+        "2026-04-14T00:00:00Z",
+        "2026-04-14 00:00:00",
+        "2026-04-14",
+    ],
+)
+def test_get_events_log_rejects_noncanonical_from_datetime(timestamp):
+    result = _invoke(
+        "v4events",
+        "get-events-log",
+        "--from",
+        timestamp,
+        "--to",
+        "2026-04-14T01:00:00",
+        "--dry-run",
+    )
+
+    assert result.exit_code != 0
+    assert "Expected YYYY-MM-DDTHH:MM:SS" in result.output
+
+
+def test_get_events_log_rejects_from_after_to_before_api_call():
+    with patch("direct_cli.commands.v4events.create_v4_client") as create_client:
+        result = _invoke(
+            "v4events",
+            "get-events-log",
+            "--from",
+            "2026-04-14T02:00:00",
+            "--to",
+            "2026-04-14T01:00:00",
+        )
+
+    assert result.exit_code != 0
+    assert "--from must be earlier than or equal to --to" in result.output
+    create_client.assert_not_called()
+
+
+def test_get_events_log_formats_mocked_response_as_json():
+    with patch("direct_cli.commands.v4events.create_v4_client") as create_client:
+        with patch(
+            "direct_cli.commands.v4events.call_v4",
+            return_value=[{"Timestamp": "2026-04-14T00:01:00", "EventType": "ADD"}],
+        ) as call:
+            result = _invoke(
+                "--token",
+                "token",
+                "--login",
+                "client-login",
+                "v4events",
+                "get-events-log",
+                "--from",
+                "2026-04-14T00:00:00",
+                "--to",
+                "2026-04-14T01:00:00",
+            )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == [
+        {"Timestamp": "2026-04-14T00:01:00", "EventType": "ADD"}
+    ]
+    create_client.assert_called_once_with(
+        token="token",
+        login="client-login",
+        profile=None,
+        sandbox=False,
+    )
+    call.assert_called_once_with(
+        create_client.return_value,
+        "GetEventsLog",
+        {
+            "TimestampFrom": "2026-04-14T00:00:00",
+            "TimestampTo": "2026-04-14T01:00:00",
+            "Currency": "RUB",
+        },
+    )
+
+
+def test_v4events_help_contains_no_json_input_flag():
+    for args in [
+        ("v4events", "--help"),
+        ("v4events", "get-events-log", "--help"),
+    ]:
+        result = _invoke(*args)
+        assert result.exit_code == 0
+        assert "--json" not in result.output
+
+
+def test_v4events_command_declares_v4_contract():
+    command = cli.commands["v4events"].commands["get-events-log"]
+
+    assert command.v4_method == "GetEventsLog"
+    assert command.v4_contract == get_v4_contract("GetEventsLog")

--- a/tests/test_v4finance_read.py
+++ b/tests/test_v4finance_read.py
@@ -83,6 +83,48 @@ def test_get_credit_limits_requires_finance_credentials_before_api_call():
     create_client.assert_not_called()
 
 
+def test_get_credit_limits_rejects_blank_finance_token_before_api_call():
+    with patch("direct_cli.commands.v4finance.create_v4_client") as create_client:
+        result = _invoke(
+            "--token",
+            "token",
+            "v4finance",
+            "get-credit-limits",
+            "--logins",
+            "client-login",
+            "--finance-token",
+            "   ",
+            "--operation-num",
+            "1",
+        )
+
+    assert result.exit_code != 0
+    assert "Provide --finance-token and --operation-num" in result.output
+    create_client.assert_not_called()
+
+
+def test_get_credit_limits_strips_finance_token_before_api_call():
+    with patch("direct_cli.commands.v4finance.create_v4_client") as create_client:
+        with patch("direct_cli.commands.v4finance.call_v4", return_value=[]) as call:
+            result = _invoke(
+                "--token",
+                "token",
+                "v4finance",
+                "get-credit-limits",
+                "--logins",
+                "client-login",
+                "--finance-token",
+                " finance-token ",
+                "--operation-num",
+                "1",
+            )
+
+    assert result.exit_code == 0
+    create_client.assert_called_once()
+    assert create_client.call_args.kwargs["finance_token"] == "finance-token"
+    call.assert_called_once()
+
+
 def test_get_credit_limits_empty_logins_fails_before_api_call():
     with patch("direct_cli.commands.v4finance.create_v4_client") as create_client:
         result = _invoke(

--- a/tests/test_v4finance_read.py
+++ b/tests/test_v4finance_read.py
@@ -1,0 +1,160 @@
+import json
+from typing import Optional
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from direct_cli.cli import cli
+from direct_cli.v4_contracts import get_v4_contract
+
+
+def _invoke(*args: str, env: Optional[dict] = None):
+    base_env = {
+        "YANDEX_DIRECT_TOKEN": "",
+        "YANDEX_DIRECT_LOGIN": "",
+        "YANDEX_DIRECT_FINANCE_TOKEN": "",
+        "YANDEX_DIRECT_OPERATION_NUM": "",
+    }
+    if env:
+        base_env.update(env)
+    with patch("direct_cli.cli.get_active_profile", return_value=None):
+        return CliRunner(env=base_env).invoke(cli, list(args))
+
+
+def test_get_credit_limits_dry_run_uses_login_list_and_masks_finance_token():
+    result = _invoke(
+        "v4finance",
+        "get-credit-limits",
+        "--logins",
+        "a,b,c",
+        "--finance-token",
+        "secret-finance-token",
+        "--operation-num",
+        "42",
+        "--dry-run",
+    )
+
+    assert result.exit_code == 0
+    assert "secret-finance-token" not in result.output
+    assert json.loads(result.output) == {
+        "method": "GetCreditLimits",
+        "param": ["a", "b", "c"],
+        "finance_token": "<redacted>",
+        "operation_num": 42,
+    }
+
+
+def test_get_credit_limits_uses_finance_env_fallback_for_dry_run():
+    result = _invoke(
+        "v4finance",
+        "get-credit-limits",
+        "--logins",
+        "client-login",
+        "--dry-run",
+        env={
+            "YANDEX_DIRECT_FINANCE_TOKEN": "env-finance-token",
+            "YANDEX_DIRECT_OPERATION_NUM": "77",
+        },
+    )
+
+    assert result.exit_code == 0
+    assert "env-finance-token" not in result.output
+    assert json.loads(result.output) == {
+        "method": "GetCreditLimits",
+        "param": ["client-login"],
+        "finance_token": "<redacted>",
+        "operation_num": 77,
+    }
+
+
+def test_get_credit_limits_requires_finance_credentials_before_api_call():
+    with patch("direct_cli.commands.v4finance.create_v4_client") as create_client:
+        result = _invoke(
+            "--token",
+            "token",
+            "v4finance",
+            "get-credit-limits",
+            "--logins",
+            "client-login",
+        )
+
+    assert result.exit_code != 0
+    assert "Provide --finance-token and --operation-num" in result.output
+    create_client.assert_not_called()
+
+
+def test_get_credit_limits_empty_logins_fails_before_api_call():
+    with patch("direct_cli.commands.v4finance.create_v4_client") as create_client:
+        result = _invoke(
+            "--token",
+            "token",
+            "v4finance",
+            "get-credit-limits",
+            "--logins",
+            ",",
+            "--finance-token",
+            "finance-token",
+            "--operation-num",
+            "1",
+        )
+
+    assert result.exit_code != 0
+    assert "--logins must not be empty" in result.output
+    create_client.assert_not_called()
+
+
+def test_get_credit_limits_formats_mocked_response_as_json():
+    with patch("direct_cli.commands.v4finance.create_v4_client") as create_client:
+        with patch(
+            "direct_cli.commands.v4finance.call_v4",
+            return_value=[{"Login": "client-login", "CreditLimit": 1000}],
+        ) as call:
+            result = _invoke(
+                "--token",
+                "token",
+                "--login",
+                "agency-login",
+                "v4finance",
+                "get-credit-limits",
+                "--logins",
+                "client-login",
+                "--finance-token",
+                "finance-token",
+                "--operation-num",
+                "42",
+            )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == [
+        {"Login": "client-login", "CreditLimit": 1000}
+    ]
+    create_client.assert_called_once_with(
+        token="token",
+        login="agency-login",
+        profile=None,
+        sandbox=False,
+        finance_token="finance-token",
+        operation_num=42,
+    )
+    call.assert_called_once_with(
+        create_client.return_value,
+        "GetCreditLimits",
+        ["client-login"],
+    )
+
+
+def test_v4finance_help_contains_no_json_input_flag():
+    for args in [
+        ("v4finance", "--help"),
+        ("v4finance", "get-credit-limits", "--help"),
+    ]:
+        result = _invoke(*args)
+        assert result.exit_code == 0
+        assert "--json" not in result.output
+
+
+def test_v4finance_command_declares_v4_contract():
+    command = cli.commands["v4finance"].commands["get-credit-limits"]
+
+    assert command.v4_method == "GetCreditLimits"
+    assert command.v4_contract == get_v4_contract("GetCreditLimits")


### PR DESCRIPTION
## Summary

Closes #131.

Adds typed V4 Live CLI coverage for events and finance:

- `direct v4events get-events-log` with strict canonical datetime validation, default `Currency=RUB`, optional `Limit` / `Offset`, output formats, and dry-run support.
- `direct v4finance get-credit-limits` with typed login input, finance credential env fallback, pre-call usage validation, and masked finance-token dry-run output.
- V4 adapter/client support for top-level `finance_token` and `operation_num` body fields.
- Contract registry, smoke matrix, safe smoke script, README examples, marker description, and package version update to `0.3.2`.

## Validation

- `pytest -q tests/test_v4events.py tests/test_v4finance_read.py tests/test_v4_contracts.py tests/test_v4_foundation.py tests/test_smoke_matrix.py`
- `python -m ruff check direct_cli tests scripts`
- Earlier full local run: `pytest -q` (`413 passed, 28 skipped`)
- Earlier read-only live run: `pytest -vv tests/test_integration.py tests/test_v4_live_contracts.py -rs` (`28 passed, 1 skipped`; finance live check skipped due missing finance credentials)

## Notes

`bash scripts/test_safe_commands.sh` was attempted. After switching it to execute the local checkout, the run was blocked by DNS/name-resolution failures across Yandex API hosts; `v4finance get-credit-limits` correctly skipped without finance credentials.