### PR TITLE
fix(coverage): add bidmodifiers.delete schema gate fixture

### DIFF
--- a/tests/api_coverage_payloads.py
+++ b/tests/api_coverage_payloads.py
@@ -23,7 +23,6 @@ DRY_RUN_PAYLOAD_EXCLUSIONS = {
     "turbopages.get": "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria tests.",
     "vcards.get": "Read path omits optional SelectionCriteria when --ids is absent.",
     "ads.get": "Read path with rich field-selection options; payload contract differs from mutating coverage focus.",
-    "bidmodifiers.delete": "Helper/legacy surface; not part of strict WSDL parity claim.",
     "agencyclients.add": "Runtime-deprecated method (Yandex error 3500); CLI rejects with UsageError before reaching dry-run. See RUNTIME_DEPRECATED_METHODS.",
     "dynamicfeedadtargets.add": "Covered by test_dry_run.py::test_dynamicfeedadtargets_add_payload.",
     "dynamicfeedadtargets.delete": "Covered by test_dry_run.py::test_dynamicfeedadtargets_delete_payload.",
@@ -468,6 +467,11 @@ PAYLOAD_CASES = [
         "audiencetargets",
         "delete",
         ["audiencetargets", "delete", "--id", "16"],
+    ),
+    (
+        "bidmodifiers",
+        "delete",
+        ["bidmodifiers", "delete", "--id", "10"],
     ),
     (
         "dynamictextadtargets",


### PR DESCRIPTION
## Summary

Closes the one accepted finding from the Codex adversarial review on milestone 0.3.8.

`bidmodifiers.delete` is a real destructive WSDL operation (`DeleteRequest` with required `SelectionCriteria.Ids`, see `tests/wsdl_cache/bidmodifiers.xml`). The CLI ships that exact request shape (`direct_cli/commands/bidmodifiers.py:delete`), but the entry was hidden in `DRY_RUN_PAYLOAD_EXCLUSIONS` with the rationale 'helper/legacy surface' — incorrect classification, leaving an irreversible operation without schema drift protection.

## Change

- Drop the exclusion line.
- Add `("bidmodifiers", "delete", ["bidmodifiers", "delete", "--id", "10"])` to `PAYLOAD_CASES`.

## Verification

- `pytest -q tests/test_api_coverage.py::TestApiCoverage::test_dry_run_payload_schema_coverage tests/test_api_coverage.py::TestApiCoverage::test_all_canonical_dry_run_commands_have_payload_coverage_or_exclusion` → 73 passed (was 72).
- `scripts/build_api_coverage_report.py` → `nested_schema_violations=[]`, `operation_waiver_misuse=[]`, `schema_parity_ok=true`.
- Offline suite → 678 passed, 5 skipped, no regressions.

## Context

Companion follow-up to the merged 0.3.8 milestone batch. The other finding from the same review (live cassettes under sandbox URL for `TestWriteBidsRead`) is declined for this single-author repo — see the response comment posted on the review thread.