### PR TITLE
feat(campaigns): typed --tracking-params for add/update (#230)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+**Added:**
+
+- `direct campaigns add` and `direct campaigns update` now expose
+  `--tracking-params` for the campaign-level tracking query string
+  (`TextCampaign` / `DynamicTextCampaign` / `SmartCampaign` `.TrackingParams`).
+  `campaigns update` gained an optional `--type` discriminator —
+  required when `--tracking-params` is set, validated against
+  the three subtypes supported by the CLI. Backward compatible:
+  existing `campaigns update --id N --name X` calls without `--type`
+  keep working unchanged. Closes #230.
+
 ## 0.3.10
 
 **Added:**

--- a/README.md
+++ b/README.md
@@ -350,8 +350,12 @@ direct campaigns add --name "Multi-Goal CPA" --start-date 2026-06-01 --type TEXT
 # Notification (Sms/Email) and TimeTargeting accept JSON with WSDL CamelCase keys
 direct campaigns add --name "Notify+Schedule" --start-date 2026-06-01 --type TEXT_CAMPAIGN --search-strategy HIGHEST_POSITION --network-strategy SERVING_OFF --notification '{"EmailSettings":{"Email":"ops@example.com","SendWarnings":"YES"}}' --time-targeting '{"Schedule":["1A0123456789ABCDEFGHIJKL"],"ConsiderWorkingWeekends":"YES"}' --dry-run
 
+# TrackingParams (campaign-level UTM / tracking query string)
+direct campaigns add --name "UTM" --start-date 2026-06-01 --type TEXT_CAMPAIGN --tracking-params "utm_source=direct&utm_campaign={campaign_id}" --dry-run
+
 # Update / lifecycle
 direct campaigns update --id 12345 --name "New Name" --status SUSPENDED --budget 100000000 --start-date 2024-02-10 --end-date 2024-03-01
+direct campaigns update --id 12345 --type TEXT_CAMPAIGN --tracking-params "utm_source=direct&utm_medium=cpc" --dry-run
 direct campaigns suspend --id 12345
 direct campaigns resume --id 12345
 direct campaigns archive --id 12345
@@ -1040,8 +1044,12 @@ direct campaigns add --name "Мульти-целевой CPA" --start-date 2026-
 # Notification (Sms/Email) и TimeTargeting принимают JSON с CamelCase ключами WSDL
 direct campaigns add --name "Уведомления+Расписание" --start-date 2026-06-01 --type TEXT_CAMPAIGN --search-strategy HIGHEST_POSITION --network-strategy SERVING_OFF --notification '{"EmailSettings":{"Email":"ops@example.com","SendWarnings":"YES"}}' --time-targeting '{"Schedule":["1A0123456789ABCDEFGHIJKL"],"ConsiderWorkingWeekends":"YES"}' --dry-run
 
+# TrackingParams — UTM/трекинг на уровне кампании (TextCampaign/DynamicTextCampaign/SmartCampaign.TrackingParams)
+direct campaigns add --name "UTM" --start-date 2026-06-01 --type TEXT_CAMPAIGN --tracking-params "utm_source=direct&utm_campaign={campaign_id}" --dry-run
+
 # Обновление и управление статусом
 direct campaigns update --id 12345 --name "Новое название" --status SUSPENDED --budget 100000000 --start-date 2024-02-10 --end-date 2024-03-01
+direct campaigns update --id 12345 --type TEXT_CAMPAIGN --tracking-params "utm_source=direct&utm_medium=cpc" --dry-run
 direct campaigns suspend --id 12345
 direct campaigns resume --id 12345
 direct campaigns archive --id 12345

--- a/direct_cli/commands/campaigns.py
+++ b/direct_cli/commands/campaigns.py
@@ -601,6 +601,15 @@ def get(
         '({"Schedule":[...], "ConsiderWorkingWeekends":"YES|NO", ...})'
     ),
 )
+@click.option(
+    "--tracking-params",
+    "tracking_params",
+    help=(
+        "Tracking params query-string for "
+        "TextCampaign/DynamicTextCampaign/SmartCampaign.TrackingParams "
+        '(e.g. "utm_source=direct&utm_campaign={campaign_id}")'
+    ),
+)
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
 def add(
@@ -623,6 +632,7 @@ def add(
     bid_ceiling,
     notification_json,
     time_targeting_json,
+    tracking_params,
     dry_run,
 ):
     """Add new campaign"""
@@ -664,12 +674,14 @@ def add(
                 "--setting",
                 "--search-strategy",
                 "--network-strategy",
+                "--tracking-params",
             }
             | text_dynamic_extras,
             "DYNAMIC_TEXT_CAMPAIGN": {
                 "--setting",
                 "--search-strategy",
                 "--network-strategy",
+                "--tracking-params",
             }
             | text_dynamic_extras,
             "SMART_CAMPAIGN": {
@@ -678,6 +690,7 @@ def add(
                 "--network-strategy",
                 "--filter-average-cpc",
                 "--counter-id",
+                "--tracking-params",
             },
         }
         _reject_incompatible_flags(
@@ -695,6 +708,7 @@ def add(
                 "--average-cpa": average_cpa,
                 "--crr": crr,
                 "--bid-ceiling": bid_ceiling,
+                "--tracking-params": tracking_params,
             },
         )
 
@@ -753,6 +767,8 @@ def add(
                 priority_goals_items=priority_goals_items,
                 sub_campaign_block=text_block,
             )
+            if tracking_params:
+                text_block["TrackingParams"] = tracking_params
             campaign_data["TextCampaign"] = text_block
         elif campaign_type_norm == "DYNAMIC_TEXT_CAMPAIGN":
             dyn_block = {
@@ -779,6 +795,8 @@ def add(
                 priority_goals_items=priority_goals_items,
                 sub_campaign_block=dyn_block,
             )
+            if tracking_params:
+                dyn_block["TrackingParams"] = tracking_params
             campaign_data["DynamicTextCampaign"] = dyn_block
         elif campaign_type_norm == "SMART_CAMPAIGN":
             # WSDL SmartCampaignAddItem.CounterId is minOccurs=1
@@ -815,6 +833,8 @@ def add(
                 }
             if parsed_settings:
                 smart_campaign["Settings"] = parsed_settings
+            if tracking_params:
+                smart_campaign["TrackingParams"] = tracking_params
             campaign_data["SmartCampaign"] = smart_campaign
 
         if budget:
@@ -863,9 +883,37 @@ def add(
 @click.option("--budget", type=MICRO_RUBLES, help="New daily budget in micro-rubles")
 @click.option("--start-date", help="New start date (YYYY-MM-DD)")
 @click.option("--end-date", help="New end date (YYYY-MM-DD)")
+@click.option(
+    "--type",
+    "campaign_type",
+    help=(
+        "Campaign subtype "
+        "(TEXT_CAMPAIGN | DYNAMIC_TEXT_CAMPAIGN | SMART_CAMPAIGN). "
+        "Required when updating subtype-specific fields."
+    ),
+)
+@click.option(
+    "--tracking-params",
+    "tracking_params",
+    help=(
+        "Tracking params query-string for "
+        "TextCampaign/DynamicTextCampaign/SmartCampaign.TrackingParams"
+    ),
+)
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def update(ctx, campaign_id, name, status, budget, start_date, end_date, dry_run):
+def update(
+    ctx,
+    campaign_id,
+    name,
+    status,
+    budget,
+    start_date,
+    end_date,
+    campaign_type,
+    tracking_params,
+    dry_run,
+):
     """Update campaign"""
     try:
         campaign_data = {"Id": campaign_id}
@@ -885,6 +933,60 @@ def update(ctx, campaign_id, name, status, budget, start_date, end_date, dry_run
             campaign_data["StartDate"] = start_date
         if end_date:
             campaign_data["EndDate"] = end_date
+
+        subtype_supported = {
+            "TEXT_CAMPAIGN",
+            "DYNAMIC_TEXT_CAMPAIGN",
+            "SMART_CAMPAIGN",
+        }
+        campaign_type_norm = (
+            campaign_type.upper().replace("-", "_") if campaign_type else None
+        )
+        subtype_flag_values = {
+            "--tracking-params": tracking_params,
+        }
+        subtype_flags_provided = [
+            flag for flag, value in subtype_flag_values.items() if value is not None
+        ]
+        if (
+            campaign_type_norm is not None
+            and campaign_type_norm not in subtype_supported
+        ):
+            raise click.UsageError(
+                "Invalid value for '--type': "
+                f"{campaign_type!r} is not one of "
+                "'TEXT_CAMPAIGN', 'DYNAMIC_TEXT_CAMPAIGN', 'SMART_CAMPAIGN'."
+            )
+        if subtype_flags_provided and campaign_type_norm is None:
+            raise click.UsageError(
+                f"{', '.join(sorted(subtype_flags_provided))} requires --type "
+                "(TEXT_CAMPAIGN | DYNAMIC_TEXT_CAMPAIGN | SMART_CAMPAIGN)."
+            )
+        if campaign_type_norm is not None:
+            allowed_subtype_flags_by_type = {
+                "TEXT_CAMPAIGN": {"--tracking-params"},
+                "DYNAMIC_TEXT_CAMPAIGN": {"--tracking-params"},
+                "SMART_CAMPAIGN": {"--tracking-params"},
+            }
+            _reject_incompatible_flags(
+                campaign_type_norm,
+                allowed_subtype_flags_by_type[campaign_type_norm],
+                subtype_flag_values,
+            )
+            sub_block: Dict[str, object] = {}
+            if tracking_params:
+                sub_block["TrackingParams"] = tracking_params
+            if not sub_block:
+                raise click.UsageError(
+                    f"--type {campaign_type_norm} requires at least one "
+                    "subtype-specific field to update."
+                )
+            subtype_container = {
+                "TEXT_CAMPAIGN": "TextCampaign",
+                "DYNAMIC_TEXT_CAMPAIGN": "DynamicTextCampaign",
+                "SMART_CAMPAIGN": "SmartCampaign",
+            }[campaign_type_norm]
+            campaign_data[subtype_container] = sub_block
 
         if len(campaign_data) == 1:
             raise click.UsageError("Provide at least one field to update")

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1762,6 +1762,176 @@ def test_campaigns_add_time_targeting_payload():
     assert "TimeTargeting" not in campaign["TextCampaign"]
 
 
+def test_campaigns_add_text_tracking_params_payload():
+    body = _dry_run(
+        *_cpa_base_args(),
+        "--tracking-params",
+        "utm_source=direct&utm_campaign={campaign_id}",
+    )
+    text = body["params"]["Campaigns"][0]["TextCampaign"]
+    assert text["TrackingParams"] == "utm_source=direct&utm_campaign={campaign_id}"
+
+
+def test_campaigns_add_dynamic_tracking_params_payload():
+    body = _dry_run(
+        "campaigns",
+        "add",
+        "--name",
+        "Dyn Track",
+        "--start-date",
+        "2026-06-01",
+        "--type",
+        "DYNAMIC_TEXT_CAMPAIGN",
+        "--tracking-params",
+        "utm_source=direct&utm_medium=cpc",
+    )
+    dyn = body["params"]["Campaigns"][0]["DynamicTextCampaign"]
+    assert dyn["TrackingParams"] == "utm_source=direct&utm_medium=cpc"
+
+
+def test_campaigns_add_smart_tracking_params_payload():
+    body = _dry_run(
+        "campaigns",
+        "add",
+        "--name",
+        "Smart Track",
+        "--start-date",
+        "2026-06-01",
+        "--type",
+        "SMART_CAMPAIGN",
+        "--counter-id",
+        "111",
+        "--filter-average-cpc",
+        "5000000",
+        "--tracking-params",
+        "utm_source=direct",
+    )
+    smart = body["params"]["Campaigns"][0]["SmartCampaign"]
+    assert smart["TrackingParams"] == "utm_source=direct"
+
+
+def test_campaigns_add_tracking_params_on_unsupported_type_rejected():
+    # MOBILE_APP_CAMPAIGN is not in supported_types for `campaigns add`,
+    # so the add guard rejects the type itself before --tracking-params
+    # is evaluated. We assert the supported-types message so the test
+    # documents this behaviour.
+    result = _rejected(
+        "campaigns",
+        "add",
+        "--name",
+        "X",
+        "--start-date",
+        "2026-06-01",
+        "--type",
+        "MOBILE_APP_CAMPAIGN",
+        "--tracking-params",
+        "utm_source=direct",
+    )
+    assert "MOBILE_APP_CAMPAIGN" in result.output
+
+
+def test_campaigns_update_text_tracking_params_payload():
+    body = _dry_run(
+        "campaigns",
+        "update",
+        "--id",
+        "123",
+        "--type",
+        "TEXT_CAMPAIGN",
+        "--tracking-params",
+        "utm_source=direct&utm_campaign={campaign_id}",
+    )
+    campaign = body["params"]["Campaigns"][0]
+    assert campaign["Id"] == 123
+    assert campaign["TextCampaign"] == {
+        "TrackingParams": "utm_source=direct&utm_campaign={campaign_id}",
+    }
+
+
+def test_campaigns_update_dynamic_tracking_params_payload():
+    body = _dry_run(
+        "campaigns",
+        "update",
+        "--id",
+        "123",
+        "--type",
+        "DYNAMIC_TEXT_CAMPAIGN",
+        "--tracking-params",
+        "utm_source=direct",
+    )
+    campaign = body["params"]["Campaigns"][0]
+    assert campaign["DynamicTextCampaign"] == {"TrackingParams": "utm_source=direct"}
+
+
+def test_campaigns_update_smart_tracking_params_payload():
+    body = _dry_run(
+        "campaigns",
+        "update",
+        "--id",
+        "123",
+        "--type",
+        "SMART_CAMPAIGN",
+        "--tracking-params",
+        "utm_source=direct",
+    )
+    campaign = body["params"]["Campaigns"][0]
+    assert campaign["SmartCampaign"] == {"TrackingParams": "utm_source=direct"}
+
+
+def test_campaigns_update_tracking_params_without_type_rejected():
+    result = _rejected(
+        "campaigns",
+        "update",
+        "--id",
+        "123",
+        "--tracking-params",
+        "utm_source=direct",
+    )
+    assert "--tracking-params" in result.output
+    assert "--type" in result.output
+
+
+def test_campaigns_update_unsupported_type_rejected():
+    result = _rejected(
+        "campaigns",
+        "update",
+        "--id",
+        "123",
+        "--type",
+        "MOBILE_APP_CAMPAIGN",
+        "--tracking-params",
+        "utm_source=direct",
+    )
+    assert "MOBILE_APP_CAMPAIGN" in result.output
+
+
+def test_campaigns_update_backward_compat_no_type():
+    body = _dry_run(
+        "campaigns",
+        "update",
+        "--id",
+        "123",
+        "--name",
+        "Renamed",
+    )
+    campaign = body["params"]["Campaigns"][0]
+    assert campaign == {"Id": 123, "Name": "Renamed"}
+
+
+def test_campaigns_update_type_without_subtype_fields_rejected():
+    # --type without any subtype-specific value must not silently
+    # build an empty TextCampaign/DynamicTextCampaign/SmartCampaign block.
+    result = _rejected(
+        "campaigns",
+        "update",
+        "--id",
+        "123",
+        "--type",
+        "TEXT_CAMPAIGN",
+    )
+    assert "TEXT_CAMPAIGN" in result.output
+
+
 def test_campaigns_add_dynamic_text_campaign_with_cpa():
     body = _dry_run(
         "campaigns",

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -280,6 +280,32 @@ SILENT_LOSS_PROBES: list[tuple[str, list[str], str]] = [
         "--filter-average-cpc",
     ),
     (
+        "campaigns.update --tracking-params without --type",
+        [
+            "campaigns",
+            "update",
+            "--id",
+            "123",
+            "--tracking-params",
+            "utm_source=direct",
+        ],
+        "--tracking-params",
+    ),
+    (
+        "campaigns.update MOBILE_APP_CAMPAIGN + --tracking-params",
+        [
+            "campaigns",
+            "update",
+            "--id",
+            "123",
+            "--type",
+            "MOBILE_APP_CAMPAIGN",
+            "--tracking-params",
+            "utm_source=direct",
+        ],
+        "MOBILE_APP_CAMPAIGN",
+    ),
+    (
         "adgroups.add DYNAMIC_TEXT_AD_GROUP + --feed-id",
         [
             "adgroups",


### PR DESCRIPTION
## Summary

- Adds `--tracking-params` to `direct campaigns add` and `direct campaigns update` for `TextCampaign` / `DynamicTextCampaign` / `SmartCampaign` `.TrackingParams` (WSDL `xsd:string`, no `maxLength`).
- `campaigns update` gains an optional `--type` discriminator. It is required when `--tracking-params` is set; without it, `campaigns update --id N --name X` keeps its old behaviour (no breakage).
- Subtype-specific flag validation reuses the existing `_reject_incompatible_flags` pattern from `add`, so MOBILE_APP / CPM_BANNER are rejected with `click.UsageError` (no silent data loss).

## Test plan

- [x] `pytest tests/ -q --timeout 60` — 945 passed, 45 skipped (integration, no token), 0 failed
- [x] `pytest tests/test_wsdl_parity_gate.py -v` — 60 passed, 6 skipped; two new `SILENT_LOSS_PROBES` for `campaigns.update`
- [x] `pytest tests/test_dry_run.py -k tracking_params` — 10 new tests (TEXT/DYNAMIC/SMART × add/update + 4 negative + backward-compat)
- [x] `flake8 direct_cli/commands/campaigns.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py` — clean
- [x] Manual dry-run sanity for all 4 scenarios: positive add/update for 3 subtypes, `--tracking-params` without `--type`, unsupported `--type MOBILE_APP_CAMPAIGN`, backward-compat `update --id N --name X`

Closes #230.

🤖 Generated with [Claude Code](https://claude.com/claude-code)