### PR TITLE
Classify clients update item parity

### DIFF
--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,8 +11,8 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 2804 |
-| `supported` | 437 |
+| `missing_followup` | 2800 |
+| `supported` | 441 |
 
 ## Confirmed Follow-Ups
 
@@ -2549,11 +2549,7 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `campaigns.update` | `TimeTargeting.HolidaysSchedule.BidPercent` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
 | `campaigns.update` | `TimeTargeting.HolidaysSchedule.StartHour` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
 | `campaigns.update` | `TimeTargeting.HolidaysSchedule.EndHour` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `clients.update` | `Notification.EmailSubscriptions.Option` | Client EmailSubscriptions item parity needs typed support or N/A. [#305](https://github.com/axisrow/direct-cli/issues/305); inherited from `Notification.EmailSubscriptions` |
-| `clients.update` | `Notification.EmailSubscriptions.Value` | Client EmailSubscriptions item parity needs typed support or N/A. [#305](https://github.com/axisrow/direct-cli/issues/305); inherited from `Notification.EmailSubscriptions` |
-| `clients.update` | `Settings.Option` | Client Settings item parity needs typed support or N/A. [#305](https://github.com/axisrow/direct-cli/issues/305); inherited from `Settings` |
-| `clients.update` | `Settings.Value` | Client Settings item parity needs typed support or N/A. [#305](https://github.com/axisrow/direct-cli/issues/305); inherited from `Settings` |
-| `clients.update` | `ErirAttributes` | clients.update item option/value path needs typed support or N/A. [#305](https://github.com/axisrow/direct-cli/issues/305) |
+| `clients.update` | `ErirAttributes` | ERIR parent wrapper is tracked with the first ERIR child issue. [#306](https://github.com/axisrow/direct-cli/issues/306) |
 | `clients.update` | `ErirAttributes.Organization` | ERIR Organization fields need typed support or N/A. [#306](https://github.com/axisrow/direct-cli/issues/306) |
 | `clients.update` | `ErirAttributes.Organization.Name` | ERIR Organization fields need typed support or N/A. [#306](https://github.com/axisrow/direct-cli/issues/306); inherited from `ErirAttributes.Organization` |
 | `clients.update` | `ErirAttributes.Organization.EpayNumber` | ERIR Organization fields need typed support or N/A. [#306](https://github.com/axisrow/direct-cli/issues/306); inherited from `ErirAttributes.Organization` |
@@ -5528,16 +5524,16 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `clients.update` | `clients.update` | `Notification` | `NotificationUpdate` | 0 | 1 | `supported` | --email-subscription, --notification-email, --notification-lang |
 | `clients.update` | `clients.update` | `Notification.Email` | `string` | 0 | 1 | `supported` | --notification-email |
 | `clients.update` | `clients.update` | `Notification.EmailSubscriptions` | `EmailSubscriptionItem` | 0 | unbounded | `supported` | --email-subscription |
-| `clients.update` | `clients.update` | `Notification.EmailSubscriptions.Option` | `EmailSubscriptionEnum` | 1 | 1 | `missing_followup` | Client EmailSubscriptions item parity needs typed support or N/A. [#305](https://github.com/axisrow/direct-cli/issues/305); inherited from `Notification.EmailSubscriptions` |
-| `clients.update` | `clients.update` | `Notification.EmailSubscriptions.Value` | `YesNoEnum` | 1 | 1 | `missing_followup` | Client EmailSubscriptions item parity needs typed support or N/A. [#305](https://github.com/axisrow/direct-cli/issues/305); inherited from `Notification.EmailSubscriptions` |
+| `clients.update` | `clients.update` | `Notification.EmailSubscriptions.Option` | `EmailSubscriptionEnum` | 1 | 1 | `supported` | --email-subscription |
+| `clients.update` | `clients.update` | `Notification.EmailSubscriptions.Value` | `YesNoEnum` | 1 | 1 | `supported` | --email-subscription |
 | `clients.update` | `clients.update` | `Notification.Lang` | `LangEnum` | 0 | 1 | `supported` | --notification-lang |
 | `clients.update` | `clients.update` | `Settings` | `ClientSettingUpdateItem` | 0 | unbounded | `supported` | --setting |
-| `clients.update` | `clients.update` | `Settings.Option` | `ClientSettingUpdateEnum` | 1 | 1 | `missing_followup` | Client Settings item parity needs typed support or N/A. [#305](https://github.com/axisrow/direct-cli/issues/305); inherited from `Settings` |
-| `clients.update` | `clients.update` | `Settings.Value` | `YesNoEnum` | 1 | 1 | `missing_followup` | Client Settings item parity needs typed support or N/A. [#305](https://github.com/axisrow/direct-cli/issues/305); inherited from `Settings` |
+| `clients.update` | `clients.update` | `Settings.Option` | `ClientSettingUpdateEnum` | 1 | 1 | `supported` | --setting |
+| `clients.update` | `clients.update` | `Settings.Value` | `YesNoEnum` | 1 | 1 | `supported` | --setting |
 | `clients.update` | `clients.update` | `TinInfo` | `TinInfoUpdate` | 0 | 1 | `supported` | --tin, --tin-type |
 | `clients.update` | `clients.update` | `TinInfo.TinType` | `TinTypeEnum` | 0 | 1 | `supported` | --tin-type |
 | `clients.update` | `clients.update` | `TinInfo.Tin` | `string` | 0 | 1 | `supported` | --tin |
-| `clients.update` | `clients.update` | `ErirAttributes` | `ErirAttributesUpdate` | 0 | 1 | `missing_followup` | clients.update item option/value path needs typed support or N/A. [#305](https://github.com/axisrow/direct-cli/issues/305) |
+| `clients.update` | `clients.update` | `ErirAttributes` | `ErirAttributesUpdate` | 0 | 1 | `missing_followup` | ERIR parent wrapper is tracked with the first ERIR child issue. [#306](https://github.com/axisrow/direct-cli/issues/306) |
 | `clients.update` | `clients.update` | `ErirAttributes.Organization` | `OrgInfo` | 0 | 1 | `missing_followup` | ERIR Organization fields need typed support or N/A. [#306](https://github.com/axisrow/direct-cli/issues/306) |
 | `clients.update` | `clients.update` | `ErirAttributes.Organization.Name` | `string` | 0 | 1 | `missing_followup` | ERIR Organization fields need typed support or N/A. [#306](https://github.com/axisrow/direct-cli/issues/306); inherited from `ErirAttributes.Organization` |
 | `clients.update` | `clients.update` | `ErirAttributes.Organization.EpayNumber` | `string` | 0 | 1 | `missing_followup` | ERIR Organization fields need typed support or N/A. [#306](https://github.com/axisrow/direct-cli/issues/306); inherited from `ErirAttributes.Organization` |

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -4730,6 +4730,33 @@ def test_clients_update_notification_only_payload():
     }
 
 
+def test_clients_update_repeated_subscription_and_setting_items():
+    body = _dry_run(
+        "clients",
+        "update",
+        "--email-subscription",
+        "RECEIVE_RECOMMENDATIONS=YES",
+        "--email-subscription",
+        "TRACK_POSITION_CHANGES=NO",
+        "--setting",
+        "DISPLAY_STORE_RATING=NO",
+        "--setting",
+        "CORRECT_TYPOS_AUTOMATICALLY=YES",
+    )
+    assert body["params"]["Clients"][0] == {
+        "Notification": {
+            "EmailSubscriptions": [
+                {"Option": "RECEIVE_RECOMMENDATIONS", "Value": "YES"},
+                {"Option": "TRACK_POSITION_CHANGES", "Value": "NO"},
+            ],
+        },
+        "Settings": [
+            {"Option": "DISPLAY_STORE_RATING", "Value": "NO"},
+            {"Option": "CORRECT_TYPOS_AUTOMATICALLY", "Value": "YES"},
+        ],
+    }
+
+
 def test_clients_update_rejects_invalid_subscription_or_setting():
     invalid_cases = [
         [

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -778,8 +778,16 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     },
     ("clients", "update", "Notification.Email"): {"--notification-email"},
     ("clients", "update", "Notification.EmailSubscriptions"): {"--email-subscription"},
+    ("clients", "update", "Notification.EmailSubscriptions.Option"): {
+        "--email-subscription"
+    },
+    ("clients", "update", "Notification.EmailSubscriptions.Value"): {
+        "--email-subscription"
+    },
     ("clients", "update", "Notification.Lang"): {"--notification-lang"},
     ("clients", "update", "Settings"): {"--setting"},
+    ("clients", "update", "Settings.Option"): {"--setting"},
+    ("clients", "update", "Settings.Value"): {"--setting"},
     ("clients", "update", "TinInfo"): {"--tin", "--tin-type"},
     ("clients", "update", "TinInfo.TinType"): {"--tin-type"},
     ("clients", "update", "TinInfo.Tin"): {"--tin"},
@@ -997,10 +1005,6 @@ OPTIONAL_FIELD_DEFAULT_FOLLOWUPS: dict[tuple[str, str], dict[str, str]] = {
     ("campaigns", "update"): {
         "issue": "#291",
         "note": "campaigns.update campaign-level optional path needs typed support or N/A.",
-    },
-    ("clients", "update"): {
-        "issue": "#305",
-        "note": "clients.update item option/value path needs typed support or N/A.",
     },
     ("dynamicads", "add"): {
         "issue": "#303",
@@ -1299,15 +1303,10 @@ OPTIONAL_FIELD_CHILD_PREFIX_FOLLOWUPS: dict[tuple[str, str, str], dict[str, str]
         "issue": "#296",
         "note": "CpmBannerCampaign optional fields need typed support or N/A.",
     },
-    ("clients", "update", "Notification.EmailSubscriptions"): {
+    ("clients", "update", "ErirAttributes"): {
         "status": "missing_followup",
-        "issue": "#305",
-        "note": "Client EmailSubscriptions item parity needs typed support or N/A.",
-    },
-    ("clients", "update", "Settings"): {
-        "status": "missing_followup",
-        "issue": "#305",
-        "note": "Client Settings item parity needs typed support or N/A.",
+        "issue": "#306",
+        "note": "ERIR parent wrapper is tracked with the first ERIR child issue.",
     },
     ("clients", "update", "ErirAttributes.Organization"): {
         "status": "missing_followup",


### PR DESCRIPTION
## Summary
- Mark clients.update Notification.EmailSubscriptions.Option and Value as supported by typed --email-subscription.
- Mark clients.update Settings.Option and Value as supported by typed --setting.
- Route the clients.update ErirAttributes parent wrapper to #306 so #305 no longer owns ERIR scope.
- Add dry-run coverage for repeated subscription and setting item arrays.

## Documentation Check
Official Yandex Direct clients.update docs place Notification.EmailSubscriptions[] and Settings[] inside Clients[] items, with required Option and Value fields on each item: https://yandex.ru/dev/direct/doc/en/clients/update

## Verification
- python3 -m black --check tests/test_wsdl_parity_gate.py tests/test_dry_run.py
- python3 -m pytest tests/test_dry_run.py -k clients_update
- python3 scripts/build_wsdl_optional_field_audit.py --check
- python3 -m pytest tests/test_wsdl_parity_gate.py
- python3 -m pytest tests/test_cli.py

Closes #305