### PR TITLE
feat(sitelinks): support escaped pipe + --sitelink-json/--sitelinks-from-file (#221)

### DIFF
--- a/direct_cli/commands/sitelinks.py
+++ b/direct_cli/commands/sitelinks.py
@@ -12,12 +12,22 @@ from ..api import create_client
 from ..output import format_output, print_error
 from ..utils import get_default_fields, parse_ids, parse_sitelink_specs
 
+_SITELINK_FIELDS = ("Title", "Href", "Description")
+
 
 def _normalize_sitelink_row(row: Any, index: int) -> Dict[str, str]:
     if not isinstance(row, dict):
         raise click.UsageError(
             f"Sitelink #{index}: expected a JSON object, got {type(row).__name__}"
         )
+
+    unknown = sorted(set(row) - set(_SITELINK_FIELDS))
+    if unknown:
+        allowed = ", ".join(_SITELINK_FIELDS)
+        raise click.UsageError(
+            f"Unknown field {unknown[0]!r} in sitelink #{index}; allowed: {allowed}"
+        )
+
     if "Title" not in row or not str(row.get("Title") or "").strip():
         raise click.UsageError(f"Sitelink #{index}: missing required field 'Title'")
     if "Href" not in row or not str(row.get("Href") or "").strip():
@@ -151,14 +161,10 @@ def add(ctx, sitelinks_specs, sitelinks_json, sitelinks_from_file, dry_run):
     Provide exactly one source: --sitelink (repeatable), --sitelink-json,
     or --sitelinks-from-file.
     """
-    sources_used = sum(
-        1
-        for value in (
-            sitelinks_specs or None,
-            sitelinks_json,
-            sitelinks_from_file,
-        )
-        if value
+    sources_used = (
+        (1 if sitelinks_specs else 0)
+        + (1 if sitelinks_json is not None else 0)
+        + (1 if sitelinks_from_file is not None else 0)
     )
     if sources_used == 0:
         raise click.UsageError(

--- a/direct_cli/commands/sitelinks.py
+++ b/direct_cli/commands/sitelinks.py
@@ -2,11 +2,68 @@
 Sitelinks commands
 """
 
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
 import click
 
 from ..api import create_client
 from ..output import format_output, print_error
 from ..utils import get_default_fields, parse_ids, parse_sitelink_specs
+
+
+def _normalize_sitelink_row(row: Any, index: int) -> Dict[str, str]:
+    if not isinstance(row, dict):
+        raise click.UsageError(
+            f"Sitelink #{index}: expected a JSON object, got {type(row).__name__}"
+        )
+    if "Title" not in row or not str(row.get("Title") or "").strip():
+        raise click.UsageError(f"Sitelink #{index}: missing required field 'Title'")
+    if "Href" not in row or not str(row.get("Href") or "").strip():
+        raise click.UsageError(f"Sitelink #{index}: missing required field 'Href'")
+
+    item: Dict[str, str] = {
+        "Title": str(row["Title"]).strip(),
+        "Href": str(row["Href"]).strip(),
+    }
+    description = row.get("Description")
+    if description is not None and str(description).strip():
+        item["Description"] = str(description).strip()
+    return item
+
+
+def _load_sitelinks_from_inline(json_str: str) -> List[Any]:
+    try:
+        decoded = json.loads(json_str)
+    except json.JSONDecodeError as exc:
+        raise click.UsageError(f"--sitelink-json: invalid JSON: {exc.msg}")
+    if not isinstance(decoded, list):
+        raise click.UsageError(
+            "--sitelink-json must be a JSON array of sitelink objects"
+        )
+    return decoded
+
+
+def _load_sitelinks_from_file(path: str) -> List[Any]:
+    file_path = Path(path)
+    try:
+        text = file_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise click.UsageError(f"Cannot read --sitelinks-from-file {path!r}: {exc}")
+
+    rows: List[Any] = []
+    for line_number, raw_line in enumerate(text.splitlines(), start=1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            rows.append(json.loads(line))
+        except json.JSONDecodeError as exc:
+            raise click.UsageError(
+                f"--sitelinks-from-file line {line_number}: invalid JSON: {exc.msg}"
+            )
+    return rows
 
 
 @click.group()
@@ -72,21 +129,71 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
     "--sitelink",
     "sitelinks_specs",
     multiple=True,
-    required=True,
-    help="Sitelink spec: TITLE|HREF[|DESCRIPTION]",
+    help="Sitelink spec: TITLE|HREF[|DESCRIPTION]. Escape literal '|' as '\\|'.",
+)
+@click.option(
+    "--sitelink-json",
+    "sitelinks_json",
+    help="Inline JSON array of sitelink objects: "
+    '[{"Title":"...","Href":"...","Description":"..."}]',
+)
+@click.option(
+    "--sitelinks-from-file",
+    "sitelinks_from_file",
+    type=click.Path(exists=True, dir_okay=False, readable=True),
+    help="JSONL file with one sitelink object per line",
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def add(ctx, sitelinks_specs, dry_run):
-    """Add sitelinks set"""
+def add(ctx, sitelinks_specs, sitelinks_json, sitelinks_from_file, dry_run):
+    """Add sitelinks set.
+
+    Provide exactly one source: --sitelink (repeatable), --sitelink-json,
+    or --sitelinks-from-file.
+    """
+    sources_used = sum(
+        1
+        for value in (
+            sitelinks_specs or None,
+            sitelinks_json,
+            sitelinks_from_file,
+        )
+        if value
+    )
+    if sources_used == 0:
+        raise click.UsageError(
+            "Provide exactly one of: --sitelink (repeatable), "
+            "--sitelink-json (inline JSON array), or --sitelinks-from-file (JSONL)."
+        )
+    if sources_used > 1:
+        raise click.UsageError(
+            "--sitelink, --sitelink-json, and --sitelinks-from-file are "
+            "mutually exclusive — provide exactly one."
+        )
+
     try:
+        if sitelinks_specs:
+            try:
+                sitelinks_payload = parse_sitelink_specs(list(sitelinks_specs))
+            except ValueError as exc:
+                raise click.UsageError(str(exc))
+        else:
+            if sitelinks_json is not None:
+                raw_rows = _load_sitelinks_from_inline(sitelinks_json)
+            else:
+                raw_rows = _load_sitelinks_from_file(sitelinks_from_file)
+
+            if not raw_rows:
+                raise click.UsageError("Input contains no sitelink rows.")
+
+            sitelinks_payload = [
+                _normalize_sitelink_row(row, idx)
+                for idx, row in enumerate(raw_rows, start=1)
+            ]
+
         body = {
             "method": "add",
-            "params": {
-                "SitelinksSets": [
-                    {"Sitelinks": parse_sitelink_specs(list(sitelinks_specs))}
-                ]
-            },
+            "params": {"SitelinksSets": [{"Sitelinks": sitelinks_payload}]},
         }
 
         if dry_run:
@@ -102,6 +209,8 @@ def add(ctx, sitelinks_specs, dry_run):
         result = client.sitelinks().post(data=body)
         format_output(result().extract(), "json", None)
 
+    except click.UsageError:
+        raise
     except Exception as e:
         print_error(str(e))
         raise click.Abort()

--- a/direct_cli/utils.py
+++ b/direct_cli/utils.py
@@ -457,18 +457,48 @@ def parse_retargeting_rule_specs(
     return rules
 
 
+def _split_sitelink_spec(spec: str) -> List[str]:
+    """Split a sitelink spec by '|', treating '\\|' as a literal pipe.
+
+    UTM templates in Yandex Direct use literal '|' inside URLs
+    (e.g. cid|{campaign_id}|gid|{gbid}); allow users to escape it as '\\|'.
+    """
+    parts: List[str] = []
+    current: List[str] = []
+    i = 0
+    while i < len(spec):
+        ch = spec[i]
+        if ch == "\\" and i + 1 < len(spec) and spec[i + 1] == "|":
+            current.append("|")
+            i += 2
+            continue
+        if ch == "|":
+            parts.append("".join(current))
+            current = []
+            i += 1
+            continue
+        current.append(ch)
+        i += 1
+    parts.append("".join(current))
+    return parts
+
+
 def parse_sitelink_specs(specs: Optional[List[str]]) -> Optional[List[Dict[str, str]]]:
-    """Parse repeated TITLE|HREF[|DESCRIPTION] sitelink specs."""
+    """Parse repeated TITLE|HREF[|DESCRIPTION] sitelink specs.
+
+    Literal '|' characters inside any field can be escaped as '\\|'.
+    """
     if not specs:
         return None
 
     sitelinks = []
     for spec in specs:
-        parts = [part.strip() for part in spec.split("|")]
+        parts = [part.strip() for part in _split_sitelink_spec(spec)]
         if len(parts) not in (2, 3):
             raise ValueError(
                 "Invalid sitelink: "
-                f"'{spec}'. Expected format: TITLE|HREF[|DESCRIPTION]"
+                f"'{spec}'. Expected format: TITLE|HREF[|DESCRIPTION]. "
+                "Escape a literal '|' inside a field as '\\|'."
             )
 
         sitelink = {"Title": parts[0], "Href": parts[1]}

--- a/tests/api_coverage_payloads.py
+++ b/tests/api_coverage_payloads.py
@@ -375,6 +375,29 @@ PAYLOAD_CASES = [
         ],
     ),
     (
+        "sitelinks",
+        "add",
+        [
+            "sitelinks",
+            "add",
+            "--sitelink",
+            "Главная|https://example.com/?utm=cid\\|{campaign_id}\\|gid|Подробнее",
+        ],
+    ),
+    (
+        "sitelinks",
+        "add",
+        [
+            "sitelinks",
+            "add",
+            "--sitelink-json",
+            (
+                '[{"Title":"Главная","Href":"https://example.com/?utm=cid|{cid}",'
+                '"Description":"Подробнее"}]'
+            ),
+        ],
+    ),
+    (
         "smartadtargets",
         "add",
         [

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -2934,6 +2934,140 @@ def test_sitelinks_add_parses_links_array():
     }
 
 
+def test_sitelinks_add_supports_escaped_pipe_in_href():
+    """UTM templates with literal '|' must round-trip via '\\|'. See #221."""
+    body = _dry_run(
+        "sitelinks",
+        "add",
+        "--sitelink",
+        (
+            "Главная|https://example.com/?utm_content=cid"
+            "\\|{campaign_id}\\|gid\\|{gbid}|Узнать больше"
+        ),
+    )
+    sitelink = body["params"]["SitelinksSets"][0]["Sitelinks"][0]
+    assert sitelink == {
+        "Title": "Главная",
+        "Href": "https://example.com/?utm_content=cid|{campaign_id}|gid|{gbid}",
+        "Description": "Узнать больше",
+    }
+
+
+def test_sitelinks_add_pipe_spec_invalid_raises():
+    """Unescaped '|' overflowing the 3-part shape must error with a hint."""
+    result = _rejected(
+        "sitelinks",
+        "add",
+        "--sitelink",
+        "Главная|https://example.com/?utm=cid|{cid}|gid|{gbid}|Узнать",
+    )
+    assert "Invalid sitelink" in result.output
+    assert "\\|" in result.output
+
+
+def test_sitelinks_add_from_inline_json():
+    body = _dry_run(
+        "sitelinks",
+        "add",
+        "--sitelink-json",
+        json.dumps(
+            [
+                {
+                    "Title": "Главная",
+                    "Href": "https://example.com/?utm=cid|{cid}",
+                    "Description": "Узнать",
+                },
+                {"Title": "Контакты", "Href": "https://example.com/contact"},
+            ]
+        ),
+    )
+    assert body["params"]["SitelinksSets"][0]["Sitelinks"] == [
+        {
+            "Title": "Главная",
+            "Href": "https://example.com/?utm=cid|{cid}",
+            "Description": "Узнать",
+        },
+        {"Title": "Контакты", "Href": "https://example.com/contact"},
+    ]
+
+
+def test_sitelinks_add_from_file_jsonl(tmp_path):
+    jsonl_path = tmp_path / "sitelinks.jsonl"
+    jsonl_path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "Title": "Главная",
+                        "Href": "https://example.com/?utm=cid|{cid}",
+                    }
+                ),
+                "",
+                json.dumps(
+                    {
+                        "Title": "Контакты",
+                        "Href": "https://example.com/contact",
+                        "Description": "Связаться",
+                    }
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+    body = _dry_run(
+        "sitelinks",
+        "add",
+        "--sitelinks-from-file",
+        str(jsonl_path),
+    )
+    assert body["params"]["SitelinksSets"][0]["Sitelinks"] == [
+        {"Title": "Главная", "Href": "https://example.com/?utm=cid|{cid}"},
+        {
+            "Title": "Контакты",
+            "Href": "https://example.com/contact",
+            "Description": "Связаться",
+        },
+    ]
+
+
+def test_sitelinks_add_mixed_sources_rejected():
+    result = _rejected(
+        "sitelinks",
+        "add",
+        "--sitelink",
+        "About|https://example.com/about",
+        "--sitelink-json",
+        '[{"Title":"X","Href":"https://example.com/"}]',
+    )
+    assert "mutually exclusive" in result.output
+
+
+def test_sitelinks_add_no_source_rejected():
+    result = _rejected("sitelinks", "add")
+    assert "Provide exactly one of" in result.output
+
+
+def test_sitelinks_add_json_missing_href_rejected():
+    result = _rejected(
+        "sitelinks",
+        "add",
+        "--sitelink-json",
+        '[{"Title":"Главная"}]',
+    )
+    assert "Sitelink #1" in result.output
+    assert "Href" in result.output
+
+
+def test_sitelinks_add_json_not_array_rejected():
+    result = _rejected(
+        "sitelinks",
+        "add",
+        "--sitelink-json",
+        '{"Title":"X","Href":"https://example.com/"}',
+    )
+    assert "must be a JSON array" in result.output
+
+
 # ----------------------------------------------------------------------
 # vcards
 # ----------------------------------------------------------------------

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -3068,6 +3068,32 @@ def test_sitelinks_add_json_not_array_rejected():
     assert "must be a JSON array" in result.output
 
 
+def test_sitelinks_add_rejects_unknown_field():
+    """Typo in a JSON key must fail loudly, not silently drop. See PR #223."""
+    result = _rejected(
+        "sitelinks",
+        "add",
+        "--sitelink-json",
+        json.dumps(
+            [
+                {
+                    "Title": "Главная",
+                    "Href": "https://example.com/",
+                    "Decsription": "typo",
+                }
+            ]
+        ),
+    )
+    assert "Unknown field 'Decsription'" in result.output
+    assert "sitelink #1" in result.output
+
+
+def test_sitelinks_add_empty_json_rejected():
+    """`--sitelink-json ''` is provided-but-invalid, not absent. See PR #223."""
+    result = _rejected("sitelinks", "add", "--sitelink-json", "")
+    assert "invalid JSON" in result.output
+
+
 # ----------------------------------------------------------------------
 # vcards
 # ----------------------------------------------------------------------

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -365,6 +365,7 @@ INTERNAL_VALIDATION: dict[tuple[str, str, str], str] = {
     ("creatives", "add", "VideoExtensionCreative"): "Missing option '--video-id'",
     ("keywords", "add", "Keyword"): "Provide exactly one of: --keyword",
     ("keywords", "add", "AdGroupId"): "Provide exactly one of: --keyword",
+    ("sitelinks", "add", "Sitelinks"): "Provide exactly one of: --sitelink",
 }
 
 
@@ -452,6 +453,7 @@ INTERNAL_VALIDATION_PROBES: dict[tuple[str, str, str], list[str]] = {
     ("creatives", "add", "VideoExtensionCreative"): ["creatives", "add"],
     ("keywords", "add", "Keyword"): ["keywords", "add"],
     ("keywords", "add", "AdGroupId"): ["keywords", "add"],
+    ("sitelinks", "add", "Sitelinks"): ["sitelinks", "add"],
 }
 
 


### PR DESCRIPTION
## Summary

- `direct sitelinks add --sitelink TITLE|HREF[|DESCRIPTION]` ломался на URL с литеральным `|` (UTM-шаблоны Яндекс.Директа вида `cid|{campaign_id}|gid|{gbid}`). Теперь литеральный pipe экранируется как `\|`; обычные spec-строки без `\|` ведут себя bit-for-bit как раньше.
- Добавлены два альтернативных структурных канала по образцу `keywords add` (#218): `--sitelink-json '<JSON-array>'` и `--sitelinks-from-file <path.jsonl>`. Источники взаимоисключающие; ровно один обязателен; ошибки про отсутствие Title/Href сообщают индекс строки.
- `ValueError` из `parse_sitelink_specs` оборачивается в `click.UsageError` — все три входа возвращают exit code 2 на невалидный ввод.

## Verification

- `pytest` — 888 passed, 45 skipped.
- `pytest tests/test_dry_run.py -k sitelinks` — 9/9 зелёные (1 страховка backwards-compat + 8 новых).
- `pytest tests/test_wsdl_parity_gate.py` — `sitelinks.add/Sitelinks` зарегистрировано в `INTERNAL_VALIDATION` (теперь validated в теле команды, а не через Click `required=True`).
- `black --check` — clean.
- `flake8 direct_cli tests` — без новых замечаний.

## Test plan
- [x] `\|` round-trips через `Href` без изменения payload (UTM-шаблон сохраняется)
- [x] Невалидный pipe spec → `UsageError` с hint про `\\|`
- [x] `--sitelink-json` с массивом объектов
- [x] `--sitelinks-from-file` с JSONL
- [x] Mixed sources → `UsageError`
- [x] No source → `UsageError`
- [x] JSON без `Href` → `UsageError` с индексом строки
- [x] JSON не-массив → `UsageError`
- [x] Существующий `test_sitelinks_add_parses_links_array` проходит без правок (backwards-compat)
- [x] WSDL parity gate зелёный

Closes #221
Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)