### PR TITLE
feat(keywords): batch add via --from-file / --keywords-json (#203)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## 0.3.9 (Unreleased)
 
+**Added:**
+
+- `direct keywords add` now supports batch mode via `--from-file PATH`
+  (JSONL, one keyword object per line) or `--keywords-json '[…]'`
+  (inline JSON array). The CLI splits input into chunks of 10 — the
+  Yandex Direct API limit for `keywords.add` documented at
+  https://yandex.ru/dev/direct/doc/dg/objects/keyword.html — preserves
+  input order, and merges `AddResults` from every chunk into a single
+  response. Item-level errors do not abort the batch. Row keys use
+  WSDL CamelCase (`Keyword`, `AdGroupId`, `Bid`, `ContextBid`,
+  `UserParam1`, `UserParam2`); unknown keys are rejected with the row
+  number. `--adgroup-id` is optional in batch mode and acts as a
+  default, overridable per row. `--dry-run` prints the first chunk's
+  payload alongside `{chunks, totalItems, chunkSize}`. Single-item
+  mode (`--keyword`) is unchanged (#203).
+
 **Fixed:**
 
 - Refreshed `TestWriteFeeds` and `TestWriteSmartAdTargets` VCR cassettes against a real sandbox, dropped the `_FEED_REGRESSION_PATTERNS` skip workaround, and updated `sandbox_feed` / `sandbox_smart_adgroup` fixtures to pass the now-WSDL-required `--business-type RETAIL` (FeedAddItem) and `--counter-id` (SmartCampaignAddItem). Tests now skip only on genuine sandbox limitations, not on the missing-option proxy that the workaround papered over (#206, fallout from #201). Test invocation now also passes `--login` and prefers env vars over an active `direct auth` profile, matching the inversion documented in CLAUDE.md.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,20 @@
   Yandex Direct API limit for `keywords.add` documented at
   https://yandex.ru/dev/direct/doc/dg/objects/keyword.html — preserves
   input order, and merges `AddResults` from every chunk into a single
-  response. Item-level errors do not abort the batch. Row keys use
-  WSDL CamelCase (`Keyword`, `AdGroupId`, `Bid`, `ContextBid`,
-  `UserParam1`, `UserParam2`); unknown keys are rejected with the row
-  number. `--adgroup-id` is optional in batch mode and acts as a
-  default, overridable per row. `--dry-run` prints the first chunk's
-  payload alongside `{chunks, totalItems, chunkSize}`. Single-item
-  mode (`--keyword`) is unchanged (#203).
+  response. Item-level errors do not abort the batch. If a chunk-level
+  exception breaks the loop, already-created Ids are printed to stderr
+  with a "Partial success before failure" header so a retry doesn't
+  duplicate them. Pre-flight warning when any AdGroupId in the input
+  exceeds the per-ad-group limit of 200 keywords (the API rejects the
+  excess with per-item errors; warning surfaces this before any chunk
+  is sent). Row keys use WSDL CamelCase (`Keyword`, `AdGroupId`,
+  `Bid`, `ContextBid`, `UserParam1`, `UserParam2`); unknown keys are
+  rejected with the row number, and JSON booleans are explicitly
+  rejected to prevent silent `True → 1` coercion. `--adgroup-id` is
+  optional in batch mode and acts as a default, overridable per row.
+  `--dry-run` prints the first chunk's payload alongside
+  `{chunks, totalItems, chunkSize}`. Single-item mode (`--keyword`)
+  is unchanged (#203).
 
 **Fixed:**
 

--- a/README.md
+++ b/README.md
@@ -413,7 +413,9 @@ Example `keywords.jsonl`:
 - `--adgroup-id` provides the default group ID; rows can override it via per-row `AdGroupId`.
 - Each effective row must resolve `Keyword` and `AdGroupId`; unknown fields are rejected with the row number.
 - API limit: 10 items per `keywords.add` request — see [Yandex Direct docs](https://yandex.ru/dev/direct/doc/dg/objects/keyword.html). The CLI sends as many chunks as needed and merges `AddResults`.
+- API limit: 200 keywords per ad group. The CLI prints a warning if any `AdGroupId` in the input exceeds it; the API rejects the excess as per-item errors.
 - Item-level errors from the API do not abort the batch; the merged output includes successes and per-item errors.
+- If a chunk fails with a network-level error mid-batch, already-created Ids are printed to stderr (`Partial success before failure`) so a retry doesn't duplicate them.
 - `--dry-run` shows the first chunk's payload plus `{chunks, totalItems, chunkSize}`.
 
 #### Reports
@@ -1093,7 +1095,9 @@ direct keywords add --keywords-json '[{"Keyword":"купить ноутбук","
 - `--adgroup-id` задаёт значение по умолчанию; в строке можно переопределить через `AdGroupId`.
 - В каждой строке должны разрешаться `Keyword` и `AdGroupId`; неизвестные поля отклоняются с указанием номера строки.
 - API-лимит: 10 элементов на запрос `keywords.add` — см. [документацию Yandex Direct](https://yandex.ru/dev/direct/doc/dg/objects/keyword.html). CLI отправит нужное число чанков и склеит `AddResults`.
+- API-лимит: 200 ключевых слов на одну группу объявлений. CLI печатает предупреждение, если в каком-то `AdGroupId` во входе их больше; API отклонит излишек item-level ошибками.
 - Item-level ошибки от API не прерывают batch; объединённый вывод содержит и успешные Id, и ошибки.
+- При сетевой ошибке в середине batch уже созданные Id выводятся в stderr (`Partial success before failure`), чтобы при retry не возникли дубли.
 - `--dry-run` показывает payload первого чанка плюс `{chunks, totalItems, chunkSize}`.
 
 #### Отчёты

--- a/README.md
+++ b/README.md
@@ -391,6 +391,31 @@ direct keywords update --id 88888 --keyword "updated keyword text"
 direct keywords delete --id 88888
 ```
 
+**Batch keyword upload** (CLI auto-chunks to the API limit of 10 per request):
+
+```bash
+# From a JSONL file (one keyword object per line)
+direct keywords add --adgroup-id 12345 --from-file keywords.jsonl
+
+# Inline JSON array
+direct keywords add --keywords-json '[{"Keyword":"buy laptop","Bid":10000000},{"Keyword":"buy desktop"}]'
+```
+
+Example `keywords.jsonl`:
+
+```jsonl
+{"Keyword":"buy laptop","Bid":10000000,"UserParam1":"src=ad1"}
+{"Keyword":"buy desktop","ContextBid":5000000}
+{"Keyword":"купить ноутбук","AdGroupId":99999}
+```
+
+- Row keys use WSDL CamelCase: `Keyword`, `AdGroupId`, `Bid`, `ContextBid`, `UserParam1`, `UserParam2`.
+- `--adgroup-id` provides the default group ID; rows can override it via per-row `AdGroupId`.
+- Each effective row must resolve `Keyword` and `AdGroupId`; unknown fields are rejected with the row number.
+- API limit: 10 items per `keywords.add` request — see [Yandex Direct docs](https://yandex.ru/dev/direct/doc/dg/objects/keyword.html). The CLI sends as many chunks as needed and merges `AddResults`.
+- Item-level errors from the API do not abort the batch; the merged output includes successes and per-item errors.
+- `--dry-run` shows the first chunk's payload plus `{chunks, totalItems, chunkSize}`.
+
 #### Reports
 
 ```bash
@@ -1045,6 +1070,31 @@ direct keywords add --adgroup-id 12345 --keyword "купить ноутбук" -
 direct keywords update --id 88888 --keyword "updated keyword text"
 direct keywords delete --id 88888
 ```
+
+**Пакетная загрузка ключевых слов** (CLI автоматически режет на куски по API-лимиту 10/запрос):
+
+```bash
+# Из JSONL-файла (по одному объекту ключевого слова на строку)
+direct keywords add --adgroup-id 12345 --from-file keywords.jsonl
+
+# Inline JSON-массив
+direct keywords add --keywords-json '[{"Keyword":"купить ноутбук","Bid":10000000},{"Keyword":"купить ПК"}]'
+```
+
+Пример `keywords.jsonl`:
+
+```jsonl
+{"Keyword":"купить ноутбук","Bid":10000000,"UserParam1":"src=ad1"}
+{"Keyword":"купить ПК","ContextBid":5000000}
+{"Keyword":"buy laptop","AdGroupId":99999}
+```
+
+- Ключи строки — WSDL CamelCase: `Keyword`, `AdGroupId`, `Bid`, `ContextBid`, `UserParam1`, `UserParam2`.
+- `--adgroup-id` задаёт значение по умолчанию; в строке можно переопределить через `AdGroupId`.
+- В каждой строке должны разрешаться `Keyword` и `AdGroupId`; неизвестные поля отклоняются с указанием номера строки.
+- API-лимит: 10 элементов на запрос `keywords.add` — см. [документацию Yandex Direct](https://yandex.ru/dev/direct/doc/dg/objects/keyword.html). CLI отправит нужное число чанков и склеит `AddResults`.
+- Item-level ошибки от API не прерывают batch; объединённый вывод содержит и успешные Id, и ошибки.
+- `--dry-run` показывает payload первого чанка плюс `{chunks, totalItems, chunkSize}`.
 
 #### Отчёты
 

--- a/direct_cli/commands/keywords.py
+++ b/direct_cli/commands/keywords.py
@@ -30,6 +30,10 @@ _KEYWORD_ROW_FIELDS: Dict[str, str] = {
 
 def _coerce_keyword_field(field: str, raw_value: Any, row_index: int) -> Any:
     kind = _KEYWORD_ROW_FIELDS[field]
+    if isinstance(raw_value, bool):
+        raise click.UsageError(
+            f"Row {row_index} field {field!r}: expected {kind}, got bool"
+        )
     if kind == "str":
         if not isinstance(raw_value, str):
             raise click.UsageError(
@@ -38,15 +42,15 @@ def _coerce_keyword_field(field: str, raw_value: Any, row_index: int) -> Any:
             )
         return raw_value
     if kind == "int":
-        if isinstance(raw_value, bool) or not isinstance(raw_value, int):
-            try:
-                return int(raw_value)
-            except (TypeError, ValueError):
-                raise click.UsageError(
-                    f"Row {row_index} field {field!r}: expected integer, "
-                    f"got {raw_value!r}"
-                )
-        return raw_value
+        if isinstance(raw_value, int):
+            return raw_value
+        try:
+            return int(raw_value)
+        except (TypeError, ValueError):
+            raise click.UsageError(
+                f"Row {row_index} field {field!r}: expected integer, "
+                f"got {raw_value!r}"
+            )
     if kind == "micro":
         try:
             return MICRO_RUBLES.convert(raw_value, None, None)
@@ -274,7 +278,9 @@ def add(
     dry_run,
 ):
     """Add one or many keywords (batch via --from-file / --keywords-json)."""
-    modes_used = sum(1 for value in (keyword, from_file, keywords_json) if value)
+    modes_used = sum(
+        1 for value in (keyword, from_file, keywords_json) if value is not None
+    )
     if modes_used == 0:
         raise click.UsageError(
             "Provide exactly one of: --keyword (single), --from-file (JSONL), "
@@ -379,6 +385,7 @@ def _bulk_add(
         print(format_json(preview, indent=2))
         return
 
+    all_results: List[Any] = []
     try:
         client = create_client(
             token=ctx.obj.get("token"),
@@ -386,7 +393,6 @@ def _bulk_add(
             sandbox=ctx.obj.get("sandbox"),
         )
 
-        all_results: List[Any] = []
         for index, chunk in enumerate(chunks, start=1):
             click.echo(
                 f"Sending chunk {index}/{len(chunks)}: {len(chunk)} items",
@@ -400,6 +406,13 @@ def _bulk_add(
     except click.UsageError:
         raise
     except Exception as e:
+        if all_results:
+            click.echo(
+                "Partial success before failure — these keywords were already "
+                "created in Yandex Direct (retrying will duplicate them):",
+                err=True,
+            )
+            click.echo(format_json({"AddResults": all_results}, indent=2), err=True)
         print_error(str(e))
         raise click.Abort()
 

--- a/direct_cli/commands/keywords.py
+++ b/direct_cli/commands/keywords.py
@@ -18,6 +18,12 @@ from ..utils import add_criteria_csv, parse_ids, get_default_fields, MICRO_RUBLE
 # https://yandex.ru/dev/direct/doc/dg/objects/keyword.html
 KEYWORDS_ADD_MAX_BATCH = 10
 
+# Yandex Direct caps the number of keywords per ad group at 200 (same docs).
+# Going over the limit doesn't fail pre-flight — the API rejects the excess
+# items with per-item errors, which the batch already surfaces. The warning
+# below just tells the operator before any chunk is sent.
+KEYWORDS_PER_ADGROUP_LIMIT = 200
+
 _KEYWORD_ROW_FIELDS: Dict[str, str] = {
     "Keyword": "str",
     "AdGroupId": "int",
@@ -132,6 +138,32 @@ def _load_keyword_rows_from_inline(json_str: str) -> List[Any]:
 def _chunked(items: List[Any], size: int) -> Iterator[List[Any]]:
     for start in range(0, len(items), size):
         yield items[start : start + size]
+
+
+def _warn_on_adgroup_overflow(items: List[Dict[str, Any]]) -> None:
+    counts: Dict[int, int] = {}
+    for item in items:
+        adgroup_id = item.get("AdGroupId")
+        if adgroup_id is None:
+            continue
+        counts[adgroup_id] = counts.get(adgroup_id, 0) + 1
+    over = sorted(
+        (gid, n) for gid, n in counts.items() if n > KEYWORDS_PER_ADGROUP_LIMIT
+    )
+    if not over:
+        return
+    click.echo(
+        f"Warning: input exceeds the Yandex Direct limit of "
+        f"{KEYWORDS_PER_ADGROUP_LIMIT} keywords per ad group; the API will "
+        "reject the excess with per-item errors:",
+        err=True,
+    )
+    for gid, count in over:
+        excess = count - KEYWORDS_PER_ADGROUP_LIMIT
+        click.echo(
+            f"  AdGroupId={gid}: {count} keywords ({excess} over the limit)",
+            err=True,
+        )
 
 
 def _normalize_add_results(raw: Any) -> List[Any]:
@@ -369,6 +401,8 @@ def _bulk_add(
         _normalize_keyword_row(row, idx, adgroup_id)
         for idx, row in enumerate(raw_rows, start=1)
     ]
+
+    _warn_on_adgroup_overflow(items)
 
     chunks = list(_chunked(items, KEYWORDS_ADD_MAX_BATCH))
 

--- a/direct_cli/commands/keywords.py
+++ b/direct_cli/commands/keywords.py
@@ -2,11 +2,143 @@
 Keywords commands
 """
 
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional
+
 import click
 
 from ..api import create_client
-from ..output import format_output, print_error
+from ..output import format_json, format_output, print_error
 from ..utils import add_criteria_csv, parse_ids, get_default_fields, MICRO_RUBLES
+
+# Yandex Direct API "keywords.add" caps a single AddItems request at 10
+# items; the WSDL declares maxOccurs="unbounded", so this limit comes from
+# the documentation rather than the contract:
+# https://yandex.ru/dev/direct/doc/dg/objects/keyword.html
+KEYWORDS_ADD_MAX_BATCH = 10
+
+_KEYWORD_ROW_FIELDS: Dict[str, str] = {
+    "Keyword": "str",
+    "AdGroupId": "int",
+    "Bid": "micro",
+    "ContextBid": "micro",
+    "UserParam1": "str",
+    "UserParam2": "str",
+}
+
+
+def _coerce_keyword_field(field: str, raw_value: Any, row_index: int) -> Any:
+    kind = _KEYWORD_ROW_FIELDS[field]
+    if kind == "str":
+        if not isinstance(raw_value, str):
+            raise click.UsageError(
+                f"Row {row_index} field {field!r}: expected string, "
+                f"got {type(raw_value).__name__}"
+            )
+        return raw_value
+    if kind == "int":
+        if isinstance(raw_value, bool) or not isinstance(raw_value, int):
+            try:
+                return int(raw_value)
+            except (TypeError, ValueError):
+                raise click.UsageError(
+                    f"Row {row_index} field {field!r}: expected integer, "
+                    f"got {raw_value!r}"
+                )
+        return raw_value
+    if kind == "micro":
+        try:
+            return MICRO_RUBLES.convert(raw_value, None, None)
+        except click.exceptions.BadParameter as exc:
+            raise click.UsageError(f"Row {row_index} field {field!r}: {exc.message}")
+    raise click.UsageError(
+        f"Row {row_index} field {field!r}: unsupported type {kind!r}"
+    )
+
+
+def _normalize_keyword_row(
+    row: Any,
+    row_index: int,
+    default_adgroup_id: Optional[int],
+) -> Dict[str, Any]:
+    if not isinstance(row, dict):
+        raise click.UsageError(
+            f"Row {row_index}: expected JSON object, got {type(row).__name__}"
+        )
+
+    unknown = sorted(set(row) - set(_KEYWORD_ROW_FIELDS))
+    if unknown:
+        allowed = ", ".join(_KEYWORD_ROW_FIELDS)
+        raise click.UsageError(
+            f"Unknown field {unknown[0]!r} in keyword row {row_index}; "
+            f"allowed: {allowed}"
+        )
+
+    item: Dict[str, Any] = {}
+    for field in _KEYWORD_ROW_FIELDS:
+        if field in row and row[field] is not None:
+            item[field] = _coerce_keyword_field(field, row[field], row_index)
+
+    if "AdGroupId" not in item:
+        if default_adgroup_id is None:
+            raise click.UsageError(
+                f"Row {row_index}: missing 'AdGroupId' and no default "
+                "--adgroup-id provided"
+            )
+        item["AdGroupId"] = default_adgroup_id
+
+    if "Keyword" not in item:
+        raise click.UsageError(f"Row {row_index}: missing required field 'Keyword'")
+
+    return item
+
+
+def _load_keyword_rows_from_file(path: str) -> List[Any]:
+    rows: List[Any] = []
+    file_path = Path(path)
+    try:
+        text = file_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise click.UsageError(f"Cannot read --from-file {path!r}: {exc}")
+
+    for line_number, raw_line in enumerate(text.splitlines(), start=1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            rows.append(json.loads(line))
+        except json.JSONDecodeError as exc:
+            raise click.UsageError(f"Row {line_number}: invalid JSON: {exc.msg}")
+    return rows
+
+
+def _load_keyword_rows_from_inline(json_str: str) -> List[Any]:
+    try:
+        decoded = json.loads(json_str)
+    except json.JSONDecodeError as exc:
+        raise click.UsageError(f"--keywords-json: invalid JSON: {exc.msg}")
+    if not isinstance(decoded, list):
+        raise click.UsageError(
+            "--keywords-json must be a JSON array of keyword objects"
+        )
+    return decoded
+
+
+def _chunked(items: List[Any], size: int) -> Iterator[List[Any]]:
+    for start in range(0, len(items), size):
+        yield items[start : start + size]
+
+
+def _normalize_add_results(raw: Any) -> List[Any]:
+    if isinstance(raw, dict):
+        results = raw.get("AddResults")
+        if isinstance(results, list):
+            return results
+        return [raw]
+    if isinstance(raw, list):
+        return raw
+    return [raw]
 
 
 @click.group()
@@ -103,12 +235,29 @@ def get(
 
 
 @keywords.command()
-@click.option("--adgroup-id", required=True, type=int, help="Ad group ID")
-@click.option("--keyword", required=True, help="Keyword text")
+@click.option("--adgroup-id", type=int, help="Ad group ID (default in batch mode)")
+@click.option("--keyword", help="Keyword text (single-item mode)")
 @click.option("--bid", type=MICRO_RUBLES, help="Search bid in micro-rubles")
 @click.option("--context-bid", type=MICRO_RUBLES, help="Context bid in micro-rubles")
 @click.option("--user-param-1", help="User parameter 1")
 @click.option("--user-param-2", help="User parameter 2")
+@click.option(
+    "--from-file",
+    "from_file",
+    type=click.Path(exists=True, dir_okay=False, readable=True),
+    help="Path to JSONL file (one keyword object per line)",
+)
+@click.option(
+    "--keywords-json",
+    "keywords_json",
+    help="Inline JSON array of keyword objects",
+)
+@click.option(
+    "--format",
+    "output_format",
+    default="json",
+    help="Output format (batch mode supports only json)",
+)
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
 def add(
@@ -119,12 +268,45 @@ def add(
     context_bid,
     user_param_1,
     user_param_2,
+    from_file,
+    keywords_json,
+    output_format,
     dry_run,
 ):
-    """Add new keyword"""
-    try:
-        keyword_data = {"AdGroupId": adgroup_id, "Keyword": keyword}
+    """Add one or many keywords (batch via --from-file / --keywords-json)."""
+    modes_used = sum(1 for value in (keyword, from_file, keywords_json) if value)
+    if modes_used == 0:
+        raise click.UsageError(
+            "Provide exactly one of: --keyword (single), --from-file (JSONL), "
+            "or --keywords-json (inline JSON array)."
+        )
+    if modes_used > 1:
+        raise click.UsageError(
+            "Provide exactly one of: --keyword, --from-file, or "
+            "--keywords-json — they are mutually exclusive."
+        )
 
+    batch_mode = from_file is not None or keywords_json is not None
+
+    if batch_mode:
+        _bulk_add(
+            ctx,
+            adgroup_id=adgroup_id,
+            from_file=from_file,
+            keywords_json=keywords_json,
+            output_format=output_format,
+            dry_run=dry_run,
+        )
+        return
+
+    if adgroup_id is None:
+        raise click.UsageError("Missing option '--adgroup-id'.")
+
+    try:
+        keyword_data: Dict[str, Any] = {
+            "AdGroupId": adgroup_id,
+            "Keyword": keyword,
+        }
         if bid is not None:
             keyword_data["Bid"] = bid
         if context_bid is not None:
@@ -137,7 +319,7 @@ def add(
         body = {"method": "add", "params": {"Keywords": [keyword_data]}}
 
         if dry_run:
-            format_output(body, "json", None)
+            format_output(body, output_format, None)
             return
 
         client = create_client(
@@ -147,8 +329,76 @@ def add(
         )
 
         result = client.keywords().post(data=body)
-        format_output(result().extract(), "json", None)
+        format_output(result().extract(), output_format, None)
 
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+def _bulk_add(
+    ctx,
+    *,
+    adgroup_id: Optional[int],
+    from_file: Optional[str],
+    keywords_json: Optional[str],
+    output_format: str,
+    dry_run: bool,
+) -> None:
+    if output_format != "json":
+        raise click.UsageError(
+            "--format other than 'json' is not supported in batch mode "
+            "(item-level results may include per-row Errors)."
+        )
+
+    if from_file is not None:
+        raw_rows = _load_keyword_rows_from_file(from_file)
+    else:
+        raw_rows = _load_keyword_rows_from_inline(keywords_json or "")
+
+    if not raw_rows:
+        raise click.UsageError("Input contains no keyword rows.")
+
+    items: List[Dict[str, Any]] = [
+        _normalize_keyword_row(row, idx, adgroup_id)
+        for idx, row in enumerate(raw_rows, start=1)
+    ]
+
+    chunks = list(_chunked(items, KEYWORDS_ADD_MAX_BATCH))
+
+    if dry_run:
+        preview = {
+            "chunks": len(chunks),
+            "totalItems": len(items),
+            "chunkSize": KEYWORDS_ADD_MAX_BATCH,
+            "firstChunk": {
+                "method": "add",
+                "params": {"Keywords": chunks[0]},
+            },
+        }
+        print(format_json(preview, indent=2))
+        return
+
+    try:
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
+
+        all_results: List[Any] = []
+        for index, chunk in enumerate(chunks, start=1):
+            click.echo(
+                f"Sending chunk {index}/{len(chunks)}: {len(chunk)} items",
+                err=True,
+            )
+            body = {"method": "add", "params": {"Keywords": chunk}}
+            response = client.keywords().post(data=body)
+            all_results.extend(_normalize_add_results(response().extract()))
+
+        print(format_json({"AddResults": all_results}, indent=2))
+    except click.UsageError:
+        raise
     except Exception as e:
         print_error(str(e))
         raise click.Abort()

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1907,6 +1907,73 @@ def test_keywords_add_single_still_raises_on_item_error():
     )
 
 
+def test_keywords_add_rejects_bool_in_row(tmp_path):
+    """JSON booleans must NOT be silently coerced to 1/0 for int/micro fields."""
+    path = _write_jsonl(tmp_path, [{"Keyword": "kw", "AdGroupId": True}])
+    result = _rejected("keywords", "add", "--from-file", path)
+    assert "Row 1 field 'AdGroupId'" in result.output
+    assert "bool" in result.output
+
+
+def test_keywords_add_empty_string_keyword_counts_as_mode():
+    """`--keyword ''` must register as mode-provided, not fall through to
+    'Provide exactly one of' (mode-detection uses `is not None`, not
+    truthiness)."""
+    body = _dry_run("keywords", "add", "--keyword", "", "--adgroup-id", "1")
+    assert body["params"]["Keywords"][0] == {"AdGroupId": 1, "Keyword": ""}
+
+
+def test_keywords_add_batch_partial_success_on_failure(tmp_path, capsys):
+    """If a later chunk raises, already-created Ids must be surfaced to stderr."""
+    rows = [{"Keyword": f"kw-{i}", "AdGroupId": 1} for i in range(15)]
+    path = _write_jsonl(tmp_path, rows)
+
+    call_count = {"n": 0}
+
+    class _StubExtract:
+        def extract(self):
+            return {"AddResults": [{"Id": i + 1} for i in range(10)]}
+
+    class _StubResult:
+        def __call__(self):
+            return _StubExtract()
+
+    class _StubKeywords:
+        def post(self, data):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return _StubResult()
+            raise RuntimeError("network blip on second chunk")
+
+    class _StubClient:
+        def keywords(self):
+            return _StubKeywords()
+
+    with patch(
+        "direct_cli.commands.keywords.create_client", return_value=_StubClient()
+    ):
+        runner = CliRunner(mix_stderr=False)
+        result = runner.invoke(
+            cli,
+            [
+                "--token",
+                "T",
+                "--login",
+                "L",
+                "keywords",
+                "add",
+                "--from-file",
+                str(path),
+            ],
+        )
+    assert result.exit_code != 0
+    # First chunk's Ids must be reported on stderr so the operator can avoid
+    # creating duplicates on retry.
+    assert "Partial success before failure" in result.stderr
+    assert '"Id": 1' in result.stderr
+    assert '"Id": 10' in result.stderr
+
+
 # ----------------------------------------------------------------------
 # bids / keywordbids
 # ----------------------------------------------------------------------

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1672,6 +1672,218 @@ def test_keywords_update_payload_user_params():
 
 
 # ----------------------------------------------------------------------
+# keywords add: batch mode (issue #203)
+# ----------------------------------------------------------------------
+
+
+def _write_jsonl(tmp_path, rows):
+    path = tmp_path / "keywords.jsonl"
+    path.write_text(
+        "\n".join(json.dumps(row, ensure_ascii=False) for row in rows) + "\n",
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+def test_keywords_add_payload_batch_from_jsonl(tmp_path):
+    path = _write_jsonl(
+        tmp_path,
+        [
+            {"Keyword": "buy laptop", "AdGroupId": 100, "Bid": 10000000},
+            {"Keyword": "buy desktop", "AdGroupId": 100},
+            {"Keyword": "купить тест", "AdGroupId": 200, "UserParam1": "src=a"},
+        ],
+    )
+    body = _dry_run("keywords", "add", "--from-file", path)
+    assert body["chunks"] == 1
+    assert body["totalItems"] == 3
+    assert body["chunkSize"] == 10
+    keywords = body["firstChunk"]["params"]["Keywords"]
+    assert body["firstChunk"]["method"] == "add"
+    assert keywords[0] == {
+        "Keyword": "buy laptop",
+        "AdGroupId": 100,
+        "Bid": 10000000,
+    }
+    assert keywords[2] == {
+        "Keyword": "купить тест",
+        "AdGroupId": 200,
+        "UserParam1": "src=a",
+    }
+
+
+def test_keywords_add_payload_batch_inline():
+    inline = json.dumps(
+        [
+            {"Keyword": "kw-a", "AdGroupId": 1},
+            {"Keyword": "kw-b", "AdGroupId": 1, "ContextBid": 5000000},
+        ]
+    )
+    body = _dry_run("keywords", "add", "--keywords-json", inline)
+    assert body["totalItems"] == 2
+    assert body["chunks"] == 1
+    assert body["firstChunk"]["params"]["Keywords"][1]["ContextBid"] == 5000000
+
+
+def test_keywords_add_payload_batch_chunks_at_10(tmp_path):
+    rows = [{"Keyword": f"kw-{i}", "AdGroupId": 1} for i in range(25)]
+    path = _write_jsonl(tmp_path, rows)
+    body = _dry_run("keywords", "add", "--from-file", path)
+    assert body["chunks"] == 3
+    assert body["totalItems"] == 25
+    first_chunk = body["firstChunk"]["params"]["Keywords"]
+    assert len(first_chunk) == 10
+    assert [k["Keyword"] for k in first_chunk] == [f"kw-{i}" for i in range(10)]
+
+
+def test_keywords_add_payload_adgroup_override(tmp_path):
+    path = _write_jsonl(
+        tmp_path,
+        [
+            {"Keyword": "kw-default"},
+            {"Keyword": "kw-override", "AdGroupId": 200},
+        ],
+    )
+    body = _dry_run("keywords", "add", "--adgroup-id", "100", "--from-file", path)
+    items = body["firstChunk"]["params"]["Keywords"]
+    assert items[0] == {"Keyword": "kw-default", "AdGroupId": 100}
+    assert items[1] == {"Keyword": "kw-override", "AdGroupId": 200}
+
+
+def test_keywords_add_payload_micro_rubles_in_row(tmp_path):
+    path = _write_jsonl(
+        tmp_path,
+        [{"Keyword": "kw", "AdGroupId": 1, "Bid": 15000000}],
+    )
+    body = _dry_run("keywords", "add", "--from-file", path)
+    assert body["firstChunk"]["params"]["Keywords"][0]["Bid"] == 15000000
+
+
+def test_keywords_add_rejects_unknown_field_in_row(tmp_path):
+    path = _write_jsonl(
+        tmp_path,
+        [{"Keyword": "kw", "AdGroupId": 1, "Foo": "bar"}],
+    )
+    result = _rejected("keywords", "add", "--from-file", path)
+    assert "Unknown field 'Foo' in keyword row 1" in result.output
+
+
+def test_keywords_add_rejects_invalid_jsonl(tmp_path):
+    path = tmp_path / "broken.jsonl"
+    path.write_text(
+        '{"Keyword": "ok", "AdGroupId": 1}\n{"Keyword": broken\n',
+        encoding="utf-8",
+    )
+    result = _rejected("keywords", "add", "--from-file", str(path))
+    assert "Row 2: invalid JSON" in result.output
+
+
+def test_keywords_add_rejects_empty_file(tmp_path):
+    path = tmp_path / "empty.jsonl"
+    path.write_text("\n   \n", encoding="utf-8")
+    result = _rejected("keywords", "add", "--from-file", str(path))
+    assert "Input contains no keyword rows" in result.output
+
+
+def test_keywords_add_rejects_mutex(tmp_path):
+    path = _write_jsonl(tmp_path, [{"Keyword": "kw", "AdGroupId": 1}])
+    result = _rejected(
+        "keywords",
+        "add",
+        "--keyword",
+        "x",
+        "--adgroup-id",
+        "1",
+        "--from-file",
+        path,
+    )
+    assert "Provide exactly one of" in result.output
+
+
+def test_keywords_add_rejects_missing_required_in_row(tmp_path):
+    path = _write_jsonl(tmp_path, [{"Keyword": "kw"}])
+    result = _rejected("keywords", "add", "--from-file", path)
+    assert "Row 1" in result.output
+    assert "AdGroupId" in result.output
+
+
+def test_keywords_add_rejects_too_low_bid_in_row(tmp_path):
+    path = _write_jsonl(
+        tmp_path,
+        [{"Keyword": "kw", "AdGroupId": 1, "Bid": 50000}],
+    )
+    result = _rejected("keywords", "add", "--from-file", path)
+    assert "Row 1 field 'Bid'" in result.output
+
+
+def test_keywords_add_rejects_non_json_format_in_batch(tmp_path):
+    path = _write_jsonl(tmp_path, [{"Keyword": "kw", "AdGroupId": 1}])
+    result = _rejected(
+        "keywords",
+        "add",
+        "--from-file",
+        path,
+        "--format",
+        "table",
+    )
+    assert "batch mode" in result.output
+
+
+def test_keywords_add_rejects_no_mode():
+    result = _rejected("keywords", "add")
+    assert "Provide exactly one of" in result.output
+
+
+def test_keywords_add_single_still_raises_on_item_error():
+    """Single-mode (non-batch) must still bubble item-level Errors."""
+    from direct_cli.output import DirectAPIResultError
+
+    class _StubExtract:
+        def extract(self):
+            return {
+                "AddResults": [{"Id": 0, "Errors": [{"Code": 8500, "Message": "bad"}]}]
+            }
+
+    class _StubResult:
+        def __call__(self):
+            return _StubExtract()
+
+    class _StubKeywords:
+        def post(self, data):
+            return _StubResult()
+
+    class _StubClient:
+        def keywords(self):
+            return _StubKeywords()
+
+    with patch(
+        "direct_cli.commands.keywords.create_client", return_value=_StubClient()
+    ):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "--token",
+                "T",
+                "--login",
+                "L",
+                "keywords",
+                "add",
+                "--adgroup-id",
+                "1",
+                "--keyword",
+                "kw",
+            ],
+        )
+    assert result.exit_code != 0
+    # Single-mode goes through format_output → raise_for_api_result_errors,
+    # which DirectAPIResultError-then-Abort. CLI surfaces it via print_error.
+    assert "Yandex Direct API returned errors" in result.output or isinstance(
+        result.exception, DirectAPIResultError
+    )
+
+
+# ----------------------------------------------------------------------
 # bids / keywordbids
 # ----------------------------------------------------------------------
 

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1923,8 +1923,40 @@ def test_keywords_add_empty_string_keyword_counts_as_mode():
     assert body["params"]["Keywords"][0] == {"AdGroupId": 1, "Keyword": ""}
 
 
-def test_keywords_add_batch_partial_success_on_failure(tmp_path, capsys):
-    """If a later chunk raises, already-created Ids must be surfaced to stderr."""
+def test_keywords_add_batch_warns_when_over_200_per_adgroup(tmp_path):
+    """Pre-flight warning when input has >200 keywords for the same AdGroupId
+    (Yandex Direct limit)."""
+    rows = [{"Keyword": f"kw-{i}", "AdGroupId": 1} for i in range(201)]
+    rows.append({"Keyword": "ok", "AdGroupId": 2})
+    path = _write_jsonl(tmp_path, rows)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["keywords", "add", "--from-file", str(path), "--dry-run"],
+    )
+    assert result.exit_code == 0
+    assert "exceeds the Yandex Direct limit of 200" in result.output
+    assert "AdGroupId=1: 201 keywords (1 over the limit)" in result.output
+    # AdGroupId=2 is within the limit; must NOT be flagged.
+    assert "AdGroupId=2" not in result.output
+
+
+def test_keywords_add_batch_no_warning_under_200(tmp_path):
+    """No warning when every adgroup is within the 200-keyword limit."""
+    rows = [{"Keyword": f"kw-{i}", "AdGroupId": 1} for i in range(150)]
+    path = _write_jsonl(tmp_path, rows)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["keywords", "add", "--from-file", str(path), "--dry-run"],
+    )
+    assert result.exit_code == 0
+    assert "exceeds the Yandex Direct limit" not in result.output
+
+
+def test_keywords_add_batch_partial_success_on_failure(tmp_path):
+    """If a later chunk raises, already-created Ids must be surfaced to the
+    user (via stderr) so a retry doesn't create duplicates."""
     rows = [{"Keyword": f"kw-{i}", "AdGroupId": 1} for i in range(15)]
     path = _write_jsonl(tmp_path, rows)
 
@@ -1952,8 +1984,10 @@ def test_keywords_add_batch_partial_success_on_failure(tmp_path, capsys):
     with patch(
         "direct_cli.commands.keywords.create_client", return_value=_StubClient()
     ):
-        runner = CliRunner(mix_stderr=False)
-        result = runner.invoke(
+        # CliRunner's default mixes stderr into result.output, which is what
+        # we want here — the partial-results message goes to stderr but lands
+        # in the combined output buffer regardless of Click version.
+        result = CliRunner().invoke(
             cli,
             [
                 "--token",
@@ -1967,11 +2001,9 @@ def test_keywords_add_batch_partial_success_on_failure(tmp_path, capsys):
             ],
         )
     assert result.exit_code != 0
-    # First chunk's Ids must be reported on stderr so the operator can avoid
-    # creating duplicates on retry.
-    assert "Partial success before failure" in result.stderr
-    assert '"Id": 1' in result.stderr
-    assert '"Id": 10' in result.stderr
+    assert "Partial success before failure" in result.output
+    assert '"Id": 1' in result.output
+    assert '"Id": 10' in result.output
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1785,6 +1785,17 @@ def test_keywords_add_rejects_empty_file(tmp_path):
     assert "Input contains no keyword rows" in result.output
 
 
+def test_keywords_add_rejects_empty_json_array():
+    result = _rejected("keywords", "add", "--keywords-json", "[]")
+    assert "Input contains no keyword rows" in result.output
+
+
+def test_keywords_add_rejects_non_object_row_in_inline():
+    result = _rejected("keywords", "add", "--keywords-json", "[1, 2, 3]")
+    assert "Row 1" in result.output
+    assert "expected JSON object" in result.output
+
+
 def test_keywords_add_rejects_mutex(tmp_path):
     path = _write_jsonl(tmp_path, [{"Keyword": "kw", "AdGroupId": 1}])
     result = _rejected(
@@ -1796,6 +1807,19 @@ def test_keywords_add_rejects_mutex(tmp_path):
         "1",
         "--from-file",
         path,
+    )
+    assert "Provide exactly one of" in result.output
+
+
+def test_keywords_add_rejects_mutex_file_and_inline(tmp_path):
+    path = _write_jsonl(tmp_path, [{"Keyword": "kw", "AdGroupId": 1}])
+    result = _rejected(
+        "keywords",
+        "add",
+        "--from-file",
+        path,
+        "--keywords-json",
+        "[]",
     )
     assert "Provide exactly one of" in result.output
 

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1858,8 +1858,11 @@ def test_keywords_add_rejects_no_mode():
     assert "Provide exactly one of" in result.output
 
 
-def test_keywords_add_single_still_raises_on_item_error():
+def test_keywords_add_single_still_raises_on_item_error(monkeypatch):
     """Single-mode (non-batch) must still bubble item-level Errors."""
+    import importlib
+
+    keywords_module = importlib.import_module("direct_cli.commands.keywords")
     from direct_cli.output import DirectAPIResultError
 
     class _StubExtract:
@@ -1880,25 +1883,23 @@ def test_keywords_add_single_still_raises_on_item_error():
         def keywords(self):
             return _StubKeywords()
 
-    with patch(
-        "direct_cli.commands.keywords.create_client", return_value=_StubClient()
-    ):
-        runner = CliRunner()
-        result = runner.invoke(
-            cli,
-            [
-                "--token",
-                "T",
-                "--login",
-                "L",
-                "keywords",
-                "add",
-                "--adgroup-id",
-                "1",
-                "--keyword",
-                "kw",
-            ],
-        )
+    monkeypatch.setattr(keywords_module, "create_client", lambda **_: _StubClient())
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "--token",
+            "T",
+            "--login",
+            "L",
+            "keywords",
+            "add",
+            "--adgroup-id",
+            "1",
+            "--keyword",
+            "kw",
+        ],
+    )
     assert result.exit_code != 0
     # Single-mode goes through format_output → raise_for_api_result_errors,
     # which DirectAPIResultError-then-Abort. CLI surfaces it via print_error.
@@ -1954,9 +1955,13 @@ def test_keywords_add_batch_no_warning_under_200(tmp_path):
     assert "exceeds the Yandex Direct limit" not in result.output
 
 
-def test_keywords_add_batch_partial_success_on_failure(tmp_path):
+def test_keywords_add_batch_partial_success_on_failure(tmp_path, monkeypatch):
     """If a later chunk raises, already-created Ids must be surfaced to the
     user (via stderr) so a retry doesn't create duplicates."""
+    import importlib
+
+    keywords_module = importlib.import_module("direct_cli.commands.keywords")
+
     rows = [{"Keyword": f"kw-{i}", "AdGroupId": 1} for i in range(15)]
     path = _write_jsonl(tmp_path, rows)
 
@@ -1981,25 +1986,23 @@ def test_keywords_add_batch_partial_success_on_failure(tmp_path):
         def keywords(self):
             return _StubKeywords()
 
-    with patch(
-        "direct_cli.commands.keywords.create_client", return_value=_StubClient()
-    ):
-        # CliRunner's default mixes stderr into result.output, which is what
-        # we want here — the partial-results message goes to stderr but lands
-        # in the combined output buffer regardless of Click version.
-        result = CliRunner().invoke(
-            cli,
-            [
-                "--token",
-                "T",
-                "--login",
-                "L",
-                "keywords",
-                "add",
-                "--from-file",
-                str(path),
-            ],
-        )
+    monkeypatch.setattr(keywords_module, "create_client", lambda **_: _StubClient())
+    # CliRunner's default mixes stderr into result.output, which is what
+    # we want here — the partial-results message goes to stderr but lands
+    # in the combined output buffer regardless of Click version.
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--token",
+            "T",
+            "--login",
+            "L",
+            "keywords",
+            "add",
+            "--from-file",
+            str(path),
+        ],
+    )
     assert result.exit_code != 0
     assert "Partial success before failure" in result.output
     assert '"Id": 1' in result.output

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -363,6 +363,8 @@ INTERNAL_VALIDATION: dict[tuple[str, str, str], str] = {
     ("bidmodifiers", "set", "BidModifier"): "Missing option '--value'",
     ("retargeting", "add", "Rules"): "Provide at least one --rule",
     ("creatives", "add", "VideoExtensionCreative"): "Missing option '--video-id'",
+    ("keywords", "add", "Keyword"): "Provide exactly one of: --keyword",
+    ("keywords", "add", "AdGroupId"): "Provide exactly one of: --keyword",
 }
 
 
@@ -448,6 +450,8 @@ INTERNAL_VALIDATION_PROBES: dict[tuple[str, str, str], list[str]] = {
     ("bidmodifiers", "set", "BidModifier"): ["bidmodifiers", "set", "--id", "1"],
     ("retargeting", "add", "Rules"): ["retargeting", "add", "--name", "X"],
     ("creatives", "add", "VideoExtensionCreative"): ["creatives", "add"],
+    ("keywords", "add", "Keyword"): ["keywords", "add"],
+    ("keywords", "add", "AdGroupId"): ["keywords", "add"],
 }
 
 


### PR DESCRIPTION
## Summary

- `direct keywords add` now accepts batch input (`--from-file PATH` JSONL or `--keywords-json TEXT` inline JSON array), pages through chunks of 10 (the Yandex Direct API limit for `keywords.add`), preserves order, and merges all `AddResults` into one response.
- Item-level errors no longer abort the whole batch — the merged output includes successful Ids and per-item errors side by side.
- Row keys mirror the WSDL `KeywordAddItem` CamelCase exactly (`Keyword`, `AdGroupId`, `Bid`, `ContextBid`, `UserParam1`, `UserParam2`); unknown keys are rejected with the row number.
- `--adgroup-id` is now optional in batch mode and acts as a default; rows may override it. Single-item mode (`--keyword`) is unchanged, including the existing fail-on-Errors behaviour.

## Contract fidelity (Yandex Direct WSDL 1:1)

- WSDL: `tests/wsdl_cache/keywords.xml:114-127` declares `Keywords` with `maxOccurs="unbounded"`. The 10-item cap is a **documentation-level runtime limit** (https://yandex.ru/dev/direct/doc/dg/objects/keyword.html), recorded as `KEYWORDS_ADD_MAX_BATCH = 10` with the doc URL inline.
- WSDL `KeywordAddItem` `minOccurs=1` fields: `Keyword`, `AdGroupId` — both registered in `INTERNAL_VALIDATION` with matching `INTERNAL_VALIDATION_PROBES` so the parity gate keeps enforcing them after the Click `required=True` flags went away.
- Row whitelist matches exactly the WSDL fields already covered by the single-mode flags. Extending the whitelist to `StrategyPriority` / `AutotargetingSettings` etc. is left to a follow-up issue to avoid scope creep.

## Out of scope (intentional)

- CSV input — the WSDL includes nested `Autotargeting*` types that don't map cleanly to a flat header; if needed, a separate issue.
- New WSDL fields (`StrategyPriority`, `Autotargeting*`) — handled in a separate feature request.
- Batch mode for `keywords update` — issue #203 only covers `add`.

## Test plan

- [x] `pytest tests/test_dry_run.py -k keywords_add -v` — 15 new tests pass (chunking, mutex, per-row validation, unknown-field reject, mode-mode rejection, `--format other than json` rejection, single-mode regression on Errors).
- [x] `pytest tests/test_wsdl_parity_gate.py` — 48 passed, 6 skipped (parity gate enforces `Keyword`/`AdGroupId` through `INTERNAL_VALIDATION`).
- [x] `pytest -m "not integration and not integration_write and not integration_live_write"` — 791 passed, 11 skipped, no regressions.
- [x] `black .` clean on changed files; `flake8` on changed files — no new warnings (the three pre-existing E501s in `_DEPRECATED_KEYWORDS_UPDATE_OPTIONS` lines pre-date this PR).
- [x] `direct keywords add --help` shows the new options.
- [x] `direct keywords add --adgroup-id N --keyword X --dry-run` payload is byte-identical to the pre-PR single-mode payload.
- [x] 12-row JSONL `--dry-run` → `chunks=2, totalItems=12, firstChunkLen=10`.

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)