### PR TITLE
fix(auth): close fd in _write_json on chmod failure (#154)

### DIFF
--- a/direct_cli/auth.py
+++ b/direct_cli/auth.py
@@ -3,6 +3,7 @@ Authentication module for Direct CLI
 """
 
 import base64
+import contextlib
 import hashlib
 import json
 import logging
@@ -148,10 +149,15 @@ def _write_json(path: Path, payload: Dict[str, Any]) -> None:
     try:
         os.chmod(tmp, 0o600)
         with os.fdopen(fd, "w", encoding="utf-8") as f:
+            fd = -1  # ownership transferred to the file object
             f.write(json.dumps(payload, ensure_ascii=False, indent=2))
         os.replace(tmp, path)
     except Exception:
-        os.unlink(tmp)
+        if fd != -1:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
         raise
 
 

--- a/tests/test_auth_write_json.py
+++ b/tests/test_auth_write_json.py
@@ -1,7 +1,6 @@
 """Tests for direct_cli.auth._write_json cleanup semantics."""
 
 import errno
-import fcntl
 import json
 import os
 import stat
@@ -11,6 +10,9 @@ from pathlib import Path
 import pytest
 
 from direct_cli.auth import _write_json
+
+# fcntl is POSIX-only; skip the whole module on platforms without it.
+fcntl = pytest.importorskip("fcntl")
 
 
 def _wrap_mkstemp(monkeypatch, captured):

--- a/tests/test_auth_write_json.py
+++ b/tests/test_auth_write_json.py
@@ -1,0 +1,94 @@
+"""Tests for direct_cli.auth._write_json cleanup semantics."""
+
+import errno
+import fcntl
+import json
+import os
+import stat
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from direct_cli.auth import _write_json
+
+
+def _wrap_mkstemp(monkeypatch, captured):
+    real_mkstemp = tempfile.mkstemp
+
+    def wrapper(*args, **kwargs):
+        fd, tmp = real_mkstemp(*args, **kwargs)
+        captured["fd"] = fd
+        captured["tmp"] = tmp
+        return fd, tmp
+
+    monkeypatch.setattr("direct_cli.auth.tempfile.mkstemp", wrapper)
+
+
+def _selective_chmod(monkeypatch, captured):
+    """Fail chmod only when targeting the captured tmp path."""
+    real_chmod = os.chmod
+
+    def fake_chmod(target, mode):
+        if "tmp" in captured and str(target) == str(captured["tmp"]):
+            raise PermissionError("simulated chmod failure")
+        return real_chmod(target, mode)
+
+    monkeypatch.setattr("direct_cli.auth.os.chmod", fake_chmod)
+
+
+def _assert_fd_closed(fd):
+    # fcntl.F_GETFD is a non-destructive probe: a live fd returns flags, a
+    # closed fd raises OSError(EBADF). Unlike os.close, it never closes an
+    # unrelated fd that the OS may have reassigned to the same number.
+    with pytest.raises(OSError) as exc_info:
+        fcntl.fcntl(fd, fcntl.F_GETFD)
+    assert exc_info.value.errno == errno.EBADF
+
+
+class TestWriteJsonCleanup:
+    def test_chmod_failure_closes_fd_and_removes_tmp(self, tmp_path, monkeypatch):
+        captured: dict = {}
+        _wrap_mkstemp(monkeypatch, captured)
+        _selective_chmod(monkeypatch, captured)
+
+        target = tmp_path / "auth.json"
+        with pytest.raises(PermissionError, match="simulated chmod failure"):
+            _write_json(target, {"any": "payload"})
+
+        assert "fd" in captured and "tmp" in captured
+        assert not Path(captured["tmp"]).exists()
+        assert not target.exists()
+        _assert_fd_closed(captured["fd"])
+
+    def test_unlink_failure_preserves_original_exception(self, tmp_path, monkeypatch):
+        captured: dict = {}
+        _wrap_mkstemp(monkeypatch, captured)
+        _selective_chmod(monkeypatch, captured)
+
+        def failing_unlink(*_args, **_kwargs):
+            raise OSError(errno.EIO, "simulated unlink failure")
+
+        monkeypatch.setattr("direct_cli.auth.os.unlink", failing_unlink)
+
+        target = tmp_path / "auth.json"
+        with pytest.raises(PermissionError, match="simulated chmod failure"):
+            _write_json(target, {"any": "payload"})
+
+        _assert_fd_closed(captured["fd"])
+
+    def test_happy_path_writes_payload_with_0600(self, tmp_path, monkeypatch):
+        captured: dict = {}
+        _wrap_mkstemp(monkeypatch, captured)
+
+        target = tmp_path / "sub" / "auth.json"
+        payload = {"a": 1, "b": "ы"}
+        _write_json(target, payload)
+
+        assert target.exists()
+        assert json.loads(target.read_text("utf-8")) == payload
+        mode = stat.S_IMODE(target.stat().st_mode)
+        assert mode == 0o600
+        # ensure_ascii=False => the raw cyrillic byte sequence is present
+        assert "ы".encode("utf-8") in target.read_bytes()
+        _assert_fd_closed(captured["fd"])


### PR DESCRIPTION
## Summary

- Harden `direct_cli/auth.py::_write_json`: track descriptor ownership via a `fd = -1` sentinel set inside `with os.fdopen(...)`. If anything between `tempfile.mkstemp` and `os.fdopen` raises (e.g. `os.chmod(tmp, 0o600)`), the raw fd is closed in the `except` branch instead of leaking until GC/process exit.
- Wrap both `os.close` and `os.unlink` cleanup calls with `contextlib.suppress(OSError)` so a cleanup error never masks the original exception (`raise` re-raises the original).
- Public behavior is preserved: atomic `os.replace`, file mode `0o600`, JSON via `ensure_ascii=False, indent=2`, signature `_write_json(path: Path, payload: Dict[str, Any]) -> None`.

## Tests

New `tests/test_auth_write_json.py` (pytest + monkeypatch + tmp_path, in the style of `tests/test_auth_oauth.py`):

- `test_chmod_failure_closes_fd_and_removes_tmp` — selective `os.chmod` patch fails only on the tmp file; verifies `PermissionError` propagates, tmp is unlinked, and the captured fd is closed (`fcntl(F_GETFD)` probe → `EBADF`, non-destructive so no fd-reuse race).
- `test_unlink_failure_preserves_original_exception` — combines chmod failure with a failing `os.unlink`; verifies the original `PermissionError` is what surfaces, not the cleanup `OSError`.
- `test_happy_path_writes_payload_with_0600` — regression: payload round-trips, mode is `0o600`, `ensure_ascii=False` preserved (raw cyrillic bytes), fd closed after success.

## Test plan

- [x] `pytest tests/test_auth_write_json.py -v` → 3/3 passed
- [x] `pytest tests/test_auth_oauth.py tests/test_auth_bw.py tests/test_auth_op.py -q` → 78/78 passed, no regressions
- [x] Full `pytest` → 877 passed, 45 skipped
- [x] `black --check direct_cli/auth.py tests/test_auth_write_json.py` clean
- [x] `flake8 direct_cli/auth.py tests/test_auth_write_json.py` clean

Closes #154