### PR TITLE
[codex] Add keyword autotargeting category flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,8 +423,9 @@ accepts `--turbo-page-id`.
 ```bash
 direct keywords get --campaign-ids 1,2,3
 direct keywords add --adgroup-id 12345 --keyword "buy laptop" --bid 10500000 --context-bid 5250000 --user-param-1 segment-a --user-param-2 segment-b --dry-run
-direct keywords add --adgroup-id 12345 --keyword "---autotargeting" --autotargeting-search-bid-is-auto YES --priority HIGH --dry-run
+direct keywords add --adgroup-id 12345 --keyword "---autotargeting" --autotargeting-search-bid-is-auto YES --priority HIGH --autotargeting-category EXACT=YES --autotargeting-category BROADER=NO --dry-run
 direct keywords update --id 88888 --keyword "updated keyword text"
+direct keywords update --id 88888 --autotargeting-category EXACT=YES --autotargeting-category BROADER=NO
 direct keywords delete --id 88888
 ```
 
@@ -1136,8 +1137,9 @@ long-единиц API Яндекс Директа (цена, умноженна�
 ```bash
 direct keywords get --campaign-ids 1,2,3
 direct keywords add --adgroup-id 12345 --keyword "купить ноутбук" --bid 10500000 --context-bid 5250000 --user-param-1 segment-a --user-param-2 segment-b --dry-run
-direct keywords add --adgroup-id 12345 --keyword "---autotargeting" --autotargeting-search-bid-is-auto YES --priority HIGH --dry-run
+direct keywords add --adgroup-id 12345 --keyword "---autotargeting" --autotargeting-search-bid-is-auto YES --priority HIGH --autotargeting-category EXACT=YES --autotargeting-category BROADER=NO --dry-run
 direct keywords update --id 88888 --keyword "updated keyword text"
+direct keywords update --id 88888 --autotargeting-category EXACT=YES --autotargeting-category BROADER=NO
 direct keywords delete --id 88888
 ```
 

--- a/direct_cli/commands/keywords.py
+++ b/direct_cli/commands/keywords.py
@@ -39,7 +39,7 @@ AUTOTARGETING_CATEGORIES = (
 
 AUTOTARGETING_CATEGORY_HELP = (
     "AutotargetingCategories item as CATEGORY=YES|NO. Categories: "
-    "EXACT, ALTERNATIVE, COMPETITOR, BROADER, ACCESSORY"
+    + ", ".join(AUTOTARGETING_CATEGORIES)
 )
 
 _KEYWORD_ROW_FIELDS: Dict[str, str] = {
@@ -620,7 +620,7 @@ def update(
     autotargeting_categories,
     dry_run,
 ):
-    """Update keyword text or user params (use 'bids set' for bid changes)"""
+    """Update keyword text, user params, or autotargeting categories."""
     keyword_data = {"Id": keyword_id}
     parsed_autotargeting_categories = _parse_autotargeting_categories(
         autotargeting_categories

--- a/direct_cli/commands/keywords.py
+++ b/direct_cli/commands/keywords.py
@@ -29,6 +29,19 @@ KEYWORDS_ADD_MAX_BATCH = 10
 # below just tells the operator before any chunk is sent.
 KEYWORDS_PER_ADGROUP_LIMIT = 200
 
+AUTOTARGETING_CATEGORIES = (
+    "EXACT",
+    "ALTERNATIVE",
+    "COMPETITOR",
+    "BROADER",
+    "ACCESSORY",
+)
+
+AUTOTARGETING_CATEGORY_HELP = (
+    "AutotargetingCategories item as CATEGORY=YES|NO. Categories: "
+    "EXACT, ALTERNATIVE, COMPETITOR, BROADER, ACCESSORY"
+)
+
 _KEYWORD_ROW_FIELDS: Dict[str, str] = {
     "Keyword": "str",
     "AdGroupId": "int",
@@ -182,6 +195,40 @@ def _normalize_add_results(raw: Any) -> List[Any]:
     return [raw]
 
 
+def _parse_autotargeting_categories(
+    raw_values: tuple[str, ...],
+) -> Optional[List[Dict[str, str]]]:
+    if not raw_values:
+        return None
+
+    items: List[Dict[str, str]] = []
+    allowed_categories = ", ".join(AUTOTARGETING_CATEGORIES)
+    for raw_value in raw_values:
+        category_raw, separator, value_raw = raw_value.strip().partition("=")
+        if not separator:
+            raise click.UsageError(
+                "--autotargeting-category expects CATEGORY=YES|NO "
+                "(for example EXACT=YES)"
+            )
+
+        category = category_raw.strip().upper()
+        value = value_raw.strip().upper()
+        if category not in AUTOTARGETING_CATEGORIES:
+            raise click.UsageError(
+                "Invalid --autotargeting-category category "
+                f"{category_raw!r}; allowed: {allowed_categories}"
+            )
+        if value not in {"YES", "NO"}:
+            raise click.UsageError(
+                "Invalid --autotargeting-category value "
+                f"{value_raw!r}; expected YES or NO"
+            )
+
+        items.append({"Category": category, "Value": value})
+
+    return items
+
+
 @click.group()
 def keywords():
     """Manage keywords"""
@@ -290,6 +337,12 @@ def get(
     type=click.Choice(["LOW", "NORMAL", "HIGH"], case_sensitive=False),
     help="StrategyPriority value: LOW, NORMAL, or HIGH",
 )
+@click.option(
+    "--autotargeting-category",
+    "autotargeting_categories",
+    multiple=True,
+    help=AUTOTARGETING_CATEGORY_HELP,
+)
 @click.option("--user-param-1", help="User parameter 1")
 @click.option("--user-param-2", help="User parameter 2")
 @click.option(
@@ -319,6 +372,7 @@ def add(
     context_bid,
     autotargeting_search_bid_is_auto,
     priority,
+    autotargeting_categories,
     user_param_1,
     user_param_2,
     from_file,
@@ -349,11 +403,12 @@ def add(
             "--context-bid": context_bid,
             "--autotargeting-search-bid-is-auto": autotargeting_search_bid_is_auto,
             "--priority": priority,
+            "--autotargeting-category": autotargeting_categories,
             "--user-param-1": user_param_1,
             "--user-param-2": user_param_2,
         }
         unsupported = [
-            flag for flag, value in single_item_flags.items() if value is not None
+            flag for flag, value in single_item_flags.items() if value not in (None, ())
         ]
         if unsupported:
             raise click.UsageError(
@@ -373,6 +428,10 @@ def add(
     if adgroup_id is None:
         raise click.UsageError("Missing option '--adgroup-id'.")
 
+    parsed_autotargeting_categories = _parse_autotargeting_categories(
+        autotargeting_categories
+    )
+
     try:
         keyword_data: Dict[str, Any] = {
             "AdGroupId": adgroup_id,
@@ -388,6 +447,8 @@ def add(
             )
         if priority is not None:
             keyword_data["StrategyPriority"] = priority.upper()
+        if parsed_autotargeting_categories is not None:
+            keyword_data["AutotargetingCategories"] = parsed_autotargeting_categories
         if user_param_1:
             keyword_data["UserParam1"] = user_param_1
         if user_param_2:
@@ -516,6 +577,12 @@ def _deprecated_bid_option(ctx, param, value):
 @click.option("--user-param-1", help="User parameter 1")
 @click.option("--user-param-2", help="User parameter 2")
 @click.option(
+    "--autotargeting-category",
+    "autotargeting_categories",
+    multiple=True,
+    help=AUTOTARGETING_CATEGORY_HELP,
+)
+@click.option(
     "--bid",
     default=None,
     expose_value=False,
@@ -544,9 +611,20 @@ def _deprecated_bid_option(ctx, param, value):
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def update(ctx, keyword_id, keyword, user_param_1, user_param_2, dry_run):
+def update(
+    ctx,
+    keyword_id,
+    keyword,
+    user_param_1,
+    user_param_2,
+    autotargeting_categories,
+    dry_run,
+):
     """Update keyword text or user params (use 'bids set' for bid changes)"""
     keyword_data = {"Id": keyword_id}
+    parsed_autotargeting_categories = _parse_autotargeting_categories(
+        autotargeting_categories
+    )
 
     if keyword:
         keyword_data["Keyword"] = keyword
@@ -554,12 +632,15 @@ def update(ctx, keyword_id, keyword, user_param_1, user_param_2, dry_run):
         keyword_data["UserParam1"] = user_param_1
     if user_param_2 is not None:
         keyword_data["UserParam2"] = user_param_2
+    if parsed_autotargeting_categories is not None:
+        keyword_data["AutotargetingCategories"] = parsed_autotargeting_categories
 
     # Reject empty-payload no-op (issue #198 H10).
     if len(keyword_data) == 1:
         raise click.UsageError(
             "keywords update requires at least one updatable field "
-            "(--keyword, --user-param-1, or --user-param-2)."
+            "(--keyword, --user-param-1, --user-param-2, or "
+            "--autotargeting-category)."
         )
 
     try:

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,8 +11,8 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 2763 |
-| `supported` | 478 |
+| `missing_followup` | 2757 |
+| `supported` | 484 |
 
 ## Confirmed Follow-Ups
 
@@ -2550,9 +2550,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `feeds.update` | `FileFeed` | FileFeed upload/base64 CLI support is split from #253. [#264](https://github.com/axisrow/direct-cli/issues/264) |
 | `feeds.update` | `FileFeed.Data` | FileFeed upload/base64 CLI support is split from #253. [#264](https://github.com/axisrow/direct-cli/issues/264); inherited from `FileFeed` |
 | `feeds.update` | `FileFeed.Filename` | FileFeed upload/base64 CLI support is split from #253. [#264](https://github.com/axisrow/direct-cli/issues/264); inherited from `FileFeed` |
-| `keywords.add` | `AutotargetingCategories` | Keyword autotargeting categories have no typed add flags. [#286](https://github.com/axisrow/direct-cli/issues/286) |
-| `keywords.add` | `AutotargetingCategories.Category` | Keyword autotargeting categories have no typed add flags. [#286](https://github.com/axisrow/direct-cli/issues/286); inherited from `AutotargetingCategories` |
-| `keywords.add` | `AutotargetingCategories.Value` | Keyword autotargeting categories have no typed add flags. [#286](https://github.com/axisrow/direct-cli/issues/286); inherited from `AutotargetingCategories` |
 | `keywords.add` | `AutotargetingBrandOptions` | Keyword autotargeting brand options have no typed add flags. [#287](https://github.com/axisrow/direct-cli/issues/287) |
 | `keywords.add` | `AutotargetingBrandOptions.Option` | Keyword autotargeting brand options have no typed add flags. [#287](https://github.com/axisrow/direct-cli/issues/287); inherited from `AutotargetingBrandOptions` |
 | `keywords.add` | `AutotargetingBrandOptions.Value` | Keyword autotargeting brand options have no typed add flags. [#287](https://github.com/axisrow/direct-cli/issues/287); inherited from `AutotargetingBrandOptions` |
@@ -2567,9 +2564,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `keywords.add` | `AutotargetingSettings.BrandOptions.WithoutBrands` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
 | `keywords.add` | `AutotargetingSettings.BrandOptions.WithAdvertiserBrand` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
 | `keywords.add` | `AutotargetingSettings.BrandOptions.WithCompetitorsBrand` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.update` | `AutotargetingCategories` | Keyword autotargeting categories have no typed update flags. [#286](https://github.com/axisrow/direct-cli/issues/286) |
-| `keywords.update` | `AutotargetingCategories.Category` | Keyword autotargeting categories have no typed update flags. [#286](https://github.com/axisrow/direct-cli/issues/286); inherited from `AutotargetingCategories` |
-| `keywords.update` | `AutotargetingCategories.Value` | Keyword autotargeting categories have no typed update flags. [#286](https://github.com/axisrow/direct-cli/issues/286); inherited from `AutotargetingCategories` |
 | `keywords.update` | `AutotargetingBrandOptions` | Keyword autotargeting brand options have no typed update flags. [#287](https://github.com/axisrow/direct-cli/issues/287) |
 | `keywords.update` | `AutotargetingBrandOptions.Option` | Keyword autotargeting brand options have no typed update flags. [#287](https://github.com/axisrow/direct-cli/issues/287); inherited from `AutotargetingBrandOptions` |
 | `keywords.update` | `AutotargetingBrandOptions.Value` | Keyword autotargeting brand options have no typed update flags. [#287](https://github.com/axisrow/direct-cli/issues/287); inherited from `AutotargetingBrandOptions` |
@@ -5579,9 +5573,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `keywords.add` | `keywords.add` | `StrategyPriority` | `PriorityEnum` | 0 | 1 | `supported` | Single-item typed flag is supported; batch/from-file parity is tracked separately. [#289](https://github.com/axisrow/direct-cli/issues/289) |
 | `keywords.add` | `keywords.add` | `UserParam1` | `string` | 0 | 1 | `supported` | --user-param-1 |
 | `keywords.add` | `keywords.add` | `UserParam2` | `string` | 0 | 1 | `supported` | --user-param-2 |
-| `keywords.add` | `keywords.add` | `AutotargetingCategories` | `AutotargetingCategory` | 0 | unbounded | `missing_followup` | Keyword autotargeting categories have no typed add flags. [#286](https://github.com/axisrow/direct-cli/issues/286) |
-| `keywords.add` | `keywords.add` | `AutotargetingCategories.Category` | `AutotargetingCategoriesEnum` | 1 | 1 | `missing_followup` | Keyword autotargeting categories have no typed add flags. [#286](https://github.com/axisrow/direct-cli/issues/286); inherited from `AutotargetingCategories` |
-| `keywords.add` | `keywords.add` | `AutotargetingCategories.Value` | `YesNoEnum` | 1 | 1 | `missing_followup` | Keyword autotargeting categories have no typed add flags. [#286](https://github.com/axisrow/direct-cli/issues/286); inherited from `AutotargetingCategories` |
+| `keywords.add` | `keywords.add` | `AutotargetingCategories` | `AutotargetingCategory` | 0 | unbounded | `supported` | --autotargeting-category |
+| `keywords.add` | `keywords.add` | `AutotargetingCategories.Category` | `AutotargetingCategoriesEnum` | 1 | 1 | `supported` | --autotargeting-category |
+| `keywords.add` | `keywords.add` | `AutotargetingCategories.Value` | `YesNoEnum` | 1 | 1 | `supported` | --autotargeting-category |
 | `keywords.add` | `keywords.add` | `AutotargetingBrandOptions` | `AutotargetingBrandOption` | 0 | unbounded | `missing_followup` | Keyword autotargeting brand options have no typed add flags. [#287](https://github.com/axisrow/direct-cli/issues/287) |
 | `keywords.add` | `keywords.add` | `AutotargetingBrandOptions.Option` | `AutotargetingBrandOptionsEnum` | 1 | 1 | `missing_followup` | Keyword autotargeting brand options have no typed add flags. [#287](https://github.com/axisrow/direct-cli/issues/287); inherited from `AutotargetingBrandOptions` |
 | `keywords.add` | `keywords.add` | `AutotargetingBrandOptions.Value` | `YesNoEnum` | 1 | 1 | `missing_followup` | Keyword autotargeting brand options have no typed add flags. [#287](https://github.com/axisrow/direct-cli/issues/287); inherited from `AutotargetingBrandOptions` |
@@ -5600,9 +5594,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `keywords.update` | `keywords.update` | `Keyword` | `string` | 0 | 1 | `supported` | --keyword |
 | `keywords.update` | `keywords.update` | `UserParam1` | `string` | 0 | 1 | `supported` | --user-param-1 |
 | `keywords.update` | `keywords.update` | `UserParam2` | `string` | 0 | 1 | `supported` | --user-param-2 |
-| `keywords.update` | `keywords.update` | `AutotargetingCategories` | `AutotargetingCategory` | 0 | unbounded | `missing_followup` | Keyword autotargeting categories have no typed update flags. [#286](https://github.com/axisrow/direct-cli/issues/286) |
-| `keywords.update` | `keywords.update` | `AutotargetingCategories.Category` | `AutotargetingCategoriesEnum` | 1 | 1 | `missing_followup` | Keyword autotargeting categories have no typed update flags. [#286](https://github.com/axisrow/direct-cli/issues/286); inherited from `AutotargetingCategories` |
-| `keywords.update` | `keywords.update` | `AutotargetingCategories.Value` | `YesNoEnum` | 1 | 1 | `missing_followup` | Keyword autotargeting categories have no typed update flags. [#286](https://github.com/axisrow/direct-cli/issues/286); inherited from `AutotargetingCategories` |
+| `keywords.update` | `keywords.update` | `AutotargetingCategories` | `AutotargetingCategory` | 0 | unbounded | `supported` | --autotargeting-category |
+| `keywords.update` | `keywords.update` | `AutotargetingCategories.Category` | `AutotargetingCategoriesEnum` | 1 | 1 | `supported` | --autotargeting-category |
+| `keywords.update` | `keywords.update` | `AutotargetingCategories.Value` | `YesNoEnum` | 1 | 1 | `supported` | --autotargeting-category |
 | `keywords.update` | `keywords.update` | `AutotargetingBrandOptions` | `AutotargetingBrandOption` | 0 | unbounded | `missing_followup` | Keyword autotargeting brand options have no typed update flags. [#287](https://github.com/axisrow/direct-cli/issues/287) |
 | `keywords.update` | `keywords.update` | `AutotargetingBrandOptions.Option` | `AutotargetingBrandOptionsEnum` | 1 | 1 | `missing_followup` | Keyword autotargeting brand options have no typed update flags. [#287](https://github.com/axisrow/direct-cli/issues/287); inherited from `AutotargetingBrandOptions` |
 | `keywords.update` | `keywords.update` | `AutotargetingBrandOptions.Value` | `YesNoEnum` | 1 | 1 | `missing_followup` | Keyword autotargeting brand options have no typed update flags. [#287](https://github.com/axisrow/direct-cli/issues/287); inherited from `AutotargetingBrandOptions` |

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -160,6 +160,14 @@ class TestCLI(unittest.TestCase):
         self.assertIn("--autotargeting-search-bid-is-auto", result.output)
         self.assertIn("--priority", result.output)
 
+    def test_keywords_help_documents_autotargeting_category_flags(self):
+        add_result = self.runner.invoke(cli, ["keywords", "add", "--help"])
+        update_result = self.runner.invoke(cli, ["keywords", "update", "--help"])
+        self.assertEqual(add_result.exit_code, 0)
+        self.assertEqual(update_result.exit_code, 0)
+        self.assertIn("--autotargeting-category", add_result.output)
+        self.assertIn("--autotargeting-category", update_result.output)
+
     def test_canonical_groups_in_help(self):
         """Test canonical transport groups"""
         result = self.runner.invoke(cli, ["--help"])

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -2827,11 +2827,36 @@ def test_keywords_add_payload_with_scalar_autotargeting_fields():
     }
 
 
+def test_keywords_add_payload_with_autotargeting_categories():
+    body = _dry_run(
+        "keywords",
+        "add",
+        "--adgroup-id",
+        "12",
+        "--keyword",
+        "---autotargeting",
+        "--autotargeting-category",
+        "exact=yes",
+        "--autotargeting-category",
+        "BROADER=NO",
+    )
+    keyword = body["params"]["Keywords"][0]
+    assert keyword == {
+        "AdGroupId": 12,
+        "Keyword": "---autotargeting",
+        "AutotargetingCategories": [
+            {"Category": "EXACT", "Value": "YES"},
+            {"Category": "BROADER", "Value": "NO"},
+        ],
+    }
+
+
 def test_keywords_add_rejects_scalar_autotargeting_flags_in_batch_mode(tmp_path):
     path = _write_jsonl(tmp_path, [{"Keyword": "kw", "AdGroupId": 100}])
     for flag, value in (
         ("--priority", "HIGH"),
         ("--autotargeting-search-bid-is-auto", "YES"),
+        ("--autotargeting-category", "EXACT=YES"),
     ):
         result = CliRunner().invoke(
             cli,
@@ -2897,6 +2922,96 @@ def test_keywords_update_payload_user_params():
     )
     keyword = body["params"]["Keywords"][0]
     assert keyword == {"Id": 777, "UserParam1": "seg-a", "UserParam2": "seg-b"}
+
+
+def test_keywords_update_rejects_noop_payload():
+    result = CliRunner().invoke(
+        cli,
+        [
+            "keywords",
+            "update",
+            "--id",
+            "777",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "requires at least one updatable field" in result.output
+
+
+def test_keywords_update_payload_with_autotargeting_categories():
+    body = _dry_run(
+        "keywords",
+        "update",
+        "--id",
+        "777",
+        "--autotargeting-category",
+        "ALTERNATIVE=YES",
+        "--autotargeting-category",
+        "competitor=no",
+    )
+    keyword = body["params"]["Keywords"][0]
+    assert keyword == {
+        "Id": 777,
+        "AutotargetingCategories": [
+            {"Category": "ALTERNATIVE", "Value": "YES"},
+            {"Category": "COMPETITOR", "Value": "NO"},
+        ],
+    }
+
+
+def test_keywords_autotargeting_category_requires_category_value_pair():
+    result = CliRunner().invoke(
+        cli,
+        [
+            "keywords",
+            "add",
+            "--adgroup-id",
+            "12",
+            "--keyword",
+            "---autotargeting",
+            "--autotargeting-category",
+            "EXACT",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "CATEGORY=YES|NO" in result.output
+
+
+def test_keywords_autotargeting_category_rejects_unknown_category():
+    result = CliRunner().invoke(
+        cli,
+        [
+            "keywords",
+            "update",
+            "--id",
+            "777",
+            "--autotargeting-category",
+            "UNKNOWN=YES",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "Invalid --autotargeting-category category" in result.output
+    assert "EXACT" in result.output
+
+
+def test_keywords_autotargeting_category_rejects_unknown_value():
+    result = CliRunner().invoke(
+        cli,
+        [
+            "keywords",
+            "update",
+            "--id",
+            "777",
+            "--autotargeting-category",
+            "EXACT=MAYBE",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "expected YES or NO" in result.output
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -939,11 +939,23 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     },
     ("keywords", "add", "ContextBid"): {"--context-bid"},
     ("keywords", "add", "StrategyPriority"): {"--priority"},
+    ("keywords", "add", "AutotargetingCategories"): {"--autotargeting-category"},
+    ("keywords", "add", "AutotargetingCategories.Category"): {
+        "--autotargeting-category"
+    },
+    ("keywords", "add", "AutotargetingCategories.Value"): {"--autotargeting-category"},
     ("keywords", "add", "UserParam1"): {"--user-param-1"},
     ("keywords", "add", "UserParam2"): {"--user-param-2"},
     ("keywords", "update", "Keyword"): {"--keyword"},
     ("keywords", "update", "UserParam1"): {"--user-param-1"},
     ("keywords", "update", "UserParam2"): {"--user-param-2"},
+    ("keywords", "update", "AutotargetingCategories"): {"--autotargeting-category"},
+    ("keywords", "update", "AutotargetingCategories.Category"): {
+        "--autotargeting-category"
+    },
+    ("keywords", "update", "AutotargetingCategories.Value"): {
+        "--autotargeting-category"
+    },
     ("negativekeywordsharedsets", "update", "Name"): {"--name"},
     ("negativekeywordsharedsets", "update", "NegativeKeywords"): {"--keywords"},
     ("audiencetargets", "add", "RetargetingListId"): {"--retargeting-list-id"},
@@ -1460,11 +1472,6 @@ OPTIONAL_FIELD_AUDIT: dict[tuple[str, str, str], dict[str, str]] = {
         "issue": "#280",
         "note": "Dynamic text ad group autotargeting settings are not exposed.",
     },
-    ("keywords", "add", "AutotargetingCategories"): {
-        "status": "missing_followup",
-        "issue": "#286",
-        "note": "Keyword autotargeting categories have no typed add flags.",
-    },
     ("keywords", "add", "AutotargetingSearchBidIsAuto"): {
         "status": "supported",
         "issue": "#289",
@@ -1490,11 +1497,6 @@ OPTIONAL_FIELD_AUDIT: dict[tuple[str, str, str], dict[str, str]] = {
         "status": "missing_followup",
         "issue": "#288",
         "note": "Keyword autotargeting settings have no typed add flags.",
-    },
-    ("keywords", "update", "AutotargetingCategories"): {
-        "status": "missing_followup",
-        "issue": "#286",
-        "note": "Keyword autotargeting categories have no typed update flags.",
     },
     ("keywords", "update", "AutotargetingBrandOptions"): {
         "status": "missing_followup",


### PR DESCRIPTION
## Summary
- add repeatable `--autotargeting-category CATEGORY=YES|NO` to `keywords add` and `keywords update`
- build top-level `AutotargetingCategories` payload arrays with `Category` and `Value`
- reject the new single-item flag in `keywords add` batch modes to avoid silently ignored input
- update README examples, dry-run coverage, and WSDL optional-field audit support rows

## Docs Checked
- https://yandex.ru/dev/direct/doc/ru/keywords/add
- https://yandex.ru/dev/direct/doc/ru/keywords/update

## Verification
- `python3 -m pytest tests/test_dry_run.py -k "keywords and autotargeting"`
- `python3 -m pytest tests/test_cli.py -k "keywords and autotargeting"`
- `python3 scripts/build_wsdl_optional_field_audit.py --check`
- `python3 -m pytest tests/test_wsdl_parity_gate.py`
- `python3 -m pytest tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py`
- `mypy .`

Closes #286