### PR TITLE
[codex] Add sitelink TurboPageId typed input

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,7 +516,7 @@ direct dynamicfeedadtargets add --adgroup-id 33 --name "Feed slice A" --conditio
 direct dynamicfeedadtargets set-bids --id 789 --bid 6500000 --context-bid 4000000 --dry-run
 
 # Extensions, assets, feeds, and clients
-direct sitelinks add --sitelink "Docs|https://example.com/docs" --sitelink "Help|https://example.com/help|Desk" --dry-run
+direct sitelinks add --sitelink "Docs|https://example.com/docs|API docs|12345" --sitelink "Help|https://example.com/help|Desk" --dry-run
 direct vcards add --campaign-id 555 --country "Russia" --city "Moscow" --company-name "Acme" --work-time 1#5#9#0#18#0 --phone-country-code +7 --phone-city-code 495 --phone-number 1234567 --dry-run
 direct adextensions add --callout-text "Free shipping" --dry-run
 direct adimages add --name banner.png --image-data BASE64DATA --type ICON --dry-run
@@ -1218,7 +1218,7 @@ direct dynamicfeedadtargets add --adgroup-id 33 --name "Срез фида А" --
 direct dynamicfeedadtargets set-bids --id 789 --bid 6500000 --context-bid 4000000 --dry-run
 
 # Расширения, ассеты, фиды и клиенты
-direct sitelinks add --sitelink "Docs|https://example.com/docs" --sitelink "Help|https://example.com/help|Desk" --dry-run
+direct sitelinks add --sitelink "Docs|https://example.com/docs|API docs|12345" --sitelink "Help|https://example.com/help|Desk" --dry-run
 direct vcards add --campaign-id 555 --country "Россия" --city "Москва" --company-name "Acme" --work-time 1#5#9#0#18#0 --phone-country-code +7 --phone-city-code 495 --phone-number 1234567 --dry-run
 direct adextensions add --callout-text "Free shipping" --dry-run
 direct adimages add --name banner.png --image-data BASE64DATA --type ICON --dry-run

--- a/direct_cli/commands/sitelinks.py
+++ b/direct_cli/commands/sitelinks.py
@@ -15,6 +15,16 @@ from ..utils import get_default_fields, parse_ids, parse_sitelink_specs
 _SITELINK_FIELDS = ("Title", "Href", "Description", "TurboPageId")
 
 
+def _coerce_turbo_page_id(raw_value: Any, index: int) -> int:
+    if isinstance(raw_value, bool):
+        raise click.UsageError(f"Sitelink #{index}: 'TurboPageId' must be an integer")
+    if isinstance(raw_value, int):
+        return raw_value
+    if isinstance(raw_value, str) and raw_value.strip().isdigit():
+        return int(raw_value.strip())
+    raise click.UsageError(f"Sitelink #{index}: 'TurboPageId' must be an integer")
+
+
 def _normalize_sitelink_row(row: Any, index: int) -> Dict[str, Any]:
     if not isinstance(row, dict):
         raise click.UsageError(
@@ -46,12 +56,7 @@ def _normalize_sitelink_row(row: Any, index: int) -> Dict[str, Any]:
     if description is not None and str(description).strip():
         item["Description"] = str(description).strip()
     if raw_turbo_page_id not in (None, ""):
-        try:
-            item["TurboPageId"] = int(raw_turbo_page_id)
-        except (TypeError, ValueError):
-            raise click.UsageError(
-                f"Sitelink #{index}: 'TurboPageId' must be an integer"
-            )
+        item["TurboPageId"] = _coerce_turbo_page_id(raw_turbo_page_id, index)
     return item
 
 

--- a/direct_cli/commands/sitelinks.py
+++ b/direct_cli/commands/sitelinks.py
@@ -12,10 +12,10 @@ from ..api import create_client
 from ..output import format_output, print_error
 from ..utils import get_default_fields, parse_ids, parse_sitelink_specs
 
-_SITELINK_FIELDS = ("Title", "Href", "Description")
+_SITELINK_FIELDS = ("Title", "Href", "Description", "TurboPageId")
 
 
-def _normalize_sitelink_row(row: Any, index: int) -> Dict[str, str]:
+def _normalize_sitelink_row(row: Any, index: int) -> Dict[str, Any]:
     if not isinstance(row, dict):
         raise click.UsageError(
             f"Sitelink #{index}: expected a JSON object, got {type(row).__name__}"
@@ -30,16 +30,28 @@ def _normalize_sitelink_row(row: Any, index: int) -> Dict[str, str]:
 
     if "Title" not in row or not str(row.get("Title") or "").strip():
         raise click.UsageError(f"Sitelink #{index}: missing required field 'Title'")
-    if "Href" not in row or not str(row.get("Href") or "").strip():
-        raise click.UsageError(f"Sitelink #{index}: missing required field 'Href'")
+    href = str(row.get("Href") or "").strip()
+    raw_turbo_page_id = row.get("TurboPageId")
+    if not href and raw_turbo_page_id in (None, ""):
+        raise click.UsageError(
+            f"Sitelink #{index}: provide at least one of 'Href' or 'TurboPageId'"
+        )
 
-    item: Dict[str, str] = {
+    item: Dict[str, Any] = {
         "Title": str(row["Title"]).strip(),
-        "Href": str(row["Href"]).strip(),
     }
+    if href:
+        item["Href"] = href
     description = row.get("Description")
     if description is not None and str(description).strip():
         item["Description"] = str(description).strip()
+    if raw_turbo_page_id not in (None, ""):
+        try:
+            item["TurboPageId"] = int(raw_turbo_page_id)
+        except (TypeError, ValueError):
+            raise click.UsageError(
+                f"Sitelink #{index}: 'TurboPageId' must be an integer"
+            )
     return item
 
 
@@ -139,7 +151,10 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
     "--sitelink",
     "sitelinks_specs",
     multiple=True,
-    help="Sitelink spec: TITLE|HREF[|DESCRIPTION]. Escape literal '|' as '\\|'.",
+    help=(
+        "Sitelink spec: TITLE|HREF[|DESCRIPTION[|TURBO_PAGE_ID]]. "
+        "Escape literal '|' as '\\|'."
+    ),
 )
 @click.option(
     "--sitelink-json",

--- a/direct_cli/utils.py
+++ b/direct_cli/utils.py
@@ -483,8 +483,8 @@ def _split_sitelink_spec(spec: str) -> List[str]:
     return parts
 
 
-def parse_sitelink_specs(specs: Optional[List[str]]) -> Optional[List[Dict[str, str]]]:
-    """Parse repeated TITLE|HREF[|DESCRIPTION] sitelink specs.
+def parse_sitelink_specs(specs: Optional[List[str]]) -> Optional[List[Dict[str, Any]]]:
+    """Parse repeated TITLE|HREF[|DESCRIPTION[|TURBO_PAGE_ID]] specs.
 
     Literal '|' characters inside any field can be escaped as '\\|'.
     """
@@ -494,16 +494,40 @@ def parse_sitelink_specs(specs: Optional[List[str]]) -> Optional[List[Dict[str, 
     sitelinks = []
     for spec in specs:
         parts = [part.strip() for part in _split_sitelink_spec(spec)]
-        if len(parts) not in (2, 3):
+        if len(parts) not in (2, 3, 4):
             raise ValueError(
                 "Invalid sitelink: "
-                f"'{spec}'. Expected format: TITLE|HREF[|DESCRIPTION]. "
+                f"'{spec}'. Expected format: "
+                "TITLE|HREF[|DESCRIPTION[|TURBO_PAGE_ID]]. "
                 "Escape a literal '|' inside a field as '\\|'."
             )
 
-        sitelink = {"Title": parts[0], "Href": parts[1]}
+        if not parts[0]:
+            raise ValueError(f"Invalid sitelink: '{spec}'. Title is required.")
+
+        sitelink: Dict[str, Any] = {"Title": parts[0]}
+        if parts[1]:
+            sitelink["Href"] = parts[1]
         if len(parts) == 3 and parts[2]:
             sitelink["Description"] = parts[2]
+        if len(parts) == 4:
+            if parts[2]:
+                sitelink["Description"] = parts[2]
+            if not parts[3]:
+                raise ValueError(
+                    f"Invalid sitelink: '{spec}'. TurboPageId must be an integer."
+                )
+            try:
+                sitelink["TurboPageId"] = int(parts[3])
+            except ValueError:
+                raise ValueError(
+                    f"Invalid sitelink: '{spec}'. TurboPageId must be an integer."
+                )
+
+        if "Href" not in sitelink and "TurboPageId" not in sitelink:
+            raise ValueError(
+                f"Invalid sitelink: '{spec}'. Provide Href or TurboPageId."
+            )
         sitelinks.append(sitelink)
     return sitelinks
 

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,8 +11,8 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 2855 |
-| `supported` | 386 |
+| `missing_followup` | 2854 |
+| `supported` | 387 |
 
 ## Confirmed Follow-Ups
 
@@ -2659,7 +2659,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `retargeting.update` | `Description` | retargeting.update optional WSDL path needs typed support or N/A. [#256](https://github.com/axisrow/direct-cli/issues/256) |
 | `retargeting.update` | `Rules.Arguments.MembershipLifeSpan` | retargeting.update optional WSDL path needs typed support or N/A. [#256](https://github.com/axisrow/direct-cli/issues/256) |
 | `retargeting.update` | `Rules.Arguments.ExternalId` | retargeting.update optional WSDL path needs typed support or N/A. [#256](https://github.com/axisrow/direct-cli/issues/256) |
-| `sitelinks.add` | `Sitelinks.TurboPageId` | Sitelink TurboPageId has no typed add flag. [#257](https://github.com/axisrow/direct-cli/issues/257) |
 | `smartadtargets.add` | `Conditions.Items.Operand` | smartadtargets.add optional WSDL path needs typed support or N/A. [#252](https://github.com/axisrow/direct-cli/issues/252) |
 | `smartadtargets.add` | `Conditions.Items.Operator` | smartadtargets.add optional WSDL path needs typed support or N/A. [#252](https://github.com/axisrow/direct-cli/issues/252) |
 | `smartadtargets.add` | `Conditions.Items.Arguments` | smartadtargets.add optional WSDL path needs typed support or N/A. [#252](https://github.com/axisrow/direct-cli/issues/252) |
@@ -5734,7 +5733,7 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `sitelinks.add` | `sitelinks.add` | `Sitelinks.Title` | `string` | 1 | 1 | `supported` | --sitelink |
 | `sitelinks.add` | `sitelinks.add` | `Sitelinks.Href` | `string` | 0 | 1 | `supported` | --sitelink |
 | `sitelinks.add` | `sitelinks.add` | `Sitelinks.Description` | `string` | 0 | 1 | `supported` | --sitelink |
-| `sitelinks.add` | `sitelinks.add` | `Sitelinks.TurboPageId` | `long` | 0 | 1 | `missing_followup` | Sitelink TurboPageId has no typed add flag. [#257](https://github.com/axisrow/direct-cli/issues/257) |
+| `sitelinks.add` | `sitelinks.add` | `Sitelinks.TurboPageId` | `long` | 0 | 1 | `supported` | --sitelink |
 | `smartadtargets.add` | `smartadtargets.add` | `Name` | `string` | 1 | 1 | `supported` | covered by minOccurs>=1 parity gate |
 | `smartadtargets.add` | `smartadtargets.add` | `AdGroupId` | `long` | 1 | 1 | `supported` | covered by minOccurs>=1 parity gate |
 | `smartadtargets.add` | `smartadtargets.add` | `AverageCpc` | `long` | 0 | 1 | `supported` | --average-cpc |

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -3428,6 +3428,17 @@ def test_sitelinks_add_pipe_spec_turbo_page_id_without_href():
     }
 
 
+def test_sitelinks_add_pipe_spec_turbo_page_id_without_href_or_description():
+    body = _dry_run(
+        "sitelinks",
+        "add",
+        "--sitelink",
+        "Turbo|||12345",
+    )
+    sitelink = body["params"]["SitelinksSets"][0]["Sitelinks"][0]
+    assert sitelink == {"Title": "Turbo", "TurboPageId": 12345}
+
+
 def test_sitelinks_add_pipe_spec_turbo_page_id_invalid_rejected():
     result = _rejected(
         "sitelinks",
@@ -3474,6 +3485,60 @@ def test_sitelinks_add_from_inline_json():
         },
         {"Title": "Контакты", "Href": "https://example.com/contact"},
     ]
+
+
+def test_sitelinks_add_from_inline_json_turbo_page_id_without_href():
+    body = _dry_run(
+        "sitelinks",
+        "add",
+        "--sitelink-json",
+        json.dumps([{"Title": "Turbo", "TurboPageId": 12345}]),
+    )
+    assert body["params"]["SitelinksSets"][0]["Sitelinks"] == [
+        {"Title": "Turbo", "TurboPageId": 12345}
+    ]
+
+
+def test_sitelinks_add_from_inline_json_turbo_page_id_string_coerced():
+    body = _dry_run(
+        "sitelinks",
+        "add",
+        "--sitelink-json",
+        json.dumps([{"Title": "Turbo", "TurboPageId": "12345"}]),
+    )
+    assert body["params"]["SitelinksSets"][0]["Sitelinks"] == [
+        {"Title": "Turbo", "TurboPageId": 12345}
+    ]
+
+
+def test_sitelinks_add_from_inline_json_turbo_page_id_invalid_rejected():
+    result = _rejected(
+        "sitelinks",
+        "add",
+        "--sitelink-json",
+        json.dumps([{"Title": "Turbo", "TurboPageId": "not-an-id"}]),
+    )
+    assert "'TurboPageId' must be an integer" in result.output
+
+
+def test_sitelinks_add_from_inline_json_turbo_page_id_bool_rejected():
+    result = _rejected(
+        "sitelinks",
+        "add",
+        "--sitelink-json",
+        json.dumps([{"Title": "Turbo", "TurboPageId": False}]),
+    )
+    assert "'TurboPageId' must be an integer" in result.output
+
+
+def test_sitelinks_add_from_inline_json_turbo_page_id_float_rejected():
+    result = _rejected(
+        "sitelinks",
+        "add",
+        "--sitelink-json",
+        json.dumps([{"Title": "Turbo", "TurboPageId": 12.5}]),
+    )
+    assert "'TurboPageId' must be an integer" in result.output
 
 
 def test_sitelinks_add_from_file_jsonl(tmp_path):

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -3395,6 +3395,49 @@ def test_sitelinks_add_supports_escaped_pipe_in_href():
     }
 
 
+def test_sitelinks_add_pipe_spec_turbo_page_id():
+    """Issue #257: --sitelink exposes Sitelinks.TurboPageId."""
+    body = _dry_run(
+        "sitelinks",
+        "add",
+        "--sitelink",
+        "Docs|https://example.com/docs|API docs|12345",
+    )
+    sitelink = body["params"]["SitelinksSets"][0]["Sitelinks"][0]
+    assert sitelink == {
+        "Title": "Docs",
+        "Href": "https://example.com/docs",
+        "Description": "API docs",
+        "TurboPageId": 12345,
+    }
+
+
+def test_sitelinks_add_pipe_spec_turbo_page_id_without_href():
+    """Yandex API allows Href or TurboPageId on a sitelink."""
+    body = _dry_run(
+        "sitelinks",
+        "add",
+        "--sitelink",
+        "Turbo||Turbo page|12345",
+    )
+    sitelink = body["params"]["SitelinksSets"][0]["Sitelinks"][0]
+    assert sitelink == {
+        "Title": "Turbo",
+        "Description": "Turbo page",
+        "TurboPageId": 12345,
+    }
+
+
+def test_sitelinks_add_pipe_spec_turbo_page_id_invalid_rejected():
+    result = _rejected(
+        "sitelinks",
+        "add",
+        "--sitelink",
+        "Docs|https://example.com/docs|API docs|not-an-id",
+    )
+    assert "TurboPageId must be an integer" in result.output
+
+
 def test_sitelinks_add_pipe_spec_invalid_raises():
     """Unescaped '|' overflowing the 3-part shape must error with a hint."""
     result = _rejected(
@@ -3498,6 +3541,7 @@ def test_sitelinks_add_json_missing_href_rejected():
     )
     assert "Sitelink #1" in result.output
     assert "Href" in result.output
+    assert "TurboPageId" in result.output
 
 
 def test_sitelinks_add_json_not_array_rejected():

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -793,6 +793,7 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     ("sitelinks", "add", "Sitelinks.Title"): {"--sitelink"},
     ("sitelinks", "add", "Sitelinks.Href"): {"--sitelink"},
     ("sitelinks", "add", "Sitelinks.Description"): {"--sitelink"},
+    ("sitelinks", "add", "Sitelinks.TurboPageId"): {"--sitelink"},
     ("smartadtargets", "add", "StrategyPriority"): {"--priority"},
     ("smartadtargets", "add", "AverageCpc"): {"--average-cpc"},
     ("smartadtargets", "add", "AverageCpa"): {"--average-cpa"},
@@ -1037,11 +1038,6 @@ OPTIONAL_FIELD_AUDIT: dict[tuple[str, str, str], dict[str, str]] = {
         "status": "missing_followup",
         "issue": "#245",
         "note": "TEXT_AD price extension update is WSDL-supported but absent.",
-    },
-    ("sitelinks", "add", "Sitelinks.TurboPageId"): {
-        "status": "missing_followup",
-        "issue": "#257",
-        "note": "Sitelink TurboPageId has no typed add flag.",
     },
     ("vcards", "add", "InstantMessenger"): {
         "status": "missing_followup",


### PR DESCRIPTION
## Summary
- Extend repeatable --sitelink specs to accept TITLE|HREF|DESCRIPTION|TURBO_PAGE_ID.
- Allow Href-only, TurboPageId-only, or both according to Yandex sitelinks.add docs.
- Move sitelinks.add Sitelinks.TurboPageId from missing_followup to supported in the WSDL audit.

## Verification
- python3 -m pytest tests/test_dry_run.py -k 'sitelinks and turbo_page_id'
- python3 -m pytest tests/test_wsdl_parity_gate.py
- python3 -m pytest tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py

Refs #257