### PR TITLE
[codex] centralize Direct API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ CI runs a scheduled API coverage workflow that:
 
 `WRITE_SANDBOX` smoke is a live check against the Yandex Direct **sandbox**.
 It does not replay stored HTTP traffic and it does not create new recordings.
-Run it only when you intentionally want to call `api-sandbox.direct.yandex.com`:
+Run it only when you intentionally want to call `api-sandbox.direct.yandex.ru`:
 
 ```bash
 set -a && source .env && set +a
@@ -1141,7 +1141,7 @@ YANDEX_DIRECT_LIVE_WRITE=1 pytest -m integration_live_write -v --record-mode=rew
 `WRITE_SANDBOX` smoke — это live-проверка против **sandbox-окружения**
 Яндекс Директа. Она не воспроизводит сохранённый HTTP-трафик и не создаёт
 новые записи. Запускайте её только когда намеренно хотите обратиться к
-`api-sandbox.direct.yandex.com`:
+`api-sandbox.direct.yandex.ru`:
 
 ```bash
 set -a && source .env && set +a

--- a/direct_cli/_vendor/tapi_yandex_direct/endpoints.py
+++ b/direct_cli/_vendor/tapi_yandex_direct/endpoints.py
@@ -1,0 +1,14 @@
+"""Runtime endpoints for Yandex Direct API transports."""
+
+from typing import Any, Dict
+
+DIRECT_API_PRODUCTION_ROOT = "https://api.direct.yandex.ru/"
+DIRECT_API_SANDBOX_ROOT = "https://api-sandbox.direct.yandex.ru/"
+DIRECT_DEBUG_ROOT = "https://"
+
+
+def get_direct_api_root(api_params: Dict[str, Any]) -> str:
+    """Return the Direct API root for production or sandbox requests."""
+    if api_params.get("is_sandbox"):
+        return DIRECT_API_SANDBOX_ROOT
+    return DIRECT_API_PRODUCTION_ROOT

--- a/direct_cli/_vendor/tapi_yandex_direct/tapi_yandex_direct.py
+++ b/direct_cli/_vendor/tapi_yandex_direct/tapi_yandex_direct.py
@@ -9,6 +9,7 @@ from tapi2 import TapiAdapter, generate_wrapper_from_adapter, JSONAdapterMixin
 from tapi2.exceptions import ResponseProcessException, ClientError, TapiException
 
 from . import exceptions
+from .endpoints import DIRECT_DEBUG_ROOT, get_direct_api_root
 from .resource_mapping import RESOURCE_MAPPING_V5
 
 logger = logging.getLogger(__name__)
@@ -72,11 +73,8 @@ class YandexDirectClientAdapter(JSONAdapterMixin, TapiAdapter):
 
     def get_api_root(self, api_params: dict, resource_name: str) -> str:
         if resource_name == "debugtoken":
-            return "https://"
-        elif api_params.get("is_sandbox"):
-            return "https://api-sandbox.direct.yandex.ru/"
-        else:
-            return "https://api.direct.yandex.ru/"
+            return DIRECT_DEBUG_ROOT
+        return get_direct_api_root(api_params)
 
     def get_request_kwargs(self, api_params: dict, *args, **kwargs) -> dict:
         """Обогащение запроса, параметрами"""
@@ -154,7 +152,7 @@ class YandexDirectClientAdapter(JSONAdapterMixin, TapiAdapter):
                 "The report generation time has exceeded the server limit. "
                 "Please try to change the request parameters, "
                 "reduce the period or the amount of requested data.",
-                **kwargs
+                **kwargs,
             )
         elif response.status_code == 405:
             raise exceptions.YandexDirectApiError(
@@ -162,7 +160,7 @@ class YandexDirectClientAdapter(JSONAdapterMixin, TapiAdapter):
                 "This resource does not support the HTTP method {}\n".format(
                     response.request.method
                 ),
-                **kwargs
+                **kwargs,
             )
 
         data = self.response_to_native(response)
@@ -190,7 +188,7 @@ class YandexDirectClientAdapter(JSONAdapterMixin, TapiAdapter):
         response: Response,
         request_kwargs: dict,
         api_params: dict,
-        **kwargs
+        **kwargs,
     ) -> None:
         if response.status_code in (201, 202):
             pass
@@ -230,7 +228,7 @@ class YandexDirectClientAdapter(JSONAdapterMixin, TapiAdapter):
         response: Response,
         request_kwargs: dict,
         api_params: dict,
-        **kwargs
+        **kwargs,
     ) -> bool:
         status_code = response.status_code
         error_data = error_message.get("error", {})
@@ -283,7 +281,7 @@ class YandexDirectClientAdapter(JSONAdapterMixin, TapiAdapter):
         response: Response,
         request_kwargs: dict,
         api_params: dict,
-        **kwargs
+        **kwargs,
     ) -> Optional[dict]:
         limit = response_data["result"].get("LimitedBy")
         if limit:

--- a/direct_cli/_vendor/tapi_yandex_direct/v4/adapter.py
+++ b/direct_cli/_vendor/tapi_yandex_direct/v4/adapter.py
@@ -18,6 +18,7 @@ from tapi2 import JSONAdapterMixin, TapiAdapter, generate_wrapper_from_adapter
 from tapi2.exceptions import ClientError, ResponseProcessException, TapiException
 
 from .. import exceptions
+from ..endpoints import get_direct_api_root
 from .resource_mapping import (
     RESOURCE_MAPPING_V4_LIVE,
     SUPPORTED_V4_METHODS,
@@ -33,9 +34,7 @@ class V4LiveClientAdapter(JSONAdapterMixin, TapiAdapter):
         super().__init__(*args, **kwargs)
 
     def get_api_root(self, api_params: dict, resource_name: str) -> str:
-        if api_params.get("is_sandbox"):
-            return "https://api-sandbox.direct.yandex.ru/"
-        return "https://api.direct.yandex.ru/"
+        return get_direct_api_root(api_params)
 
     def get_request_kwargs(self, api_params: dict, *args, **kwargs) -> dict:
         params = super().get_request_kwargs(api_params, *args, **kwargs)
@@ -107,7 +106,9 @@ class V4LiveClientAdapter(JSONAdapterMixin, TapiAdapter):
                 data = None
         return data
 
-    def process_response(self, response: Response, request_kwargs: dict, **kwargs) -> dict:
+    def process_response(
+        self, response: Response, request_kwargs: dict, **kwargs
+    ) -> dict:
         # Mirror the v5 behaviour: turn the serialised body back into a dict so
         # downstream hooks (extract, retry) can read it.
         if isinstance(request_kwargs.get("data"), (bytes, bytearray, str)):
@@ -187,8 +188,13 @@ class V4LiveClientAdapter(JSONAdapterMixin, TapiAdapter):
 
         return False
 
-    def extract(self, data, response: Optional[Response] = None,
-                request_kwargs: Optional[dict] = None, **kwargs):
+    def extract(
+        self,
+        data,
+        response: Optional[Response] = None,
+        request_kwargs: Optional[dict] = None,
+        **kwargs,
+    ):
         # v4 Live always nests payload under "data". For methods returning a
         # bare scalar (TransferMoney → 1), the scalar comes through unchanged.
         # response / request_kwargs are accepted but unused — they are kept

--- a/scripts/sandbox_write_live.py
+++ b/scripts/sandbox_write_live.py
@@ -1305,7 +1305,7 @@ def main(argv: list[str]) -> int:
     commands = args.command or commands_for_category(WRITE_SANDBOX)
     print("direct-cli WRITE_SANDBOX live sandbox")
     print(f"WRITE_SANDBOX commands: {len(commands)}")
-    print("endpoint: api-sandbox.direct.yandex.com")
+    print("endpoint: api-sandbox.direct.yandex.ru")
     print()
 
     runner = LiveSandboxRunner(

--- a/tests/cassettes/test_integration_live_write/test_live_draft_adgroups_add_update_delete.yaml
+++ b/tests/cassettes/test_integration_live_write/test_live_draft_adgroups_add_update_delete.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/campaigns
+    uri: https://api.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":100000013}]}}'
@@ -91,7 +91,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/adgroups
+    uri: https://api.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":2000000001}]}}'
@@ -153,7 +153,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/adgroups
+    uri: https://api.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"UpdateResults":[{"Id":2000000001}]}}'
@@ -215,7 +215,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/adgroups
+    uri: https://api.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"AdGroups":[{"Id":2000000001,"Name":"draft-test-group-renamed","CampaignId":100000013,"Status":"DRAFT","Type":"TEXT_AD_GROUP","RegionIds":[225]}]}}'
@@ -277,7 +277,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/adgroups
+    uri: https://api.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":2000000001}]}}'
@@ -339,7 +339,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/campaigns
+    uri: https://api.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":100000013}]}}'

--- a/tests/cassettes/test_integration_live_write/test_live_draft_adimages_add_get_delete.yaml
+++ b/tests/cassettes/test_integration_live_write/test_live_draft_adimages_add_get_delete.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/adimages
+    uri: https://api.direct.yandex.ru/json/v5/adimages
   response:
     body:
       string: '{"result":{"AddResults":[{"Errors":[{"Details":"Invalid image file

--- a/tests/cassettes/test_integration_live_write/test_live_draft_ads_add_update_delete.yaml
+++ b/tests/cassettes/test_integration_live_write/test_live_draft_ads_add_update_delete.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/campaigns
+    uri: https://api.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":100000014}]}}'
@@ -91,7 +91,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/adgroups
+    uri: https://api.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":2000000002}]}}'
@@ -154,7 +154,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/ads
+    uri: https://api.direct.yandex.ru/json/v5/ads
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":30000000001,"Warnings":[{"Code":10165,"Message":"Parameter
@@ -218,7 +218,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/ads
+    uri: https://api.direct.yandex.ru/json/v5/ads
   response:
     body:
       string: '{"result":{"UpdateResults":[{"Id":30000000001}]}}'
@@ -280,7 +280,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/ads
+    uri: https://api.direct.yandex.ru/json/v5/ads
   response:
     body:
       string: '{"result":{"Ads":[{"Id":30000000001,"CampaignId":100000014,"AdGroupId":2000000002,"Status":"DRAFT","State":"OFF","Type":"TEXT_AD","TextAd":{"Text":"Test
@@ -343,7 +343,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/ads
+    uri: https://api.direct.yandex.ru/json/v5/ads
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":30000000001}]}}'
@@ -405,7 +405,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/adgroups
+    uri: https://api.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":2000000002}]}}'
@@ -467,7 +467,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/campaigns
+    uri: https://api.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":100000014}]}}'

--- a/tests/cassettes/test_integration_live_write/test_live_draft_ads_suspend_resume_archive_unarchive.yaml
+++ b/tests/cassettes/test_integration_live_write/test_live_draft_ads_suspend_resume_archive_unarchive.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/campaigns
+    uri: https://api.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":100000018}]}}'
@@ -91,7 +91,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/adgroups
+    uri: https://api.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":2000000006}]}}'
@@ -154,7 +154,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/ads
+    uri: https://api.direct.yandex.ru/json/v5/ads
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":30000000002,"Warnings":[{"Code":10165,"Message":"Parameter
@@ -217,7 +217,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/ads
+    uri: https://api.direct.yandex.ru/json/v5/ads
   response:
     body:
       string: '{"result":{"SuspendResults":[{"Errors":[{"Code":8300,"Message":"Invalid
@@ -280,7 +280,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/ads
+    uri: https://api.direct.yandex.ru/json/v5/ads
   response:
     body:
       string: '{"result":{"ResumeResults":[{"Errors":[{"Code":8300,"Message":"Invalid
@@ -343,7 +343,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/ads
+    uri: https://api.direct.yandex.ru/json/v5/ads
   response:
     body:
       string: '{"result":{"ArchiveResults":[{"Errors":[{"Code":8300,"Message":"Invalid
@@ -406,7 +406,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/ads
+    uri: https://api.direct.yandex.ru/json/v5/ads
   response:
     body:
       string: '{"result":{"UnarchiveResults":[{"Id":30000000002,"Warnings":[{"Code":10203,"Message":"Ad
@@ -469,7 +469,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/ads
+    uri: https://api.direct.yandex.ru/json/v5/ads
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":30000000002}]}}'
@@ -531,7 +531,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/adgroups
+    uri: https://api.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":2000000006}]}}'
@@ -593,7 +593,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/campaigns
+    uri: https://api.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":100000018}]}}'

--- a/tests/cassettes/test_integration_live_write/test_live_draft_advideos_add_get.yaml
+++ b/tests/cassettes/test_integration_live_write/test_live_draft_advideos_add_get.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/advideos
+    uri: https://api.direct.yandex.ru/json/v5/advideos
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":"aabbccdd1122334455667700001"}]}}'
@@ -91,7 +91,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/advideos
+    uri: https://api.direct.yandex.ru/json/v5/advideos
   response:
     body:
       string: '{"result":{"AdVideos":[{"Id":"aabbccdd1122334455667700001","Status":"READY"}]}}'

--- a/tests/cassettes/test_integration_live_write/test_live_draft_audiencetargets_add_delete.yaml
+++ b/tests/cassettes/test_integration_live_write/test_live_draft_audiencetargets_add_delete.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/campaigns
+    uri: https://api.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":100000020}]}}'
@@ -91,7 +91,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/adgroups
+    uri: https://api.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":2000000008}]}}'
@@ -153,7 +153,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/retargetinglists
+    uri: https://api.direct.yandex.ru/json/v5/retargetinglists
   response:
     body:
       string: '{"result":{"AddResults":[{"Errors":[{"Code":8800,"Message":"Object
@@ -216,7 +216,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/adgroups
+    uri: https://api.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":2000000008}]}}'
@@ -278,7 +278,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/campaigns
+    uri: https://api.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":100000020}]}}'

--- a/tests/cassettes/test_integration_live_write/test_live_draft_audiencetargets_suspend_resume.yaml
+++ b/tests/cassettes/test_integration_live_write/test_live_draft_audiencetargets_suspend_resume.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/campaigns
+    uri: https://api.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":100000021}]}}'
@@ -91,7 +91,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/adgroups
+    uri: https://api.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":2000000009}]}}'
@@ -153,7 +153,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/retargetinglists
+    uri: https://api.direct.yandex.ru/json/v5/retargetinglists
   response:
     body:
       string: '{"result":{"AddResults":[{"Errors":[{"Code":8800,"Message":"Object
@@ -216,7 +216,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/adgroups
+    uri: https://api.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":2000000009}]}}'
@@ -278,7 +278,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/campaigns
+    uri: https://api.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":100000021}]}}'

--- a/tests/cassettes/test_integration_live_write/test_live_draft_bids_set.yaml
+++ b/tests/cassettes/test_integration_live_write/test_live_draft_bids_set.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/campaigns
+    uri: https://api.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":100000015}]}}'
@@ -91,7 +91,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/adgroups
+    uri: https://api.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":2000000003}]}}'
@@ -154,7 +154,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/keywords
+    uri: https://api.direct.yandex.ru/json/v5/keywords
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":40000000001}]}}'
@@ -216,7 +216,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/bids
+    uri: https://api.direct.yandex.ru/json/v5/bids
   response:
     body:
       string: '{"result":{"SetResults":[{"KeywordId":40000000001}]}}'
@@ -278,7 +278,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/keywords
+    uri: https://api.direct.yandex.ru/json/v5/keywords
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":40000000001}]}}'
@@ -340,7 +340,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/adgroups
+    uri: https://api.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":2000000003}]}}'
@@ -402,7 +402,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/campaigns
+    uri: https://api.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":100000015}]}}'

--- a/tests/cassettes/test_integration_live_write/test_live_draft_campaign_create_get_delete.yaml
+++ b/tests/cassettes/test_integration_live_write/test_live_draft_campaign_create_get_delete.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/campaigns
+    uri: https://api.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":100000012}]}}'
@@ -91,7 +91,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/campaigns
+    uri: https://api.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"Campaigns":[{"Id":100000012,"Name":"direct-cli-live-draft-test-cassette","Status":"DRAFT","State":"OFF"}]}}'
@@ -153,7 +153,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/campaigns
+    uri: https://api.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":100000012}]}}'
@@ -215,7 +215,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/campaigns
+    uri: https://api.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"Campaigns":[]}}'

--- a/tests/cassettes/test_integration_live_write/test_live_draft_creatives_chain_advideo_to_creative.yaml
+++ b/tests/cassettes/test_integration_live_write/test_live_draft_creatives_chain_advideo_to_creative.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/advideos
+    uri: https://api.direct.yandex.ru/json/v5/advideos
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":"aabbccdd1122334455667700002"}]}}'
@@ -91,7 +91,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/creatives
+    uri: https://api.direct.yandex.ru/json/v5/creatives
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":1000000001}]}}'
@@ -153,7 +153,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/creatives
+    uri: https://api.direct.yandex.ru/json/v5/creatives
   response:
     body:
       string: "{\"result\":{\"Creatives\":[{\"Id\":1000000001,\"Type\":\"VIDEO_EXTENSION_CREATIVE\",\"Name\":\"\u041D\u043E\u0432\u044B\u0439

--- a/tests/cassettes/test_integration_live_write/test_live_draft_dynamicads_add_delete.yaml
+++ b/tests/cassettes/test_integration_live_write/test_live_draft_dynamicads_add_delete.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/campaigns
+    uri: https://api.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: "{\"result\":{\"AddResults\":[{\"Errors\":[{\"Code\":3500,\"Message\":\"Not

--- a/tests/cassettes/test_integration_live_write/test_live_draft_dynamicads_suspend_resume.yaml
+++ b/tests/cassettes/test_integration_live_write/test_live_draft_dynamicads_suspend_resume.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/campaigns
+    uri: https://api.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: "{\"result\":{\"AddResults\":[{\"Errors\":[{\"Code\":3500,\"Message\":\"Not

--- a/tests/cassettes/test_integration_live_write/test_live_draft_keywordbids_set.yaml
+++ b/tests/cassettes/test_integration_live_write/test_live_draft_keywordbids_set.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/campaigns
+    uri: https://api.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":100000016}]}}'
@@ -91,7 +91,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/adgroups
+    uri: https://api.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":2000000004}]}}'
@@ -154,7 +154,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/keywords
+    uri: https://api.direct.yandex.ru/json/v5/keywords
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":40000000002}]}}'
@@ -216,7 +216,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/keywordbids
+    uri: https://api.direct.yandex.ru/json/v5/keywordbids
   response:
     body:
       string: '{"result":{"SetResults":[{"KeywordId":40000000002,"Warnings":[{"Code":10160,"Message":"Bid
@@ -280,7 +280,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/keywords
+    uri: https://api.direct.yandex.ru/json/v5/keywords
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":40000000002}]}}'
@@ -342,7 +342,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/adgroups
+    uri: https://api.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":2000000004}]}}'
@@ -404,7 +404,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/campaigns
+    uri: https://api.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":100000016}]}}'

--- a/tests/cassettes/test_integration_live_write/test_live_draft_keywords_add_update_delete.yaml
+++ b/tests/cassettes/test_integration_live_write/test_live_draft_keywords_add_update_delete.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/campaigns
+    uri: https://api.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":100000019}]}}'
@@ -91,7 +91,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/adgroups
+    uri: https://api.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":2000000007}]}}'
@@ -154,7 +154,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/keywords
+    uri: https://api.direct.yandex.ru/json/v5/keywords
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":40000000004}]}}'
@@ -216,7 +216,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/keywords
+    uri: https://api.direct.yandex.ru/json/v5/keywords
   response:
     body:
       string: '{"error":{"request_id":"930706505971356658","error_code":8000,"error_detail":"An
@@ -280,7 +280,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/keywords
+    uri: https://api.direct.yandex.ru/json/v5/keywords
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":40000000004}]}}'
@@ -342,7 +342,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/adgroups
+    uri: https://api.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":2000000007}]}}'
@@ -404,7 +404,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/campaigns
+    uri: https://api.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":100000019}]}}'

--- a/tests/cassettes/test_integration_live_write/test_live_draft_keywords_suspend_resume.yaml
+++ b/tests/cassettes/test_integration_live_write/test_live_draft_keywords_suspend_resume.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/campaigns
+    uri: https://api.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":100000017}]}}'
@@ -91,7 +91,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/adgroups
+    uri: https://api.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":2000000005}]}}'
@@ -154,7 +154,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/keywords
+    uri: https://api.direct.yandex.ru/json/v5/keywords
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":40000000003}]}}'
@@ -216,7 +216,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/keywords
+    uri: https://api.direct.yandex.ru/json/v5/keywords
   response:
     body:
       string: '{"result":{"SuspendResults":[{"Id":40000000003}]}}'
@@ -278,7 +278,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/keywords
+    uri: https://api.direct.yandex.ru/json/v5/keywords
   response:
     body:
       string: '{"result":{"ResumeResults":[{"Id":40000000003}]}}'
@@ -340,7 +340,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/keywords
+    uri: https://api.direct.yandex.ru/json/v5/keywords
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":40000000003}]}}'
@@ -402,7 +402,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/adgroups
+    uri: https://api.direct.yandex.ru/json/v5/adgroups
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":2000000005}]}}'
@@ -464,7 +464,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/campaigns
+    uri: https://api.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":100000017}]}}'

--- a/tests/cassettes/test_integration_live_write/test_live_draft_sitelinks_add_get_delete.yaml
+++ b/tests/cassettes/test_integration_live_write/test_live_draft_sitelinks_add_get_delete.yaml
@@ -30,7 +30,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/sitelinks
+    uri: https://api.direct.yandex.ru/json/v5/sitelinks
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":1000000002}]}}'
@@ -92,7 +92,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/sitelinks
+    uri: https://api.direct.yandex.ru/json/v5/sitelinks
   response:
     body:
       string: '{"result":{"SitelinksSets":[{"Id":1000000002,"Sitelinks":[{"Title":"CLI
@@ -156,7 +156,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/sitelinks
+    uri: https://api.direct.yandex.ru/json/v5/sitelinks
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":1000000002}]}}'

--- a/tests/cassettes/test_integration_live_write/test_live_draft_smartadtargets_add_update_delete.yaml
+++ b/tests/cassettes/test_integration_live_write/test_live_draft_smartadtargets_add_update_delete.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/feeds
+    uri: https://api.direct.yandex.ru/json/v5/feeds
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":1000001}]}}'
@@ -91,7 +91,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/campaigns
+    uri: https://api.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: "{\"result\":{\"AddResults\":[{\"Errors\":[{\"Code\":3500,\"Message\":\"Not
@@ -156,7 +156,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/feeds
+    uri: https://api.direct.yandex.ru/json/v5/feeds
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":1000001}]}}'

--- a/tests/cassettes/test_integration_live_write/test_live_draft_smartadtargets_suspend_resume.yaml
+++ b/tests/cassettes/test_integration_live_write/test_live_draft_smartadtargets_suspend_resume.yaml
@@ -29,7 +29,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/feeds
+    uri: https://api.direct.yandex.ru/json/v5/feeds
   response:
     body:
       string: '{"result":{"AddResults":[{"Id":1000002}]}}'
@@ -91,7 +91,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/campaigns
+    uri: https://api.direct.yandex.ru/json/v5/campaigns
   response:
     body:
       string: "{\"result\":{\"AddResults\":[{\"Errors\":[{\"Code\":3500,\"Message\":\"Not
@@ -156,7 +156,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/feeds
+    uri: https://api.direct.yandex.ru/json/v5/feeds
   response:
     body:
       string: '{"result":{"DeleteResults":[{"Id":1000002}]}}'

--- a/tests/test_transport_contract.py
+++ b/tests/test_transport_contract.py
@@ -2,6 +2,16 @@ from pathlib import Path
 
 from direct_cli.wsdl_coverage import CLI_TO_API_SERVICE
 from direct_cli._vendor.tapi_yandex_direct import YandexDirect
+from direct_cli._vendor.tapi_yandex_direct.endpoints import (
+    DIRECT_API_PRODUCTION_ROOT,
+    DIRECT_API_SANDBOX_ROOT,
+    DIRECT_DEBUG_ROOT,
+    get_direct_api_root,
+)
+from direct_cli._vendor.tapi_yandex_direct.tapi_yandex_direct import (
+    YandexDirectClientAdapter,
+)
+from direct_cli._vendor.tapi_yandex_direct.v4.adapter import V4LiveClientAdapter
 
 
 def test_dependency_uses_axisrow_fork():
@@ -9,7 +19,9 @@ def test_dependency_uses_axisrow_fork():
         Path(__file__).resolve().parent.parent
         / "direct_cli/_vendor/tapi_yandex_direct/__init__.py"
     )
-    assert vendor_init.exists(), "Vendored tapi_yandex_direct not found in direct_cli/_vendor/"
+    assert (
+        vendor_init.exists()
+    ), "Vendored tapi_yandex_direct not found in direct_cli/_vendor/"
 
 
 def test_tapi_transport_exposes_cli_resource_executors():
@@ -21,3 +33,34 @@ def test_tapi_transport_exposes_cli_resource_executors():
     ]
 
     assert missing == []
+
+
+def test_direct_api_root_helper_uses_ru_hosts():
+    assert get_direct_api_root({}) == DIRECT_API_PRODUCTION_ROOT
+    assert get_direct_api_root({"is_sandbox": False}) == DIRECT_API_PRODUCTION_ROOT
+    assert get_direct_api_root({"is_sandbox": True}) == DIRECT_API_SANDBOX_ROOT
+
+
+def test_v5_adapter_uses_centralized_ru_hosts():
+    adapter = YandexDirectClientAdapter()
+
+    assert adapter.get_api_root({"is_sandbox": False}, "campaigns") == (
+        DIRECT_API_PRODUCTION_ROOT
+    )
+    assert adapter.get_api_root({"is_sandbox": True}, "campaigns") == (
+        DIRECT_API_SANDBOX_ROOT
+    )
+    assert adapter.get_api_root({"is_sandbox": False}, "debugtoken") == (
+        DIRECT_DEBUG_ROOT
+    )
+
+
+def test_v4_adapter_uses_centralized_ru_hosts():
+    adapter = V4LiveClientAdapter()
+
+    assert adapter.get_api_root({"is_sandbox": False}, "live") == (
+        DIRECT_API_PRODUCTION_ROOT
+    )
+    assert adapter.get_api_root({"is_sandbox": True}, "live") == (
+        DIRECT_API_SANDBOX_ROOT
+    )


### PR DESCRIPTION
## Summary

- Centralizes Yandex Direct runtime API roots in one vendored transport module.
- Reuses the shared endpoint helper from both v5 and v4 Live adapters.
- Updates sandbox docs/runner output and production live-write cassette URIs to the `.ru` host.

## Why

Issue #151 reports DNS failures resolving the `.com` CNAME before requests reach the API. The runtime adapters already target `.ru`; this PR makes that contract explicit, shared, and covered by tests.

## Validation

- `python -m pytest tests/test_transport_contract.py`
- `python -m pytest tests/test_vendor_imports.py tests/test_smoke_matrix.py`
- `python -m pytest tests/test_integration_write.py::TestWriteCampaignDraftLifecycle::test_draft_create_get_delete`
- `black --check direct_cli/_vendor/tapi_yandex_direct/endpoints.py direct_cli/_vendor/tapi_yandex_direct/tapi_yandex_direct.py direct_cli/_vendor/tapi_yandex_direct/v4/adapter.py tests/test_transport_contract.py scripts/sandbox_write_live.py`
- Checked that stale runtime `.com` cassette and sandbox README references are gone.