### PR TITLE
Support bids set optional fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,8 +490,9 @@ direct retargeting update --id 55 --name "Renamed" --description "Updated note" 
 # Bids and modifiers
 direct bids get --campaign-ids 123 --fields CampaignId,AdGroupId,KeywordId,Bid
 direct bids set --keyword-id 123 --bid 15000000
+direct bids set --campaign-id 123 --context-bid 9000000 --autotargeting-search-bid-is-auto YES --priority HIGH
 direct bids set-auto --keyword-id 123 --max-bid 20000000 --position PREMIUMBLOCK --scope SEARCH --dry-run
-direct keywordbids set --keyword-id 321 --search-bid 8000000 --network-bid 3000000
+direct keywordbids set --adgroup-id 321 --search-bid 8000000 --network-bid 3000000 --autotargeting-search-bid-is-auto NO --priority NORMAL
 direct keywordbids set-auto --keyword-id 321 --target-traffic-volume 100 --increase-percent 10 --bid-ceiling 12500000 --dry-run
 direct bidmodifiers get --campaign-ids 123 --fields Id,CampaignId,AdGroupId,Level,Type
 direct bidmodifiers add --campaign-id 123 --type DEMOGRAPHICS_ADJUSTMENT --value 150 --gender GENDER_MALE --age AGE_25_34 --dry-run
@@ -1201,8 +1202,9 @@ direct retargeting update --id 55 --name "Переименованный спи�
 # Ставки и модификаторы
 direct bids get --campaign-ids 123 --fields CampaignId,AdGroupId,KeywordId,Bid
 direct bids set --keyword-id 123 --bid 15000000
+direct bids set --campaign-id 123 --context-bid 9000000 --autotargeting-search-bid-is-auto YES --priority HIGH
 direct bids set-auto --keyword-id 123 --max-bid 20000000 --position PREMIUMBLOCK --scope SEARCH --dry-run
-direct keywordbids set --keyword-id 321 --search-bid 8000000 --network-bid 3000000
+direct keywordbids set --adgroup-id 321 --search-bid 8000000 --network-bid 3000000 --autotargeting-search-bid-is-auto NO --priority NORMAL
 direct keywordbids set-auto --keyword-id 321 --target-traffic-volume 100 --increase-percent 10 --bid-ceiling 12500000 --dry-run
 direct bidmodifiers get --campaign-ids 123 --fields Id,CampaignId,AdGroupId,Level,Type
 direct bidmodifiers add --campaign-id 123 --type DEMOGRAPHICS_ADJUSTMENT --value 150 --gender GENDER_MALE --age AGE_25_34 --dry-run

--- a/direct_cli/commands/bids.py
+++ b/direct_cli/commands/bids.py
@@ -6,7 +6,13 @@ import click
 
 from ..api import create_client
 from ..output import format_output, print_error
-from ..utils import add_criteria_csv, get_default_fields, parse_ids, MICRO_RUBLES
+from ..utils import (
+    add_criteria_csv,
+    add_single_id_selector,
+    get_default_fields,
+    parse_ids,
+    MICRO_RUBLES,
+)
 
 
 @click.group()
@@ -88,18 +94,67 @@ def get(
 
 
 @bids.command()
-@click.option("--keyword-id", required=True, type=int, help="Keyword ID")
+@click.option("--campaign-id", type=int, help="Campaign ID selector")
+@click.option("--adgroup-id", type=int, help="Ad group ID selector")
+@click.option("--keyword-id", type=int, help="Keyword ID selector")
 @click.option("--bid", type=MICRO_RUBLES, help="Bid in micro-rubles")
+@click.option("--context-bid", type=MICRO_RUBLES, help="ContextBid in micro-rubles")
+@click.option(
+    "--autotargeting-search-bid-is-auto",
+    type=click.Choice(["YES", "NO"], case_sensitive=False),
+    help="AutotargetingSearchBidIsAuto value: YES or NO",
+)
+@click.option(
+    "--priority",
+    type=click.Choice(["LOW", "NORMAL", "HIGH"], case_sensitive=False),
+    help="StrategyPriority value: LOW, NORMAL, or HIGH",
+)
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def set(ctx, keyword_id, bid, dry_run):
+def set(
+    ctx,
+    campaign_id,
+    adgroup_id,
+    keyword_id,
+    bid,
+    context_bid,
+    autotargeting_search_bid_is_auto,
+    priority,
+    dry_run,
+):
     """Set bids"""
     # Reject empty-payload no-op (issue #198 H8).
-    if bid is None:
-        raise click.UsageError("bids set requires at least one bid value (--bid).")
+    if (
+        bid is None
+        and context_bid is None
+        and autotargeting_search_bid_is_auto is None
+        and priority is None
+    ):
+        raise click.UsageError(
+            "bids set requires at least one bid field "
+            "(--bid, --context-bid, --priority, "
+            "or --autotargeting-search-bid-is-auto)."
+        )
 
     try:
-        bid_data = {"KeywordId": keyword_id, "Bid": bid}
+        bid_data = {}
+        add_single_id_selector(
+            bid_data,
+            campaign_id=campaign_id,
+            adgroup_id=adgroup_id,
+            keyword_id=keyword_id,
+            command_name="bids set",
+        )
+        if bid is not None:
+            bid_data["Bid"] = bid
+        if context_bid is not None:
+            bid_data["ContextBid"] = context_bid
+        if autotargeting_search_bid_is_auto is not None:
+            bid_data["AutotargetingSearchBidIsAuto"] = (
+                autotargeting_search_bid_is_auto.upper()
+            )
+        if priority is not None:
+            bid_data["StrategyPriority"] = priority.upper()
 
         body = {"method": "set", "params": {"Bids": [bid_data]}}
 
@@ -115,6 +170,8 @@ def set(ctx, keyword_id, bid, dry_run):
         result = client.bids().post(data=body)
         format_output(result().extract(), "json", None)
 
+    except click.UsageError:
+        raise
     except Exception as e:
         print_error(str(e))
         raise click.Abort()

--- a/direct_cli/commands/keywordbids.py
+++ b/direct_cli/commands/keywordbids.py
@@ -6,7 +6,13 @@ import click
 
 from ..api import create_client
 from ..output import format_output, print_error
-from ..utils import add_criteria_csv, get_default_fields, parse_ids, MICRO_RUBLES
+from ..utils import (
+    add_criteria_csv,
+    add_single_id_selector,
+    get_default_fields,
+    parse_ids,
+    MICRO_RUBLES,
+)
 
 
 @click.group()
@@ -87,26 +93,68 @@ def get(
 
 
 @keywordbids.command()
-@click.option("--keyword-id", required=True, type=int, help="Keyword ID")
+@click.option("--campaign-id", type=int, help="Campaign ID selector")
+@click.option("--adgroup-id", type=int, help="Ad group ID selector")
+@click.option("--keyword-id", type=int, help="Keyword ID selector")
 @click.option("--search-bid", type=MICRO_RUBLES, help="Search bid in micro-rubles")
 @click.option("--network-bid", type=MICRO_RUBLES, help="Network bid in micro-rubles")
+@click.option(
+    "--autotargeting-search-bid-is-auto",
+    type=click.Choice(["YES", "NO"], case_sensitive=False),
+    help="AutotargetingSearchBidIsAuto value: YES or NO",
+)
+@click.option(
+    "--priority",
+    type=click.Choice(["LOW", "NORMAL", "HIGH"], case_sensitive=False),
+    help="StrategyPriority value: LOW, NORMAL, or HIGH",
+)
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def set(ctx, keyword_id, search_bid, network_bid, dry_run):
+def set(
+    ctx,
+    campaign_id,
+    adgroup_id,
+    keyword_id,
+    search_bid,
+    network_bid,
+    autotargeting_search_bid_is_auto,
+    priority,
+    dry_run,
+):
     """Set keyword bids"""
     # Reject empty-payload no-op (issue #198 H9).
-    if search_bid is None and network_bid is None:
+    if (
+        search_bid is None
+        and network_bid is None
+        and autotargeting_search_bid_is_auto is None
+        and priority is None
+    ):
         raise click.UsageError(
-            "keywordbids set requires at least one of " "--search-bid or --network-bid."
+            "keywordbids set requires at least one bid field "
+            "(--search-bid, --network-bid, --priority, "
+            "or --autotargeting-search-bid-is-auto)."
         )
 
     try:
-        bid_data = {"KeywordId": keyword_id}
+        bid_data = {}
+        add_single_id_selector(
+            bid_data,
+            campaign_id=campaign_id,
+            adgroup_id=adgroup_id,
+            keyword_id=keyword_id,
+            command_name="keywordbids set",
+        )
 
         if search_bid is not None:
             bid_data["SearchBid"] = search_bid
         if network_bid is not None:
             bid_data["NetworkBid"] = network_bid
+        if autotargeting_search_bid_is_auto is not None:
+            bid_data["AutotargetingSearchBidIsAuto"] = (
+                autotargeting_search_bid_is_auto.upper()
+            )
+        if priority is not None:
+            bid_data["StrategyPriority"] = priority.upper()
 
         body = {"method": "set", "params": {"KeywordBids": [bid_data]}}
 
@@ -122,6 +170,8 @@ def set(ctx, keyword_id, search_bid, network_bid, dry_run):
         result = client.keywordbids().post(data=body)
         format_output(result().extract(), "json", None)
 
+    except click.UsageError:
+        raise
     except Exception as e:
         print_error(str(e))
         raise click.Abort()

--- a/direct_cli/utils.py
+++ b/direct_cli/utils.py
@@ -92,6 +92,35 @@ def add_criteria_csv(
         criteria[key] = parsed
 
 
+def add_single_id_selector(
+    item: Dict[str, Any],
+    *,
+    campaign_id: Optional[int],
+    adgroup_id: Optional[int],
+    keyword_id: Optional[int],
+    command_name: str,
+) -> None:
+    """Add exactly one campaign, ad group, or keyword selector to an item."""
+    selectors = [
+        ("CampaignId", campaign_id, "--campaign-id"),
+        ("AdGroupId", adgroup_id, "--adgroup-id"),
+        ("KeywordId", keyword_id, "--keyword-id"),
+    ]
+    provided = [
+        (field_name, value, option_name)
+        for field_name, value, option_name in selectors
+        if value is not None
+    ]
+    if len(provided) != 1:
+        options = ", ".join(option for _, _, option in selectors)
+        raise click.UsageError(
+            f"{command_name} requires exactly one selector: {options}"
+        )
+
+    field_name, value, _ = provided[0]
+    item[field_name] = value
+
+
 def build_selection_criteria(
     ids: Optional[List[int]] = None,
     status: Optional[str] = None,

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,8 +11,8 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 2774 |
-| `supported` | 467 |
+| `missing_followup` | 2765 |
+| `supported` | 476 |
 
 ## Confirmed Follow-Ups
 
@@ -351,11 +351,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `ads.update` | `ListingAd.TextSources` | LISTING_AD update fields need typed support or N/A. [#269](https://github.com/axisrow/direct-cli/issues/269); inherited from `ListingAd` |
 | `ads.update` | `ListingAd.TextSources.Items` | LISTING_AD update fields need typed support or N/A. [#269](https://github.com/axisrow/direct-cli/issues/269); inherited from `ListingAd` |
 | `ads.update` | `ListingAd.DefaultTexts` | LISTING_AD update fields need typed support or N/A. [#269](https://github.com/axisrow/direct-cli/issues/269); inherited from `ListingAd` |
-| `bids.set` | `CampaignId` | bids.set optional WSDL path needs typed support or N/A. [#301](https://github.com/axisrow/direct-cli/issues/301) |
-| `bids.set` | `AdGroupId` | bids.set optional WSDL path needs typed support or N/A. [#301](https://github.com/axisrow/direct-cli/issues/301) |
-| `bids.set` | `ContextBid` | bids.set optional WSDL path needs typed support or N/A. [#301](https://github.com/axisrow/direct-cli/issues/301) |
-| `bids.set` | `AutotargetingSearchBidIsAuto` | bids.set optional WSDL path needs typed support or N/A. [#301](https://github.com/axisrow/direct-cli/issues/301) |
-| `bids.set` | `StrategyPriority` | bids.set optional WSDL path needs typed support or N/A. [#301](https://github.com/axisrow/direct-cli/issues/301) |
 | `campaigns.add` | `ClientInfo` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
 | `campaigns.add` | `Notification` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
 | `campaigns.add` | `Notification.SmsSettings` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
@@ -2555,10 +2550,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `feeds.update` | `FileFeed` | FileFeed upload/base64 CLI support is split from #253. [#264](https://github.com/axisrow/direct-cli/issues/264) |
 | `feeds.update` | `FileFeed.Data` | FileFeed upload/base64 CLI support is split from #253. [#264](https://github.com/axisrow/direct-cli/issues/264); inherited from `FileFeed` |
 | `feeds.update` | `FileFeed.Filename` | FileFeed upload/base64 CLI support is split from #253. [#264](https://github.com/axisrow/direct-cli/issues/264); inherited from `FileFeed` |
-| `keywordbids.set` | `CampaignId` | keywordbids.set optional WSDL path needs typed support or N/A. [#301](https://github.com/axisrow/direct-cli/issues/301) |
-| `keywordbids.set` | `AdGroupId` | keywordbids.set optional WSDL path needs typed support or N/A. [#301](https://github.com/axisrow/direct-cli/issues/301) |
-| `keywordbids.set` | `AutotargetingSearchBidIsAuto` | keywordbids.set optional WSDL path needs typed support or N/A. [#301](https://github.com/axisrow/direct-cli/issues/301) |
-| `keywordbids.set` | `StrategyPriority` | keywordbids.set optional WSDL path needs typed support or N/A. [#301](https://github.com/axisrow/direct-cli/issues/301) |
 | `keywords.add` | `AutotargetingSearchBidIsAuto` | Keyword autotargeting auto-search-bid has no typed add flag. [#285](https://github.com/axisrow/direct-cli/issues/285) |
 | `keywords.add` | `StrategyPriority` | Keyword strategy priority has no typed add flag. [#285](https://github.com/axisrow/direct-cli/issues/285) |
 | `keywords.add` | `AutotargetingCategories` | Keyword autotargeting categories have no typed add flags. [#286](https://github.com/axisrow/direct-cli/issues/286) |
@@ -3257,13 +3248,13 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `bidmodifiers.add` | `bidmodifiers.add` | `AdGroupAdjustment.BidModifier` | `int` | 1 | 1 | `supported` | --value |
 | `bidmodifiers.set` | `bidmodifiers.set` | `Id` | `long` | 1 | 1 | `supported` | covered by minOccurs>=1 parity gate |
 | `bidmodifiers.set` | `bidmodifiers.set` | `BidModifier` | `int` | 1 | 1 | `supported` | covered by minOccurs>=1 parity gate |
-| `bids.set` | `bids.set` | `CampaignId` | `long` | 0 | 1 | `missing_followup` | bids.set optional WSDL path needs typed support or N/A. [#301](https://github.com/axisrow/direct-cli/issues/301) |
-| `bids.set` | `bids.set` | `AdGroupId` | `long` | 0 | 1 | `missing_followup` | bids.set optional WSDL path needs typed support or N/A. [#301](https://github.com/axisrow/direct-cli/issues/301) |
+| `bids.set` | `bids.set` | `CampaignId` | `long` | 0 | 1 | `supported` | --campaign-id |
+| `bids.set` | `bids.set` | `AdGroupId` | `long` | 0 | 1 | `supported` | --adgroup-id |
 | `bids.set` | `bids.set` | `KeywordId` | `long` | 0 | 1 | `supported` | --keyword-id |
 | `bids.set` | `bids.set` | `Bid` | `long` | 0 | 1 | `supported` | --bid |
-| `bids.set` | `bids.set` | `ContextBid` | `long` | 0 | 1 | `missing_followup` | bids.set optional WSDL path needs typed support or N/A. [#301](https://github.com/axisrow/direct-cli/issues/301) |
-| `bids.set` | `bids.set` | `AutotargetingSearchBidIsAuto` | `YesNoEnum` | 0 | 1 | `missing_followup` | bids.set optional WSDL path needs typed support or N/A. [#301](https://github.com/axisrow/direct-cli/issues/301) |
-| `bids.set` | `bids.set` | `StrategyPriority` | `PriorityEnum` | 0 | 1 | `missing_followup` | bids.set optional WSDL path needs typed support or N/A. [#301](https://github.com/axisrow/direct-cli/issues/301) |
+| `bids.set` | `bids.set` | `ContextBid` | `long` | 0 | 1 | `supported` | --context-bid |
+| `bids.set` | `bids.set` | `AutotargetingSearchBidIsAuto` | `YesNoEnum` | 0 | 1 | `supported` | --autotargeting-search-bid-is-auto |
+| `bids.set` | `bids.set` | `StrategyPriority` | `PriorityEnum` | 0 | 1 | `supported` | --priority |
 | `campaigns.add` | `campaigns.add` | `ClientInfo` | `string` | 0 | 1 | `missing_followup` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
 | `campaigns.add` | `campaigns.add` | `Notification` | `Notification` | 0 | 1 | `missing_followup` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
 | `campaigns.add` | `campaigns.add` | `Notification.SmsSettings` | `SmsSettings` | 0 | 1 | `missing_followup` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
@@ -5575,13 +5566,13 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `feeds.update` | `feeds.update` | `FileFeed` | `FileFeedUpdate` | 0 | 1 | `missing_followup` | FileFeed upload/base64 CLI support is split from #253. [#264](https://github.com/axisrow/direct-cli/issues/264) |
 | `feeds.update` | `feeds.update` | `FileFeed.Data` | `base64Binary` | 1 | 1 | `missing_followup` | FileFeed upload/base64 CLI support is split from #253. [#264](https://github.com/axisrow/direct-cli/issues/264); inherited from `FileFeed` |
 | `feeds.update` | `feeds.update` | `FileFeed.Filename` | `string` | 1 | 1 | `missing_followup` | FileFeed upload/base64 CLI support is split from #253. [#264](https://github.com/axisrow/direct-cli/issues/264); inherited from `FileFeed` |
-| `keywordbids.set` | `keywordbids.set` | `CampaignId` | `long` | 0 | 1 | `missing_followup` | keywordbids.set optional WSDL path needs typed support or N/A. [#301](https://github.com/axisrow/direct-cli/issues/301) |
-| `keywordbids.set` | `keywordbids.set` | `AdGroupId` | `long` | 0 | 1 | `missing_followup` | keywordbids.set optional WSDL path needs typed support or N/A. [#301](https://github.com/axisrow/direct-cli/issues/301) |
+| `keywordbids.set` | `keywordbids.set` | `CampaignId` | `long` | 0 | 1 | `supported` | --campaign-id |
+| `keywordbids.set` | `keywordbids.set` | `AdGroupId` | `long` | 0 | 1 | `supported` | --adgroup-id |
 | `keywordbids.set` | `keywordbids.set` | `KeywordId` | `long` | 0 | 1 | `supported` | --keyword-id |
 | `keywordbids.set` | `keywordbids.set` | `SearchBid` | `long` | 0 | 1 | `supported` | --search-bid |
-| `keywordbids.set` | `keywordbids.set` | `AutotargetingSearchBidIsAuto` | `YesNoEnum` | 0 | 1 | `missing_followup` | keywordbids.set optional WSDL path needs typed support or N/A. [#301](https://github.com/axisrow/direct-cli/issues/301) |
+| `keywordbids.set` | `keywordbids.set` | `AutotargetingSearchBidIsAuto` | `YesNoEnum` | 0 | 1 | `supported` | --autotargeting-search-bid-is-auto |
 | `keywordbids.set` | `keywordbids.set` | `NetworkBid` | `long` | 0 | 1 | `supported` | --network-bid |
-| `keywordbids.set` | `keywordbids.set` | `StrategyPriority` | `PriorityEnum` | 0 | 1 | `missing_followup` | keywordbids.set optional WSDL path needs typed support or N/A. [#301](https://github.com/axisrow/direct-cli/issues/301) |
+| `keywordbids.set` | `keywordbids.set` | `StrategyPriority` | `PriorityEnum` | 0 | 1 | `supported` | --priority |
 | `keywords.add` | `keywords.add` | `Keyword` | `string` | 1 | 1 | `supported` | covered by minOccurs>=1 parity gate |
 | `keywords.add` | `keywords.add` | `AdGroupId` | `long` | 1 | 1 | `supported` | covered by minOccurs>=1 parity gate |
 | `keywords.add` | `keywords.add` | `Bid` | `long` | 0 | 1 | `supported` | --bid |

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -135,6 +135,25 @@ class TestCLI(unittest.TestCase):
         self.assertIn("--erir-contragent-tin-type", result.output)
         self.assertIn("--erir-contragent-tin", result.output)
 
+    def test_bids_set_help_documents_optional_bid_flags(self):
+        result = self.runner.invoke(cli, ["bids", "set", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("--campaign-id", result.output)
+        self.assertIn("--adgroup-id", result.output)
+        self.assertIn("--keyword-id", result.output)
+        self.assertIn("--context-bid", result.output)
+        self.assertIn("--autotargeting-search-bid-is-auto", result.output)
+        self.assertIn("--priority", result.output)
+
+    def test_keywordbids_set_help_documents_optional_bid_flags(self):
+        result = self.runner.invoke(cli, ["keywordbids", "set", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("--campaign-id", result.output)
+        self.assertIn("--adgroup-id", result.output)
+        self.assertIn("--keyword-id", result.output)
+        self.assertIn("--autotargeting-search-bid-is-auto", result.output)
+        self.assertIn("--priority", result.output)
+
     def test_canonical_groups_in_help(self):
         """Test canonical transport groups"""
         result = self.runner.invoke(cli, ["--help"])

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -3176,6 +3176,58 @@ def test_bids_set_payload():
     assert bid == {"KeywordId": 1, "Bid": 15000000}
 
 
+def test_bids_set_campaign_context_auto_priority_payload():
+    body = _dry_run(
+        "bids",
+        "set",
+        "--campaign-id",
+        "123",
+        "--context-bid",
+        "9000000",
+        "--autotargeting-search-bid-is-auto",
+        "yes",
+        "--priority",
+        "high",
+    )
+    assert body["params"]["Bids"][0] == {
+        "CampaignId": 123,
+        "ContextBid": 9000000,
+        "AutotargetingSearchBidIsAuto": "YES",
+        "StrategyPriority": "HIGH",
+    }
+
+
+def test_bids_set_adgroup_context_payload():
+    body = _dry_run(
+        "bids",
+        "set",
+        "--adgroup-id",
+        "456",
+        "--context-bid",
+        "7000000",
+    )
+    assert body["params"]["Bids"][0] == {"AdGroupId": 456, "ContextBid": 7000000}
+
+
+def test_bids_set_requires_exactly_one_selector():
+    result = CliRunner().invoke(
+        cli,
+        [
+            "bids",
+            "set",
+            "--campaign-id",
+            "1",
+            "--keyword-id",
+            "2",
+            "--bid",
+            "15000000",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "exactly one selector" in result.output
+
+
 def test_keywordbids_set_search_and_network():
     body = _dry_run(
         "keywordbids",
@@ -3194,6 +3246,58 @@ def test_keywordbids_set_search_and_network():
         "SearchBid": 8000000,
         "NetworkBid": 3000000,
     }
+
+
+def test_keywordbids_set_campaign_auto_priority_payload():
+    body = _dry_run(
+        "keywordbids",
+        "set",
+        "--campaign-id",
+        "123",
+        "--autotargeting-search-bid-is-auto",
+        "no",
+        "--priority",
+        "normal",
+    )
+    assert body["params"]["KeywordBids"][0] == {
+        "CampaignId": 123,
+        "AutotargetingSearchBidIsAuto": "NO",
+        "StrategyPriority": "NORMAL",
+    }
+
+
+def test_keywordbids_set_adgroup_network_payload():
+    body = _dry_run(
+        "keywordbids",
+        "set",
+        "--adgroup-id",
+        "456",
+        "--network-bid",
+        "3000000",
+    )
+    assert body["params"]["KeywordBids"][0] == {
+        "AdGroupId": 456,
+        "NetworkBid": 3000000,
+    }
+
+
+def test_keywordbids_set_requires_exactly_one_selector():
+    result = CliRunner().invoke(
+        cli,
+        [
+            "keywordbids",
+            "set",
+            "--campaign-id",
+            "1",
+            "--keyword-id",
+            "2",
+            "--search-bid",
+            "15000000",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "exactly one selector" in result.output
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -946,11 +946,24 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     ("audiencetargets", "add", "InterestId"): {"--interest-id"},
     ("audiencetargets", "add", "ContextBid"): {"--bid"},
     ("audiencetargets", "add", "StrategyPriority"): {"--priority"},
+    ("bids", "set", "CampaignId"): {"--campaign-id"},
+    ("bids", "set", "AdGroupId"): {"--adgroup-id"},
     ("bids", "set", "KeywordId"): {"--keyword-id"},
     ("bids", "set", "Bid"): {"--bid"},
+    ("bids", "set", "ContextBid"): {"--context-bid"},
+    ("bids", "set", "AutotargetingSearchBidIsAuto"): {
+        "--autotargeting-search-bid-is-auto"
+    },
+    ("bids", "set", "StrategyPriority"): {"--priority"},
+    ("keywordbids", "set", "CampaignId"): {"--campaign-id"},
+    ("keywordbids", "set", "AdGroupId"): {"--adgroup-id"},
     ("keywordbids", "set", "KeywordId"): {"--keyword-id"},
     ("keywordbids", "set", "SearchBid"): {"--search-bid"},
+    ("keywordbids", "set", "AutotargetingSearchBidIsAuto"): {
+        "--autotargeting-search-bid-is-auto"
+    },
     ("keywordbids", "set", "NetworkBid"): {"--network-bid"},
+    ("keywordbids", "set", "StrategyPriority"): {"--priority"},
     ("retargeting", "add", "Rules"): {"--rule"},
     ("retargeting", "add", "Type"): {"--type"},
     ("retargeting", "add", "Description"): {"--description"},
@@ -1106,10 +1119,6 @@ OPTIONAL_FIELD_DEFAULT_FOLLOWUPS: dict[tuple[str, str], dict[str, str]] = {
         "issue": "#254",
         "note": "bidmodifiers.add optional WSDL path needs typed support or N/A.",
     },
-    ("bids", "set"): {
-        "issue": "#301",
-        "note": "bids.set optional WSDL path needs typed support or N/A.",
-    },
     ("campaigns", "add"): {
         "issue": "#291",
         "note": "campaigns.add campaign-level optional path needs typed support or N/A.",
@@ -1133,10 +1142,6 @@ OPTIONAL_FIELD_DEFAULT_FOLLOWUPS: dict[tuple[str, str], dict[str, str]] = {
     ("feeds", "update"): {
         "issue": "#264",
         "note": "feeds.update optional WSDL path needs typed support or N/A.",
-    },
-    ("keywordbids", "set"): {
-        "issue": "#301",
-        "note": "keywordbids.set optional WSDL path needs typed support or N/A.",
     },
     ("retargeting", "add"): {
         "issue": "#256",


### PR DESCRIPTION
Summary:
- add typed selector, context bid, autotargeting auto, and priority flags for bids set
- add typed selector, autotargeting auto, and priority flags for keywordbids set
- move #301 WSDL audit rows from missing_followup to supported and update single-line README examples

Docs checked:
- https://yandex.ru/dev/direct/doc/ref-v5/bids/set.html
- https://yandex.ru/dev/direct/doc/ref-v5/keywordbids/set.html

Verification:
- python3 -m black --check direct_cli/commands/bids.py direct_cli/commands/keywordbids.py direct_cli/utils.py tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py
- python3 -m pytest tests/test_dry_run.py -k "bids_set and not set_auto"
- python3 -m pytest tests/test_cli.py -k "bids_set_help_documents_optional_bid_flags or keywordbids_set_help_documents_optional_bid_flags"
- python3 scripts/build_wsdl_optional_field_audit.py --check
- python3 -m pytest tests/test_wsdl_parity_gate.py
- python3 -m pytest tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py
- mypy .

Closes #301