### PR TITLE
[codex] Add adgroups negative keyword flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,10 +379,10 @@ direct campaigns delete --id 12345
 
 ```bash
 direct adgroups get --campaign-ids 1,2,3 --limit 50
-direct adgroups add --name "Group 1" --campaign-id 12345 --region-ids 1,225 --tracking-params "utm_source=direct" --dry-run
+direct adgroups add --name "Group 1" --campaign-id 12345 --region-ids 1,225 --negative-keywords "repair,used" --tracking-params "utm_source=direct" --dry-run
 direct adgroups add --name "Dynamic Group" --campaign-id 12345 --type DYNAMIC_TEXT_AD_GROUP --region-ids 1,225 --domain-url example.com --dry-run
 direct adgroups add --name "Smart Group" --campaign-id 12345 --type SMART_AD_GROUP --region-ids 1,225 --feed-id 170 --ad-title-source FEED_NAME --ad-body-source FEED_NAME --dry-run
-direct adgroups update --id 67890 --tracking-params "utm_source=direct"
+direct adgroups update --id 67890 --negative-keyword-shared-set-ids 10,11 --tracking-params "utm_source=direct"
 direct adgroups delete --id 67890
 ```
 
@@ -1080,10 +1080,10 @@ direct campaigns delete --id 12345
 
 ```bash
 direct adgroups get --campaign-ids 1,2,3 --limit 50
-direct adgroups add --name "Группа 1" --campaign-id 12345 --region-ids 1,225 --tracking-params "utm_source=direct" --dry-run
+direct adgroups add --name "Группа 1" --campaign-id 12345 --region-ids 1,225 --negative-keywords "ремонт,б/у" --tracking-params "utm_source=direct" --dry-run
 direct adgroups add --name "Динамическая группа" --campaign-id 12345 --type DYNAMIC_TEXT_AD_GROUP --region-ids 1,225 --domain-url example.com --dry-run
 direct adgroups add --name "Смарт-группа" --campaign-id 12345 --type SMART_AD_GROUP --region-ids 1,225 --feed-id 170 --ad-title-source FEED_NAME --ad-body-source FEED_NAME --dry-run
-direct adgroups update --id 67890 --tracking-params "utm_source=direct"
+direct adgroups update --id 67890 --negative-keyword-shared-set-ids 10,11 --tracking-params "utm_source=direct"
 direct adgroups delete --id 67890
 ```
 

--- a/direct_cli/commands/adgroups.py
+++ b/direct_cli/commands/adgroups.py
@@ -8,7 +8,12 @@ import click
 
 from ..api import create_client
 from ..output import format_output, print_error
-from ..utils import add_criteria_csv, get_default_fields, parse_ids
+from ..utils import (
+    add_criteria_csv,
+    get_default_fields,
+    parse_csv_strings,
+    parse_ids,
+)
 
 _TRACKING_PARAMS_MAX_LENGTH = 1024
 
@@ -168,6 +173,17 @@ def get(
 @click.option("--ad-title-source", help="Smart ad group title source")
 @click.option("--ad-body-source", help="Smart ad group body source")
 @click.option(
+    "--negative-keywords",
+    help="Comma-separated ad-group negative keywords for NegativeKeywords.Items",
+)
+@click.option(
+    "--negative-keyword-shared-set-ids",
+    help=(
+        "Comma-separated negative keyword shared set IDs for "
+        "NegativeKeywordSharedSetIds.Items"
+    ),
+)
+@click.option(
     "--tracking-params",
     "tracking_params",
     help=(
@@ -187,6 +203,8 @@ def add(
     feed_id,
     ad_title_source,
     ad_body_source,
+    negative_keywords,
+    negative_keyword_shared_set_ids,
     tracking_params,
     dry_run,
 ):
@@ -226,6 +244,16 @@ def add(
 
         if region_ids:
             adgroup_data["RegionIds"] = parse_ids(region_ids)
+        parsed_negative_keywords = parse_csv_strings(negative_keywords)
+        if parsed_negative_keywords:
+            adgroup_data["NegativeKeywords"] = {"Items": parsed_negative_keywords}
+        parsed_negative_keyword_shared_set_ids = parse_ids(
+            negative_keyword_shared_set_ids
+        )
+        if parsed_negative_keyword_shared_set_ids:
+            adgroup_data["NegativeKeywordSharedSetIds"] = {
+                "Items": parsed_negative_keyword_shared_set_ids
+            }
         if tracking_params:
             adgroup_data["TrackingParams"] = tracking_params
         if group_type_norm == "DYNAMIC_TEXT_AD_GROUP":
@@ -272,6 +300,17 @@ def add(
 @click.option("--status", help="New status")
 @click.option("--region-ids", help="Comma-separated region IDs")
 @click.option(
+    "--negative-keywords",
+    help="Comma-separated ad-group negative keywords for NegativeKeywords.Items",
+)
+@click.option(
+    "--negative-keyword-shared-set-ids",
+    help=(
+        "Comma-separated negative keyword shared set IDs for "
+        "NegativeKeywordSharedSetIds.Items"
+    ),
+)
+@click.option(
     "--tracking-params",
     "tracking_params",
     help=(
@@ -281,7 +320,17 @@ def add(
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def update(ctx, adgroup_id, name, status, region_ids, tracking_params, dry_run):
+def update(
+    ctx,
+    adgroup_id,
+    name,
+    status,
+    region_ids,
+    negative_keywords,
+    negative_keyword_shared_set_ids,
+    tracking_params,
+    dry_run,
+):
     """Update ad group"""
     _validate_tracking_params(tracking_params)
 
@@ -294,6 +343,14 @@ def update(ctx, adgroup_id, name, status, region_ids, tracking_params, dry_run):
         adgroup_data["Status"] = status
     if region_ids:
         adgroup_data["RegionIds"] = parse_ids(region_ids)
+    parsed_negative_keywords = parse_csv_strings(negative_keywords)
+    if parsed_negative_keywords:
+        adgroup_data["NegativeKeywords"] = {"Items": parsed_negative_keywords}
+    parsed_negative_keyword_shared_set_ids = parse_ids(negative_keyword_shared_set_ids)
+    if parsed_negative_keyword_shared_set_ids:
+        adgroup_data["NegativeKeywordSharedSetIds"] = {
+            "Items": parsed_negative_keyword_shared_set_ids
+        }
     if tracking_params:
         adgroup_data["TrackingParams"] = tracking_params
 
@@ -301,7 +358,8 @@ def update(ctx, adgroup_id, name, status, region_ids, tracking_params, dry_run):
     if len(adgroup_data) == 1:
         raise click.UsageError(
             "adgroups update requires at least one updatable field "
-            "(--name, --status, --region-ids, or --tracking-params)."
+            "(--name, --status, --region-ids, --negative-keywords, "
+            "--negative-keyword-shared-set-ids, or --tracking-params)."
         )
 
     try:

--- a/direct_cli/commands/adgroups.py
+++ b/direct_cli/commands/adgroups.py
@@ -35,6 +35,14 @@ def _validate_tracking_params(tracking_params: Optional[str]) -> None:
         )
 
 
+def _parse_ids_option(value: Optional[str], option_name: str) -> Optional[list[int]]:
+    """Parse comma-separated IDs and report bad input as a Click usage error."""
+    try:
+        return parse_ids(value)
+    except ValueError as exc:
+        raise click.UsageError(f"{option_name}: {exc}") from exc
+
+
 def _reject_incompatible_flags(
     group_type: str,
     allowed_flags: set[str],
@@ -243,12 +251,13 @@ def add(
         adgroup_data = {"Name": name, "CampaignId": campaign_id}
 
         if region_ids:
-            adgroup_data["RegionIds"] = parse_ids(region_ids)
+            adgroup_data["RegionIds"] = _parse_ids_option(region_ids, "--region-ids")
         parsed_negative_keywords = parse_csv_strings(negative_keywords)
         if parsed_negative_keywords:
             adgroup_data["NegativeKeywords"] = {"Items": parsed_negative_keywords}
-        parsed_negative_keyword_shared_set_ids = parse_ids(
-            negative_keyword_shared_set_ids
+        parsed_negative_keyword_shared_set_ids = _parse_ids_option(
+            negative_keyword_shared_set_ids,
+            "--negative-keyword-shared-set-ids",
         )
         if parsed_negative_keyword_shared_set_ids:
             adgroup_data["NegativeKeywordSharedSetIds"] = {
@@ -342,11 +351,13 @@ def update(
     if status:
         adgroup_data["Status"] = status
     if region_ids:
-        adgroup_data["RegionIds"] = parse_ids(region_ids)
+        adgroup_data["RegionIds"] = _parse_ids_option(region_ids, "--region-ids")
     parsed_negative_keywords = parse_csv_strings(negative_keywords)
     if parsed_negative_keywords:
         adgroup_data["NegativeKeywords"] = {"Items": parsed_negative_keywords}
-    parsed_negative_keyword_shared_set_ids = parse_ids(negative_keyword_shared_set_ids)
+    parsed_negative_keyword_shared_set_ids = _parse_ids_option(
+        negative_keyword_shared_set_ids, "--negative-keyword-shared-set-ids"
+    )
     if parsed_negative_keyword_shared_set_ids:
         adgroup_data["NegativeKeywordSharedSetIds"] = {
             "Items": parsed_negative_keyword_shared_set_ids

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,17 +11,13 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 2848 |
-| `supported` | 393 |
+| `missing_followup` | 2840 |
+| `supported` | 401 |
 
 ## Confirmed Follow-Ups
 
 | CLI command | WSDL path | Issue / note |
 |---|---|---|
-| `adgroups.add` | `NegativeKeywords` | Ad-group-level negative keywords are not exposed on add. [#243](https://github.com/axisrow/direct-cli/issues/243) |
-| `adgroups.add` | `NegativeKeywords.Items` | Ad-group-level negative keywords are not exposed on add. [#243](https://github.com/axisrow/direct-cli/issues/243); inherited from `NegativeKeywords` |
-| `adgroups.add` | `NegativeKeywordSharedSetIds` | Shared-set IDs are read-filterable but not addable. [#243](https://github.com/axisrow/direct-cli/issues/243) |
-| `adgroups.add` | `NegativeKeywordSharedSetIds.Items` | Shared-set IDs are read-filterable but not addable. [#243](https://github.com/axisrow/direct-cli/issues/243); inherited from `NegativeKeywordSharedSetIds` |
 | `adgroups.add` | `MobileAppAdGroup` | Rare ad group subtype block is not exposed by --type. [#247](https://github.com/axisrow/direct-cli/issues/247) |
 | `adgroups.add` | `MobileAppAdGroup.StoreUrl` | Rare ad group subtype block is not exposed by --type. [#247](https://github.com/axisrow/direct-cli/issues/247); inherited from `MobileAppAdGroup` |
 | `adgroups.add` | `MobileAppAdGroup.TargetDeviceType` | Rare ad group subtype block is not exposed by --type. [#247](https://github.com/axisrow/direct-cli/issues/247); inherited from `MobileAppAdGroup` |
@@ -66,10 +62,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `adgroups.add` | `TextAdGroupFeedParams.FeedId` | Rare ad group feed params block has no typed add flags. [#247](https://github.com/axisrow/direct-cli/issues/247); inherited from `TextAdGroupFeedParams` |
 | `adgroups.add` | `TextAdGroupFeedParams.FeedCategoryIds` | Rare ad group feed params block has no typed add flags. [#247](https://github.com/axisrow/direct-cli/issues/247); inherited from `TextAdGroupFeedParams` |
 | `adgroups.add` | `TextAdGroupFeedParams.FeedCategoryIds.Items` | Rare ad group feed params block has no typed add flags. [#247](https://github.com/axisrow/direct-cli/issues/247); inherited from `TextAdGroupFeedParams` |
-| `adgroups.update` | `NegativeKeywords` | Ad-group-level negative keywords are not exposed on update. [#243](https://github.com/axisrow/direct-cli/issues/243) |
-| `adgroups.update` | `NegativeKeywords.Items` | Ad-group-level negative keywords are not exposed on update. [#243](https://github.com/axisrow/direct-cli/issues/243); inherited from `NegativeKeywords` |
-| `adgroups.update` | `NegativeKeywordSharedSetIds` | Shared-set IDs are read-filterable but not updatable. [#243](https://github.com/axisrow/direct-cli/issues/243) |
-| `adgroups.update` | `NegativeKeywordSharedSetIds.Items` | Shared-set IDs are read-filterable but not updatable. [#243](https://github.com/axisrow/direct-cli/issues/243); inherited from `NegativeKeywordSharedSetIds` |
 | `adgroups.update` | `MobileAppAdGroup` | Rare ad group subtype block is not exposed by update. [#247](https://github.com/axisrow/direct-cli/issues/247) |
 | `adgroups.update` | `MobileAppAdGroup.TargetDeviceType` | Rare ad group subtype block is not exposed by update. [#247](https://github.com/axisrow/direct-cli/issues/247); inherited from `MobileAppAdGroup` |
 | `adgroups.update` | `MobileAppAdGroup.TargetCarrier` | Rare ad group subtype block is not exposed by update. [#247](https://github.com/axisrow/direct-cli/issues/247); inherited from `MobileAppAdGroup` |
@@ -2876,10 +2868,10 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `adgroups.add` | `adgroups.add` | `Name` | `string` | 1 | 1 | `supported` | covered by minOccurs>=1 parity gate |
 | `adgroups.add` | `adgroups.add` | `CampaignId` | `long` | 1 | 1 | `supported` | covered by minOccurs>=1 parity gate |
 | `adgroups.add` | `adgroups.add` | `RegionIds` | `long` | 1 | unbounded | `supported` | covered by minOccurs>=1 parity gate |
-| `adgroups.add` | `adgroups.add` | `NegativeKeywords` | `ArrayOfString` | 0 | 1 | `missing_followup` | Ad-group-level negative keywords are not exposed on add. [#243](https://github.com/axisrow/direct-cli/issues/243) |
-| `adgroups.add` | `adgroups.add` | `NegativeKeywords.Items` | `string` | 1 | unbounded | `missing_followup` | Ad-group-level negative keywords are not exposed on add. [#243](https://github.com/axisrow/direct-cli/issues/243); inherited from `NegativeKeywords` |
-| `adgroups.add` | `adgroups.add` | `NegativeKeywordSharedSetIds` | `ArrayOfLong` | 0 | 1 | `missing_followup` | Shared-set IDs are read-filterable but not addable. [#243](https://github.com/axisrow/direct-cli/issues/243) |
-| `adgroups.add` | `adgroups.add` | `NegativeKeywordSharedSetIds.Items` | `long` | 1 | unbounded | `missing_followup` | Shared-set IDs are read-filterable but not addable. [#243](https://github.com/axisrow/direct-cli/issues/243); inherited from `NegativeKeywordSharedSetIds` |
+| `adgroups.add` | `adgroups.add` | `NegativeKeywords` | `ArrayOfString` | 0 | 1 | `supported` | --negative-keywords |
+| `adgroups.add` | `adgroups.add` | `NegativeKeywords.Items` | `string` | 1 | unbounded | `supported` | --negative-keywords |
+| `adgroups.add` | `adgroups.add` | `NegativeKeywordSharedSetIds` | `ArrayOfLong` | 0 | 1 | `supported` | --negative-keyword-shared-set-ids |
+| `adgroups.add` | `adgroups.add` | `NegativeKeywordSharedSetIds.Items` | `long` | 1 | unbounded | `supported` | --negative-keyword-shared-set-ids |
 | `adgroups.add` | `adgroups.add` | `TrackingParams` | `string` | 0 | 1 | `supported` | --tracking-params |
 | `adgroups.add` | `adgroups.add` | `MobileAppAdGroup` | `MobileAppAdGroupAdd` | 0 | 1 | `missing_followup` | Rare ad group subtype block is not exposed by --type. [#247](https://github.com/axisrow/direct-cli/issues/247) |
 | `adgroups.add` | `adgroups.add` | `MobileAppAdGroup.StoreUrl` | `string` | 1 | 1 | `missing_followup` | Rare ad group subtype block is not exposed by --type. [#247](https://github.com/axisrow/direct-cli/issues/247); inherited from `MobileAppAdGroup` |
@@ -2932,10 +2924,10 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `adgroups.add` | `adgroups.add` | `TextAdGroupFeedParams.FeedCategoryIds` | `ArrayOfLong` | 0 | 1 | `missing_followup` | Rare ad group feed params block has no typed add flags. [#247](https://github.com/axisrow/direct-cli/issues/247); inherited from `TextAdGroupFeedParams` |
 | `adgroups.add` | `adgroups.add` | `TextAdGroupFeedParams.FeedCategoryIds.Items` | `long` | 1 | unbounded | `missing_followup` | Rare ad group feed params block has no typed add flags. [#247](https://github.com/axisrow/direct-cli/issues/247); inherited from `TextAdGroupFeedParams` |
 | `adgroups.update` | `adgroups.update` | `RegionIds` | `long` | 0 | unbounded | `supported` | --region-ids |
-| `adgroups.update` | `adgroups.update` | `NegativeKeywords` | `ArrayOfString` | 0 | 1 | `missing_followup` | Ad-group-level negative keywords are not exposed on update. [#243](https://github.com/axisrow/direct-cli/issues/243) |
-| `adgroups.update` | `adgroups.update` | `NegativeKeywords.Items` | `string` | 1 | unbounded | `missing_followup` | Ad-group-level negative keywords are not exposed on update. [#243](https://github.com/axisrow/direct-cli/issues/243); inherited from `NegativeKeywords` |
-| `adgroups.update` | `adgroups.update` | `NegativeKeywordSharedSetIds` | `ArrayOfLong` | 0 | 1 | `missing_followup` | Shared-set IDs are read-filterable but not updatable. [#243](https://github.com/axisrow/direct-cli/issues/243) |
-| `adgroups.update` | `adgroups.update` | `NegativeKeywordSharedSetIds.Items` | `long` | 1 | unbounded | `missing_followup` | Shared-set IDs are read-filterable but not updatable. [#243](https://github.com/axisrow/direct-cli/issues/243); inherited from `NegativeKeywordSharedSetIds` |
+| `adgroups.update` | `adgroups.update` | `NegativeKeywords` | `ArrayOfString` | 0 | 1 | `supported` | --negative-keywords |
+| `adgroups.update` | `adgroups.update` | `NegativeKeywords.Items` | `string` | 1 | unbounded | `supported` | --negative-keywords |
+| `adgroups.update` | `adgroups.update` | `NegativeKeywordSharedSetIds` | `ArrayOfLong` | 0 | 1 | `supported` | --negative-keyword-shared-set-ids |
+| `adgroups.update` | `adgroups.update` | `NegativeKeywordSharedSetIds.Items` | `long` | 1 | unbounded | `supported` | --negative-keyword-shared-set-ids |
 | `adgroups.update` | `adgroups.update` | `TrackingParams` | `string` | 0 | 1 | `supported` | --tracking-params |
 | `adgroups.update` | `adgroups.update` | `Id` | `long` | 1 | 1 | `supported` | covered by minOccurs>=1 parity gate |
 | `adgroups.update` | `adgroups.update` | `Name` | `string` | 0 | 1 | `supported` | --name |

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1537,6 +1537,23 @@ def test_adgroups_add_negative_keyword_shared_set_ids_payload():
     assert group["NegativeKeywordSharedSetIds"] == {"Items": [10, 11]}
 
 
+def test_adgroups_add_negative_keyword_shared_set_ids_rejects_invalid_id():
+    result = _rejected(
+        "adgroups",
+        "add",
+        "--name",
+        "Group A",
+        "--campaign-id",
+        "111",
+        "--region-ids",
+        "1,225",
+        "--negative-keyword-shared-set-ids",
+        "10,nope",
+    )
+    assert "--negative-keyword-shared-set-ids: Invalid ID: 'nope'" in result.output
+    assert "Traceback" not in result.output
+
+
 def test_adgroups_add_case_insensitive_default_type():
     """``--type text_ad_group`` (lowercase) still builds a valid payload.
 
@@ -1717,6 +1734,32 @@ def test_adgroups_update_negative_keyword_shared_set_ids_payload():
     )
     group = body["params"]["AdGroups"][0]
     assert group == {"Id": 222, "NegativeKeywordSharedSetIds": {"Items": [10, 11]}}
+
+
+def test_adgroups_update_negative_keyword_shared_set_ids_rejects_invalid_id():
+    result = _rejected(
+        "adgroups",
+        "update",
+        "--id",
+        "222",
+        "--negative-keyword-shared-set-ids",
+        "10,nope",
+    )
+    assert "--negative-keyword-shared-set-ids: Invalid ID: 'nope'" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_adgroups_update_region_ids_rejects_invalid_id():
+    result = _rejected(
+        "adgroups",
+        "update",
+        "--id",
+        "222",
+        "--region-ids",
+        "225,nope",
+    )
+    assert "--region-ids: Invalid ID: 'nope'" in result.output
+    assert "Traceback" not in result.output
 
 
 def test_adgroups_add_tracking_params_accepts_1024_chars():

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1503,6 +1503,40 @@ def test_adgroups_add_tracking_params_payload():
     assert "SmartAdGroup" not in group
 
 
+def test_adgroups_add_negative_keywords_payload():
+    body = _dry_run(
+        "adgroups",
+        "add",
+        "--name",
+        "Group A",
+        "--campaign-id",
+        "111",
+        "--region-ids",
+        "1,225",
+        "--negative-keywords",
+        "word1, word2",
+    )
+    group = body["params"]["AdGroups"][0]
+    assert group["NegativeKeywords"] == {"Items": ["word1", "word2"]}
+
+
+def test_adgroups_add_negative_keyword_shared_set_ids_payload():
+    body = _dry_run(
+        "adgroups",
+        "add",
+        "--name",
+        "Group A",
+        "--campaign-id",
+        "111",
+        "--region-ids",
+        "1,225",
+        "--negative-keyword-shared-set-ids",
+        "10,11",
+    )
+    group = body["params"]["AdGroups"][0]
+    assert group["NegativeKeywordSharedSetIds"] == {"Items": [10, 11]}
+
+
 def test_adgroups_add_case_insensitive_default_type():
     """``--type text_ad_group`` (lowercase) still builds a valid payload.
 
@@ -1659,6 +1693,32 @@ def test_adgroups_update_tracking_params_payload():
     assert group == {"Id": 222, "TrackingParams": "utm_source=direct"}
 
 
+def test_adgroups_update_negative_keywords_payload():
+    body = _dry_run(
+        "adgroups",
+        "update",
+        "--id",
+        "222",
+        "--negative-keywords",
+        "word1, word2",
+    )
+    group = body["params"]["AdGroups"][0]
+    assert group == {"Id": 222, "NegativeKeywords": {"Items": ["word1", "word2"]}}
+
+
+def test_adgroups_update_negative_keyword_shared_set_ids_payload():
+    body = _dry_run(
+        "adgroups",
+        "update",
+        "--id",
+        "222",
+        "--negative-keyword-shared-set-ids",
+        "10,11",
+    )
+    group = body["params"]["AdGroups"][0]
+    assert group == {"Id": 222, "NegativeKeywordSharedSetIds": {"Items": [10, 11]}}
+
+
 def test_adgroups_add_tracking_params_accepts_1024_chars():
     tracking_params = "x" * 1024
     body = _dry_run(
@@ -1708,6 +1768,8 @@ def test_adgroups_update_tracking_params_rejects_1025_chars():
 def test_adgroups_update_without_tracking_params_or_other_fields_rejected():
     result = _rejected("adgroups", "update", "--id", "222")
     assert "--tracking-params" in result.output
+    assert "--negative-keywords" in result.output
+    assert "--negative-keyword-shared-set-ids" in result.output
     assert "requires at least one updatable field" in result.output
 
 

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -632,9 +632,25 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     ("adgroups", "add", "SmartAdGroup.FeedId"): {"--feed-id"},
     ("adgroups", "add", "SmartAdGroup.AdTitleSource"): {"--ad-title-source"},
     ("adgroups", "add", "SmartAdGroup.AdBodySource"): {"--ad-body-source"},
+    ("adgroups", "add", "NegativeKeywords"): {"--negative-keywords"},
+    ("adgroups", "add", "NegativeKeywords.Items"): {"--negative-keywords"},
+    ("adgroups", "add", "NegativeKeywordSharedSetIds"): {
+        "--negative-keyword-shared-set-ids"
+    },
+    ("adgroups", "add", "NegativeKeywordSharedSetIds.Items"): {
+        "--negative-keyword-shared-set-ids"
+    },
     ("adgroups", "add", "TrackingParams"): {"--tracking-params"},
     ("adgroups", "update", "Name"): {"--name"},
     ("adgroups", "update", "RegionIds"): {"--region-ids"},
+    ("adgroups", "update", "NegativeKeywords"): {"--negative-keywords"},
+    ("adgroups", "update", "NegativeKeywords.Items"): {"--negative-keywords"},
+    ("adgroups", "update", "NegativeKeywordSharedSetIds"): {
+        "--negative-keyword-shared-set-ids"
+    },
+    ("adgroups", "update", "NegativeKeywordSharedSetIds.Items"): {
+        "--negative-keyword-shared-set-ids"
+    },
     ("adgroups", "update", "TrackingParams"): {"--tracking-params"},
     ("ads", "add", "TextAd"): {"--type"},
     ("ads", "add", "TextAd.VCardId"): {"--vcard-id"},
@@ -965,26 +981,6 @@ OPTIONAL_FIELD_DEFAULT_FOLLOWUPS: dict[tuple[str, str], dict[str, str]] = {
 }
 
 OPTIONAL_FIELD_AUDIT: dict[tuple[str, str, str], dict[str, str]] = {
-    ("adgroups", "add", "NegativeKeywords"): {
-        "status": "missing_followup",
-        "issue": "#243",
-        "note": "Ad-group-level negative keywords are not exposed on add.",
-    },
-    ("adgroups", "update", "NegativeKeywords"): {
-        "status": "missing_followup",
-        "issue": "#243",
-        "note": "Ad-group-level negative keywords are not exposed on update.",
-    },
-    ("adgroups", "add", "NegativeKeywordSharedSetIds"): {
-        "status": "missing_followup",
-        "issue": "#243",
-        "note": "Shared-set IDs are read-filterable but not addable.",
-    },
-    ("adgroups", "update", "NegativeKeywordSharedSetIds"): {
-        "status": "missing_followup",
-        "issue": "#243",
-        "note": "Shared-set IDs are read-filterable but not updatable.",
-    },
     ("adgroups", "add", "DynamicTextAdGroup.AutotargetingCategories"): {
         "status": "missing_followup",
         "issue": "#247",


### PR DESCRIPTION
## Summary
- add typed adgroups add/update flags for top-level NegativeKeywords and NegativeKeywordSharedSetIds
- build API payloads as {Items: [...]} arrays without requiring subtype blocks
- update dry-run coverage, WSDL parity mapping, audit docs, and README EN/RU one-line examples

## Verification
- python3 -m pytest tests/test_dry_run.py -k "adgroups and negative"
- python3 -m pytest tests/test_wsdl_parity_gate.py
- python3 -m pytest tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py

Closes #243