### PR TITLE
docs(claude): add Strict WSDL parity principle + guard test (#199)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,15 @@ Click group-of-groups. Each Yandex Direct API resource = one file in `direct_cli
 
 **Runtime-deprecated methods:** WSDL-visible methods that Yandex rejects at runtime belong in `RUNTIME_DEPRECATED_METHODS` (`direct_cli/wsdl_coverage.py`) and must fail with `click.UsageError` before request construction. `agencyclients add` is blocked this way; use `agencyclients add-passport-organization`.
 
+**Strict WSDL parity:** `DRY_RUN_PAYLOAD_EXCLUSIONS` in `tests/api_coverage_payloads.py` must NOT contain any entry whose rationale claims the CLI surface is a «helper», «legacy», or «not part of strict WSDL parity». If the WSDL declares the operation, the CLI mirrors it 1:1 with a `PAYLOAD_CASES` fixture. Legitimate permanent exclusions are limited to:
+- read-path `*.get` (covered by SelectionCriteria tests);
+- runtime-deprecated methods (see `RUNTIME_DEPRECATED_METHODS`);
+- v4 methods that have no v5 WSDL (covered by `direct_cli/v4_contracts.py`);
+- custom non-RPC endpoints (e.g. `reports.get` — TSV stream);
+- methods explicitly covered by `tests/test_dry_run.py::test_<service>_<op>_payload`.
+
+A guard in `tests/test_api_coverage.py::test_dry_run_exclusions_have_no_helper_or_legacy_rationale` enforces this — any rationale outside those five categories that uses the banned phrasing is a mis-classification: write a `PAYLOAD_CASES` fixture instead. See post-mortem in issue #199.
+
 **SelectionCriteria:** Resources like `adgroups`, `ads`, `keywords` require at least one of `Ids`, `CampaignIds`, or `AdGroupIds` — otherwise API error 4001.
 
 **Error handling:** All commands wrap API calls in `try/except Exception` → `print_error(str(e))` + `raise click.Abort()`.

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -367,6 +367,26 @@ class TestApiCoverage:
             f"Stale registry entries: {sorted(accounted - actual)}"
         )
 
+    def test_dry_run_exclusions_have_no_helper_or_legacy_rationale(self):
+        """Strict WSDL parity guard — see issue #199.
+
+        Any entry in DRY_RUN_PAYLOAD_EXCLUSIONS whose rationale uses the
+        phrases 'helper', 'legacy', or 'not part of strict WSDL parity'
+        indicates a mis-classification. If the WSDL declares the operation,
+        the CLI must mirror it 1:1 with a PAYLOAD_CASES fixture.
+        """
+        banned_phrases = ("helper", "legacy", "not part of strict wsdl parity")
+        offenders = [
+            (key, rationale)
+            for key, rationale in DRY_RUN_PAYLOAD_EXCLUSIONS.items()
+            if any(phrase in rationale.lower() for phrase in banned_phrases)
+        ]
+        assert not offenders, (
+            "DRY_RUN_PAYLOAD_EXCLUSIONS contains entries with banned rationale "
+            f"phrases (helper/legacy/strict parity): {offenders}. "
+            "Add a PAYLOAD_CASES fixture instead. See issue #199."
+        )
+
     def test_reports_contract_coverage(self):
         result = CliRunner().invoke(cli, ["reports", "list-types"])
         assert result.exit_code == 0, result.output


### PR DESCRIPTION
## Summary

Closes #199 — locks the «strict WSDL parity, no helper/legacy skip categories» policy in docs and CI so the `bidmodifiers.delete` mis-classification cannot regress.

## Why

`bidmodifiers.delete` was incorrectly tagged as «Helper/legacy surface; not part of strict WSDL parity claim» in `DRY_RUN_PAYLOAD_EXCLUSIONS` and propagated through PR #185 body + #176 audit + final milestone report — until PR #194 finally removed the entry. The code-fix landed, but **the policy gap** that allowed the mis-classification in the first place was never closed.

## Change

1. **CLAUDE.md** — new «Strict WSDL parity» convention in Key Conventions, listing the only five legitimate permanent exclusion categories (read-path *.get / runtime-deprecated / v4-not-in-v5-wsdl / custom non-RPC / covered by test_dry_run.py). Explicitly bans helper/legacy/not-part-of-strict-WSDL-parity rationale as mis-classification.

2. **tests/test_api_coverage.py** — new `test_dry_run_exclusions_have_no_helper_or_legacy_rationale` guard that fails if any rationale uses banned phrases. Verified both positive (passes on clean main) and negative (temporarily added `Helper/legacy surface ...` entry and it failed with clear offender list + #199 ref).

## Verification

- `pytest -q tests/test_api_coverage.py::TestApiCoverage::test_dry_run_exclusions_have_no_helper_or_legacy_rationale` → 1 passed.
- Negative manual check confirmed: guard catches helper/legacy rationale with clear error message.
- Offline suite → 684 passed, 5 skipped (was 683 — net +1 from the new guard).
- `ruff check tests/test_api_coverage.py` → clean.