### PR TITLE
fix(changes): mutex ID filters + FieldNames enum validation (#228)

### DIFF
--- a/direct_cli/commands/changes.py
+++ b/direct_cli/commands/changes.py
@@ -14,19 +14,91 @@ def changes():
     """Check for changes"""
 
 
+_CHECK_FIELD_NAMES = frozenset({"CampaignIds", "AdGroupIds", "AdIds", "CampaignsStat"})
+
+
 @changes.command()
-@click.option("--campaign-ids", required=True, help="Comma-separated campaign IDs")
+@click.option(
+    "--campaign-ids",
+    help="Comma-separated campaign IDs (up to 3000). Mutually exclusive with "
+    "--ad-group-ids and --ad-ids.",
+)
+@click.option(
+    "--ad-group-ids",
+    help="Comma-separated ad group IDs (up to 10000). Mutually exclusive with "
+    "--campaign-ids and --ad-ids.",
+)
+@click.option(
+    "--ad-ids",
+    help="Comma-separated ad IDs (up to 50000). Mutually exclusive with "
+    "--campaign-ids and --ad-group-ids.",
+)
 @click.option(
     "--timestamp",
     required=True,
     help="Timestamp for changes check (YYYY-MM-DDTHH:MM:SS)",
 )
-@click.option("--fields", help="Comma-separated field names")
+@click.option(
+    "--fields",
+    help="Comma-separated FieldNames; allowed values: "
+    "CampaignIds, AdGroupIds, AdIds, CampaignsStat. "
+    "Defaults to all four when omitted.",
+)
 @click.option("--format", "output_format", default="json", help="Output format")
 @click.option("--output", help="Output file")
 @click.pass_context
-def check(ctx, campaign_ids, timestamp, fields, output_format, output):
-    """Check changes for campaigns"""
+def check(
+    ctx, campaign_ids, ad_group_ids, ad_ids, timestamp, fields, output_format, output
+):
+    """Check changes for campaigns, ad groups, or ads.
+
+    Exactly one of --campaign-ids, --ad-group-ids, --ad-ids must be provided —
+    the Yandex Direct ``Changes.check`` method declares these three filters as
+    mutually exclusive.
+    """
+    sources_used = (
+        (1 if campaign_ids else 0) + (1 if ad_group_ids else 0) + (1 if ad_ids else 0)
+    )
+    if sources_used == 0:
+        raise click.UsageError(
+            "Provide exactly one of: --campaign-ids, --ad-group-ids, --ad-ids."
+        )
+    if sources_used > 1:
+        raise click.UsageError(
+            "--campaign-ids, --ad-group-ids, and --ad-ids are mutually "
+            "exclusive — provide exactly one."
+        )
+
+    if fields:
+        field_names = [f.strip() for f in fields.split(",") if f.strip()]
+        if not field_names:
+            raise click.UsageError(
+                "--fields produced an empty list; provide at least one of: "
+                f"{', '.join(sorted(_CHECK_FIELD_NAMES))}."
+            )
+        unknown = [f for f in field_names if f not in _CHECK_FIELD_NAMES]
+        if unknown:
+            raise click.UsageError(
+                "Unknown --fields value(s): "
+                f"{', '.join(unknown)}. Allowed: "
+                f"{', '.join(sorted(_CHECK_FIELD_NAMES))}."
+            )
+    else:
+        field_names = get_default_fields("changes")
+
+    if campaign_ids:
+        id_field, id_flag, id_raw = "CampaignIds", "--campaign-ids", campaign_ids
+    elif ad_group_ids:
+        id_field, id_flag, id_raw = "AdGroupIds", "--ad-group-ids", ad_group_ids
+    else:
+        id_field, id_flag, id_raw = "AdIds", "--ad-ids", ad_ids
+    try:
+        id_value = parse_ids(id_raw)
+    except ValueError as exc:
+        raise click.UsageError(f"{id_flag}: {exc}")
+    if not id_value:
+        raise click.UsageError(f"{id_flag} produced no valid IDs.")
+
     try:
         client = create_client(
             token=ctx.obj.get("token"),
@@ -34,9 +106,8 @@ def check(ctx, campaign_ids, timestamp, fields, output_format, output):
             sandbox=ctx.obj.get("sandbox"),
         )
 
-        field_names = fields.split(",") if fields else get_default_fields("changes")
         params = {
-            "CampaignIds": parse_ids(campaign_ids),
+            id_field: id_value,
             "Timestamp": parse_datetime(timestamp),
             "FieldNames": field_names,
         }

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -1,0 +1,179 @@
+"""Unit tests for `direct changes check` flag validation (#228)."""
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from direct_cli.cli import cli
+
+TIMESTAMP = "2026-05-21T12:00:00"
+
+
+def _invoke(*extra_args):
+    return CliRunner().invoke(
+        cli,
+        [
+            "--token",
+            "token",
+            "changes",
+            "check",
+            "--timestamp",
+            TIMESTAMP,
+            *extra_args,
+        ],
+    )
+
+
+def test_check_rejects_missing_all_id_filters():
+    """Mutex enforcement: at least one of three ID flags is required."""
+    with patch("direct_cli.commands.changes.create_client") as create_client:
+        result = _invoke()
+
+    assert result.exit_code != 0
+    assert "Provide exactly one of" in result.output
+    assert "--campaign-ids" in result.output
+    assert "--ad-group-ids" in result.output
+    assert "--ad-ids" in result.output
+    create_client.assert_not_called()
+
+
+def test_check_rejects_two_id_filters_together():
+    """Mutex enforcement: passing two filters is a UsageError."""
+    with patch("direct_cli.commands.changes.create_client") as create_client:
+        result = _invoke("--campaign-ids", "1", "--ad-group-ids", "2")
+
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+    create_client.assert_not_called()
+
+
+def test_check_rejects_all_three_id_filters_together():
+    """Mutex enforcement: even three at once is rejected with the same wording."""
+    with patch("direct_cli.commands.changes.create_client") as create_client:
+        result = _invoke("--campaign-ids", "1", "--ad-group-ids", "2", "--ad-ids", "3")
+
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+    create_client.assert_not_called()
+
+
+def _client_with_payload_capture():
+    """Build a fake client whose .changes().post() captures the request body."""
+    client = MagicMock()
+    client.changes.return_value.post.return_value.data = {"ok": True}
+    return client
+
+
+def test_check_with_campaign_ids_sends_campaign_ids_field():
+    with patch(
+        "direct_cli.commands.changes.create_client",
+        return_value=_client_with_payload_capture(),
+    ) as create_client:
+        result = _invoke("--campaign-ids", "1,2")
+
+    assert result.exit_code == 0, result.output
+    body = create_client.return_value.changes.return_value.post.call_args.kwargs["data"]
+    assert body["method"] == "check"
+    assert body["params"]["CampaignIds"] == [1, 2]
+    assert "AdGroupIds" not in body["params"]
+    assert "AdIds" not in body["params"]
+    assert body["params"]["Timestamp"].endswith("Z")
+
+
+def test_check_with_ad_group_ids_sends_ad_group_ids_field():
+    with patch(
+        "direct_cli.commands.changes.create_client",
+        return_value=_client_with_payload_capture(),
+    ) as create_client:
+        result = _invoke("--ad-group-ids", "100,200,300")
+
+    assert result.exit_code == 0, result.output
+    body = create_client.return_value.changes.return_value.post.call_args.kwargs["data"]
+    assert body["params"]["AdGroupIds"] == [100, 200, 300]
+    assert "CampaignIds" not in body["params"]
+    assert "AdIds" not in body["params"]
+
+
+def test_check_with_ad_ids_sends_ad_ids_field():
+    with patch(
+        "direct_cli.commands.changes.create_client",
+        return_value=_client_with_payload_capture(),
+    ) as create_client:
+        result = _invoke("--ad-ids", "9999")
+
+    assert result.exit_code == 0, result.output
+    body = create_client.return_value.changes.return_value.post.call_args.kwargs["data"]
+    assert body["params"]["AdIds"] == [9999]
+    assert "CampaignIds" not in body["params"]
+    assert "AdGroupIds" not in body["params"]
+
+
+def test_check_default_fields_match_wsdl_enum():
+    """Omitting --fields should emit all four CheckFieldEnum values."""
+    with patch(
+        "direct_cli.commands.changes.create_client",
+        return_value=_client_with_payload_capture(),
+    ) as create_client:
+        result = _invoke("--campaign-ids", "1")
+
+    assert result.exit_code == 0, result.output
+    body = create_client.return_value.changes.return_value.post.call_args.kwargs["data"]
+    assert sorted(body["params"]["FieldNames"]) == sorted(
+        ["CampaignIds", "AdGroupIds", "AdIds", "CampaignsStat"]
+    )
+
+
+def test_check_custom_fields_pass_through_when_in_enum():
+    with patch(
+        "direct_cli.commands.changes.create_client",
+        return_value=_client_with_payload_capture(),
+    ) as create_client:
+        result = _invoke("--campaign-ids", "1", "--fields", "CampaignIds,AdIds")
+
+    assert result.exit_code == 0, result.output
+    body = create_client.return_value.changes.return_value.post.call_args.kwargs["data"]
+    assert body["params"]["FieldNames"] == ["CampaignIds", "AdIds"]
+
+
+def test_check_rejects_unknown_field_name():
+    """Typos like 'CmapignIds' must be caught before reaching the API."""
+    with patch("direct_cli.commands.changes.create_client") as create_client:
+        result = _invoke("--campaign-ids", "1", "--fields", "CmapignIds")
+
+    assert result.exit_code != 0
+    assert "Unknown --fields value(s)" in result.output
+    assert "CmapignIds" in result.output
+    assert "CampaignIds" in result.output
+    create_client.assert_not_called()
+
+
+def test_check_rejects_unknown_field_among_valid():
+    """Mixed valid+invalid input still raises and names only the bad token."""
+    with patch("direct_cli.commands.changes.create_client") as create_client:
+        result = _invoke(
+            "--campaign-ids", "1", "--fields", "CampaignIds,BogusField,AdIds"
+        )
+
+    assert result.exit_code != 0
+    assert "BogusField" in result.output
+    create_client.assert_not_called()
+
+
+def test_check_rejects_commas_only_in_fields():
+    """`--fields ,` must not silently send FieldNames=[] (violates WSDL minOccurs=1)."""
+    with patch("direct_cli.commands.changes.create_client") as create_client:
+        result = _invoke("--campaign-ids", "1", "--fields", ",")
+
+    assert result.exit_code != 0
+    assert "empty list" in result.output
+    create_client.assert_not_called()
+
+
+def test_check_rejects_commas_only_in_campaign_ids():
+    """`--campaign-ids ,` must produce UsageError (exit 2), not Abort (exit 1)."""
+    with patch("direct_cli.commands.changes.create_client") as create_client:
+        result = _invoke("--campaign-ids", ",")
+
+    assert result.exit_code != 0
+    assert "--campaign-ids" in result.output
+    create_client.assert_not_called()

--- a/tests/test_low_coverage_payloads.py
+++ b/tests/test_low_coverage_payloads.py
@@ -66,7 +66,7 @@ def test_changes_check_builds_canonical_payload():
             "--timestamp",
             "2026-04-14T00:00:00",
             "--fields",
-            "CampaignId,ChangesIn",
+            "CampaignIds,CampaignsStat",
         ],
     )
 
@@ -75,7 +75,7 @@ def test_changes_check_builds_canonical_payload():
         "params": {
             "CampaignIds": [1, 2],
             "Timestamp": "2026-04-14T00:00:00Z",
-            "FieldNames": ["CampaignId", "ChangesIn"],
+            "FieldNames": ["CampaignIds", "CampaignsStat"],
         },
     }
 


### PR DESCRIPTION
## Summary

Брал #228 в работу, провёл триаж против кода и [официальной документации Yandex Direct: Changes.check](https://yandex.ru/dev/direct/doc/ref-v5/changes/check.html). Большая часть исходных пунктов оказалась про MCP-плагин (передал в axisrow/yandex-direct-mcp-plugin#115) либо была опровергнута кодом (`parse_datetime` уже нормализует timestamp к ISO-8601-with-Z; никакого `MAX_BATCH_SIZE = 10` в CLI нет). Реальный CLI-скоуп — два пункта:

- **Bug #2 (FIX):** в `direct changes check` была только `--campaign-ids`. По WSDL и доке API `Changes.check` принимает три взаимоисключающих ID-фильтра — `CampaignIds` / `AdGroupIds` / `AdIds`.
- **Bug #3 partial (FIX):** `--fields` не валидировался — тайпо вроде `CmapignIds` уходило в API и возвращалось мутной серверной ошибкой.

## What this PR does

- Заменяет `--campaign-ids required=True` тремя mutually-exclusive флагами: `--campaign-ids` / `--ad-group-ids` / `--ad-ids`. Проверка «exactly one of» через `click.UsageError`, **до** `try/except` обёртки — пользователь получает корректный exit code 2 и Usage hint.
- Валидирует `--fields` против WSDL-энума `CheckFieldEnum = {CampaignIds, AdGroupIds, AdIds, CampaignsStat}`. Если значения нет в энуме — `UsageError` с подсказкой допустимых значений. Дефолт (все четыре) остаётся для UX.
- Edge cases пойманные адверсариальным ревью: `--fields ,` (давал `FieldNames=[]` в нарушение `minOccurs=1`), `--campaign-ids ,` (раньше падал с exit code 1 через `parse_ids`'s `ValueError` → `Abort`) — оба теперь `UsageError`.
- Чинит существующую фикстуру в `tests/test_low_coverage_payloads.py::test_changes_check_builds_canonical_payload`: использовала `FieldNames=[\"CampaignId\", \"ChangesIn\"]` — не валидные значения `CheckFieldEnum` по WSDL (это response-поля). Заменено на корректные `[\"CampaignIds\", \"CampaignsStat\"]`.

## Out of scope

- Числовые лимиты 3000/10000/50000 на стороне клиента — Yandex отдаёт чёткую ошибку, дублировать не нужно.
- Рефакторинг широкого `except Exception` в v4/v5 командных модулях — отдельный follow-up #227.
- MCP-плагин — отдельный тикет axisrow/yandex-direct-mcp-plugin#115.

## Tests

12 новых unit-тестов в `tests/test_changes.py` (CliRunner + patched `create_client`):

- mutex: missing-all, two-at-once, all-three-at-once
- ID-маршрутизация: каждый из трёх флагов → корректное WSDL-поле в body
- FieldNames: default (все 4 значения), валидный passthrough, unknown enum, mixed valid+invalid
- edge: `--fields ,` пустой список, `--campaign-ids ,` ValueError из `parse_ids` → UsageError

## Verification

```
pytest -m "not integration" -q   # 901 passed, 44 skipped
black --check direct_cli tests   # clean on touched files
flake8 direct_cli tests          # clean on touched files
```

## Test plan

- [ ] CI зелёный (quality + test-and-report 3.9/3.11/3.13 + api coverage)
- [ ] Линтеры clean на изменённых файлах
- [ ] `--help` для `direct changes check` показывает все три ID-флага и список допустимых FieldNames

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)