### PR TITLE
feat(campaigns): add campaign get selector fields

### DIFF
--- a/direct_cli/commands/campaigns.py
+++ b/direct_cli/commands/campaigns.py
@@ -21,6 +21,35 @@ from ..utils import (
 def campaigns():
     """Manage campaigns"""
 
+CAMPAIGN_GET_SELECTOR_FLAGS = (
+    ("text_campaign_fields", "TextCampaignFieldNames"),
+    (
+        "text_campaign_search_strategy_placement_types_fields",
+        "TextCampaignSearchStrategyPlacementTypesFieldNames",
+    ),
+    ("mobile_app_campaign_fields", "MobileAppCampaignFieldNames"),
+    ("dynamic_text_campaign_fields", "DynamicTextCampaignFieldNames"),
+    (
+        "dynamic_text_campaign_search_strategy_placement_types_fields",
+        "DynamicTextCampaignSearchStrategyPlacementTypesFieldNames",
+    ),
+    ("cpm_banner_campaign_fields", "CpmBannerCampaignFieldNames"),
+    ("smart_campaign_fields", "SmartCampaignFieldNames"),
+    ("unified_campaign_fields", "UnifiedCampaignFieldNames"),
+    (
+        "unified_campaign_search_strategy_placement_types_fields",
+        "UnifiedCampaignSearchStrategyPlacementTypesFieldNames",
+    ),
+    (
+        "unified_campaign_package_bidding_strategy_platforms_fields",
+        "UnifiedCampaignPackageBiddingStrategyPlatformsFieldNames",
+    ),
+)
+
+
+def _parse_csv(value):
+    return [item.strip() for item in value.split(",") if item.strip()]
+
 
 @campaigns.command()
 @click.option("--ids", help="Comma-separated campaign IDs")
@@ -41,6 +70,40 @@ def campaigns():
 @click.option(
     "--fields", help="Comma-separated field names (default: all common fields)"
 )
+@click.option("--text-campaign-fields", help="Comma-separated TextCampaignFieldNames")
+@click.option(
+    "--text-campaign-search-strategy-placement-types-fields",
+    help="Comma-separated TextCampaignSearchStrategyPlacementTypesFieldNames",
+)
+@click.option(
+    "--mobile-app-campaign-fields",
+    help="Comma-separated MobileAppCampaignFieldNames",
+)
+@click.option(
+    "--dynamic-text-campaign-fields",
+    help="Comma-separated DynamicTextCampaignFieldNames",
+)
+@click.option(
+    "--dynamic-text-campaign-search-strategy-placement-types-fields",
+    help="Comma-separated DynamicTextCampaignSearchStrategyPlacementTypesFieldNames",
+)
+@click.option(
+    "--cpm-banner-campaign-fields",
+    help="Comma-separated CpmBannerCampaignFieldNames",
+)
+@click.option("--smart-campaign-fields", help="Comma-separated SmartCampaignFieldNames")
+@click.option(
+    "--unified-campaign-fields",
+    help="Comma-separated UnifiedCampaignFieldNames",
+)
+@click.option(
+    "--unified-campaign-search-strategy-placement-types-fields",
+    help="Comma-separated UnifiedCampaignSearchStrategyPlacementTypesFieldNames",
+)
+@click.option(
+    "--unified-campaign-package-bidding-strategy-platforms-fields",
+    help="Comma-separated UnifiedCampaignPackageBiddingStrategyPlatformsFieldNames",
+)
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
 def get(
@@ -56,6 +119,16 @@ def get(
     output_format,
     output,
     fields,
+    text_campaign_fields,
+    text_campaign_search_strategy_placement_types_fields,
+    mobile_app_campaign_fields,
+    dynamic_text_campaign_fields,
+    dynamic_text_campaign_search_strategy_placement_types_fields,
+    cpm_banner_campaign_fields,
+    smart_campaign_fields,
+    unified_campaign_fields,
+    unified_campaign_search_strategy_placement_types_fields,
+    unified_campaign_package_bidding_strategy_platforms_fields,
     dry_run,
 ):
     """Get campaigns"""
@@ -70,7 +143,7 @@ def get(
         )
 
         # Parse field names
-        field_names = fields.split(",") if fields else get_default_fields("campaigns")
+        field_names = _parse_csv(fields) if fields else get_default_fields("campaigns")
 
         # Build selection criteria
         criteria = build_selection_criteria(
@@ -86,6 +159,10 @@ def get(
         params = build_common_params(
             criteria=criteria, field_names=field_names, limit=limit
         )
+        local_values = locals()
+        for option_name, request_key in CAMPAIGN_GET_SELECTOR_FLAGS:
+            if local_values[option_name]:
+                params[request_key] = _parse_csv(local_values[option_name])
 
         body = {"method": "get", "params": params}
 

--- a/direct_cli/commands/campaigns.py
+++ b/direct_cli/commands/campaigns.py
@@ -2,6 +2,8 @@
 Campaigns commands
 """
 
+from typing import List, Optional
+
 import click
 
 from ..api import create_client
@@ -13,6 +15,7 @@ from ..utils import (
     get_default_fields,
     MICRO_RUBLES,
     parse_ids,
+    parse_csv_strings,
     parse_setting_specs,
 )
 
@@ -21,34 +24,13 @@ from ..utils import (
 def campaigns():
     """Manage campaigns"""
 
-CAMPAIGN_GET_SELECTOR_FLAGS = (
-    ("text_campaign_fields", "TextCampaignFieldNames"),
-    (
-        "text_campaign_search_strategy_placement_types_fields",
-        "TextCampaignSearchStrategyPlacementTypesFieldNames",
-    ),
-    ("mobile_app_campaign_fields", "MobileAppCampaignFieldNames"),
-    ("dynamic_text_campaign_fields", "DynamicTextCampaignFieldNames"),
-    (
-        "dynamic_text_campaign_search_strategy_placement_types_fields",
-        "DynamicTextCampaignSearchStrategyPlacementTypesFieldNames",
-    ),
-    ("cpm_banner_campaign_fields", "CpmBannerCampaignFieldNames"),
-    ("smart_campaign_fields", "SmartCampaignFieldNames"),
-    ("unified_campaign_fields", "UnifiedCampaignFieldNames"),
-    (
-        "unified_campaign_search_strategy_placement_types_fields",
-        "UnifiedCampaignSearchStrategyPlacementTypesFieldNames",
-    ),
-    (
-        "unified_campaign_package_bidding_strategy_platforms_fields",
-        "UnifiedCampaignPackageBiddingStrategyPlatformsFieldNames",
-    ),
-)
 
-
-def _parse_csv(value):
-    return [item.strip() for item in value.split(",") if item.strip()]
+def _parse_csv_option(option_name: str, value: Optional[str]) -> Optional[List[str]]:
+    """Parse a CSV option and reject explicitly empty input."""
+    parsed = parse_csv_strings(value)
+    if value is not None and not parsed:
+        raise click.UsageError(f"{option_name} must contain at least one value")
+    return parsed
 
 
 @campaigns.command()
@@ -143,7 +125,11 @@ def get(
         )
 
         # Parse field names
-        field_names = _parse_csv(fields) if fields else get_default_fields("campaigns")
+        field_names = (
+            _parse_csv_option("--fields", fields)
+            if fields is not None
+            else get_default_fields("campaigns")
+        )
 
         # Build selection criteria
         criteria = build_selection_criteria(
@@ -159,10 +145,52 @@ def get(
         params = build_common_params(
             criteria=criteria, field_names=field_names, limit=limit
         )
-        local_values = locals()
-        for option_name, request_key in CAMPAIGN_GET_SELECTOR_FLAGS:
-            if local_values[option_name]:
-                params[request_key] = _parse_csv(local_values[option_name])
+        selector_options = {
+            "TextCampaignFieldNames": (
+                "--text-campaign-fields",
+                text_campaign_fields,
+            ),
+            "TextCampaignSearchStrategyPlacementTypesFieldNames": (
+                "--text-campaign-search-strategy-placement-types-fields",
+                text_campaign_search_strategy_placement_types_fields,
+            ),
+            "MobileAppCampaignFieldNames": (
+                "--mobile-app-campaign-fields",
+                mobile_app_campaign_fields,
+            ),
+            "DynamicTextCampaignFieldNames": (
+                "--dynamic-text-campaign-fields",
+                dynamic_text_campaign_fields,
+            ),
+            "DynamicTextCampaignSearchStrategyPlacementTypesFieldNames": (
+                "--dynamic-text-campaign-search-strategy-placement-types-fields",
+                dynamic_text_campaign_search_strategy_placement_types_fields,
+            ),
+            "CpmBannerCampaignFieldNames": (
+                "--cpm-banner-campaign-fields",
+                cpm_banner_campaign_fields,
+            ),
+            "SmartCampaignFieldNames": (
+                "--smart-campaign-fields",
+                smart_campaign_fields,
+            ),
+            "UnifiedCampaignFieldNames": (
+                "--unified-campaign-fields",
+                unified_campaign_fields,
+            ),
+            "UnifiedCampaignSearchStrategyPlacementTypesFieldNames": (
+                "--unified-campaign-search-strategy-placement-types-fields",
+                unified_campaign_search_strategy_placement_types_fields,
+            ),
+            "UnifiedCampaignPackageBiddingStrategyPlatformsFieldNames": (
+                "--unified-campaign-package-bidding-strategy-platforms-fields",
+                unified_campaign_package_bidding_strategy_platforms_fields,
+            ),
+        }
+        for request_key, (option_name, value) in selector_options.items():
+            parsed = _parse_csv_option(option_name, value)
+            if parsed:
+                params[request_key] = parsed
 
         body = {"method": "get", "params": params}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "direct-cli"
-version = "0.3.5"
+version = "0.3.6"
 description = "Command-line interface for Yandex Direct API"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -326,6 +326,100 @@ def test_advideos_get_ids_required():
     assert "Missing option '--ids'" in result.output
 
 
+def test_campaigns_get_text_campaign_fields_dry_run():
+    body = _read_dry_run(
+        "campaigns",
+        "get",
+        "--fields",
+        "Id,Name,State",
+        "--text-campaign-fields",
+        "BiddingStrategy",
+    )
+
+    assert body["params"]["FieldNames"] == ["Id", "Name", "State"]
+    assert body["params"]["TextCampaignFieldNames"] == ["BiddingStrategy"]
+
+
+def test_campaigns_get_campaign_specific_fields_dry_run():
+    body = _read_dry_run(
+        "campaigns",
+        "get",
+        "--text-campaign-fields",
+        "BiddingStrategy,PriorityGoals",
+        "--mobile-app-campaign-fields",
+        "Settings,BiddingStrategy",
+        "--dynamic-text-campaign-fields",
+        "BiddingStrategy,Settings",
+        "--cpm-banner-campaign-fields",
+        "BiddingStrategy,Settings",
+        "--smart-campaign-fields",
+        "BiddingStrategy,Settings",
+        "--unified-campaign-fields",
+        "BiddingStrategy,PriorityGoals",
+    )
+
+    params = body["params"]
+    assert params["TextCampaignFieldNames"] == ["BiddingStrategy", "PriorityGoals"]
+    assert params["MobileAppCampaignFieldNames"] == ["Settings", "BiddingStrategy"]
+    assert params["DynamicTextCampaignFieldNames"] == ["BiddingStrategy", "Settings"]
+    assert params["CpmBannerCampaignFieldNames"] == ["BiddingStrategy", "Settings"]
+    assert params["SmartCampaignFieldNames"] == ["BiddingStrategy", "Settings"]
+    assert params["UnifiedCampaignFieldNames"] == ["BiddingStrategy", "PriorityGoals"]
+
+
+def test_campaigns_get_strategy_placement_fields_dry_run():
+    body = _read_dry_run(
+        "campaigns",
+        "get",
+        "--text-campaign-search-strategy-placement-types-fields",
+        "SearchResults,ProductGallery",
+        "--dynamic-text-campaign-search-strategy-placement-types-fields",
+        "SearchResults,DynamicPlaces",
+        "--unified-campaign-search-strategy-placement-types-fields",
+        "SearchResults,Maps,SearchOrganizationList",
+        "--unified-campaign-package-bidding-strategy-platforms-fields",
+        "SearchResult,Network",
+    )
+
+    params = body["params"]
+    assert params["TextCampaignSearchStrategyPlacementTypesFieldNames"] == [
+        "SearchResults",
+        "ProductGallery",
+    ]
+    assert params["DynamicTextCampaignSearchStrategyPlacementTypesFieldNames"] == [
+        "SearchResults",
+        "DynamicPlaces",
+    ]
+    assert params["UnifiedCampaignSearchStrategyPlacementTypesFieldNames"] == [
+        "SearchResults",
+        "Maps",
+        "SearchOrganizationList",
+    ]
+    assert params["UnifiedCampaignPackageBiddingStrategyPlatformsFieldNames"] == [
+        "SearchResult",
+        "Network",
+    ]
+
+
+def test_campaigns_get_omits_campaign_specific_fields_by_default():
+    body = _read_dry_run("campaigns", "get", "--fields", "Id,Name,State")
+
+    omitted_keys = {
+        "TextCampaignFieldNames",
+        "TextCampaignSearchStrategyPlacementTypesFieldNames",
+        "MobileAppCampaignFieldNames",
+        "DynamicTextCampaignFieldNames",
+        "DynamicTextCampaignSearchStrategyPlacementTypesFieldNames",
+        "CpmBannerCampaignFieldNames",
+        "SmartCampaignFieldNames",
+        "UnifiedCampaignFieldNames",
+        "UnifiedCampaignSearchStrategyPlacementTypesFieldNames",
+        "UnifiedCampaignPackageBiddingStrategyPlatformsFieldNames",
+    }
+    assert body["params"]["FieldNames"] == ["Id", "Name", "State"]
+    assert omitted_keys.isdisjoint(body["params"])
+
+
 def _reports_get_result(*extra_args: str) -> Result:
     return CliRunner().invoke(
         cli,

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -420,6 +420,36 @@ def test_campaigns_get_omits_campaign_specific_fields_by_default():
     assert omitted_keys.isdisjoint(body["params"])
 
 
+def test_campaigns_get_rejects_empty_fields_csv():
+    result = CliRunner().invoke(
+        cli,
+        ["campaigns", "get", "--fields", ",", "--dry-run"],
+        env={"YANDEX_DIRECT_TOKEN": "test-token", "YANDEX_DIRECT_LOGIN": ""},
+    )
+
+    assert result.exit_code != 0
+    assert "--fields must contain at least one value" in result.output
+
+
+def test_campaigns_get_rejects_empty_campaign_specific_fields_csv():
+    result = CliRunner().invoke(
+        cli,
+        [
+            "campaigns",
+            "get",
+            "--fields",
+            "Id",
+            "--text-campaign-fields",
+            ",",
+            "--dry-run",
+        ],
+        env={"YANDEX_DIRECT_TOKEN": "test-token", "YANDEX_DIRECT_LOGIN": ""},
+    )
+
+    assert result.exit_code != 0
+    assert "--text-campaign-fields must contain at least one value" in result.output
+
+
 def _reports_get_result(*extra_args: str) -> Result:
     return CliRunner().invoke(
         cli,


### PR DESCRIPTION
## Summary
- add campaign-type-specific selector flags to `direct campaigns get`
- include WSDL selector arrays such as `TextCampaignFieldNames` and strategy placement selectors in dry-run/live params only when explicitly provided
- bump package version to `0.3.6`

Supports axisrow/yandex-direct-mcp-plugin#80.

## Tests
- `python3 -m pytest tests/test_dry_run.py tests/test_cli.py`
- `python3 -m ruff check direct_cli/commands/campaigns.py tests/test_dry_run.py`