### PR TITLE
feat(auth): persist refresh_token + auto-refresh + expires_in (#152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.3.3
 
+**BREAKING CHANGE:** OAuth profiles created before 0.3.3 (without `refresh_token` and `expires_at`) are no longer accepted. Any such profile will fail immediately with an "incomplete profile" error. Run `direct auth login --profile <name>` to re-authenticate and create a valid 0.3.3 profile.
+
 - Added refresh token persistence for OAuth profiles.
 - Added automatic OAuth access token refresh before expiry.
 - Added `expires_in` details to `direct auth status`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.3.3
+
+- Added refresh token persistence for OAuth profiles.
+- Added automatic OAuth access token refresh before expiry.
+- Added `expires_in` details to `direct auth status`.
+- Added JSON output for `direct auth status`.
+- Kept `direct auth login --oauth-token` as a manual access-token import without auto-refresh.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ OAuth and profile commands:
 direct auth login
 direct auth login --profile agency1
 direct auth login --code abc123 --profile agency1
-direct auth login --oauth-token y0_example --profile agency1
 direct auth list
 direct auth use --profile agency1
 direct auth status --profile agency1
@@ -56,6 +55,8 @@ Notes:
 - Select credentials with `--profile`.
 - `--login` remains Direct client login.
 - Authorization is performed via `direct auth login`.
+- OAuth profiles store refresh tokens and refresh access tokens automatically.
+- `direct auth login --oauth-token TOKEN` is a manual access-token import and does not auto-refresh.
 - Alias `auth_login` is not supported.
 
 Credential resolution priority:
@@ -686,12 +687,15 @@ OAuth и profile-команды:
 direct auth login
 direct auth login --profile agency1
 direct auth login --code abc123 --profile agency1
-direct auth login --oauth-token y0_example --profile agency1
 direct auth list
 direct auth use --profile agency1
 direct auth status --profile agency1
 direct --profile agency1 campaigns get
 ```
+
+Примечания:
+- OAuth profiles сохраняют refresh token и автоматически обновляют access token.
+- `direct auth login --oauth-token TOKEN` импортирует access token вручную и не включает auto-refresh.
 
 Порядок выбора credentials:
 

--- a/direct_cli/_vendor/tapi_yandex_direct/tapi_yandex_direct.py
+++ b/direct_cli/_vendor/tapi_yandex_direct/tapi_yandex_direct.py
@@ -74,9 +74,9 @@ class YandexDirectClientAdapter(JSONAdapterMixin, TapiAdapter):
         if resource_name == "debugtoken":
             return "https://"
         elif api_params.get("is_sandbox"):
-            return "https://api-sandbox.direct.yandex.com/"
+            return "https://api-sandbox.direct.yandex.ru/"
         else:
-            return "https://api.direct.yandex.com/"
+            return "https://api.direct.yandex.ru/"
 
     def get_request_kwargs(self, api_params: dict, *args, **kwargs) -> dict:
         """Обогащение запроса, параметрами"""

--- a/direct_cli/auth.py
+++ b/direct_cli/auth.py
@@ -437,15 +437,18 @@ def refresh_access_token(profile: str, path: Optional[Path] = None) -> Dict[str,
             result = json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as error:
         if error.code in (400, 401):
-            # Another process may have already refreshed the token (parallel invocation).
-            # Re-read the store: if expires_at is now valid, return the fresh profile.
+            # Concurrent-refresh race: another process may have just rotated
+            # the token. Re-read the store and, if a fresher access token is
+            # already on disk, return it instead of falsely declaring expiry.
             fresh_store = load_auth_store(path=path)
             fresh_item = fresh_store["profiles"].get(profile)
             if isinstance(fresh_item, dict):
-                fresh_expires_at = fresh_item.get("expires_at")
-                if isinstance(fresh_expires_at, (int, float)):
-                    if float(fresh_expires_at) > time.time() + OAUTH_REFRESH_SKEW_SECONDS:
-                        return fresh_item
+                fresh_expires = fresh_item.get("expires_at")
+                if (
+                    isinstance(fresh_expires, (int, float))
+                    and float(fresh_expires) > time.time() + OAUTH_REFRESH_SKEW_SECONDS
+                ):
+                    return fresh_item
             raise RuntimeError(
                 f"OAuth refresh token expired. "
                 f"Run direct auth login --profile {profile} again."

--- a/direct_cli/auth.py
+++ b/direct_cli/auth.py
@@ -367,9 +367,9 @@ def exchange_oauth_code(
             f"OAuth token request failed with HTTP {error.code}"
         ) from error
     except urllib.error.URLError as error:
+        if isinstance(error.reason, TimeoutError):
+            raise RuntimeError("OAuth token request timed out") from error
         raise RuntimeError(f"OAuth token request failed: {error.reason}") from error
-    except TimeoutError as error:
-        raise RuntimeError("OAuth token request timed out") from error
 
     access_token = result.get("access_token")
     if not isinstance(access_token, str) or not access_token:
@@ -437,6 +437,15 @@ def refresh_access_token(profile: str, path: Optional[Path] = None) -> Dict[str,
             result = json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as error:
         if error.code in (400, 401):
+            # Another process may have already refreshed the token (parallel invocation).
+            # Re-read the store: if expires_at is now valid, return the fresh profile.
+            fresh_store = load_auth_store(path=path)
+            fresh_item = fresh_store["profiles"].get(profile)
+            if isinstance(fresh_item, dict):
+                fresh_expires_at = fresh_item.get("expires_at")
+                if isinstance(fresh_expires_at, (int, float)):
+                    if float(fresh_expires_at) > time.time() + OAUTH_REFRESH_SKEW_SECONDS:
+                        return fresh_item
             raise RuntimeError(
                 f"OAuth refresh token expired. "
                 f"Run direct auth login --profile {profile} again."
@@ -445,9 +454,9 @@ def refresh_access_token(profile: str, path: Optional[Path] = None) -> Dict[str,
             f"OAuth refresh request failed with HTTP {error.code}"
         ) from error
     except urllib.error.URLError as error:
+        if isinstance(error.reason, TimeoutError):
+            raise RuntimeError("OAuth refresh request timed out") from error
         raise RuntimeError(f"OAuth refresh request failed: {error.reason}") from error
-    except TimeoutError as error:
-        raise RuntimeError("OAuth refresh request timed out") from error
 
     access_token = result.get("access_token")
     if not isinstance(access_token, str) or not access_token:

--- a/direct_cli/auth.py
+++ b/direct_cli/auth.py
@@ -5,12 +5,13 @@ Authentication module for Direct CLI
 import base64
 import hashlib
 import json
+import logging
 import os
 import secrets
 import shutil
 import subprocess
 import tempfile
-import logging
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -29,6 +30,7 @@ YANDEX_OAUTH_AUTHORIZE_URL = "https://oauth.yandex.ru/authorize"
 YANDEX_OAUTH_TOKEN_URL = "https://oauth.yandex.ru/token"
 DEFAULT_OAUTH_CLIENT_ID = "dcf15d9625f6471d94d6d054d52017ba"
 AUTH_STORE_PATH = Path.home() / ".direct-cli" / "auth.json"
+OAUTH_REFRESH_SKEW_SECONDS = 60
 
 
 def op_read(ref: str) -> str:
@@ -175,17 +177,33 @@ def save_oauth_profile(
     profile: str,
     token: str,
     login: Optional[str] = None,
+    refresh_token: Optional[str] = None,
+    expires_at: Optional[float] = None,
+    client_id: str = DEFAULT_OAUTH_CLIENT_ID,
+    client_secret: Optional[str] = None,
+    source: str = "oauth",
     make_active: bool = True,
     path: Optional[Path] = None,
 ) -> None:
     """Save/update one OAuth profile without exposing secret values."""
     store = load_auth_store(path=path)
     profiles = store["profiles"]
-    profiles[profile] = {
+    item: Dict[str, Any] = {
         "token": token,
         "login": login,
-        "source": "oauth",
+        "source": source,
     }
+    if source == "oauth":
+        if not refresh_token:
+            raise ValueError("OAuth profile requires refresh_token")
+        if expires_at is None:
+            raise ValueError("OAuth profile requires expires_at")
+        item["refresh_token"] = refresh_token
+        item["expires_at"] = float(expires_at)
+        item["client_id"] = client_id
+        if client_secret:
+            item["client_secret"] = client_secret
+    profiles[profile] = item
     if make_active:
         store["active_profile"] = profile
     save_auth_store(store, path=path)
@@ -205,7 +223,7 @@ def get_active_profile(path: Optional[Path] = None) -> Optional[str]:
 
 def get_oauth_profile(
     profile: str, path: Optional[Path] = None
-) -> Optional[Dict[str, Optional[str]]]:
+) -> Optional[Dict[str, Any]]:
     """Get OAuth profile by name."""
     store = load_auth_store(path=path)
     item = store["profiles"].get(profile)
@@ -217,7 +235,13 @@ def get_oauth_profile(
         return None
     if login is not None and not isinstance(login, str):
         login = None
-    return {"token": token, "login": login}
+    result = dict(item)
+    result["token"] = token
+    result["login"] = login
+    source = result.get("source")
+    if not isinstance(source, str):
+        result["source"] = "oauth"
+    return result
 
 
 def get_env_profile(profile: str) -> Tuple[Optional[str], Optional[str]]:
@@ -245,9 +269,12 @@ def list_profiles(path: Optional[Path] = None) -> List[Dict[str, Any]]:
         login = data.get("login")
         if not isinstance(token, str) or not token:
             continue
+        source = data.get("source")
+        if not isinstance(source, str):
+            source = "oauth"
         profiles[profile_name] = {
             "profile": profile_name,
-            "source": "oauth",
+            "source": source,
             "has_token": True,
             "has_login": bool(login),
             "login": login,
@@ -266,7 +293,7 @@ def list_profiles(path: Optional[Path] = None) -> List[Dict[str, Any]]:
         login = env.get(f"YANDEX_DIRECT_LOGIN_{suffix}")
         existing = profiles.get(profile_name)
         if existing:
-            existing["source"] = "oauth+env"
+            existing["source"] = f"{existing['source']}+env"
             existing["has_login"] = bool(existing["has_login"] or login)
             existing["login"] = existing["login"] or login
             continue
@@ -313,7 +340,7 @@ def exchange_oauth_code(
     client_id: str = DEFAULT_OAUTH_CLIENT_ID,
     client_secret: Optional[str] = None,
     code_verifier: Optional[str] = None,
-) -> str:
+) -> Dict[str, Any]:
     """Exchange OAuth authorization code for access token."""
     payload: Dict[str, str] = {
         "grant_type": "authorization_code",
@@ -336,9 +363,6 @@ def exchange_oauth_code(
         with urllib.request.urlopen(request, timeout=20) as response:
             result = json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as error:
-        details = error.read().decode("utf-8", errors="ignore")
-        if details:
-            raise RuntimeError(f"OAuth token request failed: {details}") from error
         raise RuntimeError(
             f"OAuth token request failed with HTTP {error.code}"
         ) from error
@@ -350,8 +374,98 @@ def exchange_oauth_code(
     access_token = result.get("access_token")
     if not isinstance(access_token, str) or not access_token:
         raise RuntimeError("OAuth token response does not contain access_token")
-    # TODO: Persist refresh_token/expires_in and refresh automatically.
-    return access_token
+    refresh_token = result.get("refresh_token")
+    if not isinstance(refresh_token, str) or not refresh_token:
+        raise RuntimeError("OAuth token response does not contain refresh_token")
+    expires_in = result.get("expires_in")
+    if not isinstance(expires_in, int) or expires_in <= 0:
+        raise RuntimeError("OAuth token response does not contain expires_in")
+    return {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "expires_in": expires_in,
+    }
+
+
+def _oauth_profile_incomplete_error(profile: str) -> ValueError:
+    return ValueError(
+        f"OAuth profile '{profile}' is incomplete. "
+        f"Run direct auth login --profile {profile} again."
+    )
+
+
+def _validate_oauth_profile(profile: str, data: Dict[str, Any]) -> None:
+    refresh_token = data.get("refresh_token")
+    expires_at = data.get("expires_at")
+    if not isinstance(refresh_token, str) or not refresh_token:
+        raise _oauth_profile_incomplete_error(profile)
+    if not isinstance(expires_at, (int, float)):
+        raise _oauth_profile_incomplete_error(profile)
+
+
+def refresh_access_token(profile: str, path: Optional[Path] = None) -> Dict[str, Any]:
+    """Refresh and persist an OAuth profile access token."""
+    store = load_auth_store(path=path)
+    profiles = store["profiles"]
+    item = profiles.get(profile)
+    if not isinstance(item, dict):
+        raise ValueError(f"Profile '{profile}' is not configured.")
+    _validate_oauth_profile(profile, item)
+
+    refresh_token = item["refresh_token"]
+    client_id = item.get("client_id")
+    if not isinstance(client_id, str) or not client_id:
+        client_id = DEFAULT_OAUTH_CLIENT_ID
+    client_secret = item.get("client_secret")
+
+    payload: Dict[str, str] = {
+        "grant_type": "refresh_token",
+        "client_id": client_id,
+        "refresh_token": refresh_token,
+    }
+    if isinstance(client_secret, str) and client_secret:
+        payload["client_secret"] = client_secret
+    body = urllib.parse.urlencode(payload).encode("utf-8")
+    request = urllib.request.Request(
+        YANDEX_OAUTH_TOKEN_URL,
+        data=body,
+        method="POST",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            result = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        if error.code in (400, 401):
+            raise RuntimeError(
+                f"OAuth refresh token expired. "
+                f"Run direct auth login --profile {profile} again."
+            ) from error
+        raise RuntimeError(
+            f"OAuth refresh request failed with HTTP {error.code}"
+        ) from error
+    except urllib.error.URLError as error:
+        raise RuntimeError(f"OAuth refresh request failed: {error.reason}") from error
+    except TimeoutError as error:
+        raise RuntimeError("OAuth refresh request timed out") from error
+
+    access_token = result.get("access_token")
+    if not isinstance(access_token, str) or not access_token:
+        raise RuntimeError("OAuth refresh response does not contain access_token")
+    expires_in = result.get("expires_in")
+    if not isinstance(expires_in, int) or expires_in <= 0:
+        raise RuntimeError("OAuth refresh response does not contain expires_in")
+
+    item["token"] = access_token
+    new_refresh_token = result.get("refresh_token")
+    if isinstance(new_refresh_token, str) and new_refresh_token:
+        item["refresh_token"] = new_refresh_token
+    item["expires_at"] = time.time() + expires_in
+    item["client_id"] = client_id
+    item["source"] = "oauth"
+    profiles[profile] = item
+    save_auth_store(store, path=path)
+    return item
 
 
 def resolve_login(token: str) -> Optional[str]:
@@ -364,7 +478,12 @@ def resolve_login(token: str) -> Optional[str]:
         with urllib.request.urlopen(request, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
             return data.get("login")
-    except (urllib.error.URLError, urllib.error.HTTPError, OSError, json.JSONDecodeError) as exc:
+    except (
+        urllib.error.URLError,
+        urllib.error.HTTPError,
+        OSError,
+        json.JSONDecodeError,
+    ) as exc:
         logging.debug("resolve_login failed: %s", exc)
         return None
 
@@ -415,6 +534,11 @@ def get_credentials(
     if selected_profile and not final_token:
         oauth_profile = get_oauth_profile(selected_profile)
         if oauth_profile:
+            if oauth_profile.get("source") == "oauth":
+                _validate_oauth_profile(selected_profile, oauth_profile)
+                expires_at = float(oauth_profile["expires_at"])
+                if expires_at <= time.time() + OAUTH_REFRESH_SKEW_SECONDS:
+                    oauth_profile = refresh_access_token(selected_profile)
             final_token = oauth_profile["token"]
             if not final_login:
                 final_login = oauth_profile["login"]

--- a/direct_cli/auth.py
+++ b/direct_cli/auth.py
@@ -394,7 +394,7 @@ def _oauth_profile_incomplete_error(profile: str) -> ValueError:
     )
 
 
-def _validate_oauth_profile(profile: str, data: Dict[str, Any]) -> None:
+def validate_oauth_profile(profile: str, data: Dict[str, Any]) -> None:
     refresh_token = data.get("refresh_token")
     expires_at = data.get("expires_at")
     if not isinstance(refresh_token, str) or not refresh_token:
@@ -410,7 +410,7 @@ def refresh_access_token(profile: str, path: Optional[Path] = None) -> Dict[str,
     item = profiles.get(profile)
     if not isinstance(item, dict):
         raise ValueError(f"Profile '{profile}' is not configured.")
-    _validate_oauth_profile(profile, item)
+    validate_oauth_profile(profile, item)
 
     refresh_token = item["refresh_token"]
     client_id = item.get("client_id")
@@ -547,7 +547,7 @@ def get_credentials(
         oauth_profile = get_oauth_profile(selected_profile)
         if oauth_profile:
             if oauth_profile.get("source") == "oauth":
-                _validate_oauth_profile(selected_profile, oauth_profile)
+                validate_oauth_profile(selected_profile, oauth_profile)
                 expires_at = float(oauth_profile["expires_at"])
                 if expires_at <= time.time() + OAUTH_REFRESH_SKEW_SECONDS:
                     oauth_profile = refresh_access_token(selected_profile)

--- a/direct_cli/commands/auth.py
+++ b/direct_cli/commands/auth.py
@@ -1,5 +1,8 @@
 """Authentication commands for OAuth profile management."""
 
+import json
+import time
+
 import click
 
 from ..auth import (
@@ -38,7 +41,12 @@ def login(profile, code, oauth_token, client_id, client_secret, login):
     if token:
         if not login:
             login = resolve_login(token)
-        save_oauth_profile(profile=profile, token=token, login=login)
+        save_oauth_profile(
+            profile=profile,
+            token=token,
+            login=login,
+            source="manual",
+        )
         print_success(f"Profile '{profile}' is saved and active.")
         return
 
@@ -58,7 +66,7 @@ def login(profile, code, oauth_token, client_id, client_secret, login):
         auth_code = click.prompt("Enter OAuth code", type=str).strip()
 
     try:
-        token = exchange_oauth_code(
+        token_response = exchange_oauth_code(
             code=auth_code,
             client_id=chosen_client_id,
             client_secret=client_secret,
@@ -67,9 +75,18 @@ def login(profile, code, oauth_token, client_id, client_secret, login):
     except RuntimeError as error:
         raise click.ClickException(str(error))
 
+    access_token = token_response["access_token"]
     if not login:
-        login = resolve_login(token)
-    save_oauth_profile(profile=profile, token=token, login=login)
+        login = resolve_login(access_token)
+    save_oauth_profile(
+        profile=profile,
+        token=access_token,
+        login=login,
+        refresh_token=token_response["refresh_token"],
+        expires_at=time.time() + token_response["expires_in"],
+        client_id=chosen_client_id,
+        client_secret=client_secret,
+    )
     print_success(f"Profile '{profile}' is saved and active.")
 
 
@@ -84,9 +101,9 @@ def list_command():
     for item in profiles:
         marker = "*" if item["active"] else " "
         login_display = item.get("login") or "(not set)"
-        click.echo(
-            f"{marker} {item['profile']}  source={item['source']}  login={login_display}"
-        )
+        profile = item["profile"]
+        source = item["source"]
+        click.echo(f"{marker} {profile}  source={source}  login={login_display}")
 
 
 @auth.command()
@@ -105,7 +122,15 @@ def use(profile):
 
 @auth.command()
 @click.option("--profile", help="Profile name (defaults to active profile)")
-def status(profile):
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    show_default=True,
+    help="Output format",
+)
+def status(profile, output_format):
     """Show auth status for one profile."""
     selected = profile or get_active_profile()
     if not selected:
@@ -116,7 +141,15 @@ def status(profile):
     env_token, env_login = get_env_profile(selected)
 
     if oauth_profile:
-        source = "oauth"
+        source = oauth_profile.get("source") or "oauth"
+        if source == "oauth" and (
+            not oauth_profile.get("refresh_token")
+            or not isinstance(oauth_profile.get("expires_at"), (int, float))
+        ):
+            raise click.ClickException(
+                f"OAuth profile '{selected}' is incomplete. "
+                f"Run direct auth login --profile {selected} again."
+            )
         login_value = oauth_profile.get("login")
         if not login_value and env_login:
             login_value = env_login
@@ -127,6 +160,25 @@ def status(profile):
     else:
         raise click.ClickException(f"Profile '{selected}' is not configured.")
 
+    expires_at = None
+    expires_in_seconds = None
+    if oauth_profile and isinstance(oauth_profile.get("expires_at"), (int, float)):
+        expires_at = float(oauth_profile["expires_at"])
+        expires_in_seconds = max(0, int(expires_at - time.time()))
+
+    if output_format == "json":
+        payload = {
+            "profile": selected,
+            "source": source,
+            "has_token": True,
+            "login": login_value,
+        }
+        if expires_at is not None:
+            payload["expires_at"] = expires_at
+            payload["expires_in_seconds"] = expires_in_seconds
+        click.echo(json.dumps(payload, ensure_ascii=False))
+        return
+
     click.echo(f"profile={selected}")
     click.echo(f"source={source}")
     click.echo("has_token=yes")
@@ -134,3 +186,19 @@ def status(profile):
         click.echo(f"login={login_value}")
     else:
         click.echo("login=(not set)")
+    if expires_in_seconds is not None:
+        click.echo(f"expires_in={_format_duration(expires_in_seconds)}")
+
+
+def _format_duration(seconds: int) -> str:
+    """Format a duration for auth status text output."""
+    hours, remainder = divmod(max(0, seconds), 3600)
+    minutes, seconds = divmod(remainder, 60)
+    parts = []
+    if hours:
+        parts.append(f"{hours}h")
+    if minutes:
+        parts.append(f"{minutes}m")
+    if not parts:
+        parts.append(f"{seconds}s")
+    return " ".join(parts)

--- a/direct_cli/commands/auth.py
+++ b/direct_cli/commands/auth.py
@@ -17,6 +17,7 @@ from ..auth import (
     resolve_login,
     save_oauth_profile,
     set_active_profile,
+    validate_oauth_profile,
 )
 from ..output import print_info, print_success
 
@@ -142,14 +143,11 @@ def status(profile, output_format):
 
     if oauth_profile:
         source = oauth_profile.get("source") or "oauth"
-        if source == "oauth" and (
-            not oauth_profile.get("refresh_token")
-            or not isinstance(oauth_profile.get("expires_at"), (int, float))
-        ):
-            raise click.ClickException(
-                f"OAuth profile '{selected}' is incomplete. "
-                f"Run direct auth login --profile {selected} again."
-            )
+        if source == "oauth":
+            try:
+                validate_oauth_profile(selected, oauth_profile)
+            except ValueError as exc:
+                raise click.ClickException(str(exc)) from exc
         login_value = oauth_profile.get("login")
         if not login_value and env_login:
             login_value = env_login

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "direct-cli"
-version = "0.3.2"
+version = "0.3.3"
 description = "Command-line interface for Yandex Direct API"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/cassettes/test_integration_write/TestWriteAdExtensions.test_add_delete.yaml
+++ b/tests/cassettes/test_integration_write/TestWriteAdExtensions.test_add_delete.yaml
@@ -30,7 +30,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/adextensions
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/adextensions
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":10001}]}}'
@@ -84,7 +84,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/adextensions
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/adextensions
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":10001}]}}'

--- a/tests/cassettes/test_integration_write/TestWriteAdGroups.test_add_update_delete.yaml
+++ b/tests/cassettes/test_integration_write/TestWriteAdGroups.test_add_update_delete.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/campaigns
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":100000003}]}}'
@@ -83,7 +83,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/adgroups
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":2000001}]}}'
@@ -137,7 +137,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/adgroups
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"UpdateResults":[{"Errors":[{"Code":8800,"Message":"Object
@@ -192,7 +192,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/adgroups
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Errors":[{"Code":8800,"Message":"Object
@@ -247,7 +247,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/campaigns
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":100000003}]}}'

--- a/tests/cassettes/test_integration_write/TestWriteAdImages.test_add_delete.yaml
+++ b/tests/cassettes/test_integration_write/TestWriteAdImages.test_add_delete.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/adimages
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/adimages
   response:
     body:
       string: '{"result":{"AddResults":[{"Errors":[{"Message":"Invalid format","Details":"Invalid

--- a/tests/cassettes/test_integration_write/TestWriteAds.test_add_text_ad_update_delete.yaml
+++ b/tests/cassettes/test_integration_write/TestWriteAds.test_add_text_ad_update_delete.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/campaigns
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":100000004}]}}'
@@ -83,7 +83,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/adgroups
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":2000002}]}}'
@@ -138,7 +138,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/ads
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/ads
   response:
     body:
       string: '{"result":{"AddResults":[{"Errors":[{"Code":8800,"Message":"Object
@@ -193,7 +193,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/adgroups
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Errors":[{"Code":8800,"Message":"Object
@@ -248,7 +248,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/campaigns
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":100000004}]}}'

--- a/tests/cassettes/test_integration_write/TestWriteAudienceTargets.test_add_delete.yaml
+++ b/tests/cassettes/test_integration_write/TestWriteAudienceTargets.test_add_delete.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/campaigns
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":100000010}]}}'
@@ -83,7 +83,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/adgroups
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":2000006}]}}'
@@ -137,7 +137,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/retargetinglists
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/retargetinglists
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":1002}]}}'
@@ -191,7 +191,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/audiencetargets
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/audiencetargets
   response:
     body:
       string: '{"result":{"AddResults":[{"Errors":[{"Code":8800,"Message":"Object
@@ -247,7 +247,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/retargetinglists
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/retargetinglists
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Errors":[{"Code":8800,"Message":"Object
@@ -302,7 +302,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/adgroups
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Errors":[{"Code":8800,"Message":"Object
@@ -357,7 +357,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/campaigns
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":100000010}]}}'

--- a/tests/cassettes/test_integration_write/TestWriteBidModifiersAdd.test_add_delete_mobile.yaml
+++ b/tests/cassettes/test_integration_write/TestWriteBidModifiersAdd.test_add_delete_mobile.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/campaigns
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":100000008}]}}'
@@ -83,7 +83,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/bidmodifiers
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/bidmodifiers
   response:
     body:
       string: '{"result":{"AddResults":[{"Ids":[10000001]}]}}'
@@ -137,7 +137,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/bidmodifiers
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/bidmodifiers
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Errors":[{"Code":8800,"Message":"Object
@@ -192,7 +192,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/campaigns
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":100000008}]}}'

--- a/tests/cassettes/test_integration_write/TestWriteBidModifiersSet.test_set_without_id_is_rejected.yaml
+++ b/tests/cassettes/test_integration_write/TestWriteBidModifiersSet.test_set_without_id_is_rejected.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/campaigns
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":100000009}]}}'
@@ -83,7 +83,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/bidmodifiers
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/bidmodifiers
   response:
     body:
       string: '{"error":{"request_id":"2726106659050373240","error_code":8000,"error_detail":"The
@@ -139,7 +139,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/campaigns
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":100000009}]}}'

--- a/tests/cassettes/test_integration_write/TestWriteBids.test_set_bid.yaml
+++ b/tests/cassettes/test_integration_write/TestWriteBids.test_set_bid.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/campaigns
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":100000006}]}}'
@@ -83,7 +83,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/adgroups
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":2000004}]}}'
@@ -138,7 +138,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/keywords
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/keywords
   response:
     body:
       string: '{"result":{"AddResults":[{"Errors":[{"Code":8800,"Message":"Object
@@ -193,7 +193,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/adgroups
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Errors":[{"Code":8800,"Message":"Object
@@ -248,7 +248,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/campaigns
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":100000006}]}}'

--- a/tests/cassettes/test_integration_write/TestWriteCampaignDraftLifecycle.test_draft_create_get_delete.yaml
+++ b/tests/cassettes/test_integration_write/TestWriteCampaignDraftLifecycle.test_draft_create_get_delete.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/campaigns
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":100000002}]}}'
@@ -83,7 +83,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/campaigns
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"Campaigns":[{"Id":100000002,"Name":"draft-lifecycle-cassette","Status":"DRAFT","State":"OFF"}]}}'
@@ -137,7 +137,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/campaigns
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":100000002}]}}'
@@ -191,7 +191,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/campaigns
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"Campaigns":[]}}'

--- a/tests/cassettes/test_integration_write/TestWriteCampaigns.test_campaign_lifecycle.yaml
+++ b/tests/cassettes/test_integration_write/TestWriteCampaigns.test_campaign_lifecycle.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/campaigns
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":100000001}]}}'
@@ -83,7 +83,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/campaigns
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"UpdateResults":[{"Id":100000001}]}}'
@@ -137,7 +137,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/campaigns
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: "{\"result\":{\"SuspendResults\":[{\"Errors\":[{\"Code\":8300,\"Message\":\"Invalid
@@ -195,7 +195,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/campaigns
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: "{\"result\":{\"ArchiveResults\":[{\"Errors\":[{\"Code\":8303,\"Message\":\"Cannot
@@ -253,7 +253,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/campaigns
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"UnarchiveResults":[{"Id":100000001,"Warnings":[{"Code":10023,"Message":"Object
@@ -308,7 +308,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/campaigns
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":100000001}]}}'

--- a/tests/cassettes/test_integration_write/TestWriteDynamicAds.test_add_update_delete.yaml
+++ b/tests/cassettes/test_integration_write/TestWriteDynamicAds.test_add_update_delete.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/campaigns
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: "{\"result\":{\"AddResults\":[{\"Errors\":[{\"Code\":3500,\"Message\":\"Not

--- a/tests/cassettes/test_integration_write/TestWriteFeeds.test_add_update_delete.yaml
+++ b/tests/cassettes/test_integration_write/TestWriteFeeds.test_add_update_delete.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/feeds
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/feeds
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":101}]}}'
@@ -83,7 +83,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/feeds
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/feeds
   response:
     body:
       string: "{\"result\":{\"UpdateResults\":[{\"Errors\":[{\"Code\":8800,\"Message\":\"Object
@@ -138,7 +138,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/feeds
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/feeds
   response:
     body:
       string: "{\"result\":{\"DeleteResults\":[{\"Errors\":[{\"Code\":8800,\"Message\":\"Object

--- a/tests/cassettes/test_integration_write/TestWriteKeywordBids.test_set_keyword_bid.yaml
+++ b/tests/cassettes/test_integration_write/TestWriteKeywordBids.test_set_keyword_bid.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/campaigns
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":100000007}]}}'
@@ -83,7 +83,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/adgroups
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":2000005}]}}'
@@ -138,7 +138,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/keywords
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/keywords
   response:
     body:
       string: '{"result":{"AddResults":[{"Errors":[{"Code":8800,"Message":"Object
@@ -193,7 +193,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/adgroups
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Errors":[{"Code":8800,"Message":"Object
@@ -248,7 +248,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/campaigns
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":100000007}]}}'

--- a/tests/cassettes/test_integration_write/TestWriteKeywords.test_add_update_delete.yaml
+++ b/tests/cassettes/test_integration_write/TestWriteKeywords.test_add_update_delete.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/campaigns
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":100000005}]}}'
@@ -83,7 +83,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/adgroups
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":2000003}]}}'
@@ -138,7 +138,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/keywords
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/keywords
   response:
     body:
       string: '{"result":{"AddResults":[{"Errors":[{"Code":8800,"Message":"Object
@@ -193,7 +193,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/adgroups
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Errors":[{"Code":8800,"Message":"Object
@@ -248,7 +248,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/campaigns
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":100000005}]}}'

--- a/tests/cassettes/test_integration_write/TestWriteNegativeKeywordSharedSets.test_add_update_delete.yaml
+++ b/tests/cassettes/test_integration_write/TestWriteNegativeKeywordSharedSets.test_add_update_delete.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/negativekeywordsharedsets
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/negativekeywordsharedsets
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":100002}]}}'
@@ -83,7 +83,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/negativekeywordsharedsets
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/negativekeywordsharedsets
   response:
     body:
       string: '{"result":{"UpdateResults":[{"Id":100002}]}}'
@@ -137,7 +137,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/negativekeywordsharedsets
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/negativekeywordsharedsets
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":100002}]}}'

--- a/tests/cassettes/test_integration_write/TestWriteRetargeting.test_add_delete.yaml
+++ b/tests/cassettes/test_integration_write/TestWriteRetargeting.test_add_delete.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/retargetinglists
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/retargetinglists
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":1001}]}}'
@@ -83,7 +83,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/retargetinglists
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/retargetinglists
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Errors":[{"Code":8800,"Message":"Object

--- a/tests/cassettes/test_integration_write/TestWriteSitelinks.test_add_delete.yaml
+++ b/tests/cassettes/test_integration_write/TestWriteSitelinks.test_add_delete.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/sitelinks
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/sitelinks
   response:
     body:
       string: '{"error":{"request_id":"6414567394545914101","error_code":1000,"error_detail":"","error_string":"The

--- a/tests/cassettes/test_integration_write/TestWriteSmartAdTargets.test_add_update_delete.yaml
+++ b/tests/cassettes/test_integration_write/TestWriteSmartAdTargets.test_add_update_delete.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/feeds
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/feeds
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":102}]}}'
@@ -83,7 +83,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/campaigns
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: "{\"result\":{\"AddResults\":[{\"Errors\":[{\"Code\":3500,\"Message\":\"Not
@@ -140,7 +140,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/feeds
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/feeds
   response:
     body:
       string: "{\"result\":{\"DeleteResults\":[{\"Errors\":[{\"Code\":8800,\"Message\":\"Object

--- a/tests/cassettes/test_integration_write/TestWriteVCards.test_add_delete.yaml
+++ b/tests/cassettes/test_integration_write/TestWriteVCards.test_add_delete.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/campaigns
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":100000011}]}}'
@@ -84,7 +84,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/vcards
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/vcards
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":100001}]}}'
@@ -138,7 +138,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/vcards
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/vcards
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":100001}]}}'
@@ -192,7 +192,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api-sandbox.direct.yandex.com/json/v5/campaigns
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":100000011}]}}'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,7 @@ def _resolve_test_credentials():
 
     try:
         return get_credentials()
-    except ValueError:
+    except (RuntimeError, ValueError):
         return None, None
 
 

--- a/tests/test_auth_oauth.py
+++ b/tests/test_auth_oauth.py
@@ -450,6 +450,57 @@ class TestAuthOAuth:
         with pytest.raises(RuntimeError, match="OAuth refresh token expired"):
             refresh_access_token("agency1")
 
+    def test_refresh_access_token_recovers_from_concurrent_refresh(
+        self, isolated_auth_store
+    ):
+        save_oauth_profile(
+            profile="agency1",
+            token="access-1",
+            login="client-login",
+            refresh_token="refresh-1",
+            expires_at=1000.0,
+            client_id="cid",
+        )
+
+        def simulate_concurrent_refresh(*_args, **_kwargs):
+            # Imitate another process having just rotated the token on disk
+            # before the current refresh request could complete.
+            store = load_auth_store()
+            store["profiles"]["agency1"]["token"] = "access-2"
+            store["profiles"]["agency1"]["refresh_token"] = "refresh-2"
+            store["profiles"]["agency1"]["expires_at"] = 4_100_000_000.0
+            save_auth_store(store)
+            raise fake_http_error(code=400)
+
+        with patch(
+            "direct_cli.auth.urllib.request.urlopen",
+            side_effect=simulate_concurrent_refresh,
+        ):
+            result = refresh_access_token("agency1")
+
+        assert result["token"] == "access-2"
+        assert result["refresh_token"] == "refresh-2"
+        assert result["expires_at"] == 4_100_000_000.0
+
+    @patch(
+        "direct_cli.auth.urllib.request.urlopen",
+        side_effect=URLError(TimeoutError("timed out")),
+    )
+    def test_refresh_access_token_timeout_message(
+        self, mock_urlopen, isolated_auth_store
+    ):
+        save_oauth_profile(
+            profile="agency1",
+            token="access-1",
+            login="client-login",
+            refresh_token="refresh-1",
+            expires_at=1000.0,
+            client_id="cid",
+        )
+
+        with pytest.raises(RuntimeError, match="OAuth refresh request timed out"):
+            refresh_access_token("agency1")
+
     @patch(
         "direct_cli.auth.urllib.request.urlopen",
         return_value=FakeOAuthResponse(

--- a/tests/test_auth_oauth.py
+++ b/tests/test_auth_oauth.py
@@ -1,6 +1,10 @@
 """Tests for OAuth profile authentication flows."""
 
+import io
+import json
 import stat
+import urllib.parse
+from urllib.error import HTTPError, URLError
 from unittest.mock import patch
 
 import pytest
@@ -8,7 +12,11 @@ from click.testing import CliRunner
 
 from direct_cli.auth import (
     DEFAULT_OAUTH_CLIENT_ID,
+    exchange_oauth_code,
     get_credentials,
+    load_auth_store,
+    refresh_access_token,
+    save_auth_store,
     save_oauth_profile,
 )
 from direct_cli.cli import cli
@@ -19,6 +27,39 @@ def isolated_auth_store(monkeypatch, tmp_path):
     store_path = tmp_path / "auth.json"
     monkeypatch.setattr("direct_cli.auth.AUTH_STORE_PATH", store_path)
     return store_path
+
+
+class FakeOAuthResponse:
+    """Minimal context manager for urllib response mocks."""
+
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return None
+
+    def read(self):
+        return json.dumps(self.payload).encode("utf-8")
+
+
+def fake_http_error(code=400, body=b"invalid_grant"):
+    """Build an HTTPError with a deterministic response body."""
+    return HTTPError(
+        url="https://oauth.yandex.ru/token",
+        code=code,
+        msg="Bad Request",
+        hdrs=None,
+        fp=io.BytesIO(body),
+    )
+
+
+def request_form_body(mock_urlopen):
+    """Parse the form body from the mocked urllib Request."""
+    request = mock_urlopen.call_args.args[0]
+    return urllib.parse.parse_qs(request.data.decode("utf-8"))
 
 
 class TestAuthOAuth:
@@ -34,6 +75,9 @@ class TestAuthOAuth:
             profile="agency1",
             token="oauth-token-1",
             login="client-login-1",
+            refresh_token="refresh-1",
+            expires_at=4_100_000_000.0,
+            client_id=DEFAULT_OAUTH_CLIENT_ID,
             make_active=False,
         )
 
@@ -122,15 +166,31 @@ class TestAuthOAuth:
         assert "y0_secret_token" not in status.output
 
     def test_auth_store_uses_private_permissions(self, isolated_auth_store):
-        save_oauth_profile(profile="agency1", token="oauth-token-1")
+        save_oauth_profile(
+            profile="agency1",
+            token="oauth-token-1",
+            refresh_token="refresh-1",
+            expires_at=4_100_000_000.0,
+            client_id=DEFAULT_OAUTH_CLIENT_ID,
+        )
 
         directory_mode = stat.S_IMODE(isolated_auth_store.parent.stat().st_mode)
         file_mode = stat.S_IMODE(isolated_auth_store.stat().st_mode)
         assert directory_mode == 0o700
         assert file_mode == 0o600
 
-    @patch("direct_cli.commands.auth.exchange_oauth_code", return_value="y0_token")
-    def test_auth_login_code_mode_custom_app(self, mock_exchange, isolated_auth_store):
+    @patch(
+        "direct_cli.commands.auth.exchange_oauth_code",
+        return_value={
+            "access_token": "y0_token",
+            "refresh_token": "r1",
+            "expires_in": 3600,
+        },
+    )
+    @patch("direct_cli.commands.auth.time.time", return_value=1000.0)
+    def test_auth_login_code_mode_custom_app(
+        self, mock_time, mock_exchange, isolated_auth_store
+    ):
         runner = CliRunner()
         result = runner.invoke(
             cli,
@@ -154,10 +214,22 @@ class TestAuthOAuth:
             client_secret="csecret",
             code_verifier=None,
         )
+        profile = load_auth_store()["profiles"]["agency1"]
+        assert profile["client_secret"] == "csecret"
 
+    @patch("direct_cli.commands.auth.time.time", return_value=1000.0)
     @patch("direct_cli.commands.auth.build_pkce_pair", return_value=("ver", "chal"))
-    @patch("direct_cli.commands.auth.exchange_oauth_code", return_value="y0_pkce")
-    def test_auth_login_pkce_mode(self, mock_exchange, mock_pkce, isolated_auth_store):
+    @patch(
+        "direct_cli.commands.auth.exchange_oauth_code",
+        return_value={
+            "access_token": "y0_pkce",
+            "refresh_token": "r1",
+            "expires_in": 3600,
+        },
+    )
+    def test_auth_login_pkce_mode(
+        self, mock_exchange, mock_pkce, mock_time, isolated_auth_store
+    ):
         runner = CliRunner()
         result = runner.invoke(
             cli,
@@ -186,7 +258,13 @@ class TestAuthOAuth:
         monkeypatch.delenv("YANDEX_DIRECT_OP_LOGIN_REF", raising=False)
         monkeypatch.delenv("YANDEX_DIRECT_BW_TOKEN_REF", raising=False)
         monkeypatch.delenv("YANDEX_DIRECT_BW_LOGIN_REF", raising=False)
-        save_oauth_profile(profile="agency1", token="oauth-token-1")
+        save_oauth_profile(
+            profile="agency1",
+            token="oauth-token-1",
+            refresh_token="refresh-1",
+            expires_at=4_100_000_000.0,
+            client_id=DEFAULT_OAUTH_CLIENT_ID,
+        )
         runner = CliRunner()
 
         result = runner.invoke(cli, ["campaigns", "get", "--help"])
@@ -204,3 +282,325 @@ class TestAuthOAuth:
         result = runner.invoke(cli, ["auth", "list"])
         assert result.exit_code == 0
         assert "* agency1" in result.output
+
+    @patch(
+        "direct_cli.auth.urllib.request.urlopen",
+        return_value=FakeOAuthResponse(
+            {
+                "access_token": "access-1",
+                "refresh_token": "refresh-1",
+                "expires_in": 3600,
+            }
+        ),
+    )
+    def test_exchange_oauth_code_returns_token_response(self, mock_urlopen):
+        result = exchange_oauth_code(
+            code="abc123", client_id="cid", code_verifier="verifier"
+        )
+
+        assert result == {
+            "access_token": "access-1",
+            "refresh_token": "refresh-1",
+            "expires_in": 3600,
+        }
+
+    def test_save_oauth_profile_persists_refresh_metadata(self, isolated_auth_store):
+        save_oauth_profile(
+            profile="agency1",
+            token="access-1",
+            login="client-login",
+            refresh_token="refresh-1",
+            expires_at=2000.0,
+            client_id="cid",
+        )
+
+        store = load_auth_store()
+        assert store["profiles"]["agency1"] == {
+            "token": "access-1",
+            "login": "client-login",
+            "source": "oauth",
+            "refresh_token": "refresh-1",
+            "expires_at": 2000.0,
+            "client_id": "cid",
+        }
+
+    def test_save_oauth_profile_persists_client_secret(self, isolated_auth_store):
+        save_oauth_profile(
+            profile="agency1",
+            token="access-1",
+            login="client-login",
+            refresh_token="refresh-1",
+            expires_at=2000.0,
+            client_id="cid",
+            client_secret="csecret",
+        )
+
+        profile = load_auth_store()["profiles"]["agency1"]
+        assert profile["client_secret"] == "csecret"
+
+    @patch("direct_cli.auth.load_env_file")
+    @patch("direct_cli.auth.time.time", return_value=1000.0)
+    @patch(
+        "direct_cli.auth.urllib.request.urlopen",
+        return_value=FakeOAuthResponse(
+            {
+                "access_token": "access-2",
+                "refresh_token": "refresh-2",
+                "expires_in": 3600,
+            }
+        ),
+    )
+    def test_get_credentials_refreshes_expiring_oauth_profile(
+        self, mock_urlopen, mock_time, mock_load_env, isolated_auth_store, monkeypatch
+    ):
+        monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
+        save_oauth_profile(
+            profile="agency1",
+            token="access-1",
+            login="client-login",
+            refresh_token="refresh-1",
+            expires_at=1050.0,
+            client_id="cid",
+            make_active=False,
+        )
+
+        token, login = get_credentials(profile="agency1")
+
+        assert token == "access-2"
+        assert login == "client-login"
+        profile = load_auth_store()["profiles"]["agency1"]
+        assert profile["token"] == "access-2"
+        assert profile["refresh_token"] == "refresh-2"
+        assert profile["expires_at"] == 4600.0
+
+    @patch("direct_cli.auth.load_env_file")
+    @patch("direct_cli.auth.time.time", return_value=1000.0)
+    @patch(
+        "direct_cli.auth.urllib.request.urlopen",
+        return_value=FakeOAuthResponse(
+            {
+                "access_token": "access-2",
+                "refresh_token": "refresh-2",
+                "expires_in": 3600,
+            }
+        ),
+    )
+    def test_get_credentials_refreshes_at_refresh_skew_boundary(
+        self, mock_urlopen, mock_time, mock_load_env, isolated_auth_store, monkeypatch
+    ):
+        monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
+        save_oauth_profile(
+            profile="agency1",
+            token="access-1",
+            login="client-login",
+            refresh_token="refresh-1",
+            expires_at=1060.0,
+            client_id="cid",
+            make_active=False,
+        )
+
+        token, login = get_credentials(profile="agency1")
+
+        assert token == "access-2"
+        assert login == "client-login"
+        assert mock_urlopen.call_count == 1
+
+    @patch("direct_cli.auth.load_env_file")
+    def test_legacy_oauth_profile_without_refresh_token_fails(
+        self, mock_load_env, isolated_auth_store, monkeypatch
+    ):
+        monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
+        save_auth_store(
+            {
+                "profiles": {
+                    "agency1": {
+                        "token": "access-1",
+                        "login": "client-login",
+                        "source": "oauth",
+                    }
+                },
+                "active_profile": "agency1",
+            }
+        )
+
+        with pytest.raises(
+            ValueError, match="Run direct auth login --profile agency1 again"
+        ):
+            get_credentials(profile="agency1")
+
+    @patch(
+        "direct_cli.auth.urllib.request.urlopen",
+        side_effect=fake_http_error(code=400),
+    )
+    def test_refresh_access_token_expired_refresh_token_fails_cleanly(
+        self, mock_urlopen, isolated_auth_store
+    ):
+        save_oauth_profile(
+            profile="agency1",
+            token="access-1",
+            login="client-login",
+            refresh_token="refresh-1",
+            expires_at=1000.0,
+            client_id="cid",
+        )
+
+        with pytest.raises(RuntimeError, match="OAuth refresh token expired"):
+            refresh_access_token("agency1")
+
+    @patch(
+        "direct_cli.auth.urllib.request.urlopen",
+        return_value=FakeOAuthResponse(
+            {
+                "access_token": "access-2",
+                "expires_in": 3600,
+            }
+        ),
+    )
+    def test_refresh_access_token_sends_client_secret(
+        self, mock_urlopen, isolated_auth_store
+    ):
+        save_oauth_profile(
+            profile="agency1",
+            token="access-1",
+            login="client-login",
+            refresh_token="refresh-1",
+            expires_at=1000.0,
+            client_id="cid",
+            client_secret="csecret",
+        )
+
+        refresh_access_token("agency1")
+
+        assert request_form_body(mock_urlopen) == {
+            "grant_type": ["refresh_token"],
+            "client_id": ["cid"],
+            "refresh_token": ["refresh-1"],
+            "client_secret": ["csecret"],
+        }
+
+    @patch(
+        "direct_cli.auth.urllib.request.urlopen",
+        side_effect=URLError("temporary failure in name resolution"),
+    )
+    def test_refresh_access_token_network_error_is_readable(
+        self, mock_urlopen, isolated_auth_store
+    ):
+        save_oauth_profile(
+            profile="agency1",
+            token="access-1",
+            login="client-login",
+            refresh_token="refresh-1",
+            expires_at=1000.0,
+            client_id="cid",
+        )
+
+        with pytest.raises(RuntimeError, match="OAuth refresh request failed"):
+            refresh_access_token("agency1")
+
+    @patch(
+        "direct_cli.auth.urllib.request.urlopen",
+        side_effect=fake_http_error(code=500, body=b"super-secret-response"),
+    )
+    def test_refresh_access_token_http_error_does_not_expose_body(
+        self, mock_urlopen, isolated_auth_store
+    ):
+        save_oauth_profile(
+            profile="agency1",
+            token="access-1",
+            login="client-login",
+            refresh_token="refresh-1",
+            expires_at=1000.0,
+            client_id="cid",
+        )
+
+        with pytest.raises(RuntimeError) as exc_info:
+            refresh_access_token("agency1")
+
+        assert str(exc_info.value) == "OAuth refresh request failed with HTTP 500"
+        assert "super-secret-response" not in str(exc_info.value)
+
+    @patch(
+        "direct_cli.auth.urllib.request.urlopen",
+        side_effect=fake_http_error(code=400, body=b"super-secret-response"),
+    )
+    def test_exchange_oauth_code_http_error_does_not_expose_body(self, mock_urlopen):
+        with pytest.raises(RuntimeError) as exc_info:
+            exchange_oauth_code(code="abc123", client_id="cid")
+
+        assert str(exc_info.value) == "OAuth token request failed with HTTP 400"
+        assert "super-secret-response" not in str(exc_info.value)
+
+    @patch("direct_cli.commands.auth.time.time", return_value=1000.0)
+    def test_auth_status_json_does_not_expose_client_secret(
+        self, mock_time, isolated_auth_store
+    ):
+        save_oauth_profile(
+            profile="agency1",
+            token="access-1",
+            login="client-login",
+            refresh_token="refresh-1",
+            expires_at=4600.0,
+            client_id="cid",
+            client_secret="csecret",
+        )
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli, ["auth", "status", "--profile", "agency1", "--format", "json"]
+        )
+
+        assert result.exit_code == 0
+        assert json.loads(result.output) == {
+            "profile": "agency1",
+            "source": "oauth",
+            "has_token": True,
+            "login": "client-login",
+            "expires_at": 4600.0,
+            "expires_in_seconds": 3600,
+        }
+        assert "client_secret" not in result.output
+        assert "csecret" not in result.output
+
+    def test_auth_status_legacy_oauth_profile_fails(self, isolated_auth_store):
+        save_auth_store(
+            {
+                "profiles": {
+                    "agency1": {
+                        "token": "access-1",
+                        "login": "client-login",
+                        "source": "oauth",
+                    }
+                },
+                "active_profile": "agency1",
+            }
+        )
+        runner = CliRunner()
+
+        result = runner.invoke(cli, ["auth", "status", "--profile", "agency1"])
+
+        assert result.exit_code != 0
+        assert "Run direct auth login --profile agency1 again" in result.output
+
+    def test_auth_login_oauth_token_mode_saves_manual_profile(
+        self, isolated_auth_store
+    ):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "auth",
+                "login",
+                "--oauth-token",
+                "y0_secret_token",
+                "--profile",
+                "agency1",
+            ],
+        )
+
+        assert result.exit_code == 0
+        profile = load_auth_store()["profiles"]["agency1"]
+        assert profile["source"] == "manual"
+        assert "refresh_token" not in profile


### PR DESCRIPTION
Closes #152.

## Summary
- OAuth profiles now persist `refresh_token`, `expires_at`, `client_id`, and (optionally) `client_secret`. `direct auth login` writes them; `~/.direct-cli/auth.json` writes are atomic (`tempfile.mkstemp` + `os.replace`, mode `0600`/`0700`).
- `get_credentials` transparently refreshes the access token before any API call when `expires_at <= now + 60s`. Refresh sends `client_secret` for confidential apps. On `400/401` it raises a clean "OAuth refresh token expired. Run `direct auth login --profile X` again." without leaking the response body; network/`5xx` failures get neutral messages too.
- `direct auth status` reports `expires_in=Xh Ym` in text mode and `expires_at` (float) + `expires_in_seconds` (int) in JSON mode. Neither mode leaks `client_secret`/`refresh_token`/`token`.
- Legacy OAuth profiles without `refresh_token`/`expires_at` are rejected up front with a clear "incomplete profile" error — intentional, keeps the plugin contract clean.
- Bumps to `0.3.3`; `CHANGELOG.md` added.

A separate prep commit (`chore(vendor)`) flips the vendored Yandex Direct host from `yandex.com` → `yandex.ru` and regenerates the 19 `integration_write` VCR cassettes so replay still matches.

## Test plan
- [x] `pytest tests/test_auth_oauth.py -v` — 27/27 passed (covers persistence, skew boundary, custom client_secret, expired refresh, network/HTTP errors, JSON status redaction, legacy rejection, manual mode).
- [x] Full unit suite (excluding integration markers) — 457 passed.
- [x] `pytest -m integration_write` — 10 passed, 9 sandbox-skipped, 0 failed (vendor host change consistent with regenerated cassettes).
- [x] `flake8` clean on `direct_cli/auth.py`, `direct_cli/commands/auth.py`, `tests/test_auth_oauth.py`; `black --check` clean on the same files.
- [x] Live smoke in an isolated `HOME` (`/tmp/direct-cli-smoke152.*`) with synthetic profiles: `auth status` text + JSON, auto-refresh trigger producing the documented user-facing error on a fake `client_id`/`refresh_token`, fresh profile bypassing refresh, manual profile unaffected, legacy profile rejected on both `auth status` and API calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)