### PR TITLE
feat(v4): validate request body shape before sending (#182)

### DIFF
--- a/direct_cli/v4/__init__.py
+++ b/direct_cli/v4/__init__.py
@@ -6,8 +6,13 @@ import click
 
 from direct_cli.v4_contracts import (
     PARAM_UNDOCUMENTED_SHAPE_MSG,
+    SAFETY_DANGEROUS,
+    SAFETY_WRITE,
+    get_v4_contract,
     validate_v4_body_shape,
 )
+
+_UNSAFE_SAFETY_LEVELS = frozenset({SAFETY_WRITE, SAFETY_DANGEROUS})
 
 
 def build_v4_body(method: str, param: Optional[Any] = None) -> dict:
@@ -23,14 +28,25 @@ def call_v4(client: Any, method: str, param: Optional[Any] = None) -> Any:
     body = build_v4_body(method, param)
 
     errors = validate_v4_body_shape(method, body)
-    # Split by error class: "param shape is undocumented" is a soft
-    # contract gap (5 real methods like PayCampaignsByCard) — warn and
-    # continue. Anything else (shape mismatch, method mismatch) is a
-    # caller bug and must block the request.
+    # Hard errors (shape mismatch, method mismatch) always block.
     hard_errors = [e for e in errors if PARAM_UNDOCUMENTED_SHAPE_MSG not in e]
     if hard_errors:
         raise click.UsageError("; ".join(hard_errors))
+
     if errors:
+        # Only undocumented-shape errors remain. Fail-closed when the
+        # contract is write/dangerous — we will not blindly post a
+        # financial or write operation whose payload shape we cannot
+        # verify. For read-class undocumented methods (e.g.
+        # GetKeywordsSuggestion) a soft warning is acceptable.
+        safety = get_v4_contract(method).safety
+        if safety in _UNSAFE_SAFETY_LEVELS:
+            raise click.UsageError(
+                f"refusing to send v4 method {method!r}: param shape is "
+                f"undocumented and safety is {safety!r}. "
+                "Add a documented param_shape to V4_METHOD_CONTRACTS "
+                "before exposing this method through the CLI."
+            )
         click.echo(
             f"warning: v4 method {method!r} has an undocumented param "
             "shape; sending request as-is.",

--- a/direct_cli/v4/__init__.py
+++ b/direct_cli/v4/__init__.py
@@ -2,6 +2,13 @@
 
 from typing import Any, Optional
 
+import click
+
+from direct_cli.v4_contracts import (
+    PARAM_UNDOCUMENTED_SHAPE_MSG,
+    validate_v4_body_shape,
+)
+
 
 def build_v4_body(method: str, param: Optional[Any] = None) -> dict:
     """Build a v4 Live request body."""
@@ -13,5 +20,22 @@ def build_v4_body(method: str, param: Optional[Any] = None) -> dict:
 
 def call_v4(client: Any, method: str, param: Optional[Any] = None) -> Any:
     """Call one v4 Live method and return the extracted response payload."""
-    result = client.v4live().post(data=build_v4_body(method, param))
+    body = build_v4_body(method, param)
+
+    errors = validate_v4_body_shape(method, body)
+    # Split by error class: "param shape is undocumented" is a soft
+    # contract gap (5 real methods like PayCampaignsByCard) — warn and
+    # continue. Anything else (shape mismatch, method mismatch) is a
+    # caller bug and must block the request.
+    hard_errors = [e for e in errors if PARAM_UNDOCUMENTED_SHAPE_MSG not in e]
+    if hard_errors:
+        raise click.UsageError("; ".join(hard_errors))
+    if errors:
+        click.echo(
+            f"warning: v4 method {method!r} has an undocumented param "
+            "shape; sending request as-is.",
+            err=True,
+        )
+
+    result = client.v4live().post(data=body)
     return result().extract()

--- a/direct_cli/v4_contracts.py
+++ b/direct_cli/v4_contracts.py
@@ -13,6 +13,11 @@ PARAM_OPTIONAL_OBJECT = "optional-object"
 PARAM_SCALAR = "scalar"
 PARAM_UNDOCUMENTED = "undocumented"
 
+# Substring marker for runtime callers (e.g. call_v4) that need to
+# distinguish "soft" undocumented-shape errors from hard shape mismatches.
+# Keep in sync with the message emitted by validate_v4_body_shape.
+PARAM_UNDOCUMENTED_SHAPE_MSG = "param shape is undocumented"
+
 SAFETY_READ = "read"
 SAFETY_WRITE = "write"
 SAFETY_DANGEROUS = "dangerous"
@@ -526,6 +531,34 @@ def v4_method_contract(method: str):
         return command
 
     return decorator
+
+
+def validate_v4_body_shape(method: str, body: dict[str, Any]) -> list[str]:
+    """Return shape errors for a v4 Live request body."""
+    contract = get_v4_contract(method)
+    errors: list[str] = []
+
+    if body.get("method") != method:
+        errors.append(f"method mismatch: {body.get('method')!r} != {method!r}")
+
+    has_param = "param" in body
+    param = body.get("param")
+    if contract.param_shape == PARAM_ARRAY:
+        if not has_param or not isinstance(param, list):
+            errors.append(f"{method} param must be an array")
+    elif contract.param_shape == PARAM_OBJECT:
+        if not has_param or not isinstance(param, dict):
+            errors.append(f"{method} param must be an object")
+    elif contract.param_shape == PARAM_OPTIONAL_OBJECT:
+        if has_param and not isinstance(param, dict):
+            errors.append(f"{method} param must be omitted or an object")
+    elif contract.param_shape == PARAM_SCALAR:
+        if not has_param or isinstance(param, (dict, list)) or param is None:
+            errors.append(f"{method} param must be a scalar")
+    elif contract.param_shape == PARAM_UNDOCUMENTED:
+        errors.append(f"{method} {PARAM_UNDOCUMENTED_SHAPE_MSG}")
+
+    return errors
 
 
 def validate_v4_contract_registry() -> list[str]:

--- a/tests/test_v4_runtime_shape.py
+++ b/tests/test_v4_runtime_shape.py
@@ -13,6 +13,9 @@ from direct_cli.v4_contracts import (
     PARAM_SCALAR,
     PARAM_UNDOCUMENTED,
     PARAM_UNDOCUMENTED_SHAPE_MSG,
+    SAFETY_DANGEROUS,
+    SAFETY_READ,
+    SAFETY_WRITE,
     V4_METHOD_CONTRACTS,
 )
 
@@ -23,6 +26,16 @@ def _first_method_with_shape(shape: str) -> str:
         if contract.param_shape == shape:
             return method
     raise AssertionError(f"No v4 method registered with param_shape={shape!r}")
+
+
+def _first_method_with_shape_and_safety(shape: str, safety: str) -> str:
+    """Pick a registry method by (shape, safety)."""
+    for method, contract in V4_METHOD_CONTRACTS.items():
+        if contract.param_shape == shape and contract.safety == safety:
+            return method
+    raise AssertionError(
+        f"No v4 method registered with param_shape={shape!r} and safety={safety!r}"
+    )
 
 
 def _fake_client(extract_value=None):
@@ -67,8 +80,9 @@ def test_call_v4_rejects_optional_object_with_list():
     client.v4live.return_value.post.assert_not_called()
 
 
-def test_call_v4_warns_on_undocumented_but_proceeds(capfd):
-    method = _first_method_with_shape(PARAM_UNDOCUMENTED)
+def test_call_v4_warns_on_undocumented_read_method_but_proceeds(capfd):
+    """READ-class undocumented methods are soft: warn + proceed."""
+    method = _first_method_with_shape_and_safety(PARAM_UNDOCUMENTED, SAFETY_READ)
     sentinel = {"undocumented": "passthrough"}
     client = _fake_client(extract_value=sentinel)
 
@@ -82,6 +96,30 @@ def test_call_v4_warns_on_undocumented_but_proceeds(capfd):
     assert "undocumented param" in err
 
 
+def test_call_v4_refuses_undocumented_write_method():
+    """WRITE-class undocumented methods are hard: refuse to send. See Codex review."""
+    method = _first_method_with_shape_and_safety(PARAM_UNDOCUMENTED, SAFETY_WRITE)
+    client = _fake_client()
+
+    with pytest.raises(click.UsageError, match="refusing to send"):
+        call_v4(client, method, param={"any": "shape"})
+    client.v4live.return_value.post.assert_not_called()
+
+
+def test_call_v4_refuses_undocumented_dangerous_method():
+    """DANGEROUS-class undocumented methods are hard: refuse to send.
+
+    PayCampaignsByCard is financial — blind shape pass-through is unacceptable
+    even with a stderr warning. See Codex adversarial review on issue #182.
+    """
+    method = _first_method_with_shape_and_safety(PARAM_UNDOCUMENTED, SAFETY_DANGEROUS)
+    client = _fake_client()
+
+    with pytest.raises(click.UsageError, match="refusing to send"):
+        call_v4(client, method, param={"arbitrary": ["payload"]})
+    client.v4live.return_value.post.assert_not_called()
+
+
 def test_call_v4_undocumented_still_rejects_hard_errors():
     """A hard error coexisting with the undocumented marker must still raise.
 
@@ -89,7 +127,7 @@ def test_call_v4_undocumented_still_rejects_hard_errors():
     marker, call_v4's gate must classify by message content and raise
     UsageError — not silently warn. See issue #182 review.
     """
-    method = _first_method_with_shape(PARAM_UNDOCUMENTED)
+    method = _first_method_with_shape_and_safety(PARAM_UNDOCUMENTED, SAFETY_READ)
     client = _fake_client()
     mixed_errors = [
         "method mismatch: 'WrongMethod' != 'ActualMethod'",

--- a/tests/test_v4_runtime_shape.py
+++ b/tests/test_v4_runtime_shape.py
@@ -1,0 +1,150 @@
+"""Runtime shape validation for V4 Live calls. See issue #182."""
+
+from unittest.mock import MagicMock, patch
+
+import click
+import pytest
+
+from direct_cli.v4 import call_v4
+from direct_cli.v4_contracts import (
+    PARAM_ARRAY,
+    PARAM_OBJECT,
+    PARAM_OPTIONAL_OBJECT,
+    PARAM_SCALAR,
+    PARAM_UNDOCUMENTED,
+    PARAM_UNDOCUMENTED_SHAPE_MSG,
+    V4_METHOD_CONTRACTS,
+)
+
+
+def _first_method_with_shape(shape: str) -> str:
+    """Pick a registry method by shape — keeps tests resilient to edits."""
+    for method, contract in V4_METHOD_CONTRACTS.items():
+        if contract.param_shape == shape:
+            return method
+    raise AssertionError(f"No v4 method registered with param_shape={shape!r}")
+
+
+def _fake_client(extract_value=None):
+    client = MagicMock()
+    client.v4live.return_value.post.return_value.return_value.extract.return_value = (
+        extract_value if extract_value is not None else {"result": "ok"}
+    )
+    return client
+
+
+def test_call_v4_rejects_array_method_with_dict():
+    method = _first_method_with_shape(PARAM_ARRAY)
+    client = _fake_client()
+    with pytest.raises(click.UsageError, match=f"{method} param must be an array"):
+        call_v4(client, method, param={"foo": 1})
+    client.v4live.return_value.post.assert_not_called()
+
+
+def test_call_v4_rejects_object_method_with_list():
+    method = _first_method_with_shape(PARAM_OBJECT)
+    client = _fake_client()
+    with pytest.raises(click.UsageError, match=f"{method} param must be an object"):
+        call_v4(client, method, param=[1, 2, 3])
+    client.v4live.return_value.post.assert_not_called()
+
+
+def test_call_v4_rejects_scalar_method_with_list():
+    method = _first_method_with_shape(PARAM_SCALAR)
+    client = _fake_client()
+    with pytest.raises(click.UsageError, match=f"{method} param must be a scalar"):
+        call_v4(client, method, param=[1, 2, 3])
+    client.v4live.return_value.post.assert_not_called()
+
+
+def test_call_v4_rejects_optional_object_with_list():
+    method = _first_method_with_shape(PARAM_OPTIONAL_OBJECT)
+    client = _fake_client()
+    with pytest.raises(
+        click.UsageError, match=f"{method} param must be omitted or an object"
+    ):
+        call_v4(client, method, param=[1, 2, 3])
+    client.v4live.return_value.post.assert_not_called()
+
+
+def test_call_v4_warns_on_undocumented_but_proceeds(capfd):
+    method = _first_method_with_shape(PARAM_UNDOCUMENTED)
+    sentinel = {"undocumented": "passthrough"}
+    client = _fake_client(extract_value=sentinel)
+
+    result = call_v4(client, method, param={"any": "shape"})
+
+    assert result is sentinel
+    client.v4live.return_value.post.assert_called_once()
+    err = capfd.readouterr().err
+    assert "warning" in err.lower()
+    assert method in err
+    assert "undocumented param" in err
+
+
+def test_call_v4_undocumented_still_rejects_hard_errors():
+    """A hard error coexisting with the undocumented marker must still raise.
+
+    If the validator returns BOTH a hard shape error and the undocumented
+    marker, call_v4's gate must classify by message content and raise
+    UsageError — not silently warn. See issue #182 review.
+    """
+    method = _first_method_with_shape(PARAM_UNDOCUMENTED)
+    client = _fake_client()
+    mixed_errors = [
+        "method mismatch: 'WrongMethod' != 'ActualMethod'",
+        f"{method} {PARAM_UNDOCUMENTED_SHAPE_MSG}",
+    ]
+    with patch("direct_cli.v4.validate_v4_body_shape", return_value=mixed_errors):
+        with pytest.raises(click.UsageError, match="method mismatch"):
+            call_v4(client, method, param={"any": "shape"})
+    client.v4live.return_value.post.assert_not_called()
+
+
+def test_call_v4_accepts_correct_array_shape():
+    method = _first_method_with_shape(PARAM_ARRAY)
+    client = _fake_client(extract_value=["ok"])
+    assert call_v4(client, method, param=[1]) == ["ok"]
+    client.v4live.return_value.post.assert_called_once()
+
+
+def test_call_v4_accepts_correct_object_shape():
+    method = _first_method_with_shape(PARAM_OBJECT)
+    client = _fake_client(extract_value={"ok": True})
+    assert call_v4(client, method, param={"key": "value"}) == {"ok": True}
+    client.v4live.return_value.post.assert_called_once()
+
+
+def test_call_v4_accepts_correct_optional_object_shape_with_param():
+    method = _first_method_with_shape(PARAM_OPTIONAL_OBJECT)
+    client = _fake_client(extract_value={"ok": True})
+    assert call_v4(client, method, param={"key": "value"}) == {"ok": True}
+    client.v4live.return_value.post.assert_called_once()
+
+
+def test_call_v4_accepts_correct_optional_object_shape_without_param():
+    method = _first_method_with_shape(PARAM_OPTIONAL_OBJECT)
+    client = _fake_client(extract_value={"ok": True})
+    assert call_v4(client, method) == {"ok": True}
+    client.v4live.return_value.post.assert_called_once()
+
+
+def test_call_v4_accepts_correct_scalar_shape():
+    method = _first_method_with_shape(PARAM_SCALAR)
+    client = _fake_client(extract_value={"ok": True})
+    assert call_v4(client, method, param=42) == {"ok": True}
+    client.v4live.return_value.post.assert_called_once()
+
+
+def test_call_v4_rejects_array_method_with_missing_param():
+    """A PARAM_ARRAY method must reject param=None (omitted)."""
+    method = _first_method_with_shape(PARAM_ARRAY)
+    client = _fake_client()
+    with pytest.raises(click.UsageError, match=f"{method} param must be an array"):
+        call_v4(client, method, param=None)
+    client.v4live.return_value.post.assert_not_called()
+
+
+def test_validate_v4_body_shape_is_exported():
+    """Public API guarantee from issue #182."""
+    from direct_cli.v4_contracts import validate_v4_body_shape  # noqa: F401


### PR DESCRIPTION
## Summary

Wires the long-dormant `validate_v4_body_shape` helper into the V4 Live runtime path. The `V4_METHOD_CONTRACTS` registry already declares every method's expected `param_shape`; until now the runtime ignored it, so any CLI parser bug (e.g. emitting a dict where the contract expects a list) flew straight to Yandex and surfaced as a far-away 500. This PR brings the helper from branch `codex/v4-shape-validation` (commit `c9bf708`) into `direct_cli/v4_contracts.py` and calls it from `direct_cli/v4/__init__.py::call_v4` immediately after `build_v4_body`.

The gate is **content-based**, not shape-based:

- Any error whose message does **not** contain the `PARAM_UNDOCUMENTED_SHAPE_MSG` marker → `click.UsageError` before the network call.
- If only soft undocumented-shape errors remain → one stderr warning, request proceeds. This keeps the five `PARAM_UNDOCUMENTED` methods (`PayCampaignsByCard`, `DeleteOfflineReport`, `DeleteReport`, `AdImageAssociation`, `GetKeywordsSuggestion`) working while the operator sees that the contract is unverified.
- `PARAM_UNDOCUMENTED_SHAPE_MSG` is the single source of truth for the marker — imported by validator, gate, and tests, so a future rename can't silently flip a hard error into a soft warning.

## Why not import the codex `V4_CLI_DRY_RUN_FIXTURES`

The codex branch also added a 200-line fixture replaying every V4 CLI command. Its job is exercising the validator, which the registry-driven targeted tests below already do — without colliding with main's existing v4 dry-run fixtures or the `PARAM_UNDOCUMENTED` methods. Deliberately omitted.

## Tests

`tests/test_v4_runtime_shape.py` — 13 tests, no HTTP, no token:

- Reject paths — array/object/scalar/optional-object methods with the wrong shape, plus omitted-param for `PARAM_ARRAY`. All assert `UsageError` is raised before `client.v4live().post` is called.
- Soft path — an `UNDOCUMENTED` method with a plausible payload proceeds; the warning lands in stderr (captured via `capfd`, not `capsys`).
- Mixed-errors regression — patches `validate_v4_body_shape` on the `call_v4` import path to return both a hard `method mismatch` and the undocumented marker, then asserts `UsageError`. Locks the gate against a future change that reintroduces shape-based classification.
- Happy paths — one per shape family, plus the optional-object no-param case, plus an export smoke test for the public API.

Test method selection walks `V4_METHOD_CONTRACTS` for each shape, so registry edits don't break the test names.

## Verification

- `pytest` — 906 passed (+13 new), 45 skipped.
- `pytest tests/test_v4_runtime_shape.py -v` — 13/13.
- Existing v4 / dry-run tests untouched.
- `black --check` — clean. `flake8` touched files — clean.

## Test plan
- [x] PARAM_ARRAY with dict → UsageError, no API call
- [x] PARAM_OBJECT with list → UsageError, no API call
- [x] PARAM_SCALAR with list → UsageError, no API call
- [x] PARAM_OPTIONAL_OBJECT with list → UsageError, no API call
- [x] PARAM_ARRAY with `param=None` → UsageError, no API call
- [x] PARAM_UNDOCUMENTED → stderr warning, request still proceeds
- [x] PARAM_UNDOCUMENTED + hard error → UsageError (regression lock)
- [x] Happy paths for each shape family
- [x] Existing V4 tests / dry-run regression unchanged

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)