### PR TITLE
[codex] Add vcards nested contact flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ direct dynamicfeedadtargets set-bids --id 789 --bid 6500000 --context-bid 400000
 
 # Extensions, assets, feeds, and clients
 direct sitelinks add --sitelink "Docs|https://example.com/docs|API docs|12345" --sitelink "Help|https://example.com/help|Desk" --dry-run
-direct vcards add --campaign-id 555 --country "Russia" --city "Moscow" --company-name "Acme" --work-time 1#5#9#0#18#0 --phone-country-code +7 --phone-city-code 495 --phone-number 1234567 --dry-run
+direct vcards add --campaign-id 555 --country "Russia" --city "Moscow" --company-name "Acme" --work-time 1#5#9#0#18#0 --phone-country-code +7 --phone-city-code 495 --phone-number 1234567 --instant-messenger-client telegram --instant-messenger-login acme_support --point-on-map-x 37.6173 --point-on-map-y 55.7558 --point-on-map-x1 37.60 --point-on-map-y1 55.74 --point-on-map-x2 37.63 --point-on-map-y2 55.77 --dry-run
 direct adextensions add --callout-text "Free shipping" --dry-run
 direct adimages add --name banner.png --image-data BASE64DATA --type ICON --dry-run
 direct creatives add --video-id video-id --dry-run
@@ -1219,7 +1219,7 @@ direct dynamicfeedadtargets set-bids --id 789 --bid 6500000 --context-bid 400000
 
 # Расширения, ассеты, фиды и клиенты
 direct sitelinks add --sitelink "Docs|https://example.com/docs|API docs|12345" --sitelink "Help|https://example.com/help|Desk" --dry-run
-direct vcards add --campaign-id 555 --country "Россия" --city "Москва" --company-name "Acme" --work-time 1#5#9#0#18#0 --phone-country-code +7 --phone-city-code 495 --phone-number 1234567 --dry-run
+direct vcards add --campaign-id 555 --country "Россия" --city "Москва" --company-name "Acme" --work-time 1#5#9#0#18#0 --phone-country-code +7 --phone-city-code 495 --phone-number 1234567 --instant-messenger-client telegram --instant-messenger-login acme_support --point-on-map-x 37.6173 --point-on-map-y 55.7558 --point-on-map-x1 37.60 --point-on-map-y1 55.74 --point-on-map-x2 37.63 --point-on-map-y2 55.77 --dry-run
 direct adextensions add --callout-text "Free shipping" --dry-run
 direct adimages add --name banner.png --image-data BASE64DATA --type ICON --dry-run
 direct creatives add --video-id video-id --dry-run

--- a/direct_cli/commands/vcards.py
+++ b/direct_cli/commands/vcards.py
@@ -245,6 +245,8 @@ def add(
         result = client.vcards().post(data=body)
         format_output(result().extract(), "json", None)
 
+    except click.UsageError:
+        raise
     except Exception as e:
         print_error(str(e))
         raise click.Abort()

--- a/direct_cli/commands/vcards.py
+++ b/direct_cli/commands/vcards.py
@@ -2,6 +2,8 @@
 VCards commands
 """
 
+from typing import Dict, Optional
+
 import click
 
 from ..api import create_client
@@ -12,6 +14,51 @@ from ..utils import get_default_fields, parse_ids
 @click.group()
 def vcards():
     """Manage vCards"""
+
+
+def _build_instant_messenger(
+    messenger_client: Optional[str],
+    messenger_login: Optional[str],
+) -> Optional[Dict[str, str]]:
+    if not messenger_client and not messenger_login:
+        return None
+    if not messenger_client or not messenger_login:
+        raise click.UsageError(
+            "--instant-messenger-client and --instant-messenger-login must be "
+            "provided together"
+        )
+    return {
+        "MessengerClient": messenger_client,
+        "MessengerLogin": messenger_login,
+    }
+
+
+def _build_point_on_map(
+    x: Optional[float],
+    y: Optional[float],
+    x1: Optional[float],
+    y1: Optional[float],
+    x2: Optional[float],
+    y2: Optional[float],
+) -> Optional[Dict[str, float]]:
+    values = {
+        "X": x,
+        "Y": y,
+        "X1": x1,
+        "Y1": y1,
+        "X2": x2,
+        "Y2": y2,
+    }
+    provided = {name for name, value in values.items() if value is not None}
+    if not provided:
+        return None
+    if len(provided) != len(values):
+        missing = ", ".join(
+            f"--point-on-map-{name.lower()}"
+            for name in sorted(values.keys() - provided)
+        )
+        raise click.UsageError(f"PointOnMap requires all coordinate flags: {missing}")
+    return {name: value for name, value in values.items() if value is not None}
 
 
 @vcards.command()
@@ -86,6 +133,20 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
 @click.option("--extra-message", help="Extra message")
 @click.option("--ogrn", help="OGRN")
 @click.option("--metro-station-id", type=int, help="Metro station ID")
+@click.option(
+    "--instant-messenger-client",
+    help="Instant messenger client for InstantMessenger.MessengerClient",
+)
+@click.option(
+    "--instant-messenger-login",
+    help="Instant messenger login for InstantMessenger.MessengerLogin",
+)
+@click.option("--point-on-map-x", type=float, help="PointOnMap.X coordinate")
+@click.option("--point-on-map-y", type=float, help="PointOnMap.Y coordinate")
+@click.option("--point-on-map-x1", type=float, help="PointOnMap.X1 coordinate")
+@click.option("--point-on-map-y1", type=float, help="PointOnMap.Y1 coordinate")
+@click.option("--point-on-map-x2", type=float, help="PointOnMap.X2 coordinate")
+@click.option("--point-on-map-y2", type=float, help="PointOnMap.Y2 coordinate")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
 def add(
@@ -108,10 +169,30 @@ def add(
     extra_message,
     ogrn,
     metro_station_id,
+    instant_messenger_client,
+    instant_messenger_login,
+    point_on_map_x,
+    point_on_map_y,
+    point_on_map_x1,
+    point_on_map_y1,
+    point_on_map_x2,
+    point_on_map_y2,
     dry_run,
 ):
     """Add vCard"""
     try:
+        instant_messenger = _build_instant_messenger(
+            instant_messenger_client,
+            instant_messenger_login,
+        )
+        point_on_map = _build_point_on_map(
+            point_on_map_x,
+            point_on_map_y,
+            point_on_map_x1,
+            point_on_map_y1,
+            point_on_map_x2,
+            point_on_map_y2,
+        )
         vcard = {
             "CampaignId": campaign_id,
             "Country": country,
@@ -144,6 +225,10 @@ def add(
             vcard["Ogrn"] = ogrn
         if metro_station_id is not None:
             vcard["MetroStationId"] = metro_station_id
+        if instant_messenger:
+            vcard["InstantMessenger"] = instant_messenger
+        if point_on_map:
+            vcard["PointOnMap"] = point_on_map
 
         body = {"method": "add", "params": {"VCards": [vcard]}}
 

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,8 +11,8 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 2840 |
-| `supported` | 401 |
+| `missing_followup` | 2830 |
+| `supported` | 411 |
 
 ## Confirmed Follow-Ups
 
@@ -2848,16 +2848,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `strategies.update` | `PayForConversionMultipleGoals.CustomPeriodBudget.StartDate` | strategies.update optional WSDL path needs typed support or N/A. [#251](https://github.com/axisrow/direct-cli/issues/251) |
 | `strategies.update` | `PayForConversionMultipleGoals.CustomPeriodBudget.EndDate` | strategies.update optional WSDL path needs typed support or N/A. [#251](https://github.com/axisrow/direct-cli/issues/251) |
 | `strategies.update` | `PayForConversionMultipleGoals.CustomPeriodBudget.AutoContinue` | strategies.update optional WSDL path needs typed support or N/A. [#251](https://github.com/axisrow/direct-cli/issues/251) |
-| `vcards.add` | `InstantMessenger` | VCard InstantMessenger nested object has no typed flags. [#246](https://github.com/axisrow/direct-cli/issues/246) |
-| `vcards.add` | `InstantMessenger.MessengerClient` | VCard InstantMessenger nested object has no typed flags. [#246](https://github.com/axisrow/direct-cli/issues/246); inherited from `InstantMessenger` |
-| `vcards.add` | `InstantMessenger.MessengerLogin` | VCard InstantMessenger nested object has no typed flags. [#246](https://github.com/axisrow/direct-cli/issues/246); inherited from `InstantMessenger` |
-| `vcards.add` | `PointOnMap` | VCard PointOnMap nested object has no typed flags. [#246](https://github.com/axisrow/direct-cli/issues/246) |
-| `vcards.add` | `PointOnMap.X` | VCard PointOnMap nested object has no typed flags. [#246](https://github.com/axisrow/direct-cli/issues/246); inherited from `PointOnMap` |
-| `vcards.add` | `PointOnMap.Y` | VCard PointOnMap nested object has no typed flags. [#246](https://github.com/axisrow/direct-cli/issues/246); inherited from `PointOnMap` |
-| `vcards.add` | `PointOnMap.X1` | VCard PointOnMap nested object has no typed flags. [#246](https://github.com/axisrow/direct-cli/issues/246); inherited from `PointOnMap` |
-| `vcards.add` | `PointOnMap.Y1` | VCard PointOnMap nested object has no typed flags. [#246](https://github.com/axisrow/direct-cli/issues/246); inherited from `PointOnMap` |
-| `vcards.add` | `PointOnMap.X2` | VCard PointOnMap nested object has no typed flags. [#246](https://github.com/axisrow/direct-cli/issues/246); inherited from `PointOnMap` |
-| `vcards.add` | `PointOnMap.Y2` | VCard PointOnMap nested object has no typed flags. [#246](https://github.com/axisrow/direct-cli/issues/246); inherited from `PointOnMap` |
 
 ## Field Table
 
@@ -6089,18 +6079,18 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `vcards.add` | `vcards.add` | `House` | `string` | 0 | 1 | `supported` | --house |
 | `vcards.add` | `vcards.add` | `Building` | `string` | 0 | 1 | `supported` | --building |
 | `vcards.add` | `vcards.add` | `Apartment` | `string` | 0 | 1 | `supported` | --apartment |
-| `vcards.add` | `vcards.add` | `InstantMessenger` | `InstantMessenger` | 0 | 1 | `missing_followup` | VCard InstantMessenger nested object has no typed flags. [#246](https://github.com/axisrow/direct-cli/issues/246) |
-| `vcards.add` | `vcards.add` | `InstantMessenger.MessengerClient` | `string` | 1 | 1 | `missing_followup` | VCard InstantMessenger nested object has no typed flags. [#246](https://github.com/axisrow/direct-cli/issues/246); inherited from `InstantMessenger` |
-| `vcards.add` | `vcards.add` | `InstantMessenger.MessengerLogin` | `string` | 1 | 1 | `missing_followup` | VCard InstantMessenger nested object has no typed flags. [#246](https://github.com/axisrow/direct-cli/issues/246); inherited from `InstantMessenger` |
+| `vcards.add` | `vcards.add` | `InstantMessenger` | `InstantMessenger` | 0 | 1 | `supported` | --instant-messenger-client, --instant-messenger-login |
+| `vcards.add` | `vcards.add` | `InstantMessenger.MessengerClient` | `string` | 1 | 1 | `supported` | --instant-messenger-client |
+| `vcards.add` | `vcards.add` | `InstantMessenger.MessengerLogin` | `string` | 1 | 1 | `supported` | --instant-messenger-login |
 | `vcards.add` | `vcards.add` | `ExtraMessage` | `string` | 0 | 1 | `supported` | --extra-message |
 | `vcards.add` | `vcards.add` | `ContactEmail` | `string` | 0 | 1 | `supported` | --contact-email |
 | `vcards.add` | `vcards.add` | `Ogrn` | `string` | 0 | 1 | `supported` | --ogrn |
 | `vcards.add` | `vcards.add` | `MetroStationId` | `long` | 0 | 1 | `supported` | --metro-station-id |
-| `vcards.add` | `vcards.add` | `PointOnMap` | `MapPoint` | 0 | 1 | `missing_followup` | VCard PointOnMap nested object has no typed flags. [#246](https://github.com/axisrow/direct-cli/issues/246) |
-| `vcards.add` | `vcards.add` | `PointOnMap.X` | `decimal` | 1 | 1 | `missing_followup` | VCard PointOnMap nested object has no typed flags. [#246](https://github.com/axisrow/direct-cli/issues/246); inherited from `PointOnMap` |
-| `vcards.add` | `vcards.add` | `PointOnMap.Y` | `decimal` | 1 | 1 | `missing_followup` | VCard PointOnMap nested object has no typed flags. [#246](https://github.com/axisrow/direct-cli/issues/246); inherited from `PointOnMap` |
-| `vcards.add` | `vcards.add` | `PointOnMap.X1` | `decimal` | 1 | 1 | `missing_followup` | VCard PointOnMap nested object has no typed flags. [#246](https://github.com/axisrow/direct-cli/issues/246); inherited from `PointOnMap` |
-| `vcards.add` | `vcards.add` | `PointOnMap.Y1` | `decimal` | 1 | 1 | `missing_followup` | VCard PointOnMap nested object has no typed flags. [#246](https://github.com/axisrow/direct-cli/issues/246); inherited from `PointOnMap` |
-| `vcards.add` | `vcards.add` | `PointOnMap.X2` | `decimal` | 1 | 1 | `missing_followup` | VCard PointOnMap nested object has no typed flags. [#246](https://github.com/axisrow/direct-cli/issues/246); inherited from `PointOnMap` |
-| `vcards.add` | `vcards.add` | `PointOnMap.Y2` | `decimal` | 1 | 1 | `missing_followup` | VCard PointOnMap nested object has no typed flags. [#246](https://github.com/axisrow/direct-cli/issues/246); inherited from `PointOnMap` |
+| `vcards.add` | `vcards.add` | `PointOnMap` | `MapPoint` | 0 | 1 | `supported` | --point-on-map-x, --point-on-map-x1, --point-on-map-x2, --point-on-map-y, --point-on-map-y1, --point-on-map-y2 |
+| `vcards.add` | `vcards.add` | `PointOnMap.X` | `decimal` | 1 | 1 | `supported` | --point-on-map-x |
+| `vcards.add` | `vcards.add` | `PointOnMap.Y` | `decimal` | 1 | 1 | `supported` | --point-on-map-y |
+| `vcards.add` | `vcards.add` | `PointOnMap.X1` | `decimal` | 1 | 1 | `supported` | --point-on-map-x1 |
+| `vcards.add` | `vcards.add` | `PointOnMap.Y1` | `decimal` | 1 | 1 | `supported` | --point-on-map-y1 |
+| `vcards.add` | `vcards.add` | `PointOnMap.X2` | `decimal` | 1 | 1 | `supported` | --point-on-map-x2 |
+| `vcards.add` | `vcards.add` | `PointOnMap.Y2` | `decimal` | 1 | 1 | `supported` | --point-on-map-y2 |
 | `vcards.add` | `vcards.add` | `ContactPerson` | `string` | 0 | 1 | `supported` | --contact-person |

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -3853,6 +3853,135 @@ def test_vcards_add_uses_typed_flags():
     ]
 
 
+def test_vcards_add_instant_messenger_payload():
+    body = _dry_run(
+        "vcards",
+        "add",
+        "--campaign-id",
+        "555",
+        "--country",
+        "Россия",
+        "--city",
+        "Москва",
+        "--company-name",
+        "Acme",
+        "--work-time",
+        "1#5#9#0#18#0",
+        "--phone-country-code",
+        "+7",
+        "--phone-city-code",
+        "495",
+        "--phone-number",
+        "1234567",
+        "--instant-messenger-client",
+        "telegram",
+        "--instant-messenger-login",
+        "acme_support",
+    )
+    vcard = body["params"]["VCards"][0]
+    assert vcard["InstantMessenger"] == {
+        "MessengerClient": "telegram",
+        "MessengerLogin": "acme_support",
+    }
+
+
+def test_vcards_add_instant_messenger_partial_rejected():
+    result = _rejected(
+        "vcards",
+        "add",
+        "--campaign-id",
+        "555",
+        "--country",
+        "Россия",
+        "--city",
+        "Москва",
+        "--company-name",
+        "Acme",
+        "--work-time",
+        "1#5#9#0#18#0",
+        "--phone-country-code",
+        "+7",
+        "--phone-city-code",
+        "495",
+        "--phone-number",
+        "1234567",
+        "--instant-messenger-client",
+        "telegram",
+    )
+    assert "--instant-messenger-client and --instant-messenger-login" in result.output
+
+
+def test_vcards_add_point_on_map_payload():
+    body = _dry_run(
+        "vcards",
+        "add",
+        "--campaign-id",
+        "555",
+        "--country",
+        "Россия",
+        "--city",
+        "Москва",
+        "--company-name",
+        "Acme",
+        "--work-time",
+        "1#5#9#0#18#0",
+        "--phone-country-code",
+        "+7",
+        "--phone-city-code",
+        "495",
+        "--phone-number",
+        "1234567",
+        "--point-on-map-x",
+        "37.6173",
+        "--point-on-map-y",
+        "55.7558",
+        "--point-on-map-x1",
+        "37.60",
+        "--point-on-map-y1",
+        "55.74",
+        "--point-on-map-x2",
+        "37.63",
+        "--point-on-map-y2",
+        "55.77",
+    )
+    vcard = body["params"]["VCards"][0]
+    assert vcard["PointOnMap"] == {
+        "X": 37.6173,
+        "Y": 55.7558,
+        "X1": 37.60,
+        "Y1": 55.74,
+        "X2": 37.63,
+        "Y2": 55.77,
+    }
+
+
+def test_vcards_add_point_on_map_partial_rejected():
+    result = _rejected(
+        "vcards",
+        "add",
+        "--campaign-id",
+        "555",
+        "--country",
+        "Россия",
+        "--city",
+        "Москва",
+        "--company-name",
+        "Acme",
+        "--work-time",
+        "1#5#9#0#18#0",
+        "--phone-country-code",
+        "+7",
+        "--phone-city-code",
+        "495",
+        "--phone-number",
+        "1234567",
+        "--point-on-map-x",
+        "37.6173",
+    )
+    assert "PointOnMap requires all coordinate flags" in result.output
+    assert "--point-on-map-y" in result.output
+
+
 # ----------------------------------------------------------------------
 # adextensions
 # ----------------------------------------------------------------------

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -3909,6 +3909,7 @@ def test_vcards_add_instant_messenger_partial_rejected():
         "telegram",
     )
     assert "--instant-messenger-client and --instant-messenger-login" in result.output
+    assert result.exit_code == 2
 
 
 def test_vcards_add_point_on_map_payload():
@@ -3980,6 +3981,7 @@ def test_vcards_add_point_on_map_partial_rejected():
     )
     assert "PointOnMap requires all coordinate flags" in result.output
     assert "--point-on-map-y" in result.output
+    assert result.exit_code == 2
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -834,6 +834,16 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     ("vcards", "add", "Phone.CityCode"): {"--phone-city-code"},
     ("vcards", "add", "Phone.PhoneNumber"): {"--phone-number"},
     ("vcards", "add", "Phone.Extension"): {"--phone-extension"},
+    ("vcards", "add", "InstantMessenger"): {
+        "--instant-messenger-client",
+        "--instant-messenger-login",
+    },
+    ("vcards", "add", "InstantMessenger.MessengerClient"): {
+        "--instant-messenger-client"
+    },
+    ("vcards", "add", "InstantMessenger.MessengerLogin"): {
+        "--instant-messenger-login"
+    },
     ("vcards", "add", "Street"): {"--street"},
     ("vcards", "add", "House"): {"--house"},
     ("vcards", "add", "Building"): {"--building"},
@@ -842,6 +852,20 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     ("vcards", "add", "ContactEmail"): {"--contact-email"},
     ("vcards", "add", "Ogrn"): {"--ogrn"},
     ("vcards", "add", "MetroStationId"): {"--metro-station-id"},
+    ("vcards", "add", "PointOnMap"): {
+        "--point-on-map-x",
+        "--point-on-map-y",
+        "--point-on-map-x1",
+        "--point-on-map-y1",
+        "--point-on-map-x2",
+        "--point-on-map-y2",
+    },
+    ("vcards", "add", "PointOnMap.X"): {"--point-on-map-x"},
+    ("vcards", "add", "PointOnMap.Y"): {"--point-on-map-y"},
+    ("vcards", "add", "PointOnMap.X1"): {"--point-on-map-x1"},
+    ("vcards", "add", "PointOnMap.Y1"): {"--point-on-map-y1"},
+    ("vcards", "add", "PointOnMap.X2"): {"--point-on-map-x2"},
+    ("vcards", "add", "PointOnMap.Y2"): {"--point-on-map-y2"},
     ("vcards", "add", "ContactPerson"): {"--contact-person"},
 }
 
@@ -1040,16 +1064,6 @@ OPTIONAL_FIELD_AUDIT: dict[tuple[str, str, str], dict[str, str]] = {
         "status": "missing_followup",
         "issue": "#245",
         "note": "TEXT_AD price extension update is WSDL-supported but absent.",
-    },
-    ("vcards", "add", "InstantMessenger"): {
-        "status": "missing_followup",
-        "issue": "#246",
-        "note": "VCard InstantMessenger nested object has no typed flags.",
-    },
-    ("vcards", "add", "PointOnMap"): {
-        "status": "missing_followup",
-        "issue": "#246",
-        "note": "VCard PointOnMap nested object has no typed flags.",
     },
     ("adgroups", "add", "MobileAppAdGroup"): {
         "status": "missing_followup",


### PR DESCRIPTION
## Summary
- add typed vcards add flags for InstantMessenger and PointOnMap nested objects
- validate all-or-none grouped inputs so partial nested objects are rejected locally
- update dry-run coverage, WSDL parity mapping, audit docs, and README EN/RU one-line examples

## Verification
- python3 -m pytest tests/test_dry_run.py -k "vcards and (instant_messenger or point_on_map)"
- python3 -m pytest tests/test_wsdl_parity_gate.py
- python3 -m pytest tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py

Closes #246