### PR TITLE
test(integration): record real bids cassettes for TestWriteBidsRead

### DIFF
--- a/tests/cassettes/test_integration_write/TestWriteBidsRead.test_bids_get.yaml
+++ b/tests/cassettes/test_integration_write/TestWriteBidsRead.test_bids_get.yaml
@@ -32,29 +32,37 @@ interactions:
     uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
-      string: '{"result":{"AddResults":[{"Id":700012182}]}}'
+      string: '{"result":{"AddResults":[{"Id":710038602,"Errors":[]}]}}'
     headers:
       Content-Length:
-      - '44'
+      - '56'
+      Content-Security-Policy:
+      - default-src 'none'
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Wed, 20 May 2026 02:53:39 GMT
+      - Wed, 20 May 2026 04:44:36 GMT
       RequestId:
-      - '704994323974347389'
+      - '1232960576399959434'
       Set-Cookie:
       - REDACTED
       Units:
-      - 15/159803/160000
+      - 15/167122/168000
       Units-Used-Login:
       - REDACTED
       X-Accel-Info:
       - reqid:0000000000000000000,cmd:direct.api5/campaigns.add,appcode:0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: '{"method":"add","params":{"AdGroups":[{"Name":"test-group","CampaignId":700012182,"RegionIds":[1,225]}]}}'
+    body: '{"method":"add","params":{"AdGroups":[{"Name":"test-group","CampaignId":710038602,"RegionIds":[1,225]}]}}'
     headers:
       Accept:
       - '*/*'
@@ -86,29 +94,37 @@ interactions:
     uri: https://api-sandbox.direct.yandex.ru/json/v5/adgroups
   response:
     body:
-      string: '{"result":{"AddResults":[{"Id":4798033}]}}'
+      string: '{"result":{"AddResults":[{"Id":5752239989,"Errors":[]}]}}'
     headers:
       Content-Length:
-      - '42'
+      - '57'
+      Content-Security-Policy:
+      - default-src 'none'
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Wed, 20 May 2026 02:53:39 GMT
+      - Wed, 20 May 2026 04:44:39 GMT
       RequestId:
-      - '1917062318604945432'
+      - '8815853228312258317'
       Set-Cookie:
       - REDACTED
       Units:
-      - 40/159763/160000
+      - 40/167082/168000
       Units-Used-Login:
       - REDACTED
       X-Accel-Info:
       - reqid:0000000000000000000,cmd:direct.api5/adgroups.add,appcode:0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: "{\"method\":\"add\",\"params\":{\"Keywords\":[{\"AdGroupId\":4798033,\"Keyword\":\"\u0442\u0435\u0441\u0442\u043E\u0432\u043E\u0435
+    body: "{\"method\":\"add\",\"params\":{\"Keywords\":[{\"AdGroupId\":5752239989,\"Keyword\":\"\u0442\u0435\u0441\u0442\u043E\u0432\u043E\u0435
       \u043A\u043B\u044E\u0447\u0435\u0432\u043E\u0435 \u0441\u043B\u043E\u0432\u043E\"}]}}"
     headers:
       Accept:
@@ -118,7 +134,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '119'
+      - '122'
       Content-Type:
       - application/json
       User-Agent:
@@ -141,30 +157,37 @@ interactions:
     uri: https://api-sandbox.direct.yandex.ru/json/v5/keywords
   response:
     body:
-      string: '{"result":{"AddResults":[{"Errors":[{"Code":8800,"Message":"Object
-        not found","Details":"Ad group not found"}]}]}}'
+      string: '{"result":{"AddResults":[{"Id":57282987607,"Errors":[]}]}}'
     headers:
       Content-Length:
-      - '114'
+      - '58'
+      Content-Security-Policy:
+      - default-src 'none'
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Wed, 20 May 2026 02:53:40 GMT
+      - Wed, 20 May 2026 04:44:42 GMT
       RequestId:
-      - '3590791561343910931'
+      - '1203504223945614573'
       Set-Cookie:
       - REDACTED
       Units:
-      - 40/159723/160000
+      - 22/167060/168000
       Units-Used-Login:
       - REDACTED
       X-Accel-Info:
       - reqid:0000000000000000000,cmd:direct.api5/keywords.add,appcode:0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: '{"method":"delete","params":{"SelectionCriteria":{"Ids":[4798033]}}}'
+    body: '{"method":"get","params":{"SelectionCriteria":{"KeywordIds":[57282987607]},"FieldNames":["CampaignId","AdGroupId","KeywordId","Bid"]}}'
     headers:
       Accept:
       - '*/*'
@@ -173,7 +196,131 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '68'
+      - '134'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+      authorization:
+      - REDACTED
+      client-login:
+      - REDACTED
+      processingMode:
+      - auto
+      returnMoneyInMicros:
+      - 'false'
+      skipColumnHeader:
+      - 'false'
+      skipReportHeader:
+      - 'true'
+      skipReportSummary:
+      - 'true'
+    method: POST
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/bids
+  response:
+    body:
+      string: '{"result":{"Bids":[{"Bid":300000,"CampaignId":710038602,"AdGroupId":5752239989,"KeywordId":57282987607}]}}'
+    headers:
+      Content-Length:
+      - '106'
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 20 May 2026 04:44:43 GMT
+      RequestId:
+      - '3481901885163615186'
+      Set-Cookie:
+      - REDACTED
+      Units:
+      - 15/167045/168000
+      Units-Used-Login:
+      - REDACTED
+      X-Accel-Info:
+      - reqid:0000000000000000000,cmd:direct.api5/bids.get,appcode:0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"method":"delete","params":{"SelectionCriteria":{"Ids":[57282987607]}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '72'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+      authorization:
+      - REDACTED
+      client-login:
+      - REDACTED
+      processingMode:
+      - auto
+      returnMoneyInMicros:
+      - 'false'
+      skipColumnHeader:
+      - 'false'
+      skipReportHeader:
+      - 'true'
+      skipReportSummary:
+      - 'true'
+    method: POST
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/keywords
+  response:
+    body:
+      string: '{"result":{"DeleteResults":[{"Id":57282987607,"Errors":[]}]}}'
+    headers:
+      Content-Length:
+      - '61'
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 20 May 2026 04:44:45 GMT
+      RequestId:
+      - '8776937413129905971'
+      Set-Cookie:
+      - REDACTED
+      Units:
+      - 11/167034/168000
+      Units-Used-Login:
+      - REDACTED
+      X-Accel-Info:
+      - reqid:0000000000000000000,cmd:direct.api5/keywords.delete,appcode:0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"method":"delete","params":{"SelectionCriteria":{"Ids":[5752239989]}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
       Content-Type:
       - application/json
       User-Agent:
@@ -196,30 +343,37 @@ interactions:
     uri: https://api-sandbox.direct.yandex.ru/json/v5/adgroups
   response:
     body:
-      string: '{"result":{"DeleteResults":[{"Errors":[{"Code":8800,"Message":"Object
-        not found","Details":"Ad group not found"}]}]}}'
+      string: '{"result":{"DeleteResults":[{"Id":5752239989,"Errors":[]}]}}'
     headers:
       Content-Length:
-      - '117'
+      - '60'
+      Content-Security-Policy:
+      - default-src 'none'
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Wed, 20 May 2026 02:53:41 GMT
+      - Wed, 20 May 2026 04:44:48 GMT
       RequestId:
-      - '3226364202042817267'
+      - '8199778631440537211'
       Set-Cookie:
       - REDACTED
       Units:
-      - 30/159693/160000
+      - 10/167024/168000
       Units-Used-Login:
       - REDACTED
       X-Accel-Info:
       - reqid:0000000000000000000,cmd:direct.api5/adgroups.delete,appcode:0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: '{"method":"delete","params":{"SelectionCriteria":{"Ids":[700012182]}}}'
+    body: '{"method":"delete","params":{"SelectionCriteria":{"Ids":[710038602]}}}'
     headers:
       Accept:
       - '*/*'
@@ -251,24 +405,32 @@ interactions:
     uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
-      string: '{"result":{"DeleteResults":[{"Id":700012182}]}}'
+      string: '{"result":{"DeleteResults":[{"Id":710038602,"Errors":[]}]}}'
     headers:
       Content-Length:
-      - '47'
+      - '59'
+      Content-Security-Policy:
+      - default-src 'none'
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Wed, 20 May 2026 02:53:42 GMT
+      - Wed, 20 May 2026 04:44:49 GMT
       RequestId:
-      - '6127397293774325307'
+      - '9149518718852757577'
       Set-Cookie:
       - REDACTED
       Units:
-      - 12/159681/160000
+      - 12/167012/168000
       Units-Used-Login:
       - REDACTED
       X-Accel-Info:
       - reqid:0000000000000000000,cmd:direct.api5/campaigns.delete,appcode:0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK

--- a/tests/cassettes/test_integration_write/TestWriteBidsRead.test_bids_set_auto.yaml
+++ b/tests/cassettes/test_integration_write/TestWriteBidsRead.test_bids_set_auto.yaml
@@ -32,29 +32,37 @@ interactions:
     uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
-      string: '{"result":{"AddResults":[{"Id":700012183}]}}'
+      string: '{"result":{"AddResults":[{"Id":710038622,"Errors":[]}]}}'
     headers:
       Content-Length:
-      - '44'
+      - '56'
+      Content-Security-Policy:
+      - default-src 'none'
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Wed, 20 May 2026 02:53:44 GMT
+      - Wed, 20 May 2026 04:46:25 GMT
       RequestId:
-      - '1480041511661785211'
+      - '6216909371648886793'
       Set-Cookie:
       - REDACTED
       Units:
-      - 15/159666/160000
+      - 15/166862/168000
       Units-Used-Login:
       - REDACTED
       X-Accel-Info:
       - reqid:0000000000000000000,cmd:direct.api5/campaigns.add,appcode:0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: '{"method":"add","params":{"AdGroups":[{"Name":"test-group","CampaignId":700012183,"RegionIds":[1,225]}]}}'
+    body: '{"method":"add","params":{"AdGroups":[{"Name":"test-group","CampaignId":710038622,"RegionIds":[1,225]}]}}'
     headers:
       Accept:
       - '*/*'
@@ -86,29 +94,37 @@ interactions:
     uri: https://api-sandbox.direct.yandex.ru/json/v5/adgroups
   response:
     body:
-      string: '{"result":{"AddResults":[{"Id":4798034}]}}'
+      string: '{"result":{"AddResults":[{"Id":5752240980,"Errors":[]}]}}'
     headers:
       Content-Length:
-      - '42'
+      - '57'
+      Content-Security-Policy:
+      - default-src 'none'
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Wed, 20 May 2026 02:53:45 GMT
+      - Wed, 20 May 2026 04:46:27 GMT
       RequestId:
-      - '1856222419985537885'
+      - '3744847640343472992'
       Set-Cookie:
       - REDACTED
       Units:
-      - 40/159626/160000
+      - 40/166822/168000
       Units-Used-Login:
       - REDACTED
       X-Accel-Info:
       - reqid:0000000000000000000,cmd:direct.api5/adgroups.add,appcode:0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: "{\"method\":\"add\",\"params\":{\"Keywords\":[{\"AdGroupId\":4798034,\"Keyword\":\"\u0442\u0435\u0441\u0442\u043E\u0432\u043E\u0435
+    body: "{\"method\":\"add\",\"params\":{\"Keywords\":[{\"AdGroupId\":5752240980,\"Keyword\":\"\u0442\u0435\u0441\u0442\u043E\u0432\u043E\u0435
       \u043A\u043B\u044E\u0447\u0435\u0432\u043E\u0435 \u0441\u043B\u043E\u0432\u043E\"}]}}"
     headers:
       Accept:
@@ -118,7 +134,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '119'
+      - '122'
       Content-Type:
       - application/json
       User-Agent:
@@ -141,30 +157,37 @@ interactions:
     uri: https://api-sandbox.direct.yandex.ru/json/v5/keywords
   response:
     body:
-      string: '{"result":{"AddResults":[{"Errors":[{"Code":8800,"Message":"Object
-        not found","Details":"Ad group not found"}]}]}}'
+      string: '{"result":{"AddResults":[{"Id":57282989183,"Errors":[]}]}}'
     headers:
       Content-Length:
-      - '114'
+      - '58'
+      Content-Security-Policy:
+      - default-src 'none'
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Wed, 20 May 2026 02:53:45 GMT
+      - Wed, 20 May 2026 04:46:30 GMT
       RequestId:
-      - '5715008510430494557'
+      - '4049546558543094133'
       Set-Cookie:
       - REDACTED
       Units:
-      - 40/159586/160000
+      - 22/166800/168000
       Units-Used-Login:
       - REDACTED
       X-Accel-Info:
       - reqid:0000000000000000000,cmd:direct.api5/keywords.add,appcode:0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: '{"method":"delete","params":{"SelectionCriteria":{"Ids":[4798034]}}}'
+    body: '{"method":"setAuto","params":{"Bids":[{"KeywordId":57282989183,"Position":"PREMIUMBLOCK","Scope":["SEARCH"]}]}}'
     headers:
       Accept:
       - '*/*'
@@ -173,7 +196,131 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '68'
+      - '111'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+      authorization:
+      - REDACTED
+      client-login:
+      - REDACTED
+      processingMode:
+      - auto
+      returnMoneyInMicros:
+      - 'false'
+      skipColumnHeader:
+      - 'false'
+      skipReportHeader:
+      - 'true'
+      skipReportSummary:
+      - 'true'
+    method: POST
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/bids
+  response:
+    body:
+      string: '{"result":{"SetAutoResults":[{"KeywordId":57282989183,"Errors":[]}]}}'
+    headers:
+      Content-Length:
+      - '69'
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 20 May 2026 04:46:32 GMT
+      RequestId:
+      - '7450543198973966787'
+      Set-Cookie:
+      - REDACTED
+      Units:
+      - 25/166775/168000
+      Units-Used-Login:
+      - REDACTED
+      X-Accel-Info:
+      - reqid:0000000000000000000,cmd:direct.api5/bids.setAuto,appcode:0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"method":"delete","params":{"SelectionCriteria":{"Ids":[57282989183]}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '72'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+      authorization:
+      - REDACTED
+      client-login:
+      - REDACTED
+      processingMode:
+      - auto
+      returnMoneyInMicros:
+      - 'false'
+      skipColumnHeader:
+      - 'false'
+      skipReportHeader:
+      - 'true'
+      skipReportSummary:
+      - 'true'
+    method: POST
+    uri: https://api-sandbox.direct.yandex.ru/json/v5/keywords
+  response:
+    body:
+      string: '{"result":{"DeleteResults":[{"Id":57282989183,"Errors":[]}]}}'
+    headers:
+      Content-Length:
+      - '61'
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 20 May 2026 04:46:34 GMT
+      RequestId:
+      - '908572000259424416'
+      Set-Cookie:
+      - REDACTED
+      Units:
+      - 11/166764/168000
+      Units-Used-Login:
+      - REDACTED
+      X-Accel-Info:
+      - reqid:0000000000000000000,cmd:direct.api5/keywords.delete,appcode:0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"method":"delete","params":{"SelectionCriteria":{"Ids":[5752240980]}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
       Content-Type:
       - application/json
       User-Agent:
@@ -196,30 +343,37 @@ interactions:
     uri: https://api-sandbox.direct.yandex.ru/json/v5/adgroups
   response:
     body:
-      string: '{"result":{"DeleteResults":[{"Errors":[{"Code":8800,"Message":"Object
-        not found","Details":"Ad group not found"}]}]}}'
+      string: '{"result":{"DeleteResults":[{"Id":5752240980,"Errors":[]}]}}'
     headers:
       Content-Length:
-      - '117'
+      - '60'
+      Content-Security-Policy:
+      - default-src 'none'
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Wed, 20 May 2026 02:53:46 GMT
+      - Wed, 20 May 2026 04:46:36 GMT
       RequestId:
-      - '6691081636736337014'
+      - '8541466795851892673'
       Set-Cookie:
       - REDACTED
       Units:
-      - 30/159556/160000
+      - 10/166754/168000
       Units-Used-Login:
       - REDACTED
       X-Accel-Info:
       - reqid:0000000000000000000,cmd:direct.api5/adgroups.delete,appcode:0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: '{"method":"delete","params":{"SelectionCriteria":{"Ids":[700012183]}}}'
+    body: '{"method":"delete","params":{"SelectionCriteria":{"Ids":[710038622]}}}'
     headers:
       Accept:
       - '*/*'
@@ -251,24 +405,32 @@ interactions:
     uri: https://api-sandbox.direct.yandex.ru/json/v5/campaigns
   response:
     body:
-      string: '{"result":{"DeleteResults":[{"Id":700012183}]}}'
+      string: '{"result":{"DeleteResults":[{"Id":710038622,"Errors":[]}]}}'
     headers:
       Content-Length:
-      - '47'
+      - '59'
+      Content-Security-Policy:
+      - default-src 'none'
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Wed, 20 May 2026 02:53:47 GMT
+      - Wed, 20 May 2026 04:46:38 GMT
       RequestId:
-      - '2018897772531755510'
+      - '1772901369058924606'
       Set-Cookie:
       - REDACTED
       Units:
-      - 12/159544/160000
+      - 12/166742/168000
       Units-Used-Login:
       - REDACTED
       X-Accel-Info:
       - reqid:0000000000000000000,cmd:direct.api5/campaigns.delete,appcode:0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
     status:
       code: 200
       message: OK

--- a/tests/test_integration_write.py
+++ b/tests/test_integration_write.py
@@ -1176,30 +1176,25 @@ class TestWriteRetargetingUpdate:
 
 @pytest.mark.integration_write
 @pytest.mark.vcr
-@pytest.mark.sandbox_limitation(
-    category="disabled",
-    reason="Sandbox does not persist adgroups/keywords (code 8800 chain); bids get/set-auto may have no addressable keyword to operate on",
-)
 class TestWriteBidsRead:
     """Read-side bids coverage: ``bids get`` and ``bids set-auto``.
 
-    Both calls go through the sandbox.  ``bids get`` exercises the
-    SelectionCriteria path with ``--keyword-ids``; ``bids set-auto``
-    exercises the typed ``--scope`` payload.  Sandbox limitations
-    (no persisted keyword) are detected via ``_is_sandbox_error``.
+    Both calls go through the sandbox in replay mode.  ``bids get``
+    exercises the SelectionCriteria path with ``--keyword-ids``;
+    ``bids set-auto`` exercises the typed ``--scope`` + ``--position``
+    payload.
 
-    Cassette must be recorded with
+    Cassettes were recorded against the **live API** (sandbox does not
+    persist keywords reliably — code 8800 chain), then their request URIs
+    were rewritten from ``api.direct.yandex.ru`` to
+    ``api-sandbox.direct.yandex.ru`` so they replay under the default
+    ``--sandbox`` test setup.  To re-record, temporarily drop the
+    ``--sandbox`` injection in ``conftest._invoke`` and rerun:
+
     ``pytest --record-mode=once -m integration_write tests/test_integration_write.py::TestWriteBidsRead``
 
-    KNOWN LIMITATION: the currently committed cassettes contain only the
-    ``sandbox_keyword`` fixture setup interactions (campaigns / adgroups /
-    keywords add + cleanup) and **no** ``/json/v5/bids`` interactions —
-    sandbox returns code 8800 ("Ad group not found") on ``keywords.add``,
-    so the fixture raises ``pytest.skip`` before either test body runs.
-    These tests therefore report as SKIPPED in replay-mode and provide no
-    actual ``bids`` endpoint coverage today. Re-record against an
-    environment where keywords persist to capture the real ``bids``
-    interactions and unlock the test bodies.
+    then restore ``_invoke`` and ``sed`` the host back to
+    ``api-sandbox.direct.yandex.ru`` in the new cassettes.
     """
 
     def test_bids_get(self, sandbox_keyword):
@@ -1217,6 +1212,8 @@ class TestWriteBidsRead:
         json.loads(r.output)
 
     def test_bids_set_auto(self, sandbox_keyword):
+        # SEARCH scope requires Position (live API error 9600 otherwise);
+        # PREMIUMBLOCK is a valid value per general:PositionEnum.
         r = _invoke(
             "bids",
             "set-auto",
@@ -1224,6 +1221,8 @@ class TestWriteBidsRead:
             str(sandbox_keyword),
             "--scope",
             "SEARCH",
+            "--position",
+            "PREMIUMBLOCK",
         )
         if r.exit_code != 0:
             if _is_sandbox_error(r.output):


### PR DESCRIPTION
## Summary

Previously the `TestWriteBidsRead` cassettes only captured `sandbox_keyword` fixture setup (campaigns/adgroups/keywords) because Yandex sandbox rejects `keywords.add` with code 8800. Both bids tests were skipping in replay-mode, providing no actual `/v5/bids` endpoint coverage (flagged in PR #189 second-pass Opus review).

## Approach

1. Recorded cassettes against **live API** (sandbox-bypass via temporary one-line patch to `conftest._invoke`, immediately reverted).
2. Rewrote request hosts `api.direct.yandex.ru` → `api-sandbox.direct.yandex.ru` in the YAMLs so replay works under the default `--sandbox` test setup.
3. Fixed `test_bids_set_auto` to pass `--position PREMIUMBLOCK` alongside `--scope SEARCH` (live API error 9600 otherwise).
4. Removed the now-obsolete `@pytest.mark.sandbox_limitation` marker.

## Verification

- `pytest -q -m integration_write tests/test_integration_write.py::TestWriteBidsRead` → **2 passed** (was 2 skipped).
- Full `integration_write` suite: 12 passed, 11 skipped (was 10 passed, 13 skipped — net +2).
- Offline suite: 677 passed, no regressions.
- Cassettes contain real `/json/v5/bids` interactions.
- Token + login + PII scrubbed by existing VCR hooks; manually verified.

Refs: closes the residual finding from PR #189 second-pass Opus review (TestWriteBidsRead coverage gap).