### PR TITLE
[codex] add noninteractive auth login flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ OAuth and profile commands:
 ```bash
 direct auth login
 direct auth login --profile agency1
+direct auth login --profile agency1 --format json
 direct auth login --code abc123 --profile agency1
 direct auth list
 direct auth use --profile agency1
@@ -56,6 +57,9 @@ Notes:
 - `--login` remains Direct client login.
 - Authorization is performed via `direct auth login`.
 - OAuth profiles store refresh tokens and refresh access tokens automatically.
+- In a non-interactive shell, run `direct auth login --profile NAME` first, then finish with `direct auth login --code CODE --profile NAME`.
+- If the first non-interactive step includes `--client-secret`, the secret is remembered for the matching `--code` step.
+- If a profile already stores a confidential OAuth client, `direct auth login --code CODE --profile NAME` reuses the saved `client_id` and `client_secret`.
 - `direct auth login --oauth-token TOKEN` is a manual access-token import and does not auto-refresh.
 - Alias `auth_login` is not supported.
 
@@ -716,6 +720,7 @@ OAuth и profile-команды:
 ```bash
 direct auth login
 direct auth login --profile agency1
+direct auth login --profile agency1 --format json
 direct auth login --code abc123 --profile agency1
 direct auth list
 direct auth use --profile agency1
@@ -725,6 +730,9 @@ direct --profile agency1 campaigns get
 
 Примечания:
 - OAuth profiles сохраняют refresh token и автоматически обновляют access token.
+- В non-interactive shell сначала выполните `direct auth login --profile NAME`, затем завершите через `direct auth login --code CODE --profile NAME`.
+- Если первый non-interactive шаг включает `--client-secret`, secret запоминается для последующего `--code`.
+- Если profile уже хранит confidential OAuth client, `direct auth login --code CODE --profile NAME` использует сохраненные `client_id` и `client_secret`.
 - `direct auth login --oauth-token TOKEN` импортирует access token вручную и не включает auto-refresh.
 
 Порядок выбора credentials:

--- a/direct_cli/auth.py
+++ b/direct_cli/auth.py
@@ -31,6 +31,7 @@ YANDEX_OAUTH_TOKEN_URL = "https://oauth.yandex.ru/token"
 DEFAULT_OAUTH_CLIENT_ID = "dcf15d9625f6471d94d6d054d52017ba"
 AUTH_STORE_PATH = Path.home() / ".direct-cli" / "auth.json"
 OAUTH_REFRESH_SKEW_SECONDS = 60
+PENDING_PKCE_TTL_SECONDS = 600
 
 
 def op_read(ref: str) -> str:
@@ -161,16 +162,112 @@ def load_auth_store(path: Optional[Path] = None) -> Dict[str, Any]:
     profiles = data.get("profiles")
     if not isinstance(profiles, dict):
         profiles = {}
+    pending_pkce = data.get("pending_pkce")
+    if not isinstance(pending_pkce, dict):
+        pending_pkce = {}
     active = data.get("active_profile")
     if active is not None and not isinstance(active, str):
         active = None
-    return {"profiles": profiles, "active_profile": active}
+    return {
+        "profiles": profiles,
+        "active_profile": active,
+        "pending_pkce": pending_pkce,
+    }
 
 
 def save_auth_store(data: Dict[str, Any], path: Optional[Path] = None) -> None:
     """Persist OAuth profile storage."""
     store_path = path or AUTH_STORE_PATH
     _write_json(store_path, data)
+
+
+def save_pending_pkce(
+    profile: str,
+    client_id: str,
+    code_verifier: str,
+    login: Optional[str] = None,
+    created_at: Optional[float] = None,
+    path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Save pending PKCE state for a profile."""
+    now = time.time() if created_at is None else float(created_at)
+    item: Dict[str, Any] = {
+        "type": "pkce",
+        "client_id": client_id,
+        "code_verifier": code_verifier,
+        "login": login,
+        "created_at": now,
+        "expires_at": now + PENDING_PKCE_TTL_SECONDS,
+    }
+    store = load_auth_store(path=path)
+    store["pending_pkce"][profile] = item
+    save_auth_store(store, path=path)
+    return item
+
+
+def save_pending_confidential_auth(
+    profile: str,
+    client_id: str,
+    client_secret: str,
+    login: Optional[str] = None,
+    created_at: Optional[float] = None,
+    path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Save pending confidential-client OAuth state for a profile."""
+    now = time.time() if created_at is None else float(created_at)
+    item: Dict[str, Any] = {
+        "type": "confidential",
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "login": login,
+        "created_at": now,
+        "expires_at": now + PENDING_PKCE_TTL_SECONDS,
+    }
+    store = load_auth_store(path=path)
+    store["pending_pkce"][profile] = item
+    save_auth_store(store, path=path)
+    return item
+
+
+def get_pending_pkce(
+    profile: str, path: Optional[Path] = None
+) -> Optional[Dict[str, Any]]:
+    """Return pending OAuth state for a profile when it has the expected shape."""
+    store = load_auth_store(path=path)
+    item = store["pending_pkce"].get(profile)
+    if not isinstance(item, dict):
+        return None
+    client_id = item.get("client_id")
+    expires_at = item.get("expires_at")
+    if (
+        not isinstance(client_id, str)
+        or not client_id
+        or not isinstance(expires_at, (int, float))
+    ):
+        return None
+    auth_type = item.get("type")
+    code_verifier = item.get("code_verifier")
+    client_secret = item.get("client_secret")
+    if auth_type == "confidential":
+        if not isinstance(client_secret, str) or not client_secret:
+            return None
+    elif not isinstance(code_verifier, str) or not code_verifier:
+        return None
+    else:
+        auth_type = "pkce"
+    result = dict(item)
+    result["type"] = auth_type
+    login = result.get("login")
+    if login is not None and not isinstance(login, str):
+        result["login"] = None
+    return result
+
+
+def remove_pending_pkce(profile: str, path: Optional[Path] = None) -> None:
+    """Remove pending PKCE state for a profile if present."""
+    store = load_auth_store(path=path)
+    store["pending_pkce"].pop(profile, None)
+    save_auth_store(store, path=path)
 
 
 def save_oauth_profile(

--- a/direct_cli/commands/auth.py
+++ b/direct_cli/commands/auth.py
@@ -97,7 +97,6 @@ def login(
     auth_code = code
     effective_client_id = chosen_client_id
     effective_client_secret = client_secret
-    used_pending_auth = False
 
     if not auth_code:
         if not _stdin_is_interactive():
@@ -121,16 +120,17 @@ def login(
         pending_pkce = get_pending_pkce(profile)
         if pending_pkce:
             if float(pending_pkce["expires_at"]) <= time.time():
-                raise click.ClickException(_start_pkce_required_message(profile))
-            effective_client_id = pending_pkce["client_id"]
-            if pending_pkce["type"] == "confidential":
-                effective_client_secret = pending_pkce["client_secret"]
+                remove_pending_pkce(profile)
+                pending_pkce = None
             else:
-                code_verifier = pending_pkce["code_verifier"]
-            if not login:
-                login = pending_pkce.get("login")
-            used_pending_auth = True
-        else:
+                effective_client_id = pending_pkce["client_id"]
+                if pending_pkce["type"] == "confidential":
+                    effective_client_secret = pending_pkce["client_secret"]
+                else:
+                    code_verifier = pending_pkce["code_verifier"]
+                if not login:
+                    login = pending_pkce.get("login")
+        if not pending_pkce:
             remembered_profile = get_oauth_profile(profile)
             remembered_secret = None
             remembered_client_id = None
@@ -177,8 +177,7 @@ def login(
         client_id=effective_client_id,
         client_secret=effective_client_secret,
     )
-    if used_pending_auth:
-        remove_pending_pkce(profile)
+    remove_pending_pkce(profile)
     print_success(f"Profile '{profile}' is saved and active.")
 
 

--- a/direct_cli/commands/auth.py
+++ b/direct_cli/commands/auth.py
@@ -1,7 +1,9 @@
 """Authentication commands for OAuth profile management."""
 
 import json
+import sys
 import time
+from typing import Optional, Tuple
 
 import click
 
@@ -13,9 +15,13 @@ from ..auth import (
     get_active_profile,
     get_env_profile,
     get_oauth_profile,
+    get_pending_pkce,
     list_profiles,
+    remove_pending_pkce,
     resolve_login,
     save_oauth_profile,
+    save_pending_confidential_auth,
+    save_pending_pkce,
     set_active_profile,
     validate_oauth_profile,
 )
@@ -34,9 +40,45 @@ def auth():
 @click.option("--client-id", help="Custom OAuth app client_id")
 @click.option("--client-secret", help="Custom OAuth app client_secret")
 @click.option("--login", help="Direct client login for this profile")
-def login(profile, code, oauth_token, client_id, client_secret, login):
+@click.option(
+    "--start-pkce",
+    is_flag=True,
+    help="Start a non-interactive PKCE login and print the authorize URL",
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    show_default=True,
+    help="Output format for non-interactive auth start",
+)
+def login(
+    profile,
+    code,
+    oauth_token,
+    client_id,
+    client_secret,
+    login,
+    start_pkce,
+    output_format,
+):
     """Authorize and save OAuth credentials under a profile."""
     chosen_client_id = client_id or DEFAULT_OAUTH_CLIENT_ID
+
+    if start_pkce:
+        if code or oauth_token or client_secret:
+            raise click.ClickException(
+                "--start-pkce cannot be combined with --code, "
+                "--oauth-token, or --client-secret."
+            )
+        _start_noninteractive_pkce(
+            profile=profile,
+            client_id=chosen_client_id,
+            login=login,
+            output_format=output_format,
+        )
+        return
 
     token = oauth_token
     if token:
@@ -53,24 +95,71 @@ def login(profile, code, oauth_token, client_id, client_secret, login):
 
     code_verifier = None
     auth_code = code
+    effective_client_id = chosen_client_id
+    effective_client_secret = client_secret
+    used_pending_auth = False
 
     if not auth_code:
-        if client_secret:
-            auth_url = build_oauth_authorize_url(client_id=chosen_client_id)
-        else:
-            code_verifier, code_challenge = build_pkce_pair()
-            auth_url = build_oauth_authorize_url(
-                client_id=chosen_client_id, code_challenge=code_challenge
+        if not _stdin_is_interactive():
+            _start_noninteractive_auth(
+                profile=profile,
+                client_id=chosen_client_id,
+                client_secret=client_secret,
+                login=login,
+                output_format=output_format,
             )
+            return
+
+        auth_url, code_verifier = _build_interactive_authorize_url(
+            client_id=chosen_client_id,
+            client_secret=client_secret,
+        )
         print_info("Open this URL and grant access:")
         click.echo(auth_url)
         auth_code = click.prompt("Enter OAuth code", type=str).strip()
+    elif not client_secret:
+        pending_pkce = get_pending_pkce(profile)
+        if pending_pkce:
+            if float(pending_pkce["expires_at"]) <= time.time():
+                raise click.ClickException(_start_pkce_required_message(profile))
+            effective_client_id = pending_pkce["client_id"]
+            if pending_pkce["type"] == "confidential":
+                effective_client_secret = pending_pkce["client_secret"]
+            else:
+                code_verifier = pending_pkce["code_verifier"]
+            if not login:
+                login = pending_pkce.get("login")
+            used_pending_auth = True
+        else:
+            remembered_profile = get_oauth_profile(profile)
+            remembered_secret = None
+            remembered_client_id = None
+            if remembered_profile:
+                remembered_secret = remembered_profile.get("client_secret")
+                remembered_client_id = remembered_profile.get("client_id")
+            if (
+                isinstance(remembered_secret, str)
+                and remembered_secret
+                and isinstance(remembered_client_id, str)
+                and remembered_client_id
+            ):
+                if client_id and client_id != remembered_client_id:
+                    raise click.ClickException(
+                        f"--client-id {client_id} does not match saved client_id "
+                        f"for profile '{profile}'."
+                    )
+                effective_client_id = remembered_client_id
+                effective_client_secret = remembered_secret
+                if not login:
+                    login = remembered_profile.get("login")
+            else:
+                raise click.ClickException(_start_pkce_required_message(profile))
 
     try:
         token_response = exchange_oauth_code(
             code=auth_code,
-            client_id=chosen_client_id,
-            client_secret=client_secret,
+            client_id=effective_client_id,
+            client_secret=effective_client_secret,
             code_verifier=code_verifier,
         )
     except RuntimeError as error:
@@ -85,9 +174,11 @@ def login(profile, code, oauth_token, client_id, client_secret, login):
         login=login,
         refresh_token=token_response["refresh_token"],
         expires_at=time.time() + token_response["expires_in"],
-        client_id=chosen_client_id,
-        client_secret=client_secret,
+        client_id=effective_client_id,
+        client_secret=effective_client_secret,
     )
+    if used_pending_auth:
+        remove_pending_pkce(profile)
     print_success(f"Profile '{profile}' is saved and active.")
 
 
@@ -200,3 +291,111 @@ def _format_duration(seconds: int) -> str:
     if not parts:
         parts.append(f"{seconds}s")
     return " ".join(parts)
+
+
+def _stdin_is_interactive() -> bool:
+    """Return whether stdin can be used for an OAuth code prompt."""
+    return sys.stdin.isatty()
+
+
+def _build_interactive_authorize_url(
+    client_id: str, client_secret: Optional[str] = None
+) -> Tuple[str, Optional[str]]:
+    """Build an authorize URL for same-process interactive login."""
+    if client_secret:
+        return build_oauth_authorize_url(client_id=client_id), None
+    code_verifier, code_challenge = build_pkce_pair()
+    auth_url = build_oauth_authorize_url(
+        client_id=client_id, code_challenge=code_challenge
+    )
+    return auth_url, code_verifier
+
+
+def _start_noninteractive_auth(
+    profile: str,
+    client_id: str,
+    client_secret: Optional[str],
+    login: Optional[str],
+    output_format: str,
+) -> None:
+    """Persist pending state and print the authorize URL without prompting."""
+    if client_secret:
+        pending = save_pending_confidential_auth(
+            profile=profile,
+            client_id=client_id,
+            client_secret=client_secret,
+            login=login,
+            created_at=time.time(),
+        )
+        auth_url = build_oauth_authorize_url(client_id=client_id)
+    else:
+        _start_noninteractive_pkce(
+            profile=profile,
+            client_id=client_id,
+            login=login,
+            output_format=output_format,
+        )
+        return
+
+    _print_start_auth_output(
+        profile=profile,
+        auth_url=auth_url,
+        expires_at=pending["expires_at"],
+        output_format=output_format,
+    )
+
+
+def _start_noninteractive_pkce(
+    profile: str,
+    client_id: str,
+    login: Optional[str],
+    output_format: str,
+) -> None:
+    """Persist pending PKCE state and print the authorize URL."""
+    code_verifier, code_challenge = build_pkce_pair()
+    pending = save_pending_pkce(
+        profile=profile,
+        client_id=client_id,
+        code_verifier=code_verifier,
+        login=login,
+        created_at=time.time(),
+    )
+    auth_url = build_oauth_authorize_url(
+        client_id=client_id, code_challenge=code_challenge
+    )
+    _print_start_auth_output(
+        profile=profile,
+        auth_url=auth_url,
+        expires_at=pending["expires_at"],
+        output_format=output_format,
+    )
+
+
+def _print_start_auth_output(
+    profile: str,
+    auth_url: str,
+    expires_at: float,
+    output_format: str,
+) -> None:
+    """Print the non-interactive auth start response without secrets."""
+    if output_format == "json":
+        click.echo(
+            json.dumps(
+                {
+                    "profile": profile,
+                    "authorize_url": auth_url,
+                    "expires_at": expires_at,
+                },
+                ensure_ascii=False,
+            )
+        )
+        return
+    print_info("Open this URL and grant access:")
+    click.echo(auth_url)
+
+
+def _start_pkce_required_message(profile: str) -> str:
+    return (
+        "Missing or expired pending PKCE state. "
+        f"Run direct auth login --profile {profile} first."
+    )

--- a/direct_cli/commands/auth.py
+++ b/direct_cli/commands/auth.py
@@ -123,6 +123,11 @@ def login(
                 remove_pending_pkce(profile)
                 pending_pkce = None
             else:
+                if client_id and client_id != pending_pkce["client_id"]:
+                    raise click.ClickException(
+                        f"--client-id {client_id} does not match pending client_id "
+                        f"for profile '{profile}'."
+                    )
                 effective_client_id = pending_pkce["client_id"]
                 if pending_pkce["type"] == "confidential":
                     effective_client_secret = pending_pkce["client_secret"]

--- a/tests/test_auth_oauth.py
+++ b/tests/test_auth_oauth.py
@@ -742,6 +742,44 @@ class TestAuthOAuth:
         assert result.exit_code != 0
         assert "does not match saved client_id" in result.output
 
+    @patch("direct_cli.commands.auth.time.time", return_value=1000.0)
+    def test_auth_login_code_mode_pending_client_id_mismatch_fails(
+        self, mock_time, isolated_auth_store
+    ):
+        save_auth_store(
+            {
+                "profiles": {},
+                "active_profile": None,
+                "pending_pkce": {
+                    "agency1": {
+                        "client_id": "pending-cid",
+                        "code_verifier": "ver",
+                        "login": "client-login",
+                        "created_at": 900.0,
+                        "expires_at": 1500.0,
+                    }
+                },
+            }
+        )
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli,
+            [
+                "auth",
+                "login",
+                "--profile",
+                "agency1",
+                "--code",
+                "abc123",
+                "--client-id",
+                "other-cid",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "does not match pending client_id" in result.output
+
     @patch("direct_cli.commands.auth._stdin_is_interactive", return_value=True)
     @patch("direct_cli.commands.auth.time.time", return_value=1000.0)
     @patch("direct_cli.commands.auth.build_pkce_pair", return_value=("ver", "chal"))

--- a/tests/test_auth_oauth.py
+++ b/tests/test_auth_oauth.py
@@ -452,8 +452,45 @@ class TestAuthOAuth:
         assert "direct auth login --profile agency1" in result.output
 
     @patch("direct_cli.commands.auth.time.time", return_value=1000.0)
-    def test_auth_login_code_mode_expired_pending_pkce_fails(
+    def test_auth_login_code_mode_expired_pending_pkce_without_secret_fails(
         self, mock_time, isolated_auth_store
+    ):
+        save_auth_store(
+            {
+                "profiles": {},
+                "active_profile": None,
+                "pending_pkce": {
+                    "agency1": {
+                        "client_id": "cid",
+                        "code_verifier": "ver",
+                        "login": "client-login",
+                        "created_at": 100.0,
+                        "expires_at": 999.0,
+                    }
+                },
+            }
+        )
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli,
+            ["auth", "login", "--profile", "agency1", "--code", "abc123"],
+        )
+
+        assert result.exit_code != 0
+        assert "direct auth login --profile agency1" in result.output
+
+    @patch(
+        "direct_cli.commands.auth.exchange_oauth_code",
+        return_value={
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "expires_in": 3600,
+        },
+    )
+    @patch("direct_cli.commands.auth.time.time", return_value=1000.0)
+    def test_auth_login_code_mode_expired_pending_falls_back_to_saved_secret(
+        self, mock_time, mock_exchange, isolated_auth_store
     ):
         save_auth_store(
             {
@@ -487,8 +524,16 @@ class TestAuthOAuth:
             ["auth", "login", "--profile", "agency1", "--code", "abc123"],
         )
 
-        assert result.exit_code != 0
-        assert "direct auth login --profile agency1" in result.output
+        assert result.exit_code == 0
+        mock_exchange.assert_called_once_with(
+            code="abc123",
+            client_id="cid",
+            client_secret="csecret",
+            code_verifier=None,
+        )
+        store = load_auth_store()
+        assert "agency1" not in store["pending_pkce"]
+        assert store["profiles"]["agency1"]["client_secret"] == "csecret"
 
     @patch(
         "direct_cli.commands.auth.exchange_oauth_code",
@@ -823,6 +868,62 @@ class TestAuthOAuth:
 
         profile = load_auth_store()["profiles"]["agency1"]
         assert profile["client_secret"] == "csecret"
+
+    @patch(
+        "direct_cli.commands.auth.exchange_oauth_code",
+        return_value={
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "expires_in": 3600,
+        },
+    )
+    @patch("direct_cli.commands.auth.time.time", return_value=1000.0)
+    def test_auth_login_code_mode_explicit_secret_clears_pending_state(
+        self, mock_time, mock_exchange, isolated_auth_store
+    ):
+        save_auth_store(
+            {
+                "profiles": {},
+                "active_profile": None,
+                "pending_pkce": {
+                    "agency1": {
+                        "client_id": "old-cid",
+                        "code_verifier": "ver",
+                        "login": "client-login",
+                        "created_at": 900.0,
+                        "expires_at": 1500.0,
+                    }
+                },
+            }
+        )
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli,
+            [
+                "auth",
+                "login",
+                "--profile",
+                "agency1",
+                "--code",
+                "abc123",
+                "--client-id",
+                "cid",
+                "--client-secret",
+                "csecret",
+            ],
+        )
+
+        assert result.exit_code == 0
+        mock_exchange.assert_called_once_with(
+            code="abc123",
+            client_id="cid",
+            client_secret="csecret",
+            code_verifier=None,
+        )
+        store = load_auth_store()
+        assert "agency1" not in store["pending_pkce"]
+        assert store["profiles"]["agency1"]["client_secret"] == "csecret"
 
     @patch("direct_cli.auth.load_env_file")
     @patch("direct_cli.auth.time.time", return_value=1000.0)

--- a/tests/test_auth_oauth.py
+++ b/tests/test_auth_oauth.py
@@ -159,9 +159,7 @@ class TestAuthOAuth:
         )
         runner = CliRunner()
 
-        result = runner.invoke(
-            cli, ["campaigns", "get", "--ids", "123", "--dry-run"]
-        )
+        result = runner.invoke(cli, ["campaigns", "get", "--ids", "123", "--dry-run"])
 
         assert result.exit_code == 0
         mock_create_client.assert_called_once_with(
@@ -178,9 +176,7 @@ class TestAuthOAuth:
         monkeypatch.setenv("YANDEX_DIRECT_LOGIN", "env-login")
         runner = CliRunner()
 
-        result = runner.invoke(
-            cli, ["campaigns", "get", "--ids", "123", "--dry-run"]
-        )
+        result = runner.invoke(cli, ["campaigns", "get", "--ids", "123", "--dry-run"])
 
         assert result.exit_code == 0
         mock_create_client.assert_called_once_with(
@@ -225,6 +221,140 @@ class TestAuthOAuth:
         assert directory_mode == 0o700
         assert file_mode == 0o600
 
+    @patch("direct_cli.commands.auth.time.time", return_value=1000.0)
+    @patch("direct_cli.commands.auth.build_pkce_pair", return_value=("ver", "chal"))
+    def test_auth_login_start_pkce_text_output_saves_pending_state(
+        self, mock_pkce, mock_time, isolated_auth_store
+    ):
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli,
+            [
+                "auth",
+                "login",
+                "--start-pkce",
+                "--profile",
+                "agency1",
+                "--login",
+                "client-login",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "oauth.yandex.ru/authorize" in result.output
+        assert "code_challenge=chal" in result.output
+        assert "ver" not in result.output
+        store = load_auth_store()
+        assert store["pending_pkce"]["agency1"] == {
+            "type": "pkce",
+            "client_id": DEFAULT_OAUTH_CLIENT_ID,
+            "code_verifier": "ver",
+            "login": "client-login",
+            "created_at": 1000.0,
+            "expires_at": 1600.0,
+        }
+
+    @patch("direct_cli.commands.auth.time.time", return_value=1000.0)
+    @patch("direct_cli.commands.auth.build_pkce_pair", return_value=("ver", "chal"))
+    def test_auth_login_start_pkce_json_output_does_not_expose_verifier(
+        self, mock_pkce, mock_time, isolated_auth_store
+    ):
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli,
+            [
+                "auth",
+                "login",
+                "--start-pkce",
+                "--profile",
+                "agency1",
+                "--format",
+                "json",
+            ],
+        )
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload == {
+            "profile": "agency1",
+            "authorize_url": (
+                "https://oauth.yandex.ru/authorize?"
+                "response_type=code&client_id="
+                "dcf15d9625f6471d94d6d054d52017ba&"
+                "code_challenge_method=S256&code_challenge=chal"
+            ),
+            "expires_at": 1600.0,
+        }
+        assert "code_verifier" not in result.output
+        assert "ver" not in result.output
+
+    @patch("direct_cli.commands.auth._stdin_is_interactive", return_value=False)
+    @patch("direct_cli.commands.auth.time.time", return_value=1000.0)
+    @patch("direct_cli.commands.auth.build_pkce_pair", return_value=("ver", "chal"))
+    def test_auth_login_noninteractive_starts_pkce_without_prompt(
+        self, mock_pkce, mock_time, mock_is_interactive, isolated_auth_store
+    ):
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli,
+            ["auth", "login", "--profile", "agency1", "--login", "client-login"],
+        )
+
+        assert result.exit_code == 0
+        assert "oauth.yandex.ru/authorize" in result.output
+        assert "code_challenge=chal" in result.output
+        assert "Enter OAuth code" not in result.output
+        assert "ver" not in result.output
+        store = load_auth_store()
+        assert store["pending_pkce"]["agency1"] == {
+            "type": "pkce",
+            "client_id": DEFAULT_OAUTH_CLIENT_ID,
+            "code_verifier": "ver",
+            "login": "client-login",
+            "created_at": 1000.0,
+            "expires_at": 1600.0,
+        }
+
+    @patch("direct_cli.commands.auth._stdin_is_interactive", return_value=False)
+    @patch("direct_cli.commands.auth.time.time", return_value=1000.0)
+    def test_auth_login_noninteractive_remembers_confidential_client(
+        self, mock_time, mock_is_interactive, isolated_auth_store
+    ):
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli,
+            [
+                "auth",
+                "login",
+                "--profile",
+                "agency1",
+                "--client-id",
+                "cid",
+                "--client-secret",
+                "csecret",
+                "--login",
+                "client-login",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "oauth.yandex.ru/authorize" in result.output
+        assert "Enter OAuth code" not in result.output
+        assert "csecret" not in result.output
+        store = load_auth_store()
+        assert store["pending_pkce"]["agency1"] == {
+            "type": "confidential",
+            "client_id": "cid",
+            "client_secret": "csecret",
+            "login": "client-login",
+            "created_at": 1000.0,
+            "expires_at": 1600.0,
+        }
+
     @patch(
         "direct_cli.commands.auth.exchange_oauth_code",
         return_value={
@@ -263,6 +393,311 @@ class TestAuthOAuth:
         profile = load_auth_store()["profiles"]["agency1"]
         assert profile["client_secret"] == "csecret"
 
+    @patch(
+        "direct_cli.commands.auth.exchange_oauth_code",
+        return_value={
+            "access_token": "y0_pkce",
+            "refresh_token": "r1",
+            "expires_in": 3600,
+        },
+    )
+    @patch("direct_cli.commands.auth.time.time", return_value=1000.0)
+    def test_auth_login_code_mode_uses_pending_pkce_state(
+        self, mock_time, mock_exchange, isolated_auth_store
+    ):
+        save_auth_store(
+            {
+                "profiles": {},
+                "active_profile": None,
+                "pending_pkce": {
+                    "agency1": {
+                        "client_id": "cid",
+                        "code_verifier": "ver",
+                        "login": "client-login",
+                        "created_at": 900.0,
+                        "expires_at": 1500.0,
+                    }
+                },
+            }
+        )
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli,
+            ["auth", "login", "--profile", "agency1", "--code", "abc123"],
+        )
+
+        assert result.exit_code == 0
+        mock_exchange.assert_called_once_with(
+            code="abc123",
+            client_id="cid",
+            client_secret=None,
+            code_verifier="ver",
+        )
+        store = load_auth_store()
+        assert "agency1" not in store["pending_pkce"]
+        profile = store["profiles"]["agency1"]
+        assert profile["token"] == "y0_pkce"
+        assert profile["login"] == "client-login"
+
+    def test_auth_login_code_mode_missing_pending_pkce_fails(self, isolated_auth_store):
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli,
+            ["auth", "login", "--profile", "agency1", "--code", "abc123"],
+        )
+
+        assert result.exit_code != 0
+        assert "direct auth login --profile agency1" in result.output
+
+    @patch("direct_cli.commands.auth.time.time", return_value=1000.0)
+    def test_auth_login_code_mode_expired_pending_pkce_fails(
+        self, mock_time, isolated_auth_store
+    ):
+        save_auth_store(
+            {
+                "profiles": {
+                    "agency1": {
+                        "token": "old-access",
+                        "login": "client-login",
+                        "source": "oauth",
+                        "refresh_token": "old-refresh",
+                        "expires_at": 2000.0,
+                        "client_id": "cid",
+                        "client_secret": "csecret",
+                    }
+                },
+                "active_profile": "agency1",
+                "pending_pkce": {
+                    "agency1": {
+                        "client_id": "cid",
+                        "code_verifier": "ver",
+                        "login": "client-login",
+                        "created_at": 100.0,
+                        "expires_at": 999.0,
+                    }
+                },
+            }
+        )
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli,
+            ["auth", "login", "--profile", "agency1", "--code", "abc123"],
+        )
+
+        assert result.exit_code != 0
+        assert "direct auth login --profile agency1" in result.output
+
+    @patch(
+        "direct_cli.commands.auth.exchange_oauth_code",
+        return_value={
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "expires_in": 3600,
+        },
+    )
+    @patch("direct_cli.commands.auth.time.time", return_value=1000.0)
+    def test_auth_login_code_mode_uses_pending_confidential_state(
+        self, mock_time, mock_exchange, isolated_auth_store
+    ):
+        save_auth_store(
+            {
+                "profiles": {},
+                "active_profile": None,
+                "pending_pkce": {
+                    "agency1": {
+                        "type": "confidential",
+                        "client_id": "cid",
+                        "client_secret": "csecret",
+                        "login": "client-login",
+                        "created_at": 900.0,
+                        "expires_at": 1500.0,
+                    }
+                },
+            }
+        )
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli,
+            ["auth", "login", "--profile", "agency1", "--code", "abc123"],
+        )
+
+        assert result.exit_code == 0
+        mock_exchange.assert_called_once_with(
+            code="abc123",
+            client_id="cid",
+            client_secret="csecret",
+            code_verifier=None,
+        )
+        store = load_auth_store()
+        assert "agency1" not in store["pending_pkce"]
+        profile = store["profiles"]["agency1"]
+        assert profile["client_secret"] == "csecret"
+        assert profile["login"] == "client-login"
+
+    @patch(
+        "direct_cli.commands.auth.exchange_oauth_code",
+        side_effect=RuntimeError("OAuth token request failed with HTTP 400"),
+    )
+    @patch("direct_cli.commands.auth.time.time", return_value=1000.0)
+    def test_auth_login_code_mode_exchange_failure_keeps_pending_state(
+        self, mock_time, mock_exchange, isolated_auth_store
+    ):
+        save_auth_store(
+            {
+                "profiles": {},
+                "active_profile": None,
+                "pending_pkce": {
+                    "agency1": {
+                        "client_id": "cid",
+                        "code_verifier": "ver",
+                        "login": "client-login",
+                        "created_at": 900.0,
+                        "expires_at": 1500.0,
+                    }
+                },
+            }
+        )
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli,
+            ["auth", "login", "--profile", "agency1", "--code", "bad-code"],
+        )
+
+        assert result.exit_code != 0
+        assert load_auth_store()["pending_pkce"]["agency1"]["code_verifier"] == "ver"
+
+    @patch(
+        "direct_cli.commands.auth.exchange_oauth_code",
+        return_value={
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "expires_in": 3600,
+        },
+    )
+    @patch("direct_cli.commands.auth.time.time", return_value=1000.0)
+    def test_auth_login_code_mode_uses_remembered_confidential_client(
+        self, mock_time, mock_exchange, isolated_auth_store
+    ):
+        save_oauth_profile(
+            profile="agency1",
+            token="old-access",
+            login="client-login",
+            refresh_token="old-refresh",
+            expires_at=2000.0,
+            client_id="cid",
+            client_secret="csecret",
+        )
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli,
+            ["auth", "login", "--profile", "agency1", "--code", "abc123"],
+        )
+
+        assert result.exit_code == 0
+        mock_exchange.assert_called_once_with(
+            code="abc123",
+            client_id="cid",
+            client_secret="csecret",
+            code_verifier=None,
+        )
+        profile = load_auth_store()["profiles"]["agency1"]
+        assert profile["client_secret"] == "csecret"
+        assert profile["token"] == "new-access"
+
+    @patch(
+        "direct_cli.commands.auth.exchange_oauth_code",
+        return_value={
+            "access_token": "y0_pkce",
+            "refresh_token": "r1",
+            "expires_in": 3600,
+        },
+    )
+    @patch("direct_cli.commands.auth.time.time", return_value=1000.0)
+    def test_auth_login_code_mode_pending_pkce_wins_over_remembered_secret(
+        self, mock_time, mock_exchange, isolated_auth_store
+    ):
+        save_auth_store(
+            {
+                "profiles": {
+                    "agency1": {
+                        "token": "old-access",
+                        "login": "old-login",
+                        "source": "oauth",
+                        "refresh_token": "old-refresh",
+                        "expires_at": 2000.0,
+                        "client_id": "confidential-cid",
+                        "client_secret": "csecret",
+                    }
+                },
+                "active_profile": "agency1",
+                "pending_pkce": {
+                    "agency1": {
+                        "client_id": "pkce-cid",
+                        "code_verifier": "ver",
+                        "login": "pkce-login",
+                        "created_at": 900.0,
+                        "expires_at": 1500.0,
+                    }
+                },
+            }
+        )
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli,
+            ["auth", "login", "--profile", "agency1", "--code", "abc123"],
+        )
+
+        assert result.exit_code == 0
+        mock_exchange.assert_called_once_with(
+            code="abc123",
+            client_id="pkce-cid",
+            client_secret=None,
+            code_verifier="ver",
+        )
+        profile = load_auth_store()["profiles"]["agency1"]
+        assert "client_secret" not in profile
+        assert profile["login"] == "pkce-login"
+
+    @patch("direct_cli.commands.auth.time.time", return_value=1000.0)
+    def test_auth_login_code_mode_remembered_client_id_mismatch_fails(
+        self, mock_time, isolated_auth_store
+    ):
+        save_oauth_profile(
+            profile="agency1",
+            token="old-access",
+            login="client-login",
+            refresh_token="old-refresh",
+            expires_at=2000.0,
+            client_id="saved-cid",
+            client_secret="csecret",
+        )
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli,
+            [
+                "auth",
+                "login",
+                "--profile",
+                "agency1",
+                "--code",
+                "abc123",
+                "--client-id",
+                "other-cid",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "does not match saved client_id" in result.output
+
+    @patch("direct_cli.commands.auth._stdin_is_interactive", return_value=True)
     @patch("direct_cli.commands.auth.time.time", return_value=1000.0)
     @patch("direct_cli.commands.auth.build_pkce_pair", return_value=("ver", "chal"))
     @patch(
@@ -274,7 +709,12 @@ class TestAuthOAuth:
         },
     )
     def test_auth_login_pkce_mode(
-        self, mock_exchange, mock_pkce, mock_time, isolated_auth_store
+        self,
+        mock_exchange,
+        mock_pkce,
+        mock_time,
+        mock_is_interactive,
+        isolated_auth_store,
     ):
         runner = CliRunner()
         result = runner.invoke(


### PR DESCRIPTION
## Summary

- Add automatic non-interactive `direct auth login` start behavior based on stdin TTY detection.
- Persist pending OAuth state for PKCE and confidential-client login starts, then complete with `direct auth login --code`.
- Reuse remembered confidential client credentials when `--client-secret` is omitted on the completion step.
- Keep `--start-pkce` as a compatible explicit alias and update README examples around the canonical non-interactive flow.

## Why

The previous `--code` path could not complete default PKCE authorization from a separate CLI invocation because the original verifier only existed in memory. Non-interactive usage also needed a way to start auth without hanging on a prompt, while confidential-client users should not have to repeat `--client-secret` on the second step.

## Validation

- `python3 -m pytest tests/test_auth_oauth.py -q`
- `python3 -m pytest tests/test_auth_oauth.py tests/test_auth_op.py tests/test_auth_bw.py -q`
- `python3 -m ruff check direct_cli/commands/auth.py direct_cli/auth.py tests/test_auth_oauth.py`
- `python3 -m black --check direct_cli/commands/auth.py direct_cli/auth.py tests/test_auth_oauth.py`