### PR TITLE
fix(ads): align CLI with WSDL — MOBILE_APP_AD, drop --status, reject TEXT_IMAGE_AD title/text (#183)

### DIFF
--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -163,21 +163,40 @@ def get(
     default="TEXT_AD",
     help="Ad type",
 )
-@click.option("--title", help="Ad title (TEXT_AD only)")
-@click.option("--text", help="Ad text (TEXT_AD only)")
-@click.option("--href", help="Ad URL (TEXT_AD only)")
-@click.option("--image-hash", help="Ad image hash for TEXT_IMAGE_AD")
+@click.option("--title", help="Ad title (TEXT_AD / MOBILE_APP_AD)")
+@click.option("--text", help="Ad text (TEXT_AD / MOBILE_APP_AD)")
+@click.option("--href", help="Ad URL (TEXT_AD / TEXT_IMAGE_AD)")
+@click.option("--image-hash", help="Ad image hash (TEXT_IMAGE_AD / MOBILE_APP_AD)")
+@click.option(
+    "--action",
+    help="MOBILE_APP_AD call-to-action (MobileAppAdActionEnum, e.g. INSTALL)",
+)
+@click.option("--tracking-url", help="MOBILE_APP_AD tracking URL")
+@click.option("--age-label", help="MOBILE_APP_AD age label (MobAppAgeLabelEnum)")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def add(ctx, adgroup_id, ad_type, title, text, href, image_hash, dry_run):
+def add(
+    ctx,
+    adgroup_id,
+    ad_type,
+    title,
+    text,
+    href,
+    image_hash,
+    action,
+    tracking_url,
+    age_label,
+    dry_run,
+):
     """Add new ad"""
     try:
         ad_type_norm = (ad_type or "TEXT_AD").upper().replace("-", "_")
-        supported_types = {"TEXT_AD", "TEXT_IMAGE_AD"}
+        supported_types = {"TEXT_AD", "TEXT_IMAGE_AD", "MOBILE_APP_AD"}
         if ad_type_norm not in supported_types:
             raise click.UsageError(
                 "Invalid value for '--type': "
-                f"{ad_type!r} is not one of 'TEXT_AD', 'TEXT_IMAGE_AD'."
+                f"{ad_type!r} is not one of "
+                "'TEXT_AD', 'TEXT_IMAGE_AD', 'MOBILE_APP_AD'."
             )
 
         ad_data = {"AdGroupId": adgroup_id}
@@ -200,6 +219,11 @@ def add(ctx, adgroup_id, ad_type, title, text, href, image_hash, dry_run):
                 "Href": href,
             }
         elif ad_type_norm == "TEXT_IMAGE_AD":
+            if title or text:
+                raise click.UsageError(
+                    "--title/--text are only valid for TEXT_AD. "
+                    "For TEXT_IMAGE_AD, use --image-hash and --href."
+                )
             if not image_hash or not href:
                 raise click.UsageError(
                     "TEXT_IMAGE_AD requires both --image-hash and --href"
@@ -208,10 +232,32 @@ def add(ctx, adgroup_id, ad_type, title, text, href, image_hash, dry_run):
                 "AdImageHash": image_hash,
                 "Href": href,
             }
-            if title:
-                ad_data["TextImageAd"]["Title"] = title
-            if text:
-                ad_data["TextImageAd"]["Text"] = text
+        elif ad_type_norm == "MOBILE_APP_AD":
+            missing_fields = [
+                option_name
+                for option_name, value in (
+                    ("--title", title),
+                    ("--text", text),
+                    ("--action", action),
+                )
+                if not value
+            ]
+            if missing_fields:
+                raise click.UsageError(
+                    "MOBILE_APP_AD requires " + ", ".join(missing_fields)
+                )
+            mobile_app_ad = {
+                "Title": title,
+                "Text": text,
+                "Action": action.upper(),
+            }
+            if image_hash:
+                mobile_app_ad["AdImageHash"] = image_hash
+            if tracking_url:
+                mobile_app_ad["TrackingUrl"] = tracking_url
+            if age_label:
+                mobile_app_ad["AgeLabel"] = age_label.upper()
+            ad_data["MobileAppAd"] = mobile_app_ad
 
         body = {"method": "add", "params": {"Ads": [ad_data]}}
 
@@ -237,7 +283,13 @@ def add(ctx, adgroup_id, ad_type, title, text, href, image_hash, dry_run):
 
 @ads.command()
 @click.option("--id", "ad_id", required=True, type=int, help="Ad ID")
-@click.option("--status", help="New status")
+@click.option(
+    "--status",
+    help=(
+        "Deprecated: not part of WSDL AdUpdateItem. "
+        "Use 'direct ads suspend/resume/archive/unarchive' instead."
+    ),
+)
 @click.option("--title", help="New text ad title")
 @click.option("--text", help="New text ad text")
 @click.option("--href", help="New text ad URL")
@@ -246,11 +298,14 @@ def add(ctx, adgroup_id, ad_type, title, text, href, image_hash, dry_run):
 @click.pass_context
 def update(ctx, ad_id, status, title, text, href, image_hash, dry_run):
     """Update ad"""
+    if status:
+        raise click.UsageError(
+            "Use 'direct ads suspend/resume/archive/unarchive' to change status. "
+            "The --status flag is not supported by WSDL AdUpdateItem."
+        )
     try:
         ad_data = {"Id": ad_id}
 
-        if status:
-            ad_data["Status"] = status
         if any([title, text, href]):
             ad_data["TextAd"] = {}
             if title:

--- a/tests/api_coverage_payloads.py
+++ b/tests/api_coverage_payloads.py
@@ -645,6 +645,24 @@ PAYLOAD_CASES = [
     ),
     (
         "ads",
+        "add",
+        [
+            "ads",
+            "add",
+            "--adgroup-id",
+            "100",
+            "--type",
+            "MOBILE_APP_AD",
+            "--title",
+            "Install our app",
+            "--text",
+            "Best mobile shopping experience",
+            "--action",
+            "INSTALL",
+        ],
+    ),
+    (
+        "ads",
         "update",
         [
             "ads",

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -644,11 +644,20 @@ def test_ads_add_text_image_uses_typed_flags():
     }
 
 
-def test_ads_update_payload_status_only():
-    body = _dry_run("ads", "update", "--id", "999", "--status", "SUSPENDED")
-    assert body["method"] == "update"
-    ad = body["params"]["Ads"][0]
-    assert ad == {"Id": 999, "Status": "SUSPENDED"}
+def test_ads_update_rejects_status_flag():
+    """``--status`` is not part of WSDL ``AdUpdateItem`` (regression for #183).
+
+    Status changes must go through ``ads suspend/resume/archive/unarchive``.
+    Verify the flag now fails loudly via ``click.UsageError`` and that no
+    request body containing a top-level ``Status`` key is emitted.
+    """
+    result = CliRunner().invoke(
+        cli,
+        ["ads", "update", "--id", "1", "--status", "SUSPENDED", "--dry-run"],
+    )
+    assert result.exit_code != 0
+    assert "not supported by WSDL AdUpdateItem" in result.output
+    assert '"Status"' not in result.output
 
 
 def test_ads_update_typed_fields_build_nested_objects():

--- a/tests/test_low_coverage_payloads.py
+++ b/tests/test_low_coverage_payloads.py
@@ -814,8 +814,6 @@ def test_ads_update_combines_text_and_image_fields():
         "update",
         "--id",
         "99",
-        "--status",
-        "SUSPENDED",
         "--title",
         "New title",
         "--text",
@@ -832,7 +830,6 @@ def test_ads_update_combines_text_and_image_fields():
             "Ads": [
                 {
                     "Id": 99,
-                    "Status": "SUSPENDED",
                     "TextAd": {
                         "Title": "New title",
                         "Text": "New text",
@@ -843,6 +840,97 @@ def test_ads_update_combines_text_and_image_fields():
             ]
         },
     }
+
+
+def test_ads_update_rejects_status_flag():
+    """Status changes go through suspend/resume/archive/unarchive (#183)."""
+    result = _failing_run(
+        "ads",
+        "update",
+        "--id",
+        "1",
+        "--status",
+        "SUSPENDED",
+        "--dry-run",
+    )
+    assert result.exit_code != 0
+    assert "not supported by WSDL AdUpdateItem" in result.output
+
+
+def test_ads_add_text_image_ad_rejects_title_and_text():
+    """TEXT_IMAGE_AD has no Title/Text in WSDL TextImageAdAdd (#183)."""
+    for extra in (
+        ["--title", "T"],
+        ["--text", "Body"],
+        ["--title", "T", "--text", "Body"],
+    ):
+        result = _failing_run(
+            "ads",
+            "add",
+            "--adgroup-id",
+            "1",
+            "--type",
+            "TEXT_IMAGE_AD",
+            "--image-hash",
+            "hash",
+            "--href",
+            "https://example.com",
+            *extra,
+            "--dry-run",
+        )
+        assert result.exit_code != 0, f"expected failure for extras={extra}"
+        assert "--title/--text are only valid for TEXT_AD" in result.output
+
+
+def test_ads_add_mobile_app_ad_builds_payload():
+    """MOBILE_APP_AD builds a MobileAppAd payload (#183)."""
+    body = _dry_run(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "100",
+        "--type",
+        "MOBILE_APP_AD",
+        "--title",
+        "Install our app",
+        "--text",
+        "Best mobile shopping experience",
+        "--action",
+        "INSTALL",
+        "--tracking-url",
+        "https://tracker.example.com/click",
+        "--image-hash",
+        "hash-mobile",
+    )
+    assert body["method"] == "add"
+    ad = body["params"]["Ads"][0]
+    assert "Type" not in ad
+    assert ad["AdGroupId"] == 100
+    assert ad["MobileAppAd"] == {
+        "Title": "Install our app",
+        "Text": "Best mobile shopping experience",
+        "Action": "INSTALL",
+        "TrackingUrl": "https://tracker.example.com/click",
+        "AdImageHash": "hash-mobile",
+    }
+
+
+def test_ads_add_mobile_app_ad_requires_action():
+    result = _failing_run(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "100",
+        "--type",
+        "MOBILE_APP_AD",
+        "--title",
+        "T",
+        "--text",
+        "B",
+        "--dry-run",
+    )
+    assert result.exit_code != 0
+    assert "MOBILE_APP_AD requires --action" in result.output
 
 
 def test_ads_lifecycle_payloads_use_id_selection_criteria():


### PR DESCRIPTION
Fixes #183 (bucket C — ads CLI/WSDL drift).

## Summary

Three CLI-vs-WSDL drift bugs in `direct_cli/commands/ads.py` caught by the schema gate (#183 bucket C):

### Bug 1: MOBILE_APP_AD not supported

`ads add --type MOBILE_APP_AD` raised a misleading UsageError listing only TEXT_AD/TEXT_IMAGE_AD as valid types.

**Fix:** added a `MobileAppAd` branch in `ads add` mirroring `TextAd`/`TextImageAd`. Required WSDL fields surfaced as CLI flags:
- `--title`, `--text`, `--action` (required by `MobileAppAdAdd`)
- `--image-hash`, `--tracking-url`, `--age-label` (optional)

`MobileAppAdFeatureItem` (multi-valued, complex nested) was intentionally not exposed in this pass; it can be added when concrete UX needs emerge. The `MobileAppAdAdd.Features`, `VideoExtension`, and `ErirAdDescription` fields are all `minOccurs=0`, so the dry-run payload still validates against the WSDL.

Added `ads.add` MOBILE_APP_AD fixture to `tests/api_coverage_payloads.py::PAYLOAD_CASES` so the schema gate exercises the new branch.

### Bug 2: `--status` in `ads update` emits a non-WSDL field

`ads update --status SUSPENDED` injected a top-level `"Status"` key into the request body, but `AdUpdateItem` declares no such field — status changes belong to `suspend`/`resume`/`archive`/`unarchive`.

**Fix:** `--status` now raises `click.UsageError("Use 'direct ads suspend/resume/archive/unarchive' to change status. The --status flag is not supported by WSDL AdUpdateItem.")` before any request is built. Regression tests assert exit code != 0 and that `"Status"` never appears in the dry-run output.

### Bug 3: TEXT_IMAGE_AD `--title`/`--text` emit non-WSDL keys

`ads add --type TEXT_IMAGE_AD --title X --text Y` previously placed Title/Text under `TextImageAd`, but WSDL `TextImageAdAdd` only accepts `AdImageHash`, `ErirAdDescription`, `FinalUrl`, `Href`, `TurboPageId`.

**Fix:** the combination now raises `click.UsageError("--title/--text are only valid for TEXT_AD. For TEXT_IMAGE_AD, use --image-hash and --href.")`. Regression test covers `--title`, `--text`, and both flags together.

## Test plan
- [x] `pytest -q --ignore=tests/test_integration.py --ignore=tests/test_integration_write.py` → 669 passed, 23 skipped
- [x] `pytest -q tests/test_api_coverage.py::TestApiCoverage::test_dry_run_payload_schema_coverage tests/test_api_coverage.py::TestApiCoverage::test_all_canonical_dry_run_commands_have_payload_coverage_or_exclusion` → 64 passed
- [x] `python3 scripts/build_api_coverage_report.py | jq .schema` → all schema lists empty (no drift)
- [x] `flake8 direct_cli/commands/ads.py` clean
- [x] `black --check` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)