### PR TITLE
chore(ci): set Claude review action to opus-4-7

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,5 +46,5 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          claude_args: "--model claude-opus-4-7"
 


### PR DESCRIPTION
Switches the GitHub Action that runs PR reviews from the default model (Sonnet 4.5) to Claude Opus 4.7 — deeper review on the same hook.

No other config changes.