### PR TITLE
test(sandbox): cover clients.update and v4tags writes in live runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,6 +635,12 @@ For `v4account` sandbox smoke, `enable-shared-account` uses
 `account-management` requires `YANDEX_DIRECT_V4ACCOUNT_ACCOUNT_ID`; without it
 the runner reports `NOT_COVERED` for that command.
 
+`clients.update` is opt-in because it mutates client-level account metadata.
+Set `YANDEX_DIRECT_CLIENTS_UPDATE_LOGIN` to an expendable sandbox
+`Client-Login`; the runner passes it through `--login` and updates only
+`ClientInfo` with a unique smoke marker. Without that variable, the runner
+reports `NOT_COVERED` for `clients.update`.
+
 #### Re-recording write cassettes
 
 The `integration_write` pytest tier still replays stored write-test traffic
@@ -1242,6 +1248,12 @@ sandbox-токен не нужен.
 `YANDEX_DIRECT_V4ACCOUNT_CLIENT_LOGIN` или fallback на `YANDEX_DIRECT_LOGIN`.
 Для `account-management` нужна переменная
 `YANDEX_DIRECT_V4ACCOUNT_ACCOUNT_ID`; без неё runner покажет `NOT_COVERED`.
+
+`clients.update` включается только явно, потому что меняет client-level
+metadata аккаунта. Укажите `YANDEX_DIRECT_CLIENTS_UPDATE_LOGIN` с disposable
+sandbox `Client-Login`; runner передаст его через `--login` и изменит только
+`ClientInfo` на уникальный smoke marker. Без этой переменной runner покажет
+`NOT_COVERED` для `clients.update`.
 
 #### Перезапись write-кассет
 

--- a/scripts/sandbox_write_audit.py
+++ b/scripts/sandbox_write_audit.py
@@ -29,11 +29,7 @@ NOT_COVERED = "NOT_COVERED"
 
 ALLOWED_STATUSES = {PASS, SANDBOX_LIMITATION, DANGEROUS, NOT_COVERED}
 
-FOLLOW_UP_ISSUES = {
-    "clients.update": "https://github.com/axisrow/direct-cli/issues/213",
-    "v4tags.update-banners": "https://github.com/axisrow/direct-cli/issues/213",
-    "v4tags.update-campaigns": "https://github.com/axisrow/direct-cli/issues/213",
-}
+FOLLOW_UP_ISSUES: dict[str, str] = {}
 
 DEFAULT_JSON_OUTPUT = ROOT_DIR / "build" / "sandbox_audit.json"
 

--- a/scripts/sandbox_write_live.py
+++ b/scripts/sandbox_write_live.py
@@ -166,7 +166,7 @@ class LiveSandboxRunner:
             "campaigns.suspend": self.run_campaign_id_command,
             "campaigns.unarchive": self.run_campaign_id_command,
             "campaigns.update": self.run_campaign_id_command,
-            "clients.update": self.run_not_covered,
+            "clients.update": self.run_clients_update,
             "creatives.add": self.run_creative_add,
             "dynamicads.add": self.run_dynamic_ad_add,
             "dynamicads.delete": self.run_dynamic_ad_id_command,
@@ -210,17 +210,23 @@ class LiveSandboxRunner:
             "v4account.enable-shared-account": self.run_v4account_enable_shared_account,
             "v4forecast.create": self.run_v4forecast_create,
             "v4forecast.delete": self.run_v4forecast_delete,
-            "v4tags.update-banners": self.run_not_covered,
-            "v4tags.update-campaigns": self.run_not_covered,
+            "v4tags.update-banners": self.run_v4tags_update_banners,
+            "v4tags.update-campaigns": self.run_v4tags_update_campaigns,
             "v4wordstat.create-report": self.run_v4wordstat_create_report,
             "v4wordstat.delete-report": self.run_v4wordstat_delete_report,
             "vcards.add": self.run_vcard_add,
             "vcards.delete": self.run_vcard_id_command,
         }
 
-    def invoke(self, group: str, command: str, args: list[str]) -> CommandRun:
+    def invoke(
+        self,
+        group: str,
+        command: str,
+        args: list[str],
+        global_args: list[str] | None = None,
+    ) -> CommandRun:
         """Run one canonical CLI command against the sandbox API."""
-        full_args = ["direct", "--sandbox", group, command, *args]
+        full_args = ["direct", "--sandbox", *(global_args or []), group, command, *args]
         if self.verbose:
             print(f"$ {' '.join(shlex.quote(part) for part in full_args)}", flush=True)
         try:
@@ -354,6 +360,35 @@ class LiveSandboxRunner:
             return candidate.strip()
         return None
 
+    def campaign_tag_id(self, run: CommandRun, tag_text: str) -> str | None:
+        """Extract a positive campaign tag ID by tag text from v4 tag output."""
+        data = self.parse_json(run.stdout)
+        return self.campaign_tag_id_from_value(data, tag_text)
+
+    def campaign_tag_id_from_value(self, value: object, tag_text: str) -> str | None:
+        """Find a campaign tag ID in a v4 GetCampaignsTags response tree."""
+        if isinstance(value, dict):
+            tags = value.get("Tags")
+            if isinstance(tags, list):
+                for tag in tags:
+                    if not isinstance(tag, dict) or tag.get("Tag") != tag_text:
+                        continue
+                    tag_id = tag.get("TagID")
+                    if isinstance(tag_id, int) and tag_id > 0:
+                        return str(tag_id)
+                    if isinstance(tag_id, str) and tag_id.strip() not in {"", "0"}:
+                        return tag_id.strip()
+            for nested in value.values():
+                found = self.campaign_tag_id_from_value(nested, tag_text)
+                if found:
+                    return found
+        elif isinstance(value, list):
+            for item in value:
+                found = self.campaign_tag_id_from_value(item, tag_text)
+                if found:
+                    return found
+        return None
+
     def first_value(self, value: object, preferred_keys: tuple[str, ...]) -> str | None:
         """Find the first scalar value for any preferred key in a JSON tree."""
         if isinstance(value, dict):
@@ -417,12 +452,31 @@ class LiveSandboxRunner:
         """Build a unique resource name."""
         return f"direct-cli-{prefix}-{self.suffix}"
 
-    def run_not_covered(self, matrix_command: str) -> ReportRow:
-        return ReportRow(
-            command=matrix_command,
-            status=NOT_COVERED,
-            detail="requires account-specific existing client data",
+    def v4_tag_text(self) -> str:
+        """Build a v4 campaign tag text within the 25-character API limit."""
+        return f"dcli-{self.suffix}"[:25]
+
+    def run_clients_update(self, matrix_command: str) -> ReportRow:
+        client_login = (
+            os.environ.get("YANDEX_DIRECT_CLIENTS_UPDATE_LOGIN") or ""
+        ).strip()
+        if not client_login:
+            return ReportRow(
+                command=matrix_command,
+                status=NOT_COVERED,
+                detail=(
+                    "set YANDEX_DIRECT_CLIENTS_UPDATE_LOGIN to an expendable "
+                    "sandbox Client-Login"
+                ),
+            )
+
+        run = self.invoke(
+            "clients",
+            "update",
+            ["--client-info", self.name("clients-update")],
+            global_args=["--login", client_login],
         )
+        return self.row_from_run(matrix_command, run)
 
     def run_v4account_enable_shared_account(self, matrix_command: str) -> ReportRow:
         client_login = os.environ.get("YANDEX_DIRECT_V4ACCOUNT_CLIENT_LOGIN") or (
@@ -583,6 +637,77 @@ class LiveSandboxRunner:
             ]
         return self.row_from_run(matrix_command, run)
 
+    def create_campaign_tag(self, campaign_id: str, tag_text: str) -> str:
+        run = self.invoke(
+            "v4tags",
+            "update-campaigns",
+            ["--campaign-id", campaign_id, "--tag", f"0={tag_text}"],
+        )
+        status, detail = self.classify(run)
+        if status != PASS:
+            raise PrerequisiteError(
+                status, f"v4tags update-campaigns prerequisite: {detail}"
+            )
+        self.register_cleanup(
+            "campaign tags",
+            "v4tags",
+            "update-campaigns",
+            ["--campaign-id", campaign_id, "--clear-tags"],
+        )
+
+        get_run = self.invoke(
+            "v4tags",
+            "get-campaigns",
+            ["--campaign-ids", campaign_id],
+        )
+        status, detail = self.classify(get_run)
+        if status != PASS:
+            raise PrerequisiteError(
+                status, f"v4tags get-campaigns prerequisite: {detail}"
+            )
+        tag_id = self.campaign_tag_id(get_run, tag_text)
+        if not tag_id:
+            raise PrerequisiteError(
+                FAIL, "v4tags get-campaigns prerequisite returned no new tag ID"
+            )
+        return tag_id
+
+    def run_v4tags_update_campaigns(self, matrix_command: str) -> ReportRow:
+        campaign_id = self.create_campaign()
+        tag_text = self.v4_tag_text()
+        run = self.invoke(
+            "v4tags",
+            "update-campaigns",
+            ["--campaign-id", campaign_id, "--tag", f"0={tag_text}"],
+        )
+        if self.classify(run)[0] == PASS:
+            self.register_cleanup(
+                "campaign tags",
+                "v4tags",
+                "update-campaigns",
+                ["--campaign-id", campaign_id, "--clear-tags"],
+            )
+        return self.row_from_run(matrix_command, run)
+
+    def run_v4tags_update_banners(self, matrix_command: str) -> ReportRow:
+        campaign_id = self.create_campaign()
+        adgroup_id = self.create_adgroup(campaign_id=campaign_id)
+        ad_id = self.create_ad(adgroup_id=adgroup_id)
+        tag_id = self.create_campaign_tag(campaign_id, self.v4_tag_text())
+        run = self.invoke(
+            "v4tags",
+            "update-banners",
+            ["--banner-ids", ad_id, "--tag-ids", tag_id],
+        )
+        if self.classify(run)[0] == PASS:
+            self.register_cleanup(
+                "banner tags",
+                "v4tags",
+                "update-banners",
+                ["--banner-ids", ad_id, "--clear-tags"],
+            )
+        return self.row_from_run(matrix_command, run)
+
     def create_campaign(self, campaign_type: str = "TEXT_CAMPAIGN") -> str:
         args = [
             "--name",
@@ -599,7 +724,9 @@ class LiveSandboxRunner:
         self.register_cleanup("campaign", "campaigns", "delete", ["--id", campaign_id])
         return campaign_id
 
-    def create_adgroup(self, group_type: str = "TEXT_AD_GROUP") -> str:
+    def create_adgroup(
+        self, group_type: str = "TEXT_AD_GROUP", campaign_id: str | None = None
+    ) -> str:
         campaign_type = "TEXT_CAMPAIGN"
         extra_args: list[str] = []
         if group_type == "DYNAMIC_TEXT_AD_GROUP":
@@ -617,7 +744,8 @@ class LiveSandboxRunner:
                 "DESCRIPTION",
             ]
 
-        campaign_id = self.create_campaign(campaign_type)
+        if campaign_id is None:
+            campaign_id = self.create_campaign(campaign_type)
         run = self.invoke(
             "adgroups",
             "add",
@@ -637,8 +765,9 @@ class LiveSandboxRunner:
         self.register_cleanup("adgroup", "adgroups", "delete", ["--id", adgroup_id])
         return adgroup_id
 
-    def create_ad(self) -> str:
-        adgroup_id = self.create_adgroup()
+    def create_ad(self, adgroup_id: str | None = None) -> str:
+        if adgroup_id is None:
+            adgroup_id = self.create_adgroup()
         run = self.invoke(
             "ads",
             "add",

--- a/tests/test_sandbox_write_audit.py
+++ b/tests/test_sandbox_write_audit.py
@@ -8,12 +8,7 @@ ROOT_DIR = Path(__file__).resolve().parent.parent
 AUDIT_SCRIPT = ROOT_DIR / "scripts" / "sandbox_write_audit.py"
 SANDBOX_SCRIPT = ROOT_DIR / "scripts" / "test_sandbox_write.sh"
 
-EXPECTED_NOT_COVERED = {
-    "clients.update",
-    "v4tags.update-banners",
-    "v4tags.update-campaigns",
-}
-FOLLOW_UP_ISSUE = "https://github.com/axisrow/direct-cli/issues/213"
+EXPECTED_NOT_COVERED: set[str] = set()
 ALLOWED_STATUSES = {"PASS", "SANDBOX_LIMITATION", "DANGEROUS", "NOT_COVERED"}
 
 
@@ -45,10 +40,7 @@ def test_sandbox_write_audit_outputs_markdown_and_json(tmp_path):
     assert not_covered == EXPECTED_NOT_COVERED
 
     for row in rows:
-        if row["status"] == "NOT_COVERED":
-            assert row["follow_up"] == FOLLOW_UP_ISSUE
-        else:
-            assert row["follow_up"] == ""
+        assert row["follow_up"] == ""
 
 
 def test_sandbox_write_audit_mode_does_not_require_credentials(tmp_path):

--- a/tests/test_smoke_matrix.py
+++ b/tests/test_smoke_matrix.py
@@ -355,6 +355,208 @@ def test_sandbox_write_live_runner_builds_v4forecast_commands(monkeypatch):
     ]
 
 
+def test_sandbox_write_live_runner_clients_update_requires_opt_in_login(monkeypatch):
+    module = _load_sandbox_runner_module()
+    runner = module.LiveSandboxRunner(
+        commands=["clients.update"],
+        timeout=1,
+        verbose=False,
+        report_file=None,
+    )
+    monkeypatch.delenv("YANDEX_DIRECT_CLIENTS_UPDATE_LOGIN", raising=False)
+
+    try:
+        row = runner.run_one("clients.update")
+    finally:
+        runner.close()
+
+    assert row.status == module.NOT_COVERED
+    assert "YANDEX_DIRECT_CLIENTS_UPDATE_LOGIN" in row.detail
+
+
+def test_sandbox_write_live_runner_builds_clients_update_command(monkeypatch):
+    module = _load_sandbox_runner_module()
+    runner = module.LiveSandboxRunner(
+        commands=["clients.update"],
+        timeout=1,
+        verbose=False,
+        report_file=None,
+    )
+    calls = []
+
+    def fake_invoke(group, command, args, global_args=None):
+        calls.append((group, command, args, global_args))
+        return module.CommandRun(
+            args=["direct", "--sandbox", *(global_args or []), group, command, *args],
+            returncode=0,
+            stdout="{}",
+            stderr="",
+        )
+
+    monkeypatch.setenv("YANDEX_DIRECT_CLIENTS_UPDATE_LOGIN", "client-login")
+    monkeypatch.setattr(runner, "invoke", fake_invoke)
+
+    try:
+        row = runner.run_one("clients.update")
+    finally:
+        runner.close()
+
+    assert row.status == module.PASS
+    assert calls == [
+        (
+            "clients",
+            "update",
+            ["--client-info", runner.name("clients-update")],
+            ["--login", "client-login"],
+        )
+    ]
+
+
+def test_sandbox_write_live_runner_builds_v4tags_update_campaigns(monkeypatch):
+    module = _load_sandbox_runner_module()
+    runner = module.LiveSandboxRunner(
+        commands=["v4tags.update-campaigns"],
+        timeout=1,
+        verbose=False,
+        report_file=None,
+    )
+    calls = []
+
+    def fake_invoke(group, command, args, global_args=None):
+        calls.append((group, command, args, global_args))
+        if (group, command) == ("campaigns", "add"):
+            stdout = json.dumps({"result": {"AddResults": [{"Id": 101}]}})
+        else:
+            stdout = json.dumps({"data": 1})
+        return module.CommandRun(
+            args=["direct", "--sandbox", *(global_args or []), group, command, *args],
+            returncode=0,
+            stdout=stdout,
+            stderr="",
+        )
+
+    monkeypatch.setattr(runner, "invoke", fake_invoke)
+
+    try:
+        row = runner.run_one("v4tags.update-campaigns")
+    finally:
+        runner.close()
+
+    assert row.status == module.PASS
+    assert calls == [
+        (
+            "campaigns",
+            "add",
+            [
+                "--name",
+                runner.name("text_campaign"),
+                "--start-date",
+                runner.tomorrow(),
+                "--type",
+                "TEXT_CAMPAIGN",
+            ],
+            None,
+        ),
+        (
+            "v4tags",
+            "update-campaigns",
+            ["--campaign-id", "101", "--tag", f"0={runner.v4_tag_text()}"],
+            None,
+        ),
+        (
+            "v4tags",
+            "update-campaigns",
+            ["--campaign-id", "101", "--clear-tags"],
+            None,
+        ),
+        ("campaigns", "delete", ["--id", "101"], None),
+    ]
+
+
+def test_sandbox_write_live_runner_builds_v4tags_update_banners(monkeypatch):
+    module = _load_sandbox_runner_module()
+    runner = module.LiveSandboxRunner(
+        commands=["v4tags.update-banners"],
+        timeout=1,
+        verbose=False,
+        report_file=None,
+    )
+    calls = []
+
+    def fake_invoke(group, command, args, global_args=None):
+        calls.append((group, command, args, global_args))
+        resource_ids = {
+            ("campaigns", "add"): 101,
+            ("adgroups", "add"): 202,
+            ("ads", "add"): 303,
+        }
+        if (group, command) in resource_ids:
+            stdout = json.dumps(
+                {"result": {"AddResults": [{"Id": resource_ids[(group, command)]}]}}
+            )
+        elif (group, command) == ("v4tags", "get-campaigns"):
+            stdout = json.dumps(
+                [
+                    {
+                        "CampaignID": 101,
+                        "Tags": [{"TagID": 404, "Tag": runner.v4_tag_text()}],
+                    }
+                ]
+            )
+        else:
+            stdout = json.dumps({"data": 1})
+        return module.CommandRun(
+            args=["direct", "--sandbox", *(global_args or []), group, command, *args],
+            returncode=0,
+            stdout=stdout,
+            stderr="",
+        )
+
+    monkeypatch.setattr(runner, "invoke", fake_invoke)
+
+    try:
+        row = runner.run_one("v4tags.update-banners")
+    finally:
+        runner.close()
+
+    assert row.status == module.PASS
+    assert (
+        "v4tags",
+        "update-campaigns",
+        ["--campaign-id", "101", "--tag", f"0={runner.v4_tag_text()}"],
+        None,
+    ) in calls
+    assert (
+        "v4tags",
+        "get-campaigns",
+        ["--campaign-ids", "101"],
+        None,
+    ) in calls
+    assert (
+        "v4tags",
+        "update-banners",
+        ["--banner-ids", "303", "--tag-ids", "404"],
+        None,
+    ) in calls
+    assert calls[-5:] == [
+        (
+            "v4tags",
+            "update-banners",
+            ["--banner-ids", "303", "--clear-tags"],
+            None,
+        ),
+        (
+            "v4tags",
+            "update-campaigns",
+            ["--campaign-id", "101", "--clear-tags"],
+            None,
+        ),
+        ("ads", "delete", ["--id", "303"], None),
+        ("adgroups", "delete", ["--id", "202"], None),
+        ("campaigns", "delete", ["--id", "101"], None),
+    ]
+
+
 def test_sandbox_write_live_runner_marks_v4account_account_id_missing(monkeypatch):
     module = _load_sandbox_runner_module()
     runner = module.LiveSandboxRunner(


### PR DESCRIPTION
## Summary
- Implement live sandbox runners for `clients.update`, `v4tags.update-banners`, and `v4tags.update-campaigns`, replacing the previous `NOT_COVERED` stubs
- `clients.update` stays opt-in via `YANDEX_DIRECT_CLIENTS_UPDATE_LOGIN` (an expendable sandbox `Client-Login`) so we never mutate shared account metadata by accident
- v4tags runners create disposable campaign/adgroup/ad fixtures, register `--clear-tags` cleanup, and look up the new `TagID` from `v4tags get-campaigns` for the banner update path
- Drop the `FOLLOW_UP_ISSUES` mapping (issue #213) from the audit script and tests now that all three commands are exercised

## Test plan
- [ ] `pytest tests/test_smoke_matrix.py tests/test_sandbox_write_audit.py`
- [ ] `python scripts/sandbox_write_audit.py --json build/sandbox_audit.json` (verifies audit emits empty `follow_up`)
- [ ] Optional live smoke against the sandbox with `YANDEX_DIRECT_CLIENTS_UPDATE_LOGIN` set for the `clients.update` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)