### PR TITLE
[codex] Document v4account shared-account contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,9 @@ direct v4finance pay-campaigns --campaign-ids 123,456 --amount 100.50 --currency
 ### V4 Live Shared Account
 
 Shared-account mutations are dry-run-only in this release and always require
-`--dry-run`.
+`--dry-run`. These commands follow the official v4 Live shared-account method
+shapes: `EnableSharedAccount` accepts one client `Login`, and
+`AccountManagement` updates shared-account settings through `Accounts`.
 
 ```bash
 direct v4account enable-shared-account --client-login client-login --dry-run


### PR DESCRIPTION
## Summary

- document that v4account shared-account commands follow the official v4 Live method shapes
- clarify that EnableSharedAccount uses one client Login and AccountManagement updates shared-account settings through Accounts

## Validation

- python3 -m pytest -q tests/test_v4account.py tests/test_v4_safety.py tests/test_v4_contracts.py tests/test_smoke_matrix.py

Closes #133