### PR TITLE
feat: add v4 Wordstat report commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,19 @@ direct v4events get-events-log --from 2026-04-14T00:00:00 --to 2026-04-15T00:00:
 direct v4events get-events-log --from 2026-04-14T00:00:00 --to 2026-04-15T00:00:00 --currency RUB --limit 100 --offset 0 --format table
 ```
 
+### V4 Live Wordstat Reports
+
+Wordstat reports are asynchronous. Direct CLI makes exactly one API call per
+command and does not poll automatically; repeat `list-reports` or `get-report`
+yourself until the report is ready.
+
+```bash
+direct v4wordstat create-report --phrases "buy laptop,buy desktop" --geo-ids 213
+direct v4wordstat list-reports --format table
+direct v4wordstat get-report --report-id 123 --format table
+direct v4wordstat delete-report --report-id 123
+```
+
 ### V4 Live Finance
 
 Finance methods require an extra financial token for money operations. In the

--- a/direct_cli/cli.py
+++ b/direct_cli/cli.py
@@ -45,12 +45,9 @@ from .commands.balance import balance
 from .commands.v4events import v4events
 from .commands.v4finance import v4finance
 from .commands.v4account import v4account
-from .commands.v4shells import (
-    v4forecast,
-    v4meta,
-    v4wordstat,
-)
+from .commands.v4shells import v4forecast, v4meta
 from .commands.v4goals import v4goals
+from .commands.v4wordstat import v4wordstat
 
 # Load .env file
 load_dotenv()

--- a/direct_cli/commands/v4wordstat.py
+++ b/direct_cli/commands/v4wordstat.py
@@ -1,0 +1,157 @@
+"""Yandex Direct v4 Live Wordstat report commands."""
+
+from typing import Optional
+
+import click
+
+from ..api import create_v4_client
+from ..output import format_output, print_error
+from ..utils import parse_csv_strings, parse_ids
+from ..v4 import build_v4_body, call_v4
+from ..v4_contracts import v4_method_contract
+from .v4shells import V4_EPILOG
+
+
+def _wordstat_report_param(phrases: str, geo_ids: Optional[str]) -> dict:
+    """Build the v4 Live CreateNewWordstatReport parameter."""
+    phrase_list = parse_csv_strings(phrases)
+    if not phrase_list:
+        raise click.UsageError("--phrases must not be empty")
+    if len(phrase_list) > 10:
+        raise click.UsageError("--phrases accepts at most 10 phrases")
+
+    param = {"Phrases": phrase_list}
+    if geo_ids:
+        try:
+            parsed_geo_ids = parse_ids(geo_ids)
+        except ValueError as exc:
+            raise click.UsageError(str(exc)) from exc
+        if parsed_geo_ids:
+            param["GeoID"] = parsed_geo_ids
+    return param
+
+
+def _call_wordstat(
+    ctx,
+    method: str,
+    param,
+    output_format: str,
+    output: Optional[str],
+) -> None:
+    """Call one v4 Live Wordstat method and print formatted output."""
+    try:
+        client = create_v4_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            profile=ctx.obj.get("profile"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+        data = call_v4(client, method, param)
+        format_output(data, output_format, output)
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+@click.group(epilog=V4_EPILOG)
+def v4wordstat():
+    """Yandex Direct v4 Live Wordstat report commands."""
+
+
+@v4_method_contract("CreateNewWordstatReport")
+@v4wordstat.command(name="create-report")
+@click.option("--phrases", required=True, help="Comma-separated phrases, up to 10")
+@click.option("--geo-ids", help="Comma-separated geo region IDs")
+@click.option(
+    "--format",
+    "output_format",
+    default="json",
+    type=click.Choice(["json", "table", "csv", "tsv"]),
+    help="Output format",
+)
+@click.option("--output", help="Output file")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def create_report(ctx, phrases, geo_ids, output_format, output, dry_run):
+    """Create a v4 Live Wordstat report."""
+    param = _wordstat_report_param(phrases, geo_ids)
+    if dry_run:
+        format_output(build_v4_body("CreateNewWordstatReport", param), "json", None)
+        return
+
+    _call_wordstat(ctx, "CreateNewWordstatReport", param, output_format, output)
+
+
+@v4_method_contract("GetWordstatReportList")
+@v4wordstat.command(name="list-reports")
+@click.option(
+    "--format",
+    "output_format",
+    default="json",
+    type=click.Choice(["json", "table", "csv", "tsv"]),
+    help="Output format",
+)
+@click.option("--output", help="Output file")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def list_reports(ctx, output_format, output, dry_run):
+    """List v4 Live Wordstat reports."""
+    if dry_run:
+        format_output(build_v4_body("GetWordstatReportList"), "json", None)
+        return
+
+    _call_wordstat(ctx, "GetWordstatReportList", None, output_format, output)
+
+
+@v4_method_contract("GetWordstatReport")
+@v4wordstat.command(name="get-report")
+@click.option(
+    "--report-id",
+    required=True,
+    type=click.IntRange(min=1),
+    help="Wordstat report ID",
+)
+@click.option(
+    "--format",
+    "output_format",
+    default="json",
+    type=click.Choice(["json", "table", "csv", "tsv"]),
+    help="Output format",
+)
+@click.option("--output", help="Output file")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def get_report(ctx, report_id, output_format, output, dry_run):
+    """Get a ready v4 Live Wordstat report."""
+    if dry_run:
+        format_output(build_v4_body("GetWordstatReport", report_id), "json", None)
+        return
+
+    _call_wordstat(ctx, "GetWordstatReport", report_id, output_format, output)
+
+
+@v4_method_contract("DeleteWordstatReport")
+@v4wordstat.command(name="delete-report")
+@click.option(
+    "--report-id",
+    required=True,
+    type=click.IntRange(min=1),
+    help="Wordstat report ID",
+)
+@click.option(
+    "--format",
+    "output_format",
+    default="json",
+    type=click.Choice(["json", "table", "csv", "tsv"]),
+    help="Output format",
+)
+@click.option("--output", help="Output file")
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@click.pass_context
+def delete_report(ctx, report_id, output_format, output, dry_run):
+    """Delete a v4 Live Wordstat report."""
+    if dry_run:
+        format_output(build_v4_body("DeleteWordstatReport", report_id), "json", None)
+        return
+
+    _call_wordstat(ctx, "DeleteWordstatReport", report_id, output_format, output)

--- a/direct_cli/smoke_matrix.py
+++ b/direct_cli/smoke_matrix.py
@@ -63,6 +63,8 @@ SMOKE_MATRIX = {
         "v4finance.get-credit-limits",
         "v4goals.get-retargeting-goals",
         "v4goals.get-stat-goals",
+        "v4wordstat.get-report",
+        "v4wordstat.list-reports",
         "vcards.get",
     ],
     WRITE_SANDBOX: [
@@ -141,6 +143,8 @@ SMOKE_MATRIX = {
         "strategies.update",
         "v4account.account-management",
         "v4account.enable-shared-account",
+        "v4wordstat.create-report",
+        "v4wordstat.delete-report",
         "vcards.add",
         "vcards.delete",
     ],

--- a/direct_cli/v4_contracts.py
+++ b/direct_cli/v4_contracts.py
@@ -243,38 +243,58 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
     "CreateNewWordstatReport": V4MethodContract(
         method="CreateNewWordstatReport",
         group="wordstat",
-        param_shape=PARAM_UNDOCUMENTED,
-        login_placement="unknown",
+        param_shape=PARAM_OBJECT,
+        login_placement=(
+            "param contains documented Phrases and optional GeoID; global "
+            "--login uses Client-Login header"
+        ),
         safety=SAFETY_ASYNC,
-        source_status=SOURCE_UNDOCUMENTED,
+        source_status=SOURCE_DOCS,
         live_probe_allowed=False,
+        example_param={"Phrases": ["buy laptop"], "GeoID": [213]},
+        notes=(
+            "Creates an asynchronous Wordstat report. The CLI performs one API "
+            "call only and does not poll for readiness."
+        ),
     ),
     "GetWordstatReportList": V4MethodContract(
         method="GetWordstatReportList",
         group="wordstat",
-        param_shape=PARAM_UNDOCUMENTED,
-        login_placement="unknown",
+        param_shape=PARAM_OPTIONAL_OBJECT,
+        login_placement="global --login uses Client-Login header",
         safety=SAFETY_READ,
-        source_status=SOURCE_UNDOCUMENTED,
+        source_status=SOURCE_DOCS,
         live_probe_allowed=False,
+        example_param=None,
+        notes="Official docs define no required param for listing Wordstat reports.",
     ),
     "GetWordstatReport": V4MethodContract(
         method="GetWordstatReport",
         group="wordstat",
-        param_shape=PARAM_UNDOCUMENTED,
-        login_placement="unknown",
+        param_shape=PARAM_SCALAR,
+        login_placement=(
+            "param is the scalar Wordstat report ID; global --login uses "
+            "Client-Login header"
+        ),
         safety=SAFETY_READ,
-        source_status=SOURCE_UNDOCUMENTED,
+        source_status=SOURCE_DOCS,
         live_probe_allowed=False,
+        example_param=123,
+        notes="Official docs define scalar param, not an object with ReportID.",
     ),
     "DeleteWordstatReport": V4MethodContract(
         method="DeleteWordstatReport",
         group="wordstat",
-        param_shape=PARAM_UNDOCUMENTED,
-        login_placement="unknown",
+        param_shape=PARAM_SCALAR,
+        login_placement=(
+            "param is the scalar Wordstat report ID; global --login uses "
+            "Client-Login header"
+        ),
         safety=SAFETY_WRITE,
-        source_status=SOURCE_UNDOCUMENTED,
+        source_status=SOURCE_DOCS,
         live_probe_allowed=False,
+        example_param=123,
+        notes="Official docs define scalar param, not an object with ReportID.",
     ),
     "CreateNewForecast": V4MethodContract(
         method="CreateNewForecast",

--- a/scripts/sandbox_write_live.py
+++ b/scripts/sandbox_write_live.py
@@ -208,6 +208,8 @@ class LiveSandboxRunner:
             "strategies.update": self.run_strategy_id_command,
             "v4account.account-management": self.run_v4account_account_management,
             "v4account.enable-shared-account": self.run_v4account_enable_shared_account,
+            "v4wordstat.create-report": self.run_v4wordstat_create_report,
+            "v4wordstat.delete-report": self.run_v4wordstat_delete_report,
             "vcards.add": self.run_vcard_add,
             "vcards.delete": self.run_vcard_id_command,
         }
@@ -336,6 +338,18 @@ class LiveSandboxRunner:
         data = self.parse_json(run.stdout)
         return self.first_value(data, preferred_keys)
 
+    def scalar_data_id(self, run: CommandRun) -> str | None:
+        """Extract a v4 Live scalar identifier returned under top-level data."""
+        data = self.parse_json(run.stdout)
+        if not isinstance(data, dict):
+            return None
+        candidate = data.get("data")
+        if isinstance(candidate, int):
+            return str(candidate)
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate.strip()
+        return None
+
     def first_value(self, value: object, preferred_keys: tuple[str, ...]) -> str | None:
         """Find the first scalar value for any preferred key in a JSON tree."""
         if isinstance(value, dict):
@@ -458,6 +472,58 @@ class LiveSandboxRunner:
                 "No",
             ],
         )
+        return self.row_from_run(matrix_command, run)
+
+    def create_wordstat_report(self) -> str:
+        phrase = self.name("wordstat")
+        run = self.invoke(
+            "v4wordstat",
+            "create-report",
+            ["--phrases", phrase, "--geo-ids", "213"],
+        )
+        status, detail = self.classify(run)
+        if status != PASS:
+            raise PrerequisiteError(status, f"v4wordstat create prerequisite: {detail}")
+        report_id = self.scalar_data_id(run)
+        if not report_id:
+            raise PrerequisiteError(
+                FAIL, "v4wordstat create prerequisite returned no scalar report ID"
+            )
+        self.register_cleanup(
+            "wordstat report",
+            "v4wordstat",
+            "delete-report",
+            ["--report-id", report_id],
+        )
+        return report_id
+
+    def run_v4wordstat_create_report(self, matrix_command: str) -> ReportRow:
+        run = self.invoke(
+            "v4wordstat",
+            "create-report",
+            ["--phrases", self.name("wordstat"), "--geo-ids", "213"],
+        )
+        report_id = self.scalar_data_id(run)
+        if report_id:
+            self.register_cleanup(
+                "wordstat report",
+                "v4wordstat",
+                "delete-report",
+                ["--report-id", report_id],
+            )
+        return self.row_from_run(matrix_command, run)
+
+    def run_v4wordstat_delete_report(self, matrix_command: str) -> ReportRow:
+        report_id = self.create_wordstat_report()
+        run = self.invoke(
+            "v4wordstat",
+            "delete-report",
+            ["--report-id", report_id],
+        )
+        if self.classify(run)[0] == PASS:
+            self.cleanup_steps = [
+                step for step in self.cleanup_steps if step[0] != "wordstat report"
+            ]
         return self.row_from_run(matrix_command, run)
 
     def create_campaign(self, campaign_type: str = "TEXT_CAMPAIGN") -> str:

--- a/scripts/test_safe_commands.sh
+++ b/scripts/test_safe_commands.sh
@@ -183,6 +183,11 @@ run_v4finance_check_payment_contract() {
   run_test "v4finance check-payment dry-run (env auth)" direct v4finance check-payment --custom-transaction-id A123456789012345678901234567890B --dry-run
 }
 
+run_v4wordstat_contracts() {
+  run_test "v4wordstat list-reports dry-run (env auth)" direct v4wordstat list-reports --dry-run
+  run_test "v4wordstat get-report dry-run (env auth)" direct v4wordstat get-report --report-id 1 --dry-run
+}
+
 # ─── Section A: Auth via env variables (no CLI flags) ────────────────────────
 echo -e "${BOLD}=== A. Аутентификация через env-переменные ===${RESET}"
 echo ""
@@ -282,6 +287,7 @@ run_test "v4events get-events-log (env auth)"      direct v4events get-events-lo
 run_v4finance_check_payment_contract
 run_v4finance_get_clients_units
 run_v4finance_get_credit_limits
+run_v4wordstat_contracts
 
 if [ -n "$CAMPAIGN_ID" ]; then
   run_test "changes check-campaigns (env auth)"    direct changes check-campaigns --timestamp 2026-04-23T00:00:00

--- a/tests/api_coverage_payloads.py
+++ b/tests/api_coverage_payloads.py
@@ -76,6 +76,10 @@ DRY_RUN_PAYLOAD_EXCLUSIONS = {
     "v4finance.transfer-money": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
     "v4goals.get-retargeting-goals": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
     "v4goals.get-stat-goals": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
+    "v4wordstat.create-report": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
+    "v4wordstat.delete-report": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
+    "v4wordstat.get-report": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
+    "v4wordstat.list-reports": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
 }
 
 PAYLOAD_CASES = [

--- a/tests/test_smoke_matrix.py
+++ b/tests/test_smoke_matrix.py
@@ -61,8 +61,8 @@ def test_smoke_matrix_counts_match_current_cli_surface():
     summary = smoke_summary()
 
     assert summary["total_cli_groups"] == 39
-    assert summary["total_cli_subcommands"] == 132
-    assert summary["api_cli_subcommands"] == 128
+    assert summary["total_cli_subcommands"] == 136
+    assert summary["api_cli_subcommands"] == 132
     assert summary["wsdl_services"] == 29
     assert summary["non_wsdl_services"] == sorted(NON_WSDL_SERVICES)
     assert summary["api_services_total"] == 30
@@ -132,6 +132,9 @@ def test_safe_smoke_script_runs_v4_safe_commands():
     assert "run_v4finance_check_payment_contract" in contents
     assert "run_v4finance_get_clients_units" in contents
     assert "run_v4finance_get_credit_limits" in contents
+    assert "run_v4wordstat_contracts" in contents
+    assert "v4wordstat list-reports --dry-run" in contents
+    assert "v4wordstat get-report --report-id 1 --dry-run" in contents
     assert 'v4goals get-stat-goals --campaign-ids "$CAMPAIGN_ID"' in contents
     assert 'v4goals get-retargeting-goals (env auth)"' in contents
     assert 'v4goals get-retargeting-goals --campaign-ids "$CAMPAIGN_ID"' in contents
@@ -148,7 +151,7 @@ def test_sandbox_write_live_runner_covers_write_sandbox_matrix():
     )
     try:
         assert set(runner.handlers()) == set(SMOKE_MATRIX[WRITE_SANDBOX])
-        assert len(SMOKE_MATRIX[WRITE_SANDBOX]) == 77
+        assert len(SMOKE_MATRIX[WRITE_SANDBOX]) == 79
     finally:
         runner.close()
 
@@ -199,6 +202,84 @@ def test_sandbox_write_live_runner_builds_v4account_commands(monkeypatch):
                 "--money-in-sms",
                 "No",
             ],
+        ),
+    ]
+
+
+def test_sandbox_write_live_runner_extracts_v4wordstat_scalar_id():
+    module = _load_sandbox_runner_module()
+    runner = module.LiveSandboxRunner(
+        commands=["v4wordstat.create-report"],
+        timeout=1,
+        verbose=False,
+        report_file=None,
+    )
+    try:
+        run = module.CommandRun(
+            args=["direct", "--sandbox", "v4wordstat", "create-report"],
+            returncode=0,
+            stdout=json.dumps({"data": 123}),
+            stderr="",
+        )
+        assert runner.scalar_data_id(run) == "123"
+    finally:
+        runner.close()
+
+
+def test_sandbox_write_live_runner_builds_v4wordstat_commands(monkeypatch):
+    module = _load_sandbox_runner_module()
+    runner = module.LiveSandboxRunner(
+        commands=["v4wordstat.create-report", "v4wordstat.delete-report"],
+        timeout=1,
+        verbose=False,
+        report_file=None,
+    )
+    calls = []
+
+    def fake_invoke(group, command, args):
+        calls.append((group, command, args))
+        if command == "create-report":
+            return module.CommandRun(
+                args=["direct", "--sandbox", group, command, *args],
+                returncode=0,
+                stdout=json.dumps({"data": 456}),
+                stderr="",
+            )
+        return module.CommandRun(
+            args=["direct", "--sandbox", group, command, *args],
+            returncode=0,
+            stdout=json.dumps({"data": 1}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(runner, "invoke", fake_invoke)
+
+    try:
+        assert runner.run_one("v4wordstat.create-report").status == module.PASS
+        assert runner.run_one("v4wordstat.delete-report").status == module.PASS
+    finally:
+        runner.close()
+
+    assert calls == [
+        (
+            "v4wordstat",
+            "create-report",
+            ["--phrases", runner.name("wordstat"), "--geo-ids", "213"],
+        ),
+        (
+            "v4wordstat",
+            "delete-report",
+            ["--report-id", "456"],
+        ),
+        (
+            "v4wordstat",
+            "create-report",
+            ["--phrases", runner.name("wordstat"), "--geo-ids", "213"],
+        ),
+        (
+            "v4wordstat",
+            "delete-report",
+            ["--report-id", "456"],
         ),
     ]
 

--- a/tests/test_v4wordstat.py
+++ b/tests/test_v4wordstat.py
@@ -1,0 +1,250 @@
+import json
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from direct_cli.cli import cli
+from direct_cli.v4_contracts import (
+    PARAM_OBJECT,
+    PARAM_OPTIONAL_OBJECT,
+    PARAM_SCALAR,
+    SOURCE_DOCS,
+    get_v4_contract,
+)
+
+
+def _invoke(*args: str):
+    env = {"YANDEX_DIRECT_TOKEN": "", "YANDEX_DIRECT_LOGIN": ""}
+    with patch("direct_cli.cli.get_active_profile", return_value=None):
+        return CliRunner(env=env).invoke(cli, list(args))
+
+
+def test_create_report_dry_run_uses_phrases_only_body():
+    result = _invoke(
+        "v4wordstat",
+        "create-report",
+        "--phrases",
+        "buy laptop",
+        "--dry-run",
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "method": "CreateNewWordstatReport",
+        "param": {"Phrases": ["buy laptop"]},
+    }
+
+
+def test_create_report_dry_run_adds_geo_ids():
+    result = _invoke(
+        "v4wordstat",
+        "create-report",
+        "--phrases",
+        "buy laptop,buy desktop",
+        "--geo-ids",
+        "213,225",
+        "--dry-run",
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "method": "CreateNewWordstatReport",
+        "param": {
+            "Phrases": ["buy laptop", "buy desktop"],
+            "GeoID": [213, 225],
+        },
+    }
+
+
+def test_create_report_parses_three_phrase_entries():
+    result = _invoke(
+        "v4wordstat",
+        "create-report",
+        "--phrases",
+        "a,b,c",
+        "--dry-run",
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output)["param"]["Phrases"] == ["a", "b", "c"]
+
+
+def test_create_report_empty_phrases_fail_before_api_call():
+    with patch("direct_cli.commands.v4wordstat.create_v4_client") as create_client:
+        result = _invoke(
+            "v4wordstat",
+            "create-report",
+            "--phrases",
+            ",",
+        )
+
+    assert result.exit_code != 0
+    assert "--phrases must not be empty" in result.output
+    create_client.assert_not_called()
+
+
+def test_create_report_more_than_10_phrases_fail_before_api_call():
+    phrases = ",".join(str(index) for index in range(11))
+    with patch("direct_cli.commands.v4wordstat.create_v4_client") as create_client:
+        result = _invoke(
+            "v4wordstat",
+            "create-report",
+            "--phrases",
+            phrases,
+        )
+
+    assert result.exit_code != 0
+    assert "--phrases accepts at most 10 phrases" in result.output
+    create_client.assert_not_called()
+
+
+def test_create_report_invalid_geo_ids_fail_before_api_call():
+    with patch("direct_cli.commands.v4wordstat.create_v4_client") as create_client:
+        result = _invoke(
+            "v4wordstat",
+            "create-report",
+            "--phrases",
+            "buy laptop",
+            "--geo-ids",
+            "213,abc",
+        )
+
+    assert result.exit_code != 0
+    assert "Invalid ID: 'abc'" in result.output
+    create_client.assert_not_called()
+
+
+def test_list_reports_dry_run_has_no_param():
+    result = _invoke("v4wordstat", "list-reports", "--dry-run")
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {"method": "GetWordstatReportList"}
+
+
+def test_get_report_dry_run_uses_scalar_report_id():
+    result = _invoke(
+        "v4wordstat",
+        "get-report",
+        "--report-id",
+        "123",
+        "--dry-run",
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "method": "GetWordstatReport",
+        "param": 123,
+    }
+
+
+def test_delete_report_dry_run_uses_scalar_report_id():
+    result = _invoke(
+        "v4wordstat",
+        "delete-report",
+        "--report-id",
+        "123",
+        "--dry-run",
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "method": "DeleteWordstatReport",
+        "param": 123,
+    }
+
+
+def test_list_reports_formats_mocked_response_as_json():
+    response = [{"ReportID": 123, "StatusReport": "Done"}]
+    with patch("direct_cli.commands.v4wordstat.create_v4_client") as create_client:
+        with patch(
+            "direct_cli.commands.v4wordstat.call_v4",
+            return_value=response,
+        ) as call:
+            result = _invoke(
+                "--token",
+                "token",
+                "--login",
+                "client-login",
+                "v4wordstat",
+                "list-reports",
+            )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == response
+    create_client.assert_called_once_with(
+        token="token",
+        login="client-login",
+        profile=None,
+        sandbox=False,
+    )
+    call.assert_called_once_with(
+        create_client.return_value,
+        "GetWordstatReportList",
+        None,
+    )
+
+
+def test_get_report_formats_mocked_response_as_table():
+    with patch("direct_cli.commands.v4wordstat.create_v4_client"):
+        with patch(
+            "direct_cli.commands.v4wordstat.call_v4",
+            return_value=[{"Phrase": "buy laptop", "Shows": 42}],
+        ):
+            result = _invoke(
+                "--token",
+                "token",
+                "v4wordstat",
+                "get-report",
+                "--report-id",
+                "123",
+                "--format",
+                "table",
+            )
+
+    assert result.exit_code == 0
+    assert "buy laptop" in result.output
+    assert "Shows" in result.output
+
+
+def test_v4wordstat_help_contains_no_json_input_flag():
+    for args in [
+        ("v4wordstat", "--help"),
+        ("v4wordstat", "create-report", "--help"),
+        ("v4wordstat", "list-reports", "--help"),
+        ("v4wordstat", "get-report", "--help"),
+        ("v4wordstat", "delete-report", "--help"),
+    ]:
+        result = _invoke(*args)
+        assert result.exit_code == 0
+        assert "--json" not in result.output
+
+
+def test_v4wordstat_commands_declare_v4_contracts():
+    commands = cli.commands["v4wordstat"].commands
+
+    expected = {
+        "create-report": "CreateNewWordstatReport",
+        "list-reports": "GetWordstatReportList",
+        "get-report": "GetWordstatReport",
+        "delete-report": "DeleteWordstatReport",
+    }
+    for command_name, method in expected.items():
+        assert commands[command_name].v4_method == method
+        assert commands[command_name].v4_contract == get_v4_contract(method)
+
+
+def test_v4wordstat_contracts_are_docs_backed():
+    create = get_v4_contract("CreateNewWordstatReport")
+    list_reports = get_v4_contract("GetWordstatReportList")
+    get = get_v4_contract("GetWordstatReport")
+    delete = get_v4_contract("DeleteWordstatReport")
+
+    assert create.param_shape == PARAM_OBJECT
+    assert create.source_status == SOURCE_DOCS
+    assert create.example_param == {"Phrases": ["buy laptop"], "GeoID": [213]}
+    assert list_reports.param_shape == PARAM_OPTIONAL_OBJECT
+    assert list_reports.source_status == SOURCE_DOCS
+    assert get.param_shape == PARAM_SCALAR
+    assert get.source_status == SOURCE_DOCS
+    assert delete.param_shape == PARAM_SCALAR
+    assert delete.source_status == SOURCE_DOCS


### PR DESCRIPTION
## Summary
- add the real `direct v4wordstat` command group for creating, listing, getting, and deleting v4 Live Wordstat reports
- use typed flags only, scalar report IDs for get/delete, and no implicit polling
- update v4 contracts, smoke matrix, sandbox write runner coverage, README, and focused tests

## Verification
- `ruff check .`
- `mypy .`
- `pytest tests/test_v4wordstat.py tests/test_v4_contracts.py tests/test_v4_foundation.py tests/test_comprehensive.py tests/test_smoke_matrix.py -v`
- `pytest -m "not integration"`