### PR TITLE
Add clients ERIR contract flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ direct feeds add --name "Feed A" --url "https://example.com/feed.xml" --business
 direct feeds update --id 18 --name "Feed A v2" --url "https://example.com/feed-v2.xml" --remove-utm-tags NO --clear-feed-login --clear-feed-password --dry-run
 direct clients update --client-info "Priority client" --phone +70000000000 --notification-email user@example.com --notification-lang EN --email-subscription RECEIVE_RECOMMENDATIONS=YES --setting DISPLAY_STORE_RATING=NO --dry-run
 direct clients update --erir-organization-name "Advertiser LLC" --erir-organization-kpp 770101001 --erir-organization-epay-number epay123 --erir-organization-reg-number 1027700132195 --erir-organization-oksm-number 643 --erir-organization-okved-code 62.01 --dry-run
+direct clients update --erir-contract-number C-2026-01 --erir-contract-date 2026-01-15 --erir-contract-type CONTRACT --erir-contract-action-type COMMERCIAL --erir-contract-subject-type REPRESENTATION --erir-contract-is-agency-payment NO --erir-contract-price-amount 120000.5 --erir-contract-price-including-vat YES --dry-run
 direct --login CLIENT_LOGIN clients update --phone +70000000000 --notification-email user@example.com --dry-run
 direct agencyclients add-passport-organization --name "Org" --currency RUB --notification-email ops@example.com --notification-lang EN --no-send-account-news --send-warnings --dry-run
 direct agencyclients add-passport-organization-member --passport-organization-login org-login --role CHIEF --invite-email user@example.com --dry-run
@@ -1239,6 +1240,7 @@ direct feeds add --name "Фид A" --url "https://example.com/feed.xml" --busine
 direct feeds update --id 18 --name "Фид A v2" --url "https://example.com/feed-v2.xml" --remove-utm-tags NO --clear-feed-login --clear-feed-password --dry-run
 direct clients update --client-info "Приоритетный клиент" --phone +70000000000 --notification-email user@example.com --notification-lang EN --email-subscription RECEIVE_RECOMMENDATIONS=YES --setting DISPLAY_STORE_RATING=NO --dry-run
 direct clients update --erir-organization-name "Рекламодатель ООО" --erir-organization-kpp 770101001 --erir-organization-epay-number epay123 --erir-organization-reg-number 1027700132195 --erir-organization-oksm-number 643 --erir-organization-okved-code 62.01 --dry-run
+direct clients update --erir-contract-number C-2026-01 --erir-contract-date 2026-01-15 --erir-contract-type CONTRACT --erir-contract-action-type COMMERCIAL --erir-contract-subject-type REPRESENTATION --erir-contract-is-agency-payment NO --erir-contract-price-amount 120000.5 --erir-contract-price-including-vat YES --dry-run
 direct --login CLIENT_LOGIN clients update --phone +70000000000 --notification-email user@example.com --dry-run
 direct agencyclients add-passport-organization --name "Org" --currency RUB --notification-email ops@example.com --notification-lang EN --no-send-account-news --send-warnings --dry-run
 direct agencyclients add-passport-organization-member --passport-organization-login org-login --role CHIEF --invite-email user@example.com --dry-run

--- a/direct_cli/commands/clients.py
+++ b/direct_cli/commands/clients.py
@@ -9,12 +9,17 @@ from ..output import format_output, print_error
 from ..utils import (
     build_client_update_item,
     build_erir_attributes,
+    build_erir_contract,
     build_erir_organization,
     build_notification_update,
+    CONTRACT_ACTION_TYPES,
+    CONTRACT_SUBJECT_TYPES,
+    CONTRACT_TYPES,
     get_default_fields,
     parse_client_setting_specs,
     parse_email_subscription_specs,
     parse_ids,
+    parse_positive_decimal_amount,
     parse_tin_info,
 )
 
@@ -110,6 +115,37 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields):
     "--erir-organization-okved-code",
     help="ErirAttributes.Organization.OkvedCode",
 )
+@click.option("--erir-contract-number", help="ErirAttributes.Contract.Number")
+@click.option("--erir-contract-date", help="ErirAttributes.Contract.Date (YYYY-MM-DD)")
+@click.option(
+    "--erir-contract-type",
+    type=click.Choice(sorted(CONTRACT_TYPES), case_sensitive=False),
+    help="ErirAttributes.Contract.Type",
+)
+@click.option(
+    "--erir-contract-action-type",
+    type=click.Choice(sorted(CONTRACT_ACTION_TYPES), case_sensitive=False),
+    help="ErirAttributes.Contract.ActionType",
+)
+@click.option(
+    "--erir-contract-subject-type",
+    type=click.Choice(sorted(CONTRACT_SUBJECT_TYPES), case_sensitive=False),
+    help="ErirAttributes.Contract.SubjectType",
+)
+@click.option(
+    "--erir-contract-is-agency-payment",
+    type=click.Choice(["YES", "NO"], case_sensitive=False),
+    help="ErirAttributes.Contract.IsAgencyPayment",
+)
+@click.option(
+    "--erir-contract-price-amount",
+    help="ErirAttributes.Contract.Price.Amount",
+)
+@click.option(
+    "--erir-contract-price-including-vat",
+    type=click.Choice(["YES", "NO"], case_sensitive=False),
+    help="ErirAttributes.Contract.Price.IncludingVat",
+)
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
 def update(
@@ -128,6 +164,14 @@ def update(
     erir_organization_reg_number,
     erir_organization_oksm_number,
     erir_organization_okved_code,
+    erir_contract_number,
+    erir_contract_date,
+    erir_contract_type,
+    erir_contract_action_type,
+    erir_contract_subject_type,
+    erir_contract_is_agency_payment,
+    erir_contract_price_amount,
+    erir_contract_price_including_vat,
     dry_run,
 ):
     """Update client settings"""
@@ -137,6 +181,12 @@ def update(
             notification_lang,
             parse_email_subscription_specs(list(email_subscriptions)),
         )
+        price_amount = None
+        if erir_contract_price_amount is not None:
+            price_amount = parse_positive_decimal_amount(
+                erir_contract_price_amount,
+                "--erir-contract-price-amount",
+            )
         client_data = build_client_update_item(
             client_info,
             phone,
@@ -151,7 +201,17 @@ def update(
                     erir_organization_reg_number,
                     erir_organization_oksm_number,
                     erir_organization_okved_code,
-                )
+                ),
+                contract=build_erir_contract(
+                    erir_contract_number,
+                    erir_contract_date,
+                    erir_contract_type,
+                    erir_contract_action_type,
+                    erir_contract_subject_type,
+                    erir_contract_is_agency_payment,
+                    price_amount,
+                    erir_contract_price_including_vat,
+                ),
             ),
         )
         if not client_data:

--- a/direct_cli/utils.py
+++ b/direct_cli/utils.py
@@ -4,7 +4,10 @@ Utilities for Direct CLI
 
 import base64
 import json
+import math
+import re
 from datetime import datetime
+from decimal import Decimal, InvalidOperation
 from typing import Any, Dict, Iterable, List, Optional, Union
 
 import click
@@ -267,6 +270,29 @@ TIN_TYPES = {
 
 YES_NO_VALUES = {"YES", "NO"}
 
+DECIMAL_RE = re.compile(r"^(?:0|[1-9]\d*)(?:\.\d+)?$")
+
+CONTRACT_TYPES = {
+    "CONTRACT",
+    "INTERMEDIARY_CONTRACT",
+    "ADDITIONAL_AGREEMENT",
+}
+
+CONTRACT_ACTION_TYPES = {
+    "COMMERCIAL",
+    "DISTRIBUTION",
+    "CONCLUDE",
+    "OTHER",
+}
+
+CONTRACT_SUBJECT_TYPES = {
+    "REPRESENTATION",
+    "MEDIATION",
+    "DISTRIBUTION",
+    "ORG_DISTRIBUTION",
+    "OTHER",
+}
+
 
 def parse_yes_no_spec(
     spec: str,
@@ -372,13 +398,84 @@ def build_erir_organization(
     return organization or None
 
 
+def build_erir_contract(
+    number: Optional[str],
+    date: Optional[str],
+    contract_type: Optional[str],
+    action_type: Optional[str],
+    subject_type: Optional[str],
+    is_agency_payment: Optional[str],
+    price_amount: Optional[float],
+    price_including_vat: Optional[str],
+) -> Optional[Dict[str, Any]]:
+    """Build ErirAttributes.Contract from typed flags."""
+    contract = {}
+    if number:
+        contract["Number"] = number
+    if date:
+        contract["Date"] = date
+    if contract_type:
+        contract["Type"] = contract_type.upper()
+    if action_type:
+        contract["ActionType"] = action_type.upper()
+    if subject_type:
+        contract["SubjectType"] = subject_type.upper()
+    if is_agency_payment:
+        contract["IsAgencyPayment"] = is_agency_payment.upper()
+
+    price_fields = {
+        "--erir-contract-price-amount": price_amount,
+        "--erir-contract-price-including-vat": price_including_vat,
+    }
+    provided_price_fields = {
+        option for option, value in price_fields.items() if value is not None
+    }
+    if provided_price_fields and len(provided_price_fields) != len(price_fields):
+        missing = ", ".join(sorted(set(price_fields) - provided_price_fields))
+        raise click.UsageError(f"ErirAttributes.Contract.Price requires {missing}")
+    if price_amount is not None and price_including_vat is not None:
+        contract["Price"] = {
+            "Amount": price_amount,
+            "IncludingVat": price_including_vat.upper(),
+        }
+
+    return contract or None
+
+
+def parse_positive_decimal_amount(value: str, option_name: str) -> float:
+    """Parse a positive finite decimal CLI amount."""
+    normalized = (value or "").strip()
+    if not DECIMAL_RE.fullmatch(normalized):
+        raise click.UsageError(
+            f"{option_name} must be a positive decimal amount, for example 100.50"
+        )
+
+    try:
+        amount = Decimal(normalized)
+    except InvalidOperation as exc:
+        raise click.UsageError(
+            f"{option_name} must be a positive decimal amount, for example 100.50"
+        ) from exc
+
+    if amount <= 0:
+        raise click.UsageError(f"{option_name} must be greater than zero")
+
+    result = float(amount)
+    if not math.isfinite(result):
+        raise click.UsageError(f"{option_name} must be a finite decimal amount")
+    return result
+
+
 def build_erir_attributes(
     organization: Optional[Dict[str, Any]] = None,
+    contract: Optional[Dict[str, Any]] = None,
 ) -> Optional[Dict[str, Any]]:
     """Build ErirAttributes from typed child objects."""
     erir_attributes = {}
     if organization:
         erir_attributes["Organization"] = organization
+    if contract:
+        erir_attributes["Contract"] = contract
     return erir_attributes or None
 
 

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,8 +11,8 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 2793 |
-| `supported` | 448 |
+| `missing_followup` | 2783 |
+| `supported` | 458 |
 
 ## Confirmed Follow-Ups
 
@@ -2549,16 +2549,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `campaigns.update` | `TimeTargeting.HolidaysSchedule.BidPercent` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
 | `campaigns.update` | `TimeTargeting.HolidaysSchedule.StartHour` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
 | `campaigns.update` | `TimeTargeting.HolidaysSchedule.EndHour` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `clients.update` | `ErirAttributes.Contract` | ERIR Contract fields need typed support or N/A. [#307](https://github.com/axisrow/direct-cli/issues/307) |
-| `clients.update` | `ErirAttributes.Contract.Number` | ERIR Contract fields need typed support or N/A. [#307](https://github.com/axisrow/direct-cli/issues/307); inherited from `ErirAttributes.Contract` |
-| `clients.update` | `ErirAttributes.Contract.Date` | ERIR Contract fields need typed support or N/A. [#307](https://github.com/axisrow/direct-cli/issues/307); inherited from `ErirAttributes.Contract` |
-| `clients.update` | `ErirAttributes.Contract.Type` | ERIR Contract fields need typed support or N/A. [#307](https://github.com/axisrow/direct-cli/issues/307); inherited from `ErirAttributes.Contract` |
-| `clients.update` | `ErirAttributes.Contract.ActionType` | ERIR Contract fields need typed support or N/A. [#307](https://github.com/axisrow/direct-cli/issues/307); inherited from `ErirAttributes.Contract` |
-| `clients.update` | `ErirAttributes.Contract.SubjectType` | ERIR Contract fields need typed support or N/A. [#307](https://github.com/axisrow/direct-cli/issues/307); inherited from `ErirAttributes.Contract` |
-| `clients.update` | `ErirAttributes.Contract.IsAgencyPayment` | ERIR Contract fields need typed support or N/A. [#307](https://github.com/axisrow/direct-cli/issues/307); inherited from `ErirAttributes.Contract` |
-| `clients.update` | `ErirAttributes.Contract.Price` | ERIR Contract fields need typed support or N/A. [#307](https://github.com/axisrow/direct-cli/issues/307); inherited from `ErirAttributes.Contract` |
-| `clients.update` | `ErirAttributes.Contract.Price.Amount` | ERIR Contract fields need typed support or N/A. [#307](https://github.com/axisrow/direct-cli/issues/307); inherited from `ErirAttributes.Contract` |
-| `clients.update` | `ErirAttributes.Contract.Price.IncludingVat` | ERIR Contract fields need typed support or N/A. [#307](https://github.com/axisrow/direct-cli/issues/307); inherited from `ErirAttributes.Contract` |
 | `clients.update` | `ErirAttributes.Contragent` | ERIR Contragent fields need typed support or N/A. [#308](https://github.com/axisrow/direct-cli/issues/308) |
 | `clients.update` | `ErirAttributes.Contragent.Name` | ERIR Contragent fields need typed support or N/A. [#308](https://github.com/axisrow/direct-cli/issues/308); inherited from `ErirAttributes.Contragent` |
 | `clients.update` | `ErirAttributes.Contragent.Phone` | ERIR Contragent fields need typed support or N/A. [#308](https://github.com/axisrow/direct-cli/issues/308); inherited from `ErirAttributes.Contragent` |
@@ -5526,23 +5516,23 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `clients.update` | `clients.update` | `TinInfo` | `TinInfoUpdate` | 0 | 1 | `supported` | --tin, --tin-type |
 | `clients.update` | `clients.update` | `TinInfo.TinType` | `TinTypeEnum` | 0 | 1 | `supported` | --tin-type |
 | `clients.update` | `clients.update` | `TinInfo.Tin` | `string` | 0 | 1 | `supported` | --tin |
-| `clients.update` | `clients.update` | `ErirAttributes` | `ErirAttributesUpdate` | 0 | 1 | `supported` | --erir-organization-epay-number, --erir-organization-kpp, --erir-organization-name, --erir-organization-oksm-number, --erir-organization-okved-code, --erir-organization-reg-number |
+| `clients.update` | `clients.update` | `ErirAttributes` | `ErirAttributesUpdate` | 0 | 1 | `supported` | --erir-contract-action-type, --erir-contract-date, --erir-contract-is-agency-payment, --erir-contract-number, --erir-contract-price-amount, --erir-contract-price-including-vat, --erir-contract-subject-type, --erir-contract-type, --erir-organization-epay-number, --erir-organization-kpp, --erir-organization-name, --erir-organization-oksm-number, --erir-organization-okved-code, --erir-organization-reg-number |
 | `clients.update` | `clients.update` | `ErirAttributes.Organization` | `OrgInfo` | 0 | 1 | `supported` | --erir-organization-epay-number, --erir-organization-kpp, --erir-organization-name, --erir-organization-oksm-number, --erir-organization-okved-code, --erir-organization-reg-number |
 | `clients.update` | `clients.update` | `ErirAttributes.Organization.Name` | `string` | 0 | 1 | `supported` | --erir-organization-name |
 | `clients.update` | `clients.update` | `ErirAttributes.Organization.EpayNumber` | `string` | 0 | 1 | `supported` | --erir-organization-epay-number |
 | `clients.update` | `clients.update` | `ErirAttributes.Organization.RegNumber` | `string` | 0 | 1 | `supported` | --erir-organization-reg-number |
 | `clients.update` | `clients.update` | `ErirAttributes.Organization.OksmNumber` | `string` | 0 | 1 | `supported` | --erir-organization-oksm-number |
 | `clients.update` | `clients.update` | `ErirAttributes.Organization.OkvedCode` | `string` | 0 | 1 | `supported` | --erir-organization-okved-code |
-| `clients.update` | `clients.update` | `ErirAttributes.Contract` | `ContractInfoUpdate` | 0 | 1 | `missing_followup` | ERIR Contract fields need typed support or N/A. [#307](https://github.com/axisrow/direct-cli/issues/307) |
-| `clients.update` | `clients.update` | `ErirAttributes.Contract.Number` | `string` | 0 | 1 | `missing_followup` | ERIR Contract fields need typed support or N/A. [#307](https://github.com/axisrow/direct-cli/issues/307); inherited from `ErirAttributes.Contract` |
-| `clients.update` | `clients.update` | `ErirAttributes.Contract.Date` | `string` | 0 | 1 | `missing_followup` | ERIR Contract fields need typed support or N/A. [#307](https://github.com/axisrow/direct-cli/issues/307); inherited from `ErirAttributes.Contract` |
-| `clients.update` | `clients.update` | `ErirAttributes.Contract.Type` | `ContractTypeEnum` | 0 | 1 | `missing_followup` | ERIR Contract fields need typed support or N/A. [#307](https://github.com/axisrow/direct-cli/issues/307); inherited from `ErirAttributes.Contract` |
-| `clients.update` | `clients.update` | `ErirAttributes.Contract.ActionType` | `ContractActionTypeEnum` | 0 | 1 | `missing_followup` | ERIR Contract fields need typed support or N/A. [#307](https://github.com/axisrow/direct-cli/issues/307); inherited from `ErirAttributes.Contract` |
-| `clients.update` | `clients.update` | `ErirAttributes.Contract.SubjectType` | `ContractSubjectTypeEnum` | 0 | 1 | `missing_followup` | ERIR Contract fields need typed support or N/A. [#307](https://github.com/axisrow/direct-cli/issues/307); inherited from `ErirAttributes.Contract` |
-| `clients.update` | `clients.update` | `ErirAttributes.Contract.IsAgencyPayment` | `YesNoEnum` | 0 | 1 | `missing_followup` | ERIR Contract fields need typed support or N/A. [#307](https://github.com/axisrow/direct-cli/issues/307); inherited from `ErirAttributes.Contract` |
-| `clients.update` | `clients.update` | `ErirAttributes.Contract.Price` | `ContractPrice` | 0 | 1 | `missing_followup` | ERIR Contract fields need typed support or N/A. [#307](https://github.com/axisrow/direct-cli/issues/307); inherited from `ErirAttributes.Contract` |
-| `clients.update` | `clients.update` | `ErirAttributes.Contract.Price.Amount` | `decimal` | 1 | 1 | `missing_followup` | ERIR Contract fields need typed support or N/A. [#307](https://github.com/axisrow/direct-cli/issues/307); inherited from `ErirAttributes.Contract` |
-| `clients.update` | `clients.update` | `ErirAttributes.Contract.Price.IncludingVat` | `YesNoEnum` | 1 | 1 | `missing_followup` | ERIR Contract fields need typed support or N/A. [#307](https://github.com/axisrow/direct-cli/issues/307); inherited from `ErirAttributes.Contract` |
+| `clients.update` | `clients.update` | `ErirAttributes.Contract` | `ContractInfoUpdate` | 0 | 1 | `supported` | --erir-contract-action-type, --erir-contract-date, --erir-contract-is-agency-payment, --erir-contract-number, --erir-contract-price-amount, --erir-contract-price-including-vat, --erir-contract-subject-type, --erir-contract-type |
+| `clients.update` | `clients.update` | `ErirAttributes.Contract.Number` | `string` | 0 | 1 | `supported` | --erir-contract-number |
+| `clients.update` | `clients.update` | `ErirAttributes.Contract.Date` | `string` | 0 | 1 | `supported` | --erir-contract-date |
+| `clients.update` | `clients.update` | `ErirAttributes.Contract.Type` | `ContractTypeEnum` | 0 | 1 | `supported` | --erir-contract-type |
+| `clients.update` | `clients.update` | `ErirAttributes.Contract.ActionType` | `ContractActionTypeEnum` | 0 | 1 | `supported` | --erir-contract-action-type |
+| `clients.update` | `clients.update` | `ErirAttributes.Contract.SubjectType` | `ContractSubjectTypeEnum` | 0 | 1 | `supported` | --erir-contract-subject-type |
+| `clients.update` | `clients.update` | `ErirAttributes.Contract.IsAgencyPayment` | `YesNoEnum` | 0 | 1 | `supported` | --erir-contract-is-agency-payment |
+| `clients.update` | `clients.update` | `ErirAttributes.Contract.Price` | `ContractPrice` | 0 | 1 | `supported` | --erir-contract-price-amount, --erir-contract-price-including-vat |
+| `clients.update` | `clients.update` | `ErirAttributes.Contract.Price.Amount` | `decimal` | 1 | 1 | `supported` | --erir-contract-price-amount |
+| `clients.update` | `clients.update` | `ErirAttributes.Contract.Price.IncludingVat` | `YesNoEnum` | 1 | 1 | `supported` | --erir-contract-price-including-vat |
 | `clients.update` | `clients.update` | `ErirAttributes.Contragent` | `ContragentInfoUpdate` | 0 | 1 | `missing_followup` | ERIR Contragent fields need typed support or N/A. [#308](https://github.com/axisrow/direct-cli/issues/308) |
 | `clients.update` | `clients.update` | `ErirAttributes.Contragent.Name` | `string` | 0 | 1 | `missing_followup` | ERIR Contragent fields need typed support or N/A. [#308](https://github.com/axisrow/direct-cli/issues/308); inherited from `ErirAttributes.Contragent` |
 | `clients.update` | `clients.update` | `ErirAttributes.Contragent.Phone` | `string` | 0 | 1 | `missing_followup` | ERIR Contragent fields need typed support or N/A. [#308](https://github.com/axisrow/direct-cli/issues/308); inherited from `ErirAttributes.Contragent` |

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -111,6 +111,18 @@ class TestCLI(unittest.TestCase):
         self.assertIn("--erir-organization-oksm-number", result.output)
         self.assertIn("--erir-organization-okved-code", result.output)
 
+    def test_clients_update_help_documents_erir_contract_flags(self):
+        result = self.runner.invoke(cli, ["clients", "update", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("--erir-contract-number", result.output)
+        self.assertIn("--erir-contract-date", result.output)
+        self.assertIn("--erir-contract-type", result.output)
+        self.assertIn("--erir-contract-action-type", result.output)
+        self.assertIn("--erir-contract-subject-type", result.output)
+        self.assertIn("--erir-contract-is-agency-payment", result.output)
+        self.assertIn("--erir-contract-price-amount", result.output)
+        self.assertIn("--erir-contract-price-including-vat", result.output)
+
     def test_canonical_groups_in_help(self):
         """Test canonical transport groups"""
         result = self.runner.invoke(cli, ["--help"])

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -4788,6 +4788,103 @@ def test_clients_update_erir_organization_payload():
     }
 
 
+def test_clients_update_erir_contract_payload():
+    body = _dry_run(
+        "clients",
+        "update",
+        "--erir-contract-number",
+        "C-2026-01",
+        "--erir-contract-date",
+        "2026-01-15",
+        "--erir-contract-type",
+        "contract",
+        "--erir-contract-action-type",
+        "commercial",
+        "--erir-contract-subject-type",
+        "representation",
+        "--erir-contract-is-agency-payment",
+        "no",
+        "--erir-contract-price-amount",
+        "120000.5",
+        "--erir-contract-price-including-vat",
+        "yes",
+    )
+    assert body["params"]["Clients"][0] == {
+        "ErirAttributes": {
+            "Contract": {
+                "Number": "C-2026-01",
+                "Date": "2026-01-15",
+                "Type": "CONTRACT",
+                "ActionType": "COMMERCIAL",
+                "SubjectType": "REPRESENTATION",
+                "IsAgencyPayment": "NO",
+                "Price": {"Amount": 120000.5, "IncludingVat": "YES"},
+            }
+        }
+    }
+
+
+def test_clients_update_erir_contract_partial_payload():
+    body = _dry_run(
+        "clients",
+        "update",
+        "--erir-contract-number",
+        "C-2026-01",
+    )
+    assert body["params"]["Clients"][0] == {
+        "ErirAttributes": {"Contract": {"Number": "C-2026-01"}}
+    }
+
+
+def test_clients_update_erir_contract_price_requires_amount_and_vat():
+    for args, missing in (
+        (
+            [
+                "clients",
+                "update",
+                "--erir-contract-price-amount",
+                "120000.5",
+                "--dry-run",
+            ],
+            "--erir-contract-price-including-vat",
+        ),
+        (
+            [
+                "clients",
+                "update",
+                "--erir-contract-price-including-vat",
+                "YES",
+                "--dry-run",
+            ],
+            "--erir-contract-price-amount",
+        ),
+    ):
+        result = CliRunner().invoke(cli, args)
+        assert result.exit_code != 0
+        assert "ErirAttributes.Contract.Price requires" in result.output
+        assert missing in result.output
+
+
+def test_clients_update_erir_contract_price_rejects_non_finite_amount():
+    for value in ("nan", "inf", "-inf"):
+        result = CliRunner().invoke(
+            cli,
+            [
+                "clients",
+                "update",
+                "--erir-contract-price-amount",
+                value,
+                "--erir-contract-price-including-vat",
+                "YES",
+                "--dry-run",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "--erir-contract-price-amount must be a positive decimal amount" in (
+            result.output
+        )
+
+
 def test_clients_update_rejects_invalid_subscription_or_setting():
     invalid_cases = [
         [

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -798,6 +798,14 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
         "--erir-organization-reg-number",
         "--erir-organization-oksm-number",
         "--erir-organization-okved-code",
+        "--erir-contract-number",
+        "--erir-contract-date",
+        "--erir-contract-type",
+        "--erir-contract-action-type",
+        "--erir-contract-subject-type",
+        "--erir-contract-is-agency-payment",
+        "--erir-contract-price-amount",
+        "--erir-contract-price-including-vat",
     },
     ("clients", "update", "ErirAttributes.Organization"): {
         "--erir-organization-name",
@@ -821,6 +829,38 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     },
     ("clients", "update", "ErirAttributes.Organization.OkvedCode"): {
         "--erir-organization-okved-code"
+    },
+    ("clients", "update", "ErirAttributes.Contract"): {
+        "--erir-contract-number",
+        "--erir-contract-date",
+        "--erir-contract-type",
+        "--erir-contract-action-type",
+        "--erir-contract-subject-type",
+        "--erir-contract-is-agency-payment",
+        "--erir-contract-price-amount",
+        "--erir-contract-price-including-vat",
+    },
+    ("clients", "update", "ErirAttributes.Contract.Number"): {"--erir-contract-number"},
+    ("clients", "update", "ErirAttributes.Contract.Date"): {"--erir-contract-date"},
+    ("clients", "update", "ErirAttributes.Contract.Type"): {"--erir-contract-type"},
+    ("clients", "update", "ErirAttributes.Contract.ActionType"): {
+        "--erir-contract-action-type"
+    },
+    ("clients", "update", "ErirAttributes.Contract.SubjectType"): {
+        "--erir-contract-subject-type"
+    },
+    ("clients", "update", "ErirAttributes.Contract.IsAgencyPayment"): {
+        "--erir-contract-is-agency-payment"
+    },
+    ("clients", "update", "ErirAttributes.Contract.Price"): {
+        "--erir-contract-price-amount",
+        "--erir-contract-price-including-vat",
+    },
+    ("clients", "update", "ErirAttributes.Contract.Price.Amount"): {
+        "--erir-contract-price-amount"
+    },
+    ("clients", "update", "ErirAttributes.Contract.Price.IncludingVat"): {
+        "--erir-contract-price-including-vat"
     },
     ("dynamicads", "add", "Conditions"): {"--condition"},
     ("dynamicads", "add", "Conditions.Operand"): {"--condition"},
@@ -1333,11 +1373,6 @@ OPTIONAL_FIELD_CHILD_PREFIX_FOLLOWUPS: dict[tuple[str, str, str], dict[str, str]
         "status": "missing_followup",
         "issue": "#296",
         "note": "CpmBannerCampaign optional fields need typed support or N/A.",
-    },
-    ("clients", "update", "ErirAttributes.Contract"): {
-        "status": "missing_followup",
-        "issue": "#307",
-        "note": "ERIR Contract fields need typed support or N/A.",
     },
     ("clients", "update", "ErirAttributes.Contragent"): {
         "status": "missing_followup",


### PR DESCRIPTION
## Summary
- Add typed clients update flags for ErirAttributes.Contract fields.
- Build top-level ErirAttributes.Contract payload including Price.Amount and Price.IncludingVat.
- Guard the Contract.Price pair so amount and VAT are provided together.
- Mark the clients.update ErirAttributes.Contract WSDL audit rows as supported while leaving Contragent on #308.
- Add help, README, dry-run, and parity coverage.

## Documentation Check
Official Yandex Direct clients.update docs place Contract under ErirAttributes and document Number, Date, Type, ActionType, SubjectType, Price.Amount, Price.IncludingVat, and IsAgencyPayment: https://yandex.ru/dev/direct/doc/en/clients/update

## Verification
- python3 -m black --check direct_cli/commands/clients.py direct_cli/utils.py tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py
- python3 -m pytest tests/test_dry_run.py -k "clients_update_erir_contract or clients_update_requires_at_least_one_field"
- python3 -m pytest tests/test_cli.py -k clients_update_help_documents_erir_contract_flags
- python3 scripts/build_wsdl_optional_field_audit.py --check
- python3 -m pytest tests/test_wsdl_parity_gate.py
- python3 -m pytest tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py

Closes #307