### PR TITLE
feat(v4account): support all 5 AccountManagement actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@
   the three subtypes supported by the CLI. Backward compatible:
   existing `campaigns update --id N --name X` calls without `--type`
   keep working unchanged. Closes #230.
+- `direct v4account account-management` now supports `--action Get`,
+  `Deposit`, `Invoice`, and `TransferMoney` in addition to `Update`,
+  matching the official v4 Live docs
+  (<https://yandex.ru/dev/direct/doc/dg-v4/reference/AccountManagement-docpage/>).
+  `Get` is read-only and accepts optional `--logins` / `--account-ids`
+  filters. `Deposit`, `Invoice`, and `TransferMoney` are financial
+  mutations: they need `--finance-token` (or `--master-token` +
+  `--operation-num` + `--finance-login`) and respect the existing
+  dry-run-unless-sandbox rule. A Click-side allow-list rejects flags
+  that do not belong to the chosen action before any body is built.
+  Refs #125.
 
 **Fixed:**
 

--- a/README.md
+++ b/README.md
@@ -194,14 +194,27 @@ direct v4finance pay-campaigns --campaign-ids 123,456 --amount 100.50 --currency
 
 ### V4 Live Shared Account
 
-Shared-account mutations require `--dry-run` in production and can be sent live
-only with top-level `--sandbox`. These commands follow the official v4 Live
-shared-account method shapes: `EnableSharedAccount` accepts one client `Login`,
-and `AccountManagement` updates shared-account settings through `Accounts`.
+`EnableSharedAccount` accepts one client `Login` (agencies only).
+`AccountManagement` exposes the five official v4 Live actions:
+`Get`, `Update`, `Deposit`, `Invoice`, and `TransferMoney`. `Get` is
+read-only and runs against production without `--dry-run`. `Update`,
+`Deposit`, `Invoice`, and `TransferMoney` are mutations: they require
+`--dry-run` in production and can be sent live only with top-level
+`--sandbox`. `Deposit`, `Invoice`, and `TransferMoney` are financial
+operations that need `--finance-token` (or `--master-token` +
+`--operation-num` + `--finance-login`); dry-run output masks the
+financial token.
 
 ```bash
 direct v4account enable-shared-account --client-login client-login --dry-run
+direct v4account account-management --action Get
+direct v4account account-management --action Get --logins client-a,client-b
+direct v4account account-management --action Get --account-ids 1327944,1327945
 direct v4account account-management --action Update --account-id 1327944 --day-budget 100.50 --spend-mode Default --money-in-sms Yes --money-out-sms No --email ops@example.com --money-warning-value 25 --dry-run
+direct v4account account-management --action Deposit --payment 1327944=100.50 --currency RUB --master-token MASTER_TOKEN --operation-num 124 --finance-login agency-login --dry-run
+direct v4account account-management --action Deposit --payment 1327944=100.50 --currency RUB --origin Overdraft --contract CONTRACT_ID --master-token MASTER_TOKEN --operation-num 125 --finance-login agency-login --dry-run
+direct v4account account-management --action Invoice --payment 1327944=100.50 --currency RUB --master-token MASTER_TOKEN --operation-num 126 --finance-login agency-login --dry-run
+direct v4account account-management --action TransferMoney --from-account-id 1327944 --to-account-id 1327945 --amount 50.00 --currency RUB --master-token MASTER_TOKEN --operation-num 127 --finance-login agency-login --dry-run
 direct --sandbox v4account enable-shared-account --client-login client-login
 ```
 

--- a/direct_cli/commands/v4account.py
+++ b/direct_cli/commands/v4account.py
@@ -17,7 +17,6 @@ from ..v4_contracts import v4_method_contract
 # financial sub-actions (Deposit/Invoice/TransferMoney) need the same
 # finance_token / operation_num plumbing as v4finance methods.
 from .v4finance import (  # noqa: E402
-    FINANCE_TOKEN_MASK,
     _finance_credentials,
     _masked_finance_body,
 )
@@ -220,23 +219,34 @@ def _validate_action(action: str) -> str:
     return normalized
 
 
-def _flag_supplied(name: str, value: Any) -> bool:
-    """Detect whether an action-specific Click parameter was supplied."""
+def _flag_supplied(
+    ctx: click.Context, name: str, value: Any
+) -> bool:
+    """Detect whether an action-specific Click parameter was supplied by the user.
+
+    Values sourced from envvars or defaults are NOT counted as "supplied" —
+    only ones the user typed on the command line. This lets users keep
+    ``YANDEX_DIRECT_FINANCE_TOKEN`` & friends exported in their shell while
+    still running ``--action Get`` / ``--action Update`` without spurious
+    "flag not valid for action" errors.
+    """
     if value is None:
         return False
-    # Click `multiple=True` options arrive as a tuple; empty means not supplied.
     if isinstance(value, tuple) and len(value) == 0:
         return False
-    return True
+    source = ctx.get_parameter_source(name)
+    return source == click.core.ParameterSource.COMMANDLINE
 
 
-def _reject_disallowed_flags(action: str, supplied: dict[str, Any]) -> None:
+def _reject_disallowed_flags(
+    ctx: click.Context, action: str, supplied: dict[str, Any]
+) -> None:
     """Fail fast when a flag is set that does not apply to the chosen Action."""
     allowed = _ACCOUNT_ACTION_ALLOWED_FLAGS[action] | _COMMON_PARAMS
     offenders = sorted(
         _PARAM_TO_FLAG.get(name, f"--{name.replace('_', '-')}")
         for name, value in supplied.items()
-        if name not in allowed and _flag_supplied(name, value)
+        if name not in allowed and _flag_supplied(ctx, name, value)
     )
     if offenders:
         valid_flags = sorted(_PARAM_TO_FLAG[name] for name in allowed if name in _PARAM_TO_FLAG)
@@ -389,7 +399,7 @@ def _parse_account_payments(
         parsed_items.append(
             {
                 "AccountID": account_id,
-                "Amount": parse_v4_money_sum(amount_text),
+                "Amount": parse_v4_money_sum(amount_text, option_name="--payment"),
                 "Currency": normalized_currency,
             }
         )
@@ -670,7 +680,7 @@ def account_management(
         "operation_num": operation_num,
         "finance_login": finance_login,
     }
-    _reject_disallowed_flags(action, supplied)
+    _reject_disallowed_flags(ctx, action, supplied)
 
     if action == "Get":
         param = _account_get_param(logins, account_ids)

--- a/direct_cli/commands/v4account.py
+++ b/direct_cli/commands/v4account.py
@@ -2,19 +2,107 @@
 
 import re
 from decimal import Decimal, InvalidOperation
-from typing import Optional
+from typing import Any, Optional
 
 import click
 
 from ..api import create_v4_client
 from ..output import format_output, print_error
+from ..utils import parse_csv_strings, parse_ids
 from ..v4 import build_v4_body, call_v4
+from ..v4.money import parse_v4_money_sum
 from ..v4_contracts import v4_method_contract
+
+# Cross-module helpers shared with v4finance commands. AccountManagement's
+# financial sub-actions (Deposit/Invoice/TransferMoney) need the same
+# finance_token / operation_num plumbing as v4finance methods.
+from .v4finance import (  # noqa: E402
+    FINANCE_TOKEN_MASK,
+    _finance_credentials,
+    _masked_finance_body,
+)
 from .v4shells import V4_EPILOG
 
 YES_NO = ("Yes", "No")
 SPEND_MODES = ("Default", "Stretched")
 HH_MM_RE = re.compile(r"^(?:[01]\d|2[0-3]):(?:00|15|30|45)$")
+
+V4_ACCOUNT_ACTIONS = ("Get", "Update", "Deposit", "Invoice", "TransferMoney")
+V4_ACCOUNT_FINANCIAL_ACTIONS = frozenset({"Deposit", "Invoice", "TransferMoney"})
+V4_ACCOUNT_CURRENCIES = (
+    "RUB",
+    "CHF",
+    "EUR",
+    "KZT",
+    "TRY",
+    "UAH",
+    "USD",
+    "BYN",
+)
+V4_ACCOUNT_ORIGINS = ("Overdraft",)
+
+_COMMON_PARAMS = frozenset({"action", "dry_run", "output_format", "output"})
+_FINANCE_PARAMS = frozenset(
+    {"finance_token", "master_token", "operation_num", "finance_login"}
+)
+_UPDATE_PARAMS = frozenset(
+    {
+        "account_id",
+        "day_budget",
+        "spend_mode",
+        "money_in_sms",
+        "money_out_sms",
+        "paused_by_day_budget_sms",
+        "sms_time_from",
+        "sms_time_to",
+        "email",
+        "money_warning_value",
+        "paused_by_day_budget",
+    }
+)
+_GET_PARAMS = frozenset({"logins", "account_ids"})
+_DEPOSIT_PARAMS = frozenset(
+    {"payments", "currency", "origin", "contract"} | _FINANCE_PARAMS
+)
+_INVOICE_PARAMS = frozenset({"payments", "currency"} | _FINANCE_PARAMS)
+_TRANSFER_PARAMS = frozenset(
+    {"from_account_id", "to_account_id", "amount", "currency"} | _FINANCE_PARAMS
+)
+
+_ACCOUNT_ACTION_ALLOWED_FLAGS: dict[str, frozenset[str]] = {
+    "Get": _GET_PARAMS,
+    "Update": _UPDATE_PARAMS,
+    "Deposit": _DEPOSIT_PARAMS,
+    "Invoice": _INVOICE_PARAMS,
+    "TransferMoney": _TRANSFER_PARAMS,
+}
+
+_PARAM_TO_FLAG = {
+    "account_id": "--account-id",
+    "day_budget": "--day-budget",
+    "spend_mode": "--spend-mode",
+    "money_in_sms": "--money-in-sms",
+    "money_out_sms": "--money-out-sms",
+    "paused_by_day_budget_sms": "--paused-by-day-budget-sms",
+    "sms_time_from": "--sms-time-from",
+    "sms_time_to": "--sms-time-to",
+    "email": "--email",
+    "money_warning_value": "--money-warning-value",
+    "paused_by_day_budget": "--paused-by-day-budget",
+    "logins": "--logins",
+    "account_ids": "--account-ids",
+    "payments": "--payment",
+    "currency": "--currency",
+    "origin": "--origin",
+    "contract": "--contract",
+    "from_account_id": "--from-account-id",
+    "to_account_id": "--to-account-id",
+    "amount": "--amount",
+    "finance_token": "--finance-token",
+    "master_token": "--master-token",
+    "operation_num": "--operation-num",
+    "finance_login": "--finance-login",
+}
 
 
 @click.group(epilog=V4_EPILOG)
@@ -47,6 +135,39 @@ def _emit_or_call_v4(
             login=ctx.obj.get("login"),
             profile=ctx.obj.get("profile"),
             sandbox=ctx.obj.get("sandbox"),
+        )
+        data = call_v4(client, method, param)
+        format_output(data, output_format, output)
+    except click.ClickException:
+        raise
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+
+def _emit_or_call_v4_finance(
+    ctx: click.Context,
+    method: str,
+    param: dict,
+    finance_token: str,
+    operation_num: int,
+    dry_run: bool,
+    output_format: str,
+    output: Optional[str],
+) -> None:
+    """Preview a finance-backed v4 request or execute it; masks the token."""
+    if dry_run:
+        format_output(_masked_finance_body(method, param, operation_num), "json", None)
+        return
+
+    try:
+        client = create_v4_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            profile=ctx.obj.get("profile"),
+            sandbox=ctx.obj.get("sandbox"),
+            finance_token=finance_token,
+            operation_num=operation_num,
         )
         data = call_v4(client, method, param)
         format_output(data, output_format, output)
@@ -90,16 +211,90 @@ def _parse_hh_mm(value: Optional[str], option_name: str) -> Optional[str]:
 
 
 def _validate_action(action: str) -> str:
-    """Normalize the supported AccountManagement action."""
+    """Normalize the v4 Live AccountManagement Action enum."""
     normalized = (action or "").strip()
-    if normalized != "Update":
-        raise click.UsageError("Only --action Update is supported by this command")
+    if normalized not in V4_ACCOUNT_ACTIONS:
+        raise click.UsageError(
+            "--action must be one of: " + ", ".join(V4_ACCOUNT_ACTIONS)
+        )
     return normalized
+
+
+def _flag_supplied(name: str, value: Any) -> bool:
+    """Detect whether an action-specific Click parameter was supplied."""
+    if value is None:
+        return False
+    # Click `multiple=True` options arrive as a tuple; empty means not supplied.
+    if isinstance(value, tuple) and len(value) == 0:
+        return False
+    return True
+
+
+def _reject_disallowed_flags(action: str, supplied: dict[str, Any]) -> None:
+    """Fail fast when a flag is set that does not apply to the chosen Action."""
+    allowed = _ACCOUNT_ACTION_ALLOWED_FLAGS[action] | _COMMON_PARAMS
+    offenders = sorted(
+        _PARAM_TO_FLAG.get(name, f"--{name.replace('_', '-')}")
+        for name, value in supplied.items()
+        if name not in allowed and _flag_supplied(name, value)
+    )
+    if offenders:
+        valid_flags = sorted(_PARAM_TO_FLAG[name] for name in allowed if name in _PARAM_TO_FLAG)
+        raise click.UsageError(
+            f"{', '.join(offenders)} not valid for --action {action}. "
+            f"Valid flags for {action}: {', '.join(valid_flags)}"
+        )
+
+
+def _account_selection_criteria(
+    logins: Optional[str], account_ids: Optional[str]
+) -> Optional[dict]:
+    """Build the Get SelectionCriteria object; None when no filter is provided."""
+    parsed_logins = parse_csv_strings(logins)
+    if logins is not None and not parsed_logins:
+        raise click.UsageError("--logins must not be empty when provided")
+
+    if account_ids is not None:
+        try:
+            parsed_ids = parse_ids(account_ids)
+        except ValueError as exc:
+            raise click.UsageError(str(exc)) from exc
+        if not parsed_ids:
+            raise click.UsageError("--account-ids must not be empty when provided")
+        if any(account_id <= 0 for account_id in parsed_ids):
+            raise click.UsageError(
+                "--account-ids must contain only positive integers"
+            )
+    else:
+        parsed_ids = None
+
+    if parsed_logins and len(parsed_logins) > 50:
+        raise click.UsageError("--logins accepts at most 50 entries")
+    if parsed_ids and len(parsed_ids) > 100:
+        raise click.UsageError("--account-ids accepts at most 100 entries")
+
+    criteria: dict = {}
+    if parsed_logins:
+        criteria["Logins"] = parsed_logins
+    if parsed_ids:
+        criteria["AccountIDS"] = parsed_ids
+    return criteria or None
+
+
+def _account_get_param(
+    logins: Optional[str], account_ids: Optional[str]
+) -> dict:
+    """Build the Get param object."""
+    criteria = _account_selection_criteria(logins, account_ids)
+    param: dict = {"Action": "Get"}
+    if criteria is not None:
+        param["SelectionCriteria"] = criteria
+    return param
 
 
 def _account_update_param(
     action: str,
-    account_id: int,
+    account_id: Optional[int],
     day_budget: Optional[str],
     spend_mode: Optional[str],
     money_in_sms: Optional[str],
@@ -112,7 +307,9 @@ def _account_update_param(
     paused_by_day_budget: Optional[str],
 ) -> dict:
     """Build the AccountManagement Update parameter object."""
-    account = {"AccountID": account_id}
+    if account_id is None:
+        raise click.UsageError("--account-id is required for --action Update")
+    account: dict = {"AccountID": account_id}
 
     parsed_day_budget = _parse_day_budget(day_budget)
     if parsed_day_budget is not None or spend_mode is not None:
@@ -125,7 +322,7 @@ def _account_update_param(
             "SpendMode": spend_mode,
         }
 
-    sms_notification = {}
+    sms_notification: dict = {}
     if money_in_sms is not None:
         sms_notification["MoneyInSms"] = money_in_sms
     if money_out_sms is not None:
@@ -143,7 +340,7 @@ def _account_update_param(
     if sms_notification:
         account["SmsNotification"] = sms_notification
 
-    email_notification = {}
+    email_notification: dict = {}
     if email is not None:
         email_notification["Email"] = _non_empty(email, "--email")
     if money_warning_value is not None:
@@ -157,6 +354,99 @@ def _account_update_param(
         raise click.UsageError("Provide at least one update field")
 
     return {"Action": action, "Accounts": [account]}
+
+
+def _parse_account_payments(
+    payments: tuple[str, ...], currency: str
+) -> list[dict]:
+    """Parse repeated --payment ACCOUNT_ID=AMOUNT into PayCampElement-shaped items."""
+    if not payments:
+        raise click.UsageError("--payment is required")
+    if len(payments) > 50:
+        raise click.UsageError("--payment accepts at most 50 entries per call")
+
+    normalized_currency = currency.upper()
+    parsed_items: list[dict] = []
+    seen_account_ids: set[int] = set()
+    for entry in payments:
+        spec = (entry or "").strip()
+        if "=" not in spec:
+            raise click.UsageError("--payment must use ACCOUNT_ID=AMOUNT")
+        account_id_text, amount_text = spec.split("=", 1)
+        account_id_text = account_id_text.strip()
+        amount_text = amount_text.strip()
+        try:
+            account_id = int(account_id_text)
+        except ValueError as exc:
+            raise click.UsageError(
+                "--payment account ID must be a positive integer"
+            ) from exc
+        if account_id <= 0:
+            raise click.UsageError("--payment account ID must be a positive integer")
+        if account_id in seen_account_ids:
+            raise click.UsageError("--payment account IDs must be unique")
+        seen_account_ids.add(account_id)
+        parsed_items.append(
+            {
+                "AccountID": account_id,
+                "Amount": parse_v4_money_sum(amount_text),
+                "Currency": normalized_currency,
+            }
+        )
+
+    return parsed_items
+
+
+def _account_deposit_param(
+    payments: tuple[str, ...],
+    currency: str,
+    origin: Optional[str],
+    contract: Optional[str],
+) -> dict:
+    """Build the Deposit param object."""
+    items = _parse_account_payments(payments, currency)
+    contract_clean = (contract or "").strip()
+    if origin is not None:
+        for item in items:
+            item["Origin"] = origin
+    if contract_clean:
+        for item in items:
+            item["Contract"] = contract_clean
+    return {"Action": "Deposit", "Payments": items}
+
+
+def _account_invoice_param(
+    payments: tuple[str, ...], currency: str
+) -> dict:
+    """Build the Invoice param object."""
+    return {
+        "Action": "Invoice",
+        "Payments": _parse_account_payments(payments, currency),
+    }
+
+
+def _account_transfer_param(
+    from_account_id: int,
+    to_account_id: int,
+    amount: str,
+    currency: str,
+) -> dict:
+    """Build the TransferMoney param object (single transfer per call)."""
+    if from_account_id == to_account_id:
+        raise click.UsageError(
+            "--from-account-id and --to-account-id must differ"
+        )
+    return {
+        "Action": "TransferMoney",
+        "Transfers": [
+            {
+                "FromAccountID": from_account_id,
+                "ToAccountID": to_account_id,
+                "Amount": parse_v4_money_sum(amount),
+                "Currency": currency.upper(),
+            }
+        ],
+    }
 
 
 @v4_method_contract("EnableSharedAccount")
@@ -196,34 +486,115 @@ def enable_shared_account(ctx, client_login, dry_run, output_format, output):
 
 @v4_method_contract("AccountManagement")
 @v4account.command(name="account-management")
-@click.option("--action", required=True, help="AccountManagement action: Update")
+@click.option(
+    "--action",
+    required=True,
+    help="AccountManagement action: Get / Update / Deposit / Invoice / TransferMoney",
+)
+@click.option("--logins", help="Comma-separated client logins (Get only)")
+@click.option(
+    "--account-ids",
+    help="Comma-separated shared account IDs (Get only)",
+)
 @click.option(
     "--account-id",
-    required=True,
     type=click.IntRange(min=1),
-    help="Shared account ID",
+    help="Shared account ID (Update only)",
 )
-@click.option("--day-budget", help="Shared account daily budget")
-@click.option("--spend-mode", type=click.Choice(SPEND_MODES), help="Budget spend mode")
-@click.option("--money-in-sms", type=click.Choice(YES_NO), help="Enable money-in SMS")
-@click.option("--money-out-sms", type=click.Choice(YES_NO), help="Enable money-out SMS")
+@click.option("--day-budget", help="Shared account daily budget (Update only)")
+@click.option(
+    "--spend-mode",
+    type=click.Choice(SPEND_MODES),
+    help="Budget spend mode (Update only)",
+)
+@click.option(
+    "--money-in-sms",
+    type=click.Choice(YES_NO),
+    help="Enable money-in SMS (Update only)",
+)
+@click.option(
+    "--money-out-sms",
+    type=click.Choice(YES_NO),
+    help="Enable money-out SMS (Update only)",
+)
 @click.option(
     "--paused-by-day-budget-sms",
     type=click.Choice(YES_NO),
-    help="Enable day-budget pause SMS",
+    help="Enable day-budget pause SMS (Update only)",
 )
-@click.option("--sms-time-from", help="SMS notification start time, HH:MM")
-@click.option("--sms-time-to", help="SMS notification end time, HH:MM")
-@click.option("--email", help="Notification email")
+@click.option(
+    "--sms-time-from", help="SMS notification start time, HH:MM (Update only)"
+)
+@click.option(
+    "--sms-time-to", help="SMS notification end time, HH:MM (Update only)"
+)
+@click.option("--email", help="Notification email (Update only)")
 @click.option(
     "--money-warning-value",
     type=click.IntRange(min=0),
-    help="Balance warning percentage",
+    help="Balance warning percentage (Update only)",
 )
 @click.option(
     "--paused-by-day-budget",
     type=click.Choice(YES_NO),
-    help="Enable day-budget pause email",
+    help="Enable day-budget pause email (Update only)",
+)
+@click.option(
+    "--payment",
+    "payments",
+    multiple=True,
+    help=(
+        "Payment as ACCOUNT_ID=AMOUNT; repeat for multiple accounts "
+        "(Deposit / Invoice)"
+    ),
+)
+@click.option(
+    "--currency",
+    type=click.Choice(V4_ACCOUNT_CURRENCIES, case_sensitive=False),
+    help="Payment currency (Deposit / Invoice / TransferMoney)",
+)
+@click.option(
+    "--origin",
+    type=click.Choice(V4_ACCOUNT_ORIGINS),
+    help="Funding origin (Deposit only)",
+)
+@click.option("--contract", help="Contract number (Deposit only)")
+@click.option(
+    "--from-account-id",
+    type=click.IntRange(min=1),
+    help="Source account ID (TransferMoney only)",
+)
+@click.option(
+    "--to-account-id",
+    type=click.IntRange(min=1),
+    help="Destination account ID (TransferMoney only)",
+)
+@click.option(
+    "--amount", help="Positive amount, e.g. 100.50 (TransferMoney only)"
+)
+@click.option(
+    "--finance-token",
+    envvar="YANDEX_DIRECT_FINANCE_TOKEN",
+    help="Precomputed financial token (Deposit / Invoice / TransferMoney)",
+)
+@click.option(
+    "--master-token",
+    envvar="YANDEX_DIRECT_MASTER_TOKEN",
+    help=(
+        "Financial master token; computes the per-request token from "
+        "operation_num + method + login (Deposit / Invoice / TransferMoney)"
+    ),
+)
+@click.option(
+    "--operation-num",
+    type=click.IntRange(min=1, max=9223372036854775807),
+    envvar="YANDEX_DIRECT_OPERATION_NUM",
+    help="Financial operation number (Deposit / Invoice / TransferMoney)",
+)
+@click.option(
+    "--finance-login",
+    envvar="YANDEX_DIRECT_FINANCE_LOGIN",
+    help="Login used in financial token generation",
 )
 @click.option(
     "--dry-run",
@@ -242,6 +613,8 @@ def enable_shared_account(ctx, client_login, dry_run, output_format, output):
 def account_management(
     ctx,
     action,
+    logins,
+    account_ids,
     account_id,
     day_budget,
     spend_mode,
@@ -253,30 +626,111 @@ def account_management(
     email,
     money_warning_value,
     paused_by_day_budget,
+    payments,
+    currency,
+    origin,
+    contract,
+    from_account_id,
+    to_account_id,
+    amount,
+    finance_token,
+    master_token,
+    operation_num,
+    finance_login,
     dry_run,
     output_format,
     output,
 ):
-    """Update shared-account settings in sandbox, or preview the request."""
+    """Manage shared accounts: Get / Update / Deposit / Invoice / TransferMoney."""
+    action = _validate_action(action)
+
+    supplied = {
+        "logins": logins,
+        "account_ids": account_ids,
+        "account_id": account_id,
+        "day_budget": day_budget,
+        "spend_mode": spend_mode,
+        "money_in_sms": money_in_sms,
+        "money_out_sms": money_out_sms,
+        "paused_by_day_budget_sms": paused_by_day_budget_sms,
+        "sms_time_from": sms_time_from,
+        "sms_time_to": sms_time_to,
+        "email": email,
+        "money_warning_value": money_warning_value,
+        "paused_by_day_budget": paused_by_day_budget,
+        "payments": payments,
+        "currency": currency,
+        "origin": origin,
+        "contract": contract,
+        "from_account_id": from_account_id,
+        "to_account_id": to_account_id,
+        "amount": amount,
+        "finance_token": finance_token,
+        "master_token": master_token,
+        "operation_num": operation_num,
+        "finance_login": finance_login,
+    }
+    _reject_disallowed_flags(action, supplied)
+
+    if action == "Get":
+        param = _account_get_param(logins, account_ids)
+        _emit_or_call_v4(ctx, "AccountManagement", param, dry_run, output_format, output)
+        return
+
     _require_dry_run_or_sandbox(dry_run, ctx.obj.get("sandbox"))
-    param = _account_update_param(
-        _validate_action(action),
-        account_id,
-        day_budget,
-        spend_mode,
-        money_in_sms,
-        money_out_sms,
-        paused_by_day_budget_sms,
-        sms_time_from,
-        sms_time_to,
-        email,
-        money_warning_value,
-        paused_by_day_budget,
+
+    if action == "Update":
+        param = _account_update_param(
+            action,
+            account_id,
+            day_budget,
+            spend_mode,
+            money_in_sms,
+            money_out_sms,
+            paused_by_day_budget_sms,
+            sms_time_from,
+            sms_time_to,
+            email,
+            money_warning_value,
+            paused_by_day_budget,
+        )
+        _emit_or_call_v4(ctx, "AccountManagement", param, dry_run, output_format, output)
+        return
+
+    # Deposit / Invoice / TransferMoney — financial sub-actions.
+    if currency is None:
+        raise click.UsageError(
+            f"--currency is required for --action {action}"
+        )
+    resolved_token, resolved_op_num = _finance_credentials(
+        finance_token,
+        master_token,
+        operation_num,
+        finance_login,
+        "AccountManagement",
+        ctx.obj.get("login"),
     )
-    _emit_or_call_v4(
+
+    if action == "Deposit":
+        param = _account_deposit_param(payments, currency, origin, contract)
+    elif action == "Invoice":
+        param = _account_invoice_param(payments, currency)
+    else:  # TransferMoney
+        if from_account_id is None or to_account_id is None or amount is None:
+            raise click.UsageError(
+                "--from-account-id, --to-account-id, and --amount are required "
+                "for --action TransferMoney"
+            )
+        param = _account_transfer_param(
+            from_account_id, to_account_id, amount, currency
+        )
+
+    _emit_or_call_v4_finance(
         ctx,
         "AccountManagement",
         param,
+        resolved_token,
+        resolved_op_num,
         dry_run,
         output_format,
         output,

--- a/direct_cli/v4/money.py
+++ b/direct_cli/v4/money.py
@@ -13,27 +13,32 @@ _MONEY_RE = re.compile(r"^(?:0|[1-9]\d*)(?:\.\d{1,2})?$")
 MAX_OPERATION_NUM = 9223372036854775807
 
 
-def parse_v4_money_sum(value: str) -> float:
-    """Parse a positive human-readable money amount for v4 ``Sum`` fields."""
+def parse_v4_money_sum(value: str, option_name: str = "--amount") -> float:
+    """Parse a positive human-readable money amount for v4 ``Sum`` fields.
+
+    ``option_name`` controls the CLI flag label that appears in error messages
+    so callers (e.g. ``--payment ACCOUNT_ID=AMOUNT`` parsers) get a diagnostic
+    that names the flag the user actually typed.
+    """
     normalized = (value or "").strip()
     if not _MONEY_RE.fullmatch(normalized):
         raise click.UsageError(
-            "--amount must be a positive decimal amount, for example 100.50"
+            f"{option_name} must be a positive decimal amount, for example 100.50"
         )
 
     try:
         amount = Decimal(normalized)
     except InvalidOperation as exc:
         raise click.UsageError(
-            "--amount must be a positive decimal amount, for example 100.50"
+            f"{option_name} must be a positive decimal amount, for example 100.50"
         ) from exc
 
     if amount <= 0:
-        raise click.UsageError("--amount must be greater than zero")
+        raise click.UsageError(f"{option_name} must be greater than zero")
 
     result = float(amount)
     if not math.isfinite(result):
-        raise click.UsageError("--amount must be a finite decimal amount")
+        raise click.UsageError(f"{option_name} must be a finite decimal amount")
     return result
 
 

--- a/direct_cli/v4_contracts.py
+++ b/direct_cli/v4_contracts.py
@@ -179,11 +179,20 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
         live_probe_allowed=True,
         example_param={"Action": "Get"},
         notes=(
-            "Action=Get is live-confirmed read-only and returns "
-            "Accounts[].Amount/Currency; the docs-backed Update action changes "
-            "shared-account settings with Accounts[].AccountID, AccountDayBudget, "
-            "SmsNotification, and EmailNotification. The v4account Update command "
-            "is production dry-run-only and can be sent live only with --sandbox."
+            "Action in {Get, Update, Deposit, Invoice, TransferMoney}. "
+            "Get is live-confirmed read-only and returns Accounts[]."
+            "Amount/Currency; Get accepts optional SelectionCriteria.Logins "
+            "(max 50) or AccountIDS (max 100). Update is docs-backed and "
+            "changes shared-account settings via Accounts[].AccountID/"
+            "AccountDayBudget/SmsNotification/EmailNotification. Deposit, "
+            "Invoice, and TransferMoney are docs-backed financial mutations "
+            "that require finance_token and operation_num at the top level: "
+            "Deposit and Invoice send Payments[].AccountID/Amount/Currency "
+            "(max 50); TransferMoney sends Transfers[].FromAccountID/"
+            "ToAccountID/Amount/Currency (max 1 per call, max 3 per account "
+            "per day). All v4account.account-management actions other than "
+            "Get require --dry-run in production and live execution only "
+            "with --sandbox."
         ),
     ),
     "EnableSharedAccount": V4MethodContract(

--- a/tests/API_COVERAGE.md
+++ b/tests/API_COVERAGE.md
@@ -89,6 +89,30 @@ no `param`. An earlier CLI surface required `--logins` and shipped a
 `example_param=None`, and `v4finance get-credit-limits` accepts no positional
 list arguments.
 
+## V4 Live Shared Account Contract Notes
+
+The official `AccountManagement` page
+(<https://yandex.ru/dev/direct/doc/dg-v4/reference/AccountManagement-docpage/>)
+defines five `Action` values: `Get`, `Update`, `Deposit`, `Invoice`, and
+`TransferMoney`. The `direct v4account account-management` command surfaces all
+five through `--action`. Per-action shapes:
+
+| Action | Required fields | Finance token? | Dry-run rule |
+|---|---|---|---|
+| `Get` | `Action="Get"`, optional `SelectionCriteria.Logins` (≤50) and/or `AccountIDS` (≤100) | no | no rule (read-only) |
+| `Update` | `Action="Update"`, `Accounts[]` (one item) with `AccountID` plus at least one of `AccountDayBudget` / `SmsNotification` / `EmailNotification` | no | `--dry-run` required outside `--sandbox` |
+| `Deposit` | `Action="Deposit"`, `Payments[].AccountID/Amount/Currency` (≤50); optional `Origin="Overdraft"`, `Contract` per payment | yes | `--dry-run` required outside `--sandbox` |
+| `Invoice` | `Action="Invoice"`, `Payments[].AccountID/Amount/Currency` (≤50) | yes | `--dry-run` required outside `--sandbox` |
+| `TransferMoney` | `Action="TransferMoney"`, `Transfers[].FromAccountID/ToAccountID/Amount/Currency` (exactly 1 per call) | yes | `--dry-run` required outside `--sandbox` |
+
+Click-side allow-list (`_ACCOUNT_ACTION_ALLOWED_FLAGS` in
+`direct_cli/commands/v4account.py`) rejects flags that do not belong to the
+chosen action before any body is built, so an `--action Get --day-budget …`
+typo fails with a usage error and never produces a request. Currency on
+`Deposit`/`Invoice`/`TransferMoney` is one of
+`RUB / CHF / EUR / KZT / TRY / UAH / USD / BYN`; mismatches with the account
+currency surface as `error_code=245` from the API.
+
 ## Maintenance Rules
 
 - When a missing service is implemented, add it to `CLI_TO_API_SERVICE`,

--- a/tests/test_v4_contracts.py
+++ b/tests/test_v4_contracts.py
@@ -84,7 +84,7 @@ def test_account_management_get_contract_returns_money_balance():
     contract = get_v4_contract("AccountManagement")
 
     assert contract.example_param == {"Action": "Get"}
-    assert "docs-backed Update action" in contract.notes
+    assert "Get, Update, Deposit, Invoice, TransferMoney" in contract.notes
     assert build_v4_body("AccountManagement", {"Action": "Get"}) == {
         "method": "AccountManagement",
         "param": {"Action": "Get"},
@@ -105,6 +105,59 @@ def test_account_management_update_contract_uses_shared_account_objects():
                     "Email": "agrom@yandex.ru",
                     "MoneyWarningValue": 25,
                 },
+            }
+        ],
+    }
+
+    assert build_v4_body("AccountManagement", param) == {
+        "method": "AccountManagement",
+        "param": param,
+    }
+
+
+def test_account_management_deposit_contract_uses_payments_with_origin():
+    param = {
+        "Action": "Deposit",
+        "Payments": [
+            {
+                "AccountID": 1327944,
+                "Amount": 100.5,
+                "Currency": "RUB",
+                "Origin": "Overdraft",
+                "Contract": "C-1",
+            }
+        ],
+    }
+
+    assert build_v4_body("AccountManagement", param) == {
+        "method": "AccountManagement",
+        "param": param,
+    }
+
+
+def test_account_management_invoice_contract_uses_payments():
+    param = {
+        "Action": "Invoice",
+        "Payments": [
+            {"AccountID": 1327944, "Amount": 100.5, "Currency": "RUB"}
+        ],
+    }
+
+    assert build_v4_body("AccountManagement", param) == {
+        "method": "AccountManagement",
+        "param": param,
+    }
+
+
+def test_account_management_transfer_contract_uses_transfers():
+    param = {
+        "Action": "TransferMoney",
+        "Transfers": [
+            {
+                "FromAccountID": 10,
+                "ToAccountID": 20,
+                "Amount": 50.0,
+                "Currency": "RUB",
             }
         ],
     }

--- a/tests/test_v4account.py
+++ b/tests/test_v4account.py
@@ -248,14 +248,10 @@ def test_account_management_sandbox_formats_mocked_response_as_table():
                 "v4account",
                 "account-management",
                 "--action",
-                "Get",
-                "--account-id",
-                "1327944",
-                "--money-in-sms",
-                "Yes",
+                "Bogus",
                 "--dry-run",
             ),
-            "Only --action Update is supported",
+            "--action must be one of: Get, Update, Deposit, Invoice, TransferMoney",
         ),
         (
             (
@@ -381,9 +377,17 @@ def test_v4account_missing_required_flags_fail():
     assert result.exit_code != 0
     assert "Missing option '--client-login'" in result.output
 
-    result = _invoke("v4account", "account-management", "--action", "Update")
+    # --action is required for account-management.
+    result = _invoke("v4account", "account-management", "--dry-run")
     assert result.exit_code != 0
-    assert "Missing option '--account-id'" in result.output
+    assert "Missing option '--action'" in result.output
+
+    # --account-id is required for Update specifically.
+    result = _invoke(
+        "v4account", "account-management", "--action", "Update", "--dry-run"
+    )
+    assert result.exit_code != 0
+    assert "--account-id is required for --action Update" in result.output
 
 
 def test_v4account_help_contains_no_json_input_flag():
@@ -407,4 +411,540 @@ def test_v4account_commands_declare_v4_contracts():
     assert commands["account-management"].v4_method == "AccountManagement"
     assert commands["account-management"].v4_contract == get_v4_contract(
         "AccountManagement"
+    )
+
+
+# ─── AccountManagement Get ────────────────────────────────────────────────
+
+
+def test_account_management_get_dry_run_omits_selection_criteria_when_no_filters():
+    result = _invoke(
+        "v4account", "account-management", "--action", "Get", "--dry-run"
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "method": "AccountManagement",
+        "param": {"Action": "Get"},
+    }
+
+
+def test_account_management_get_dry_run_with_logins_only():
+    result = _invoke(
+        "v4account",
+        "account-management",
+        "--action",
+        "Get",
+        "--logins",
+        "client-a,client-b",
+        "--dry-run",
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "method": "AccountManagement",
+        "param": {
+            "Action": "Get",
+            "SelectionCriteria": {"Logins": ["client-a", "client-b"]},
+        },
+    }
+
+
+def test_account_management_get_dry_run_with_account_ids_only():
+    result = _invoke(
+        "v4account",
+        "account-management",
+        "--action",
+        "Get",
+        "--account-ids",
+        "1,2,3",
+        "--dry-run",
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "method": "AccountManagement",
+        "param": {
+            "Action": "Get",
+            "SelectionCriteria": {"AccountIDS": [1, 2, 3]},
+        },
+    }
+
+
+def test_account_management_get_dry_run_with_both_filters():
+    result = _invoke(
+        "v4account",
+        "account-management",
+        "--action",
+        "Get",
+        "--logins",
+        "client-a",
+        "--account-ids",
+        "1,2",
+        "--dry-run",
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "method": "AccountManagement",
+        "param": {
+            "Action": "Get",
+            "SelectionCriteria": {
+                "Logins": ["client-a"],
+                "AccountIDS": [1, 2],
+            },
+        },
+    }
+
+
+def test_account_management_get_rejects_update_only_flag():
+    with patch("direct_cli.commands.v4account.build_v4_body") as build_body:
+        result = _invoke(
+            "v4account",
+            "account-management",
+            "--action",
+            "Get",
+            "--day-budget",
+            "100",
+            "--dry-run",
+        )
+
+    assert result.exit_code != 0
+    assert "--day-budget not valid for --action Get" in result.output
+    build_body.assert_not_called()
+
+
+def test_account_management_get_does_not_require_dry_run_or_sandbox():
+    with patch("direct_cli.commands.v4account.create_v4_client") as create_client:
+        with patch(
+            "direct_cli.commands.v4account.call_v4",
+            return_value={"Accounts": []},
+        ):
+            result = _invoke(
+                "--token",
+                "token",
+                "--login",
+                "agency-login",
+                "v4account",
+                "account-management",
+                "--action",
+                "Get",
+            )
+
+    assert result.exit_code == 0
+    create_client.assert_called_once()
+
+
+def test_account_management_get_caps_logins_at_50():
+    logins = ",".join(f"login-{i}" for i in range(51))
+    with patch("direct_cli.commands.v4account.build_v4_body") as build_body:
+        result = _invoke(
+            "v4account",
+            "account-management",
+            "--action",
+            "Get",
+            "--logins",
+            logins,
+            "--dry-run",
+        )
+
+    assert result.exit_code != 0
+    assert "--logins accepts at most 50 entries" in result.output
+    build_body.assert_not_called()
+
+
+def test_account_management_get_caps_account_ids_at_100():
+    ids = ",".join(str(i) for i in range(1, 102))
+    with patch("direct_cli.commands.v4account.build_v4_body") as build_body:
+        result = _invoke(
+            "v4account",
+            "account-management",
+            "--action",
+            "Get",
+            "--account-ids",
+            ids,
+            "--dry-run",
+        )
+
+    assert result.exit_code != 0
+    assert "--account-ids accepts at most 100 entries" in result.output
+    build_body.assert_not_called()
+
+
+# ─── AccountManagement Update — additional misuse cases ───────────────────
+
+
+def test_account_management_update_rejects_get_flag():
+    with patch("direct_cli.commands.v4account.build_v4_body") as build_body:
+        result = _invoke(
+            "v4account",
+            "account-management",
+            "--action",
+            "Update",
+            "--account-id",
+            "1",
+            "--logins",
+            "a",
+            "--money-in-sms",
+            "No",
+            "--dry-run",
+        )
+
+    assert result.exit_code != 0
+    assert "--logins not valid for --action Update" in result.output
+    build_body.assert_not_called()
+
+
+# ─── AccountManagement Deposit ────────────────────────────────────────────
+
+
+def test_account_management_deposit_dry_run_masks_finance_token():
+    result = _invoke(
+        "v4account",
+        "account-management",
+        "--action",
+        "Deposit",
+        "--payment",
+        "1327944=100.50",
+        "--currency",
+        "RUB",
+        "--finance-token",
+        "secret-finance-token",
+        "--operation-num",
+        "42",
+        "--dry-run",
+    )
+
+    assert result.exit_code == 0
+    assert "secret-finance-token" not in result.output
+    assert json.loads(result.output) == {
+        "method": "AccountManagement",
+        "param": {
+            "Action": "Deposit",
+            "Payments": [
+                {"AccountID": 1327944, "Amount": 100.5, "Currency": "RUB"}
+            ],
+        },
+        "finance_token": "<redacted>",
+        "operation_num": 42,
+    }
+
+
+def test_account_management_deposit_with_origin_and_contract():
+    result = _invoke(
+        "v4account",
+        "account-management",
+        "--action",
+        "Deposit",
+        "--payment",
+        "1=10.00",
+        "--payment",
+        "2=20.00",
+        "--currency",
+        "USD",
+        "--origin",
+        "Overdraft",
+        "--contract",
+        "CONTRACT-123",
+        "--finance-token",
+        "tok",
+        "--operation-num",
+        "1",
+        "--dry-run",
+    )
+
+    assert result.exit_code == 0
+    body = json.loads(result.output)
+    assert body["param"]["Action"] == "Deposit"
+    for item in body["param"]["Payments"]:
+        assert item["Origin"] == "Overdraft"
+        assert item["Contract"] == "CONTRACT-123"
+
+
+def test_account_management_deposit_requires_dry_run_or_sandbox():
+    with patch("direct_cli.commands.v4account.create_v4_client") as create_client:
+        result = _invoke(
+            "--token",
+            "token",
+            "v4account",
+            "account-management",
+            "--action",
+            "Deposit",
+            "--payment",
+            "1=10",
+            "--currency",
+            "RUB",
+            "--finance-token",
+            "tok",
+            "--operation-num",
+            "1",
+        )
+
+    assert result.exit_code != 0
+    assert "--dry-run is required unless --sandbox is set" in result.output
+    create_client.assert_not_called()
+
+
+def test_account_management_deposit_requires_finance_credentials():
+    with patch("direct_cli.commands.v4account.build_v4_body") as build_body:
+        result = _invoke(
+            "v4account",
+            "account-management",
+            "--action",
+            "Deposit",
+            "--payment",
+            "1=10",
+            "--currency",
+            "RUB",
+            "--dry-run",
+        )
+
+    assert result.exit_code != 0
+    assert "Provide --finance-token and --operation-num" in result.output
+    build_body.assert_not_called()
+
+
+def test_account_management_deposit_requires_currency():
+    with patch("direct_cli.commands.v4account.build_v4_body") as build_body:
+        result = _invoke(
+            "v4account",
+            "account-management",
+            "--action",
+            "Deposit",
+            "--payment",
+            "1=10",
+            "--finance-token",
+            "tok",
+            "--operation-num",
+            "1",
+            "--dry-run",
+        )
+
+    assert result.exit_code != 0
+    assert "--currency is required for --action Deposit" in result.output
+    build_body.assert_not_called()
+
+
+def test_account_management_deposit_rejects_duplicate_account_ids():
+    with patch("direct_cli.commands.v4account.build_v4_body") as build_body:
+        result = _invoke(
+            "v4account",
+            "account-management",
+            "--action",
+            "Deposit",
+            "--payment",
+            "1=10",
+            "--payment",
+            "1=20",
+            "--currency",
+            "RUB",
+            "--finance-token",
+            "tok",
+            "--operation-num",
+            "1",
+            "--dry-run",
+        )
+
+    assert result.exit_code != 0
+    assert "--payment account IDs must be unique" in result.output
+    build_body.assert_not_called()
+
+
+# ─── AccountManagement Invoice ────────────────────────────────────────────
+
+
+def test_account_management_invoice_dry_run_uses_payments_without_origin():
+    result = _invoke(
+        "v4account",
+        "account-management",
+        "--action",
+        "Invoice",
+        "--payment",
+        "1=50.00",
+        "--currency",
+        "EUR",
+        "--finance-token",
+        "tok",
+        "--operation-num",
+        "1",
+        "--dry-run",
+    )
+
+    assert result.exit_code == 0
+    body = json.loads(result.output)
+    assert body["param"] == {
+        "Action": "Invoice",
+        "Payments": [{"AccountID": 1, "Amount": 50.0, "Currency": "EUR"}],
+    }
+    assert "Origin" not in body["param"]["Payments"][0]
+    assert "Contract" not in body["param"]["Payments"][0]
+
+
+def test_account_management_invoice_rejects_origin_flag():
+    with patch("direct_cli.commands.v4account.build_v4_body") as build_body:
+        result = _invoke(
+            "v4account",
+            "account-management",
+            "--action",
+            "Invoice",
+            "--payment",
+            "1=10",
+            "--currency",
+            "RUB",
+            "--origin",
+            "Overdraft",
+            "--finance-token",
+            "tok",
+            "--operation-num",
+            "1",
+            "--dry-run",
+        )
+
+    assert result.exit_code != 0
+    assert "--origin not valid for --action Invoice" in result.output
+    build_body.assert_not_called()
+
+
+# ─── AccountManagement TransferMoney ──────────────────────────────────────
+
+
+def test_account_management_transfer_dry_run_uses_single_transfer():
+    result = _invoke(
+        "v4account",
+        "account-management",
+        "--action",
+        "TransferMoney",
+        "--from-account-id",
+        "10",
+        "--to-account-id",
+        "20",
+        "--amount",
+        "50.00",
+        "--currency",
+        "RUB",
+        "--finance-token",
+        "tok",
+        "--operation-num",
+        "1",
+        "--dry-run",
+    )
+
+    assert result.exit_code == 0
+    body = json.loads(result.output)
+    assert body["param"] == {
+        "Action": "TransferMoney",
+        "Transfers": [
+            {
+                "FromAccountID": 10,
+                "ToAccountID": 20,
+                "Amount": 50.0,
+                "Currency": "RUB",
+            }
+        ],
+    }
+
+
+def test_account_management_transfer_rejects_equal_from_to():
+    with patch("direct_cli.commands.v4account.build_v4_body") as build_body:
+        result = _invoke(
+            "v4account",
+            "account-management",
+            "--action",
+            "TransferMoney",
+            "--from-account-id",
+            "10",
+            "--to-account-id",
+            "10",
+            "--amount",
+            "50",
+            "--currency",
+            "RUB",
+            "--finance-token",
+            "tok",
+            "--operation-num",
+            "1",
+            "--dry-run",
+        )
+
+    assert result.exit_code != 0
+    assert "--from-account-id and --to-account-id must differ" in result.output
+    build_body.assert_not_called()
+
+
+def test_account_management_transfer_requires_currency():
+    with patch("direct_cli.commands.v4account.build_v4_body") as build_body:
+        result = _invoke(
+            "v4account",
+            "account-management",
+            "--action",
+            "TransferMoney",
+            "--from-account-id",
+            "10",
+            "--to-account-id",
+            "20",
+            "--amount",
+            "50",
+            "--finance-token",
+            "tok",
+            "--operation-num",
+            "1",
+            "--dry-run",
+        )
+
+    assert result.exit_code != 0
+    assert "--currency is required for --action TransferMoney" in result.output
+    build_body.assert_not_called()
+
+
+def test_account_management_transfer_requires_all_three_flags():
+    with patch("direct_cli.commands.v4account.build_v4_body") as build_body:
+        result = _invoke(
+            "v4account",
+            "account-management",
+            "--action",
+            "TransferMoney",
+            "--from-account-id",
+            "10",
+            "--currency",
+            "RUB",
+            "--finance-token",
+            "tok",
+            "--operation-num",
+            "1",
+            "--dry-run",
+        )
+
+    assert result.exit_code != 0
+    assert (
+        "--from-account-id, --to-account-id, and --amount are required"
+        in result.output
+    )
+    build_body.assert_not_called()
+
+
+# ─── Allow-list integrity ─────────────────────────────────────────────────
+
+
+def test_account_management_options_are_all_in_allow_list():
+    """Every Click option on account-management must appear in some allow-list."""
+    from direct_cli.commands.v4account import (
+        _ACCOUNT_ACTION_ALLOWED_FLAGS,
+        _COMMON_PARAMS,
+    )
+
+    command = cli.commands["v4account"].commands["account-management"]
+    option_param_names = {
+        opt.name
+        for opt in command.params
+        if opt.name not in {"format"}  # 'format' is the dest for --format
+    }
+    option_param_names.add("output_format")  # explicit dest
+
+    covered = set(_COMMON_PARAMS)
+    for allowed in _ACCOUNT_ACTION_ALLOWED_FLAGS.values():
+        covered |= allowed
+
+    uncovered = option_param_names - covered
+    assert not uncovered, (
+        f"account-management options not in any allow-list: {sorted(uncovered)}"
     )

--- a/tests/test_v4account.py
+++ b/tests/test_v4account.py
@@ -14,7 +14,9 @@ def _invoke(*args: str, env: Optional[dict] = None):
         "YANDEX_DIRECT_TOKEN": "",
         "YANDEX_DIRECT_LOGIN": "",
         "YANDEX_DIRECT_FINANCE_TOKEN": "",
+        "YANDEX_DIRECT_MASTER_TOKEN": "",
         "YANDEX_DIRECT_OPERATION_NUM": "",
+        "YANDEX_DIRECT_FINANCE_LOGIN": "",
     }
     if env:
         base_env.update(env)
@@ -948,3 +950,77 @@ def test_account_management_options_are_all_in_allow_list():
     assert not uncovered, (
         f"account-management options not in any allow-list: {sorted(uncovered)}"
     )
+
+
+# ─── Envvar-vs-CLI source distinction (regression for PR #234 review) ────
+
+
+def test_account_management_get_ignores_finance_envvars():
+    """Finance envvars exported in the shell must not break --action Get."""
+    result = _invoke(
+        "v4account",
+        "account-management",
+        "--action",
+        "Get",
+        "--dry-run",
+        env={
+            "YANDEX_DIRECT_FINANCE_TOKEN": "env-finance-token",
+            "YANDEX_DIRECT_MASTER_TOKEN": "env-master-token",
+            "YANDEX_DIRECT_OPERATION_NUM": "42",
+            "YANDEX_DIRECT_FINANCE_LOGIN": "env-login",
+        },
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == {
+        "method": "AccountManagement",
+        "param": {"Action": "Get"},
+    }
+
+
+def test_account_management_update_ignores_finance_envvars():
+    """Finance envvars exported in the shell must not break --action Update."""
+    result = _invoke(
+        "v4account",
+        "account-management",
+        "--action",
+        "Update",
+        "--account-id",
+        "1",
+        "--money-in-sms",
+        "No",
+        "--dry-run",
+        env={
+            "YANDEX_DIRECT_FINANCE_TOKEN": "env-finance-token",
+            "YANDEX_DIRECT_MASTER_TOKEN": "env-master-token",
+            "YANDEX_DIRECT_OPERATION_NUM": "42",
+            "YANDEX_DIRECT_FINANCE_LOGIN": "env-login",
+        },
+    )
+
+    assert result.exit_code == 0, result.output
+
+
+def test_account_management_deposit_misleading_amount_message_uses_payment_label():
+    """A bad amount in --payment must point at --payment, not --amount."""
+    with patch("direct_cli.commands.v4account.build_v4_body") as build_body:
+        result = _invoke(
+            "v4account",
+            "account-management",
+            "--action",
+            "Deposit",
+            "--payment",
+            "1=bad",
+            "--currency",
+            "RUB",
+            "--finance-token",
+            "tok",
+            "--operation-num",
+            "1",
+            "--dry-run",
+        )
+
+    assert result.exit_code != 0
+    assert "--payment" in result.output
+    assert "--amount" not in result.output
+    build_body.assert_not_called()


### PR DESCRIPTION
## Summary

Per the [official v4 Live docs](https://yandex.ru/dev/direct/doc/dg-v4/reference/AccountManagement-docpage/), the `AccountManagement` method exposes five `Action` values. The CLI previously hard-rejected everything except `Update`. This PR extends `direct v4account account-management` to dispatch all five actions through the existing single-command + `--action` switch (mirroring the API: one method, five actions).

| Action | What it does | Needs finance token? | Dry-run rule |
|---|---|---|---|
| `Get` | Read-only; `--logins` / `--account-ids` → `SelectionCriteria` | no | none (read-only) |
| `Update` | Existing behavior; `--account-id` now Update-specific | no | dry-run unless `--sandbox` |
| `Deposit` | `--payment ACCOUNT_ID=AMOUNT` (≤50), `--currency`, optional `--origin Overdraft`, optional `--contract` | yes | dry-run unless `--sandbox` |
| `Invoice` | Same Payments shape as Deposit, no Origin/Contract | yes | dry-run unless `--sandbox` |
| `TransferMoney` | Single `--from-account-id` / `--to-account-id` / `--amount` / `--currency` → `Transfers[0]` | yes | dry-run unless `--sandbox` |

Financial sub-actions reuse v4finance's finance-token plumbing (`_finance_credentials`, `_masked_finance_body`). A Click-side allow-list (`_ACCOUNT_ACTION_ALLOWED_FLAGS`) rejects flags that do not belong to the chosen action before any body is built, so `--action Get --day-budget …` fails with a usage error and never produces a request.

## Test plan

- [x] `pytest tests/test_v4account.py tests/test_v4_contracts.py tests/test_v4_safety.py tests/test_v4_foundation.py tests/test_v4_runtime_shape.py tests/test_comprehensive.py tests/test_smoke_matrix.py tests/test_v4finance_money.py tests/test_v4finance_read.py` (194 passed)
- [x] Manual smoke (dry-run) — all 5 actions emit the expected request bodies:
  - `--action Get` / `Get --logins …` / `Get --account-ids …` / `Get --logins … --account-ids …`
  - `--action Update --account-id 1 --money-in-sms No`
  - `--action Deposit --payment 100=50.00 --currency RUB --master-token T --operation-num 1 --finance-login me` (with and without `--origin Overdraft --contract C1`)
  - `--action Invoice --payment 100=50.00 --currency RUB …`
  - `--action TransferMoney --from-account-id 1 --to-account-id 2 --amount 50.00 --currency RUB …`
- [x] Manual smoke (negative paths) — all exit 2 with the expected message:
  - `--action Get --day-budget 100` → `--day-budget not valid for --action Get`
  - `--action Update --payment 1=2` → `--payment not valid for --action Update`
  - `--action Deposit --payment 100=50.00 --currency RUB` without finance creds → `Provide --finance-token and --operation-num...`
  - `--action Bogus` → `--action must be one of: Get, Update, Deposit, Invoice, TransferMoney`

Part of #125 (see audit comment for full context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)