### PR TITLE
fix(cli): augment NoSuchOption errors with cross-command hints (#236)

### DIFF
--- a/direct_cli/cli.py
+++ b/direct_cli/cli.py
@@ -68,7 +68,106 @@ API errors:
 """
 
 
-@click.group(name="direct", epilog=CLI_EPILOG)
+def _command_has_option(cmd: click.Command, option_name: str) -> bool:
+    """Whether *cmd* declares *option_name* among its Click options.
+
+    Searches all option names (including hidden ones), so `keywords update`
+    with its hidden deprecated traps still counts as "having" `--bid` and
+    won't be advertised as a sibling that accepts the flag.
+    """
+    return any(
+        isinstance(param, click.Option) and option_name in param.opts
+        for param in cmd.params
+    )
+
+
+def _augment_no_such_option(
+    exc: click.exceptions.NoSuchOption, ctx: click.Context
+) -> None:
+    """Append a cross-command hint to a NoSuchOption error.
+
+    For `direct <group> <cmd> --bad-flag`, finds sibling subcommands of
+    `<group>` that declare `--bad-flag` and tells the user where to use
+    it instead. When no sibling matches, points at `--help`.
+    """
+    parent = ctx.parent
+    if parent is None or parent.command is None:
+        return  # Unknown option on the root group — leave Click's default.
+
+    group = parent.command
+    if not isinstance(group, click.Group):
+        return
+
+    bad = exc.option_name
+    siblings = sorted(
+        name
+        for name, sibling in group.commands.items()
+        if name != ctx.info_name and _command_has_option(sibling, bad)
+    )
+    group_path = parent.command_path  # e.g. "direct ads" (leaf) or "direct" (group)
+    current_path = ctx.command_path  # e.g. "direct ads update" or "direct ads"
+
+    if siblings:
+        sibling_paths = " or ".join(f"`{group_path} {name}`" for name in siblings)
+        hint = (
+            f"Hint: {bad} is accepted by {sibling_paths}, not by `{current_path}`. "
+            f"This usually means the Yandex Direct API does not expose that "
+            f"field on the selected operation. Run `{current_path} --help` to "
+            f"see available flags."
+        )
+    else:
+        hint = f"Run `{current_path} --help` to see available flags."
+
+    # Fold the "Did you mean..." suggestion into self.message now and clear
+    # `possibilities` so Click's NoSuchOption.format_message() does not
+    # re-append it after the Hint on print.
+    exc.message = f"{exc.format_message()}\n\n{hint}"
+    exc.possibilities = None
+
+
+class _NoSuchOptionHintMixin:
+    """Mixin that augments NoSuchOption errors raised by ``parse_args``."""
+
+    def parse_args(self, ctx, args):
+        try:
+            return super().parse_args(ctx, args)
+        except click.exceptions.NoSuchOption as exc:
+            _augment_no_such_option(exc, ctx)
+            raise
+
+
+class DirectCliCommand(_NoSuchOptionHintMixin, click.Command):
+    """Click Command that augments NoSuchOption errors with sibling hints."""
+
+
+class DirectCliGroup(_NoSuchOptionHintMixin, click.Group):
+    """Click Group that retypes descendants and augments NoSuchOption on
+    the group itself (e.g. `direct ads --bogus get`)."""
+
+    command_class = DirectCliCommand
+
+
+def _apply_directcli_classes(command: click.Command) -> None:
+    """Recursively retype *command* (and subcommands) so every node in the
+    tree intercepts NoSuchOption.
+
+    Subcommand modules use plain ``@click.group()`` / ``@click.command()``
+    without ``cls=``. Rather than touch 39 command files, we mutate
+    ``__class__`` after registration. The identity check (``type(...) is``
+    rather than ``isinstance``) is deliberate: a contributor who registers
+    a command with a custom subclass is opting out of the hint, not into
+    silent retyping that would discard their behaviour.
+    """
+    if isinstance(command, click.Group):
+        if type(command) is click.Group:  # noqa: PIE789 — see docstring
+            command.__class__ = DirectCliGroup
+        for subcommand in command.commands.values():
+            _apply_directcli_classes(subcommand)
+    elif type(command) is click.Command:  # noqa: PIE789 — see docstring
+        command.__class__ = DirectCliCommand
+
+
+@click.group(name="direct", cls=DirectCliGroup, epilog=CLI_EPILOG)
 @click.version_option(__version__, prog_name="direct")
 @click.option("--token", envvar="YANDEX_DIRECT_TOKEN", help="API access token")
 @click.option("--login", envvar="YANDEX_DIRECT_LOGIN", help="Client login")
@@ -160,6 +259,7 @@ def _register_command(command: click.Command) -> None:
         command.epilog = (
             f"{command.epilog}\n\n{docs_line}" if command.epilog else docs_line
         )
+    _apply_directcli_classes(command)
     cli.add_command(command)
 
 

--- a/direct_cli/cli.py
+++ b/direct_cli/cli.py
@@ -71,12 +71,14 @@ API errors:
 def _command_has_option(cmd: click.Command, option_name: str) -> bool:
     """Whether *cmd* declares *option_name* among its Click options.
 
-    Searches all option names (including hidden ones), so `keywords update`
-    with its hidden deprecated traps still counts as "having" `--bid` and
-    won't be advertised as a sibling that accepts the flag.
+    Searches both ``opts`` (e.g. ``--send-warnings``) and ``secondary_opts``
+    (e.g. ``--no-send-warnings`` for ``--foo/--no-foo`` style switches), and
+    includes hidden options — so `keywords update`'s hidden deprecated traps
+    still count as "having" `--bid` and won't be advertised as siblings.
     """
     return any(
-        isinstance(param, click.Option) and option_name in param.opts
+        isinstance(param, click.Option)
+        and (option_name in param.opts or option_name in param.secondary_opts)
         for param in cmd.params
     )
 

--- a/tests/test_unknown_option_hints.py
+++ b/tests/test_unknown_option_hints.py
@@ -1,0 +1,150 @@
+"""Regression for issue #236.
+
+When a user passes an option that does not exist on the selected
+subcommand, the CLI augments Click's stock ``NoSuchOption`` error with a
+hint pointing at sibling subcommands (within the same group) that *do*
+declare the option. The first line of the message is still the standard
+``Error: No such option '--X'``, so legacy substring asserts keep
+working.
+"""
+
+from click.testing import CliRunner
+
+from direct_cli.cli import cli
+
+
+def _invoke(*argv: str):
+    return CliRunner().invoke(cli, list(argv))
+
+
+def test_ads_update_unknown_option_hints_at_ads_add():
+    """--ad-extensions exists only in `ads add` — hint must say so."""
+    result = _invoke(
+        "ads",
+        "update",
+        "--id",
+        "1",
+        "--type",
+        "TEXT_AD",
+        "--ad-extensions",
+        "1,2",
+        "--dry-run",
+    )
+    assert result.exit_code == 2
+    # First line preserves the stock Click message (substring contract
+    # from tests/test_dry_run.py:1209).
+    assert "No such option" in result.output
+    assert "--ad-extensions" in result.output
+    # Hint points the user at the sibling that accepts the flag.
+    assert "Hint:" in result.output
+    assert "`direct ads add`" in result.output
+    assert "`direct ads update`" in result.output
+    assert "`direct ads update --help`" in result.output
+
+
+def test_ads_update_unknown_mobile_hints_at_ads_add():
+    """--mobile is the original symptom from issue #236 along with
+    --ad-extensions."""
+    result = _invoke(
+        "ads",
+        "update",
+        "--id",
+        "1",
+        "--type",
+        "TEXT_AD",
+        "--mobile",
+        "NO",
+        "--dry-run",
+    )
+    assert result.exit_code == 2
+    assert "No such option" in result.output
+    assert "--mobile" in result.output
+    assert "Hint:" in result.output
+    assert "`direct ads add`" in result.output
+
+
+def test_campaigns_update_unknown_option_hints_at_campaigns_add():
+    """campaigns add carries many flags absent from campaigns update —
+    --counter-ids is one of them."""
+    result = _invoke(
+        "campaigns",
+        "update",
+        "--id",
+        "1",
+        "--counter-ids",
+        "1,2",
+    )
+    assert result.exit_code == 2
+    assert "No such option" in result.output
+    assert "--counter-ids" in result.output
+    assert "Hint:" in result.output
+    assert "`direct campaigns add`" in result.output
+
+
+def test_typo_with_no_sibling_match_falls_back_to_help_hint():
+    """When no sibling declares the option, we just point at --help."""
+    result = _invoke("ads", "update", "--id", "1", "--this-flag-does-not-exist", "X")
+    assert result.exit_code == 2
+    assert "No such option" in result.output
+    assert "--this-flag-does-not-exist" in result.output
+    # No sibling has this — make sure we did not hallucinate one.
+    assert "is accepted by" not in result.output
+    # We still nudge to --help.
+    assert "`direct ads update --help`" in result.output
+
+
+def test_unknown_option_on_subgroup_also_gets_hint():
+    """Unknown option passed to a group node (not a leaf command) — e.g.
+    `direct ads --bogus get` — still goes through DirectCliGroup.parse_args
+    and gets the help-hint fallback (no siblings can declare it because the
+    siblings here are the root group's children)."""
+    result = _invoke("ads", "--bogus-group-flag", "get")
+    assert result.exit_code == 2
+    assert "No such option" in result.output
+    assert "--bogus-group-flag" in result.output
+    # parent is the root `cli`; siblings (campaigns, adgroups, ...) don't
+    # share command-level options. We expect the help fallback, not silence.
+    assert "`direct ads --help`" in result.output
+
+
+def test_unknown_option_on_root_group_is_unchanged():
+    """Root-level unknown options keep Click's default formatting; we do
+    not have meaningful sibling info to add."""
+    result = _invoke("--definitely-not-a-root-flag", "campaigns", "get")
+    assert result.exit_code == 2
+    assert "No such option" in result.output
+    assert "--definitely-not-a-root-flag" in result.output
+    # We deliberately do not augment at the root.
+    assert "Hint:" not in result.output
+
+
+def test_hidden_deprecated_callback_still_takes_precedence():
+    """`keywords update --bid` is a hidden deprecated trap with a
+    custom message (keywords.py:_DEPRECATED_KEYWORDS_UPDATE_OPTIONS).
+    The flag exists on the command (hidden), so parse_args succeeds and
+    our NoSuchOption hook is never reached — the existing message wins.
+    """
+    result = _invoke("keywords", "update", "--id", "1", "--bid", "5")
+    assert result.exit_code == 2
+    assert "is no longer accepted on 'keywords update'" in result.output
+    assert "direct bids set" in result.output
+    # Our hook must not have fired.
+    assert "Hint:" not in result.output
+
+
+def test_existing_substring_assert_for_ad_extensions_still_holds():
+    """Backwards-compat: the assert from tests/test_dry_run.py:1209 must
+    continue to match — our augmentation only appends to the message."""
+    result = _invoke(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "TEXT_AD",
+        "--ad-extensions",
+        "1,2",
+        "--dry-run",
+    )
+    assert result.exit_code != 0
+    assert "No such option" in result.output and "--ad-extensions" in result.output

--- a/tests/test_unknown_option_hints.py
+++ b/tests/test_unknown_option_hints.py
@@ -132,6 +132,29 @@ def test_hidden_deprecated_callback_still_takes_precedence():
     assert "Hint:" not in result.output
 
 
+def test_no_foo_secondary_opt_is_recognised_as_sibling_option():
+    """Regression for the Copilot/claude review on PR #237: Click stores
+    the negative spelling of ``--foo/--no-foo`` switches in
+    ``param.secondary_opts``, not ``param.opts``. ``agencyclients add``
+    declares ``--send-warnings/--no-send-warnings`` and so does
+    ``add-passport-organization``; ``agencyclients update`` does not.
+    The hint must point at the right siblings.
+    """
+    result = _invoke(
+        "agencyclients",
+        "update",
+        "--client-id",
+        "1",
+        "--no-send-warnings",
+    )
+    assert result.exit_code == 2
+    assert "No such option" in result.output
+    assert "--no-send-warnings" in result.output
+    assert "Hint:" in result.output
+    assert "`direct agencyclients add`" in result.output
+    assert "`direct agencyclients add-passport-organization`" in result.output
+
+
 def test_existing_substring_assert_for_ad_extensions_still_holds():
     """Backwards-compat: the assert from tests/test_dry_run.py:1209 must
     continue to match — our augmentation only appends to the message."""


### PR DESCRIPTION
## Summary

- Adds a `DirectCliGroup`/`DirectCliCommand` pair that intercepts `click.exceptions.NoSuchOption` in `parse_args` and appends a hint pointing at sibling subcommands that **do** accept the unknown option.
- For `direct ads update --ad-extensions ...` (issue #236), the user now sees that `--ad-extensions` is accepted by `direct ads add` but not by `direct ads update` (the WSDL `TextAdUpdate` type does not declare `AdExtensionIds` — API rejects with error 8000).
- Generalises beyond #236: the hint surfaces all add/update flag asymmetries across the CLI (campaigns, adgroups, bidmodifiers, keywords, feeds, …), not just `ads`.

## Behaviour

```
$ direct ads update --id 1 --type TEXT_AD --ad-extensions "1,2" --dry-run
Usage: direct ads update [OPTIONS]
Try 'direct ads update --help' for help.

Error: No such option '--ad-extensions'. Did you mean '--action'?

Hint: --ad-extensions is accepted by \`direct ads add\`, not by \`direct ads update\`.
This usually means the Yandex Direct API does not expose that field on the
selected operation. Run \`direct ads update --help\` to see available flags.
```

For unknown options with no sibling match (typos), the hint falls back to `--help`. Unknown options on the root group are left untouched. Hidden deprecated callbacks (`keywords update --bid`, `bidmodifiers set --campaign-id`) continue to fire with their own messages — they parse successfully and never raise `NoSuchOption`.

The first line of the error is unchanged (`Error: No such option '--X'`), so the five existing substring asserts in `tests/test_dry_run.py` and `tests/test_low_coverage_payloads.py` keep working.

## Implementation notes

- Single touch point: `direct_cli/cli.py`. The 39 command modules and the four local copies of `_reject_incompatible_flags` are untouched.
- `_apply_directcli_classes()` mutates `__class__` after `add_command()` so the override applies tree-wide without forcing every command module to pass `cls=`.
- `ctx.command_path` is used for path rendering so group-level errors (`direct ads --bogus get`) don't produce `direct direct ads` duplicates.
- `exc.possibilities = None` after the first `format_message()` prevents Click from re-appending "Did you mean…" after the hint.

## Test plan

- [x] `tests/test_unknown_option_hints.py` (new, 8 tests) — sibling-hint, no-sibling fallback, root group untouched, group-node path, hidden-callback precedence, substring back-compat.
- [x] Full unit suite: `995 passed, 45 skipped, 30 subtests passed`.
- [x] Regression: `tests/test_dry_run.py::test_ads_update_rejects_ad_extensions_flag`, `test_ads_update_rejects_mobile_flag`, `tests/test_low_coverage_payloads.py::test_strategies_rejects_legacy_json_blob_flags`, `tests/test_v4_exit_codes.py` (exit_code 2 for UsageError contract).
- [x] `black --check` and `flake8` clean.

## Downstream

This stabilises the message that [axisrow/yandex-direct-mcp-plugin#125](https://github.com/axisrow/yandex-direct-mcp-plugin/issues/125) was waiting for. The plugin can now either drop `ad_extensions` from its `ads_update` schema or relay the new hint to its users.

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)