### PR TITLE
fix(v4): let ClickException propagate from command wrappers (#227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@
   existing `campaigns update --id N --name X` calls without `--type`
   keep working unchanged. Closes #230.
 
+**Fixed:**
+
+- `direct v4 *` command wrappers now let `click.ClickException`
+  (including `UsageError` from `call_v4` shape validation) propagate to
+  Click instead of swallowing it in the generic `except Exception`.
+  Shape-validation errors keep their usage hint and exit with code 2,
+  matching Click's contract; non-Click runtime errors still surface
+  through `print_error` + `Abort` (exit 1). Closes #227.
+
 ## 0.3.10
 
 **Added:**

--- a/direct_cli/commands/v4account.py
+++ b/direct_cli/commands/v4account.py
@@ -50,6 +50,8 @@ def _emit_or_call_v4(
         )
         data = call_v4(client, method, param)
         format_output(data, output_format, output)
+    except click.ClickException:
+        raise
     except Exception as e:
         print_error(str(e))
         raise click.Abort()

--- a/direct_cli/commands/v4events.py
+++ b/direct_cli/commands/v4events.py
@@ -113,6 +113,8 @@ def get_events_log(
         )
         data = call_v4(client, "GetEventsLog", param)
         format_output(data, output_format, output)
+    except click.ClickException:
+        raise
     except Exception as e:
         print_error(str(e))
         raise click.Abort()

--- a/direct_cli/commands/v4finance.py
+++ b/direct_cli/commands/v4finance.py
@@ -189,6 +189,8 @@ def get_clients_units(ctx, logins, output_format, output, dry_run):
         )
         data = call_v4(client, "GetClientsUnits", login_list)
         format_output(data, output_format, output)
+    except click.ClickException:
+        raise
     except Exception as e:
         print_error(str(e))
         raise click.Abort()
@@ -272,6 +274,8 @@ def get_credit_limits(
         )
         data = call_v4(client, "GetCreditLimits", login_list)
         format_output(data, output_format, output)
+    except click.ClickException:
+        raise
     except Exception as e:
         print_error(str(e))
         raise click.Abort()
@@ -316,6 +320,8 @@ def check_payment(
         )
         data = call_v4(client, "CheckPayment", param)
         format_output(data, output_format, output)
+    except click.ClickException:
+        raise
     except Exception as e:
         print_error(str(e))
         raise click.Abort()
@@ -413,6 +419,8 @@ def create_invoice(
         )
         data = call_v4(client, "CreateInvoice", param)
         format_output(data, output_format, output)
+    except click.ClickException:
+        raise
     except Exception as e:
         print_error(str(e))
         raise click.Abort()

--- a/direct_cli/commands/v4forecast.py
+++ b/direct_cli/commands/v4forecast.py
@@ -53,6 +53,8 @@ def _call_forecast(
         )
         data = call_v4(client, method, param)
         format_output(data, output_format, output)
+    except click.ClickException:
+        raise
     except Exception as e:
         print_error(str(e))
         raise click.Abort()

--- a/direct_cli/commands/v4goals.py
+++ b/direct_cli/commands/v4goals.py
@@ -43,6 +43,8 @@ def _run_goals_command(
         )
         data = call_v4(client, method, param)
         format_output(data, output_format, output)
+    except click.ClickException:
+        raise
     except Exception as e:
         print_error(str(e))
         raise click.Abort()

--- a/direct_cli/commands/v4tags.py
+++ b/direct_cli/commands/v4tags.py
@@ -142,6 +142,8 @@ def _call_v4tags(ctx, method: str, param, output_format: str, output: str) -> No
         )
         data = call_v4(client, method, param)
         format_output(data, output_format, output)
+    except click.ClickException:
+        raise
     except Exception as e:
         print_error(str(e))
         raise click.Abort()

--- a/direct_cli/commands/v4wordstat.py
+++ b/direct_cli/commands/v4wordstat.py
@@ -48,6 +48,8 @@ def _call_wordstat(
         )
         data = call_v4(client, method, param)
         format_output(data, output_format, output)
+    except click.ClickException:
+        raise
     except Exception as e:
         print_error(str(e))
         raise click.Abort()

--- a/tests/test_v4_exit_codes.py
+++ b/tests/test_v4_exit_codes.py
@@ -1,0 +1,125 @@
+"""Regression for issue #227.
+
+v4 command wrappers must let `click.ClickException` (UsageError, BadParameter)
+propagate so Click can format the message with a usage hint and exit with
+status code 2. Generic runtime exceptions still fall through to
+`print_error` + `click.Abort` (exit code 1).
+"""
+
+from unittest.mock import patch
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from direct_cli.cli import cli
+
+
+# (module short name, argv invoked through the top-level `cli` group).
+# Each argv hits a code path that calls `call_v4` inside the wrapped
+# `try` block of the v4 command module. We patch the module-local alias
+# of `call_v4` (the wrappers do `from ..v4 import call_v4` so the alias
+# is rebound on `direct_cli.commands.<module>.call_v4`).
+V4_COMMAND_PROBES = [
+    (
+        "v4account",
+        # `--sandbox` is required at the top level because the command
+        # rejects non-sandbox runs without `--dry-run` before reaching
+        # the wrapped `call_v4`. We want the wrapper, not the guard.
+        [
+            "--sandbox",
+            "v4account",
+            "enable-shared-account",
+            "--client-login",
+            "agency-test",
+        ],
+    ),
+    (
+        "v4events",
+        [
+            "v4events",
+            "get-events-log",
+            "--from",
+            "2026-05-01T00:00:00",
+            "--to",
+            "2026-05-02T00:00:00",
+        ],
+    ),
+    (
+        "v4finance",
+        ["v4finance", "get-clients-units", "--logins", "client1"],
+    ),
+    (
+        "v4forecast",
+        ["v4forecast", "create", "--phrases", "buy laptop"],
+    ),
+    (
+        "v4goals",
+        ["v4goals", "get-stat-goals", "--campaign-ids", "1"],
+    ),
+    (
+        "v4tags",
+        ["v4tags", "get-campaigns", "--campaign-ids", "1"],
+    ),
+    (
+        "v4wordstat",
+        ["v4wordstat", "list-reports"],
+    ),
+]
+
+
+def _invoke(*args: str):
+    env = {"YANDEX_DIRECT_TOKEN": "fake-token", "YANDEX_DIRECT_LOGIN": "fake-login"}
+    with patch("direct_cli.cli.get_active_profile", return_value=None):
+        return CliRunner(env=env).invoke(cli, list(args))
+
+
+@pytest.mark.parametrize(
+    ("module_name", "argv"),
+    V4_COMMAND_PROBES,
+    ids=[probe[0] for probe in V4_COMMAND_PROBES],
+)
+def test_usage_error_from_call_v4_yields_exit_code_2(module_name, argv):
+    """If call_v4 raises UsageError, Click must format it and exit with 2."""
+    sentinel = "v4 shape validation failed: bogus"
+
+    with patch(
+        f"direct_cli.commands.{module_name}.call_v4",
+        side_effect=click.UsageError(sentinel),
+    ), patch(
+        f"direct_cli.commands.{module_name}.create_v4_client",
+        return_value=object(),
+    ):
+        result = _invoke(*argv)
+
+    assert result.exit_code == 2, (
+        f"{module_name}: UsageError was swallowed by `except Exception` — "
+        f"got exit_code={result.exit_code}. Output: {result.output!r}"
+    )
+    assert sentinel in result.output, (
+        f"{module_name}: UsageError message was not propagated. "
+        f"Output: {result.output!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("module_name", "argv"),
+    V4_COMMAND_PROBES,
+    ids=[probe[0] for probe in V4_COMMAND_PROBES],
+)
+def test_runtime_error_from_call_v4_still_exits_with_abort(module_name, argv):
+    """Non-Click exceptions must still go through print_error + Abort (exit 1)."""
+    with patch(
+        f"direct_cli.commands.{module_name}.call_v4",
+        side_effect=RuntimeError("boom"),
+    ), patch(
+        f"direct_cli.commands.{module_name}.create_v4_client",
+        return_value=object(),
+    ):
+        result = _invoke(*argv)
+
+    assert result.exit_code == 1, (
+        f"{module_name}: RuntimeError should map to Abort/exit 1, "
+        f"got exit_code={result.exit_code}. Output: {result.output!r}"
+    )
+    assert "boom" in result.output


### PR DESCRIPTION
## Summary

- v4 command wrappers (`v4account`, `v4events`, `v4finance` ×4, `v4forecast`, `v4goals`, `v4tags`, `v4wordstat`) added `except click.ClickException: raise` before the generic `except Exception`. UsageError from `call_v4` shape validation (PR #225) now propagates to Click and exits with code 2 + usage hint instead of 1.
- Non-Click runtime errors still go through `print_error` + `Abort` (exit 1) — semantics for unexpected errors preserved.
- Regression test `tests/test_v4_exit_codes.py` parametrises across all seven v4 modules: 7 × UsageError-exit-2 + 7 × RuntimeError-exit-1.

## Test plan

- [x] `pytest tests/ -q --timeout 60` — 959 passed, 45 skipped (integration without token), 0 failed
- [x] `pytest tests/test_v4_exit_codes.py -v` — 14/14 passed
- [x] Counter-test: temporarily reverted `v4forecast.py` fix → the new test failed as expected (`exit_code=1, "Aborted!"`), then re-applied and the test passed
- [x] `flake8 direct_cli/commands/v4{account,events,finance,forecast,goals,tags,wordstat}.py tests/test_v4_exit_codes.py` — clean

Closes #227.

🤖 Generated with [Claude Code](https://claude.com/claude-code)