### PR TITLE
[codex] improve v4finance financial token guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,18 +118,24 @@ direct v4events get-events-log --from 2026-04-14T00:00:00 --to 2026-04-15T00:00:
 
 ### V4 Live Finance
 
-`get-credit-limits` requires a financial token and operation number. Pass them
-with `--finance-token` and `--operation-num`, or set
-`YANDEX_DIRECT_FINANCE_TOKEN` and `YANDEX_DIRECT_OPERATION_NUM`.
-Money mutation commands are dry-run-only in this release and always require
-`--dry-run`; dry-run output masks the financial token.
+Finance methods require an extra financial token for money operations. In the
+Yandex Direct web UI, open Tools -> API -> Financial operations, enable the
+financial operations checkbox, click Save, then issue the master token on the
+same Financial operations page and confirm by SMS. Direct CLI can compute the
+per-request token from `--master-token`, `--operation-num`, and
+`--finance-login`; alternatively pass a precomputed token with `--finance-token`.
+Environment variables are
+`YANDEX_DIRECT_MASTER_TOKEN`, `YANDEX_DIRECT_FINANCE_LOGIN`,
+`YANDEX_DIRECT_FINANCE_TOKEN`, and `YANDEX_DIRECT_OPERATION_NUM`. Money mutation
+commands are dry-run-only in this release and always require `--dry-run`; dry-run
+output masks the financial token.
 
 ```bash
-direct v4finance get-credit-limits --logins client-login --finance-token FINANCE_TOKEN --operation-num 123
+direct v4finance get-credit-limits --logins client-login --master-token MASTER_TOKEN --operation-num 123 --finance-login agency-login
 direct v4finance get-credit-limits --logins client-login,other-client --format table
 direct v4finance check-payment --custom-transaction-id A123456789012345678901234567890B
-direct v4finance transfer-money --from-campaign-id 123 --to-campaign-id 456 --amount 100.50 --finance-token FINANCE_TOKEN --operation-num 123 --dry-run
-direct v4finance pay-campaigns --campaign-id 123 --amount 100.50 --contract-id CONTRACT_ID --pay-method CREDIT --finance-token FINANCE_TOKEN --operation-num 123 --dry-run
+direct v4finance transfer-money --from-campaign-id 123 --to-campaign-id 456 --amount 100.50 --currency RUB --master-token MASTER_TOKEN --operation-num 123 --finance-login agency-login --dry-run
+direct v4finance pay-campaigns --campaign-ids 123,456 --amount 100.50 --currency RUB --contract-id CONTRACT_ID --pay-method Bank --master-token MASTER_TOKEN --operation-num 123 --finance-login agency-login --dry-run
 ```
 
 ### V4 Live Shared Account

--- a/direct_cli/commands/v4finance.py
+++ b/direct_cli/commands/v4finance.py
@@ -7,14 +7,23 @@ import click
 
 from ..api import create_v4_client
 from ..output import format_output, print_error
-from ..utils import parse_csv_strings
+from ..utils import parse_csv_strings, parse_ids
 from ..v4 import build_v4_body, call_v4
-from ..v4.money import parse_v4_money_sum
+from ..v4.money import build_finance_token, parse_v4_money_sum, validate_operation_num
 from ..v4_contracts import v4_method_contract
 from .v4shells import V4_EPILOG
 
 FINANCE_TOKEN_MASK = "<redacted>"
 CUSTOM_TRANSACTION_ID_RE = re.compile(r"[A-Za-z0-9]{32}")
+V4_FINANCE_CURRENCIES = ["RUB", "USD", "EUR", "BYN", "KZT", "TRY", "UAH", "CHF"]
+V4_PAY_METHODS = ["Bank", "Overdraft"]
+FINANCE_HELP_EPILOG = (
+    "To issue a master token in the Yandex Direct UI, open Tools -> API -> "
+    "Financial operations, enable the 'Allow financial operations' checkbox, "
+    "click Save, then issue the master token on the same Financial operations "
+    "page and confirm by SMS.\n\n"
+    f"{V4_EPILOG}"
+)
 
 
 def _logins_param(logins: str) -> list[str]:
@@ -27,18 +36,39 @@ def _logins_param(logins: str) -> list[str]:
 
 def _finance_credentials(
     finance_token: Optional[str],
+    master_token: Optional[str],
     operation_num: Optional[int],
+    finance_login: Optional[str],
+    method: str,
+    fallback_login: Optional[str],
 ) -> tuple[str, int]:
     """Validate and normalize finance credentials before any v4 Live API call."""
     normalized_token = (finance_token or "").strip()
-    if normalized_token and operation_num is not None:
+    normalized_master_token = (master_token or "").strip()
+    if normalized_token and normalized_master_token:
+        raise click.UsageError("Use either --finance-token or --master-token, not both")
+    if operation_num is None:
+        raise click.UsageError(_FINANCE_CREDENTIALS_ERROR)
+    operation_num = validate_operation_num(operation_num)
+    if normalized_token:
         return normalized_token, operation_num
+    if normalized_master_token:
+        login = (finance_login or fallback_login or "").strip()
+        if not login:
+            raise click.UsageError(
+                "Provide --finance-login or set YANDEX_DIRECT_FINANCE_LOGIN "
+                "when using --master-token"
+            )
+        return (
+            build_finance_token(normalized_master_token, operation_num, method, login),
+            operation_num,
+        )
     raise click.UsageError(_FINANCE_CREDENTIALS_ERROR)
 
 
 _FINANCE_CREDENTIALS_ERROR = (
-    "Provide --finance-token and --operation-num, or set "
-    "YANDEX_DIRECT_FINANCE_TOKEN and YANDEX_DIRECT_OPERATION_NUM"
+    "Provide --finance-token and --operation-num, or provide --master-token, "
+    "--operation-num, and --finance-login"
 )
 
 
@@ -64,6 +94,17 @@ def _non_empty_option(value: str, option_name: str) -> str:
     return normalized
 
 
+def _campaign_ids_param(campaign_ids: str) -> list[int]:
+    """Parse one or more campaign IDs."""
+    try:
+        parsed = parse_ids(campaign_ids)
+    except ValueError as exc:
+        raise click.UsageError(str(exc)) from exc
+    if not parsed:
+        raise click.UsageError("--campaign-ids must not be empty")
+    return parsed
+
+
 def _custom_transaction_id_param(custom_transaction_id: str) -> dict:
     """Build the v4 Live CheckPayment parameter."""
     normalized = (custom_transaction_id or "").strip()
@@ -74,7 +115,7 @@ def _custom_transaction_id_param(custom_transaction_id: str) -> dict:
     return {"CustomTransactionID": normalized}
 
 
-@click.group(epilog=V4_EPILOG)
+@click.group(epilog=FINANCE_HELP_EPILOG)
 def v4finance():
     """Yandex Direct v4 Live finance commands."""
 
@@ -85,13 +126,26 @@ def v4finance():
 @click.option(
     "--finance-token",
     envvar="YANDEX_DIRECT_FINANCE_TOKEN",
-    help="Financial token",
+    help="Precomputed financial token for this method",
+)
+@click.option(
+    "--master-token",
+    envvar="YANDEX_DIRECT_MASTER_TOKEN",
+    help=(
+        "Financial master token issued after enabling and saving financial "
+        "operations in Tools -> API -> Financial operations"
+    ),
 )
 @click.option(
     "--operation-num",
-    type=click.IntRange(min=0),
+    type=click.IntRange(min=1, max=9223372036854775807),
     envvar="YANDEX_DIRECT_OPERATION_NUM",
     help="Financial operation number",
+)
+@click.option(
+    "--finance-login",
+    envvar="YANDEX_DIRECT_FINANCE_LOGIN",
+    help="Login used in financial token generation",
 )
 @click.option(
     "--format",
@@ -107,14 +161,23 @@ def get_credit_limits(
     ctx,
     logins,
     finance_token,
+    master_token,
     operation_num,
+    finance_login,
     output_format,
     output,
     dry_run,
 ):
     """Get client credit limits."""
     login_list = _logins_param(logins)
-    finance_token, operation_num = _finance_credentials(finance_token, operation_num)
+    finance_token, operation_num = _finance_credentials(
+        finance_token,
+        master_token,
+        operation_num,
+        finance_login,
+        "GetCreditLimits",
+        ctx.obj.get("login"),
+    )
 
     if dry_run:
         format_output(
@@ -200,39 +263,80 @@ def check_payment(
 )
 @click.option("--amount", required=True, help="Positive amount, for example 100.50")
 @click.option(
+    "--currency",
+    default="RUB",
+    show_default=True,
+    type=click.Choice(V4_FINANCE_CURRENCIES, case_sensitive=False),
+    help="Payment currency",
+)
+@click.option(
     "--finance-token",
     envvar="YANDEX_DIRECT_FINANCE_TOKEN",
-    help="Financial token",
+    help="Precomputed financial token for this method",
+)
+@click.option(
+    "--master-token",
+    envvar="YANDEX_DIRECT_MASTER_TOKEN",
+    help=(
+        "Financial master token issued after enabling and saving financial "
+        "operations in Tools -> API -> Financial operations"
+    ),
 )
 @click.option(
     "--operation-num",
-    type=click.IntRange(min=0),
+    type=click.IntRange(min=1, max=9223372036854775807),
     envvar="YANDEX_DIRECT_OPERATION_NUM",
     help="Financial operation number",
+)
+@click.option(
+    "--finance-login",
+    envvar="YANDEX_DIRECT_FINANCE_LOGIN",
+    help="Login used in financial token generation",
 )
 @click.option(
     "--dry-run",
     is_flag=True,
     help="Show request without sending; required for this command",
 )
+@click.pass_context
 def transfer_money(
+    ctx,
     from_campaign_id,
     to_campaign_id,
     amount,
+    currency,
     finance_token,
+    master_token,
     operation_num,
+    finance_login,
     dry_run,
 ):
     """Preview transferring funds between campaigns."""
     _require_dry_run(dry_run)
-    _, operation_num = _finance_credentials(finance_token, operation_num)
+    _, operation_num = _finance_credentials(
+        finance_token,
+        master_token,
+        operation_num,
+        finance_login,
+        "TransferMoney",
+        ctx.obj.get("login"),
+    )
     parsed_amount = parse_v4_money_sum(amount)
+    currency = currency.upper()
     param = {
         "FromCampaigns": [
-            {"CampaignID": from_campaign_id, "Sum": parsed_amount},
+            {
+                "CampaignID": from_campaign_id,
+                "Sum": parsed_amount,
+                "Currency": currency,
+            },
         ],
         "ToCampaigns": [
-            {"CampaignID": to_campaign_id, "Sum": parsed_amount},
+            {
+                "CampaignID": to_campaign_id,
+                "Sum": parsed_amount,
+                "Currency": currency,
+            },
         ],
     }
 
@@ -246,50 +350,94 @@ def transfer_money(
 @v4_method_contract("PayCampaigns")
 @v4finance.command(name="pay-campaigns")
 @click.option(
-    "--campaign-id",
+    "--campaign-ids",
     required=True,
-    type=click.IntRange(min=1),
-    help="Campaign ID to pay",
+    help="Comma-separated campaign IDs to pay",
 )
 @click.option("--amount", required=True, help="Positive amount, for example 100.50")
-@click.option("--contract-id", required=True, help="Agency contract ID")
-@click.option("--pay-method", required=True, help="Payment method")
+@click.option(
+    "--currency",
+    default="RUB",
+    show_default=True,
+    type=click.Choice(V4_FINANCE_CURRENCIES, case_sensitive=False),
+    help="Payment currency",
+)
+@click.option("--contract-id", help="Agency contract ID; required for Bank")
+@click.option(
+    "--pay-method",
+    required=True,
+    type=click.Choice(V4_PAY_METHODS, case_sensitive=False),
+    help="Payment method",
+)
 @click.option(
     "--finance-token",
     envvar="YANDEX_DIRECT_FINANCE_TOKEN",
-    help="Financial token",
+    help="Precomputed financial token for this method",
+)
+@click.option(
+    "--master-token",
+    envvar="YANDEX_DIRECT_MASTER_TOKEN",
+    help=(
+        "Financial master token issued after enabling and saving financial "
+        "operations in Tools -> API -> Financial operations"
+    ),
 )
 @click.option(
     "--operation-num",
-    type=click.IntRange(min=0),
+    type=click.IntRange(min=1, max=9223372036854775807),
     envvar="YANDEX_DIRECT_OPERATION_NUM",
     help="Financial operation number",
+)
+@click.option(
+    "--finance-login",
+    envvar="YANDEX_DIRECT_FINANCE_LOGIN",
+    help="Login used in financial token generation",
 )
 @click.option(
     "--dry-run",
     is_flag=True,
     help="Show request without sending; required for this command",
 )
+@click.pass_context
 def pay_campaigns(
-    campaign_id,
+    ctx,
+    campaign_ids,
     amount,
+    currency,
     contract_id,
     pay_method,
     finance_token,
+    master_token,
     operation_num,
+    finance_login,
     dry_run,
 ):
     """Preview paying for a campaign from an agency credit limit."""
     _require_dry_run(dry_run)
-    _, operation_num = _finance_credentials(finance_token, operation_num)
+    _, operation_num = _finance_credentials(
+        finance_token,
+        master_token,
+        operation_num,
+        finance_login,
+        "PayCampaigns",
+        ctx.obj.get("login"),
+    )
     parsed_amount = parse_v4_money_sum(amount)
+    parsed_campaign_ids = _campaign_ids_param(campaign_ids)
+    currency = currency.upper()
+    pay_method = _non_empty_option(pay_method, "--pay-method")
+    contract_id = (contract_id or "").strip()
+    if pay_method == "Bank" and not contract_id:
+        raise click.UsageError("--contract-id is required when --pay-method Bank")
     param = {
         "Payments": [
-            {"CampaignID": campaign_id, "Sum": parsed_amount},
+            {"CampaignID": campaign_id, "Sum": parsed_amount, "Currency": currency}
+            for campaign_id in parsed_campaign_ids
         ],
-        "ContractID": _non_empty_option(contract_id, "--contract-id"),
-        "PayMethod": _non_empty_option(pay_method, "--pay-method"),
+        "PayMethod": pay_method,
     }
+    if contract_id:
+        param["ContractID"] = contract_id
 
     format_output(
         _masked_finance_body("PayCampaigns", param, operation_num),

--- a/direct_cli/commands/v4finance.py
+++ b/direct_cli/commands/v4finance.py
@@ -102,6 +102,8 @@ def _campaign_ids_param(campaign_ids: str) -> list[int]:
         raise click.UsageError(str(exc)) from exc
     if not parsed:
         raise click.UsageError("--campaign-ids must not be empty")
+    if any(campaign_id <= 0 for campaign_id in parsed):
+        raise click.UsageError("--campaign-ids must contain only positive integers")
     return parsed
 
 

--- a/direct_cli/v4/money.py
+++ b/direct_cli/v4/money.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from decimal import Decimal, InvalidOperation
+import hashlib
 import math
 import re
 
 import click
 
 _MONEY_RE = re.compile(r"^(?:0|[1-9]\d*)(?:\.\d{1,2})?$")
+MAX_OPERATION_NUM = 9223372036854775807
 
 
 def parse_v4_money_sum(value: str) -> float:
@@ -33,3 +35,44 @@ def parse_v4_money_sum(value: str) -> float:
     if not math.isfinite(result):
         raise click.UsageError("--amount must be a finite decimal amount")
     return result
+
+
+def normalize_finance_login(login: str) -> str:
+    """Normalize a Yandex login before financial token generation."""
+    normalized = (login or "").strip().lower()
+    if not normalized:
+        raise click.UsageError("--finance-login must not be empty")
+    return normalized
+
+
+def validate_operation_num(operation_num: int) -> int:
+    """Validate the v4 Live finance operation counter."""
+    if operation_num < 1 or operation_num > MAX_OPERATION_NUM:
+        raise click.UsageError(
+            "--operation-num must be between 1 and 9223372036854775807"
+        )
+    return operation_num
+
+
+def build_finance_token(
+    master_token: str,
+    operation_num: int,
+    method: str,
+    login: str,
+) -> str:
+    """Build a v4 Live finance token from the master token and operation data."""
+    normalized_master_token = (master_token or "").strip()
+    if not normalized_master_token:
+        raise click.UsageError("--master-token must not be empty")
+    normalized_operation_num = validate_operation_num(operation_num)
+    normalized_method = (method or "").strip()
+    if not normalized_method:
+        raise click.UsageError("finance method must not be empty")
+    normalized_login = normalize_finance_login(login)
+    payload = (
+        f"{normalized_master_token}"
+        f"{normalized_operation_num}"
+        f"{normalized_method}"
+        f"{normalized_login}"
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/direct_cli/v4_contracts.py
+++ b/direct_cli/v4_contracts.py
@@ -80,11 +80,12 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
         source_status=SOURCE_DOCS,
         live_probe_allowed=False,
         example_param={
-            "FromCampaigns": [{"CampaignID": 123, "Sum": 100.5}],
-            "ToCampaigns": [{"CampaignID": 456, "Sum": 100.5}],
+            "FromCampaigns": [{"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"}],
+            "ToCampaigns": [{"CampaignID": 456, "Sum": 100.5, "Currency": "RUB"}],
         },
         notes=(
-            "Official v4 docs define campaign-to-campaign transfer. "
+            "Official v4 docs define campaign-to-campaign transfer with "
+            "Currency on each transfer item. "
             "This CLI exposes dry-run only; the method is not live-probed."
         ),
     ),
@@ -100,12 +101,13 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
         source_status=SOURCE_DOCS,
         live_probe_allowed=False,
         example_param={
-            "Payments": [{"CampaignID": 123, "Sum": 100.5}],
+            "Payments": [{"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"}],
             "ContractID": "contract-id",
-            "PayMethod": "CREDIT",
+            "PayMethod": "Bank",
         },
         notes=(
-            "Official v4 docs define agency credit-limit payment. "
+            "Official v4 docs define agency credit-limit payment with "
+            "Currency on each payment item and PayMethod Bank/Overdraft. "
             "This CLI exposes dry-run only; the method is not live-probed."
         ),
     ),

--- a/scripts/test_dangerous_commands.sh
+++ b/scripts/test_dangerous_commands.sh
@@ -21,8 +21,8 @@ Local credential mutations:
   - direct auth use ...
 
 V4 Live finance money mutations (0.3.3 exposes dry-run-only previews):
-  - direct v4finance transfer-money --from-campaign-id ... --to-campaign-id ... --amount ... --dry-run
-  - direct v4finance pay-campaigns --campaign-id ... --amount ... --contract-id ... --pay-method ... --dry-run
+  - direct v4finance transfer-money --from-campaign-id ... --to-campaign-id ... --amount ... --currency ... --dry-run
+  - direct v4finance pay-campaigns --campaign-ids ... --amount ... --contract-id ... --pay-method ... --dry-run
 
 Production commands that are only allowed in automated smoke tests with --sandbox:
   - direct bids set ...

--- a/tests/API_COVERAGE.md
+++ b/tests/API_COVERAGE.md
@@ -57,6 +57,10 @@ appears in multiple categories, or if the current service/command counts drift.
 The public v4/Live4 finance docs found during milestone 0.3.3 list
 `CreateInvoice`, `GetCreditLimits`, `PayCampaigns`, and `TransferMoney`.
 No official `CheckPayment` page or `PaymentID` contract was found.
+Financial methods use an additional `finance_token`, computed from the
+master token, operation number, method name, and normalized login. Public
+dry-run examples mask the computed token. The docs-backed `PayCampaigns` and
+`TransferMoney` contracts require `Currency` on each payment/transfer item.
 
 Sandbox v4 Live probes on 2026-04-30 confirmed the runtime request shape for
 `CheckPayment`:

--- a/tests/MANUAL_COVERAGE.md
+++ b/tests/MANUAL_COVERAGE.md
@@ -32,8 +32,9 @@ account requirements, or external dependencies.
   `PayCampaigns`, and `TransferMoney` are financial side-effect operations.
   `TransferMoney` and `PayCampaigns` remain dry-run-only in the public CLI.
   `CreateInvoice` is not exposed until a separate sandbox-write contract probe
-  can run with `YANDEX_DIRECT_FINANCE_TOKEN` and
-  `YANDEX_DIRECT_OPERATION_NUM`; without them sandbox returns
+  can run with either `YANDEX_DIRECT_FINANCE_TOKEN` or
+  `YANDEX_DIRECT_MASTER_TOKEN` plus `YANDEX_DIRECT_FINANCE_LOGIN`, and
+  `YANDEX_DIRECT_OPERATION_NUM`; without financial credentials sandbox returns
   `error_code=350 Invalid financial transaction token`.
 - **v4finance check-payment** — read-only. Official public docs were not found;
   sandbox v4 Live confirms `CustomTransactionID` (32 latin alphanumeric

--- a/tests/test_v4_contracts.py
+++ b/tests/test_v4_contracts.py
@@ -143,8 +143,8 @@ def test_v4finance_money_contracts_are_docs_backed_dangerous_objects():
     assert build_v4_body("TransferMoney", transfer.example_param) == {
         "method": "TransferMoney",
         "param": {
-            "FromCampaigns": [{"CampaignID": 123, "Sum": 100.5}],
-            "ToCampaigns": [{"CampaignID": 456, "Sum": 100.5}],
+            "FromCampaigns": [{"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"}],
+            "ToCampaigns": [{"CampaignID": 456, "Sum": 100.5, "Currency": "RUB"}],
         },
     }
 
@@ -154,9 +154,9 @@ def test_v4finance_money_contracts_are_docs_backed_dangerous_objects():
     assert build_v4_body("PayCampaigns", pay.example_param) == {
         "method": "PayCampaigns",
         "param": {
-            "Payments": [{"CampaignID": 123, "Sum": 100.5}],
+            "Payments": [{"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"}],
             "ContractID": "contract-id",
-            "PayMethod": "CREDIT",
+            "PayMethod": "Bank",
         },
     }
 

--- a/tests/test_v4finance_money.py
+++ b/tests/test_v4finance_money.py
@@ -344,6 +344,27 @@ def test_pay_campaigns_requires_contract_for_bank():
     assert "--contract-id is required when --pay-method Bank" in result.output
 
 
+def test_pay_campaigns_rejects_non_positive_campaign_ids():
+    result = _invoke(
+        "v4finance",
+        "pay-campaigns",
+        "--campaign-ids",
+        "0,-1",
+        "--amount",
+        "100.50",
+        "--pay-method",
+        "Overdraft",
+        "--finance-token",
+        "finance-token",
+        "--operation-num",
+        "42",
+        "--dry-run",
+    )
+
+    assert result.exit_code != 0
+    assert "--campaign-ids must contain only positive integers" in result.output
+
+
 def test_pay_campaigns_allows_overdraft_without_contract():
     result = _invoke(
         "v4finance",

--- a/tests/test_v4finance_money.py
+++ b/tests/test_v4finance_money.py
@@ -8,7 +8,11 @@ from click.testing import CliRunner
 
 from direct_cli.cli import cli
 from direct_cli.v4_contracts import get_v4_contract
-from direct_cli.v4.money import parse_v4_money_sum
+from direct_cli.v4.money import (
+    build_finance_token,
+    normalize_finance_login,
+    parse_v4_money_sum,
+)
 
 
 def _invoke(*args: str, env: Optional[dict] = None):
@@ -16,7 +20,9 @@ def _invoke(*args: str, env: Optional[dict] = None):
         "YANDEX_DIRECT_TOKEN": "",
         "YANDEX_DIRECT_LOGIN": "",
         "YANDEX_DIRECT_FINANCE_TOKEN": "",
+        "YANDEX_DIRECT_MASTER_TOKEN": "",
         "YANDEX_DIRECT_OPERATION_NUM": "",
+        "YANDEX_DIRECT_FINANCE_LOGIN": "",
     }
     if env:
         base_env.update(env)
@@ -44,6 +50,23 @@ def test_parse_v4_money_sum_rejects_invalid_amounts(value):
         parse_v4_money_sum(value)
 
 
+def test_build_finance_token_uses_docs_formula_and_normalized_login():
+    token = build_finance_token(
+        "master-token",
+        42,
+        "TransferMoney",
+        " Agency-Login ",
+    )
+
+    assert normalize_finance_login(" Agency-Login ") == "agency-login"
+    assert token == "26a042849d1c395595b87a4248f34489788ab4c83d23bdabb4fa128042a0904c"
+
+
+def test_build_finance_token_rejects_invalid_operation_num():
+    with pytest.raises(UsageError):
+        build_finance_token("master-token", 0, "TransferMoney", "agency-login")
+
+
 def test_transfer_money_dry_run_uses_campaign_arrays_and_masks_finance_token():
     result = _invoke(
         "v4finance",
@@ -66,8 +89,8 @@ def test_transfer_money_dry_run_uses_campaign_arrays_and_masks_finance_token():
     assert json.loads(result.output) == {
         "method": "TransferMoney",
         "param": {
-            "FromCampaigns": [{"CampaignID": 123, "Sum": 100.5}],
-            "ToCampaigns": [{"CampaignID": 456, "Sum": 100.5}],
+            "FromCampaigns": [{"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"}],
+            "ToCampaigns": [{"CampaignID": 456, "Sum": 100.5, "Currency": "RUB"}],
         },
         "finance_token": "<redacted>",
         "operation_num": 42,
@@ -78,14 +101,14 @@ def test_pay_campaigns_dry_run_uses_payment_object_and_masks_finance_token():
     result = _invoke(
         "v4finance",
         "pay-campaigns",
-        "--campaign-id",
-        "123",
+        "--campaign-ids",
+        "123,456",
         "--amount",
         "100.50",
         "--contract-id",
         "contract-id",
         "--pay-method",
-        "CREDIT",
+        "Bank",
         "--finance-token",
         "secret-finance-token",
         "--operation-num",
@@ -98,9 +121,12 @@ def test_pay_campaigns_dry_run_uses_payment_object_and_masks_finance_token():
     assert json.loads(result.output) == {
         "method": "PayCampaigns",
         "param": {
-            "Payments": [{"CampaignID": 123, "Sum": 100.5}],
+            "Payments": [
+                {"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"},
+                {"CampaignID": 456, "Sum": 100.5, "Currency": "RUB"},
+            ],
             "ContractID": "contract-id",
-            "PayMethod": "CREDIT",
+            "PayMethod": "Bank",
         },
         "finance_token": "<redacted>",
         "operation_num": 42,
@@ -127,6 +153,81 @@ def test_transfer_money_uses_finance_env_fallback_for_dry_run():
     assert result.exit_code == 0
     assert "env-finance-token" not in result.output
     assert json.loads(result.output)["operation_num"] == 77
+
+
+def test_transfer_money_can_compute_finance_token_from_master_token():
+    with patch("direct_cli.commands.v4finance.build_finance_token") as build_token:
+        build_token.return_value = "computed-finance-token"
+        result = _invoke(
+            "v4finance",
+            "transfer-money",
+            "--from-campaign-id",
+            "123",
+            "--to-campaign-id",
+            "456",
+            "--amount",
+            "100.50",
+            "--master-token",
+            "master-token",
+            "--operation-num",
+            "42",
+            "--finance-login",
+            "Agency-Login",
+            "--dry-run",
+        )
+
+    assert result.exit_code == 0
+    assert "computed-finance-token" not in result.output
+    build_token.assert_called_once_with(
+        "master-token",
+        42,
+        "TransferMoney",
+        "Agency-Login",
+    )
+
+
+def test_finance_credentials_reject_token_and_master_token_conflict():
+    result = _invoke(
+        "v4finance",
+        "transfer-money",
+        "--from-campaign-id",
+        "123",
+        "--to-campaign-id",
+        "456",
+        "--amount",
+        "100.50",
+        "--finance-token",
+        "finance-token",
+        "--master-token",
+        "master-token",
+        "--operation-num",
+        "42",
+        "--dry-run",
+    )
+
+    assert result.exit_code != 0
+    assert "Use either --finance-token or --master-token" in result.output
+
+
+def test_master_token_requires_finance_login_without_login_fallback():
+    result = _invoke(
+        "v4finance",
+        "transfer-money",
+        "--from-campaign-id",
+        "123",
+        "--to-campaign-id",
+        "456",
+        "--amount",
+        "100.50",
+        "--master-token",
+        "master-token",
+        "--operation-num",
+        "42",
+        "--dry-run",
+    )
+
+    assert result.exit_code != 0
+    assert "Provide --finance-login" in result.output
 
 
 def test_v4finance_money_commands_require_dry_run_before_api_call():
@@ -160,14 +261,14 @@ def test_v4finance_money_commands_require_finance_credentials_before_api_call():
             "token",
             "v4finance",
             "pay-campaigns",
-            "--campaign-id",
+            "--campaign-ids",
             "123",
             "--amount",
             "100.50",
             "--contract-id",
             "contract-id",
             "--pay-method",
-            "CREDIT",
+            "Bank",
             "--dry-run",
         )
 
@@ -203,14 +304,14 @@ def test_v4finance_money_commands_reject_blank_string_options():
     result = _invoke(
         "v4finance",
         "pay-campaigns",
-        "--campaign-id",
+        "--campaign-ids",
         "123",
         "--amount",
         "100.50",
         "--contract-id",
         "contract-id",
         "--pay-method",
-        "   ",
+        "Invalid",
         "--finance-token",
         "finance-token",
         "--operation-num",
@@ -219,7 +320,54 @@ def test_v4finance_money_commands_reject_blank_string_options():
     )
 
     assert result.exit_code != 0
-    assert "--pay-method must not be empty" in result.output
+    assert "Invalid value for '--pay-method'" in result.output
+
+
+def test_pay_campaigns_requires_contract_for_bank():
+    result = _invoke(
+        "v4finance",
+        "pay-campaigns",
+        "--campaign-ids",
+        "123",
+        "--amount",
+        "100.50",
+        "--pay-method",
+        "Bank",
+        "--finance-token",
+        "finance-token",
+        "--operation-num",
+        "42",
+        "--dry-run",
+    )
+
+    assert result.exit_code != 0
+    assert "--contract-id is required when --pay-method Bank" in result.output
+
+
+def test_pay_campaigns_allows_overdraft_without_contract():
+    result = _invoke(
+        "v4finance",
+        "pay-campaigns",
+        "--campaign-ids",
+        "123",
+        "--amount",
+        "100.50",
+        "--pay-method",
+        "Overdraft",
+        "--currency",
+        "usd",
+        "--finance-token",
+        "finance-token",
+        "--operation-num",
+        "42",
+        "--dry-run",
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output)["param"] == {
+        "Payments": [{"CampaignID": 123, "Sum": 100.5, "Currency": "USD"}],
+        "PayMethod": "Overdraft",
+    }
 
 
 def test_check_payment_dry_run_uses_custom_transaction_id_object():

--- a/tests/test_v4finance_read.py
+++ b/tests/test_v4finance_read.py
@@ -13,7 +13,9 @@ def _invoke(*args: str, env: Optional[dict] = None):
         "YANDEX_DIRECT_TOKEN": "",
         "YANDEX_DIRECT_LOGIN": "",
         "YANDEX_DIRECT_FINANCE_TOKEN": "",
+        "YANDEX_DIRECT_MASTER_TOKEN": "",
         "YANDEX_DIRECT_OPERATION_NUM": "",
+        "YANDEX_DIRECT_FINANCE_LOGIN": "",
     }
     if env:
         base_env.update(env)
@@ -65,6 +67,33 @@ def test_get_credit_limits_uses_finance_env_fallback_for_dry_run():
         "finance_token": "<redacted>",
         "operation_num": 77,
     }
+
+
+def test_get_credit_limits_can_compute_finance_token_from_master_token():
+    with patch("direct_cli.commands.v4finance.build_finance_token") as build_token:
+        build_token.return_value = "computed-finance-token"
+        result = _invoke(
+            "v4finance",
+            "get-credit-limits",
+            "--logins",
+            "client-login",
+            "--master-token",
+            "master-token",
+            "--operation-num",
+            "42",
+            "--finance-login",
+            "Agency-Login",
+            "--dry-run",
+        )
+
+    assert result.exit_code == 0
+    assert "computed-finance-token" not in result.output
+    build_token.assert_called_once_with(
+        "master-token",
+        42,
+        "GetCreditLimits",
+        "Agency-Login",
+    )
 
 
 def test_get_credit_limits_requires_finance_credentials_before_api_call():
@@ -167,9 +196,7 @@ def test_get_credit_limits_formats_mocked_response_as_json():
             )
 
     assert result.exit_code == 0
-    assert json.loads(result.output) == [
-        {"Login": "client-login", "CreditLimit": 1000}
-    ]
+    assert json.loads(result.output) == [{"Login": "client-login", "CreditLimit": 1000}]
     create_client.assert_called_once_with(
         token="token",
         login="agency-login",


### PR DESCRIPTION
## Summary

- add v4 finance token generation from master token, operation number, method, and finance login
- update v4finance money dry-run bodies to match docs-backed Currency and PayMethod contracts
- document the Russian Yandex Direct UI flow for enabling financial operations, saving, issuing the master token, and confirming by SMS

## Validation

- python3 -m pytest -q
- python3 -m pytest -q tests/test_v4finance_money.py tests/test_v4finance_read.py
- git diff --check