### PR TITLE
[codex] fix reports json defaults

### DIFF
--- a/direct_cli/_vendor/tapi_yandex_direct/tapi_yandex_direct.py
+++ b/direct_cli/_vendor/tapi_yandex_direct/tapi_yandex_direct.py
@@ -1,5 +1,6 @@
 import io
 import logging
+import re
 import time
 from typing import Union, Optional, Dict, List, Iterator
 
@@ -63,6 +64,7 @@ RESULT_DICTIONARY_KEYS_OF_API_METHODS = {
     },
 }
 REPORTS_RESOURCE_URL = "/json/v5/reports"
+REPORT_SUMMARY_RE = re.compile(r"^Total rows: \d+$")
 
 
 class YandexDirectClientAdapter(JSONAdapterMixin, TapiAdapter):
@@ -173,10 +175,11 @@ class YandexDirectClientAdapter(JSONAdapterMixin, TapiAdapter):
             data = super().process_response(response, request_kwargs, **kwargs)
 
         if response.request.path_url == REPORTS_RESOURCE_URL:
-            lines = self._iter_lines(data=data, response=response, **kwargs)
-            kwargs["store"]["columns"] = next(lines).split("\t")
+            self._store_report_columns(data, response, request_kwargs, **kwargs)
         else:
             kwargs["store"].pop("columns", None)
+            kwargs["store"].pop("report_data_start_line", None)
+            kwargs["store"].pop("report_header_offset", None)
 
         return data
 
@@ -306,14 +309,89 @@ class YandexDirectClientAdapter(JSONAdapterMixin, TapiAdapter):
             raise NotImplementedError("For reports resource only")
 
         lines = io.StringIO(data)
-        iterator = (line.replace("\n", "") for line in lines)
+        iterator = (line.rstrip("\r\n") for line in lines)
 
         return iterator
 
+    def _store_report_columns(
+        self,
+        data: str,
+        response: Response,
+        request_kwargs: dict,
+        **kwargs,
+    ) -> None:
+        field_names = self._get_report_field_names(request_kwargs)
+        if self._is_skip_column_header(request_kwargs):
+            if not field_names:
+                raise ValueError("Report response has no column header or FieldNames")
+            data_start_line = self._find_first_report_data_line(
+                data, response, **kwargs
+            )
+            kwargs["store"]["columns"] = field_names
+            kwargs["store"]["report_data_start_line"] = data_start_line
+            kwargs["store"]["report_header_offset"] = data_start_line
+            return
+
+        for index, line in enumerate(
+            self._iter_lines(data=data, response=response, **kwargs)
+        ):
+            if self._is_report_prelude_line(line):
+                continue
+            values = line.split("\t")
+            if field_names and values == field_names:
+                kwargs["store"]["columns"] = values
+                kwargs["store"]["report_data_start_line"] = index + 1
+                kwargs["store"]["report_header_offset"] = index
+                return
+            if "\t" in line:
+                kwargs["store"]["columns"] = values
+                kwargs["store"]["report_data_start_line"] = index + 1
+                kwargs["store"]["report_header_offset"] = index
+                return
+
+        raise ValueError("Report response has no column header")
+
+    def _find_first_report_data_line(
+        self, data: str, response: Response, **kwargs
+    ) -> int:
+        for index, line in enumerate(
+            self._iter_lines(data=data, response=response, **kwargs)
+        ):
+            if self._is_report_prelude_line(line) or self._is_report_summary_line(line):
+                continue
+            return index
+        return index + 1 if "index" in locals() else 0
+
+    @staticmethod
+    def _get_report_field_names(request_kwargs: dict) -> List[str]:
+        params = request_kwargs.get("data", {}).get("params", {})
+        return list(params.get("FieldNames") or [])
+
+    @staticmethod
+    def _is_skip_column_header(request_kwargs: dict) -> bool:
+        value = request_kwargs.get("headers", {}).get("skipColumnHeader")
+        return str(value).lower() == "true"
+
+    @staticmethod
+    def _is_report_title_line(line: str) -> bool:
+        return "\t" not in line and line.strip().startswith('"')
+
+    @staticmethod
+    def _is_report_summary_line(line: str) -> bool:
+        return bool(REPORT_SUMMARY_RE.match(line.strip()))
+
+    def _is_report_prelude_line(self, line: str) -> bool:
+        return not line.strip() or self._is_report_title_line(line)
+
     def iter_lines(self, **kwargs) -> Iterator[str]:
         iterator = self._iter_lines(**kwargs)
-        next(iterator)  # skipping columns
-        yield from iterator
+        data_start_line = kwargs["store"].get("report_data_start_line", 1)
+        for index, line in enumerate(iterator):
+            if index < data_start_line:
+                continue
+            if not line.strip() or self._is_report_summary_line(line):
+                continue
+            yield line
 
     def iter_values(self, **kwargs) -> Iterator[list]:
         for line in self.iter_lines(**kwargs):

--- a/direct_cli/_vendor/tapi_yandex_direct/tapi_yandex_direct.py
+++ b/direct_cli/_vendor/tapi_yandex_direct/tapi_yandex_direct.py
@@ -176,10 +176,14 @@ class YandexDirectClientAdapter(JSONAdapterMixin, TapiAdapter):
 
         if response.request.path_url == REPORTS_RESOURCE_URL:
             self._store_report_columns(data, response, request_kwargs, **kwargs)
+            kwargs["store"]["skip_report_summary"] = self._is_skip_report_summary(
+                request_kwargs
+            )
         else:
             kwargs["store"].pop("columns", None)
             kwargs["store"].pop("report_data_start_line", None)
             kwargs["store"].pop("report_header_offset", None)
+            kwargs["store"].pop("skip_report_summary", None)
 
         return data
 
@@ -373,6 +377,11 @@ class YandexDirectClientAdapter(JSONAdapterMixin, TapiAdapter):
         return str(value).lower() == "true"
 
     @staticmethod
+    def _is_skip_report_summary(request_kwargs: dict) -> bool:
+        value = request_kwargs.get("headers", {}).get("skipReportSummary", True)
+        return str(value).lower() == "true"
+
+    @staticmethod
     def _is_report_title_line(line: str) -> bool:
         return "\t" not in line and line.strip().startswith('"')
 
@@ -386,20 +395,27 @@ class YandexDirectClientAdapter(JSONAdapterMixin, TapiAdapter):
     def iter_lines(self, **kwargs) -> Iterator[str]:
         iterator = self._iter_lines(**kwargs)
         data_start_line = kwargs["store"].get("report_data_start_line", 1)
+        skip_report_summary = kwargs["store"].get("skip_report_summary", True)
         for index, line in enumerate(iterator):
             if index < data_start_line:
                 continue
-            if not line.strip() or self._is_report_summary_line(line):
+            if not line.strip():
+                continue
+            if skip_report_summary and self._is_report_summary_line(line):
                 continue
             yield line
 
     def iter_values(self, **kwargs) -> Iterator[list]:
         for line in self.iter_lines(**kwargs):
-            yield line.split("\t")
+            values = line.split("\t")
+            if self._is_report_summary_line(line):
+                columns_count = len(kwargs["store"]["columns"])
+                values.extend([""] * (columns_count - len(values)))
+            yield values
 
     def iter_dicts(self, **kwargs) -> Iterator[dict]:
-        for line in self.iter_lines(**kwargs):
-            yield dict(zip(kwargs["store"]["columns"], line.split("\t")))
+        for values in self.iter_values(**kwargs):
+            yield dict(zip(kwargs["store"]["columns"], values))
 
     def to_values(self, **kwargs) -> List[list]:
         return list(self.iter_values(**kwargs))

--- a/direct_cli/commands/reports.py
+++ b/direct_cli/commands/reports.py
@@ -323,10 +323,9 @@ def reports():
     help="Processing mode: auto, online, offline",
 )
 @click.option(
-    "--skip-report-header",
-    is_flag=True,
-    default=False,
-    help="Omit report header row",
+    "--skip-report-header/--no-skip-report-header",
+    default=True,
+    help="Omit report header row (default: yes)",
 )
 @click.option(
     "--skip-column-header",
@@ -335,10 +334,9 @@ def reports():
     help="Omit column header row",
 )
 @click.option(
-    "--skip-report-summary",
-    is_flag=True,
-    default=False,
-    help="Omit report summary row",
+    "--skip-report-summary/--no-skip-report-summary",
+    default=True,
+    help="Omit report summary row (default: yes)",
 )
 @click.option(
     "--return-money-in-micros",

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -520,8 +520,123 @@ class TestApiCoverage:
         assert captured["kwargs"]["processing_mode"] == "online"
         assert captured["kwargs"]["skip_report_header"] is True
         assert captured["kwargs"]["skip_column_header"] is True
+        assert captured["kwargs"]["skip_report_summary"] is True
         assert captured["kwargs"]["return_money_in_micros"] is True
         assert captured["kwargs"]["language"] == "ru"
+
+    def test_reports_get_cli_defaults_skip_report_header_and_summary(
+        self, monkeypatch
+    ):
+        """reports get defaults keep column header but omit report header/summary."""
+        captured = {}
+        reports_module = importlib.import_module("direct_cli.commands.reports")
+
+        class _FakeResponse:
+            columns = ["Date"]
+
+            def __call__(self):
+                return self
+
+            def to_dicts(self):
+                return [{"Date": "2026-01-01"}]
+
+            def to_values(self):
+                return [["2026-01-01"]]
+
+        class _FakeReports:
+            def post(self, data):
+                return _FakeResponse()
+
+        class _FakeClient:
+            def reports(self):
+                return _FakeReports()
+
+        def _fake_create_client(**kwargs):
+            captured["kwargs"] = kwargs
+            return _FakeClient()
+
+        monkeypatch.setattr(reports_module, "create_client", _fake_create_client)
+
+        result = CliRunner().invoke(
+            cli,
+            [
+                "reports",
+                "get",
+                "--type",
+                "campaign_performance_report",
+                "--from",
+                "2026-01-01",
+                "--to",
+                "2026-01-31",
+                "--name",
+                "Test",
+                "--fields",
+                "Date",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert captured["kwargs"]["skip_report_header"] is True
+        assert captured["kwargs"]["skip_column_header"] is False
+        assert captured["kwargs"]["skip_report_summary"] is True
+
+    def test_reports_get_cli_no_skip_report_header_and_summary_opt_out(
+        self, monkeypatch
+    ):
+        """--no-skip-* lets users request report header/summary rows."""
+        captured = {}
+        reports_module = importlib.import_module("direct_cli.commands.reports")
+
+        class _FakeResponse:
+            columns = ["Date"]
+
+            def __call__(self):
+                return self
+
+            def to_dicts(self):
+                return [{"Date": "2026-01-01"}]
+
+            def to_values(self):
+                return [["2026-01-01"]]
+
+        class _FakeReports:
+            def post(self, data):
+                return _FakeResponse()
+
+        class _FakeClient:
+            def reports(self):
+                return _FakeReports()
+
+        def _fake_create_client(**kwargs):
+            captured["kwargs"] = kwargs
+            return _FakeClient()
+
+        monkeypatch.setattr(reports_module, "create_client", _fake_create_client)
+
+        result = CliRunner().invoke(
+            cli,
+            [
+                "reports",
+                "get",
+                "--type",
+                "campaign_performance_report",
+                "--from",
+                "2026-01-01",
+                "--to",
+                "2026-01-31",
+                "--name",
+                "Test",
+                "--fields",
+                "Date",
+                "--no-skip-report-header",
+                "--no-skip-report-summary",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert captured["kwargs"]["skip_report_header"] is False
+        assert captured["kwargs"]["skip_column_header"] is False
+        assert captured["kwargs"]["skip_report_summary"] is False
 
     def test_api_coverage_report_script_matches_strict_parity_contract(self):
         result = subprocess.run(

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -2346,8 +2346,6 @@ def test_reports_get_dry_run_outputs_request():
             "Date,CampaignId",
             "--processing-mode",
             "online",
-            "--skip-report-header",
-            "--skip-report-summary",
             "--dry-run",
         ],
     )
@@ -2362,6 +2360,35 @@ def test_reports_get_dry_run_outputs_request():
     assert body_params["ReportType"] == "CAMPAIGN_PERFORMANCE_REPORT"
     assert body_params["DateRangeType"] == "CUSTOM_DATE"
     assert "SelectionCriteria" in body_params
+
+
+def test_reports_get_dry_run_no_skip_header_summary_opt_out():
+    """--no-skip-report-* omits default skip headers from dry-run output."""
+    result = CliRunner().invoke(
+        cli,
+        [
+            "reports",
+            "get",
+            "--type",
+            "campaign_performance_report",
+            "--from",
+            "2026-01-01",
+            "--to",
+            "2026-01-31",
+            "--name",
+            "Dry Run Report",
+            "--fields",
+            "Date,CampaignId",
+            "--no-skip-report-header",
+            "--no-skip-report-summary",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert "skipReportHeader" not in data["headers"]
+    assert "skipReportSummary" not in data["headers"]
+    assert "skipColumnHeader" not in data["headers"]
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_reports_parsing.py
+++ b/tests/test_reports_parsing.py
@@ -1,0 +1,208 @@
+import json
+
+import pytest
+from click.testing import CliRunner
+from requests import PreparedRequest, Response
+
+from direct_cli.cli import cli
+from direct_cli._vendor.tapi_yandex_direct.tapi_yandex_direct import (
+    YandexDirectClientAdapter,
+)
+
+
+FIELD_NAMES = ["Month", "Impressions", "Clicks", "Cost"]
+REPORT_ROWS = [
+    ["2026-03-01", "10", "2", "1500000"],
+    ["2026-03-02", "20", "3", "2500000"],
+]
+EXPECTED_DICTS = [
+    {
+        "Month": "2026-03-01",
+        "Impressions": "10",
+        "Clicks": "2",
+        "Cost": "1500000",
+    },
+    {
+        "Month": "2026-03-02",
+        "Impressions": "20",
+        "Clicks": "3",
+        "Cost": "2500000",
+    },
+]
+
+
+def _report_body(
+    *,
+    skip_report_header: bool,
+    skip_column_header: bool,
+    skip_report_summary: bool,
+    field_names: list[str] | None = None,
+    rows: list[list[str]] | None = None,
+) -> str:
+    field_names = field_names or FIELD_NAMES
+    rows = rows or REPORT_ROWS
+    lines = []
+    if not skip_report_header:
+        lines.extend(['"Test"', ""])
+    if not skip_column_header:
+        lines.append("\t".join(field_names))
+    lines.extend("\t".join(row) for row in rows)
+    if not skip_report_summary:
+        lines.append(f"Total rows: {len(rows)}")
+    return "\n".join(lines) + "\n"
+
+
+class _ParsedReport:
+    def __init__(
+        self,
+        body: str,
+        *,
+        field_names: list[str] | None = None,
+        skip_column_header: bool = False,
+    ):
+        self.adapter = YandexDirectClientAdapter()
+        self.response = self._make_response(body)
+        self.store = {}
+        self.data = self.adapter.process_response(
+            self.response,
+            {
+                "data": json.dumps(
+                    {"params": {"FieldNames": field_names or FIELD_NAMES}}
+                ).encode(),
+                "headers": {
+                    "skipColumnHeader": str(skip_column_header).lower(),
+                },
+            },
+            store=self.store,
+        )
+
+    @staticmethod
+    def _make_response(body: str) -> Response:
+        request = PreparedRequest()
+        request.prepare(
+            method="POST",
+            url="https://api.direct.yandex.com/json/v5/reports",
+        )
+        response = Response()
+        response.status_code = 200
+        response._content = body.encode()
+        response.request = request
+        return response
+
+    def __call__(self):
+        return self
+
+    @property
+    def columns(self):
+        return self.store["columns"]
+
+    def to_dicts(self):
+        return self.adapter.to_dicts(
+            data=self.data,
+            response=self.response,
+            store=self.store,
+        )
+
+    def to_values(self):
+        return self.adapter.to_values(
+            data=self.data,
+            response=self.response,
+            store=self.store,
+        )
+
+    def to_lines(self):
+        return self.adapter.to_lines(
+            data=self.data,
+            response=self.response,
+            store=self.store,
+        )
+
+
+@pytest.mark.parametrize("skip_report_header", [True, False])
+@pytest.mark.parametrize("skip_column_header", [True, False])
+@pytest.mark.parametrize("skip_report_summary", [True, False])
+def test_reports_adapter_parses_rows_for_all_header_summary_combinations(
+    skip_report_header,
+    skip_column_header,
+    skip_report_summary,
+):
+    report = _ParsedReport(
+        _report_body(
+            skip_report_header=skip_report_header,
+            skip_column_header=skip_column_header,
+            skip_report_summary=skip_report_summary,
+        ),
+        skip_column_header=skip_column_header,
+    )
+
+    assert report.columns == FIELD_NAMES
+    assert report.to_dicts() == EXPECTED_DICTS
+    assert report.to_values() == REPORT_ROWS
+
+
+def test_reports_adapter_parses_single_field_report_with_header_and_summary():
+    report = _ParsedReport(
+        _report_body(
+            skip_report_header=False,
+            skip_column_header=False,
+            skip_report_summary=False,
+            field_names=["Month"],
+            rows=[["2026-03-01"], ["2026-03-02"]],
+        ),
+        field_names=["Month"],
+    )
+
+    assert report.columns == ["Month"]
+    assert report.to_dicts() == [
+        {"Month": "2026-03-01"},
+        {"Month": "2026-03-02"},
+    ]
+
+
+def test_reports_get_json_opt_out_uses_columns_not_report_title(monkeypatch):
+    reports_module = pytest.importorskip("direct_cli.commands.reports")
+
+    class _FakeReports:
+        def post(self, data):
+            return _ParsedReport(
+                _report_body(
+                    skip_report_header=False,
+                    skip_column_header=False,
+                    skip_report_summary=False,
+                )
+            )
+
+    class _FakeClient:
+        def reports(self):
+            return _FakeReports()
+
+    monkeypatch.setattr(
+        reports_module,
+        "create_client",
+        lambda **kwargs: _FakeClient(),
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "reports",
+            "get",
+            "--type",
+            "custom_report",
+            "--from",
+            "2026-03-01",
+            "--to",
+            "2026-03-31",
+            "--name",
+            "Test",
+            "--fields",
+            "Month,Impressions,Clicks,Cost",
+            "--format",
+            "json",
+            "--no-skip-report-header",
+            "--no-skip-report-summary",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == EXPECTED_DICTS

--- a/tests/test_reports_parsing.py
+++ b/tests/test_reports_parsing.py
@@ -59,6 +59,7 @@ class _ParsedReport:
         *,
         field_names: list[str] | None = None,
         skip_column_header: bool = False,
+        skip_report_summary: bool = True,
     ):
         self.adapter = YandexDirectClientAdapter()
         self.response = self._make_response(body)
@@ -71,6 +72,7 @@ class _ParsedReport:
                 ).encode(),
                 "headers": {
                     "skipColumnHeader": str(skip_column_header).lower(),
+                    "skipReportSummary": str(skip_report_summary).lower(),
                 },
             },
             store=self.store,
@@ -117,6 +119,15 @@ class _ParsedReport:
             store=self.store,
         )
 
+    def iter_dicts(self):
+        return list(
+            self.adapter.iter_dicts(
+                data=self.data,
+                response=self.response,
+                store=self.store,
+            )
+        )
+
 
 @pytest.mark.parametrize("skip_report_header", [True, False])
 @pytest.mark.parametrize("skip_column_header", [True, False])
@@ -133,11 +144,26 @@ def test_reports_adapter_parses_rows_for_all_header_summary_combinations(
             skip_report_summary=skip_report_summary,
         ),
         skip_column_header=skip_column_header,
+        skip_report_summary=skip_report_summary,
     )
 
+    expected_values = list(REPORT_ROWS)
+    expected_dicts = list(EXPECTED_DICTS)
+    if not skip_report_summary:
+        expected_values.append(["Total rows: 2", "", "", ""])
+        expected_dicts.append(
+            {
+                "Month": "Total rows: 2",
+                "Impressions": "",
+                "Clicks": "",
+                "Cost": "",
+            }
+        )
+
     assert report.columns == FIELD_NAMES
-    assert report.to_dicts() == EXPECTED_DICTS
-    assert report.to_values() == REPORT_ROWS
+    assert report.to_dicts() == expected_dicts
+    assert report.iter_dicts() == expected_dicts
+    assert report.to_values() == expected_values
 
 
 def test_reports_adapter_parses_single_field_report_with_header_and_summary():
@@ -150,12 +176,14 @@ def test_reports_adapter_parses_single_field_report_with_header_and_summary():
             rows=[["2026-03-01"], ["2026-03-02"]],
         ),
         field_names=["Month"],
+        skip_report_summary=False,
     )
 
     assert report.columns == ["Month"]
     assert report.to_dicts() == [
         {"Month": "2026-03-01"},
         {"Month": "2026-03-02"},
+        {"Month": "Total rows: 2"},
     ]
 
 
@@ -169,7 +197,8 @@ def test_reports_get_json_opt_out_uses_columns_not_report_title(monkeypatch):
                     skip_report_header=False,
                     skip_column_header=False,
                     skip_report_summary=False,
-                )
+                ),
+                skip_report_summary=False,
             )
 
     class _FakeClient:
@@ -205,4 +234,12 @@ def test_reports_get_json_opt_out_uses_columns_not_report_title(monkeypatch):
     )
 
     assert result.exit_code == 0, result.output
-    assert json.loads(result.output) == EXPECTED_DICTS
+    assert json.loads(result.output) == [
+        *EXPECTED_DICTS,
+        {
+            "Month": "Total rows: 2",
+            "Impressions": "",
+            "Clicks": "",
+            "Cost": "",
+        },
+    ]


### PR DESCRIPTION
## Summary

- Default `reports get` to skip the Yandex report header and report summary rows.
- Keep the column header row enabled by default so TSV parsing still has field names for JSON/table/CSV output.
- Add explicit `--no-skip-report-header` and `--no-skip-report-summary` opt-outs for users who need the previous raw-style rows.

## Why

`direct reports get --format json` could parse the report name row as the data header when report headers were included by default, producing JSON objects keyed by the report name instead of report fields like `Month` or `Clicks`.

## Validation

- `ruff check .`
- `mypy .`
- `pytest tests/test_api_coverage.py tests/test_dry_run.py -v`
- `pytest -m "not integration"`