### PR TITLE
fix(ads): require explicit --type on ads update (mirrors API Yandex)

### DIFF
--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -289,47 +289,97 @@ def add(
 @ads.command()
 @click.option("--id", "ad_id", required=True, type=int, help="Ad ID")
 @click.option(
+    "--type",
+    "ad_type",
+    required=True,
+    help="Ad subtype: TEXT_AD | TEXT_IMAGE_AD | MOBILE_APP_AD",
+)
+@click.option(
     "--status",
     help=(
         "Deprecated: not part of WSDL AdUpdateItem. "
         "Use 'direct ads suspend/resume/archive/unarchive' instead."
     ),
 )
-@click.option("--title", help="New text ad title")
-@click.option("--text", help="New text ad text")
-@click.option("--href", help="New text ad URL")
-@click.option("--image-hash", help="New text image ad image hash")
+@click.option("--title", help="Title (TEXT_AD / MOBILE_APP_AD)")
+@click.option("--text", help="Text (TEXT_AD / MOBILE_APP_AD)")
+@click.option("--href", help="URL (TEXT_AD / TEXT_IMAGE_AD)")
+@click.option("--image-hash", help="Image hash (TEXT_IMAGE_AD / MOBILE_APP_AD)")
+@click.option(
+    "--action",
+    help="MOBILE_APP_AD call-to-action (MobileAppAdActionEnum, e.g. INSTALL)",
+)
+@click.option("--tracking-url", help="MOBILE_APP_AD tracking URL")
+@click.option("--age-label", help="MOBILE_APP_AD age label (MobAppAgeLabelEnum)")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def update(ctx, ad_id, status, title, text, href, image_hash, dry_run):
+def update(
+    ctx,
+    ad_id,
+    ad_type,
+    status,
+    title,
+    text,
+    href,
+    image_hash,
+    action,
+    tracking_url,
+    age_label,
+    dry_run,
+):
     """Update ad"""
     if status:
         raise click.UsageError(
             "Use 'direct ads suspend/resume/archive/unarchive' to change status. "
             "The --status flag is not supported by WSDL AdUpdateItem."
         )
-    text_ad_flags_set = any([title, text, href])
-    image_ad_flag_set = bool(image_hash)
-    if text_ad_flags_set and image_ad_flag_set:
+
+    ad_type_norm = ad_type.upper().replace("-", "_")
+    supported_types = {"TEXT_AD", "TEXT_IMAGE_AD", "MOBILE_APP_AD"}
+    if ad_type_norm not in supported_types:
         raise click.UsageError(
-            "Cannot mix --title/--text/--href (TextAd) with --image-hash "
-            "(TextImageAd) in one update. WSDL AdUpdateItem expects a "
-            "single ad-subtype block."
+            "Invalid value for '--type': "
+            f"{ad_type!r} is not one of "
+            "'TEXT_AD', 'TEXT_IMAGE_AD', 'MOBILE_APP_AD'."
         )
 
     try:
         ad_data = {"Id": ad_id}
 
-        if text_ad_flags_set:
-            ad_data["TextAd"] = {}
+        if ad_type_norm == "TEXT_AD":
+            text_ad = {}
             if title:
-                ad_data["TextAd"]["Title"] = title
+                text_ad["Title"] = title
             if text:
-                ad_data["TextAd"]["Text"] = text
+                text_ad["Text"] = text
             if href:
-                ad_data["TextAd"]["Href"] = href
-        if image_ad_flag_set:
-            ad_data["TextImageAd"] = {"AdImageHash": image_hash}
+                text_ad["Href"] = href
+            if text_ad:
+                ad_data["TextAd"] = text_ad
+        elif ad_type_norm == "TEXT_IMAGE_AD":
+            text_image_ad = {}
+            if image_hash:
+                text_image_ad["AdImageHash"] = image_hash
+            if href:
+                text_image_ad["Href"] = href
+            if text_image_ad:
+                ad_data["TextImageAd"] = text_image_ad
+        elif ad_type_norm == "MOBILE_APP_AD":
+            mobile_app_ad = {}
+            if title:
+                mobile_app_ad["Title"] = title
+            if text:
+                mobile_app_ad["Text"] = text
+            if image_hash:
+                mobile_app_ad["AdImageHash"] = image_hash
+            if action:
+                mobile_app_ad["Action"] = action.upper()
+            if tracking_url:
+                mobile_app_ad["TrackingUrl"] = tracking_url
+            if age_label:
+                mobile_app_ad["AgeLabel"] = age_label.upper()
+            if mobile_app_ad:
+                ad_data["MobileAppAd"] = mobile_app_ad
 
         body = {"method": "update", "params": {"Ads": [ad_data]}}
 

--- a/tests/api_coverage_payloads.py
+++ b/tests/api_coverage_payloads.py
@@ -673,6 +673,8 @@ PAYLOAD_CASES = [
             "update",
             "--id",
             "7",
+            "--type",
+            "TEXT_AD",
             "--title",
             "Updated title",
             "--text",

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -653,7 +653,17 @@ def test_ads_update_rejects_status_flag():
     """
     result = CliRunner().invoke(
         cli,
-        ["ads", "update", "--id", "1", "--status", "SUSPENDED", "--dry-run"],
+        [
+            "ads",
+            "update",
+            "--id",
+            "1",
+            "--type",
+            "TEXT_AD",
+            "--status",
+            "SUSPENDED",
+            "--dry-run",
+        ],
     )
     assert result.exit_code != 0
     assert "not supported by WSDL AdUpdateItem" in result.output
@@ -667,6 +677,8 @@ def test_ads_update_text_ad_flags_build_nested_textad():
         "update",
         "--id",
         "999",
+        "--type",
+        "TEXT_AD",
         "--title",
         "Updated",
         "--text",
@@ -691,6 +703,8 @@ def test_ads_update_image_hash_builds_nested_textimagead():
         "update",
         "--id",
         "999",
+        "--type",
+        "TEXT_IMAGE_AD",
         "--image-hash",
         "ygqa6jmlkgsbz7vnewp0",
     )

--- a/tests/test_low_coverage_payloads.py
+++ b/tests/test_low_coverage_payloads.py
@@ -808,35 +808,15 @@ def test_ads_add_rejects_incomplete_text_image_ad():
     assert "TEXT_IMAGE_AD requires both --image-hash and --href" in missing_href.output
 
 
-def test_ads_update_rejects_mixing_text_ad_and_image_ad_flags():
-    """WSDL AdUpdateItem is a one-of choice; mixing subtype flags must
-    be rejected at CLI level rather than emitting an invalid payload."""
-    result = _failing_run(
-        "ads",
-        "update",
-        "--id",
-        "99",
-        "--title",
-        "New title",
-        "--text",
-        "New text",
-        "--href",
-        "https://example.com",
-        "--image-hash",
-        "hash",
-    )
-    assert result.exit_code != 0
-    assert "Cannot mix --title/--text/--href" in result.output
-
-
-def test_ads_update_single_text_ad_flags_still_work():
-    """Updating with only TextAd flags must keep producing the canonical
-    TextAd payload — the rejection above is a guard, not a regression."""
+def test_ads_update_text_ad_builds_textad_payload():
+    """TEXT_AD subtype: --title/--text/--href produce a TextAd block."""
     body = _dry_run(
         "ads",
         "update",
         "--id",
         "99",
+        "--type",
+        "TEXT_AD",
         "--title",
         "New title",
         "--text",
@@ -862,16 +842,20 @@ def test_ads_update_single_text_ad_flags_still_work():
     }
 
 
-def test_ads_update_single_image_ad_flag_still_works():
-    """Updating with only --image-hash must keep producing the canonical
-    TextImageAd payload."""
+def test_ads_update_text_image_ad_builds_textimagead_payload():
+    """TEXT_IMAGE_AD subtype: --image-hash + --href produce a single
+    TextImageAd block (per WSDL TextImageAdUpdate)."""
     body = _dry_run(
         "ads",
         "update",
         "--id",
         "99",
+        "--type",
+        "TEXT_IMAGE_AD",
         "--image-hash",
         "hash",
+        "--href",
+        "https://example.com",
     )
 
     assert body == {
@@ -880,11 +864,72 @@ def test_ads_update_single_image_ad_flag_still_works():
             "Ads": [
                 {
                     "Id": 99,
-                    "TextImageAd": {"AdImageHash": "hash"},
+                    "TextImageAd": {
+                        "AdImageHash": "hash",
+                        "Href": "https://example.com",
+                    },
                 }
             ]
         },
     }
+
+
+def test_ads_update_mobile_app_ad_builds_mobileapp_payload():
+    """MOBILE_APP_AD subtype: all six flags map into a MobileAppAd block."""
+    body = _dry_run(
+        "ads",
+        "update",
+        "--id",
+        "99",
+        "--type",
+        "MOBILE_APP_AD",
+        "--title",
+        "App title",
+        "--text",
+        "App text",
+        "--image-hash",
+        "icon-hash",
+        "--action",
+        "INSTALL",
+        "--tracking-url",
+        "https://track.example",
+        "--age-label",
+        "AGE_12",
+    )
+
+    assert body == {
+        "method": "update",
+        "params": {
+            "Ads": [
+                {
+                    "Id": 99,
+                    "MobileAppAd": {
+                        "Title": "App title",
+                        "Text": "App text",
+                        "AdImageHash": "icon-hash",
+                        "Action": "INSTALL",
+                        "TrackingUrl": "https://track.example",
+                        "AgeLabel": "AGE_12",
+                    },
+                }
+            ]
+        },
+    }
+
+
+def test_ads_update_requires_explicit_type():
+    """ads update without --type must fail with a clear error rather
+    than guessing the subtype from the flags present."""
+    result = _failing_run(
+        "ads",
+        "update",
+        "--id",
+        "99",
+        "--title",
+        "New title",
+    )
+    assert result.exit_code != 0
+    assert "Missing option '--type'" in result.output
 
 
 def test_ads_update_rejects_status_flag():
@@ -894,6 +939,8 @@ def test_ads_update_rejects_status_flag():
         "update",
         "--id",
         "1",
+        "--type",
+        "TEXT_AD",
         "--status",
         "SUSPENDED",
         "--dry-run",


### PR DESCRIPTION
## Summary

Closes the high-severity finding from the latest Codex adversarial review on milestone 0.3.8.

## What was broken (post-PR #196)

PR #196's heuristic for picking the ad subtype from flag presence created two new bugs:

1. **Valid TextImageAd updates were rejected.** `ads update --type ... --image-hash H --href U` raised UsageError, but `TextImageAdUpdate` in WSDL declares both `AdImageHash` (via `ImageAdUpdateBase`) and `Href` — they belong in the same block.
2. **--href silently routed to TextAd.** A bare `--href` was always wrapped in `TextAd`, even when the underlying ad is a TEXT_IMAGE_AD. The user's URL ended up under the wrong subtype.

## Fix

Replace the heuristic with an explicit `--type` flag that mirrors `ads add` and the WSDL choice. Each subtype builds only its own fields:

| --type | Block | Fields |
|---|---|---|
| `TEXT_AD` | `TextAd` | Title, Text, Href |
| `TEXT_IMAGE_AD` | `TextImageAd` | AdImageHash, Href |
| `MOBILE_APP_AD` | `MobileAppAd` | Title, Text, AdImageHash, Action, TrackingUrl, AgeLabel |

No autodetection, no guessing — same one-of-subtype model the API itself uses.

## ⚠️ BREAKING CHANGE

`direct ads update` now **requires** `--type {TEXT_AD,TEXT_IMAGE_AD,MOBILE_APP_AD}`. Scripts that previously called `ads update --id X --title T` will fail with `Missing option '--type'`. The error message is loud and clear.

## Tests

- Replace three PR #196 update tests with three positive subtype tests (TextAd, TextImageAd with both --image-hash + --href, MobileAppAd with all six fields) plus a negative test for missing --type.
- Add `--type TEXT_AD` to the two existing `test_dry_run.py` update tests and to `api_coverage_payloads.py::ads.update` fixture so the schema gate stays green.

## Verification

- `pytest -q tests/test_low_coverage_payloads.py tests/test_dry_run.py tests/test_api_coverage.py` → 322 passed.
- Offline regression → 683 passed, 5 skipped (was 682 → +1 from the new MOBILE_APP_AD test).
- `schema_parity_ok=true`, `nested_schema_violations=[]`.
- Manual reproduction confirms each subtype builds the correct block; `ads update` without `--type` fails with Click's standard missing-option error.