### PR TITLE
[codex] Add keyword autotargeting brand option flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,9 +423,9 @@ accepts `--turbo-page-id`.
 ```bash
 direct keywords get --campaign-ids 1,2,3
 direct keywords add --adgroup-id 12345 --keyword "buy laptop" --bid 10500000 --context-bid 5250000 --user-param-1 segment-a --user-param-2 segment-b --dry-run
-direct keywords add --adgroup-id 12345 --keyword "---autotargeting" --autotargeting-search-bid-is-auto YES --priority HIGH --autotargeting-category EXACT=YES --autotargeting-category BROADER=NO --dry-run
+direct keywords add --adgroup-id 12345 --keyword "---autotargeting" --autotargeting-search-bid-is-auto YES --priority HIGH --autotargeting-category EXACT=YES --autotargeting-category BROADER=NO --autotargeting-brand-option WITHOUT_BRANDS=YES --dry-run
 direct keywords update --id 88888 --keyword "updated keyword text"
-direct keywords update --id 88888 --autotargeting-category EXACT=YES --autotargeting-category BROADER=NO
+direct keywords update --id 88888 --autotargeting-category EXACT=YES --autotargeting-category BROADER=NO --autotargeting-brand-option WITHOUT_BRANDS=YES
 direct keywords delete --id 88888
 ```
 
@@ -1137,9 +1137,9 @@ long-единиц API Яндекс Директа (цена, умноженна�
 ```bash
 direct keywords get --campaign-ids 1,2,3
 direct keywords add --adgroup-id 12345 --keyword "купить ноутбук" --bid 10500000 --context-bid 5250000 --user-param-1 segment-a --user-param-2 segment-b --dry-run
-direct keywords add --adgroup-id 12345 --keyword "---autotargeting" --autotargeting-search-bid-is-auto YES --priority HIGH --autotargeting-category EXACT=YES --autotargeting-category BROADER=NO --dry-run
+direct keywords add --adgroup-id 12345 --keyword "---autotargeting" --autotargeting-search-bid-is-auto YES --priority HIGH --autotargeting-category EXACT=YES --autotargeting-category BROADER=NO --autotargeting-brand-option WITHOUT_BRANDS=YES --dry-run
 direct keywords update --id 88888 --keyword "updated keyword text"
-direct keywords update --id 88888 --autotargeting-category EXACT=YES --autotargeting-category BROADER=NO
+direct keywords update --id 88888 --autotargeting-category EXACT=YES --autotargeting-category BROADER=NO --autotargeting-brand-option WITHOUT_BRANDS=YES
 direct keywords delete --id 88888
 ```
 

--- a/direct_cli/commands/keywords.py
+++ b/direct_cli/commands/keywords.py
@@ -36,10 +36,18 @@ AUTOTARGETING_CATEGORIES = (
     "BROADER",
     "ACCESSORY",
 )
+AUTOTARGETING_BRAND_OPTIONS = (
+    "WITHOUT_BRANDS",
+    "WITH_ADVERTISER_BRAND",
+)
 
 AUTOTARGETING_CATEGORY_HELP = (
     "AutotargetingCategories item as CATEGORY=YES|NO. Categories: "
     + ", ".join(AUTOTARGETING_CATEGORIES)
+)
+AUTOTARGETING_BRAND_OPTION_HELP = (
+    "AutotargetingBrandOptions item as OPTION=YES|NO. Options: "
+    + ", ".join(AUTOTARGETING_BRAND_OPTIONS)
 )
 
 _KEYWORD_ROW_FIELDS: Dict[str, str] = {
@@ -229,6 +237,40 @@ def _parse_autotargeting_categories(
     return items
 
 
+def _parse_autotargeting_brand_options(
+    raw_values: tuple[str, ...],
+) -> Optional[List[Dict[str, str]]]:
+    if not raw_values:
+        return None
+
+    items: List[Dict[str, str]] = []
+    allowed_options = ", ".join(AUTOTARGETING_BRAND_OPTIONS)
+    for raw_value in raw_values:
+        option_raw, separator, value_raw = raw_value.strip().partition("=")
+        if not separator:
+            raise click.UsageError(
+                "--autotargeting-brand-option expects OPTION=YES|NO "
+                "(for example WITHOUT_BRANDS=YES)"
+            )
+
+        option = option_raw.strip().upper()
+        value = value_raw.strip().upper()
+        if option not in AUTOTARGETING_BRAND_OPTIONS:
+            raise click.UsageError(
+                "Invalid --autotargeting-brand-option option "
+                f"{option_raw!r}; allowed: {allowed_options}"
+            )
+        if value not in {"YES", "NO"}:
+            raise click.UsageError(
+                "Invalid --autotargeting-brand-option value "
+                f"{value_raw!r}; expected YES or NO"
+            )
+
+        items.append({"Option": option, "Value": value})
+
+    return items
+
+
 @click.group()
 def keywords():
     """Manage keywords"""
@@ -343,6 +385,12 @@ def get(
     multiple=True,
     help=AUTOTARGETING_CATEGORY_HELP,
 )
+@click.option(
+    "--autotargeting-brand-option",
+    "autotargeting_brand_options",
+    multiple=True,
+    help=AUTOTARGETING_BRAND_OPTION_HELP,
+)
 @click.option("--user-param-1", help="User parameter 1")
 @click.option("--user-param-2", help="User parameter 2")
 @click.option(
@@ -373,6 +421,7 @@ def add(
     autotargeting_search_bid_is_auto,
     priority,
     autotargeting_categories,
+    autotargeting_brand_options,
     user_param_1,
     user_param_2,
     from_file,
@@ -404,6 +453,7 @@ def add(
             "--autotargeting-search-bid-is-auto": autotargeting_search_bid_is_auto,
             "--priority": priority,
             "--autotargeting-category": autotargeting_categories,
+            "--autotargeting-brand-option": autotargeting_brand_options,
             "--user-param-1": user_param_1,
             "--user-param-2": user_param_2,
         }
@@ -431,6 +481,9 @@ def add(
     parsed_autotargeting_categories = _parse_autotargeting_categories(
         autotargeting_categories
     )
+    parsed_autotargeting_brand_options = _parse_autotargeting_brand_options(
+        autotargeting_brand_options
+    )
 
     try:
         keyword_data: Dict[str, Any] = {
@@ -449,6 +502,10 @@ def add(
             keyword_data["StrategyPriority"] = priority.upper()
         if parsed_autotargeting_categories is not None:
             keyword_data["AutotargetingCategories"] = parsed_autotargeting_categories
+        if parsed_autotargeting_brand_options is not None:
+            keyword_data["AutotargetingBrandOptions"] = (
+                parsed_autotargeting_brand_options
+            )
         if user_param_1:
             keyword_data["UserParam1"] = user_param_1
         if user_param_2:
@@ -583,6 +640,12 @@ def _deprecated_bid_option(ctx, param, value):
     help=AUTOTARGETING_CATEGORY_HELP,
 )
 @click.option(
+    "--autotargeting-brand-option",
+    "autotargeting_brand_options",
+    multiple=True,
+    help=AUTOTARGETING_BRAND_OPTION_HELP,
+)
+@click.option(
     "--bid",
     default=None,
     expose_value=False,
@@ -618,12 +681,16 @@ def update(
     user_param_1,
     user_param_2,
     autotargeting_categories,
+    autotargeting_brand_options,
     dry_run,
 ):
-    """Update keyword text, user params, or autotargeting categories."""
+    """Update keyword text, user params, or autotargeting options."""
     keyword_data = {"Id": keyword_id}
     parsed_autotargeting_categories = _parse_autotargeting_categories(
         autotargeting_categories
+    )
+    parsed_autotargeting_brand_options = _parse_autotargeting_brand_options(
+        autotargeting_brand_options
     )
 
     if keyword:
@@ -634,13 +701,15 @@ def update(
         keyword_data["UserParam2"] = user_param_2
     if parsed_autotargeting_categories is not None:
         keyword_data["AutotargetingCategories"] = parsed_autotargeting_categories
+    if parsed_autotargeting_brand_options is not None:
+        keyword_data["AutotargetingBrandOptions"] = parsed_autotargeting_brand_options
 
     # Reject empty-payload no-op (issue #198 H10).
     if len(keyword_data) == 1:
         raise click.UsageError(
             "keywords update requires at least one updatable field "
-            "(--keyword, --user-param-1, --user-param-2, or "
-            "--autotargeting-category)."
+            "(--keyword, --user-param-1, --user-param-2, "
+            "--autotargeting-category, or --autotargeting-brand-option)."
         )
 
     try:

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,8 +11,8 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 2757 |
-| `supported` | 484 |
+| `missing_followup` | 2751 |
+| `supported` | 490 |
 
 ## Confirmed Follow-Ups
 
@@ -2550,9 +2550,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `feeds.update` | `FileFeed` | FileFeed upload/base64 CLI support is split from #253. [#264](https://github.com/axisrow/direct-cli/issues/264) |
 | `feeds.update` | `FileFeed.Data` | FileFeed upload/base64 CLI support is split from #253. [#264](https://github.com/axisrow/direct-cli/issues/264); inherited from `FileFeed` |
 | `feeds.update` | `FileFeed.Filename` | FileFeed upload/base64 CLI support is split from #253. [#264](https://github.com/axisrow/direct-cli/issues/264); inherited from `FileFeed` |
-| `keywords.add` | `AutotargetingBrandOptions` | Keyword autotargeting brand options have no typed add flags. [#287](https://github.com/axisrow/direct-cli/issues/287) |
-| `keywords.add` | `AutotargetingBrandOptions.Option` | Keyword autotargeting brand options have no typed add flags. [#287](https://github.com/axisrow/direct-cli/issues/287); inherited from `AutotargetingBrandOptions` |
-| `keywords.add` | `AutotargetingBrandOptions.Value` | Keyword autotargeting brand options have no typed add flags. [#287](https://github.com/axisrow/direct-cli/issues/287); inherited from `AutotargetingBrandOptions` |
 | `keywords.add` | `AutotargetingSettings` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288) |
 | `keywords.add` | `AutotargetingSettings.Categories` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
 | `keywords.add` | `AutotargetingSettings.Categories.Exact` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
@@ -2564,9 +2561,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `keywords.add` | `AutotargetingSettings.BrandOptions.WithoutBrands` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
 | `keywords.add` | `AutotargetingSettings.BrandOptions.WithAdvertiserBrand` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
 | `keywords.add` | `AutotargetingSettings.BrandOptions.WithCompetitorsBrand` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.update` | `AutotargetingBrandOptions` | Keyword autotargeting brand options have no typed update flags. [#287](https://github.com/axisrow/direct-cli/issues/287) |
-| `keywords.update` | `AutotargetingBrandOptions.Option` | Keyword autotargeting brand options have no typed update flags. [#287](https://github.com/axisrow/direct-cli/issues/287); inherited from `AutotargetingBrandOptions` |
-| `keywords.update` | `AutotargetingBrandOptions.Value` | Keyword autotargeting brand options have no typed update flags. [#287](https://github.com/axisrow/direct-cli/issues/287); inherited from `AutotargetingBrandOptions` |
 | `keywords.update` | `AutotargetingSettings` | Keyword autotargeting settings have no typed update flags. [#288](https://github.com/axisrow/direct-cli/issues/288) |
 | `keywords.update` | `AutotargetingSettings.Categories` | Keyword autotargeting settings have no typed update flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
 | `keywords.update` | `AutotargetingSettings.Categories.Exact` | Keyword autotargeting settings have no typed update flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
@@ -5576,9 +5570,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `keywords.add` | `keywords.add` | `AutotargetingCategories` | `AutotargetingCategory` | 0 | unbounded | `supported` | --autotargeting-category |
 | `keywords.add` | `keywords.add` | `AutotargetingCategories.Category` | `AutotargetingCategoriesEnum` | 1 | 1 | `supported` | --autotargeting-category |
 | `keywords.add` | `keywords.add` | `AutotargetingCategories.Value` | `YesNoEnum` | 1 | 1 | `supported` | --autotargeting-category |
-| `keywords.add` | `keywords.add` | `AutotargetingBrandOptions` | `AutotargetingBrandOption` | 0 | unbounded | `missing_followup` | Keyword autotargeting brand options have no typed add flags. [#287](https://github.com/axisrow/direct-cli/issues/287) |
-| `keywords.add` | `keywords.add` | `AutotargetingBrandOptions.Option` | `AutotargetingBrandOptionsEnum` | 1 | 1 | `missing_followup` | Keyword autotargeting brand options have no typed add flags. [#287](https://github.com/axisrow/direct-cli/issues/287); inherited from `AutotargetingBrandOptions` |
-| `keywords.add` | `keywords.add` | `AutotargetingBrandOptions.Value` | `YesNoEnum` | 1 | 1 | `missing_followup` | Keyword autotargeting brand options have no typed add flags. [#287](https://github.com/axisrow/direct-cli/issues/287); inherited from `AutotargetingBrandOptions` |
+| `keywords.add` | `keywords.add` | `AutotargetingBrandOptions` | `AutotargetingBrandOption` | 0 | unbounded | `supported` | --autotargeting-brand-option |
+| `keywords.add` | `keywords.add` | `AutotargetingBrandOptions.Option` | `AutotargetingBrandOptionsEnum` | 1 | 1 | `supported` | --autotargeting-brand-option |
+| `keywords.add` | `keywords.add` | `AutotargetingBrandOptions.Value` | `YesNoEnum` | 1 | 1 | `supported` | --autotargeting-brand-option |
 | `keywords.add` | `keywords.add` | `AutotargetingSettings` | `AutotargetingSettings` | 0 | 1 | `missing_followup` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288) |
 | `keywords.add` | `keywords.add` | `AutotargetingSettings.Categories` | `AutotargetingCategories` | 0 | 1 | `missing_followup` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
 | `keywords.add` | `keywords.add` | `AutotargetingSettings.Categories.Exact` | `YesNoEnum` | 0 | 1 | `missing_followup` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
@@ -5597,9 +5591,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `keywords.update` | `keywords.update` | `AutotargetingCategories` | `AutotargetingCategory` | 0 | unbounded | `supported` | --autotargeting-category |
 | `keywords.update` | `keywords.update` | `AutotargetingCategories.Category` | `AutotargetingCategoriesEnum` | 1 | 1 | `supported` | --autotargeting-category |
 | `keywords.update` | `keywords.update` | `AutotargetingCategories.Value` | `YesNoEnum` | 1 | 1 | `supported` | --autotargeting-category |
-| `keywords.update` | `keywords.update` | `AutotargetingBrandOptions` | `AutotargetingBrandOption` | 0 | unbounded | `missing_followup` | Keyword autotargeting brand options have no typed update flags. [#287](https://github.com/axisrow/direct-cli/issues/287) |
-| `keywords.update` | `keywords.update` | `AutotargetingBrandOptions.Option` | `AutotargetingBrandOptionsEnum` | 1 | 1 | `missing_followup` | Keyword autotargeting brand options have no typed update flags. [#287](https://github.com/axisrow/direct-cli/issues/287); inherited from `AutotargetingBrandOptions` |
-| `keywords.update` | `keywords.update` | `AutotargetingBrandOptions.Value` | `YesNoEnum` | 1 | 1 | `missing_followup` | Keyword autotargeting brand options have no typed update flags. [#287](https://github.com/axisrow/direct-cli/issues/287); inherited from `AutotargetingBrandOptions` |
+| `keywords.update` | `keywords.update` | `AutotargetingBrandOptions` | `AutotargetingBrandOption` | 0 | unbounded | `supported` | --autotargeting-brand-option |
+| `keywords.update` | `keywords.update` | `AutotargetingBrandOptions.Option` | `AutotargetingBrandOptionsEnum` | 1 | 1 | `supported` | --autotargeting-brand-option |
+| `keywords.update` | `keywords.update` | `AutotargetingBrandOptions.Value` | `YesNoEnum` | 1 | 1 | `supported` | --autotargeting-brand-option |
 | `keywords.update` | `keywords.update` | `AutotargetingSettings` | `AutotargetingSettings` | 0 | 1 | `missing_followup` | Keyword autotargeting settings have no typed update flags. [#288](https://github.com/axisrow/direct-cli/issues/288) |
 | `keywords.update` | `keywords.update` | `AutotargetingSettings.Categories` | `AutotargetingCategories` | 0 | 1 | `missing_followup` | Keyword autotargeting settings have no typed update flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
 | `keywords.update` | `keywords.update` | `AutotargetingSettings.Categories.Exact` | `YesNoEnum` | 0 | 1 | `missing_followup` | Keyword autotargeting settings have no typed update flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -168,6 +168,14 @@ class TestCLI(unittest.TestCase):
         self.assertIn("--autotargeting-category", add_result.output)
         self.assertIn("--autotargeting-category", update_result.output)
 
+    def test_keywords_help_documents_autotargeting_brand_option_flags(self):
+        add_result = self.runner.invoke(cli, ["keywords", "add", "--help"])
+        update_result = self.runner.invoke(cli, ["keywords", "update", "--help"])
+        self.assertEqual(add_result.exit_code, 0)
+        self.assertEqual(update_result.exit_code, 0)
+        self.assertIn("--autotargeting-brand-option", add_result.output)
+        self.assertIn("--autotargeting-brand-option", update_result.output)
+
     def test_canonical_groups_in_help(self):
         """Test canonical transport groups"""
         result = self.runner.invoke(cli, ["--help"])

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -2851,12 +2851,37 @@ def test_keywords_add_payload_with_autotargeting_categories():
     }
 
 
+def test_keywords_add_payload_with_autotargeting_brand_options():
+    body = _dry_run(
+        "keywords",
+        "add",
+        "--adgroup-id",
+        "12",
+        "--keyword",
+        "---autotargeting",
+        "--autotargeting-brand-option",
+        "without_brands=yes",
+        "--autotargeting-brand-option",
+        "WITH_ADVERTISER_BRAND=NO",
+    )
+    keyword = body["params"]["Keywords"][0]
+    assert keyword == {
+        "AdGroupId": 12,
+        "Keyword": "---autotargeting",
+        "AutotargetingBrandOptions": [
+            {"Option": "WITHOUT_BRANDS", "Value": "YES"},
+            {"Option": "WITH_ADVERTISER_BRAND", "Value": "NO"},
+        ],
+    }
+
+
 def test_keywords_add_rejects_scalar_autotargeting_flags_in_batch_mode(tmp_path):
     path = _write_jsonl(tmp_path, [{"Keyword": "kw", "AdGroupId": 100}])
     for flag, value in (
         ("--priority", "HIGH"),
         ("--autotargeting-search-bid-is-auto", "YES"),
         ("--autotargeting-category", "EXACT=YES"),
+        ("--autotargeting-brand-option", "WITHOUT_BRANDS=YES"),
     ):
         result = CliRunner().invoke(
             cli,
@@ -2960,6 +2985,27 @@ def test_keywords_update_payload_with_autotargeting_categories():
     }
 
 
+def test_keywords_update_payload_with_autotargeting_brand_options():
+    body = _dry_run(
+        "keywords",
+        "update",
+        "--id",
+        "777",
+        "--autotargeting-brand-option",
+        "WITHOUT_BRANDS=NO",
+        "--autotargeting-brand-option",
+        "with_advertiser_brand=yes",
+    )
+    keyword = body["params"]["Keywords"][0]
+    assert keyword == {
+        "Id": 777,
+        "AutotargetingBrandOptions": [
+            {"Option": "WITHOUT_BRANDS", "Value": "NO"},
+            {"Option": "WITH_ADVERTISER_BRAND", "Value": "YES"},
+        ],
+    }
+
+
 def test_keywords_autotargeting_category_requires_category_value_pair():
     result = CliRunner().invoke(
         cli,
@@ -3007,6 +3053,60 @@ def test_keywords_autotargeting_category_rejects_unknown_value():
             "777",
             "--autotargeting-category",
             "EXACT=MAYBE",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "expected YES or NO" in result.output
+
+
+def test_keywords_autotargeting_brand_option_requires_option_value_pair():
+    result = CliRunner().invoke(
+        cli,
+        [
+            "keywords",
+            "add",
+            "--adgroup-id",
+            "12",
+            "--keyword",
+            "---autotargeting",
+            "--autotargeting-brand-option",
+            "WITHOUT_BRANDS",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "OPTION=YES|NO" in result.output
+
+
+def test_keywords_autotargeting_brand_option_rejects_unknown_option():
+    result = CliRunner().invoke(
+        cli,
+        [
+            "keywords",
+            "update",
+            "--id",
+            "777",
+            "--autotargeting-brand-option",
+            "WITH_COMPETITORS_BRAND=YES",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "Invalid --autotargeting-brand-option option" in result.output
+    assert "WITHOUT_BRANDS" in result.output
+
+
+def test_keywords_autotargeting_brand_option_rejects_unknown_value():
+    result = CliRunner().invoke(
+        cli,
+        [
+            "keywords",
+            "update",
+            "--id",
+            "777",
+            "--autotargeting-brand-option",
+            "WITHOUT_BRANDS=MAYBE",
             "--dry-run",
         ],
     )

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -944,6 +944,13 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
         "--autotargeting-category"
     },
     ("keywords", "add", "AutotargetingCategories.Value"): {"--autotargeting-category"},
+    ("keywords", "add", "AutotargetingBrandOptions"): {"--autotargeting-brand-option"},
+    ("keywords", "add", "AutotargetingBrandOptions.Option"): {
+        "--autotargeting-brand-option"
+    },
+    ("keywords", "add", "AutotargetingBrandOptions.Value"): {
+        "--autotargeting-brand-option"
+    },
     ("keywords", "add", "UserParam1"): {"--user-param-1"},
     ("keywords", "add", "UserParam2"): {"--user-param-2"},
     ("keywords", "update", "Keyword"): {"--keyword"},
@@ -955,6 +962,15 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     },
     ("keywords", "update", "AutotargetingCategories.Value"): {
         "--autotargeting-category"
+    },
+    ("keywords", "update", "AutotargetingBrandOptions"): {
+        "--autotargeting-brand-option"
+    },
+    ("keywords", "update", "AutotargetingBrandOptions.Option"): {
+        "--autotargeting-brand-option"
+    },
+    ("keywords", "update", "AutotargetingBrandOptions.Value"): {
+        "--autotargeting-brand-option"
     },
     ("negativekeywordsharedsets", "update", "Name"): {"--name"},
     ("negativekeywordsharedsets", "update", "NegativeKeywords"): {"--keywords"},
@@ -1480,11 +1496,6 @@ OPTIONAL_FIELD_AUDIT: dict[tuple[str, str, str], dict[str, str]] = {
             "tracked separately."
         ),
     },
-    ("keywords", "add", "AutotargetingBrandOptions"): {
-        "status": "missing_followup",
-        "issue": "#287",
-        "note": "Keyword autotargeting brand options have no typed add flags.",
-    },
     ("keywords", "add", "StrategyPriority"): {
         "status": "supported",
         "issue": "#289",
@@ -1497,11 +1508,6 @@ OPTIONAL_FIELD_AUDIT: dict[tuple[str, str, str], dict[str, str]] = {
         "status": "missing_followup",
         "issue": "#288",
         "note": "Keyword autotargeting settings have no typed add flags.",
-    },
-    ("keywords", "update", "AutotargetingBrandOptions"): {
-        "status": "missing_followup",
-        "issue": "#287",
-        "note": "Keyword autotargeting brand options have no typed update flags.",
     },
     ("keywords", "update", "AutotargetingSettings"): {
         "status": "missing_followup",


### PR DESCRIPTION
## Summary
- add repeatable `--autotargeting-brand-option OPTION=YES|NO` to `keywords add` and `keywords update`
- build top-level `AutotargetingBrandOptions` payload arrays with `Option` and `Value`
- reject the new single-item flag in `keywords add` batch modes to avoid silently ignored input
- update README examples, dry-run coverage, and WSDL optional-field audit support rows

## Docs / Contract Checked
- Current Yandex HTML docs for `keywords.add/update` surface brand options under `AutotargetingSettings.BrandOptions` rather than top-level `AutotargetingBrandOptions`; that settings shape is tracked by #288.
- The official WSDL cache for this audit declares top-level `KeywordAddItem/KeywordUpdateItem.AutotargetingBrandOptions` as `general:AutotargetingBrandOption` with `maxOccurs="unbounded"`, with `Option` enum values `WITHOUT_BRANDS` and `WITH_ADVERTISER_BRAND` and `Value` as `YES|NO`.
- This PR implements only those #287 WSDL audit rows and does not change `AutotargetingSettings`.

## Verification
- `python3 -m pytest tests/test_dry_run.py -k "keywords and autotargeting"`
- `python3 -m pytest tests/test_cli.py -k "keywords and autotargeting"`
- `python3 scripts/build_wsdl_optional_field_audit.py --check`
- `python3 -m pytest tests/test_wsdl_parity_gate.py`
- `python3 -m pytest tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py`
- `mypy .`

Closes #287