### PR TITLE
Add clients ERIR organization flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,7 @@ direct creatives add --video-id video-id --dry-run
 direct feeds add --name "Feed A" --url "https://example.com/feed.xml" --business-type RETAIL --remove-utm-tags YES --feed-login feedbot --dry-run
 direct feeds update --id 18 --name "Feed A v2" --url "https://example.com/feed-v2.xml" --remove-utm-tags NO --clear-feed-login --clear-feed-password --dry-run
 direct clients update --client-info "Priority client" --phone +70000000000 --notification-email user@example.com --notification-lang EN --email-subscription RECEIVE_RECOMMENDATIONS=YES --setting DISPLAY_STORE_RATING=NO --dry-run
+direct clients update --erir-organization-name "Advertiser LLC" --erir-organization-kpp 770101001 --erir-organization-epay-number epay123 --erir-organization-reg-number 1027700132195 --erir-organization-oksm-number 643 --erir-organization-okved-code 62.01 --dry-run
 direct --login CLIENT_LOGIN clients update --phone +70000000000 --notification-email user@example.com --dry-run
 direct agencyclients add-passport-organization --name "Org" --currency RUB --notification-email ops@example.com --notification-lang EN --no-send-account-news --send-warnings --dry-run
 direct agencyclients add-passport-organization-member --passport-organization-login org-login --role CHIEF --invite-email user@example.com --dry-run
@@ -1237,6 +1238,7 @@ direct creatives add --video-id video-id --dry-run
 direct feeds add --name "Фид A" --url "https://example.com/feed.xml" --business-type RETAIL --remove-utm-tags YES --feed-login feedbot --dry-run
 direct feeds update --id 18 --name "Фид A v2" --url "https://example.com/feed-v2.xml" --remove-utm-tags NO --clear-feed-login --clear-feed-password --dry-run
 direct clients update --client-info "Приоритетный клиент" --phone +70000000000 --notification-email user@example.com --notification-lang EN --email-subscription RECEIVE_RECOMMENDATIONS=YES --setting DISPLAY_STORE_RATING=NO --dry-run
+direct clients update --erir-organization-name "Рекламодатель ООО" --erir-organization-kpp 770101001 --erir-organization-epay-number epay123 --erir-organization-reg-number 1027700132195 --erir-organization-oksm-number 643 --erir-organization-okved-code 62.01 --dry-run
 direct --login CLIENT_LOGIN clients update --phone +70000000000 --notification-email user@example.com --dry-run
 direct agencyclients add-passport-organization --name "Org" --currency RUB --notification-email ops@example.com --notification-lang EN --no-send-account-news --send-warnings --dry-run
 direct agencyclients add-passport-organization-member --passport-organization-login org-login --role CHIEF --invite-email user@example.com --dry-run

--- a/direct_cli/commands/clients.py
+++ b/direct_cli/commands/clients.py
@@ -8,6 +8,8 @@ from ..api import create_client
 from ..output import format_output, print_error
 from ..utils import (
     build_client_update_item,
+    build_erir_attributes,
+    build_erir_organization,
     build_notification_update,
     get_default_fields,
     parse_client_setting_specs,
@@ -90,6 +92,24 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields):
 )
 @click.option("--tin-type", help="TIN type")
 @click.option("--tin", help="Taxpayer identification number")
+@click.option("--erir-organization-name", help="ErirAttributes.Organization.Name")
+@click.option("--erir-organization-kpp", help="ErirAttributes.Organization.Kpp")
+@click.option(
+    "--erir-organization-epay-number",
+    help="ErirAttributes.Organization.EpayNumber",
+)
+@click.option(
+    "--erir-organization-reg-number",
+    help="ErirAttributes.Organization.RegNumber",
+)
+@click.option(
+    "--erir-organization-oksm-number",
+    help="ErirAttributes.Organization.OksmNumber",
+)
+@click.option(
+    "--erir-organization-okved-code",
+    help="ErirAttributes.Organization.OkvedCode",
+)
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
 def update(
@@ -102,6 +122,12 @@ def update(
     settings,
     tin_type,
     tin,
+    erir_organization_name,
+    erir_organization_kpp,
+    erir_organization_epay_number,
+    erir_organization_reg_number,
+    erir_organization_oksm_number,
+    erir_organization_okved_code,
     dry_run,
 ):
     """Update client settings"""
@@ -117,6 +143,16 @@ def update(
             notification,
             parse_client_setting_specs(list(settings)),
             parse_tin_info(tin_type, tin),
+            erir_attributes=build_erir_attributes(
+                organization=build_erir_organization(
+                    erir_organization_name,
+                    erir_organization_kpp,
+                    erir_organization_epay_number,
+                    erir_organization_reg_number,
+                    erir_organization_oksm_number,
+                    erir_organization_okved_code,
+                )
+            ),
         )
         if not client_data:
             raise click.UsageError("Provide at least one field to update")

--- a/direct_cli/utils.py
+++ b/direct_cli/utils.py
@@ -347,6 +347,41 @@ def parse_tin_info(
     return tin_info or None
 
 
+def build_erir_organization(
+    name: Optional[str],
+    kpp: Optional[str],
+    epay_number: Optional[str],
+    reg_number: Optional[str],
+    oksm_number: Optional[str],
+    okved_code: Optional[str],
+) -> Optional[Dict[str, str]]:
+    """Build ErirAttributes.Organization from typed flags."""
+    organization = {}
+    if name:
+        organization["Name"] = name
+    if kpp:
+        organization["Kpp"] = kpp
+    if epay_number:
+        organization["EpayNumber"] = epay_number
+    if reg_number:
+        organization["RegNumber"] = reg_number
+    if oksm_number:
+        organization["OksmNumber"] = oksm_number
+    if okved_code:
+        organization["OkvedCode"] = okved_code
+    return organization or None
+
+
+def build_erir_attributes(
+    organization: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Any]]:
+    """Build ErirAttributes from typed child objects."""
+    erir_attributes = {}
+    if organization:
+        erir_attributes["Organization"] = organization
+    return erir_attributes or None
+
+
 def build_notification_update(
     email: Optional[str],
     lang: Optional[str],
@@ -369,6 +404,7 @@ def build_client_update_item(
     notification: Optional[Dict[str, Any]],
     settings: Optional[List[Dict[str, str]]],
     tin_info: Optional[Dict[str, str]],
+    erir_attributes: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Build a generalclients ClientUpdateItem with WSDL-valid keys only."""
     item = {}
@@ -382,6 +418,8 @@ def build_client_update_item(
         item["Settings"] = settings
     if tin_info:
         item["TinInfo"] = tin_info
+    if erir_attributes:
+        item["ErirAttributes"] = erir_attributes
     return item
 
 

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,8 +11,8 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 2800 |
-| `supported` | 441 |
+| `missing_followup` | 2793 |
+| `supported` | 448 |
 
 ## Confirmed Follow-Ups
 
@@ -2549,13 +2549,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `campaigns.update` | `TimeTargeting.HolidaysSchedule.BidPercent` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
 | `campaigns.update` | `TimeTargeting.HolidaysSchedule.StartHour` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
 | `campaigns.update` | `TimeTargeting.HolidaysSchedule.EndHour` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `clients.update` | `ErirAttributes` | ERIR parent wrapper is tracked with the first ERIR child issue. [#306](https://github.com/axisrow/direct-cli/issues/306) |
-| `clients.update` | `ErirAttributes.Organization` | ERIR Organization fields need typed support or N/A. [#306](https://github.com/axisrow/direct-cli/issues/306) |
-| `clients.update` | `ErirAttributes.Organization.Name` | ERIR Organization fields need typed support or N/A. [#306](https://github.com/axisrow/direct-cli/issues/306); inherited from `ErirAttributes.Organization` |
-| `clients.update` | `ErirAttributes.Organization.EpayNumber` | ERIR Organization fields need typed support or N/A. [#306](https://github.com/axisrow/direct-cli/issues/306); inherited from `ErirAttributes.Organization` |
-| `clients.update` | `ErirAttributes.Organization.RegNumber` | ERIR Organization fields need typed support or N/A. [#306](https://github.com/axisrow/direct-cli/issues/306); inherited from `ErirAttributes.Organization` |
-| `clients.update` | `ErirAttributes.Organization.OksmNumber` | ERIR Organization fields need typed support or N/A. [#306](https://github.com/axisrow/direct-cli/issues/306); inherited from `ErirAttributes.Organization` |
-| `clients.update` | `ErirAttributes.Organization.OkvedCode` | ERIR Organization fields need typed support or N/A. [#306](https://github.com/axisrow/direct-cli/issues/306); inherited from `ErirAttributes.Organization` |
 | `clients.update` | `ErirAttributes.Contract` | ERIR Contract fields need typed support or N/A. [#307](https://github.com/axisrow/direct-cli/issues/307) |
 | `clients.update` | `ErirAttributes.Contract.Number` | ERIR Contract fields need typed support or N/A. [#307](https://github.com/axisrow/direct-cli/issues/307); inherited from `ErirAttributes.Contract` |
 | `clients.update` | `ErirAttributes.Contract.Date` | ERIR Contract fields need typed support or N/A. [#307](https://github.com/axisrow/direct-cli/issues/307); inherited from `ErirAttributes.Contract` |
@@ -5533,13 +5526,13 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `clients.update` | `clients.update` | `TinInfo` | `TinInfoUpdate` | 0 | 1 | `supported` | --tin, --tin-type |
 | `clients.update` | `clients.update` | `TinInfo.TinType` | `TinTypeEnum` | 0 | 1 | `supported` | --tin-type |
 | `clients.update` | `clients.update` | `TinInfo.Tin` | `string` | 0 | 1 | `supported` | --tin |
-| `clients.update` | `clients.update` | `ErirAttributes` | `ErirAttributesUpdate` | 0 | 1 | `missing_followup` | ERIR parent wrapper is tracked with the first ERIR child issue. [#306](https://github.com/axisrow/direct-cli/issues/306) |
-| `clients.update` | `clients.update` | `ErirAttributes.Organization` | `OrgInfo` | 0 | 1 | `missing_followup` | ERIR Organization fields need typed support or N/A. [#306](https://github.com/axisrow/direct-cli/issues/306) |
-| `clients.update` | `clients.update` | `ErirAttributes.Organization.Name` | `string` | 0 | 1 | `missing_followup` | ERIR Organization fields need typed support or N/A. [#306](https://github.com/axisrow/direct-cli/issues/306); inherited from `ErirAttributes.Organization` |
-| `clients.update` | `clients.update` | `ErirAttributes.Organization.EpayNumber` | `string` | 0 | 1 | `missing_followup` | ERIR Organization fields need typed support or N/A. [#306](https://github.com/axisrow/direct-cli/issues/306); inherited from `ErirAttributes.Organization` |
-| `clients.update` | `clients.update` | `ErirAttributes.Organization.RegNumber` | `string` | 0 | 1 | `missing_followup` | ERIR Organization fields need typed support or N/A. [#306](https://github.com/axisrow/direct-cli/issues/306); inherited from `ErirAttributes.Organization` |
-| `clients.update` | `clients.update` | `ErirAttributes.Organization.OksmNumber` | `string` | 0 | 1 | `missing_followup` | ERIR Organization fields need typed support or N/A. [#306](https://github.com/axisrow/direct-cli/issues/306); inherited from `ErirAttributes.Organization` |
-| `clients.update` | `clients.update` | `ErirAttributes.Organization.OkvedCode` | `string` | 0 | 1 | `missing_followup` | ERIR Organization fields need typed support or N/A. [#306](https://github.com/axisrow/direct-cli/issues/306); inherited from `ErirAttributes.Organization` |
+| `clients.update` | `clients.update` | `ErirAttributes` | `ErirAttributesUpdate` | 0 | 1 | `supported` | --erir-organization-epay-number, --erir-organization-kpp, --erir-organization-name, --erir-organization-oksm-number, --erir-organization-okved-code, --erir-organization-reg-number |
+| `clients.update` | `clients.update` | `ErirAttributes.Organization` | `OrgInfo` | 0 | 1 | `supported` | --erir-organization-epay-number, --erir-organization-kpp, --erir-organization-name, --erir-organization-oksm-number, --erir-organization-okved-code, --erir-organization-reg-number |
+| `clients.update` | `clients.update` | `ErirAttributes.Organization.Name` | `string` | 0 | 1 | `supported` | --erir-organization-name |
+| `clients.update` | `clients.update` | `ErirAttributes.Organization.EpayNumber` | `string` | 0 | 1 | `supported` | --erir-organization-epay-number |
+| `clients.update` | `clients.update` | `ErirAttributes.Organization.RegNumber` | `string` | 0 | 1 | `supported` | --erir-organization-reg-number |
+| `clients.update` | `clients.update` | `ErirAttributes.Organization.OksmNumber` | `string` | 0 | 1 | `supported` | --erir-organization-oksm-number |
+| `clients.update` | `clients.update` | `ErirAttributes.Organization.OkvedCode` | `string` | 0 | 1 | `supported` | --erir-organization-okved-code |
 | `clients.update` | `clients.update` | `ErirAttributes.Contract` | `ContractInfoUpdate` | 0 | 1 | `missing_followup` | ERIR Contract fields need typed support or N/A. [#307](https://github.com/axisrow/direct-cli/issues/307) |
 | `clients.update` | `clients.update` | `ErirAttributes.Contract.Number` | `string` | 0 | 1 | `missing_followup` | ERIR Contract fields need typed support or N/A. [#307](https://github.com/axisrow/direct-cli/issues/307); inherited from `ErirAttributes.Contract` |
 | `clients.update` | `clients.update` | `ErirAttributes.Contract.Date` | `string` | 0 | 1 | `missing_followup` | ERIR Contract fields need typed support or N/A. [#307](https://github.com/axisrow/direct-cli/issues/307); inherited from `ErirAttributes.Contract` |

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -101,6 +101,16 @@ class TestCLI(unittest.TestCase):
         collapsed = " ".join(result.output.split())
         self.assertIn("Image hash (TEXT_AD / TEXT_IMAGE_AD / MOBILE_APP_AD)", collapsed)
 
+    def test_clients_update_help_documents_erir_organization_flags(self):
+        result = self.runner.invoke(cli, ["clients", "update", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("--erir-organization-name", result.output)
+        self.assertIn("--erir-organization-kpp", result.output)
+        self.assertIn("--erir-organization-epay-number", result.output)
+        self.assertIn("--erir-organization-reg-number", result.output)
+        self.assertIn("--erir-organization-oksm-number", result.output)
+        self.assertIn("--erir-organization-okved-code", result.output)
+
     def test_canonical_groups_in_help(self):
         """Test canonical transport groups"""
         result = self.runner.invoke(cli, ["--help"])

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -4757,6 +4757,37 @@ def test_clients_update_repeated_subscription_and_setting_items():
     }
 
 
+def test_clients_update_erir_organization_payload():
+    body = _dry_run(
+        "clients",
+        "update",
+        "--erir-organization-name",
+        "Advertiser LLC",
+        "--erir-organization-kpp",
+        "770101001",
+        "--erir-organization-epay-number",
+        "epay123",
+        "--erir-organization-reg-number",
+        "1027700132195",
+        "--erir-organization-oksm-number",
+        "643",
+        "--erir-organization-okved-code",
+        "62.01",
+    )
+    assert body["params"]["Clients"][0] == {
+        "ErirAttributes": {
+            "Organization": {
+                "Name": "Advertiser LLC",
+                "Kpp": "770101001",
+                "EpayNumber": "epay123",
+                "RegNumber": "1027700132195",
+                "OksmNumber": "643",
+                "OkvedCode": "62.01",
+            }
+        }
+    }
+
+
 def test_clients_update_rejects_invalid_subscription_or_setting():
     invalid_cases = [
         [

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -791,6 +791,37 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     ("clients", "update", "TinInfo"): {"--tin", "--tin-type"},
     ("clients", "update", "TinInfo.TinType"): {"--tin-type"},
     ("clients", "update", "TinInfo.Tin"): {"--tin"},
+    ("clients", "update", "ErirAttributes"): {
+        "--erir-organization-name",
+        "--erir-organization-kpp",
+        "--erir-organization-epay-number",
+        "--erir-organization-reg-number",
+        "--erir-organization-oksm-number",
+        "--erir-organization-okved-code",
+    },
+    ("clients", "update", "ErirAttributes.Organization"): {
+        "--erir-organization-name",
+        "--erir-organization-kpp",
+        "--erir-organization-epay-number",
+        "--erir-organization-reg-number",
+        "--erir-organization-oksm-number",
+        "--erir-organization-okved-code",
+    },
+    ("clients", "update", "ErirAttributes.Organization.Name"): {
+        "--erir-organization-name"
+    },
+    ("clients", "update", "ErirAttributes.Organization.EpayNumber"): {
+        "--erir-organization-epay-number"
+    },
+    ("clients", "update", "ErirAttributes.Organization.RegNumber"): {
+        "--erir-organization-reg-number"
+    },
+    ("clients", "update", "ErirAttributes.Organization.OksmNumber"): {
+        "--erir-organization-oksm-number"
+    },
+    ("clients", "update", "ErirAttributes.Organization.OkvedCode"): {
+        "--erir-organization-okved-code"
+    },
     ("dynamicads", "add", "Conditions"): {"--condition"},
     ("dynamicads", "add", "Conditions.Operand"): {"--condition"},
     ("dynamicads", "add", "Conditions.Operator"): {"--condition"},
@@ -1302,16 +1333,6 @@ OPTIONAL_FIELD_CHILD_PREFIX_FOLLOWUPS: dict[tuple[str, str, str], dict[str, str]
         "status": "missing_followup",
         "issue": "#296",
         "note": "CpmBannerCampaign optional fields need typed support or N/A.",
-    },
-    ("clients", "update", "ErirAttributes"): {
-        "status": "missing_followup",
-        "issue": "#306",
-        "note": "ERIR parent wrapper is tracked with the first ERIR child issue.",
-    },
-    ("clients", "update", "ErirAttributes.Organization"): {
-        "status": "missing_followup",
-        "issue": "#306",
-        "note": "ERIR Organization fields need typed support or N/A.",
     },
     ("clients", "update", "ErirAttributes.Contract"): {
         "status": "missing_followup",


### PR DESCRIPTION
## Summary
- Add typed clients update flags for ErirAttributes.Organization fields.
- Build top-level ErirAttributes.Organization payload in dry-run and live request bodies.
- Mark the clients.update ErirAttributes.Organization WSDL audit rows as supported while leaving Contract and Contragent on #307/#308.
- Add help, README, dry-run, and parity coverage.

## Documentation Check
Official Yandex Direct clients.update docs place Organization under ErirAttributes and document Name, Kpp, EpayNumber, RegNumber, OksmNumber, and OkvedCode: https://yandex.ru/dev/direct/doc/en/clients/update

The cached WSDL audit currently contains Name, EpayNumber, RegNumber, OksmNumber, and OkvedCode rows; Kpp is implemented from the official docs but has no audit row in the current cache.

## Verification
- python3 -m black --check direct_cli/commands/clients.py direct_cli/utils.py tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py
- python3 -m pytest tests/test_dry_run.py -k clients_update
- python3 scripts/build_wsdl_optional_field_audit.py --check
- python3 -m pytest tests/test_wsdl_parity_gate.py
- python3 -m pytest tests/test_cli.py -k clients
- python3 -m pytest tests/test_cli.py
- python3 -m pytest tests/test_dry_run.py tests/test_wsdl_parity_gate.py

Closes #306