### PR TITLE
[codex] Add TEXT_AD extension update flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ direct ads update --id 99999 --type TEXT_AD --image-hash abcdefghijklmnopqrst
 direct ads update --id 99999 --type TEXT_AD --title2 "New second headline" --vcard-id 222
 direct ads update --id 99999 --type TEXT_AD --callouts-add "111,222" --callouts-remove "333"
 direct ads update --id 99999 --type TEXT_AD --callouts-set "444,555"
+direct ads update --id 99999 --type TEXT_AD --video-extension-creative-id 777 --price-extension-price 123450000 --price-extension-price-qualifier FROM --price-extension-price-currency RUB
 direct ads delete --id 99999
 ```
 
@@ -409,6 +410,9 @@ Available TEXT_AD typed flags for `ads add` / `ads update`: `--title`, `--text`,
 `TextAdUpdateBase.CalloutSetting` (`ext:AdExtensionSetting`) field on an
 existing ad — `--callouts-set` replaces the whole callout list and is mutually
 exclusive with the incremental `--callouts-add` / `--callouts-remove` pair.
+It also exposes `--video-extension-creative-id` and `--price-extension-*` flags
+for `TextAd.VideoExtension` and `TextAd.PriceExtension`; price values use the
+Yandex Direct API long-unit format (price multiplied by 1,000,000).
 `--mobile` (default `NO`) and `--ad-extensions` are `ads add`-only —
 `TextAdUpdate` does not contain `Mobile`, and on update ad-extensions are
 managed through the `--callouts-*` flags above. TEXT_IMAGE_AD additionally
@@ -1100,6 +1104,7 @@ direct ads update --id 99999 --type TEXT_AD --image-hash abcdefghijklmnopqrst
 direct ads update --id 99999 --type TEXT_AD --title2 "Новый второй заголовок" --vcard-id 222
 direct ads update --id 99999 --type TEXT_AD --callouts-add "111,222" --callouts-remove "333"
 direct ads update --id 99999 --type TEXT_AD --callouts-set "444,555"
+direct ads update --id 99999 --type TEXT_AD --video-extension-creative-id 777 --price-extension-price 123450000 --price-extension-price-qualifier FROM --price-extension-price-currency RUB
 direct ads delete --id 99999
 ```
 
@@ -1110,7 +1115,11 @@ direct ads delete --id 99999
 `--callouts-set` для управления полем `TextAdUpdateBase.CalloutSetting`
 (`ext:AdExtensionSetting`) у существующего объявления — `--callouts-set`
 заменяет весь список выносок и взаимоисключим с инкрементальной парой
-`--callouts-add` / `--callouts-remove`. `--mobile` (default `NO`) и
+`--callouts-add` / `--callouts-remove`. Также доступны
+`--video-extension-creative-id` и флаги `--price-extension-*` для
+`TextAd.VideoExtension` и `TextAd.PriceExtension`; цены передаются в формате
+long-единиц API Яндекс Директа (цена, умноженная на 1 000 000). `--mobile`
+(default `NO`) и
 `--ad-extensions` доступны только в `ads add` — WSDL `TextAdUpdate` не
 содержит `Mobile`, а в `ads update` расширения управляются через флаги
 `--callouts-*` выше. Для TEXT_IMAGE_AD дополнительно доступен

--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -70,6 +70,25 @@ def _build_callout_setting(callouts_add, callouts_remove, callouts_set):
     return {"AdExtensions": items}
 
 
+def _build_price_extension(
+    price_extension_price,
+    price_extension_old_price,
+    price_extension_price_qualifier,
+    price_extension_price_currency,
+):
+    """Build TextAd.PriceExtension update payload from typed flags."""
+    price_extension = {}
+    if price_extension_price is not None:
+        price_extension["Price"] = price_extension_price
+    if price_extension_old_price is not None:
+        price_extension["OldPrice"] = price_extension_old_price
+    if price_extension_price_qualifier:
+        price_extension["PriceQualifier"] = price_extension_price_qualifier.upper()
+    if price_extension_price_currency:
+        price_extension["PriceCurrency"] = price_extension_price_currency.upper()
+    return price_extension or None
+
+
 @ads.command()
 @click.option("--ids", help="Comma-separated ad IDs")
 @click.option("--campaign-ids", help="Comma-separated campaign IDs")
@@ -509,6 +528,40 @@ def add(
         "--callouts-add / --callouts-remove. TEXT_AD only."
     ),
 )
+@click.option(
+    "--video-extension-creative-id",
+    type=int,
+    help="Video extension CreativeId for TextAd.VideoExtension. TEXT_AD only.",
+)
+@click.option(
+    "--price-extension-price",
+    type=int,
+    help=(
+        "PriceExtension.Price as API long units "
+        "(price multiplied by 1,000,000). TEXT_AD only."
+    ),
+)
+@click.option(
+    "--price-extension-old-price",
+    type=int,
+    help=(
+        "PriceExtension.OldPrice as API long units "
+        "(price multiplied by 1,000,000). TEXT_AD only."
+    ),
+)
+@click.option(
+    "--price-extension-price-qualifier",
+    type=click.Choice(["FROM", "UP_TO", "NONE"], case_sensitive=False),
+    help="PriceExtension.PriceQualifier: FROM, UP_TO, or NONE. TEXT_AD only.",
+)
+@click.option(
+    "--price-extension-price-currency",
+    type=click.Choice(
+        ["RUB", "UAH", "BYN", "USD", "EUR", "KZT", "TRY", "CHF", "UZS"],
+        case_sensitive=False,
+    ),
+    help="PriceExtension.PriceCurrency enum value. TEXT_AD only.",
+)
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
 def update(
@@ -531,6 +584,11 @@ def update(
     callouts_add,
     callouts_remove,
     callouts_set,
+    video_extension_creative_id,
+    price_extension_price,
+    price_extension_old_price,
+    price_extension_price_qualifier,
+    price_extension_price_currency,
     dry_run,
 ):
     """Update ad"""
@@ -568,6 +626,11 @@ def update(
             "callouts_add",
             "callouts_remove",
             "callouts_set",
+            "video_extension_creative_id",
+            "price_extension_price",
+            "price_extension_old_price",
+            "price_extension_price_qualifier",
+            "price_extension_price_currency",
         },
         "TEXT_IMAGE_AD": {"image_hash", "href", "turbo_page_id"},
         "MOBILE_APP_AD": {
@@ -595,6 +658,11 @@ def update(
         "callouts_add": callouts_add,
         "callouts_remove": callouts_remove,
         "callouts_set": callouts_set,
+        "video_extension_creative_id": video_extension_creative_id,
+        "price_extension_price": price_extension_price,
+        "price_extension_old_price": price_extension_old_price,
+        "price_extension_price_qualifier": price_extension_price_qualifier,
+        "price_extension_price_currency": price_extension_price_currency,
     }
     flag_for = {
         "title": "--title",
@@ -612,6 +680,11 @@ def update(
         "callouts_add": "--callouts-add",
         "callouts_remove": "--callouts-remove",
         "callouts_set": "--callouts-set",
+        "video_extension_creative_id": "--video-extension-creative-id",
+        "price_extension_price": "--price-extension-price",
+        "price_extension_old_price": "--price-extension-old-price",
+        "price_extension_price_qualifier": "--price-extension-price-qualifier",
+        "price_extension_price_currency": "--price-extension-price-currency",
     }
     try:
         _reject_incompatible_flags(
@@ -628,6 +701,12 @@ def update(
     # net wrapped around the network call below.
     callout_setting = _build_callout_setting(
         callouts_add, callouts_remove, callouts_set
+    )
+    price_extension = _build_price_extension(
+        price_extension_price,
+        price_extension_old_price,
+        price_extension_price_qualifier,
+        price_extension_price_currency,
     )
 
     ad_data = {"Id": ad_id}
@@ -654,6 +733,10 @@ def update(
             text_ad["TurboPageId"] = turbo_page_id
         if callout_setting:
             text_ad["CalloutSetting"] = callout_setting
+        if video_extension_creative_id is not None:
+            text_ad["VideoExtension"] = {"CreativeId": video_extension_creative_id}
+        if price_extension:
+            text_ad["PriceExtension"] = price_extension
         if text_ad:
             ad_data["TextAd"] = text_ad
     elif ad_type_norm == "TEXT_IMAGE_AD":

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,8 +11,8 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 2830 |
-| `supported` | 411 |
+| `missing_followup` | 2823 |
+| `supported` | 418 |
 
 ## Confirmed Follow-Ups
 
@@ -223,13 +223,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `ads.update` | `TextAd.CalloutSetting.AdExtensions.Operation` | ads.update optional WSDL path needs typed support or N/A. [#240](https://github.com/axisrow/direct-cli/issues/240) |
 | `ads.update` | `TextAd.FinalUrl` | ads.update optional WSDL path needs typed support or N/A. [#240](https://github.com/axisrow/direct-cli/issues/240) |
 | `ads.update` | `TextAd.AgeLabel` | ads.update optional WSDL path needs typed support or N/A. [#240](https://github.com/axisrow/direct-cli/issues/240) |
-| `ads.update` | `TextAd.VideoExtension` | TEXT_AD video extension update is WSDL-supported but absent. [#245](https://github.com/axisrow/direct-cli/issues/245) |
-| `ads.update` | `TextAd.VideoExtension.CreativeId` | TEXT_AD video extension update is WSDL-supported but absent. [#245](https://github.com/axisrow/direct-cli/issues/245); inherited from `TextAd.VideoExtension` |
-| `ads.update` | `TextAd.PriceExtension` | TEXT_AD price extension update is WSDL-supported but absent. [#245](https://github.com/axisrow/direct-cli/issues/245) |
-| `ads.update` | `TextAd.PriceExtension.Price` | TEXT_AD price extension update is WSDL-supported but absent. [#245](https://github.com/axisrow/direct-cli/issues/245); inherited from `TextAd.PriceExtension` |
-| `ads.update` | `TextAd.PriceExtension.OldPrice` | TEXT_AD price extension update is WSDL-supported but absent. [#245](https://github.com/axisrow/direct-cli/issues/245); inherited from `TextAd.PriceExtension` |
-| `ads.update` | `TextAd.PriceExtension.PriceQualifier` | TEXT_AD price extension update is WSDL-supported but absent. [#245](https://github.com/axisrow/direct-cli/issues/245); inherited from `TextAd.PriceExtension` |
-| `ads.update` | `TextAd.PriceExtension.PriceCurrency` | TEXT_AD price extension update is WSDL-supported but absent. [#245](https://github.com/axisrow/direct-cli/issues/245); inherited from `TextAd.PriceExtension` |
 | `ads.update` | `TextAd.BusinessId` | ads.update optional WSDL path needs typed support or N/A. [#240](https://github.com/axisrow/direct-cli/issues/240) |
 | `ads.update` | `TextAd.PreferVCardOverBusiness` | ads.update optional WSDL path needs typed support or N/A. [#240](https://github.com/axisrow/direct-cli/issues/240) |
 | `ads.update` | `TextAd.ErirAdDescription` | ads.update optional WSDL path needs typed support or N/A. [#240](https://github.com/axisrow/direct-cli/issues/240) |
@@ -3120,13 +3113,13 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `ads.update` | `ads.update` | `TextAd.Href` | `string` | 0 | 1 | `supported` | --href |
 | `ads.update` | `ads.update` | `TextAd.AgeLabel` | `AgeLabelEnum` | 0 | 1 | `missing_followup` | ads.update optional WSDL path needs typed support or N/A. [#240](https://github.com/axisrow/direct-cli/issues/240) |
 | `ads.update` | `ads.update` | `TextAd.DisplayUrlPath` | `string` | 0 | 1 | `supported` | --display-url-path |
-| `ads.update` | `ads.update` | `TextAd.VideoExtension` | `VideoExtensionUpdateItem` | 0 | 1 | `missing_followup` | TEXT_AD video extension update is WSDL-supported but absent. [#245](https://github.com/axisrow/direct-cli/issues/245) |
-| `ads.update` | `ads.update` | `TextAd.VideoExtension.CreativeId` | `long` | 0 | 1 | `missing_followup` | TEXT_AD video extension update is WSDL-supported but absent. [#245](https://github.com/axisrow/direct-cli/issues/245); inherited from `TextAd.VideoExtension` |
-| `ads.update` | `ads.update` | `TextAd.PriceExtension` | `PriceExtensionUpdateItem` | 0 | 1 | `missing_followup` | TEXT_AD price extension update is WSDL-supported but absent. [#245](https://github.com/axisrow/direct-cli/issues/245) |
-| `ads.update` | `ads.update` | `TextAd.PriceExtension.Price` | `long` | 0 | 1 | `missing_followup` | TEXT_AD price extension update is WSDL-supported but absent. [#245](https://github.com/axisrow/direct-cli/issues/245); inherited from `TextAd.PriceExtension` |
-| `ads.update` | `ads.update` | `TextAd.PriceExtension.OldPrice` | `long` | 0 | 1 | `missing_followup` | TEXT_AD price extension update is WSDL-supported but absent. [#245](https://github.com/axisrow/direct-cli/issues/245); inherited from `TextAd.PriceExtension` |
-| `ads.update` | `ads.update` | `TextAd.PriceExtension.PriceQualifier` | `PriceQualifierEnum` | 0 | 1 | `missing_followup` | TEXT_AD price extension update is WSDL-supported but absent. [#245](https://github.com/axisrow/direct-cli/issues/245); inherited from `TextAd.PriceExtension` |
-| `ads.update` | `ads.update` | `TextAd.PriceExtension.PriceCurrency` | `PriceCurrencyEnum` | 0 | 1 | `missing_followup` | TEXT_AD price extension update is WSDL-supported but absent. [#245](https://github.com/axisrow/direct-cli/issues/245); inherited from `TextAd.PriceExtension` |
+| `ads.update` | `ads.update` | `TextAd.VideoExtension` | `VideoExtensionUpdateItem` | 0 | 1 | `supported` | --video-extension-creative-id |
+| `ads.update` | `ads.update` | `TextAd.VideoExtension.CreativeId` | `long` | 0 | 1 | `supported` | --video-extension-creative-id |
+| `ads.update` | `ads.update` | `TextAd.PriceExtension` | `PriceExtensionUpdateItem` | 0 | 1 | `supported` | --price-extension-old-price, --price-extension-price, --price-extension-price-currency, --price-extension-price-qualifier |
+| `ads.update` | `ads.update` | `TextAd.PriceExtension.Price` | `long` | 0 | 1 | `supported` | --price-extension-price |
+| `ads.update` | `ads.update` | `TextAd.PriceExtension.OldPrice` | `long` | 0 | 1 | `supported` | --price-extension-old-price |
+| `ads.update` | `ads.update` | `TextAd.PriceExtension.PriceQualifier` | `PriceQualifierEnum` | 0 | 1 | `supported` | --price-extension-price-qualifier |
+| `ads.update` | `ads.update` | `TextAd.PriceExtension.PriceCurrency` | `PriceCurrencyEnum` | 0 | 1 | `supported` | --price-extension-price-currency |
 | `ads.update` | `ads.update` | `TextAd.TurboPageId` | `long` | 0 | 1 | `supported` | --turbo-page-id |
 | `ads.update` | `ads.update` | `TextAd.BusinessId` | `long` | 0 | 1 | `missing_followup` | ads.update optional WSDL path needs typed support or N/A. [#240](https://github.com/axisrow/direct-cli/issues/240) |
 | `ads.update` | `ads.update` | `TextAd.PreferVCardOverBusiness` | `YesNoEnum` | 0 | 1 | `missing_followup` | ads.update optional WSDL path needs typed support or N/A. [#240](https://github.com/axisrow/direct-cli/issues/240) |

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1397,6 +1397,127 @@ def test_ads_update_callouts_invalid_id_rejected_with_usage_error():
     assert "Traceback" not in result.output
 
 
+def test_ads_update_text_ad_video_extension_payload():
+    """Issue #245: TEXT_AD update exposes VideoExtension.CreativeId."""
+    body = _dry_run(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "TEXT_AD",
+        "--video-extension-creative-id",
+        "777",
+    )
+    assert body["params"]["Ads"][0] == {
+        "Id": 999,
+        "TextAd": {"VideoExtension": {"CreativeId": 777}},
+    }
+
+
+def test_ads_update_text_ad_price_extension_payload():
+    """Issue #245: TEXT_AD update exposes PriceExtension fields."""
+    body = _dry_run(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "TEXT_AD",
+        "--price-extension-price",
+        "123450000",
+        "--price-extension-old-price",
+        "150000000",
+        "--price-extension-price-qualifier",
+        "from",
+        "--price-extension-price-currency",
+        "rub",
+    )
+    assert body["params"]["Ads"][0] == {
+        "Id": 999,
+        "TextAd": {
+            "PriceExtension": {
+                "Price": 123450000,
+                "OldPrice": 150000000,
+                "PriceQualifier": "FROM",
+                "PriceCurrency": "RUB",
+            }
+        },
+    }
+
+
+def test_ads_update_text_ad_price_extension_partial_payload():
+    """PriceExtensionUpdateItem children are optional in WSDL update."""
+    body = _dry_run(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "TEXT_AD",
+        "--price-extension-price-currency",
+        "USD",
+    )
+    assert body["params"]["Ads"][0] == {
+        "Id": 999,
+        "TextAd": {"PriceExtension": {"PriceCurrency": "USD"}},
+    }
+
+
+def test_ads_update_text_ad_extension_flags_rejected_for_text_image_ad():
+    """Issue #245: TEXT_AD extension flags must not silently drop by subtype."""
+    result = _rejected(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "TEXT_IMAGE_AD",
+        "--video-extension-creative-id",
+        "777",
+    )
+    assert (
+        "--video-extension-creative-id is not compatible with --type TEXT_IMAGE_AD"
+        in result.output
+    )
+
+
+def test_ads_update_text_ad_price_extension_flags_rejected_for_mobile_app_ad():
+    """Issue #245: PriceExtension flags are TEXT_AD-only in this patch scope."""
+    result = _rejected(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "MOBILE_APP_AD",
+        "--price-extension-price",
+        "123450000",
+    )
+    assert (
+        "--price-extension-price is not compatible with --type MOBILE_APP_AD"
+        in result.output
+    )
+
+
+def test_ads_update_text_ad_extension_flags_count_as_updatable_fields():
+    """Issue #245: extension-only updates must not trip the no-op guard."""
+    body = _dry_run(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "TEXT_AD",
+        "--price-extension-price-qualifier",
+        "NONE",
+    )
+    assert body["params"]["Ads"][0] == {
+        "Id": 999,
+        "TextAd": {"PriceExtension": {"PriceQualifier": "NONE"}},
+    }
+
+
 def test_ads_update_rejects_title2_on_text_image_ad():
     """Issue #202 (Pattern B): --title2 is TEXT_AD-only in update too."""
     result = CliRunner().invoke(

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -690,6 +690,26 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
         "--callouts-remove",
         "--callouts-set",
     },
+    ("ads", "update", "TextAd.VideoExtension"): {"--video-extension-creative-id"},
+    ("ads", "update", "TextAd.VideoExtension.CreativeId"): {
+        "--video-extension-creative-id"
+    },
+    ("ads", "update", "TextAd.PriceExtension"): {
+        "--price-extension-price",
+        "--price-extension-old-price",
+        "--price-extension-price-qualifier",
+        "--price-extension-price-currency",
+    },
+    ("ads", "update", "TextAd.PriceExtension.Price"): {"--price-extension-price"},
+    ("ads", "update", "TextAd.PriceExtension.OldPrice"): {
+        "--price-extension-old-price"
+    },
+    ("ads", "update", "TextAd.PriceExtension.PriceQualifier"): {
+        "--price-extension-price-qualifier"
+    },
+    ("ads", "update", "TextAd.PriceExtension.PriceCurrency"): {
+        "--price-extension-price-currency"
+    },
     ("ads", "update", "MobileAppAd"): {"--type"},
     ("ads", "update", "MobileAppAd.AdImageHash"): {"--image-hash"},
     ("ads", "update", "MobileAppAd.Text"): {"--text"},
@@ -1054,16 +1074,6 @@ OPTIONAL_FIELD_AUDIT: dict[tuple[str, str, str], dict[str, str]] = {
         "status": "missing_followup",
         "issue": "#244",
         "note": "Keyword autotargeting settings have no typed update flags.",
-    },
-    ("ads", "update", "TextAd.VideoExtension"): {
-        "status": "missing_followup",
-        "issue": "#245",
-        "note": "TEXT_AD video extension update is WSDL-supported but absent.",
-    },
-    ("ads", "update", "TextAd.PriceExtension"): {
-        "status": "missing_followup",
-        "issue": "#245",
-        "note": "TEXT_AD price extension update is WSDL-supported but absent.",
     },
     ("adgroups", "add", "MobileAppAdGroup"): {
         "status": "missing_followup",


### PR DESCRIPTION
## Summary
- add typed ads update TEXT_AD flags for VideoExtension.CreativeId and PriceExtension fields
- keep the new extension flags TEXT_AD-only through existing subtype compatibility validation
- update dry-run coverage, WSDL parity mapping, audit docs, and README EN/RU one-line examples

## Documentation check
- Checked official Yandex Direct ads.update docs: TextAd.VideoExtension.CreativeId is long/nillable and TextAd.PriceExtension fields are Price/OldPrice long-unit values plus PriceQualifier/PriceCurrency enums.

## Verification
- python3 -m pytest tests/test_dry_run.py -k "ads_update_text_ad and (video_extension or price_extension or extension_flags)"
- python3 -m pytest tests/test_wsdl_parity_gate.py
- python3 -m pytest tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py

Closes #245