### PR TITLE
Complete #198 mutating WSDL audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,8 +438,8 @@ direct dynamicads set-bids --id 789 --bid 12500000 --context-bid 9000000 --prior
 
 # Shared bidding strategies
 direct strategies get --limit 5
-direct strategies add --name "Shared Clicks" --type WbMaximumClicks --spend-limit 1000000000 --average-cpc 30000000 --dry-run
-direct strategies update --id 42 --type WbMaximumClicks --average-cpc 35000000 --dry-run
+direct strategies add --name "Shared Clicks" --type WbMaximumClicks --weekly-spend-limit 1000000000 --bid-ceiling 30000000 --dry-run
+direct strategies update --id 42 --type WbMaximumClicks --weekly-spend-limit 35000000 --dry-run
 direct strategies archive --id 42 --dry-run
 
 # Dynamic feed ad targets
@@ -1077,8 +1077,8 @@ direct dynamicads set-bids --id 789 --bid 12500000 --context-bid 9000000 --prior
 
 # Общие стратегии ставок
 direct strategies get --limit 5
-direct strategies add --name "Общая стратегия" --type WbMaximumClicks --spend-limit 1000000000 --average-cpc 30000000 --dry-run
-direct strategies update --id 42 --type WbMaximumClicks --average-cpc 35000000 --dry-run
+direct strategies add --name "Общая стратегия" --type WbMaximumClicks --weekly-spend-limit 1000000000 --bid-ceiling 30000000 --dry-run
+direct strategies update --id 42 --type WbMaximumClicks --weekly-spend-limit 35000000 --dry-run
 direct strategies archive --id 42 --dry-run
 
 # Динамические таргеты по фиду

--- a/direct_cli/commands/adgroups.py
+++ b/direct_cli/commands/adgroups.py
@@ -14,6 +14,24 @@ def adgroups():
     """Manage ad groups"""
 
 
+def _reject_incompatible_flags(
+    group_type: str,
+    allowed_flags: set[str],
+    provided_flags: dict[str, object],
+) -> None:
+    """Reject subtype-specific flags that do not apply to ``group_type``."""
+    incompatible = [
+        flag
+        for flag, value in provided_flags.items()
+        if value is not None and flag not in allowed_flags
+    ]
+    if incompatible:
+        raise click.UsageError(
+            f"{', '.join(sorted(incompatible))} is not compatible with --type "
+            f"{group_type}."
+        )
+
+
 @adgroups.command()
 @click.option("--ids", help="Comma-separated ad group IDs")
 @click.option("--campaign-ids", help="Comma-separated campaign IDs")
@@ -161,6 +179,21 @@ def add(
                 f"{group_type!r} is not one of "
                 "'TEXT_AD_GROUP', 'DYNAMIC_TEXT_AD_GROUP', 'SMART_AD_GROUP'."
             )
+        allowed_flags_by_type = {
+            "TEXT_AD_GROUP": set(),
+            "DYNAMIC_TEXT_AD_GROUP": {"--domain-url"},
+            "SMART_AD_GROUP": {"--feed-id", "--ad-title-source", "--ad-body-source"},
+        }
+        _reject_incompatible_flags(
+            group_type_norm,
+            allowed_flags_by_type[group_type_norm],
+            {
+                "--domain-url": domain_url,
+                "--feed-id": feed_id,
+                "--ad-title-source": ad_title_source,
+                "--ad-body-source": ad_body_source,
+            },
+        )
 
         adgroup_data = {"Name": name, "CampaignId": campaign_id}
 

--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -14,6 +14,26 @@ def ads():
     """Manage ads"""
 
 
+def _reject_incompatible_flags(
+    ad_type: str,
+    allowed_fields: set[str],
+    provided: dict[str, object],
+    flag_for: dict[str, str],
+) -> None:
+    """Reject typed flags that do not belong to the selected ad subtype."""
+    incompatible = [
+        flag_for[name]
+        for name, value in provided.items()
+        if value is not None and name not in allowed_fields
+    ]
+    if incompatible:
+        allowed_flags = ", ".join(sorted(flag_for[name] for name in allowed_fields))
+        raise click.UsageError(
+            f"{', '.join(incompatible)} is not compatible with --type {ad_type}. "
+            f"Allowed flags for {ad_type}: {allowed_flags}."
+        )
+
+
 @ads.command()
 @click.option("--ids", help="Comma-separated ad IDs")
 @click.option("--campaign-ids", help="Comma-separated campaign IDs")
@@ -199,6 +219,40 @@ def add(
                 "'TEXT_AD', 'TEXT_IMAGE_AD', 'MOBILE_APP_AD'."
             )
 
+        type_fields = {
+            "TEXT_AD": {"title", "text", "href", "image_hash"},
+            "TEXT_IMAGE_AD": {"href", "image_hash"},
+            "MOBILE_APP_AD": {
+                "title",
+                "text",
+                "image_hash",
+                "action",
+                "tracking_url",
+                "age_label",
+            },
+        }
+        provided = {
+            "title": title,
+            "text": text,
+            "href": href,
+            "image_hash": image_hash,
+            "action": action,
+            "tracking_url": tracking_url,
+            "age_label": age_label,
+        }
+        flag_for = {
+            "title": "--title",
+            "text": "--text",
+            "href": "--href",
+            "image_hash": "--image-hash",
+            "action": "--action",
+            "tracking_url": "--tracking-url",
+            "age_label": "--age-label",
+        }
+        _reject_incompatible_flags(
+            ad_type_norm, type_fields[ad_type_norm], provided, flag_for
+        )
+
         ad_data = {"AdGroupId": adgroup_id}
         if ad_type_norm == "TEXT_AD":
             missing_fields = [
@@ -218,6 +272,8 @@ def add(
                 "Text": text,
                 "Href": href,
             }
+            if image_hash:
+                ad_data["TextAd"]["AdImageHash"] = image_hash
         elif ad_type_norm == "TEXT_IMAGE_AD":
             if title or text:
                 raise click.UsageError(
@@ -380,21 +436,14 @@ def update(
         "tracking_url": "--tracking-url",
         "age_label": "--age-label",
     }
-    incompatible = [
-        flag_for[name]
-        for name, value in provided.items()
-        if value is not None and name not in type_fields[ad_type_norm]
-    ]
-    if incompatible:
-        allowed_flags = ", ".join(
-            sorted(flag_for[name] for name in type_fields[ad_type_norm])
+    try:
+        _reject_incompatible_flags(
+            ad_type_norm, type_fields[ad_type_norm], provided, flag_for
         )
+    except click.UsageError as exc:
         raise click.UsageError(
-            f"{', '.join(incompatible)} is not compatible with --type {ad_type_norm}. "
-            "--type selects the existing ad subtype update block; it does not "
-            "convert an ad between subtypes. "
-            f"Allowed flags for {ad_type_norm}: "
-            f"{allowed_flags}."
+            f"{exc.message} --type selects the existing ad subtype update block; "
+            "it does not convert an ad between subtypes."
         )
 
     ad_data = {"Id": ad_id}

--- a/direct_cli/commands/bidmodifiers.py
+++ b/direct_cli/commands/bidmodifiers.py
@@ -109,6 +109,7 @@ _BIDMODIFIER_TYPE_TO_NESTED = {
     "TABLET_ADJUSTMENT": "TabletAdjustment",
     "DESKTOP_ADJUSTMENT": "DesktopAdjustment",
     "DESKTOP_ONLY_ADJUSTMENT": "DesktopOnlyAdjustment",
+    "SMART_TV_ADJUSTMENT": "SmartTvAdjustment",
     "DEMOGRAPHICS_ADJUSTMENT": "DemographicsAdjustments",  # plural per WSDL
     "RETARGETING_ADJUSTMENT": "RetargetingAdjustments",  # plural per WSDL
     "REGIONAL_ADJUSTMENT": "RegionalAdjustments",  # plural per WSDL
@@ -123,6 +124,40 @@ _BIDMODIFIER_TYPE_TO_NESTED = {
 _PLURAL_NESTED_KEYS = {
     v for v in _BIDMODIFIER_TYPE_TO_NESTED.values() if v.endswith("Adjustments")
 }
+
+_BIDMODIFIER_ALLOWED_EXTRA_FLAGS = {
+    "MOBILE_ADJUSTMENT": set(),
+    "TABLET_ADJUSTMENT": set(),
+    "DESKTOP_ADJUSTMENT": set(),
+    "DESKTOP_ONLY_ADJUSTMENT": set(),
+    "SMART_TV_ADJUSTMENT": set(),
+    "VIDEO_ADJUSTMENT": set(),
+    "SMART_AD_ADJUSTMENT": set(),
+    "AD_GROUP_ADJUSTMENT": set(),
+    "DEMOGRAPHICS_ADJUSTMENT": {"--gender", "--age"},
+    "RETARGETING_ADJUSTMENT": {"--retargeting-condition-id"},
+    "REGIONAL_ADJUSTMENT": {"--region-id"},
+    "SERP_LAYOUT_ADJUSTMENT": {"--serp-layout"},
+    "INCOME_GRADE_ADJUSTMENT": {"--income-grade"},
+}
+
+
+def _reject_incompatible_extra_flags(
+    modifier_type: str,
+    provided_flags: dict[str, object],
+) -> None:
+    """Reject extra flags that do not belong to the selected modifier type."""
+    allowed = _BIDMODIFIER_ALLOWED_EXTRA_FLAGS[modifier_type]
+    incompatible = [
+        flag
+        for flag, value in provided_flags.items()
+        if value is not None and flag not in allowed
+    ]
+    if incompatible:
+        raise click.UsageError(
+            f"{', '.join(sorted(incompatible))} is not compatible with --type "
+            f"{modifier_type}."
+        )
 
 
 @bidmodifiers.command()
@@ -190,9 +225,21 @@ def add(
                 "Exactly one of --campaign-id or --adgroup-id is required"
             )
 
-        nested_key = _BIDMODIFIER_TYPE_TO_NESTED[modifier_type.upper()]
-        nested = {"BidModifier": value}
         modifier_type_upper = modifier_type.upper()
+        _reject_incompatible_extra_flags(
+            modifier_type_upper,
+            {
+                "--gender": gender,
+                "--age": age,
+                "--retargeting-condition-id": retargeting_condition_id,
+                "--region-id": region_id,
+                "--serp-layout": serp_layout,
+                "--income-grade": income_grade,
+            },
+        )
+
+        nested_key = _BIDMODIFIER_TYPE_TO_NESTED[modifier_type_upper]
+        nested = {"BidModifier": value}
         if modifier_type_upper == "DEMOGRAPHICS_ADJUSTMENT":
             if gender:
                 nested["Gender"] = gender
@@ -221,7 +268,7 @@ def add(
                 raise click.UsageError(
                     "INCOME_GRADE_ADJUSTMENT requires --income-grade"
                 )
-            nested["IncomeGrade"] = income_grade
+            nested["Grade"] = income_grade
 
         # Plural fields expect a list per WSDL BidModifierAddItem
         if nested_key in _PLURAL_NESTED_KEYS:
@@ -295,8 +342,7 @@ def set(ctx, modifier_id, campaign_id, modifier_type, value, dry_run):
 
     The Yandex Direct API's ``bidmodifiers/set`` method updates existing
     modifiers by ``Id``. To create a new modifier, use ``bidmodifiers add``
-    instead. Prefer ``--id`` with ``--value``; the legacy
-    ``--campaign-id``/``--type`` form is kept only for compatibility.
+    instead.
     """
     try:
         # Validate the mutex up front.
@@ -308,25 +354,16 @@ def set(ctx, modifier_id, campaign_id, modifier_type, value, dry_run):
                 "Use --id + --value for the correct bidmodifiers/set shape."
             )
 
-        if modifier_id is None and (campaign_id is None or modifier_type is None):
+        if modifier_id is None:
             raise click.UsageError(
-                "Provide either --id (preferred) or both --campaign-id "
-                "and --type (legacy)."
+                "Provide --id with --value for bidmodifiers set. "
+                "The legacy --campaign-id/--type shape is not supported by "
+                "WSDL BidModifierSetItem; use bidmodifiers add to create a "
+                "new modifier."
             )
 
-        if modifier_id is not None:
-            # Correct API shape: Id + BidModifier. Nothing else.
-            modifier_data = {"Id": modifier_id, "BidModifier": value}
-        else:
-            # Legacy broken-by-design path — kept for backwards
-            # compatibility with the existing regression test.  The
-            # click.Choice above has already validated/normalized
-            # modifier_type, so we forward it unchanged.
-            modifier_data = {
-                "CampaignId": campaign_id,
-                "Type": modifier_type,
-                "BidModifier": value,
-            }
+        # Correct API shape: Id + BidModifier. Nothing else.
+        modifier_data = {"Id": modifier_id, "BidModifier": value}
 
         body = {"method": "set", "params": {"BidModifiers": [modifier_data]}}
 

--- a/direct_cli/commands/campaigns.py
+++ b/direct_cli/commands/campaigns.py
@@ -33,6 +33,24 @@ def _parse_csv_option(option_name: str, value: Optional[str]) -> Optional[List[s
     return parsed
 
 
+def _reject_incompatible_flags(
+    command_type: str,
+    allowed_flags: set[str],
+    provided_flags: dict[str, object],
+) -> None:
+    """Reject typed flags that do not belong to the chosen subtype."""
+    incompatible = [
+        flag
+        for flag, value in provided_flags.items()
+        if value is not None and flag not in allowed_flags
+    ]
+    if incompatible:
+        raise click.UsageError(
+            f"{', '.join(sorted(incompatible))} is not compatible with --type "
+            f"{command_type}."
+        )
+
+
 @campaigns.command()
 @click.option("--ids", help="Comma-separated campaign IDs")
 @click.option("--status", help="Filter by status (ACTIVE, SUSPENDED, etc.)")
@@ -273,6 +291,33 @@ def add(
                 "'TEXT_CAMPAIGN', 'DYNAMIC_TEXT_CAMPAIGN', 'SMART_CAMPAIGN'."
             )
 
+        allowed_flags_by_type = {
+            "TEXT_CAMPAIGN": {"--setting", "--search-strategy", "--network-strategy"},
+            "DYNAMIC_TEXT_CAMPAIGN": {
+                "--setting",
+                "--search-strategy",
+                "--network-strategy",
+            },
+            "SMART_CAMPAIGN": {
+                "--setting",
+                "--search-strategy",
+                "--network-strategy",
+                "--filter-average-cpc",
+                "--counter-id",
+            },
+        }
+        _reject_incompatible_flags(
+            campaign_type_norm,
+            allowed_flags_by_type[campaign_type_norm],
+            {
+                "--setting": list(settings) or None,
+                "--search-strategy": search_strategy,
+                "--network-strategy": network_strategy,
+                "--filter-average-cpc": filter_average_cpc,
+                "--counter-id": counter_id,
+            },
+        )
+
         campaign_data = {"Name": name, "StartDate": start_date}
         parsed_settings = parse_setting_specs(list(settings))
         if campaign_type_norm == "TEXT_CAMPAIGN":
@@ -308,6 +353,14 @@ def add(
                     "(WSDL SmartCampaignAddItem.CounterId minOccurs=1)"
                 )
             network_strategy_type = network_strategy or "AVERAGE_CPC_PER_FILTER"
+            if (
+                filter_average_cpc is not None
+                and network_strategy_type != "AVERAGE_CPC_PER_FILTER"
+            ):
+                raise click.UsageError(
+                    "--filter-average-cpc is only valid for SMART_CAMPAIGN "
+                    "with AVERAGE_CPC_PER_FILTER network strategy"
+                )
             smart_campaign = {
                 "BiddingStrategy": {
                     "Search": {"BiddingStrategyType": search_strategy or "SERVING_OFF"},

--- a/direct_cli/commands/strategies.py
+++ b/direct_cli/commands/strategies.py
@@ -66,8 +66,102 @@ GOAL_ID_STRATEGY_TYPES = (
     | FILTER_CPA_STRATEGY_TYPES
     | PAY_FOR_CONVERSION_STRATEGY_TYPES
     | CRR_STRATEGY_TYPES
+    | {"WbMaximumConversionRate"}
     | {"PayForConversionMultipleGoals"}
 )
+STRATEGY_FIELD_OPTIONS = {
+    "WbMaximumClicks": {
+        "weekly_spend_limit": "WeeklySpendLimit",
+        "bid_ceiling": "BidCeiling",
+    },
+    "WbMaximumConversionRate": {
+        "weekly_spend_limit": "WeeklySpendLimit",
+        "bid_ceiling": "BidCeiling",
+        "goal_id": "GoalId",
+    },
+    "AverageCpc": {
+        "average_cpc": "AverageCpc",
+        "weekly_spend_limit": "WeeklySpendLimit",
+    },
+    "AverageCpcPerCampaign": {
+        "average_cpc": "AverageCpc",
+        "weekly_spend_limit": "WeeklySpendLimit",
+        "bid_ceiling": "BidCeiling",
+    },
+    "AverageCpcPerFilter": {
+        "average_cpc": "FilterAverageCpc",
+        "weekly_spend_limit": "WeeklySpendLimit",
+        "bid_ceiling": "BidCeiling",
+    },
+    "AverageCpa": {
+        "average_cpa": "AverageCpa",
+        "goal_id": "GoalId",
+        "weekly_spend_limit": "WeeklySpendLimit",
+        "bid_ceiling": "BidCeiling",
+    },
+    "AverageCpaPerCampaign": {
+        "average_cpa": "AverageCpa",
+        "goal_id": "GoalId",
+        "weekly_spend_limit": "WeeklySpendLimit",
+        "bid_ceiling": "BidCeiling",
+    },
+    "AverageCpaPerFilter": {
+        "average_cpa": "FilterAverageCpa",
+        "goal_id": "GoalId",
+        "weekly_spend_limit": "WeeklySpendLimit",
+        "bid_ceiling": "BidCeiling",
+    },
+    "AverageCpaMultipleGoals": {
+        "weekly_spend_limit": "WeeklySpendLimit",
+        "bid_ceiling": "BidCeiling",
+    },
+    "AverageCrr": {
+        "average_crr": "Crr",
+        "goal_id": "GoalId",
+        "weekly_spend_limit": "WeeklySpendLimit",
+    },
+    "MaxProfit": {
+        "weekly_spend_limit": "WeeklySpendLimit",
+    },
+    "PayForConversion": {
+        "average_cpa": "Cpa",
+        "goal_id": "GoalId",
+        "weekly_spend_limit": "WeeklySpendLimit",
+    },
+    "PayForConversionPerCampaign": {
+        "average_cpa": "Cpa",
+        "goal_id": "GoalId",
+        "weekly_spend_limit": "WeeklySpendLimit",
+    },
+    "PayForConversionPerFilter": {
+        "average_cpa": "Cpa",
+        "goal_id": "GoalId",
+        "weekly_spend_limit": "WeeklySpendLimit",
+    },
+    "PayForConversionCrr": {
+        "average_crr": "Crr",
+        "goal_id": "GoalId",
+        "weekly_spend_limit": "WeeklySpendLimit",
+    },
+    "PayForConversionMultipleGoals": {
+        "goal_id": "GoalId",
+        "weekly_spend_limit": "WeeklySpendLimit",
+    },
+}
+STRATEGY_UPDATE_FIELD_OPTIONS = {
+    strategy_type: dict(options)
+    for strategy_type, options in STRATEGY_FIELD_OPTIONS.items()
+}
+STRATEGY_UPDATE_FIELD_OPTIONS["PayForConversionMultipleGoals"].pop("goal_id")
+STRATEGY_FLAG_NAMES = {
+    "average_cpc": "--average-cpc",
+    "average_cpa": "--average-cpa",
+    "average_crr": "--average-crr",
+    "goal_id": "--goal-id",
+    "spend_limit": "--spend-limit",
+    "weekly_spend_limit": "--weekly-spend-limit",
+    "bid_ceiling": "--bid-ceiling",
+}
 
 
 def _parse_priority_goal(spec: str) -> dict:
@@ -94,38 +188,62 @@ def _build_strategy_fields(
     spend_limit,
     weekly_spend_limit,
     bid_ceiling,
+    *,
+    update=False,
 ):
     """Build typed strategy-specific fields."""
+    if strategy_type is None:
+        if any(
+            value is not None
+            for value in (
+                average_cpc,
+                average_cpa,
+                average_crr,
+                goal_id,
+                spend_limit,
+                weekly_spend_limit,
+                bid_ceiling,
+            )
+        ):
+            raise click.UsageError(
+                "Provide --type when setting strategy-specific fields"
+            )
+        return {}
+
+    field_options = STRATEGY_UPDATE_FIELD_OPTIONS if update else STRATEGY_FIELD_OPTIONS
+    allowed_options = field_options[strategy_type]
+    provided_options = {
+        "average_cpc": average_cpc,
+        "average_cpa": average_cpa,
+        "average_crr": average_crr,
+        "goal_id": goal_id,
+        "spend_limit": spend_limit,
+        "weekly_spend_limit": weekly_spend_limit,
+        "bid_ceiling": bid_ceiling,
+    }
+    incompatible = [
+        STRATEGY_FLAG_NAMES[name]
+        for name, value in provided_options.items()
+        if value is not None and name not in allowed_options
+    ]
+    if incompatible:
+        allowed_flags = ", ".join(
+            sorted(STRATEGY_FLAG_NAMES[name] for name in allowed_options)
+        )
+        raise click.UsageError(
+            f"{', '.join(incompatible)} is not valid for --type {strategy_type}. "
+            f"Allowed strategy field flags: {allowed_flags}."
+        )
+
     fields = {}
     if average_cpc is not None:
-        if strategy_type in FILTER_CPC_STRATEGY_TYPES:
-            fields["FilterAverageCpc"] = average_cpc
-        else:
-            fields["AverageCpc"] = average_cpc
+        fields[allowed_options["average_cpc"]] = average_cpc
     if average_cpa is not None:
-        if strategy_type in MULTI_GOAL_STRATEGY_TYPES:
-            # StrategyAverageCpaMultipleGoalsAddItem and
-            # StrategyPayForConversionMultipleGoalsAddItem have no Cpa
-            # field — reject the flag explicitly rather than emit a
-            # WSDL-unknown key.
-            raise click.UsageError(
-                f"--average-cpa is not valid for --type {strategy_type}"
-            )
-        if strategy_type in PAY_FOR_CONVERSION_STRATEGY_TYPES:
-            fields["Cpa"] = average_cpa
-        elif strategy_type in FILTER_CPA_STRATEGY_TYPES:
-            fields["FilterAverageCpa"] = average_cpa
-        else:
-            fields["AverageCpa"] = average_cpa
-    if strategy_type in CRR_STRATEGY_TYPES:
-        if average_crr is not None:
-            fields["Crr"] = average_crr
-    elif average_crr is not None:
-        fields["AverageCrr"] = average_crr
-    if strategy_type in GOAL_ID_STRATEGY_TYPES and goal_id is not None:
-        fields["GoalId"] = goal_id
-    if spend_limit is not None:
-        fields["SpendLimit"] = spend_limit
+        fields[allowed_options["average_cpa"]] = average_cpa
+    if average_crr is not None:
+        fields[allowed_options["average_crr"]] = average_crr
+    if goal_id is not None:
+        fields[allowed_options["goal_id"]] = goal_id
     if weekly_spend_limit is not None:
         fields["WeeklySpendLimit"] = weekly_spend_limit
     if bid_ceiling is not None:
@@ -364,6 +482,7 @@ def update(
             spend_limit,
             weekly_spend_limit,
             bid_ceiling,
+            update=True,
         )
         if strategy_fields and not strategy_type:
             raise click.UsageError(
@@ -382,7 +501,7 @@ def update(
             # GoalId is minOccurs=0 in every Strategy*Base used by
             # Strategy*UpdateItem (cached WSDL strategies.xml), so update
             # must NOT require --goal-id even for the goal-id family —
-            # users may change AverageCpa/Crr/SpendLimit without
+            # users may change AverageCpa/Crr/WeeklySpendLimit without
             # re-specifying the existing goal. The add command keeps the
             # required-on-add validation because *AddItem.GoalId is
             # minOccurs=1.

--- a/docs/audits/issue-198-mutating-wsdl-audit.md
+++ b/docs/audits/issue-198-mutating-wsdl-audit.md
@@ -1,0 +1,148 @@
+# Issue #198 Mutating WSDL Audit
+
+Date: 2026-05-20
+Branch: `codex/reopen-198-full-mutating-audit`
+Base observed before work: `main` at `8f2a9e3` or newer
+
+## Scope
+
+This pass treats `#198` as incomplete until the full current
+`direct_cli.smoke_matrix.WRITE_SANDBOX` surface is accounted for:
+
+- 83 write-class commands total.
+- 32 v5 `add` / `update` / `set` commands covered by
+  `tests/test_wsdl_parity_gate.py::COMMAND_WSDL_MAP`.
+- 43 v5 lifecycle / other write commands covered by dry-run payload fixtures or
+  focused dry-run tests.
+- 8 v4 write-class commands checked against `direct_cli/v4_contracts.py` and
+  focused v4 tests, not v5 WSDL.
+
+The old "7 Med + 4 Low" table could not be recovered from the repo, GitHub
+issue text, or targeted local transcript search available in this workspace.
+This artifact therefore records a fresh regenerated audit against cached WSDL,
+current CLI code, and dry-run payload evidence. The confirmed remaining tail
+from that pass is tracked here as `#198/#210` subtype compatibility plus the
+`smartadtargets` gate-map gap found while building this table.
+
+## Confirmed Findings Fixed In This Pass
+
+- `campaigns add`: reject smart-only flags on non-smart campaign types and
+  reject `--filter-average-cpc` unless the smart network strategy is
+  `AVERAGE_CPC_PER_FILTER`.
+- `adgroups add`: reject dynamic/smart subtype flags when `--type` selects a
+  different WSDL subtype.
+- `ads add`: preserve WSDL-valid `TextAd.AdImageHash` and reject incompatible
+  subtype flags instead of silently dropping them.
+- `bidmodifiers add`: reject incompatible extra flags, emit
+  `IncomeGradeAdjustments[].Grade`, and expose WSDL `SmartTvAdjustment`.
+- `bidmodifiers set`: reject the legacy `CampaignId + Type + BidModifier`
+  shape locally; WSDL `BidModifierSetItem` supports only `Id + BidModifier`.
+- `strategies add/update`: validate typed strategy flags against the selected
+  WSDL subtype. `--spend-limit` is rejected for now because WSDL exposes that
+  value only inside `CustomPeriodBudget`, which also requires dates and
+  `AutoContinue`.
+- `smartadtargets add/update`: fix the parity gate map from the stale
+  `Webpages` container to the actual `SmartAdTargets` WSDL container.
+
+## Audit Table
+
+| command | API/WSDL operation | request shape | CLI flags checked | dry-run evidence | verdict | issue/fix PR |
+|---|---|---|---|---|---|---|
+| adextensions.add | adextensions.add | params.AdExtensions[] | --callout-text | PAYLOAD_CASES dry-run: method=add; params=AdExtensions | pass: no confirmed Med/Low drift in this pass | n/a |
+| adextensions.delete | adextensions.delete | params.SelectionCriteria.Ids[] | --id | PAYLOAD_CASES dry-run: method=delete; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+| adgroups.add | adgroups.add | params.AdGroups[] | --campaign-id --name --type --domain-url --region-ids | PAYLOAD_CASES dry-run: method=add; params=AdGroups | fixed: subtype flag validation (#198/#210) | this PR |
+| adgroups.delete | adgroups.delete | params.SelectionCriteria.Ids[] | --id | PAYLOAD_CASES dry-run: method=delete; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+| adgroups.update | adgroups.update | params.AdGroups[] | --id --name --region-ids | PAYLOAD_CASES dry-run: method=update; params=AdGroups | pass: no confirmed Med/Low drift in this pass | n/a |
+| adimages.add | adimages.add | params.AdImages[] | --name --image-data | PAYLOAD_CASES dry-run: method=add; params=AdImages | pass: no confirmed Med/Low drift in this pass | n/a |
+| adimages.delete | adimages.delete | params.SelectionCriteria.Ids[] | --hash | PAYLOAD_CASES dry-run: method=delete; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+| ads.add | ads.add | params.Ads[] | --adgroup-id --type --title --text --action | PAYLOAD_CASES dry-run: method=add; params=Ads | fixed: TextAd.AdImageHash + subtype validation (#198/#210) | this PR |
+| ads.archive | ads.archive | params.SelectionCriteria.Ids[] | --id | PAYLOAD_CASES dry-run: method=archive; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+| ads.delete | ads.delete | params.SelectionCriteria.Ids[] | --id | PAYLOAD_CASES dry-run: method=delete; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+| ads.moderate | ads.moderate | params.SelectionCriteria.Ids[] | --id | PAYLOAD_CASES dry-run: method=moderate; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+| ads.resume | ads.resume | params.SelectionCriteria.Ids[] | --id | PAYLOAD_CASES dry-run: method=resume; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+| ads.suspend | ads.suspend | params.SelectionCriteria.Ids[] | --id | PAYLOAD_CASES dry-run: method=suspend; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+| ads.unarchive | ads.unarchive | params.SelectionCriteria.Ids[] | --id | PAYLOAD_CASES dry-run: method=unarchive; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+| ads.update | ads.update | params.Ads[] | --id --type --title --text --href | PAYLOAD_CASES dry-run: method=update; params=Ads | pass: prior #212 + expanded subtype gate | this PR |
+| advideos.add | advideos.add | params.AdVideos[] | --url --name | PAYLOAD_CASES dry-run: method=add; params=AdVideos | pass: no confirmed Med/Low drift in this pass | n/a |
+| audiencetargets.add | audiencetargets.add | params.AudienceTargets[] | --adgroup-id --retargeting-list-id --bid --priority | PAYLOAD_CASES dry-run: method=add; params=AudienceTargets | pass: no confirmed Med/Low drift in this pass | n/a |
+| audiencetargets.delete | audiencetargets.delete | params.SelectionCriteria.Ids[] | --id | PAYLOAD_CASES dry-run: method=delete; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+| audiencetargets.resume | audiencetargets.resume | params.SelectionCriteria.Ids[] | --id | PAYLOAD_CASES dry-run: method=resume; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+| audiencetargets.set-bids | audiencetargets.setBids | typed setter array/criteria per dry-run fixture | --id --context-bid --priority | PAYLOAD_CASES dry-run: method=setBids; params=Bids | pass: no confirmed Med/Low drift in this pass | n/a |
+| audiencetargets.suspend | audiencetargets.suspend | params.SelectionCriteria.Ids[] | --id | PAYLOAD_CASES dry-run: method=suspend; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+| bidmodifiers.add | bidmodifiers.add | params.BidModifiers[] | --campaign-id --type --value | PAYLOAD_CASES dry-run: method=add; params=BidModifiers | fixed: extra-flag validation, Grade, SmartTvAdjustment (#198/#210) | this PR |
+| bidmodifiers.delete | bidmodifiers.delete | params.SelectionCriteria.Ids[] | --id | PAYLOAD_CASES dry-run: method=delete; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+| bidmodifiers.set | bidmodifiers.set | params.BidModifiers[] | --id --value | PAYLOAD_CASES dry-run: method=set; params=BidModifiers | fixed: legacy CampaignId+Type shape rejected (#198/#210) | this PR |
+| bids.set | bids.set | params.Bids[] | --keyword-id --bid | PAYLOAD_CASES dry-run: method=set; params=Bids | pass: no confirmed Med/Low drift in this pass | n/a |
+| bids.set-auto | bids.setAuto | typed setter array/criteria per dry-run fixture | --keyword-id --max-bid --position --scope | PAYLOAD_CASES dry-run: method=setAuto; params=Bids | pass: no confirmed Med/Low drift in this pass | n/a |
+| campaigns.add | campaigns.add | params.Campaigns[] | --name --start-date --type --budget --search-strategy --network-strategy --setting | PAYLOAD_CASES dry-run: method=add; params=Campaigns | fixed: subtype flag validation (#198/#210) | this PR |
+| campaigns.archive | campaigns.archive | params.SelectionCriteria.Ids[] | --id | PAYLOAD_CASES dry-run: method=archive; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+| campaigns.delete | campaigns.delete | params.SelectionCriteria.Ids[] | --id | PAYLOAD_CASES dry-run: method=delete; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+| campaigns.resume | campaigns.resume | params.SelectionCriteria.Ids[] | --id | PAYLOAD_CASES dry-run: method=resume; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+| campaigns.suspend | campaigns.suspend | params.SelectionCriteria.Ids[] | --id | PAYLOAD_CASES dry-run: method=suspend; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+| campaigns.unarchive | campaigns.unarchive | params.SelectionCriteria.Ids[] | --id | PAYLOAD_CASES dry-run: method=unarchive; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+| campaigns.update | campaigns.update | params.Campaigns[] | --id --name --budget --end-date | PAYLOAD_CASES dry-run: method=update; params=Campaigns | pass: no confirmed Med/Low drift in this pass | n/a |
+| clients.update | clients.update | params.Clients[] | --client-info --phone --notification-email --notification-lang --email-subscription --setting --tin-type --tin | PAYLOAD_CASES dry-run: method=update; params=Clients | pass: no confirmed Med/Low drift in this pass | n/a |
+| creatives.add | creatives.add | params.Creatives[] | --video-id | PAYLOAD_CASES dry-run: method=add; params=Creatives | pass: no confirmed Med/Low drift in this pass | n/a |
+| dynamicads.add | dynamictextadtargets.add | params.Webpages[] | --adgroup-id --name --condition --bid --context-bid --priority | PAYLOAD_CASES dry-run: method=add; params=Webpages | pass: no confirmed Med/Low drift in this pass | n/a |
+| dynamicads.delete | dynamicads.delete | params.SelectionCriteria.Ids[] | --id | PAYLOAD_CASES dry-run: method=delete; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+| dynamicads.resume | dynamicads.resume | params.SelectionCriteria.Ids[] | --id | PAYLOAD_CASES dry-run: method=resume; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+| dynamicads.set-bids | dynamicads.setBids | typed setter array/criteria per dry-run fixture | --id --bid --context-bid --priority | PAYLOAD_CASES dry-run: method=setBids; params=Bids | pass: no confirmed Med/Low drift in this pass | n/a |
+| dynamicads.suspend | dynamicads.suspend | params.SelectionCriteria.Ids[] | --id | PAYLOAD_CASES dry-run: method=suspend; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+| dynamicfeedadtargets.add | dynamicfeedadtargets.add | params.DynamicFeedAdTargets[] | focused dry-run/v4 test flags | Covered by test_dry_run.py::test_dynamicfeedadtargets_add_payload. | pass: no confirmed Med/Low drift in this pass | n/a |
+| dynamicfeedadtargets.delete | dynamicfeedadtargets.delete | params.SelectionCriteria.Ids[] | focused dry-run/v4 test flags | Covered by test_dry_run.py::test_dynamicfeedadtargets_delete_payload. | pass: no confirmed Med/Low drift in this pass | n/a |
+| dynamicfeedadtargets.resume | dynamicfeedadtargets.resume | params.SelectionCriteria.Ids[] | focused dry-run/v4 test flags | Covered by test_dry_run.py::test_dynamicfeedadtargets_resume_payload. | pass: no confirmed Med/Low drift in this pass | n/a |
+| dynamicfeedadtargets.set-bids | dynamicfeedadtargets.setBids | typed setter array/criteria per dry-run fixture | focused dry-run/v4 test flags | Covered by test_dry_run.py::test_dynamicfeedadtargets_set_bids_payload. | pass: no confirmed Med/Low drift in this pass | n/a |
+| dynamicfeedadtargets.suspend | dynamicfeedadtargets.suspend | params.SelectionCriteria.Ids[] | focused dry-run/v4 test flags | Covered by test_dry_run.py::test_dynamicfeedadtargets_suspend_payload. | pass: no confirmed Med/Low drift in this pass | n/a |
+| feeds.add | feeds.add | params.Feeds[] | --name --url --business-type | PAYLOAD_CASES dry-run: method=add; params=Feeds | pass: no confirmed Med/Low drift in this pass | n/a |
+| feeds.delete | feeds.delete | params.SelectionCriteria.Ids[] | --id | PAYLOAD_CASES dry-run: method=delete; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+| feeds.update | feeds.update | params.Feeds[] | --id --name | PAYLOAD_CASES dry-run: method=update; params=Feeds | pass: no confirmed Med/Low drift in this pass | n/a |
+| keywordbids.set | keywordbids.set | params.KeywordBids[] | --keyword-id --search-bid --network-bid | PAYLOAD_CASES dry-run: method=set; params=KeywordBids | pass: no confirmed Med/Low drift in this pass | n/a |
+| keywordbids.set-auto | keywordbids.setAuto | typed setter array/criteria per dry-run fixture | --keyword-id --target-traffic-volume --increase-percent --bid-ceiling | PAYLOAD_CASES dry-run: method=setAuto; params=KeywordBids | pass: no confirmed Med/Low drift in this pass | n/a |
+| keywords.add | keywords.add | params.Keywords[] | --adgroup-id --keyword --bid --context-bid --user-param-1 --user-param-2 | PAYLOAD_CASES dry-run: method=add; params=Keywords | pass: no confirmed Med/Low drift in this pass | n/a |
+| keywords.delete | keywords.delete | params.SelectionCriteria.Ids[] | --id | PAYLOAD_CASES dry-run: method=delete; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+| keywords.resume | keywords.resume | params.SelectionCriteria.Ids[] | --id | PAYLOAD_CASES dry-run: method=resume; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+| keywords.suspend | keywords.suspend | params.SelectionCriteria.Ids[] | --id | PAYLOAD_CASES dry-run: method=suspend; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+| keywords.update | keywords.update | params.Keywords[] | --id --keyword --user-param-1 --user-param-2 | PAYLOAD_CASES dry-run: method=update; params=Keywords | pass: no confirmed Med/Low drift in this pass | n/a |
+| negativekeywordsharedsets.add | negativekeywordsharedsets.add | params.NegativeKeywordSharedSets[] | --name --keywords | PAYLOAD_CASES dry-run: method=add; params=NegativeKeywordSharedSets | pass: no confirmed Med/Low drift in this pass | n/a |
+| negativekeywordsharedsets.delete | negativekeywordsharedsets.delete | params.SelectionCriteria.Ids[] | --id | PAYLOAD_CASES dry-run: method=delete; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+| negativekeywordsharedsets.update | negativekeywordsharedsets.update | params.NegativeKeywordSharedSets[] | --id --keywords | PAYLOAD_CASES dry-run: method=update; params=NegativeKeywordSharedSets | pass: no confirmed Med/Low drift in this pass | n/a |
+| retargeting.add | retargetinglists.add | params.RetargetingLists[] | --name --type --rule | PAYLOAD_CASES dry-run: method=add; params=RetargetingLists | pass: no confirmed Med/Low drift in this pass | n/a |
+| retargeting.delete | retargeting.delete | params.SelectionCriteria.Ids[] | --id | PAYLOAD_CASES dry-run: method=delete; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+| retargeting.update | retargetinglists.update | params.RetargetingLists[] | --id --name --rule | PAYLOAD_CASES dry-run: method=update; params=RetargetingLists | pass: no confirmed Med/Low drift in this pass | n/a |
+| sitelinks.add | sitelinks.add | params.SitelinksSets[] | --sitelink | PAYLOAD_CASES dry-run: method=add; params=SitelinksSets | pass: no confirmed Med/Low drift in this pass | n/a |
+| sitelinks.delete | sitelinks.delete | params.SelectionCriteria.Ids[] | --id | PAYLOAD_CASES dry-run: method=delete; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+| smartadtargets.add | smartadtargets.add | params.SmartAdTargets[] | --adgroup-id --name --audience --condition --average-cpc --priority | PAYLOAD_CASES dry-run: method=add; params=SmartAdTargets | fixed gate map: SmartAdTargets container checked (#198) | this PR |
+| smartadtargets.delete | smartadtargets.delete | params.SelectionCriteria.Ids[] | --id | PAYLOAD_CASES dry-run: method=delete; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+| smartadtargets.resume | smartadtargets.resume | params.SelectionCriteria.Ids[] | --id | PAYLOAD_CASES dry-run: method=resume; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+| smartadtargets.set-bids | smartadtargets.setBids | typed setter array/criteria per dry-run fixture | --id --average-cpc --average-cpa --priority | PAYLOAD_CASES dry-run: method=setBids; params=Bids | pass: no confirmed Med/Low drift in this pass | n/a |
+| smartadtargets.suspend | smartadtargets.suspend | params.SelectionCriteria.Ids[] | --id | PAYLOAD_CASES dry-run: method=suspend; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+| smartadtargets.update | smartadtargets.update | params.SmartAdTargets[] | --id --name --average-cpc --priority | PAYLOAD_CASES dry-run: method=update; params=SmartAdTargets | fixed gate map: SmartAdTargets container checked (#198) | this PR |
+| strategies.add | strategies.add | params.Strategies[] | focused dry-run/v4 test flags | Covered by test_dry_run.py::test_strategies_add_payload. | fixed: WSDL field allow-list, no raw SpendLimit (#198/#210) | this PR |
+| strategies.archive | strategies.archive | params.SelectionCriteria.Ids[] | focused dry-run/v4 test flags | Covered by test_dry_run.py::test_strategies_archive_payload. | pass: no confirmed Med/Low drift in this pass | n/a |
+| strategies.unarchive | strategies.unarchive | params.SelectionCriteria.Ids[] | focused dry-run/v4 test flags | Covered by test_dry_run.py::test_strategies_unarchive_payload. | pass: no confirmed Med/Low drift in this pass | n/a |
+| strategies.update | strategies.update | params.Strategies[] | focused dry-run/v4 test flags | Covered by test_dry_run.py::test_strategies_update_payload. | fixed: WSDL update field allow-list (#198/#210) | this PR |
+| v4account.account-management | v4_contracts.py / accountManagement | V4 Live request contract; dry-run only for write-class commands | typed v4 flags in focused v4 tests | tests/test_v4_* + DRY_RUN_PAYLOAD_EXCLUSIONS | pass: v4 contract, out of v5 WSDL | n/a |
+| v4account.enable-shared-account | v4_contracts.py / enableSharedAccount | V4 Live request contract; dry-run only for write-class commands | typed v4 flags in focused v4 tests | tests/test_v4_* + DRY_RUN_PAYLOAD_EXCLUSIONS | pass: v4 contract, out of v5 WSDL | n/a |
+| v4forecast.create | v4_contracts.py / create | V4 Live request contract; dry-run only for write-class commands | typed v4 flags in focused v4 tests | tests/test_v4_* + DRY_RUN_PAYLOAD_EXCLUSIONS | pass: v4 contract, out of v5 WSDL | n/a |
+| v4forecast.delete | v4_contracts.py / delete | V4 Live request contract; dry-run only for write-class commands | typed v4 flags in focused v4 tests | tests/test_v4_* + DRY_RUN_PAYLOAD_EXCLUSIONS | pass: v4 contract, out of v5 WSDL | n/a |
+| v4tags.update-banners | v4_contracts.py / updateBanners | V4 Live request contract; dry-run only for write-class commands | typed v4 flags in focused v4 tests | tests/test_v4_* + DRY_RUN_PAYLOAD_EXCLUSIONS | pass: v4 contract, out of v5 WSDL | n/a |
+| v4tags.update-campaigns | v4_contracts.py / updateCampaigns | V4 Live request contract; dry-run only for write-class commands | typed v4 flags in focused v4 tests | tests/test_v4_* + DRY_RUN_PAYLOAD_EXCLUSIONS | pass: v4 contract, out of v5 WSDL | n/a |
+| v4wordstat.create-report | v4_contracts.py / createReport | V4 Live request contract; dry-run only for write-class commands | typed v4 flags in focused v4 tests | tests/test_v4_* + DRY_RUN_PAYLOAD_EXCLUSIONS | pass: v4 contract, out of v5 WSDL | n/a |
+| v4wordstat.delete-report | v4_contracts.py / deleteReport | V4 Live request contract; dry-run only for write-class commands | typed v4 flags in focused v4 tests | tests/test_v4_* + DRY_RUN_PAYLOAD_EXCLUSIONS | pass: v4 contract, out of v5 WSDL | n/a |
+| vcards.add | vcards.add | params.VCards[] | --campaign-id --country --city --company-name --work-time --phone-country-code --phone-city-code --phone-number | PAYLOAD_CASES dry-run: method=add; params=VCards | pass: no confirmed Med/Low drift in this pass | n/a |
+| vcards.delete | vcards.delete | params.SelectionCriteria.Ids[] | --id | PAYLOAD_CASES dry-run: method=delete; params=SelectionCriteria | pass: no confirmed Med/Low drift in this pass | n/a |
+
+## Verification Log
+
+- `python3 -m pytest tests/test_wsdl_parity_gate.py -q`: 46 passed, 6 skipped.
+- `python3 -m pytest tests/test_dry_run.py tests/test_low_coverage_payloads.py tests/test_api_coverage.py tests/test_smoke_matrix.py -q`: 355 passed.
+- `python3 -m pytest -m "not integration"`: 760 passed, 44 skipped, 32 deselected.
+- `python3 scripts/build_api_coverage_report.py > /tmp/api_coverage_report.json`:
+  `summary.schema_parity_ok == true`; `schema.nested_schema_violations == []`.
+- `python3 -m ruff check .`: pass.
+- `mypy .`: pass.
+- `git diff --check`: pass.
+- `python3 -m black --check` on changed Python files: pass.
+- `python3 scripts/sandbox_write_audit.py --json-output /tmp/sandbox_audit.json`:
+  83 WRITE_SANDBOX rows audited; live-runner static coverage has 80 PASS and
+  3 NOT_COVERED rows tracked separately in `#213`.

--- a/scripts/sandbox_write_audit.py
+++ b/scripts/sandbox_write_audit.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Static WRITE_SANDBOX coverage audit.
+
+The live runner exercises commands against the Yandex Direct sandbox. This
+script only audits the command matrix and runner coverage so it can run in CI
+without credentials or live API calls.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Callable
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from direct_cli.smoke_matrix import WRITE_SANDBOX, commands_for_category  # noqa: E402
+
+PASS = "PASS"
+SANDBOX_LIMITATION = "SANDBOX_LIMITATION"
+DANGEROUS = "DANGEROUS"
+NOT_COVERED = "NOT_COVERED"
+
+ALLOWED_STATUSES = {PASS, SANDBOX_LIMITATION, DANGEROUS, NOT_COVERED}
+
+FOLLOW_UP_ISSUES = {
+    "clients.update": "https://github.com/axisrow/direct-cli/issues/213",
+    "v4tags.update-banners": "https://github.com/axisrow/direct-cli/issues/213",
+    "v4tags.update-campaigns": "https://github.com/axisrow/direct-cli/issues/213",
+}
+
+DEFAULT_JSON_OUTPUT = ROOT_DIR / "build" / "sandbox_audit.json"
+
+
+@dataclass(frozen=True)
+class AuditRow:
+    """One static audit row for a WRITE_SANDBOX command."""
+
+    group: str
+    subcommand: str
+    command: str
+    status: str
+    evidence: str
+    follow_up: str
+
+
+def load_live_runner_module():
+    """Load sandbox_write_live.py without requiring it to be importable package code."""
+    runner_path = ROOT_DIR / "scripts" / "sandbox_write_live.py"
+    spec = importlib.util.spec_from_file_location("sandbox_write_live", runner_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load {runner_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def split_command(command: str) -> tuple[str, str]:
+    """Split a smoke-matrix command into CLI group and subcommand."""
+    if "." not in command:
+        return command, ""
+    return command.split(".", 1)
+
+
+def row_for_command(command: str, handler: Callable[..., object] | None) -> AuditRow:
+    """Classify one WRITE_SANDBOX command from static runner coverage."""
+    group, subcommand = split_command(command)
+    if handler is None:
+        return AuditRow(
+            group=group,
+            subcommand=subcommand,
+            command=command,
+            status=NOT_COVERED,
+            evidence="missing LiveSandboxRunner handler",
+            follow_up=FOLLOW_UP_ISSUES.get(command, ""),
+        )
+
+    handler_name = getattr(handler, "__name__", repr(handler))
+    evidence = f"LiveSandboxRunner.{handler_name}"
+    if handler_name == "run_not_covered":
+        return AuditRow(
+            group=group,
+            subcommand=subcommand,
+            command=command,
+            status=NOT_COVERED,
+            evidence=evidence,
+            follow_up=FOLLOW_UP_ISSUES.get(command, ""),
+        )
+
+    return AuditRow(
+        group=group,
+        subcommand=subcommand,
+        command=command,
+        status=PASS,
+        evidence=evidence,
+        follow_up="",
+    )
+
+
+def build_rows() -> list[AuditRow]:
+    """Build the full static WRITE_SANDBOX audit table."""
+    module = load_live_runner_module()
+    commands = commands_for_category(WRITE_SANDBOX)
+    runner = module.LiveSandboxRunner(
+        commands=commands,
+        timeout=1,
+        verbose=False,
+        report_file=None,
+    )
+    try:
+        handlers = runner.handlers()
+        return [row_for_command(command, handlers.get(command)) for command in commands]
+    finally:
+        runner.close()
+
+
+def validate_rows(rows: list[AuditRow]) -> list[str]:
+    """Return validation errors that should fail CI."""
+    errors: list[str] = []
+    for row in rows:
+        if row.status not in ALLOWED_STATUSES:
+            errors.append(f"{row.command}: unknown status {row.status}")
+        if row.status == NOT_COVERED and not row.follow_up:
+            errors.append(f"{row.command}: NOT_COVERED row has no follow-up issue")
+    return errors
+
+
+def markdown_table(rows: list[AuditRow]) -> str:
+    """Render the audit as a Markdown table for issue comments and chat output."""
+    lines = [
+        "| group | subcommand | status | evidence | follow_up |",
+        "|---|---|---|---|---|",
+    ]
+    for row in rows:
+        follow_up = row.follow_up or ""
+        lines.append(
+            "| "
+            f"{row.group} | "
+            f"{row.subcommand} | "
+            f"{row.status} | "
+            f"`{row.evidence}` | "
+            f"{follow_up} |"
+        )
+    return "\n".join(lines)
+
+
+def write_json(rows: list[AuditRow], path: Path) -> None:
+    """Write the machine-readable audit artifact."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    counts = {status: 0 for status in sorted(ALLOWED_STATUSES)}
+    for row in rows:
+        counts[row.status] = counts.get(row.status, 0) + 1
+    payload = {
+        "summary": {
+            "category": WRITE_SANDBOX,
+            "total": len(rows),
+            "counts": counts,
+            "ok": not validate_rows(rows),
+        },
+        "rows": [asdict(row) for row in rows],
+    }
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Audit WRITE_SANDBOX live-runner coverage without live API calls."
+    )
+    parser.add_argument(
+        "--json-output",
+        type=Path,
+        default=DEFAULT_JSON_OUTPUT,
+        help="Path for the JSON audit artifact.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the static audit."""
+    args = parse_args()
+    rows = build_rows()
+    errors = validate_rows(rows)
+    write_json(rows, args.json_output)
+    print(markdown_table(rows))
+    if errors:
+        print("\nValidation errors:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_sandbox_write.sh
+++ b/scripts/test_sandbox_write.sh
@@ -7,6 +7,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 ENV_FILE="$ROOT_DIR/.env"
 
+cd "$ROOT_DIR"
+if [[ "${1:-}" == "--audit" ]]; then
+  shift
+  python3 scripts/sandbox_write_audit.py "$@"
+  exit $?
+fi
+
 if [[ -f "$ENV_FILE" ]]; then
   set -a
   # shellcheck disable=SC1090
@@ -34,5 +41,4 @@ print(f"export YANDEX_DIRECT_LOGIN={shlex.quote(login)}")
   eval "$resolved"
 fi
 
-cd "$ROOT_DIR"
 python3 scripts/sandbox_write_live.py "$@"

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -12,8 +12,10 @@ difference between declared strict parity and live-discovered model gaps.
 import json
 import importlib
 import importlib.util
+import re
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
@@ -375,7 +377,16 @@ class TestApiCoverage:
         indicates a mis-classification. If the WSDL declares the operation,
         the CLI must mirror it 1:1 with a PAYLOAD_CASES fixture.
         """
-        banned_phrases = ("helper", "legacy", "not part of strict wsdl parity")
+        banned_phrases = (
+            "helper",
+            "legacy",
+            "not part of strict wsdl parity",
+            "no fixture written",
+            "fixture not written",
+            "not written yet",
+            "todo",
+            "tbd",
+        )
         offenders = [
             (key, rationale)
             for key, rationale in DRY_RUN_PAYLOAD_EXCLUSIONS.items()
@@ -383,9 +394,27 @@ class TestApiCoverage:
         ]
         assert not offenders, (
             "DRY_RUN_PAYLOAD_EXCLUSIONS contains entries with banned rationale "
-            f"phrases (helper/legacy/strict parity): {offenders}. "
+            f"phrases (helper/legacy/strict parity/no fixture): {offenders}. "
             "Add a PAYLOAD_CASES fixture instead. See issue #199."
         )
+
+    def test_dry_run_exclusion_focused_test_references_exist(self):
+        test_dry_run = Path(__file__).with_name("test_dry_run.py")
+        contents = test_dry_run.read_text()
+        declared_tests = set(re.findall(r"^def (test_[A-Za-z0-9_]+)\(", contents, re.M))
+        declared_tests.update(
+            re.findall(r"^\s+def (test_[A-Za-z0-9_]+)\(", contents, re.M)
+        )
+
+        missing = []
+        for key, rationale in DRY_RUN_PAYLOAD_EXCLUSIONS.items():
+            for test_name in re.findall(
+                r"test_dry_run\.py::(test_[A-Za-z0-9_]+)", rationale
+            ):
+                if test_name not in declared_tests:
+                    missing.append((key, test_name))
+
+        assert missing == []
 
     def test_reports_contract_coverage(self):
         result = CliRunner().invoke(cli, ["reports", "list-types"])

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -83,6 +83,16 @@ def _read_dry_run(*args: str) -> dict:
     return json.loads(result.output)
 
 
+def _rejected(*args: str) -> Result:
+    """Invoke a CLI command expecting Click-level rejection."""
+    result = CliRunner().invoke(cli, list(args) + ["--dry-run"])
+    assert result.exit_code != 0, (
+        f"command unexpectedly succeeded: direct {' '.join(args)} --dry-run\n"
+        f"output: {result.output}"
+    )
+    return result
+
+
 def test_get_selection_criteria_new_typed_flags_payloads():
     """Focused payload coverage for WSDL SelectionCriteria flags added for #146."""
     cases = [
@@ -543,6 +553,68 @@ def test_ads_add_text_ad_payload_omits_type():
     }
 
 
+def test_ads_add_text_ad_accepts_wsdl_image_hash():
+    image_hash = "ygqa6jmlkgsbz7vnewp0"
+    body = _dry_run(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "12345",
+        "--type",
+        "TEXT_AD",
+        "--title",
+        "T",
+        "--text",
+        "Some text",
+        "--href",
+        "https://example.com",
+        "--image-hash",
+        image_hash,
+    )
+
+    ad = body["params"]["Ads"][0]
+    assert ad["TextAd"]["AdImageHash"] == image_hash
+
+
+def test_ads_add_rejects_incompatible_subtype_flags():
+    text_ad = _rejected(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "1",
+        "--type",
+        "TEXT_AD",
+        "--title",
+        "T",
+        "--text",
+        "Body",
+        "--href",
+        "https://example.com",
+        "--action",
+        "INSTALL",
+    )
+    text_image = _rejected(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "1",
+        "--type",
+        "TEXT_IMAGE_AD",
+        "--image-hash",
+        "hash",
+        "--href",
+        "https://example.com",
+        "--tracking-url",
+        "https://tracker.example.com",
+    )
+
+    assert "--action is not compatible with --type TEXT_AD" in text_ad.output
+    assert (
+        "--tracking-url is not compatible with --type TEXT_IMAGE_AD"
+        in text_image.output
+    )
+
+
 def test_ads_add_default_type_builds_textad():
     """Without --type, convenience flags still build a TextAd payload."""
     body = _dry_run(
@@ -897,6 +969,67 @@ def test_adgroups_add_smart_payload_omits_type():
     }
 
 
+def test_adgroups_add_rejects_incompatible_subtype_flags():
+    text_result = _rejected(
+        "adgroups",
+        "add",
+        "--name",
+        "Group A",
+        "--campaign-id",
+        "111",
+        "--region-ids",
+        "225",
+        "--type",
+        "TEXT_AD_GROUP",
+        "--domain-url",
+        "example.com",
+    )
+    dynamic_result = _rejected(
+        "adgroups",
+        "add",
+        "--name",
+        "Dynamic Group",
+        "--campaign-id",
+        "111",
+        "--region-ids",
+        "225",
+        "--type",
+        "DYNAMIC_TEXT_AD_GROUP",
+        "--domain-url",
+        "example.com",
+        "--feed-id",
+        "77",
+    )
+    smart_result = _rejected(
+        "adgroups",
+        "add",
+        "--name",
+        "Smart Group",
+        "--campaign-id",
+        "111",
+        "--region-ids",
+        "225",
+        "--type",
+        "SMART_AD_GROUP",
+        "--feed-id",
+        "77",
+        "--domain-url",
+        "example.com",
+    )
+
+    assert (
+        "--domain-url is not compatible with --type TEXT_AD_GROUP" in text_result.output
+    )
+    assert (
+        "--feed-id is not compatible with --type DYNAMIC_TEXT_AD_GROUP"
+        in dynamic_result.output
+    )
+    assert (
+        "--domain-url is not compatible with --type SMART_AD_GROUP"
+        in smart_result.output
+    )
+
+
 def test_adgroups_update_payload_name_only():
     body = _dry_run("adgroups", "update", "--id", "222", "--name", "Renamed")
     assert body["method"] == "update"
@@ -1053,6 +1186,42 @@ def test_campaigns_add_smart_requires_filter_average_cpc():
     assert "--filter-average-cpc" in combined or "AVERAGE_CPC_PER_FILTER" in combined
 
 
+def test_campaigns_add_rejects_incompatible_subtype_flags():
+    text_result = _rejected(
+        "campaigns",
+        "add",
+        "--name",
+        "C-text",
+        "--start-date",
+        "2026-04-10",
+        "--type",
+        "TEXT_CAMPAIGN",
+        "--counter-id",
+        "123",
+    )
+    smart_result = _rejected(
+        "campaigns",
+        "add",
+        "--name",
+        "C-smart",
+        "--start-date",
+        "2026-04-10",
+        "--type",
+        "SMART_CAMPAIGN",
+        "--counter-id",
+        "123",
+        "--network-strategy",
+        "SERVING_OFF",
+        "--filter-average-cpc",
+        "1000000",
+    )
+
+    assert (
+        "--counter-id is not compatible with --type TEXT_CAMPAIGN" in text_result.output
+    )
+    assert "AVERAGE_CPC_PER_FILTER" in smart_result.output
+
+
 # ----------------------------------------------------------------------
 # keywords
 # ----------------------------------------------------------------------
@@ -1137,21 +1306,8 @@ def test_keywordbids_set_search_and_network():
 # ----------------------------------------------------------------------
 
 
-def test_bidmodifiers_set_legacy_payload_keeps_modifier_type():
-    """Legacy (broken-by-design) ``bidmodifiers set`` path.
-
-    The API rejects this shape with ``required field Id is omitted``
-    — see ``TestWriteBidModifiersSet.test_set_without_id_is_rejected``.
-    It is preserved only so that existing integration cassette keeps
-    passing; new callers should use ``--id`` (see test below).
-
-    Regression guard: the enum is the same as ``bidmodifiers add``
-    (``MOBILE_ADJUSTMENT``), not the short form ``MOBILE`` that an
-    older version of this test asserted — the cassette actually
-    sends ``MOBILE_ADJUSTMENT``, and click.Choice now enforces the
-    full enum form.
-    """
-    body = _dry_run(
+def test_bidmodifiers_set_rejects_legacy_campaign_type_shape():
+    result = _rejected(
         "bidmodifiers",
         "set",
         "--campaign-id",
@@ -1161,34 +1317,8 @@ def test_bidmodifiers_set_legacy_payload_keeps_modifier_type():
         "--value",
         "150",
     )
-    assert body["method"] == "set"
-    modifier = body["params"]["BidModifiers"][0]
-    assert modifier == {
-        "CampaignId": 1,
-        "Type": "MOBILE_ADJUSTMENT",
-        "BidModifier": 150,
-    }
 
-
-def test_bidmodifiers_set_legacy_type_is_case_insensitive():
-    """Legacy path: ``--type mobile_adjustment`` (lowercase) is accepted.
-
-    click.Choice(..., case_sensitive=False) normalizes to the canonical
-    uppercase form, so users can't get a silent typo drop.  Regression
-    guard for axisrow/direct-cli#23.
-    """
-    body = _dry_run(
-        "bidmodifiers",
-        "set",
-        "--campaign-id",
-        "1",
-        "--type",
-        "mobile_adjustment",
-        "--value",
-        "150",
-    )
-    modifier = body["params"]["BidModifiers"][0]
-    assert modifier["Type"] == "MOBILE_ADJUSTMENT"
+    assert "legacy --campaign-id/--type shape is not supported" in result.output
 
 
 def test_bidmodifiers_set_with_id_builds_correct_payload():
@@ -1259,7 +1389,7 @@ def test_bidmodifiers_set_without_any_key_errors():
     combined = (result.output or "") + (
         str(result.exception) if result.exception else ""
     )
-    assert "--id" in combined or "--campaign-id" in combined
+    assert "Provide --id with --value" in combined
 
 
 def test_bidmodifiers_add_mobile_uses_nested_object():
@@ -1278,6 +1408,76 @@ def test_bidmodifiers_add_mobile_uses_nested_object():
     assert "Type" not in modifier
     assert modifier["CampaignId"] == 1
     assert modifier["MobileAdjustment"] == {"BidModifier": 120}
+
+
+def test_bidmodifiers_add_rejects_incompatible_extra_flags():
+    mobile_result = _rejected(
+        "bidmodifiers",
+        "add",
+        "--campaign-id",
+        "1",
+        "--type",
+        "MOBILE_ADJUSTMENT",
+        "--value",
+        "120",
+        "--gender",
+        "GENDER_MALE",
+    )
+    demographics_result = _rejected(
+        "bidmodifiers",
+        "add",
+        "--campaign-id",
+        "1",
+        "--type",
+        "DEMOGRAPHICS_ADJUSTMENT",
+        "--value",
+        "120",
+        "--retargeting-condition-id",
+        "123",
+    )
+
+    assert (
+        "--gender is not compatible with --type MOBILE_ADJUSTMENT"
+        in mobile_result.output
+    )
+    assert (
+        "--retargeting-condition-id is not compatible with --type "
+        "DEMOGRAPHICS_ADJUSTMENT"
+    ) in demographics_result.output
+
+
+def test_bidmodifiers_add_income_grade_uses_wsdl_grade_field():
+    body = _dry_run(
+        "bidmodifiers",
+        "add",
+        "--campaign-id",
+        "1",
+        "--type",
+        "INCOME_GRADE_ADJUSTMENT",
+        "--value",
+        "120",
+        "--income-grade",
+        "HIGH",
+    )
+
+    modifier = body["params"]["BidModifiers"][0]
+    assert modifier["IncomeGradeAdjustments"] == [{"BidModifier": 120, "Grade": "HIGH"}]
+
+
+def test_bidmodifiers_add_smart_tv_uses_wsdl_subtype():
+    body = _dry_run(
+        "bidmodifiers",
+        "add",
+        "--campaign-id",
+        "1",
+        "--type",
+        "SMART_TV_ADJUSTMENT",
+        "--value",
+        "120",
+    )
+
+    modifier = body["params"]["BidModifiers"][0]
+    assert modifier["SmartTvAdjustment"] == {"BidModifier": 120}
 
 
 # ----------------------------------------------------------------------
@@ -2153,7 +2353,7 @@ class TestBidModifiersAddPluralFields:
         item = body["params"]["BidModifiers"][0]
         assert "IncomeGradeAdjustments" in item, f"got keys: {list(item.keys())}"
         assert item["IncomeGradeAdjustments"] == [
-            {"BidModifier": 103, "IncomeGrade": "VERY_HIGH"}
+            {"BidModifier": 103, "Grade": "VERY_HIGH"}
         ]
 
     def test_mobile_singular(self):

--- a/tests/test_integration_write.py
+++ b/tests/test_integration_write.py
@@ -34,7 +34,7 @@ Passing in replay (10 tests, cassettes up to date):
   - campaigns draft parity (add/get/delete/get, mirrors live draft tier)
   - adgroups add-update-delete
   - bidmodifiers add/delete (mobile adjustment)
-  - bidmodifiers set regression guard (no-id rejection)
+  - bidmodifiers set regression guard (local no-id rejection)
   - feeds add-update-delete
   - retargeting add-delete
   - vcards add-delete
@@ -547,17 +547,13 @@ class TestWriteBidModifiersAdd:
 @pytest.mark.integration_write
 @pytest.mark.vcr
 class TestWriteBidModifiersSet:
-    """Regression guard: ``bidmodifiers set`` without ``--id`` is rejected.
+    """Regression guard: ``bidmodifiers set`` without ``--id`` is rejected locally.
 
     The API's ``set`` method updates EXISTING modifiers only — it
-    requires the ``Id`` field.  The CLI's ``set`` subcommand builds a
-    payload without ``Id``, so the call is by-design rejected.  New
-    modifiers go through the ``bidmodifiers add`` subcommand instead
-    (covered by ``TestWriteBidModifiersAdd``).
-
-    This test freezes the broken-by-design behaviour: if the CLI ever
-    starts including ``Id`` automatically, or the API stops returning
-    this specific error, the cassette miss will flag it.
+    requires the ``Id`` field.  New modifiers go through
+    ``bidmodifiers add`` instead (covered by ``TestWriteBidModifiersAdd``).
+    The CLI must not send the old ``CampaignId + Type`` shape because
+    it is not a WSDL-valid ``BidModifierSetItem``.
     """
 
     def test_set_without_id_is_rejected(self, sandbox_campaign):
@@ -572,12 +568,11 @@ class TestWriteBidModifiersSet:
             "120",
         )
         assert r.exit_code != 0, (
-            "bidmodifiers set unexpectedly succeeded without --id; either the "
-            "CLI was fixed to include Id, or the API now allows creating "
-            "modifiers via set. Update this test accordingly."
+            "bidmodifiers set unexpectedly succeeded without --id; it must "
+            "reject the legacy CampaignId + Type shape locally."
         )
         assert (
-            "The required field Id is omitted" in r.output
+            "legacy --campaign-id/--type shape is not supported" in r.output
         ), f"Unexpected failure mode from bidmodifiers set: {r.output[:500]}"
 
 

--- a/tests/test_low_coverage_payloads.py
+++ b/tests/test_low_coverage_payloads.py
@@ -169,9 +169,9 @@ def test_strategies_add_typed_fields_payload():
         "Shared Clicks",
         "--type",
         "WbMaximumClicks",
-        "--spend-limit",
+        "--weekly-spend-limit",
         "1000000000",
-        "--average-cpc",
+        "--bid-ceiling",
         "30000000",
         "--counter-ids",
         "1,2",
@@ -182,8 +182,8 @@ def test_strategies_add_typed_fields_payload():
     strategy = body["params"]["Strategies"][0]
     assert body["method"] == "add"
     assert strategy["WbMaximumClicks"] == {
-        "AverageCpc": 30000000,
-        "SpendLimit": 1000000000,
+        "BidCeiling": 30000000,
+        "WeeklySpendLimit": 1000000000,
     }
     assert strategy["CounterIds"] == {"Items": [1, 2]}
     assert strategy["PriorityGoals"] == {"Items": [{"GoalId": 123, "Value": 4560000}]}
@@ -396,6 +396,47 @@ def test_strategies_add_multi_goal_rejects_average_cpa():
     )
 
 
+def test_strategies_add_wb_maximum_clicks_rejects_unknown_strategy_fields():
+    result = _failing_run(
+        "strategies",
+        "add",
+        "--name",
+        "Shared Clicks",
+        "--type",
+        "WbMaximumClicks",
+        "--spend-limit",
+        "1000000000",
+        "--average-cpc",
+        "30000000",
+        "--dry-run",
+    )
+
+    assert result.exit_code != 0
+    assert "--spend-limit" in result.output
+    assert "--average-cpc" in result.output
+    assert "WbMaximumClicks" in result.output
+
+
+def test_strategies_update_multi_goal_rejects_goal_id():
+    result = _failing_run(
+        "strategies",
+        "update",
+        "--id",
+        "42",
+        "--type",
+        "PayForConversionMultipleGoals",
+        "--goal-id",
+        "123",
+        "--dry-run",
+    )
+
+    assert result.exit_code != 0
+    assert (
+        "--goal-id is not valid for --type PayForConversionMultipleGoals"
+        in result.output
+    )
+
+
 def test_strategies_add_pay_for_conversion_multi_goal_requires_goal_id():
     result = _failing_run(
         "strategies",
@@ -419,7 +460,7 @@ def test_strategies_update_typed_metadata_payload():
         "42",
         "--type",
         "WbMaximumClicks",
-        "--average-cpc",
+        "--weekly-spend-limit",
         "35000000",
         "--counter-ids",
         "10,20",
@@ -432,7 +473,7 @@ def test_strategies_update_typed_metadata_payload():
     strategy = body["params"]["Strategies"][0]
     assert strategy == {
         "Id": 42,
-        "WbMaximumClicks": {"AverageCpc": 35000000},
+        "WbMaximumClicks": {"WeeklySpendLimit": 35000000},
         "CounterIds": {"Items": [10, 20]},
         "PriorityGoals": {"Items": [{"GoalId": 123, "Value": 4560000}]},
         "AttributionModel": "LC",
@@ -1046,7 +1087,7 @@ def test_ads_add_text_image_ad_rejects_title_and_text():
             "--dry-run",
         )
         assert result.exit_code != 0, f"expected failure for extras={extra}"
-        assert "--title/--text are only valid for TEXT_AD" in result.output
+        assert "is not compatible with --type TEXT_IMAGE_AD" in result.output
 
 
 def test_ads_add_mobile_app_ad_builds_payload():
@@ -1103,7 +1144,7 @@ def test_ads_add_mobile_app_ad_rejects_href():
         "--dry-run",
     )
     assert result.exit_code != 0
-    assert "--href does not apply to MOBILE_APP_AD" in result.output
+    assert "--href is not compatible with --type MOBILE_APP_AD" in result.output
 
 
 def test_ads_add_mobile_app_ad_requires_action():

--- a/tests/test_sandbox_write_audit.py
+++ b/tests/test_sandbox_write_audit.py
@@ -1,0 +1,75 @@
+import json
+import subprocess
+from pathlib import Path
+
+from direct_cli.smoke_matrix import WRITE_SANDBOX, commands_for_category
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+AUDIT_SCRIPT = ROOT_DIR / "scripts" / "sandbox_write_audit.py"
+SANDBOX_SCRIPT = ROOT_DIR / "scripts" / "test_sandbox_write.sh"
+
+EXPECTED_NOT_COVERED = {
+    "clients.update",
+    "v4tags.update-banners",
+    "v4tags.update-campaigns",
+}
+FOLLOW_UP_ISSUE = "https://github.com/axisrow/direct-cli/issues/213"
+ALLOWED_STATUSES = {"PASS", "SANDBOX_LIMITATION", "DANGEROUS", "NOT_COVERED"}
+
+
+def test_sandbox_write_audit_outputs_markdown_and_json(tmp_path):
+    json_output = tmp_path / "sandbox_audit.json"
+
+    result = subprocess.run(
+        ["python3", str(AUDIT_SCRIPT), "--json-output", str(json_output)],
+        cwd=ROOT_DIR,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "| group | subcommand | status | evidence | follow_up |" in result.stdout
+    assert json_output.exists()
+
+    audit = json.loads(json_output.read_text())
+    rows = audit["rows"]
+
+    assert audit["summary"]["category"] == WRITE_SANDBOX
+    assert audit["summary"]["total"] == len(commands_for_category(WRITE_SANDBOX))
+    assert audit["summary"]["total"] == 83
+    assert len(rows) == 83
+    assert {row["status"] for row in rows} <= ALLOWED_STATUSES
+
+    not_covered = {row["command"] for row in rows if row["status"] == "NOT_COVERED"}
+    assert not_covered == EXPECTED_NOT_COVERED
+
+    for row in rows:
+        if row["status"] == "NOT_COVERED":
+            assert row["follow_up"] == FOLLOW_UP_ISSUE
+        else:
+            assert row["follow_up"] == ""
+
+
+def test_sandbox_write_audit_mode_does_not_require_credentials(tmp_path):
+    json_output = tmp_path / "sandbox_audit.json"
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(SANDBOX_SCRIPT),
+            "--audit",
+            "--json-output",
+            str(json_output),
+        ],
+        cwd=ROOT_DIR,
+        env={},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ERROR: no credentials" not in result.stderr
+    assert "| group | subcommand | status | evidence | follow_up |" in result.stdout
+    assert json_output.exists()

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -100,8 +100,9 @@ def test_empty_payload_no_op_rejected(
     )
     assert expected_error.lower() in result.output.lower(), (
         f"{command_key}: rejection happened but the error message lacks the "
-        f"guard substring {expected_error!r}. PR 2 must add an empty-payload "
-        f"guard, not just any Click required-option. Output: {result.output!r}"
+        f"guard substring {expected_error!r}. The command must have a real "
+        f"empty-payload guard, not just any Click required-option. "
+        f"Output: {result.output!r}"
     )
 
 
@@ -128,6 +129,104 @@ SILENT_LOSS_PROBES: list[tuple[str, list[str], str]] = [
         ],
         "--action",
     ),
+    (
+        "campaigns.add TEXT_CAMPAIGN + --counter-id",
+        [
+            "campaigns",
+            "add",
+            "--name",
+            "C",
+            "--start-date",
+            "2026-04-10",
+            "--type",
+            "TEXT_CAMPAIGN",
+            "--counter-id",
+            "123",
+        ],
+        "--counter-id",
+    ),
+    (
+        "adgroups.add TEXT_AD_GROUP + --domain-url",
+        [
+            "adgroups",
+            "add",
+            "--name",
+            "G",
+            "--campaign-id",
+            "1",
+            "--region-ids",
+            "225",
+            "--type",
+            "TEXT_AD_GROUP",
+            "--domain-url",
+            "example.com",
+        ],
+        "--domain-url",
+    ),
+    (
+        "ads.add TEXT_AD + --action",
+        [
+            "ads",
+            "add",
+            "--adgroup-id",
+            "1",
+            "--type",
+            "TEXT_AD",
+            "--title",
+            "T",
+            "--text",
+            "Body",
+            "--href",
+            "https://example.com",
+            "--action",
+            "INSTALL",
+        ],
+        "--action",
+    ),
+    (
+        "bidmodifiers.add MOBILE_ADJUSTMENT + --gender",
+        [
+            "bidmodifiers",
+            "add",
+            "--campaign-id",
+            "1",
+            "--type",
+            "MOBILE_ADJUSTMENT",
+            "--value",
+            "120",
+            "--gender",
+            "GENDER_MALE",
+        ],
+        "--gender",
+    ),
+    (
+        "strategies.add WbMaximumClicks + --average-cpc",
+        [
+            "strategies",
+            "add",
+            "--name",
+            "S",
+            "--type",
+            "WbMaximumClicks",
+            "--average-cpc",
+            "1000000",
+        ],
+        "--average-cpc",
+    ),
+    (
+        "strategies.update PayForConversionMultipleGoals + --goal-id",
+        [
+            "strategies",
+            "update",
+            "--id",
+            "1",
+            "--type",
+            "PayForConversionMultipleGoals",
+            "--goal-id",
+            "123",
+        ],
+        "--goal-id",
+    ),
 ]
 
 
@@ -145,8 +244,8 @@ def test_silent_data_loss_rejected(
     )
     assert expected_error.lower() in result.output.lower(), (
         f"{probe_id}: rejection happened but the error message does not "
-        f"reference the offending flag {expected_error!r}. PR 2 must add "
-        f"per-type flag validation, not just any UsageError. "
+        f"reference the offending flag {expected_error!r}. The command must "
+        f"have per-type flag validation, not just any UsageError. "
         f"Output: {result.output!r}"
     )
 
@@ -197,8 +296,8 @@ COMMAND_WSDL_MAP: dict[tuple[str, str], tuple[str, str, str]] = {
     ("retargeting", "add"): ("retargetinglists", "add", "RetargetingLists"),
     ("retargeting", "update"): ("retargetinglists", "update", "RetargetingLists"),
     ("sitelinks", "add"): ("sitelinks", "add", "SitelinksSets"),
-    ("smartadtargets", "add"): ("smartadtargets", "add", "Webpages"),
-    ("smartadtargets", "update"): ("smartadtargets", "update", "Webpages"),
+    ("smartadtargets", "add"): ("smartadtargets", "add", "SmartAdTargets"),
+    ("smartadtargets", "update"): ("smartadtargets", "update", "SmartAdTargets"),
     ("strategies", "add"): ("strategies", "add", "Strategies"),
     ("strategies", "update"): ("strategies", "update", "Strategies"),
     ("vcards", "add"): ("vcards", "add", "VCards"),
@@ -215,6 +314,7 @@ COMMAND_WSDL_MAP: dict[tuple[str, str], tuple[str, str, str]] = {
 WSDL_FIELD_TO_CLI_OPTION: dict[str, set[str]] = {
     "AdGroupId": {"--adgroup-id", "--ad-group-id"},
     "CampaignId": {"--campaign-id"},
+    "SmartTvAdjustment": {"--type"},
     "RegionIds": {"--region-ids"},
     "Name": {"--name"},
     "StartDate": {"--start-date"},
@@ -251,7 +351,7 @@ INTERNAL_VALIDATION: dict[tuple[str, str, str], str] = {
         "add",
         "ImageData",
     ): "Provide exactly one of --image-data or --image-file",
-    ("bidmodifiers", "set", "Id"): "Provide either --id",
+    ("bidmodifiers", "set", "Id"): "Provide --id with --value",
     ("bidmodifiers", "set", "BidModifier"): "Missing option '--value'",
     ("retargeting", "add", "Rules"): "Provide at least one --rule",
     ("creatives", "add", "VideoExtensionCreative"): "Missing option '--video-id'",


### PR DESCRIPTION
Refs #198
Refs #210
Refs #213

## Summary

- re-audits the full current `WRITE_SANDBOX` surface with a committed 83-row artifact in `docs/audits/issue-198-mutating-wsdl-audit.md`
- fixes the confirmed remaining WSDL/CLI drift from the subtype-compatibility tail:
  - `campaigns add` smart-only flag rejection and `--filter-average-cpc` strategy guard
  - `adgroups add` subtype flag compatibility
  - `ads add` `TextAd.AdImageHash` plus incompatible subtype flag rejection
  - `bidmodifiers add` incompatible extra flag rejection, WSDL `Grade`, and `SmartTvAdjustment`
  - `bidmodifiers set` local rejection for the legacy WSDL-invalid `CampaignId + Type` shape
  - `strategies add/update` WSDL subtype field allow-list and explicit rejection for raw `--spend-limit`
- expands the WSDL gate for silent-loss probes and fixes the stale `smartadtargets` gate container from `Webpages` to `SmartAdTargets`
- adds a static `WRITE_SANDBOX` live-runner audit mode (`scripts/test_sandbox_write.sh --audit`) with follow-up-only live-runner gaps tracked in #213

## Verification

- `python3 -m pytest tests/test_wsdl_parity_gate.py -q` -> 46 passed, 6 skipped
- `python3 -m pytest tests/test_dry_run.py tests/test_low_coverage_payloads.py tests/test_api_coverage.py tests/test_smoke_matrix.py -q` -> 355 passed
- `python3 -m pytest -m "not integration"` -> 760 passed, 44 skipped, 32 deselected
- `python3 scripts/build_api_coverage_report.py > /tmp/api_coverage_report.json`
  - `summary.schema_parity_ok == true`
  - `schema.nested_schema_violations == []`
- `python3 scripts/sandbox_write_audit.py --json-output /tmp/sandbox_audit.json` -> 83 rows audited; 80 PASS, 3 NOT_COVERED tracked in #213
- `python3 -m ruff check .` -> pass
- `mypy .` -> pass
- `git diff --check` -> pass
- `python3 -m black --check` on changed Python files -> pass

## Notes

The original "7 Med + 4 Low" table was not recoverable from the repo, issue text, or targeted local transcript search available in this workspace, so the artifact records a fresh regenerated WSDL/code/dry-run audit instead. #198 should remain open until this PR has passed CI/review and the final issue comment is posted.
