### PR TITLE
fix(auth): support OAuth code via stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ direct auth login
 direct auth login --profile agency1
 direct auth login --profile agency1 --format json
 direct auth login --code abc123 --profile agency1
+printf '%s\n' abc123 | direct auth login --code-stdin --profile agency1
 direct auth list
 direct auth use --profile agency1
 direct auth status --profile agency1
@@ -57,8 +58,9 @@ Notes:
 - `--login` remains Direct client login.
 - Authorization is performed via `direct auth login`.
 - OAuth profiles store refresh tokens and refresh access tokens automatically.
-- In a non-interactive shell, run `direct auth login --profile NAME` first, then finish with `direct auth login --code CODE --profile NAME`.
-- If the first non-interactive step includes `--client-secret`, the secret is remembered for the matching `--code` step.
+- In a non-interactive shell, run `direct auth login --profile NAME` first, then finish with `direct auth login --code-stdin --profile NAME` and pass the browser code on stdin.
+- `direct auth login --code CODE --profile NAME` remains supported for compatibility, but `--code-stdin` avoids exposing the code in process arguments.
+- If the first non-interactive step includes `--client-secret`, the secret is remembered for the matching completion step.
 - If a profile already stores a confidential OAuth client, `direct auth login --code CODE --profile NAME` reuses the saved `client_id` and `client_secret`.
 - `direct auth login --oauth-token TOKEN` is a manual access-token import and does not auto-refresh.
 - Alias `auth_login` is not supported.
@@ -705,6 +707,7 @@ direct auth login
 direct auth login --profile agency1
 direct auth login --profile agency1 --format json
 direct auth login --code abc123 --profile agency1
+printf '%s\n' abc123 | direct auth login --code-stdin --profile agency1
 direct auth list
 direct auth use --profile agency1
 direct auth status --profile agency1
@@ -713,8 +716,9 @@ direct --profile agency1 campaigns get
 
 Примечания:
 - OAuth profiles сохраняют refresh token и автоматически обновляют access token.
-- В non-interactive shell сначала выполните `direct auth login --profile NAME`, затем завершите через `direct auth login --code CODE --profile NAME`.
-- Если первый non-interactive шаг включает `--client-secret`, secret запоминается для последующего `--code`.
+- В non-interactive shell сначала выполните `direct auth login --profile NAME`, затем завершите через `direct auth login --code-stdin --profile NAME` и передайте browser code через stdin.
+- `direct auth login --code CODE --profile NAME` сохраняется для совместимости, но `--code-stdin` не раскрывает код в process arguments.
+- Если первый non-interactive шаг включает `--client-secret`, secret запоминается для последующего completion step.
 - Если profile уже хранит confidential OAuth client, `direct auth login --code CODE --profile NAME` использует сохраненные `client_id` и `client_secret`.
 - `direct auth login --oauth-token TOKEN` импортирует access token вручную и не включает auto-refresh.
 

--- a/direct_cli/commands/auth.py
+++ b/direct_cli/commands/auth.py
@@ -36,6 +36,11 @@ def auth():
 @auth.command()
 @click.option("--profile", default="default", show_default=True, help="Profile name")
 @click.option("--code", help="OAuth authorization code")
+@click.option(
+    "--code-stdin",
+    is_flag=True,
+    help="Read OAuth authorization code from stdin",
+)
 @click.option("--oauth-token", help="Ready OAuth access token")
 @click.option("--client-id", help="Custom OAuth app client_id")
 @click.option("--client-secret", help="Custom OAuth app client_secret")
@@ -56,6 +61,7 @@ def auth():
 def login(
     profile,
     code,
+    code_stdin,
     oauth_token,
     client_id,
     client_secret,
@@ -65,6 +71,16 @@ def login(
 ):
     """Authorize and save OAuth credentials under a profile."""
     chosen_client_id = client_id or DEFAULT_OAUTH_CLIENT_ID
+
+    if code_stdin:
+        if code or oauth_token or start_pkce:
+            raise click.ClickException(
+                "--code-stdin cannot be combined with --code, "
+                "--oauth-token, or --start-pkce."
+            )
+        code = sys.stdin.read().strip()
+        if not code:
+            raise click.ClickException("--code-stdin requires a code on stdin.")
 
     if start_pkce:
         if code or oauth_token or client_secret:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "direct-cli"
-version = "0.3.4"
+version = "0.3.5"
 description = "Command-line interface for Yandex Direct API"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_auth_oauth.py
+++ b/tests/test_auth_oauth.py
@@ -451,6 +451,129 @@ class TestAuthOAuth:
         assert result.exit_code != 0
         assert "direct auth login --profile agency1" in result.output
 
+    @patch(
+        "direct_cli.commands.auth.exchange_oauth_code",
+        return_value={
+            "access_token": "y0_pkce",
+            "refresh_token": "r1",
+            "expires_in": 3600,
+        },
+    )
+    @patch("direct_cli.commands.auth.time.time", return_value=1000.0)
+    def test_auth_login_code_stdin_uses_pending_pkce_state(
+        self, mock_time, mock_exchange, isolated_auth_store
+    ):
+        save_auth_store(
+            {
+                "profiles": {},
+                "active_profile": None,
+                "pending_pkce": {
+                    "agency1": {
+                        "type": "pkce",
+                        "client_id": "cid",
+                        "code_verifier": "ver",
+                        "login": "client-login",
+                        "created_at": 900.0,
+                        "expires_at": 1500.0,
+                    }
+                },
+            }
+        )
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli,
+            ["auth", "login", "--profile", "agency1", "--code-stdin"],
+            input="abc123\n",
+        )
+
+        assert result.exit_code == 0
+        assert "abc123" not in result.output
+        mock_exchange.assert_called_once_with(
+            code="abc123",
+            client_id="cid",
+            client_secret=None,
+            code_verifier="ver",
+        )
+        store = load_auth_store()
+        assert "agency1" not in store["pending_pkce"]
+        profile = store["profiles"]["agency1"]
+        assert profile["token"] == "y0_pkce"
+        assert profile["login"] == "client-login"
+
+    def test_auth_login_code_stdin_requires_input(self, isolated_auth_store):
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli,
+            ["auth", "login", "--profile", "agency1", "--code-stdin"],
+            input="\n",
+        )
+
+        assert result.exit_code != 0
+        assert "--code-stdin requires a code on stdin" in result.output
+
+    def test_auth_login_code_stdin_conflicts_with_code(self, isolated_auth_store):
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli,
+            [
+                "auth",
+                "login",
+                "--profile",
+                "agency1",
+                "--code",
+                "abc123",
+                "--code-stdin",
+            ],
+            input="stdin-code\n",
+        )
+
+        assert result.exit_code != 0
+        assert "--code-stdin cannot be combined with --code" in result.output
+
+    @patch(
+        "direct_cli.commands.auth.exchange_oauth_code",
+        return_value={
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "expires_in": 3600,
+        },
+    )
+    @patch("direct_cli.commands.auth.time.time", return_value=1000.0)
+    def test_auth_login_code_stdin_custom_app(
+        self, mock_time, mock_exchange, isolated_auth_store
+    ):
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli,
+            [
+                "auth",
+                "login",
+                "--profile",
+                "agency1",
+                "--code-stdin",
+                "--client-id",
+                "cid",
+                "--client-secret",
+                "csecret",
+            ],
+            input="abc123\n",
+        )
+
+        assert result.exit_code == 0
+        assert "abc123" not in result.output
+        mock_exchange.assert_called_once_with(
+            code="abc123",
+            client_id="cid",
+            client_secret="csecret",
+            code_verifier=None,
+        )
+        profile = load_auth_store()["profiles"]["agency1"]
+        assert profile["client_secret"] == "csecret"
+
     @patch("direct_cli.commands.auth.time.time", return_value=1000.0)
     def test_auth_login_code_mode_expired_pending_pkce_without_secret_fails(
         self, mock_time, isolated_auth_store


### PR DESCRIPTION
## Summary
- add direct auth login --code-stdin as a non-argv OAuth code completion channel
- keep --code behavior for compatibility while recommending --code-stdin for non-interactive flows
- bump direct-cli to 0.3.5 and document the safer completion path

## Tests
- python3 -m pytest tests/test_auth_oauth.py -q
- python3 -m ruff check direct_cli/commands/auth.py tests/test_auth_oauth.py
- python3 -m black --check direct_cli/commands/auth.py tests/test_auth_oauth.py