### PR TITLE
fix(v4finance): get-credit-limits drops --logins per official docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@
   matching Click's contract; non-Click runtime errors still surface
   through `print_error` + `Abort` (exit 1). Closes #227.
 
+**Breaking changes:**
+
+- `direct v4finance get-credit-limits` no longer accepts `--logins`; the
+  request body now omits `param` per the official v4 Live docs
+  (<https://yandex.ru/dev/direct/doc/dg-v4/reference/GetCreditLimits.html>),
+  which define the body as `method`, `finance_token`, and `operation_num`
+  only. Refs #125.
+
 ## 0.3.10
 
 **Added:**

--- a/README.md
+++ b/README.md
@@ -185,8 +185,7 @@ is omitted. Dry-run output masks the financial token.
 
 ```bash
 direct v4finance get-clients-units --logins client-login,other-client --format table
-direct v4finance get-credit-limits --logins client-login --master-token MASTER_TOKEN --operation-num 123 --finance-login agency-login
-direct v4finance get-credit-limits --logins client-login,other-client --format table
+direct v4finance get-credit-limits --master-token MASTER_TOKEN --operation-num 123 --finance-login agency-login
 direct v4finance create-invoice --payment 123=100.50 --payment 456=25 --currency RUB --master-token MASTER_TOKEN --operation-num 124 --finance-login agency-login --dry-run
 direct v4finance check-payment --custom-transaction-id A123456789012345678901234567890B
 direct v4finance transfer-money --from-campaign-id 123 --to-campaign-id 456 --amount 100.50 --currency RUB --master-token MASTER_TOKEN --operation-num 123 --finance-login agency-login --dry-run

--- a/direct_cli/commands/v4finance.py
+++ b/direct_cli/commands/v4finance.py
@@ -198,7 +198,6 @@ def get_clients_units(ctx, logins, output_format, output, dry_run):
 
 @v4_method_contract("GetCreditLimits")
 @v4finance.command(name="get-credit-limits")
-@click.option("--logins", required=True, help="Comma-separated client logins")
 @click.option(
     "--finance-token",
     envvar="YANDEX_DIRECT_FINANCE_TOKEN",
@@ -235,7 +234,6 @@ def get_clients_units(ctx, logins, output_format, output, dry_run):
 @click.pass_context
 def get_credit_limits(
     ctx,
-    logins,
     finance_token,
     master_token,
     operation_num,
@@ -245,7 +243,6 @@ def get_credit_limits(
     dry_run,
 ):
     """Get client credit limits."""
-    login_list = _logins_param(logins)
     finance_token, operation_num = _finance_credentials(
         finance_token,
         master_token,
@@ -257,7 +254,7 @@ def get_credit_limits(
 
     if dry_run:
         format_output(
-            _masked_finance_body("GetCreditLimits", login_list, operation_num),
+            _masked_finance_body("GetCreditLimits", None, operation_num),
             "json",
             None,
         )
@@ -272,7 +269,7 @@ def get_credit_limits(
             finance_token=finance_token,
             operation_num=operation_num,
         )
-        data = call_v4(client, "GetCreditLimits", login_list)
+        data = call_v4(client, "GetCreditLimits", None)
         format_output(data, output_format, output)
     except click.ClickException:
         raise

--- a/direct_cli/v4_contracts.py
+++ b/direct_cli/v4_contracts.py
@@ -59,18 +59,20 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
     "GetCreditLimits": V4MethodContract(
         method="GetCreditLimits",
         group="finance",
-        param_shape=PARAM_ARRAY,
+        param_shape=PARAM_OPTIONAL_OBJECT,
         login_placement=(
-            "param is a list of client logins; finance_token and "
-            "operation_num are top-level v4 Live body fields"
+            "param is omitted; finance_token and operation_num are top-level "
+            "v4 Live body fields"
         ),
         safety=SAFETY_READ,
         source_status=SOURCE_CONFIRMED_LIVE,
         live_probe_allowed=False,
-        example_param=["client-login"],
+        example_param=None,
         notes=(
-            "Requires finance_token and operation_num at the top level. "
-            "Live probe without them returns error_code=350."
+            "Official docs (dg-v4/reference/GetCreditLimits) define the "
+            "request body as method + finance_token + operation_num only; "
+            "no param. Live probe without finance credentials returns "
+            "error_code=350."
         ),
     ),
     "TransferMoney": V4MethodContract(

--- a/scripts/test_safe_commands.sh
+++ b/scripts/test_safe_commands.sh
@@ -165,7 +165,7 @@ run_v4finance_get_credit_limits() {
     return
   fi
 
-  run_test "$name" direct v4finance get-credit-limits --logins "$AUTH_LOGIN"
+  run_test "$name" direct v4finance get-credit-limits
 }
 
 run_v4finance_get_clients_units() {

--- a/tests/API_COVERAGE.md
+++ b/tests/API_COVERAGE.md
@@ -80,6 +80,15 @@ method-level shape validation and failed only because the transaction is a
 dummy value. Do not expose a public `--payment-id` flag unless Yandex documents
 or live-confirms a separate `PaymentID` contract.
 
+The official `GetCreditLimits` page
+(<https://yandex.ru/dev/direct/doc/dg-v4/reference/GetCreditLimits.html>)
+defines the request body as `{method, finance_token, operation_num}` only —
+no `param`. An earlier CLI surface required `--logins` and shipped a
+`param=[logins]` array; that contradicted the docs and has been removed
+(breaking change). The contract entry now uses `PARAM_OPTIONAL_OBJECT` with
+`example_param=None`, and `v4finance get-credit-limits` accepts no positional
+list arguments.
+
 ## Maintenance Rules
 
 - When a missing service is implemented, add it to `CLI_TO_API_SERVICE`,

--- a/tests/test_v4_contracts.py
+++ b/tests/test_v4_contracts.py
@@ -53,9 +53,9 @@ def test_confirmed_contracts_are_not_undocumented():
     for contract in confirmed:
         assert contract.param_shape != PARAM_UNDOCUMENTED
         if contract.param_shape != PARAM_OPTIONAL_OBJECT:
-            # PARAM_OPTIONAL_OBJECT means the method accepts no param at all
-            # (e.g. GetCreditLimits per official v4 Live docs), so example_param
-            # is legitimately None.
+            # PARAM_OPTIONAL_OBJECT means param may be omitted; if present it
+            # must be an object (e.g. GetCreditLimits per official v4 Live docs
+            # omits param), so example_param is legitimately None.
             assert contract.example_param is not None
 
     assert {
@@ -346,7 +346,7 @@ def test_v4_adapter_sends_finance_credentials_as_top_level_body_fields():
 
     request = adapter.get_request_kwargs(
         api_params,
-        data={"method": "GetCreditLimits", "param": ["client-login"]},
+        data={"method": "GetClientsUnits", "param": ["client-login"]},
     )
     body = json.loads(request["data"])
 

--- a/tests/test_v4_contracts.py
+++ b/tests/test_v4_contracts.py
@@ -52,7 +52,11 @@ def test_confirmed_contracts_are_not_undocumented():
     }
     for contract in confirmed:
         assert contract.param_shape != PARAM_UNDOCUMENTED
-        assert contract.example_param is not None
+        if contract.param_shape != PARAM_OPTIONAL_OBJECT:
+            # PARAM_OPTIONAL_OBJECT means the method accepts no param at all
+            # (e.g. GetCreditLimits per official v4 Live docs), so example_param
+            # is legitimately None.
+            assert contract.example_param is not None
 
     assert {
         contract.method for contract in confirmed if contract.live_probe_allowed
@@ -123,16 +127,13 @@ def test_enable_shared_account_contract_is_docs_backed_dangerous_object():
     }
 
 
-def test_get_credit_limits_contract_uses_login_array_and_finance_top_level():
+def test_get_credit_limits_contract_omits_param_and_finance_top_level():
     contract = get_v4_contract("GetCreditLimits")
 
-    assert contract.param_shape == PARAM_ARRAY
-    assert contract.example_param == ["client-login"]
+    assert contract.param_shape == PARAM_OPTIONAL_OBJECT
+    assert contract.example_param is None
     assert "finance_token" in contract.login_placement
-    assert build_v4_body("GetCreditLimits", ["client-login"]) == {
-        "method": "GetCreditLimits",
-        "param": ["client-login"],
-    }
+    assert build_v4_body("GetCreditLimits") == {"method": "GetCreditLimits"}
 
 
 def test_v4finance_money_contracts_are_docs_backed_dangerous_objects():

--- a/tests/test_v4_live_contracts.py
+++ b/tests/test_v4_live_contracts.py
@@ -167,7 +167,7 @@ def test_v4_live_get_credit_limits_contract():
         operation_num=operation_num,
     )
 
-    data = call_v4(client, "GetCreditLimits", [login])
+    data = call_v4(client, "GetCreditLimits")
 
     assert data is not None
 

--- a/tests/test_v4finance_read.py
+++ b/tests/test_v4finance_read.py
@@ -23,12 +23,10 @@ def _invoke(*args: str, env: Optional[dict] = None):
         return CliRunner(env=base_env).invoke(cli, list(args))
 
 
-def test_get_credit_limits_dry_run_uses_login_list_and_masks_finance_token():
+def test_get_credit_limits_dry_run_omits_param_and_masks_finance_token():
     result = _invoke(
         "v4finance",
         "get-credit-limits",
-        "--logins",
-        "a,b,c",
         "--finance-token",
         "secret-finance-token",
         "--operation-num",
@@ -40,7 +38,6 @@ def test_get_credit_limits_dry_run_uses_login_list_and_masks_finance_token():
     assert "secret-finance-token" not in result.output
     assert json.loads(result.output) == {
         "method": "GetCreditLimits",
-        "param": ["a", "b", "c"],
         "finance_token": "<redacted>",
         "operation_num": 42,
     }
@@ -98,8 +95,6 @@ def test_get_credit_limits_uses_finance_env_fallback_for_dry_run():
     result = _invoke(
         "v4finance",
         "get-credit-limits",
-        "--logins",
-        "client-login",
         "--dry-run",
         env={
             "YANDEX_DIRECT_FINANCE_TOKEN": "env-finance-token",
@@ -111,7 +106,6 @@ def test_get_credit_limits_uses_finance_env_fallback_for_dry_run():
     assert "env-finance-token" not in result.output
     assert json.loads(result.output) == {
         "method": "GetCreditLimits",
-        "param": ["client-login"],
         "finance_token": "<redacted>",
         "operation_num": 77,
     }
@@ -123,8 +117,6 @@ def test_get_credit_limits_can_compute_finance_token_from_master_token():
         result = _invoke(
             "v4finance",
             "get-credit-limits",
-            "--logins",
-            "client-login",
             "--master-token",
             "master-token",
             "--operation-num",
@@ -151,8 +143,6 @@ def test_get_credit_limits_requires_finance_credentials_before_api_call():
             "token",
             "v4finance",
             "get-credit-limits",
-            "--logins",
-            "client-login",
         )
 
     assert result.exit_code != 0
@@ -167,8 +157,6 @@ def test_get_credit_limits_rejects_blank_finance_token_before_api_call():
             "token",
             "v4finance",
             "get-credit-limits",
-            "--logins",
-            "client-login",
             "--finance-token",
             "   ",
             "--operation-num",
@@ -188,8 +176,6 @@ def test_get_credit_limits_strips_finance_token_before_api_call():
                 "token",
                 "v4finance",
                 "get-credit-limits",
-                "--logins",
-                "client-login",
                 "--finance-token",
                 " finance-token ",
                 "--operation-num",
@@ -199,10 +185,15 @@ def test_get_credit_limits_strips_finance_token_before_api_call():
     assert result.exit_code == 0
     create_client.assert_called_once()
     assert create_client.call_args.kwargs["finance_token"] == "finance-token"
-    call.assert_called_once()
+    call.assert_called_once_with(
+        create_client.return_value,
+        "GetCreditLimits",
+        None,
+    )
 
 
-def test_get_credit_limits_empty_logins_fails_before_api_call():
+def test_get_credit_limits_rejects_unknown_logins_flag():
+    """--logins is no longer accepted; docs define the body without param."""
     with patch("direct_cli.commands.v4finance.create_v4_client") as create_client:
         result = _invoke(
             "--token",
@@ -210,7 +201,7 @@ def test_get_credit_limits_empty_logins_fails_before_api_call():
             "v4finance",
             "get-credit-limits",
             "--logins",
-            ",",
+            "client-login",
             "--finance-token",
             "finance-token",
             "--operation-num",
@@ -218,7 +209,7 @@ def test_get_credit_limits_empty_logins_fails_before_api_call():
         )
 
     assert result.exit_code != 0
-    assert "--logins must not be empty" in result.output
+    assert "no such option" in result.output.lower()
     create_client.assert_not_called()
 
 
@@ -235,8 +226,6 @@ def test_get_credit_limits_formats_mocked_response_as_json():
                 "agency-login",
                 "v4finance",
                 "get-credit-limits",
-                "--logins",
-                "client-login",
                 "--finance-token",
                 "finance-token",
                 "--operation-num",
@@ -256,7 +245,7 @@ def test_get_credit_limits_formats_mocked_response_as_json():
     call.assert_called_once_with(
         create_client.return_value,
         "GetCreditLimits",
-        ["client-login"],
+        None,
     )
 
 


### PR DESCRIPTION
## Summary

- Official v4 Live docs at [`dg-v4/reference/GetCreditLimits`](https://yandex.ru/dev/direct/doc/dg-v4/reference/GetCreditLimits.html) define the request body as `{method, finance_token, operation_num}` only — no `param`.
- CLI previously required `--logins` and shipped `param=[logins]`, contradicting the docs.
- This PR removes `--logins` from `direct v4finance get-credit-limits` (BREAKING) and aligns the v4 contract entry: `param_shape=PARAM_OPTIONAL_OBJECT`, `example_param=None`.

## Breaking change

Any script that passed `--logins` to `direct v4finance get-credit-limits` will fail with `Error: No such option '--logins'` (exit 2). Replace with:

```bash
direct v4finance get-credit-limits --master-token MASTER_TOKEN --operation-num 123 --finance-login agency-login
```

## Test plan

- [x] `pytest tests/test_v4finance_read.py tests/test_v4_contracts.py tests/test_v4_safety.py tests/test_v4_foundation.py` (41 passed)
- [x] `pytest tests/test_comprehensive.py tests/test_smoke_matrix.py tests/test_api_coverage.py tests/test_v4_runtime_shape.py tests/test_v4account.py tests/test_v4finance_money.py tests/test_v4goals.py tests/test_v4events.py` (311 passed)
- [x] `direct v4finance get-credit-limits --master-token T --operation-num 1 --finance-login me --dry-run` produces body without `"param"` key
- [x] `direct v4finance get-credit-limits --logins x --master-token T --operation-num 1 --finance-login me --dry-run` exits 2 with `Error: No such option '--logins'`

Part of #125 (see audit comment for full context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)