### PR TITLE
Add keyword scalar autotargeting flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ accepts `--turbo-page-id`.
 
 ```bash
 direct keywords get --campaign-ids 1,2,3
-direct keywords add --adgroup-id 12345 --keyword "buy laptop" --bid 10500000 --context-bid 5250000 --user-param-1 segment-a --user-param-2 segment-b --dry-run
+direct keywords add --adgroup-id 12345 --keyword "---autotargeting" --bid 10500000 --context-bid 5250000 --autotargeting-search-bid-is-auto YES --priority HIGH --user-param-1 segment-a --user-param-2 segment-b --dry-run
 direct keywords update --id 88888 --keyword "updated keyword text"
 direct keywords delete --id 88888
 ```
@@ -1134,7 +1134,7 @@ long-единиц API Яндекс Директа (цена, умноженна�
 
 ```bash
 direct keywords get --campaign-ids 1,2,3
-direct keywords add --adgroup-id 12345 --keyword "купить ноутбук" --bid 10500000 --context-bid 5250000 --user-param-1 segment-a --user-param-2 segment-b --dry-run
+direct keywords add --adgroup-id 12345 --keyword "---autotargeting" --bid 10500000 --context-bid 5250000 --autotargeting-search-bid-is-auto YES --priority HIGH --user-param-1 segment-a --user-param-2 segment-b --dry-run
 direct keywords update --id 88888 --keyword "updated keyword text"
 direct keywords delete --id 88888
 ```

--- a/README.md
+++ b/README.md
@@ -422,7 +422,8 @@ accepts `--turbo-page-id`.
 
 ```bash
 direct keywords get --campaign-ids 1,2,3
-direct keywords add --adgroup-id 12345 --keyword "---autotargeting" --bid 10500000 --context-bid 5250000 --autotargeting-search-bid-is-auto YES --priority HIGH --user-param-1 segment-a --user-param-2 segment-b --dry-run
+direct keywords add --adgroup-id 12345 --keyword "buy laptop" --bid 10500000 --context-bid 5250000 --user-param-1 segment-a --user-param-2 segment-b --dry-run
+direct keywords add --adgroup-id 12345 --keyword "---autotargeting" --autotargeting-search-bid-is-auto YES --priority HIGH --dry-run
 direct keywords update --id 88888 --keyword "updated keyword text"
 direct keywords delete --id 88888
 ```
@@ -1134,7 +1135,8 @@ long-единиц API Яндекс Директа (цена, умноженна�
 
 ```bash
 direct keywords get --campaign-ids 1,2,3
-direct keywords add --adgroup-id 12345 --keyword "---autotargeting" --bid 10500000 --context-bid 5250000 --autotargeting-search-bid-is-auto YES --priority HIGH --user-param-1 segment-a --user-param-2 segment-b --dry-run
+direct keywords add --adgroup-id 12345 --keyword "купить ноутбук" --bid 10500000 --context-bid 5250000 --user-param-1 segment-a --user-param-2 segment-b --dry-run
+direct keywords add --adgroup-id 12345 --keyword "---autotargeting" --autotargeting-search-bid-is-auto YES --priority HIGH --dry-run
 direct keywords update --id 88888 --keyword "updated keyword text"
 direct keywords delete --id 88888
 ```

--- a/direct_cli/commands/keywords.py
+++ b/direct_cli/commands/keywords.py
@@ -280,6 +280,16 @@ def get(
 @click.option("--keyword", help="Keyword text (single-item mode)")
 @click.option("--bid", type=MICRO_RUBLES, help="Search bid in micro-rubles")
 @click.option("--context-bid", type=MICRO_RUBLES, help="Context bid in micro-rubles")
+@click.option(
+    "--autotargeting-search-bid-is-auto",
+    type=click.Choice(["YES", "NO"], case_sensitive=False),
+    help="AutotargetingSearchBidIsAuto value: YES or NO",
+)
+@click.option(
+    "--priority",
+    type=click.Choice(["LOW", "NORMAL", "HIGH"], case_sensitive=False),
+    help="StrategyPriority value: LOW, NORMAL, or HIGH",
+)
 @click.option("--user-param-1", help="User parameter 1")
 @click.option("--user-param-2", help="User parameter 2")
 @click.option(
@@ -307,6 +317,8 @@ def add(
     keyword,
     bid,
     context_bid,
+    autotargeting_search_bid_is_auto,
+    priority,
     user_param_1,
     user_param_2,
     from_file,
@@ -332,6 +344,11 @@ def add(
     batch_mode = from_file is not None or keywords_json is not None
 
     if batch_mode:
+        if autotargeting_search_bid_is_auto is not None or priority is not None:
+            raise click.UsageError(
+                "--autotargeting-search-bid-is-auto and --priority are "
+                "supported only with --keyword single-item mode"
+            )
         _bulk_add(
             ctx,
             adgroup_id=adgroup_id,
@@ -354,6 +371,12 @@ def add(
             keyword_data["Bid"] = bid
         if context_bid is not None:
             keyword_data["ContextBid"] = context_bid
+        if autotargeting_search_bid_is_auto is not None:
+            keyword_data["AutotargetingSearchBidIsAuto"] = (
+                autotargeting_search_bid_is_auto.upper()
+            )
+        if priority is not None:
+            keyword_data["StrategyPriority"] = priority.upper()
         if user_param_1:
             keyword_data["UserParam1"] = user_param_1
         if user_param_2:

--- a/direct_cli/commands/keywords.py
+++ b/direct_cli/commands/keywords.py
@@ -344,10 +344,21 @@ def add(
     batch_mode = from_file is not None or keywords_json is not None
 
     if batch_mode:
-        if autotargeting_search_bid_is_auto is not None or priority is not None:
+        single_item_flags = {
+            "--bid": bid,
+            "--context-bid": context_bid,
+            "--autotargeting-search-bid-is-auto": autotargeting_search_bid_is_auto,
+            "--priority": priority,
+            "--user-param-1": user_param_1,
+            "--user-param-2": user_param_2,
+        }
+        unsupported = [
+            flag for flag, value in single_item_flags.items() if value is not None
+        ]
+        if unsupported:
             raise click.UsageError(
-                "--autotargeting-search-bid-is-auto and --priority are "
-                "supported only with --keyword single-item mode"
+                f"{', '.join(unsupported)} supported only with --keyword "
+                "single-item mode"
             )
         _bulk_add(
             ctx,

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -5574,9 +5574,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `keywords.add` | `keywords.add` | `Keyword` | `string` | 1 | 1 | `supported` | covered by minOccurs>=1 parity gate |
 | `keywords.add` | `keywords.add` | `AdGroupId` | `long` | 1 | 1 | `supported` | covered by minOccurs>=1 parity gate |
 | `keywords.add` | `keywords.add` | `Bid` | `long` | 0 | 1 | `supported` | --bid |
-| `keywords.add` | `keywords.add` | `AutotargetingSearchBidIsAuto` | `YesNoEnum` | 0 | 1 | `supported` | --autotargeting-search-bid-is-auto |
+| `keywords.add` | `keywords.add` | `AutotargetingSearchBidIsAuto` | `YesNoEnum` | 0 | 1 | `supported` | Single-item typed flag is supported; batch/from-file parity is tracked separately. [#289](https://github.com/axisrow/direct-cli/issues/289) |
 | `keywords.add` | `keywords.add` | `ContextBid` | `long` | 0 | 1 | `supported` | --context-bid |
-| `keywords.add` | `keywords.add` | `StrategyPriority` | `PriorityEnum` | 0 | 1 | `supported` | --priority |
+| `keywords.add` | `keywords.add` | `StrategyPriority` | `PriorityEnum` | 0 | 1 | `supported` | Single-item typed flag is supported; batch/from-file parity is tracked separately. [#289](https://github.com/axisrow/direct-cli/issues/289) |
 | `keywords.add` | `keywords.add` | `UserParam1` | `string` | 0 | 1 | `supported` | --user-param-1 |
 | `keywords.add` | `keywords.add` | `UserParam2` | `string` | 0 | 1 | `supported` | --user-param-2 |
 | `keywords.add` | `keywords.add` | `AutotargetingCategories` | `AutotargetingCategory` | 0 | unbounded | `missing_followup` | Keyword autotargeting categories have no typed add flags. [#286](https://github.com/axisrow/direct-cli/issues/286) |

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,8 +11,8 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 2765 |
-| `supported` | 476 |
+| `missing_followup` | 2763 |
+| `supported` | 478 |
 
 ## Confirmed Follow-Ups
 
@@ -2550,8 +2550,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `feeds.update` | `FileFeed` | FileFeed upload/base64 CLI support is split from #253. [#264](https://github.com/axisrow/direct-cli/issues/264) |
 | `feeds.update` | `FileFeed.Data` | FileFeed upload/base64 CLI support is split from #253. [#264](https://github.com/axisrow/direct-cli/issues/264); inherited from `FileFeed` |
 | `feeds.update` | `FileFeed.Filename` | FileFeed upload/base64 CLI support is split from #253. [#264](https://github.com/axisrow/direct-cli/issues/264); inherited from `FileFeed` |
-| `keywords.add` | `AutotargetingSearchBidIsAuto` | Keyword autotargeting auto-search-bid has no typed add flag. [#285](https://github.com/axisrow/direct-cli/issues/285) |
-| `keywords.add` | `StrategyPriority` | Keyword strategy priority has no typed add flag. [#285](https://github.com/axisrow/direct-cli/issues/285) |
 | `keywords.add` | `AutotargetingCategories` | Keyword autotargeting categories have no typed add flags. [#286](https://github.com/axisrow/direct-cli/issues/286) |
 | `keywords.add` | `AutotargetingCategories.Category` | Keyword autotargeting categories have no typed add flags. [#286](https://github.com/axisrow/direct-cli/issues/286); inherited from `AutotargetingCategories` |
 | `keywords.add` | `AutotargetingCategories.Value` | Keyword autotargeting categories have no typed add flags. [#286](https://github.com/axisrow/direct-cli/issues/286); inherited from `AutotargetingCategories` |
@@ -5576,9 +5574,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `keywords.add` | `keywords.add` | `Keyword` | `string` | 1 | 1 | `supported` | covered by minOccurs>=1 parity gate |
 | `keywords.add` | `keywords.add` | `AdGroupId` | `long` | 1 | 1 | `supported` | covered by minOccurs>=1 parity gate |
 | `keywords.add` | `keywords.add` | `Bid` | `long` | 0 | 1 | `supported` | --bid |
-| `keywords.add` | `keywords.add` | `AutotargetingSearchBidIsAuto` | `YesNoEnum` | 0 | 1 | `missing_followup` | Keyword autotargeting auto-search-bid has no typed add flag. [#285](https://github.com/axisrow/direct-cli/issues/285) |
+| `keywords.add` | `keywords.add` | `AutotargetingSearchBidIsAuto` | `YesNoEnum` | 0 | 1 | `supported` | --autotargeting-search-bid-is-auto |
 | `keywords.add` | `keywords.add` | `ContextBid` | `long` | 0 | 1 | `supported` | --context-bid |
-| `keywords.add` | `keywords.add` | `StrategyPriority` | `PriorityEnum` | 0 | 1 | `missing_followup` | Keyword strategy priority has no typed add flag. [#285](https://github.com/axisrow/direct-cli/issues/285) |
+| `keywords.add` | `keywords.add` | `StrategyPriority` | `PriorityEnum` | 0 | 1 | `supported` | --priority |
 | `keywords.add` | `keywords.add` | `UserParam1` | `string` | 0 | 1 | `supported` | --user-param-1 |
 | `keywords.add` | `keywords.add` | `UserParam2` | `string` | 0 | 1 | `supported` | --user-param-2 |
 | `keywords.add` | `keywords.add` | `AutotargetingCategories` | `AutotargetingCategory` | 0 | unbounded | `missing_followup` | Keyword autotargeting categories have no typed add flags. [#286](https://github.com/axisrow/direct-cli/issues/286) |

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -154,6 +154,12 @@ class TestCLI(unittest.TestCase):
         self.assertIn("--autotargeting-search-bid-is-auto", result.output)
         self.assertIn("--priority", result.output)
 
+    def test_keywords_add_help_documents_scalar_autotargeting_flags(self):
+        result = self.runner.invoke(cli, ["keywords", "add", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("--autotargeting-search-bid-is-auto", result.output)
+        self.assertIn("--priority", result.output)
+
     def test_canonical_groups_in_help(self):
         """Test canonical transport groups"""
         result = self.runner.invoke(cli, ["--help"])

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -2845,6 +2845,31 @@ def test_keywords_add_rejects_scalar_autotargeting_flags_in_batch_mode(tmp_path)
     assert "single-item mode" in result.output
 
 
+def test_keywords_add_rejects_single_item_flags_in_batch_mode(tmp_path):
+    path = _write_jsonl(tmp_path, [{"Keyword": "kw", "AdGroupId": 100}])
+    result = CliRunner().invoke(
+        cli,
+        [
+            "keywords",
+            "add",
+            "--from-file",
+            path,
+            "--bid",
+            "15000000",
+            "--context-bid",
+            "5000000",
+            "--user-param-1",
+            "segment-a",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "single-item mode" in result.output
+    assert "--bid" in result.output
+    assert "--context-bid" in result.output
+    assert "--user-param-1" in result.output
+
+
 def test_keywords_update_payload_keyword_text():
     body = _dry_run("keywords", "update", "--id", "777", "--keyword", "new text")
     keyword = body["params"]["Keywords"][0]

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -2865,6 +2865,8 @@ def test_keywords_add_rejects_single_item_flags_in_batch_mode(tmp_path):
             "5000000",
             "--user-param-1",
             "segment-a",
+            "--user-param-2",
+            "segment-b",
             "--dry-run",
         ],
     )
@@ -2873,6 +2875,7 @@ def test_keywords_add_rejects_single_item_flags_in_batch_mode(tmp_path):
     assert "--bid" in result.output
     assert "--context-bid" in result.output
     assert "--user-param-1" in result.output
+    assert "--user-param-2" in result.output
 
 
 def test_keywords_update_payload_keyword_text():

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -2829,20 +2829,25 @@ def test_keywords_add_payload_with_scalar_autotargeting_fields():
 
 def test_keywords_add_rejects_scalar_autotargeting_flags_in_batch_mode(tmp_path):
     path = _write_jsonl(tmp_path, [{"Keyword": "kw", "AdGroupId": 100}])
-    result = CliRunner().invoke(
-        cli,
-        [
-            "keywords",
-            "add",
-            "--from-file",
-            path,
-            "--priority",
-            "HIGH",
-            "--dry-run",
-        ],
-    )
-    assert result.exit_code != 0
-    assert "single-item mode" in result.output
+    for flag, value in (
+        ("--priority", "HIGH"),
+        ("--autotargeting-search-bid-is-auto", "YES"),
+    ):
+        result = CliRunner().invoke(
+            cli,
+            [
+                "keywords",
+                "add",
+                "--from-file",
+                path,
+                flag,
+                value,
+                "--dry-run",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "single-item mode" in result.output
+        assert flag in result.output
 
 
 def test_keywords_add_rejects_single_item_flags_in_batch_mode(tmp_path):

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -2805,6 +2805,46 @@ def test_keywords_add_payload_with_bids():
     assert keyword["ContextBid"] == 5000000
 
 
+def test_keywords_add_payload_with_scalar_autotargeting_fields():
+    body = _dry_run(
+        "keywords",
+        "add",
+        "--adgroup-id",
+        "12",
+        "--keyword",
+        "---autotargeting",
+        "--autotargeting-search-bid-is-auto",
+        "yes",
+        "--priority",
+        "high",
+    )
+    keyword = body["params"]["Keywords"][0]
+    assert keyword == {
+        "AdGroupId": 12,
+        "Keyword": "---autotargeting",
+        "AutotargetingSearchBidIsAuto": "YES",
+        "StrategyPriority": "HIGH",
+    }
+
+
+def test_keywords_add_rejects_scalar_autotargeting_flags_in_batch_mode(tmp_path):
+    path = _write_jsonl(tmp_path, [{"Keyword": "kw", "AdGroupId": 100}])
+    result = CliRunner().invoke(
+        cli,
+        [
+            "keywords",
+            "add",
+            "--from-file",
+            path,
+            "--priority",
+            "HIGH",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "single-item mode" in result.output
+
+
 def test_keywords_update_payload_keyword_text():
     body = _dry_run("keywords", "update", "--id", "777", "--keyword", "new text")
     keyword = body["params"]["Keywords"][0]

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -934,7 +934,11 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     },
     ("creatives", "add", "VideoExtensionCreative.VideoId"): {"--video-id"},
     ("keywords", "add", "Bid"): {"--bid"},
+    ("keywords", "add", "AutotargetingSearchBidIsAuto"): {
+        "--autotargeting-search-bid-is-auto"
+    },
     ("keywords", "add", "ContextBid"): {"--context-bid"},
+    ("keywords", "add", "StrategyPriority"): {"--priority"},
     ("keywords", "add", "UserParam1"): {"--user-param-1"},
     ("keywords", "add", "UserParam2"): {"--user-param-2"},
     ("keywords", "update", "Keyword"): {"--keyword"},
@@ -1460,16 +1464,6 @@ OPTIONAL_FIELD_AUDIT: dict[tuple[str, str, str], dict[str, str]] = {
         "status": "missing_followup",
         "issue": "#286",
         "note": "Keyword autotargeting categories have no typed add flags.",
-    },
-    ("keywords", "add", "AutotargetingSearchBidIsAuto"): {
-        "status": "missing_followup",
-        "issue": "#285",
-        "note": "Keyword autotargeting auto-search-bid has no typed add flag.",
-    },
-    ("keywords", "add", "StrategyPriority"): {
-        "status": "missing_followup",
-        "issue": "#285",
-        "note": "Keyword strategy priority has no typed add flag.",
     },
     ("keywords", "add", "AutotargetingBrandOptions"): {
         "status": "missing_followup",

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -1465,10 +1465,26 @@ OPTIONAL_FIELD_AUDIT: dict[tuple[str, str, str], dict[str, str]] = {
         "issue": "#286",
         "note": "Keyword autotargeting categories have no typed add flags.",
     },
+    ("keywords", "add", "AutotargetingSearchBidIsAuto"): {
+        "status": "supported",
+        "issue": "#289",
+        "note": (
+            "Single-item typed flag is supported; batch/from-file parity is "
+            "tracked separately."
+        ),
+    },
     ("keywords", "add", "AutotargetingBrandOptions"): {
         "status": "missing_followup",
         "issue": "#287",
         "note": "Keyword autotargeting brand options have no typed add flags.",
+    },
+    ("keywords", "add", "StrategyPriority"): {
+        "status": "supported",
+        "issue": "#289",
+        "note": (
+            "Single-item typed flag is supported; batch/from-file parity is "
+            "tracked separately."
+        ),
     },
     ("keywords", "add", "AutotargetingSettings"): {
         "status": "missing_followup",


### PR DESCRIPTION
Summary:
- add typed keywords add flags for AutotargetingSearchBidIsAuto and StrategyPriority
- emit top-level Keywords[0] scalar autotargeting fields in single-item dry-run payloads
- reject all single-item-only top-level flags in batch modes (--bid, --context-bid, --autotargeting-search-bid-is-auto, --priority, --user-param-1, --user-param-2) so they are not silently ignored before #289
- move #285 WSDL audit rows from missing_followup to supported with explicit single-item-only evidence and batch/from-file parity tracked in #289
- keep regular keyword README examples and add adjacent autotargeting examples

Docs checked:
- https://yandex.ru/dev/direct/doc/ru/keywords/add

Verification:
- python3 -m black --check direct_cli/commands/keywords.py tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py
- python3 -m pytest tests/test_dry_run.py -k "keywords_add and scalar_autotargeting"
- python3 -m pytest tests/test_dry_run.py -k "keywords_add and batch_mode"
- python3 -m pytest tests/test_dry_run.py -k "keywords_add and (batch_mode or scalar_autotargeting)"
- python3 -m pytest tests/test_cli.py -k keywords_add_help_documents_scalar_autotargeting_flags
- python3 scripts/build_wsdl_optional_field_audit.py --check
- python3 -m pytest tests/test_wsdl_parity_gate.py
- python3 -m pytest tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py
- mypy .

Closes #285