### PR TITLE
Classify audiencetargets add bid flags (#302)

### DIFF
--- a/direct_cli/commands/audiencetargets.py
+++ b/direct_cli/commands/audiencetargets.py
@@ -101,8 +101,12 @@ def get(
 @click.option("--adgroup-id", required=True, type=int, help="Ad group ID")
 @click.option("--retargeting-list-id", type=int, help="Retargeting list ID")
 @click.option("--interest-id", type=int, help="Interest ID")
-@click.option("--bid", type=MICRO_RUBLES, help="Context bid in micro-rubles")
-@click.option("--priority", help="Strategy priority")
+@click.option("--bid", type=MICRO_RUBLES, help="ContextBid value in micro-rubles")
+@click.option(
+    "--priority",
+    type=click.Choice(["LOW", "NORMAL", "HIGH"], case_sensitive=False),
+    help="StrategyPriority value for automatic strategies",
+)
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
 def add(
@@ -132,7 +136,7 @@ def add(
         if bid is not None:
             target_data["ContextBid"] = bid
         if priority:
-            target_data["StrategyPriority"] = priority
+            target_data["StrategyPriority"] = priority.upper()
 
         body = {"method": "add", "params": {"AudienceTargets": [target_data]}}
 

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,8 +11,8 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 2815 |
-| `supported` | 426 |
+| `missing_followup` | 2813 |
+| `supported` | 428 |
 
 ## Confirmed Follow-Ups
 
@@ -351,8 +351,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `ads.update` | `ListingAd.TextSources` | LISTING_AD update fields need typed support or N/A. [#269](https://github.com/axisrow/direct-cli/issues/269); inherited from `ListingAd` |
 | `ads.update` | `ListingAd.TextSources.Items` | LISTING_AD update fields need typed support or N/A. [#269](https://github.com/axisrow/direct-cli/issues/269); inherited from `ListingAd` |
 | `ads.update` | `ListingAd.DefaultTexts` | LISTING_AD update fields need typed support or N/A. [#269](https://github.com/axisrow/direct-cli/issues/269); inherited from `ListingAd` |
-| `audiencetargets.add` | `ContextBid` | target bid optional WSDL path needs typed support or N/A. [#302](https://github.com/axisrow/direct-cli/issues/302) |
-| `audiencetargets.add` | `StrategyPriority` | target bid optional WSDL path needs typed support or N/A. [#302](https://github.com/axisrow/direct-cli/issues/302) |
 | `bids.set` | `CampaignId` | bids.set optional WSDL path needs typed support or N/A. [#301](https://github.com/axisrow/direct-cli/issues/301) |
 | `bids.set` | `AdGroupId` | bids.set optional WSDL path needs typed support or N/A. [#301](https://github.com/axisrow/direct-cli/issues/301) |
 | `bids.set` | `ContextBid` | bids.set optional WSDL path needs typed support or N/A. [#301](https://github.com/axisrow/direct-cli/issues/301) |
@@ -3255,8 +3253,8 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `advideos.add` | `advideos.add` | `Url` | `string` | 0 | 1 | `supported` | --url |
 | `advideos.add` | `advideos.add` | `VideoData` | `base64Binary` | 0 | 1 | `supported` | --video-data, --video-file |
 | `advideos.add` | `advideos.add` | `Name` | `string` | 0 | 1 | `supported` | --name |
-| `audiencetargets.add` | `audiencetargets.add` | `ContextBid` | `long` | 0 | 1 | `missing_followup` | target bid optional WSDL path needs typed support or N/A. [#302](https://github.com/axisrow/direct-cli/issues/302) |
-| `audiencetargets.add` | `audiencetargets.add` | `StrategyPriority` | `PriorityEnum` | 0 | 1 | `missing_followup` | target bid optional WSDL path needs typed support or N/A. [#302](https://github.com/axisrow/direct-cli/issues/302) |
+| `audiencetargets.add` | `audiencetargets.add` | `ContextBid` | `long` | 0 | 1 | `supported` | --bid |
+| `audiencetargets.add` | `audiencetargets.add` | `StrategyPriority` | `PriorityEnum` | 0 | 1 | `supported` | --priority |
 | `audiencetargets.add` | `audiencetargets.add` | `AdGroupId` | `long` | 1 | 1 | `supported` | covered by minOccurs>=1 parity gate |
 | `audiencetargets.add` | `audiencetargets.add` | `RetargetingListId` | `long` | 0 | 1 | `supported` | --retargeting-list-id |
 | `audiencetargets.add` | `audiencetargets.add` | `InterestId` | `long` | 0 | 1 | `supported` | --interest-id |

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -3736,7 +3736,7 @@ def test_audiencetargets_add_context_bid():
         "--bid",
         "12000000",
         "--priority",
-        "HIGH",
+        "high",
     )
     assert body["method"] == "add"
     target = body["params"]["AudienceTargets"][0]
@@ -3746,6 +3746,21 @@ def test_audiencetargets_add_context_bid():
         "ContextBid": 12000000,
         "StrategyPriority": "HIGH",
     }
+
+
+def test_audiencetargets_add_rejects_invalid_priority():
+    result = _rejected(
+        "audiencetargets",
+        "add",
+        "--adgroup-id",
+        "100",
+        "--retargeting-list-id",
+        "200",
+        "--priority",
+        "MAX",
+    )
+
+    assert "Invalid value for '--priority'" in result.output
 
 
 def test_audiencetargets_add_accepts_interest_id():

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -821,6 +821,8 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     ("negativekeywordsharedsets", "update", "NegativeKeywords"): {"--keywords"},
     ("audiencetargets", "add", "RetargetingListId"): {"--retargeting-list-id"},
     ("audiencetargets", "add", "InterestId"): {"--interest-id"},
+    ("audiencetargets", "add", "ContextBid"): {"--bid"},
+    ("audiencetargets", "add", "StrategyPriority"): {"--priority"},
     ("bids", "set", "KeywordId"): {"--keyword-id"},
     ("bids", "set", "Bid"): {"--bid"},
     ("keywordbids", "set", "KeywordId"): {"--keyword-id"},


### PR DESCRIPTION
## Summary
- route audiencetargets.add ContextBid and StrategyPriority optional WSDL rows to existing typed flags
- validate --priority against the documented PriorityEnum LOW/NORMAL/HIGH and normalize output
- update dry-run coverage and WSDL optional-field audit counts

Official docs checked: https://yandex.ru/dev/direct/doc/ru/audiencetargets/add

## Verification
- python3 -m black --check direct_cli/commands/audiencetargets.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py
- python3 -m pytest tests/test_dry_run.py -k "audiencetargets_add"
- python3 scripts/build_wsdl_optional_field_audit.py --check
- python3 -m pytest tests/test_wsdl_parity_gate.py
- python3 -m direct_cli.cli audiencetargets add --help
- python3 -m pytest tests/test_dry_run.py

Closes #302