### PR TITLE
[codex] Add adgroup tracking params flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,10 +379,10 @@ direct campaigns delete --id 12345
 
 ```bash
 direct adgroups get --campaign-ids 1,2,3 --limit 50
-direct adgroups add --name "Group 1" --campaign-id 12345 --region-ids 1,225 --dry-run
+direct adgroups add --name "Group 1" --campaign-id 12345 --region-ids 1,225 --tracking-params "utm_source=direct" --dry-run
 direct adgroups add --name "Dynamic Group" --campaign-id 12345 --type DYNAMIC_TEXT_AD_GROUP --region-ids 1,225 --domain-url example.com --dry-run
 direct adgroups add --name "Smart Group" --campaign-id 12345 --type SMART_AD_GROUP --region-ids 1,225 --feed-id 170 --ad-title-source FEED_NAME --ad-body-source FEED_NAME --dry-run
-direct adgroups update --id 67890 --name "New Name" --status SUSPENDED --region-ids 1,225
+direct adgroups update --id 67890 --tracking-params "utm_source=direct"
 direct adgroups delete --id 67890
 ```
 
@@ -1080,10 +1080,10 @@ direct campaigns delete --id 12345
 
 ```bash
 direct adgroups get --campaign-ids 1,2,3 --limit 50
-direct adgroups add --name "Группа 1" --campaign-id 12345 --region-ids 1,225 --dry-run
+direct adgroups add --name "Группа 1" --campaign-id 12345 --region-ids 1,225 --tracking-params "utm_source=direct" --dry-run
 direct adgroups add --name "Динамическая группа" --campaign-id 12345 --type DYNAMIC_TEXT_AD_GROUP --region-ids 1,225 --domain-url example.com --dry-run
 direct adgroups add --name "Смарт-группа" --campaign-id 12345 --type SMART_AD_GROUP --region-ids 1,225 --feed-id 170 --ad-title-source FEED_NAME --ad-body-source FEED_NAME --dry-run
-direct adgroups update --id 67890 --name "Новое название" --status SUSPENDED --region-ids 1,225
+direct adgroups update --id 67890 --tracking-params "utm_source=direct"
 direct adgroups delete --id 67890
 ```
 

--- a/direct_cli/commands/adgroups.py
+++ b/direct_cli/commands/adgroups.py
@@ -2,16 +2,32 @@
 Ad Groups commands
 """
 
+from typing import Optional
+
 import click
 
 from ..api import create_client
 from ..output import format_output, print_error
 from ..utils import add_criteria_csv, get_default_fields, parse_ids
 
+_TRACKING_PARAMS_MAX_LENGTH = 1024
+
 
 @click.group()
 def adgroups():
     """Manage ad groups"""
+
+
+def _validate_tracking_params(tracking_params: Optional[str]) -> None:
+    """Validate AdGroup*.TrackingParams documented API constraints."""
+    if (
+        tracking_params is not None
+        and len(tracking_params) > _TRACKING_PARAMS_MAX_LENGTH
+    ):
+        raise click.UsageError(
+            "--tracking-params must be at most "
+            f"{_TRACKING_PARAMS_MAX_LENGTH} characters"
+        )
 
 
 def _reject_incompatible_flags(
@@ -151,6 +167,14 @@ def get(
 @click.option("--feed-id", type=int, help="Smart ad group feed ID")
 @click.option("--ad-title-source", help="Smart ad group title source")
 @click.option("--ad-body-source", help="Smart ad group body source")
+@click.option(
+    "--tracking-params",
+    "tracking_params",
+    help=(
+        "Tracking params query-string for AdGroupAddItem.TrackingParams "
+        "(max 1024 chars)"
+    ),
+)
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
 def add(
@@ -163,10 +187,13 @@ def add(
     feed_id,
     ad_title_source,
     ad_body_source,
+    tracking_params,
     dry_run,
 ):
     """Add new ad group"""
     try:
+        _validate_tracking_params(tracking_params)
+
         group_type_norm = (group_type or "TEXT_AD_GROUP").upper().replace("-", "_")
         supported_types = {
             "TEXT_AD_GROUP",
@@ -199,6 +226,8 @@ def add(
 
         if region_ids:
             adgroup_data["RegionIds"] = parse_ids(region_ids)
+        if tracking_params:
+            adgroup_data["TrackingParams"] = tracking_params
         if group_type_norm == "DYNAMIC_TEXT_AD_GROUP":
             if not domain_url:
                 raise click.UsageError(
@@ -242,10 +271,20 @@ def add(
 @click.option("--name", help="New ad group name")
 @click.option("--status", help="New status")
 @click.option("--region-ids", help="Comma-separated region IDs")
+@click.option(
+    "--tracking-params",
+    "tracking_params",
+    help=(
+        "Tracking params query-string for AdGroupUpdateItem.TrackingParams "
+        "(max 1024 chars)"
+    ),
+)
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def update(ctx, adgroup_id, name, status, region_ids, dry_run):
+def update(ctx, adgroup_id, name, status, region_ids, tracking_params, dry_run):
     """Update ad group"""
+    _validate_tracking_params(tracking_params)
+
     adgroup_data = {"Id": adgroup_id}
 
     if name:
@@ -255,12 +294,14 @@ def update(ctx, adgroup_id, name, status, region_ids, dry_run):
         adgroup_data["Status"] = status
     if region_ids:
         adgroup_data["RegionIds"] = parse_ids(region_ids)
+    if tracking_params:
+        adgroup_data["TrackingParams"] = tracking_params
 
     # Reject empty-payload no-op (issue #198 H5).
     if len(adgroup_data) == 1:
         raise click.UsageError(
             "adgroups update requires at least one updatable field "
-            "(--name, --status, or --region-ids)."
+            "(--name, --status, --region-ids, or --tracking-params)."
         )
 
     try:

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,8 +11,8 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 2857 |
-| `supported` | 384 |
+| `missing_followup` | 2855 |
+| `supported` | 386 |
 
 ## Confirmed Follow-Ups
 
@@ -22,7 +22,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `adgroups.add` | `NegativeKeywords.Items` | Ad-group-level negative keywords are not exposed on add. [#243](https://github.com/axisrow/direct-cli/issues/243); inherited from `NegativeKeywords` |
 | `adgroups.add` | `NegativeKeywordSharedSetIds` | Shared-set IDs are read-filterable but not addable. [#243](https://github.com/axisrow/direct-cli/issues/243) |
 | `adgroups.add` | `NegativeKeywordSharedSetIds.Items` | Shared-set IDs are read-filterable but not addable. [#243](https://github.com/axisrow/direct-cli/issues/243); inherited from `NegativeKeywordSharedSetIds` |
-| `adgroups.add` | `TrackingParams` | AdGroupAddItem.TrackingParams has no typed flag. [#242](https://github.com/axisrow/direct-cli/issues/242) |
 | `adgroups.add` | `MobileAppAdGroup` | Rare ad group subtype block is not exposed by --type. [#247](https://github.com/axisrow/direct-cli/issues/247) |
 | `adgroups.add` | `MobileAppAdGroup.StoreUrl` | Rare ad group subtype block is not exposed by --type. [#247](https://github.com/axisrow/direct-cli/issues/247); inherited from `MobileAppAdGroup` |
 | `adgroups.add` | `MobileAppAdGroup.TargetDeviceType` | Rare ad group subtype block is not exposed by --type. [#247](https://github.com/axisrow/direct-cli/issues/247); inherited from `MobileAppAdGroup` |
@@ -71,7 +70,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `adgroups.update` | `NegativeKeywords.Items` | Ad-group-level negative keywords are not exposed on update. [#243](https://github.com/axisrow/direct-cli/issues/243); inherited from `NegativeKeywords` |
 | `adgroups.update` | `NegativeKeywordSharedSetIds` | Shared-set IDs are read-filterable but not updatable. [#243](https://github.com/axisrow/direct-cli/issues/243) |
 | `adgroups.update` | `NegativeKeywordSharedSetIds.Items` | Shared-set IDs are read-filterable but not updatable. [#243](https://github.com/axisrow/direct-cli/issues/243); inherited from `NegativeKeywordSharedSetIds` |
-| `adgroups.update` | `TrackingParams` | AdGroupUpdateItem.TrackingParams has no typed flag. [#242](https://github.com/axisrow/direct-cli/issues/242) |
 | `adgroups.update` | `MobileAppAdGroup` | Rare ad group subtype block is not exposed by update. [#247](https://github.com/axisrow/direct-cli/issues/247) |
 | `adgroups.update` | `MobileAppAdGroup.TargetDeviceType` | Rare ad group subtype block is not exposed by update. [#247](https://github.com/axisrow/direct-cli/issues/247); inherited from `MobileAppAdGroup` |
 | `adgroups.update` | `MobileAppAdGroup.TargetCarrier` | Rare ad group subtype block is not exposed by update. [#247](https://github.com/axisrow/direct-cli/issues/247); inherited from `MobileAppAdGroup` |
@@ -2889,7 +2887,7 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `adgroups.add` | `adgroups.add` | `NegativeKeywords.Items` | `string` | 1 | unbounded | `missing_followup` | Ad-group-level negative keywords are not exposed on add. [#243](https://github.com/axisrow/direct-cli/issues/243); inherited from `NegativeKeywords` |
 | `adgroups.add` | `adgroups.add` | `NegativeKeywordSharedSetIds` | `ArrayOfLong` | 0 | 1 | `missing_followup` | Shared-set IDs are read-filterable but not addable. [#243](https://github.com/axisrow/direct-cli/issues/243) |
 | `adgroups.add` | `adgroups.add` | `NegativeKeywordSharedSetIds.Items` | `long` | 1 | unbounded | `missing_followup` | Shared-set IDs are read-filterable but not addable. [#243](https://github.com/axisrow/direct-cli/issues/243); inherited from `NegativeKeywordSharedSetIds` |
-| `adgroups.add` | `adgroups.add` | `TrackingParams` | `string` | 0 | 1 | `missing_followup` | AdGroupAddItem.TrackingParams has no typed flag. [#242](https://github.com/axisrow/direct-cli/issues/242) |
+| `adgroups.add` | `adgroups.add` | `TrackingParams` | `string` | 0 | 1 | `supported` | --tracking-params |
 | `adgroups.add` | `adgroups.add` | `MobileAppAdGroup` | `MobileAppAdGroupAdd` | 0 | 1 | `missing_followup` | Rare ad group subtype block is not exposed by --type. [#247](https://github.com/axisrow/direct-cli/issues/247) |
 | `adgroups.add` | `adgroups.add` | `MobileAppAdGroup.StoreUrl` | `string` | 1 | 1 | `missing_followup` | Rare ad group subtype block is not exposed by --type. [#247](https://github.com/axisrow/direct-cli/issues/247); inherited from `MobileAppAdGroup` |
 | `adgroups.add` | `adgroups.add` | `MobileAppAdGroup.TargetDeviceType` | `TargetDeviceTypeEnum` | 1 | unbounded | `missing_followup` | Rare ad group subtype block is not exposed by --type. [#247](https://github.com/axisrow/direct-cli/issues/247); inherited from `MobileAppAdGroup` |
@@ -2945,7 +2943,7 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `adgroups.update` | `adgroups.update` | `NegativeKeywords.Items` | `string` | 1 | unbounded | `missing_followup` | Ad-group-level negative keywords are not exposed on update. [#243](https://github.com/axisrow/direct-cli/issues/243); inherited from `NegativeKeywords` |
 | `adgroups.update` | `adgroups.update` | `NegativeKeywordSharedSetIds` | `ArrayOfLong` | 0 | 1 | `missing_followup` | Shared-set IDs are read-filterable but not updatable. [#243](https://github.com/axisrow/direct-cli/issues/243) |
 | `adgroups.update` | `adgroups.update` | `NegativeKeywordSharedSetIds.Items` | `long` | 1 | unbounded | `missing_followup` | Shared-set IDs are read-filterable but not updatable. [#243](https://github.com/axisrow/direct-cli/issues/243); inherited from `NegativeKeywordSharedSetIds` |
-| `adgroups.update` | `adgroups.update` | `TrackingParams` | `string` | 0 | 1 | `missing_followup` | AdGroupUpdateItem.TrackingParams has no typed flag. [#242](https://github.com/axisrow/direct-cli/issues/242) |
+| `adgroups.update` | `adgroups.update` | `TrackingParams` | `string` | 0 | 1 | `supported` | --tracking-params |
 | `adgroups.update` | `adgroups.update` | `Id` | `long` | 1 | 1 | `supported` | covered by minOccurs>=1 parity gate |
 | `adgroups.update` | `adgroups.update` | `Name` | `string` | 0 | 1 | `supported` | --name |
 | `adgroups.update` | `adgroups.update` | `MobileAppAdGroup` | `MobileAppAdGroupUpdate` | 0 | 1 | `missing_followup` | Rare ad group subtype block is not exposed by update. [#247](https://github.com/axisrow/direct-cli/issues/247) |

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1484,6 +1484,25 @@ def test_adgroups_add_payload_omits_type():
     assert group["RegionIds"] == [1, 225]
 
 
+def test_adgroups_add_tracking_params_payload():
+    body = _dry_run(
+        "adgroups",
+        "add",
+        "--name",
+        "Group A",
+        "--campaign-id",
+        "111",
+        "--region-ids",
+        "1,225",
+        "--tracking-params",
+        "utm_source=direct",
+    )
+    group = body["params"]["AdGroups"][0]
+    assert group["TrackingParams"] == "utm_source=direct"
+    assert "DynamicTextAdGroup" not in group
+    assert "SmartAdGroup" not in group
+
+
 def test_adgroups_add_case_insensitive_default_type():
     """``--type text_ad_group`` (lowercase) still builds a valid payload.
 
@@ -1625,6 +1644,55 @@ def test_adgroups_update_payload_name_only():
     assert body["method"] == "update"
     group = body["params"]["AdGroups"][0]
     assert group == {"Id": 222, "Name": "Renamed"}
+
+
+def test_adgroups_update_tracking_params_payload():
+    body = _dry_run(
+        "adgroups",
+        "update",
+        "--id",
+        "222",
+        "--tracking-params",
+        "utm_source=direct",
+    )
+    group = body["params"]["AdGroups"][0]
+    assert group == {"Id": 222, "TrackingParams": "utm_source=direct"}
+
+
+def test_adgroups_add_tracking_params_accepts_1024_chars():
+    tracking_params = "x" * 1024
+    body = _dry_run(
+        "adgroups",
+        "add",
+        "--name",
+        "Group A",
+        "--campaign-id",
+        "111",
+        "--region-ids",
+        "225",
+        "--tracking-params",
+        tracking_params,
+    )
+    group = body["params"]["AdGroups"][0]
+    assert group["TrackingParams"] == tracking_params
+
+
+def test_adgroups_update_tracking_params_rejects_1025_chars():
+    result = _rejected(
+        "adgroups",
+        "update",
+        "--id",
+        "222",
+        "--tracking-params",
+        "x" * 1025,
+    )
+    assert "--tracking-params must be at most 1024 characters" in result.output
+
+
+def test_adgroups_update_without_tracking_params_or_other_fields_rejected():
+    result = _rejected("adgroups", "update", "--id", "222")
+    assert "--tracking-params" in result.output
+    assert "requires at least one updatable field" in result.output
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1677,6 +1677,22 @@ def test_adgroups_add_tracking_params_accepts_1024_chars():
     assert group["TrackingParams"] == tracking_params
 
 
+def test_adgroups_add_tracking_params_rejects_1025_chars():
+    result = _rejected(
+        "adgroups",
+        "add",
+        "--name",
+        "Group A",
+        "--campaign-id",
+        "111",
+        "--region-ids",
+        "225",
+        "--tracking-params",
+        "x" * 1025,
+    )
+    assert "--tracking-params must be at most 1024 characters" in result.output
+
+
 def test_adgroups_update_tracking_params_rejects_1025_chars():
     result = _rejected(
         "adgroups",

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -632,8 +632,10 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     ("adgroups", "add", "SmartAdGroup.FeedId"): {"--feed-id"},
     ("adgroups", "add", "SmartAdGroup.AdTitleSource"): {"--ad-title-source"},
     ("adgroups", "add", "SmartAdGroup.AdBodySource"): {"--ad-body-source"},
+    ("adgroups", "add", "TrackingParams"): {"--tracking-params"},
     ("adgroups", "update", "Name"): {"--name"},
     ("adgroups", "update", "RegionIds"): {"--region-ids"},
+    ("adgroups", "update", "TrackingParams"): {"--tracking-params"},
     ("ads", "add", "TextAd"): {"--type"},
     ("ads", "add", "TextAd.VCardId"): {"--vcard-id"},
     ("ads", "add", "TextAd.AdImageHash"): {"--image-hash"},
@@ -956,16 +958,6 @@ OPTIONAL_FIELD_DEFAULT_FOLLOWUPS: dict[tuple[str, str], dict[str, str]] = {
 }
 
 OPTIONAL_FIELD_AUDIT: dict[tuple[str, str, str], dict[str, str]] = {
-    ("adgroups", "add", "TrackingParams"): {
-        "status": "missing_followup",
-        "issue": "#242",
-        "note": "AdGroupAddItem.TrackingParams has no typed flag.",
-    },
-    ("adgroups", "update", "TrackingParams"): {
-        "status": "missing_followup",
-        "issue": "#242",
-        "note": "AdGroupUpdateItem.TrackingParams has no typed flag.",
-    },
     ("adgroups", "add", "NegativeKeywords"): {
         "status": "missing_followup",
         "issue": "#243",


### PR DESCRIPTION
## Summary

- Adds typed `--tracking-params` support to `direct adgroups add` and `direct adgroups update`.
- Builds top-level `AdGroups[].TrackingParams` payloads to match the Yandex Direct API docs.
- Validates the documented 1024-character limit locally and updates optional WSDL audit coverage.

## Validation

- `python3 -m pytest tests/test_dry_run.py -k "adgroups and tracking_params"`
- `python3 -m pytest tests/test_wsdl_parity_gate.py`
- `python3 -m pytest tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py`
- `python3 -m black --check direct_cli/commands/adgroups.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py`

Fixes #242.