### PR TITLE
fix(keywords): surface item-level Errors in bulk add (#211)

### DIFF
--- a/direct_cli/commands/keywords.py
+++ b/direct_cli/commands/keywords.py
@@ -9,7 +9,12 @@ from typing import Any, Dict, Iterator, List, Optional
 import click
 
 from ..api import create_client
-from ..output import format_json, format_output, print_error
+from ..output import (
+    format_json,
+    format_output,
+    print_error,
+    raise_for_api_result_errors,
+)
 from ..utils import add_criteria_csv, parse_ids, get_default_fields, MICRO_RUBLES
 
 # Yandex Direct API "keywords.add" caps a single AddItems request at 10
@@ -434,9 +439,17 @@ def _bulk_add(
             )
             body = {"method": "add", "params": {"Keywords": chunk}}
             response = client.keywords().post(data=body)
-            all_results.extend(_normalize_add_results(response().extract()))
+            chunk_results = _normalize_add_results(response().extract())
+            # Only items without per-item Errors are "already created" — the
+            # partial-success diagnostic must not lie about failed items.
+            all_results.extend(
+                item
+                for item in chunk_results
+                if not (isinstance(item, dict) and item.get("Errors"))
+            )
+            raise_for_api_result_errors(chunk_results)
 
-        print(format_json({"AddResults": all_results}, indent=2))
+        format_output({"AddResults": all_results}, "json", None)
     except click.UsageError:
         raise
     except Exception as e:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ Tests for Direct CLI
 """
 
 import io
+import json
 import os
 import unittest
 from contextlib import redirect_stderr
@@ -174,6 +175,191 @@ class TestCLI(unittest.TestCase):
         self.assertIn("Details: Ad not found", result.output)
         self.assertIn("current Client-Login/account", result.output)
         self.assertIn("YANDEX_DIRECT_LOGIN", result.output)
+
+    def test_keywords_bulk_add_surfaces_item_errors(self):
+        """Bulk-add path must not bypass the item-level error renderer. See #211."""
+
+        class FakeResponse:
+            def __call__(self):
+                return self
+
+            def extract(self):
+                return [
+                    {
+                        "Errors": [
+                            {
+                                "Code": 8800,
+                                "Message": "Object not found",
+                                "Details": "Ad group not found",
+                            }
+                        ]
+                    }
+                ]
+
+        class FakeClient:
+            def keywords(self):
+                return self
+
+            def post(self, data):
+                return FakeResponse()
+
+        keywords_module = import_module("direct_cli.commands.keywords")
+        with patch.object(keywords_module, "create_client", return_value=FakeClient()):
+            result = self.runner.invoke(
+                cli,
+                [
+                    "keywords",
+                    "add",
+                    "--keywords-json",
+                    '[{"AdGroupId": 1, "Keyword": "shoes"}]',
+                ],
+                env={
+                    "YANDEX_DIRECT_TOKEN": "test-token",
+                    "YANDEX_DIRECT_LOGIN": "axisrow",
+                },
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Yandex Direct API returned errors", result.output)
+        self.assertIn("Error 8800: Object not found", result.output)
+        self.assertIn("Details: Ad group not found", result.output)
+        self.assertIn("current Client-Login/account", result.output)
+
+    def test_keywords_bulk_add_multi_chunk_partial_success(self):
+        """Earlier chunk OK, later chunk fails: diagnostic shows both. See #211."""
+
+        good_chunk_result = [
+            {"Id": idx} for idx in range(1, 11)  # KEYWORDS_ADD_MAX_BATCH = 10
+        ]
+        # Mixed chunk: one item succeeds, one fails. The success item must
+        # land in partial-success diagnostic; the failure item must not.
+        bad_chunk_result = [
+            {"Id": 999},
+            {
+                "Errors": [
+                    {
+                        "Code": 8800,
+                        "Message": "Object not found",
+                        "Details": "Ad group not found",
+                    }
+                ]
+            },
+        ]
+
+        class FakeResponse:
+            def __init__(self, payload):
+                self.payload = payload
+
+            def __call__(self):
+                return self
+
+            def extract(self):
+                return self.payload
+
+        class FakeClient:
+            def __init__(self):
+                self.calls = 0
+
+            def keywords(self):
+                return self
+
+            def post(self, data):
+                self.calls += 1
+                if self.calls == 1:
+                    return FakeResponse(good_chunk_result)
+                return FakeResponse(bad_chunk_result)
+
+        keywords_json = json.dumps(
+            [{"AdGroupId": 1, "Keyword": f"kw-{i}"} for i in range(12)]
+        )
+
+        keywords_module = import_module("direct_cli.commands.keywords")
+        with patch.object(keywords_module, "create_client", return_value=FakeClient()):
+            result = self.runner.invoke(
+                cli,
+                ["keywords", "add", "--keywords-json", keywords_json],
+                env={
+                    "YANDEX_DIRECT_TOKEN": "test-token",
+                    "YANDEX_DIRECT_LOGIN": "axisrow",
+                },
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Yandex Direct API returned errors", result.output)
+        self.assertIn("Error 8800: Object not found", result.output)
+        self.assertIn("Partial success before failure", result.output)
+        # Successful items (chunk 1 ids 1..10 + mixed chunk id 999) must
+        # appear in the partial-success diagnostic.
+        self.assertIn('"Id": 1', result.output)
+        self.assertIn('"Id": 10', result.output)
+        self.assertIn('"Id": 999', result.output)
+        # The failed item must NOT be claimed as "already created".
+        diagnostic = result.output.split("Partial success before failure")[1]
+        self.assertNotIn('"Errors"', diagnostic)
+
+    def test_keywords_bulk_add_all_failure_second_chunk(self):
+        """Chunk 1 OK, chunk 2 all-failure: diagnostic shows chunk 1 only. See #211."""
+
+        good_chunk_result = [{"Id": idx} for idx in range(1, 11)]
+        all_failure_chunk_result = [
+            {
+                "Errors": [
+                    {
+                        "Code": 8800,
+                        "Message": "Object not found",
+                        "Details": "Ad group not found",
+                    }
+                ]
+            }
+        ]
+
+        class FakeResponse:
+            def __init__(self, payload):
+                self.payload = payload
+
+            def __call__(self):
+                return self
+
+            def extract(self):
+                return self.payload
+
+        class FakeClient:
+            def __init__(self):
+                self.calls = 0
+
+            def keywords(self):
+                return self
+
+            def post(self, data):
+                self.calls += 1
+                if self.calls == 1:
+                    return FakeResponse(good_chunk_result)
+                return FakeResponse(all_failure_chunk_result)
+
+        keywords_json = json.dumps(
+            [{"AdGroupId": 1, "Keyword": f"kw-{i}"} for i in range(11)]
+        )
+
+        keywords_module = import_module("direct_cli.commands.keywords")
+        with patch.object(keywords_module, "create_client", return_value=FakeClient()):
+            result = self.runner.invoke(
+                cli,
+                ["keywords", "add", "--keywords-json", keywords_json],
+                env={
+                    "YANDEX_DIRECT_TOKEN": "test-token",
+                    "YANDEX_DIRECT_LOGIN": "axisrow",
+                },
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Error 8800: Object not found", result.output)
+        self.assertIn("Partial success before failure", result.output)
+        # Only chunk-1 ids must appear in the diagnostic.
+        diagnostic = result.output.split("Partial success before failure")[1]
+        self.assertIn('"Id": 1', diagnostic)
+        self.assertIn('"Id": 10', diagnostic)
+        # The failed chunk's Errors item must NOT be in the diagnostic.
+        self.assertNotIn('"Errors"', diagnostic)
 
     def test_changes_help_uses_canonical_names(self):
         """Test changes help only exposes canonical command names"""


### PR DESCRIPTION
## Summary

PR #212 wired the item-level error renderer (`raise_for_api_result_errors` + `DirectAPIResultError`) into `format_output`, so every mutating command exits non-zero with a human-readable message — including 8800-specific Client-Login guidance — when the API response contains embedded `Errors`.

A repo-wide audit (all 84 `format_output(result().extract(), …)` call sites + grep on direct `print(format_json(…))` / `click.echo(format_json(…))`) found one remaining bypass: `keywords add` bulk path (added later by PR #218). It accumulated chunk results into `all_results` and emitted them via `print(format_json({"AddResults": all_results}, indent=2))` — completely sidestepping the renderer, so per-chunk item-level `Errors` produced raw JSON and exit code 0.

This PR fixes that one bypass.

## Changes

- `direct_cli/commands/keywords.py::_bulk_add`:
  - Per-chunk: only items **without** per-item `Errors` are appended to `all_results` — the partial-success diagnostic now lists only the keywords Yandex actually accepted, never failed items.
  - `raise_for_api_result_errors(chunk_results)` is called on the **raw** chunk results so the renderer sees the full Errors payload and surfaces the 8800 Client-Login hint.
  - Final happy-path printout via `format_output({"AddResults": all_results}, "json", None)` instead of `print(format_json(...))` — defence-in-depth.

- `tests/test_cli.py` — three focused unit tests (mock client, no HTTP):
  - `test_keywords_bulk_add_surfaces_item_errors` — single chunk all Errors → non-zero exit + full 8800 messaging.
  - `test_keywords_bulk_add_multi_chunk_partial_success` — chunk 1 all-success, chunk 2 mixed (one `Id` + one `Errors`); success-id from mixed chunk appears in diagnostic; Errors-item does **not**.
  - `test_keywords_bulk_add_all_failure_second_chunk` — chunk 1 all-success, chunk 2 all-Errors; diagnostic contains only chunk-1 ids, no `Errors`.

## Verification

- `pytest` — 893 passed, 45 skipped (+3 new tests vs main).
- `pytest tests/test_cli.py -k 'bulk_add or embedded_api_errors' -v` — 4/4 green (1 existing + 3 new).
- `black --check direct_cli/commands/keywords.py tests/test_cli.py` — clean.
- `flake8 direct_cli/commands/keywords.py tests/test_cli.py` — no new findings (pre-existing E501 in unrelated `_DEPRECATED_KEYWORDS_UPDATE_OPTIONS` lines untouched).
- Existing `test_embedded_api_errors_are_reported_as_cli_errors` (ads update 8800) passes unchanged.

## Test plan
- [x] Single chunk with item-level Errors → non-zero exit, formatted message, 8800 guidance
- [x] Mixed-result chunk: success items recorded, failed item not claimed as "already created"
- [x] All-failure chunk after a clean chunk: diagnostic shows only the clean chunk's items
- [x] Existing 8800 regression test for `ads update` still passes
- [x] WSDL parity / dry-run regressions untouched

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)