### PR TITLE
Implement v4finance check-payment

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Money mutation commands are dry-run-only in this release and always require
 ```bash
 direct v4finance get-credit-limits --logins client-login --finance-token FINANCE_TOKEN --operation-num 123
 direct v4finance get-credit-limits --logins client-login,other-client --format table
+direct v4finance check-payment --custom-transaction-id A123456789012345678901234567890B
 direct v4finance transfer-money --from-campaign-id 123 --to-campaign-id 456 --amount 100.50 --finance-token FINANCE_TOKEN --operation-num 123 --dry-run
 direct v4finance pay-campaigns --campaign-id 123 --amount 100.50 --contract-id CONTRACT_ID --pay-method CREDIT --finance-token FINANCE_TOKEN --operation-num 123 --dry-run
 ```
@@ -504,8 +505,8 @@ Current command surface:
 | Supported API services including Reports | 30 |
 | WSDL operations | 112 |
 | CLI groups including `auth` | 39 |
-| CLI subcommands including `auth` | 127 |
-| API CLI subcommands excluding `auth` | 123 |
+| CLI subcommands including `auth` | 130 |
+| API CLI subcommands excluding `auth` | 126 |
 
 ### API Coverage And Drift Monitoring
 
@@ -1128,8 +1129,8 @@ YANDEX_DIRECT_LIVE_WRITE=1 pytest -m integration_live_write -v --record-mode=rew
 | API services с учётом Reports | 30 |
 | WSDL operations | 112 |
 | CLI groups с `auth` | 39 |
-| CLI subcommands с `auth` | 127 |
-| API CLI subcommands без `auth` | 123 |
+| CLI subcommands с `auth` | 130 |
+| API CLI subcommands без `auth` | 126 |
 
 #### Live sandbox write smoke
 

--- a/direct_cli/commands/v4finance.py
+++ b/direct_cli/commands/v4finance.py
@@ -1,5 +1,6 @@
 """Yandex Direct v4 Live finance commands."""
 
+import re
 from typing import Any, Optional
 
 import click
@@ -13,6 +14,7 @@ from ..v4_contracts import v4_method_contract
 from .v4shells import V4_EPILOG
 
 FINANCE_TOKEN_MASK = "<redacted>"
+CUSTOM_TRANSACTION_ID_RE = re.compile(r"[A-Za-z0-9]{32}")
 
 
 def _logins_param(logins: str) -> list[str]:
@@ -60,6 +62,16 @@ def _non_empty_option(value: str, option_name: str) -> str:
     if not normalized:
         raise click.UsageError(f"{option_name} must not be empty")
     return normalized
+
+
+def _custom_transaction_id_param(custom_transaction_id: str) -> dict:
+    """Build the v4 Live CheckPayment parameter."""
+    normalized = (custom_transaction_id or "").strip()
+    if not CUSTOM_TRANSACTION_ID_RE.fullmatch(normalized):
+        raise click.UsageError(
+            "--custom-transaction-id must be exactly 32 latin letters or digits"
+        )
+    return {"CustomTransactionID": normalized}
 
 
 @click.group(epilog=V4_EPILOG)
@@ -122,6 +134,50 @@ def get_credit_limits(
             operation_num=operation_num,
         )
         data = call_v4(client, "GetCreditLimits", login_list)
+        format_output(data, output_format, output)
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@v4_method_contract("CheckPayment")
+@v4finance.command(name="check-payment")
+@click.option(
+    "--custom-transaction-id",
+    required=True,
+    help="32-character latin alphanumeric transaction ID",
+)
+@click.option(
+    "--format",
+    "output_format",
+    default="json",
+    type=click.Choice(["json", "table", "csv", "tsv"]),
+    help="Output format",
+)
+@click.option("--output", help="Output file")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def check_payment(
+    ctx,
+    custom_transaction_id,
+    output_format,
+    output,
+    dry_run,
+):
+    """Check a v4 Live payment transaction."""
+    param = _custom_transaction_id_param(custom_transaction_id)
+    if dry_run:
+        format_output(build_v4_body("CheckPayment", param), "json", None)
+        return
+
+    try:
+        client = create_v4_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            profile=ctx.obj.get("profile"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+        data = call_v4(client, "CheckPayment", param)
         format_output(data, output_format, output)
     except Exception as e:
         print_error(str(e))

--- a/direct_cli/smoke_matrix.py
+++ b/direct_cli/smoke_matrix.py
@@ -58,6 +58,7 @@ SMOKE_MATRIX = {
         "strategies.get",
         "turbopages.get",
         "v4events.get-events-log",
+        "v4finance.check-payment",
         "v4finance.get-credit-limits",
         "v4goals.get-retargeting-goals",
         "v4goals.get-stat-goals",

--- a/direct_cli/v4_contracts.py
+++ b/direct_cli/v4_contracts.py
@@ -121,11 +121,21 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
     "CheckPayment": V4MethodContract(
         method="CheckPayment",
         group="finance",
-        param_shape=PARAM_UNDOCUMENTED,
-        login_placement="unknown",
+        param_shape=PARAM_OBJECT,
+        login_placement=(
+            "param contains CustomTransactionID; global --login uses "
+            "Client-Login header"
+        ),
         safety=SAFETY_READ,
-        source_status=SOURCE_UNDOCUMENTED,
-        live_probe_allowed=False,
+        source_status=SOURCE_CONFIRMED_LIVE,
+        live_probe_allowed=True,
+        example_param={"CustomTransactionID": "A123456789012345678901234567890B"},
+        notes=(
+            "Official public docs were not found. Sandbox v4 Live rejects "
+            "PaymentID with error_code=71 and requires CustomTransactionID; "
+            "a valid 32-character unknown CustomTransactionID reaches method "
+            "validation and returns error_code=370."
+        ),
     ),
     "CreateInvoice": V4MethodContract(
         method="CreateInvoice",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "direct-cli"
-version = "0.3.4"
+version = "0.3.2"
 description = "Command-line interface for Yandex Direct API"
 readme = "README.md"
 license = {text = "MIT"}

--- a/scripts/test_safe_commands.sh
+++ b/scripts/test_safe_commands.sh
@@ -168,6 +168,10 @@ run_v4finance_get_credit_limits() {
   run_test "$name" direct v4finance get-credit-limits --logins "$AUTH_LOGIN"
 }
 
+run_v4finance_check_payment_contract() {
+  run_test "v4finance check-payment dry-run (env auth)" direct v4finance check-payment --custom-transaction-id A123456789012345678901234567890B --dry-run
+}
+
 # ─── Section A: Auth via env variables (no CLI flags) ────────────────────────
 echo -e "${BOLD}=== A. Аутентификация через env-переменные ===${RESET}"
 echo ""
@@ -264,6 +268,7 @@ run_test "balance (env auth)"                      direct balance
 EVENTS_FROM=$(date -u -d 'yesterday' '+%Y-%m-%dT00:00:00' 2>/dev/null || date -u -v-1d '+%Y-%m-%dT00:00:00')
 EVENTS_TO=$(date -u '+%Y-%m-%dT00:00:00')
 run_test "v4events get-events-log (env auth)"      direct v4events get-events-log --from "$EVENTS_FROM" --to "$EVENTS_TO" --limit 1
+run_v4finance_check_payment_contract
 run_v4finance_get_credit_limits
 
 if [ -n "$CAMPAIGN_ID" ]; then

--- a/tests/API_COVERAGE.md
+++ b/tests/API_COVERAGE.md
@@ -33,8 +33,8 @@ report values:
 | Non-WSDL API services | 1 |
 | Supported API services including Reports | 30 |
 | CLI top-level groups including auth | 31 |
-| CLI subcommands including auth | 122 |
-| API CLI subcommands excluding auth | 118 |
+| CLI subcommands including auth | 130 |
+| API CLI subcommands excluding auth | 126 |
 | Live-discovered missing services | 0 |
 | Live-discovered missing methods | 0 |
 
@@ -51,6 +51,26 @@ Every registered Click subcommand is classified exactly once in
 
 `tests/test_smoke_matrix.py` fails if a CLI command is missing from the matrix,
 appears in multiple categories, or if the current service/command counts drift.
+
+## V4 Live Finance Contract Notes
+
+The public v4/Live4 finance docs found during milestone 0.3.3 list
+`CreateInvoice`, `GetCreditLimits`, `PayCampaigns`, and `TransferMoney`.
+No official `CheckPayment` page or `PaymentID` contract was found.
+
+Sandbox v4 Live probes on 2026-04-30 confirmed the runtime request shape for
+`CheckPayment`:
+
+| Probe | Result |
+|---|---|
+| `{"PaymentID": 1}` | `error_code=71`, `Field CustomTransactionID must not be empty` |
+| `{"CustomTransactionID": "short"}` | `error_code=71`, requires 32 latin alphanumeric characters |
+| `{"CustomTransactionID": "A123456789012345678901234567890B"}` | `error_code=370`, `Transaction does not exist` |
+
+`error_code=370` is treated as positive contract evidence: the request passed
+method-level shape validation and failed only because the transaction is a
+dummy value. Do not expose a public `--payment-id` flag unless Yandex documents
+or live-confirms a separate `PaymentID` contract.
 
 ## Maintenance Rules
 

--- a/tests/MANUAL_COVERAGE.md
+++ b/tests/MANUAL_COVERAGE.md
@@ -28,6 +28,18 @@ account requirements, or external dependencies.
 - **bids set** / **keywordbids set** / **bidmodifiers set** on existing
   non-draft objects — spends real budget. Live-write tests only verify
   request assembly via `--dry-run`.
+- **v4finance create/pay/transfer operations** — `CreateInvoice`,
+  `PayCampaigns`, and `TransferMoney` are financial side-effect operations.
+  `TransferMoney` and `PayCampaigns` remain dry-run-only in the public CLI.
+  `CreateInvoice` is not exposed until a separate sandbox-write contract probe
+  can run with `YANDEX_DIRECT_FINANCE_TOKEN` and
+  `YANDEX_DIRECT_OPERATION_NUM`; without them sandbox returns
+  `error_code=350 Invalid financial transaction token`.
+- **v4finance check-payment** — read-only. Official public docs were not found;
+  sandbox v4 Live confirms `CustomTransactionID` (32 latin alphanumeric
+  characters), not `PaymentID`. A dummy valid transaction ID returns
+  `error_code=370 Transaction does not exist`, which is accepted as request
+  shape proof.
 
 ## Campaign-Type Restrictions (Category B)
 

--- a/tests/api_coverage_payloads.py
+++ b/tests/api_coverage_payloads.py
@@ -68,6 +68,7 @@ DRY_RUN_PAYLOAD_EXCLUSIONS = {
     "v4account.account-management": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
     "v4account.enable-shared-account": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
     "v4events.get-events-log": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
+    "v4finance.check-payment": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
     "v4finance.get-credit-limits": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
     "v4finance.pay-campaigns": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
     "v4finance.transfer-money": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",

--- a/tests/test_smoke_matrix.py
+++ b/tests/test_smoke_matrix.py
@@ -61,8 +61,8 @@ def test_smoke_matrix_counts_match_current_cli_surface():
     summary = smoke_summary()
 
     assert summary["total_cli_groups"] == 39
-    assert summary["total_cli_subcommands"] == 129
-    assert summary["api_cli_subcommands"] == 125
+    assert summary["total_cli_subcommands"] == 130
+    assert summary["api_cli_subcommands"] == 126
     assert summary["wsdl_services"] == 29
     assert summary["non_wsdl_services"] == sorted(NON_WSDL_SERVICES)
     assert summary["api_services_total"] == 30
@@ -129,6 +129,7 @@ def test_safe_smoke_script_runs_v4_safe_commands():
     assert 'run_test "balance (env auth)"' in contents
     assert "EVENTS_FROM=" in contents
     assert 'v4events get-events-log --from "$EVENTS_FROM" --to "$EVENTS_TO"' in contents
+    assert "run_v4finance_check_payment_contract" in contents
     assert "run_v4finance_get_credit_limits" in contents
     assert 'v4goals get-stat-goals --campaign-ids "$CAMPAIGN_ID"' in contents
     assert 'v4goals get-retargeting-goals (env auth)"' in contents

--- a/tests/test_v4_contracts.py
+++ b/tests/test_v4_contracts.py
@@ -43,6 +43,7 @@ def test_confirmed_contracts_are_not_undocumented():
         "AccountManagement",
         "GetClientsUnits",
         "GetCreditLimits",
+        "CheckPayment",
         "GetEventsLog",
         "GetStatGoals",
         "GetRetargetingGoals",
@@ -56,6 +57,7 @@ def test_confirmed_contracts_are_not_undocumented():
     } == {
         "AccountManagement",
         "GetClientsUnits",
+        "CheckPayment",
         "GetEventsLog",
         "GetStatGoals",
         "GetRetargetingGoals",
@@ -156,6 +158,22 @@ def test_v4finance_money_contracts_are_docs_backed_dangerous_objects():
             "ContractID": "contract-id",
             "PayMethod": "CREDIT",
         },
+    }
+
+
+def test_check_payment_contract_uses_custom_transaction_id_object():
+    contract = get_v4_contract("CheckPayment")
+
+    assert contract.param_shape == PARAM_OBJECT
+    assert contract.source_status == SOURCE_CONFIRMED_LIVE
+    assert "PaymentID" in contract.notes
+    assert "CustomTransactionID" in contract.login_placement
+    assert contract.example_param == {
+        "CustomTransactionID": "A123456789012345678901234567890B"
+    }
+    assert build_v4_body("CheckPayment", contract.example_param) == {
+        "method": "CheckPayment",
+        "param": {"CustomTransactionID": "A123456789012345678901234567890B"},
     }
 
 

--- a/tests/test_v4_live_contracts.py
+++ b/tests/test_v4_live_contracts.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from dotenv import load_dotenv
 
+from direct_cli._vendor.tapi_yandex_direct.exceptions import V4LiveError
 from direct_cli.api import create_client, create_v4_client
 from direct_cli.v4 import call_v4
 
@@ -51,9 +52,7 @@ def _finance_credentials():
 
 
 def _events_window() -> tuple[str, str]:
-    timestamp_to = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(
-        days=1
-    )
+    timestamp_to = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(days=1)
     timestamp_from = timestamp_to - timedelta(hours=1)
     return (
         timestamp_from.strftime("%Y-%m-%dT%H:%M:%S"),
@@ -136,3 +135,20 @@ def test_v4_live_get_credit_limits_contract():
     data = call_v4(client, "GetCreditLimits", [login])
 
     assert data is not None
+
+
+def test_v4_sandbox_check_payment_custom_transaction_id_contract():
+    if os.getenv("YANDEX_DIRECT_V4_SANDBOX_CONTRACT") != "1":
+        pytest.skip("YANDEX_DIRECT_V4_SANDBOX_CONTRACT=1 is required")
+    token, login = _credentials()
+    client = create_v4_client(token=token, login=login, sandbox=True)
+
+    with pytest.raises(V4LiveError) as exc_info:
+        call_v4(
+            client,
+            "CheckPayment",
+            {"CustomTransactionID": "A123456789012345678901234567890B"},
+        )
+
+    assert exc_info.value.error_code == 370
+    assert exc_info.value.error_str == "Transaction does not exist"

--- a/tests/test_v4_safety.py
+++ b/tests/test_v4_safety.py
@@ -1,9 +1,13 @@
-from direct_cli.smoke_matrix import DANGEROUS, command_category
+from direct_cli.smoke_matrix import DANGEROUS, SAFE, command_category
 
 
 def test_v4finance_money_commands_are_dangerous():
     assert command_category("v4finance.transfer-money") == DANGEROUS
     assert command_category("v4finance.pay-campaigns") == DANGEROUS
+
+
+def test_v4finance_check_payment_is_safe():
+    assert command_category("v4finance.check-payment") == SAFE
 
 
 def test_v4account_mutation_commands_are_dangerous():

--- a/tests/test_v4finance_money.py
+++ b/tests/test_v4finance_money.py
@@ -222,14 +222,87 @@ def test_v4finance_money_commands_reject_blank_string_options():
     assert "--pay-method must not be empty" in result.output
 
 
-def test_check_payment_is_not_registered_without_official_docs():
-    assert "check-payment" not in cli.commands["v4finance"].commands
+def test_check_payment_dry_run_uses_custom_transaction_id_object():
+    result = _invoke(
+        "v4finance",
+        "check-payment",
+        "--custom-transaction-id",
+        "A123456789012345678901234567890B",
+        "--dry-run",
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "method": "CheckPayment",
+        "param": {"CustomTransactionID": "A123456789012345678901234567890B"},
+    }
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        " ",
+        "short",
+        "A123456789012345678901234567890",
+        "A123456789012345678901234567890BC",
+        "A12345678901234567890123456789-B",
+        "A12345678901234567890123456789 Б",
+    ],
+)
+def test_check_payment_rejects_invalid_custom_transaction_id_before_api_call(value):
+    with patch("direct_cli.commands.v4finance.create_v4_client") as create_client:
+        result = _invoke(
+            "v4finance",
+            "check-payment",
+            "--custom-transaction-id",
+            value,
+        )
+
+    assert result.exit_code != 0
+    assert "--custom-transaction-id must be exactly 32 latin letters or digits" in (
+        result.output
+    )
+    create_client.assert_not_called()
+
+
+def test_check_payment_formats_mocked_response_as_json():
+    with patch("direct_cli.commands.v4finance.create_v4_client") as create_client:
+        with patch(
+            "direct_cli.commands.v4finance.call_v4",
+            return_value={"Status": "Done"},
+        ) as call:
+            result = _invoke(
+                "--token",
+                "token",
+                "--login",
+                "client-login",
+                "v4finance",
+                "check-payment",
+                "--custom-transaction-id",
+                "A123456789012345678901234567890B",
+            )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {"Status": "Done"}
+    create_client.assert_called_once_with(
+        token="token",
+        login="client-login",
+        profile=None,
+        sandbox=False,
+    )
+    call.assert_called_once_with(
+        create_client.return_value,
+        "CheckPayment",
+        {"CustomTransactionID": "A123456789012345678901234567890B"},
+    )
 
 
 def test_v4finance_money_help_contains_no_json_input_flag():
     for args in [
         ("v4finance", "transfer-money", "--help"),
         ("v4finance", "pay-campaigns", "--help"),
+        ("v4finance", "check-payment", "--help"),
     ]:
         result = _invoke(*args)
         assert result.exit_code == 0
@@ -243,3 +316,5 @@ def test_v4finance_money_commands_declare_v4_contracts():
     assert commands["transfer-money"].v4_contract == get_v4_contract("TransferMoney")
     assert commands["pay-campaigns"].v4_method == "PayCampaigns"
     assert commands["pay-campaigns"].v4_contract == get_v4_contract("PayCampaigns")
+    assert commands["check-payment"].v4_method == "CheckPayment"
+    assert commands["check-payment"].v4_contract == get_v4_contract("CheckPayment")


### PR DESCRIPTION
## Summary
- add direct v4finance check-payment with typed --custom-transaction-id input
- mark CheckPayment as confirmed-live based on sandbox contract probes
- document PaymentID rejection, CustomTransactionID validation, and finance token follow-up in issue #148
- set package version to 0.3.2 per request

## Sandbox contract notes
- CheckPayment rejects PaymentID-only payloads with error 71: CustomTransactionID must not be empty
- CheckPayment validates CustomTransactionID as 32 latin alphanumeric characters
- a valid dummy CustomTransactionID reaches method validation and returns error 370: transaction does not exist
- CreateInvoice without finance credentials returns error 350: financial transaction token not transferred

## Tests
- python3 -m pytest -q tests/test_v4finance_money.py tests/test_v4finance_read.py tests/test_v4_contracts.py tests/test_v4_safety.py tests/test_smoke_matrix.py
- python3 -m pytest tests/test_api_coverage.py tests/test_dry_run.py tests/test_cli.py tests/test_comprehensive.py tests/test_reports_drift.py
- python3 -m pytest -q tests/test_v4finance_money.py tests/test_v4_contracts.py tests/test_smoke_matrix.py
- optional sandbox contract test passed with YANDEX_DIRECT_V4_SANDBOX_CONTRACT=1 and DNS override
- black --check on touched Python files
- bash -n scripts/test_safe_commands.sh