### PR TITLE
fix(auth): read OAuth code via --code -

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ direct auth login
 direct auth login --profile agency1
 direct auth login --profile agency1 --format json
 direct auth login --code abc123 --profile agency1
-printf '%s\n' abc123 | direct auth login --code-stdin --profile agency1
+printf '%s\n' abc123 | direct auth login --code - --profile agency1
 direct auth list
 direct auth use --profile agency1
 direct auth status --profile agency1
@@ -58,8 +58,8 @@ Notes:
 - `--login` remains Direct client login.
 - Authorization is performed via `direct auth login`.
 - OAuth profiles store refresh tokens and refresh access tokens automatically.
-- In a non-interactive shell, run `direct auth login --profile NAME` first, then finish with `direct auth login --code-stdin --profile NAME` and pass the browser code on stdin.
-- `direct auth login --code CODE --profile NAME` remains supported for compatibility, but `--code-stdin` avoids exposing the code in process arguments.
+- In a non-interactive shell, run `direct auth login --profile NAME` first, then finish with `direct auth login --code - --profile NAME` and pass the browser code on stdin.
+- `direct auth login --code CODE --profile NAME` remains supported for compatibility, but automation should use `--code -` to avoid exposing the code in process arguments.
 - If the first non-interactive step includes `--client-secret`, the secret is remembered for the matching completion step.
 - If a profile already stores a confidential OAuth client, `direct auth login --code CODE --profile NAME` reuses the saved `client_id` and `client_secret`.
 - `direct auth login --oauth-token TOKEN` is a manual access-token import and does not auto-refresh.
@@ -707,7 +707,7 @@ direct auth login
 direct auth login --profile agency1
 direct auth login --profile agency1 --format json
 direct auth login --code abc123 --profile agency1
-printf '%s\n' abc123 | direct auth login --code-stdin --profile agency1
+printf '%s\n' abc123 | direct auth login --code - --profile agency1
 direct auth list
 direct auth use --profile agency1
 direct auth status --profile agency1
@@ -716,8 +716,8 @@ direct --profile agency1 campaigns get
 
 Примечания:
 - OAuth profiles сохраняют refresh token и автоматически обновляют access token.
-- В non-interactive shell сначала выполните `direct auth login --profile NAME`, затем завершите через `direct auth login --code-stdin --profile NAME` и передайте browser code через stdin.
-- `direct auth login --code CODE --profile NAME` сохраняется для совместимости, но `--code-stdin` не раскрывает код в process arguments.
+- В non-interactive shell сначала выполните `direct auth login --profile NAME`, затем завершите через `direct auth login --code - --profile NAME` и передайте browser code через stdin.
+- `direct auth login --code CODE --profile NAME` сохраняется для совместимости, но automation должна использовать `--code -`, чтобы не раскрывать код в process arguments.
 - Если первый non-interactive шаг включает `--client-secret`, secret запоминается для последующего completion step.
 - Если profile уже хранит confidential OAuth client, `direct auth login --code CODE --profile NAME` использует сохраненные `client_id` и `client_secret`.
 - `direct auth login --oauth-token TOKEN` импортирует access token вручную и не включает auto-refresh.

--- a/README.md
+++ b/README.md
@@ -717,7 +717,7 @@ direct --profile agency1 campaigns get
 Примечания:
 - OAuth profiles сохраняют refresh token и автоматически обновляют access token.
 - В non-interactive shell сначала выполните `direct auth login --profile NAME`, затем завершите через `direct auth login --code - --profile NAME` и передайте browser code через stdin.
-- `direct auth login --code CODE --profile NAME` сохраняется для совместимости, но automation должна использовать `--code -`, чтобы не раскрывать код в process arguments.
+- `direct auth login --code CODE --profile NAME` сохраняется для совместимости, но автоматизация должна использовать `--code -`, чтобы не раскрывать код в process arguments.
 - Если первый non-interactive шаг включает `--client-secret`, secret запоминается для последующего completion step.
 - Если profile уже хранит confidential OAuth client, `direct auth login --code CODE --profile NAME` использует сохраненные `client_id` и `client_secret`.
 - `direct auth login --oauth-token TOKEN` импортирует access token вручную и не включает auto-refresh.

--- a/direct_cli/commands/auth.py
+++ b/direct_cli/commands/auth.py
@@ -35,7 +35,10 @@ def auth():
 
 @auth.command()
 @click.option("--profile", default="default", show_default=True, help="Profile name")
-@click.option("--code", help="OAuth authorization code")
+@click.option(
+    "--code",
+    help="OAuth authorization code; use '-' to read from stdin for automation",
+)
 @click.option(
     "--code-stdin",
     is_flag=True,

--- a/direct_cli/commands/auth.py
+++ b/direct_cli/commands/auth.py
@@ -39,6 +39,7 @@ def auth():
 @click.option(
     "--code-stdin",
     is_flag=True,
+    hidden=True,
     help="Read OAuth authorization code from stdin",
 )
 @click.option("--oauth-token", help="Ready OAuth access token")
@@ -78,9 +79,16 @@ def login(
                 "--code-stdin cannot be combined with --code, "
                 "--oauth-token, or --start-pkce."
             )
+        code = "-"
+
+    if code == "-":
+        if oauth_token or start_pkce:
+            raise click.ClickException(
+                "--code - cannot be combined with --oauth-token or --start-pkce."
+            )
         code = sys.stdin.read().strip()
         if not code:
-            raise click.ClickException("--code-stdin requires a code on stdin.")
+            raise click.ClickException("--code - requires a code on stdin.")
 
     if start_pkce:
         if code or oauth_token or client_secret:

--- a/tests/test_auth_oauth.py
+++ b/tests/test_auth_oauth.py
@@ -579,6 +579,29 @@ class TestAuthOAuth:
         assert result.exit_code != 0
         assert "--code - cannot be combined" in result.output
 
+    def test_auth_login_code_dash_oauth_token_conflict_before_reading_stdin(
+        self, isolated_auth_store
+    ):
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli,
+            [
+                "auth",
+                "login",
+                "--profile",
+                "agency1",
+                "--code",
+                "-",
+                "--oauth-token",
+                "token",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "--code - cannot be combined" in result.output
+        assert "--code - requires a code on stdin" not in result.output
+
     def test_auth_login_code_stdin_alias_conflicts_with_code(self, isolated_auth_store):
         runner = CliRunner()
 

--- a/tests/test_auth_oauth.py
+++ b/tests/test_auth_oauth.py
@@ -460,7 +460,57 @@ class TestAuthOAuth:
         },
     )
     @patch("direct_cli.commands.auth.time.time", return_value=1000.0)
-    def test_auth_login_code_stdin_uses_pending_pkce_state(
+    def test_auth_login_code_dash_uses_pending_pkce_state(
+        self, mock_time, mock_exchange, isolated_auth_store
+    ):
+        save_auth_store(
+            {
+                "profiles": {},
+                "active_profile": None,
+                "pending_pkce": {
+                    "agency1": {
+                        "type": "pkce",
+                        "client_id": "cid",
+                        "code_verifier": "ver",
+                        "login": "client-login",
+                        "created_at": 900.0,
+                        "expires_at": 1500.0,
+                    }
+                },
+            }
+        )
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli,
+            ["auth", "login", "--profile", "agency1", "--code", "-"],
+            input="abc123\n",
+        )
+
+        assert result.exit_code == 0
+        assert "abc123" not in result.output
+        mock_exchange.assert_called_once_with(
+            code="abc123",
+            client_id="cid",
+            client_secret=None,
+            code_verifier="ver",
+        )
+        store = load_auth_store()
+        assert "agency1" not in store["pending_pkce"]
+        profile = store["profiles"]["agency1"]
+        assert profile["token"] == "y0_pkce"
+        assert profile["login"] == "client-login"
+
+    @patch(
+        "direct_cli.commands.auth.exchange_oauth_code",
+        return_value={
+            "access_token": "y0_pkce",
+            "refresh_token": "r1",
+            "expires_in": 3600,
+        },
+    )
+    @patch("direct_cli.commands.auth.time.time", return_value=1000.0)
+    def test_auth_login_code_stdin_alias_uses_pending_pkce_state(
         self, mock_time, mock_exchange, isolated_auth_store
     ):
         save_auth_store(
@@ -495,25 +545,41 @@ class TestAuthOAuth:
             client_secret=None,
             code_verifier="ver",
         )
-        store = load_auth_store()
-        assert "agency1" not in store["pending_pkce"]
-        profile = store["profiles"]["agency1"]
-        assert profile["token"] == "y0_pkce"
-        assert profile["login"] == "client-login"
 
-    def test_auth_login_code_stdin_requires_input(self, isolated_auth_store):
+    def test_auth_login_code_dash_requires_input(self, isolated_auth_store):
         runner = CliRunner()
 
         result = runner.invoke(
             cli,
-            ["auth", "login", "--profile", "agency1", "--code-stdin"],
+            ["auth", "login", "--profile", "agency1", "--code", "-"],
             input="\n",
         )
 
         assert result.exit_code != 0
-        assert "--code-stdin requires a code on stdin" in result.output
+        assert "--code - requires a code on stdin" in result.output
 
-    def test_auth_login_code_stdin_conflicts_with_code(self, isolated_auth_store):
+    def test_auth_login_code_dash_conflicts_before_reading_stdin(
+        self, isolated_auth_store
+    ):
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli,
+            [
+                "auth",
+                "login",
+                "--profile",
+                "agency1",
+                "--code",
+                "-",
+                "--start-pkce",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "--code - cannot be combined" in result.output
+
+    def test_auth_login_code_stdin_alias_conflicts_with_code(self, isolated_auth_store):
         runner = CliRunner()
 
         result = runner.invoke(
@@ -542,7 +608,7 @@ class TestAuthOAuth:
         },
     )
     @patch("direct_cli.commands.auth.time.time", return_value=1000.0)
-    def test_auth_login_code_stdin_custom_app(
+    def test_auth_login_code_dash_custom_app(
         self, mock_time, mock_exchange, isolated_auth_store
     ):
         runner = CliRunner()
@@ -554,7 +620,8 @@ class TestAuthOAuth:
                 "login",
                 "--profile",
                 "agency1",
-                "--code-stdin",
+                "--code",
+                "-",
                 "--client-id",
                 "cid",
                 "--client-secret",


### PR DESCRIPTION
## Summary
- add safe stdin completion via `direct auth login --code -`
- keep `--code CODE` for manual/legacy use
- hide `--code-stdin` from help while preserving it as a compatibility alias
- update auth docs and tests for the sentinel contract

## Tests
- `python3 -m pytest tests/test_auth_oauth.py`
- `python3 -m ruff check direct_cli/commands/auth.py tests/test_auth_oauth.py`