### PR TITLE
[codex] Add keyword autotargeting settings flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,8 +424,10 @@ accepts `--turbo-page-id`.
 direct keywords get --campaign-ids 1,2,3
 direct keywords add --adgroup-id 12345 --keyword "buy laptop" --bid 10500000 --context-bid 5250000 --user-param-1 segment-a --user-param-2 segment-b --dry-run
 direct keywords add --adgroup-id 12345 --keyword "---autotargeting" --autotargeting-search-bid-is-auto YES --priority HIGH --autotargeting-category EXACT=YES --autotargeting-category BROADER=NO --autotargeting-brand-option WITHOUT_BRANDS=YES --dry-run
+direct keywords add --adgroup-id 12345 --keyword "---autotargeting" --autotargeting-settings-exact YES --autotargeting-settings-narrow NO --autotargeting-settings-without-brands YES --dry-run
 direct keywords update --id 88888 --keyword "updated keyword text"
 direct keywords update --id 88888 --autotargeting-category EXACT=YES --autotargeting-category BROADER=NO --autotargeting-brand-option WITHOUT_BRANDS=YES
+direct keywords update --id 88888 --autotargeting-settings-broader YES --autotargeting-settings-with-competitors-brand NO
 direct keywords delete --id 88888
 ```
 
@@ -1138,8 +1140,10 @@ long-единиц API Яндекс Директа (цена, умноженна�
 direct keywords get --campaign-ids 1,2,3
 direct keywords add --adgroup-id 12345 --keyword "купить ноутбук" --bid 10500000 --context-bid 5250000 --user-param-1 segment-a --user-param-2 segment-b --dry-run
 direct keywords add --adgroup-id 12345 --keyword "---autotargeting" --autotargeting-search-bid-is-auto YES --priority HIGH --autotargeting-category EXACT=YES --autotargeting-category BROADER=NO --autotargeting-brand-option WITHOUT_BRANDS=YES --dry-run
+direct keywords add --adgroup-id 12345 --keyword "---autotargeting" --autotargeting-settings-exact YES --autotargeting-settings-narrow NO --autotargeting-settings-without-brands YES --dry-run
 direct keywords update --id 88888 --keyword "updated keyword text"
 direct keywords update --id 88888 --autotargeting-category EXACT=YES --autotargeting-category BROADER=NO --autotargeting-brand-option WITHOUT_BRANDS=YES
+direct keywords update --id 88888 --autotargeting-settings-broader YES --autotargeting-settings-with-competitors-brand NO
 direct keywords delete --id 88888
 ```
 

--- a/direct_cli/commands/keywords.py
+++ b/direct_cli/commands/keywords.py
@@ -271,6 +271,67 @@ def _parse_autotargeting_brand_options(
     return items
 
 
+def _build_autotargeting_settings(
+    *,
+    exact: Optional[str],
+    narrow: Optional[str],
+    alternative: Optional[str],
+    accessory: Optional[str],
+    broader: Optional[str],
+    without_brands: Optional[str],
+    with_advertiser_brand: Optional[str],
+    with_competitors_brand: Optional[str],
+) -> Optional[Dict[str, Dict[str, str]]]:
+    categories: Dict[str, str] = {}
+    for field_name, value in (
+        ("Exact", exact),
+        ("Narrow", narrow),
+        ("Alternative", alternative),
+        ("Accessory", accessory),
+        ("Broader", broader),
+    ):
+        if value is not None:
+            categories[field_name] = value.upper()
+
+    brand_options: Dict[str, str] = {}
+    for field_name, value in (
+        ("WithoutBrands", without_brands),
+        ("WithAdvertiserBrand", with_advertiser_brand),
+        ("WithCompetitorsBrand", with_competitors_brand),
+    ):
+        if value is not None:
+            brand_options[field_name] = value.upper()
+
+    settings: Dict[str, Dict[str, str]] = {}
+    if categories:
+        settings["Categories"] = categories
+    if brand_options:
+        settings["BrandOptions"] = brand_options
+
+    return settings or None
+
+
+def _reject_legacy_autotargeting_mix(
+    *,
+    settings: Optional[Dict[str, Dict[str, str]]],
+    categories: tuple[str, ...],
+    brand_options: tuple[str, ...],
+) -> None:
+    if settings is None:
+        return
+
+    legacy_flags = []
+    if categories:
+        legacy_flags.append("--autotargeting-category")
+    if brand_options:
+        legacy_flags.append("--autotargeting-brand-option")
+    if legacy_flags:
+        raise click.UsageError(
+            "AutotargetingSettings flags cannot be combined with legacy "
+            f"{', '.join(legacy_flags)} flags."
+        )
+
+
 @click.group()
 def keywords():
     """Manage keywords"""
@@ -391,6 +452,46 @@ def get(
     multiple=True,
     help=AUTOTARGETING_BRAND_OPTION_HELP,
 )
+@click.option(
+    "--autotargeting-settings-exact",
+    type=click.Choice(["YES", "NO"], case_sensitive=False),
+    help="AutotargetingSettings.Categories.Exact value: YES or NO",
+)
+@click.option(
+    "--autotargeting-settings-narrow",
+    type=click.Choice(["YES", "NO"], case_sensitive=False),
+    help="AutotargetingSettings.Categories.Narrow value: YES or NO",
+)
+@click.option(
+    "--autotargeting-settings-alternative",
+    type=click.Choice(["YES", "NO"], case_sensitive=False),
+    help="AutotargetingSettings.Categories.Alternative value: YES or NO",
+)
+@click.option(
+    "--autotargeting-settings-accessory",
+    type=click.Choice(["YES", "NO"], case_sensitive=False),
+    help="AutotargetingSettings.Categories.Accessory value: YES or NO",
+)
+@click.option(
+    "--autotargeting-settings-broader",
+    type=click.Choice(["YES", "NO"], case_sensitive=False),
+    help="AutotargetingSettings.Categories.Broader value: YES or NO",
+)
+@click.option(
+    "--autotargeting-settings-without-brands",
+    type=click.Choice(["YES", "NO"], case_sensitive=False),
+    help="AutotargetingSettings.BrandOptions.WithoutBrands value: YES or NO",
+)
+@click.option(
+    "--autotargeting-settings-with-advertiser-brand",
+    type=click.Choice(["YES", "NO"], case_sensitive=False),
+    help=("AutotargetingSettings.BrandOptions.WithAdvertiserBrand value: YES or NO"),
+)
+@click.option(
+    "--autotargeting-settings-with-competitors-brand",
+    type=click.Choice(["YES", "NO"], case_sensitive=False),
+    help=("AutotargetingSettings.BrandOptions.WithCompetitorsBrand value: YES or NO"),
+)
 @click.option("--user-param-1", help="User parameter 1")
 @click.option("--user-param-2", help="User parameter 2")
 @click.option(
@@ -422,6 +523,14 @@ def add(
     priority,
     autotargeting_categories,
     autotargeting_brand_options,
+    autotargeting_settings_exact,
+    autotargeting_settings_narrow,
+    autotargeting_settings_alternative,
+    autotargeting_settings_accessory,
+    autotargeting_settings_broader,
+    autotargeting_settings_without_brands,
+    autotargeting_settings_with_advertiser_brand,
+    autotargeting_settings_with_competitors_brand,
     user_param_1,
     user_param_2,
     from_file,
@@ -454,6 +563,22 @@ def add(
             "--priority": priority,
             "--autotargeting-category": autotargeting_categories,
             "--autotargeting-brand-option": autotargeting_brand_options,
+            "--autotargeting-settings-exact": autotargeting_settings_exact,
+            "--autotargeting-settings-narrow": autotargeting_settings_narrow,
+            "--autotargeting-settings-alternative": (
+                autotargeting_settings_alternative
+            ),
+            "--autotargeting-settings-accessory": autotargeting_settings_accessory,
+            "--autotargeting-settings-broader": autotargeting_settings_broader,
+            "--autotargeting-settings-without-brands": (
+                autotargeting_settings_without_brands
+            ),
+            "--autotargeting-settings-with-advertiser-brand": (
+                autotargeting_settings_with_advertiser_brand
+            ),
+            "--autotargeting-settings-with-competitors-brand": (
+                autotargeting_settings_with_competitors_brand
+            ),
             "--user-param-1": user_param_1,
             "--user-param-2": user_param_2,
         }
@@ -484,6 +609,21 @@ def add(
     parsed_autotargeting_brand_options = _parse_autotargeting_brand_options(
         autotargeting_brand_options
     )
+    autotargeting_settings = _build_autotargeting_settings(
+        exact=autotargeting_settings_exact,
+        narrow=autotargeting_settings_narrow,
+        alternative=autotargeting_settings_alternative,
+        accessory=autotargeting_settings_accessory,
+        broader=autotargeting_settings_broader,
+        without_brands=autotargeting_settings_without_brands,
+        with_advertiser_brand=autotargeting_settings_with_advertiser_brand,
+        with_competitors_brand=autotargeting_settings_with_competitors_brand,
+    )
+    _reject_legacy_autotargeting_mix(
+        settings=autotargeting_settings,
+        categories=autotargeting_categories,
+        brand_options=autotargeting_brand_options,
+    )
 
     try:
         keyword_data: Dict[str, Any] = {
@@ -506,6 +646,8 @@ def add(
             keyword_data["AutotargetingBrandOptions"] = (
                 parsed_autotargeting_brand_options
             )
+        if autotargeting_settings is not None:
+            keyword_data["AutotargetingSettings"] = autotargeting_settings
         if user_param_1:
             keyword_data["UserParam1"] = user_param_1
         if user_param_2:
@@ -646,6 +788,46 @@ def _deprecated_bid_option(ctx, param, value):
     help=AUTOTARGETING_BRAND_OPTION_HELP,
 )
 @click.option(
+    "--autotargeting-settings-exact",
+    type=click.Choice(["YES", "NO"], case_sensitive=False),
+    help="AutotargetingSettings.Categories.Exact value: YES or NO",
+)
+@click.option(
+    "--autotargeting-settings-narrow",
+    type=click.Choice(["YES", "NO"], case_sensitive=False),
+    help="AutotargetingSettings.Categories.Narrow value: YES or NO",
+)
+@click.option(
+    "--autotargeting-settings-alternative",
+    type=click.Choice(["YES", "NO"], case_sensitive=False),
+    help="AutotargetingSettings.Categories.Alternative value: YES or NO",
+)
+@click.option(
+    "--autotargeting-settings-accessory",
+    type=click.Choice(["YES", "NO"], case_sensitive=False),
+    help="AutotargetingSettings.Categories.Accessory value: YES or NO",
+)
+@click.option(
+    "--autotargeting-settings-broader",
+    type=click.Choice(["YES", "NO"], case_sensitive=False),
+    help="AutotargetingSettings.Categories.Broader value: YES or NO",
+)
+@click.option(
+    "--autotargeting-settings-without-brands",
+    type=click.Choice(["YES", "NO"], case_sensitive=False),
+    help="AutotargetingSettings.BrandOptions.WithoutBrands value: YES or NO",
+)
+@click.option(
+    "--autotargeting-settings-with-advertiser-brand",
+    type=click.Choice(["YES", "NO"], case_sensitive=False),
+    help=("AutotargetingSettings.BrandOptions.WithAdvertiserBrand value: YES or NO"),
+)
+@click.option(
+    "--autotargeting-settings-with-competitors-brand",
+    type=click.Choice(["YES", "NO"], case_sensitive=False),
+    help=("AutotargetingSettings.BrandOptions.WithCompetitorsBrand value: YES or NO"),
+)
+@click.option(
     "--bid",
     default=None,
     expose_value=False,
@@ -682,6 +864,14 @@ def update(
     user_param_2,
     autotargeting_categories,
     autotargeting_brand_options,
+    autotargeting_settings_exact,
+    autotargeting_settings_narrow,
+    autotargeting_settings_alternative,
+    autotargeting_settings_accessory,
+    autotargeting_settings_broader,
+    autotargeting_settings_without_brands,
+    autotargeting_settings_with_advertiser_brand,
+    autotargeting_settings_with_competitors_brand,
     dry_run,
 ):
     """Update keyword text, user params, or autotargeting options."""
@@ -691,6 +881,21 @@ def update(
     )
     parsed_autotargeting_brand_options = _parse_autotargeting_brand_options(
         autotargeting_brand_options
+    )
+    autotargeting_settings = _build_autotargeting_settings(
+        exact=autotargeting_settings_exact,
+        narrow=autotargeting_settings_narrow,
+        alternative=autotargeting_settings_alternative,
+        accessory=autotargeting_settings_accessory,
+        broader=autotargeting_settings_broader,
+        without_brands=autotargeting_settings_without_brands,
+        with_advertiser_brand=autotargeting_settings_with_advertiser_brand,
+        with_competitors_brand=autotargeting_settings_with_competitors_brand,
+    )
+    _reject_legacy_autotargeting_mix(
+        settings=autotargeting_settings,
+        categories=autotargeting_categories,
+        brand_options=autotargeting_brand_options,
     )
 
     if keyword:
@@ -703,13 +908,16 @@ def update(
         keyword_data["AutotargetingCategories"] = parsed_autotargeting_categories
     if parsed_autotargeting_brand_options is not None:
         keyword_data["AutotargetingBrandOptions"] = parsed_autotargeting_brand_options
+    if autotargeting_settings is not None:
+        keyword_data["AutotargetingSettings"] = autotargeting_settings
 
     # Reject empty-payload no-op (issue #198 H10).
     if len(keyword_data) == 1:
         raise click.UsageError(
             "keywords update requires at least one updatable field "
             "(--keyword, --user-param-1, --user-param-2, "
-            "--autotargeting-category, or --autotargeting-brand-option)."
+            "--autotargeting-category, --autotargeting-brand-option, "
+            "or AutotargetingSettings flags)."
         )
 
     try:

--- a/direct_cli/commands/keywords.py
+++ b/direct_cli/commands/keywords.py
@@ -917,7 +917,7 @@ def update(
             "keywords update requires at least one updatable field "
             "(--keyword, --user-param-1, --user-param-2, "
             "--autotargeting-category, --autotargeting-brand-option, "
-            "or AutotargetingSettings flags)."
+            "or --autotargeting-settings-* flags)."
         )
 
     try:

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,8 +11,8 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 2751 |
-| `supported` | 490 |
+| `missing_followup` | 2729 |
+| `supported` | 512 |
 
 ## Confirmed Follow-Ups
 
@@ -2550,28 +2550,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `feeds.update` | `FileFeed` | FileFeed upload/base64 CLI support is split from #253. [#264](https://github.com/axisrow/direct-cli/issues/264) |
 | `feeds.update` | `FileFeed.Data` | FileFeed upload/base64 CLI support is split from #253. [#264](https://github.com/axisrow/direct-cli/issues/264); inherited from `FileFeed` |
 | `feeds.update` | `FileFeed.Filename` | FileFeed upload/base64 CLI support is split from #253. [#264](https://github.com/axisrow/direct-cli/issues/264); inherited from `FileFeed` |
-| `keywords.add` | `AutotargetingSettings` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288) |
-| `keywords.add` | `AutotargetingSettings.Categories` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.add` | `AutotargetingSettings.Categories.Exact` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.add` | `AutotargetingSettings.Categories.Narrow` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.add` | `AutotargetingSettings.Categories.Alternative` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.add` | `AutotargetingSettings.Categories.Accessory` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.add` | `AutotargetingSettings.Categories.Broader` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.add` | `AutotargetingSettings.BrandOptions` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.add` | `AutotargetingSettings.BrandOptions.WithoutBrands` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.add` | `AutotargetingSettings.BrandOptions.WithAdvertiserBrand` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.add` | `AutotargetingSettings.BrandOptions.WithCompetitorsBrand` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.update` | `AutotargetingSettings` | Keyword autotargeting settings have no typed update flags. [#288](https://github.com/axisrow/direct-cli/issues/288) |
-| `keywords.update` | `AutotargetingSettings.Categories` | Keyword autotargeting settings have no typed update flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.update` | `AutotargetingSettings.Categories.Exact` | Keyword autotargeting settings have no typed update flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.update` | `AutotargetingSettings.Categories.Narrow` | Keyword autotargeting settings have no typed update flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.update` | `AutotargetingSettings.Categories.Alternative` | Keyword autotargeting settings have no typed update flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.update` | `AutotargetingSettings.Categories.Accessory` | Keyword autotargeting settings have no typed update flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.update` | `AutotargetingSettings.Categories.Broader` | Keyword autotargeting settings have no typed update flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.update` | `AutotargetingSettings.BrandOptions` | Keyword autotargeting settings have no typed update flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.update` | `AutotargetingSettings.BrandOptions.WithoutBrands` | Keyword autotargeting settings have no typed update flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.update` | `AutotargetingSettings.BrandOptions.WithAdvertiserBrand` | Keyword autotargeting settings have no typed update flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.update` | `AutotargetingSettings.BrandOptions.WithCompetitorsBrand` | Keyword autotargeting settings have no typed update flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
 | `strategies.add` | `PriorityGoals.Items.GoalId` | strategies.add residual optional WSDL path needs typed support or N/A. [#299](https://github.com/axisrow/direct-cli/issues/299) |
 | `strategies.add` | `PriorityGoals.Items.Value` | strategies.add residual optional WSDL path needs typed support or N/A. [#299](https://github.com/axisrow/direct-cli/issues/299) |
 | `strategies.add` | `PriorityGoals.Items.IsMetrikaSourceOfValue` | strategies.add residual optional WSDL path needs typed support or N/A. [#299](https://github.com/axisrow/direct-cli/issues/299) |
@@ -5573,17 +5551,17 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `keywords.add` | `keywords.add` | `AutotargetingBrandOptions` | `AutotargetingBrandOption` | 0 | unbounded | `supported` | --autotargeting-brand-option |
 | `keywords.add` | `keywords.add` | `AutotargetingBrandOptions.Option` | `AutotargetingBrandOptionsEnum` | 1 | 1 | `supported` | --autotargeting-brand-option |
 | `keywords.add` | `keywords.add` | `AutotargetingBrandOptions.Value` | `YesNoEnum` | 1 | 1 | `supported` | --autotargeting-brand-option |
-| `keywords.add` | `keywords.add` | `AutotargetingSettings` | `AutotargetingSettings` | 0 | 1 | `missing_followup` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288) |
-| `keywords.add` | `keywords.add` | `AutotargetingSettings.Categories` | `AutotargetingCategories` | 0 | 1 | `missing_followup` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.add` | `keywords.add` | `AutotargetingSettings.Categories.Exact` | `YesNoEnum` | 0 | 1 | `missing_followup` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.add` | `keywords.add` | `AutotargetingSettings.Categories.Narrow` | `YesNoEnum` | 0 | 1 | `missing_followup` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.add` | `keywords.add` | `AutotargetingSettings.Categories.Alternative` | `YesNoEnum` | 0 | 1 | `missing_followup` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.add` | `keywords.add` | `AutotargetingSettings.Categories.Accessory` | `YesNoEnum` | 0 | 1 | `missing_followup` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.add` | `keywords.add` | `AutotargetingSettings.Categories.Broader` | `YesNoEnum` | 0 | 1 | `missing_followup` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.add` | `keywords.add` | `AutotargetingSettings.BrandOptions` | `AutotargetingBrandOptions` | 0 | 1 | `missing_followup` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.add` | `keywords.add` | `AutotargetingSettings.BrandOptions.WithoutBrands` | `YesNoEnum` | 0 | 1 | `missing_followup` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.add` | `keywords.add` | `AutotargetingSettings.BrandOptions.WithAdvertiserBrand` | `YesNoEnum` | 0 | 1 | `missing_followup` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.add` | `keywords.add` | `AutotargetingSettings.BrandOptions.WithCompetitorsBrand` | `YesNoEnum` | 0 | 1 | `missing_followup` | Keyword autotargeting settings have no typed add flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
+| `keywords.add` | `keywords.add` | `AutotargetingSettings` | `AutotargetingSettings` | 0 | 1 | `supported` | --autotargeting-settings-exact, --autotargeting-settings-without-brands |
+| `keywords.add` | `keywords.add` | `AutotargetingSettings.Categories` | `AutotargetingCategories` | 0 | 1 | `supported` | --autotargeting-settings-accessory, --autotargeting-settings-alternative, --autotargeting-settings-broader, --autotargeting-settings-exact, --autotargeting-settings-narrow |
+| `keywords.add` | `keywords.add` | `AutotargetingSettings.Categories.Exact` | `YesNoEnum` | 0 | 1 | `supported` | --autotargeting-settings-exact |
+| `keywords.add` | `keywords.add` | `AutotargetingSettings.Categories.Narrow` | `YesNoEnum` | 0 | 1 | `supported` | --autotargeting-settings-narrow |
+| `keywords.add` | `keywords.add` | `AutotargetingSettings.Categories.Alternative` | `YesNoEnum` | 0 | 1 | `supported` | --autotargeting-settings-alternative |
+| `keywords.add` | `keywords.add` | `AutotargetingSettings.Categories.Accessory` | `YesNoEnum` | 0 | 1 | `supported` | --autotargeting-settings-accessory |
+| `keywords.add` | `keywords.add` | `AutotargetingSettings.Categories.Broader` | `YesNoEnum` | 0 | 1 | `supported` | --autotargeting-settings-broader |
+| `keywords.add` | `keywords.add` | `AutotargetingSettings.BrandOptions` | `AutotargetingBrandOptions` | 0 | 1 | `supported` | --autotargeting-settings-with-advertiser-brand, --autotargeting-settings-with-competitors-brand, --autotargeting-settings-without-brands |
+| `keywords.add` | `keywords.add` | `AutotargetingSettings.BrandOptions.WithoutBrands` | `YesNoEnum` | 0 | 1 | `supported` | --autotargeting-settings-without-brands |
+| `keywords.add` | `keywords.add` | `AutotargetingSettings.BrandOptions.WithAdvertiserBrand` | `YesNoEnum` | 0 | 1 | `supported` | --autotargeting-settings-with-advertiser-brand |
+| `keywords.add` | `keywords.add` | `AutotargetingSettings.BrandOptions.WithCompetitorsBrand` | `YesNoEnum` | 0 | 1 | `supported` | --autotargeting-settings-with-competitors-brand |
 | `keywords.update` | `keywords.update` | `Id` | `long` | 1 | 1 | `supported` | covered by minOccurs>=1 parity gate |
 | `keywords.update` | `keywords.update` | `Keyword` | `string` | 0 | 1 | `supported` | --keyword |
 | `keywords.update` | `keywords.update` | `UserParam1` | `string` | 0 | 1 | `supported` | --user-param-1 |
@@ -5594,17 +5572,17 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `keywords.update` | `keywords.update` | `AutotargetingBrandOptions` | `AutotargetingBrandOption` | 0 | unbounded | `supported` | --autotargeting-brand-option |
 | `keywords.update` | `keywords.update` | `AutotargetingBrandOptions.Option` | `AutotargetingBrandOptionsEnum` | 1 | 1 | `supported` | --autotargeting-brand-option |
 | `keywords.update` | `keywords.update` | `AutotargetingBrandOptions.Value` | `YesNoEnum` | 1 | 1 | `supported` | --autotargeting-brand-option |
-| `keywords.update` | `keywords.update` | `AutotargetingSettings` | `AutotargetingSettings` | 0 | 1 | `missing_followup` | Keyword autotargeting settings have no typed update flags. [#288](https://github.com/axisrow/direct-cli/issues/288) |
-| `keywords.update` | `keywords.update` | `AutotargetingSettings.Categories` | `AutotargetingCategories` | 0 | 1 | `missing_followup` | Keyword autotargeting settings have no typed update flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.update` | `keywords.update` | `AutotargetingSettings.Categories.Exact` | `YesNoEnum` | 0 | 1 | `missing_followup` | Keyword autotargeting settings have no typed update flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.update` | `keywords.update` | `AutotargetingSettings.Categories.Narrow` | `YesNoEnum` | 0 | 1 | `missing_followup` | Keyword autotargeting settings have no typed update flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.update` | `keywords.update` | `AutotargetingSettings.Categories.Alternative` | `YesNoEnum` | 0 | 1 | `missing_followup` | Keyword autotargeting settings have no typed update flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.update` | `keywords.update` | `AutotargetingSettings.Categories.Accessory` | `YesNoEnum` | 0 | 1 | `missing_followup` | Keyword autotargeting settings have no typed update flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.update` | `keywords.update` | `AutotargetingSettings.Categories.Broader` | `YesNoEnum` | 0 | 1 | `missing_followup` | Keyword autotargeting settings have no typed update flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.update` | `keywords.update` | `AutotargetingSettings.BrandOptions` | `AutotargetingBrandOptions` | 0 | 1 | `missing_followup` | Keyword autotargeting settings have no typed update flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.update` | `keywords.update` | `AutotargetingSettings.BrandOptions.WithoutBrands` | `YesNoEnum` | 0 | 1 | `missing_followup` | Keyword autotargeting settings have no typed update flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.update` | `keywords.update` | `AutotargetingSettings.BrandOptions.WithAdvertiserBrand` | `YesNoEnum` | 0 | 1 | `missing_followup` | Keyword autotargeting settings have no typed update flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
-| `keywords.update` | `keywords.update` | `AutotargetingSettings.BrandOptions.WithCompetitorsBrand` | `YesNoEnum` | 0 | 1 | `missing_followup` | Keyword autotargeting settings have no typed update flags. [#288](https://github.com/axisrow/direct-cli/issues/288); inherited from `AutotargetingSettings` |
+| `keywords.update` | `keywords.update` | `AutotargetingSettings` | `AutotargetingSettings` | 0 | 1 | `supported` | --autotargeting-settings-exact, --autotargeting-settings-without-brands |
+| `keywords.update` | `keywords.update` | `AutotargetingSettings.Categories` | `AutotargetingCategories` | 0 | 1 | `supported` | --autotargeting-settings-accessory, --autotargeting-settings-alternative, --autotargeting-settings-broader, --autotargeting-settings-exact, --autotargeting-settings-narrow |
+| `keywords.update` | `keywords.update` | `AutotargetingSettings.Categories.Exact` | `YesNoEnum` | 0 | 1 | `supported` | --autotargeting-settings-exact |
+| `keywords.update` | `keywords.update` | `AutotargetingSettings.Categories.Narrow` | `YesNoEnum` | 0 | 1 | `supported` | --autotargeting-settings-narrow |
+| `keywords.update` | `keywords.update` | `AutotargetingSettings.Categories.Alternative` | `YesNoEnum` | 0 | 1 | `supported` | --autotargeting-settings-alternative |
+| `keywords.update` | `keywords.update` | `AutotargetingSettings.Categories.Accessory` | `YesNoEnum` | 0 | 1 | `supported` | --autotargeting-settings-accessory |
+| `keywords.update` | `keywords.update` | `AutotargetingSettings.Categories.Broader` | `YesNoEnum` | 0 | 1 | `supported` | --autotargeting-settings-broader |
+| `keywords.update` | `keywords.update` | `AutotargetingSettings.BrandOptions` | `AutotargetingBrandOptions` | 0 | 1 | `supported` | --autotargeting-settings-with-advertiser-brand, --autotargeting-settings-with-competitors-brand, --autotargeting-settings-without-brands |
+| `keywords.update` | `keywords.update` | `AutotargetingSettings.BrandOptions.WithoutBrands` | `YesNoEnum` | 0 | 1 | `supported` | --autotargeting-settings-without-brands |
+| `keywords.update` | `keywords.update` | `AutotargetingSettings.BrandOptions.WithAdvertiserBrand` | `YesNoEnum` | 0 | 1 | `supported` | --autotargeting-settings-with-advertiser-brand |
+| `keywords.update` | `keywords.update` | `AutotargetingSettings.BrandOptions.WithCompetitorsBrand` | `YesNoEnum` | 0 | 1 | `supported` | --autotargeting-settings-with-competitors-brand |
 | `negativekeywordsharedsets.add` | `negativekeywordsharedsets.add` | `Name` | `string` | 1 | 1 | `supported` | covered by minOccurs>=1 parity gate |
 | `negativekeywordsharedsets.add` | `negativekeywordsharedsets.add` | `NegativeKeywords` | `string` | 1 | unbounded | `supported` | covered by minOccurs>=1 parity gate |
 | `negativekeywordsharedsets.update` | `negativekeywordsharedsets.update` | `Name` | `string` | 0 | 1 | `supported` | --name |

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -176,6 +176,24 @@ class TestCLI(unittest.TestCase):
         self.assertIn("--autotargeting-brand-option", add_result.output)
         self.assertIn("--autotargeting-brand-option", update_result.output)
 
+    def test_keywords_help_documents_autotargeting_settings_flags(self):
+        add_result = self.runner.invoke(cli, ["keywords", "add", "--help"])
+        update_result = self.runner.invoke(cli, ["keywords", "update", "--help"])
+        self.assertEqual(add_result.exit_code, 0)
+        self.assertEqual(update_result.exit_code, 0)
+        for option in (
+            "--autotargeting-settings-exact",
+            "--autotargeting-settings-narrow",
+            "--autotargeting-settings-alternative",
+            "--autotargeting-settings-accessory",
+            "--autotargeting-settings-broader",
+            "--autotargeting-settings-without-brands",
+            "--autotargeting-settings-with-advertiser-brand",
+            "--autotargeting-settings-with-competitors-brand",
+        ):
+            self.assertIn(option, add_result.output)
+            self.assertIn(option, update_result.output)
+
     def test_canonical_groups_in_help(self):
         """Test canonical transport groups"""
         result = self.runner.invoke(cli, ["--help"])

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -2875,6 +2875,40 @@ def test_keywords_add_payload_with_autotargeting_brand_options():
     }
 
 
+def test_keywords_add_payload_with_autotargeting_settings():
+    body = _dry_run(
+        "keywords",
+        "add",
+        "--adgroup-id",
+        "12",
+        "--keyword",
+        "---autotargeting",
+        "--autotargeting-settings-exact",
+        "yes",
+        "--autotargeting-settings-narrow",
+        "no",
+        "--autotargeting-settings-without-brands",
+        "YES",
+        "--autotargeting-settings-with-competitors-brand",
+        "no",
+    )
+    keyword = body["params"]["Keywords"][0]
+    assert keyword == {
+        "AdGroupId": 12,
+        "Keyword": "---autotargeting",
+        "AutotargetingSettings": {
+            "Categories": {
+                "Exact": "YES",
+                "Narrow": "NO",
+            },
+            "BrandOptions": {
+                "WithoutBrands": "YES",
+                "WithCompetitorsBrand": "NO",
+            },
+        },
+    }
+
+
 def test_keywords_add_rejects_scalar_autotargeting_flags_in_batch_mode(tmp_path):
     path = _write_jsonl(tmp_path, [{"Keyword": "kw", "AdGroupId": 100}])
     for flag, value in (
@@ -2882,6 +2916,7 @@ def test_keywords_add_rejects_scalar_autotargeting_flags_in_batch_mode(tmp_path)
         ("--autotargeting-search-bid-is-auto", "YES"),
         ("--autotargeting-category", "EXACT=YES"),
         ("--autotargeting-brand-option", "WITHOUT_BRANDS=YES"),
+        ("--autotargeting-settings-exact", "YES"),
     ):
         result = CliRunner().invoke(
             cli,
@@ -3004,6 +3039,59 @@ def test_keywords_update_payload_with_autotargeting_brand_options():
             {"Option": "WITH_ADVERTISER_BRAND", "Value": "YES"},
         ],
     }
+
+
+def test_keywords_update_payload_with_autotargeting_settings():
+    body = _dry_run(
+        "keywords",
+        "update",
+        "--id",
+        "777",
+        "--autotargeting-settings-alternative",
+        "YES",
+        "--autotargeting-settings-accessory",
+        "no",
+        "--autotargeting-settings-broader",
+        "yes",
+        "--autotargeting-settings-with-advertiser-brand",
+        "NO",
+    )
+    keyword = body["params"]["Keywords"][0]
+    assert keyword == {
+        "Id": 777,
+        "AutotargetingSettings": {
+            "Categories": {
+                "Alternative": "YES",
+                "Accessory": "NO",
+                "Broader": "YES",
+            },
+            "BrandOptions": {
+                "WithAdvertiserBrand": "NO",
+            },
+        },
+    }
+
+
+def test_keywords_autotargeting_settings_rejects_legacy_category_mix():
+    result = CliRunner().invoke(
+        cli,
+        [
+            "keywords",
+            "add",
+            "--adgroup-id",
+            "12",
+            "--keyword",
+            "---autotargeting",
+            "--autotargeting-category",
+            "EXACT=YES",
+            "--autotargeting-settings-exact",
+            "YES",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "cannot be combined" in result.output
+    assert "--autotargeting-category" in result.output
 
 
 def test_keywords_autotargeting_category_requires_category_value_pair():

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -2997,6 +2997,7 @@ def test_keywords_update_rejects_noop_payload():
     )
     assert result.exit_code != 0
     assert "requires at least one updatable field" in result.output
+    assert "--autotargeting-settings-* flags" in result.output
 
 
 def test_keywords_update_payload_with_autotargeting_categories():

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -3094,6 +3094,26 @@ def test_keywords_autotargeting_settings_rejects_legacy_category_mix():
     assert "--autotargeting-category" in result.output
 
 
+def test_keywords_autotargeting_settings_rejects_legacy_brand_option_mix():
+    result = CliRunner().invoke(
+        cli,
+        [
+            "keywords",
+            "update",
+            "--id",
+            "777",
+            "--autotargeting-brand-option",
+            "WITHOUT_BRANDS=YES",
+            "--autotargeting-settings-without-brands",
+            "YES",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "cannot be combined" in result.output
+    assert "--autotargeting-brand-option" in result.output
+
+
 def test_keywords_autotargeting_category_requires_category_value_pair():
     result = CliRunner().invoke(
         cli,

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -951,6 +951,46 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     ("keywords", "add", "AutotargetingBrandOptions.Value"): {
         "--autotargeting-brand-option"
     },
+    ("keywords", "add", "AutotargetingSettings"): {
+        "--autotargeting-settings-exact",
+        "--autotargeting-settings-without-brands",
+    },
+    ("keywords", "add", "AutotargetingSettings.Categories"): {
+        "--autotargeting-settings-exact",
+        "--autotargeting-settings-narrow",
+        "--autotargeting-settings-alternative",
+        "--autotargeting-settings-accessory",
+        "--autotargeting-settings-broader",
+    },
+    ("keywords", "add", "AutotargetingSettings.Categories.Exact"): {
+        "--autotargeting-settings-exact"
+    },
+    ("keywords", "add", "AutotargetingSettings.Categories.Narrow"): {
+        "--autotargeting-settings-narrow"
+    },
+    ("keywords", "add", "AutotargetingSettings.Categories.Alternative"): {
+        "--autotargeting-settings-alternative"
+    },
+    ("keywords", "add", "AutotargetingSettings.Categories.Accessory"): {
+        "--autotargeting-settings-accessory"
+    },
+    ("keywords", "add", "AutotargetingSettings.Categories.Broader"): {
+        "--autotargeting-settings-broader"
+    },
+    ("keywords", "add", "AutotargetingSettings.BrandOptions"): {
+        "--autotargeting-settings-without-brands",
+        "--autotargeting-settings-with-advertiser-brand",
+        "--autotargeting-settings-with-competitors-brand",
+    },
+    ("keywords", "add", "AutotargetingSettings.BrandOptions.WithoutBrands"): {
+        "--autotargeting-settings-without-brands"
+    },
+    ("keywords", "add", "AutotargetingSettings.BrandOptions.WithAdvertiserBrand"): {
+        "--autotargeting-settings-with-advertiser-brand"
+    },
+    ("keywords", "add", "AutotargetingSettings.BrandOptions.WithCompetitorsBrand"): {
+        "--autotargeting-settings-with-competitors-brand"
+    },
     ("keywords", "add", "UserParam1"): {"--user-param-1"},
     ("keywords", "add", "UserParam2"): {"--user-param-2"},
     ("keywords", "update", "Keyword"): {"--keyword"},
@@ -972,6 +1012,50 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     ("keywords", "update", "AutotargetingBrandOptions.Value"): {
         "--autotargeting-brand-option"
     },
+    ("keywords", "update", "AutotargetingSettings"): {
+        "--autotargeting-settings-exact",
+        "--autotargeting-settings-without-brands",
+    },
+    ("keywords", "update", "AutotargetingSettings.Categories"): {
+        "--autotargeting-settings-exact",
+        "--autotargeting-settings-narrow",
+        "--autotargeting-settings-alternative",
+        "--autotargeting-settings-accessory",
+        "--autotargeting-settings-broader",
+    },
+    ("keywords", "update", "AutotargetingSettings.Categories.Exact"): {
+        "--autotargeting-settings-exact"
+    },
+    ("keywords", "update", "AutotargetingSettings.Categories.Narrow"): {
+        "--autotargeting-settings-narrow"
+    },
+    ("keywords", "update", "AutotargetingSettings.Categories.Alternative"): {
+        "--autotargeting-settings-alternative"
+    },
+    ("keywords", "update", "AutotargetingSettings.Categories.Accessory"): {
+        "--autotargeting-settings-accessory"
+    },
+    ("keywords", "update", "AutotargetingSettings.Categories.Broader"): {
+        "--autotargeting-settings-broader"
+    },
+    ("keywords", "update", "AutotargetingSettings.BrandOptions"): {
+        "--autotargeting-settings-without-brands",
+        "--autotargeting-settings-with-advertiser-brand",
+        "--autotargeting-settings-with-competitors-brand",
+    },
+    ("keywords", "update", "AutotargetingSettings.BrandOptions.WithoutBrands"): {
+        "--autotargeting-settings-without-brands"
+    },
+    (
+        "keywords",
+        "update",
+        "AutotargetingSettings.BrandOptions.WithAdvertiserBrand",
+    ): {"--autotargeting-settings-with-advertiser-brand"},
+    (
+        "keywords",
+        "update",
+        "AutotargetingSettings.BrandOptions.WithCompetitorsBrand",
+    ): {"--autotargeting-settings-with-competitors-brand"},
     ("negativekeywordsharedsets", "update", "Name"): {"--name"},
     ("negativekeywordsharedsets", "update", "NegativeKeywords"): {"--keywords"},
     ("audiencetargets", "add", "RetargetingListId"): {"--retargeting-list-id"},
@@ -1503,16 +1587,6 @@ OPTIONAL_FIELD_AUDIT: dict[tuple[str, str, str], dict[str, str]] = {
             "Single-item typed flag is supported; batch/from-file parity is "
             "tracked separately."
         ),
-    },
-    ("keywords", "add", "AutotargetingSettings"): {
-        "status": "missing_followup",
-        "issue": "#288",
-        "note": "Keyword autotargeting settings have no typed add flags.",
-    },
-    ("keywords", "update", "AutotargetingSettings"): {
-        "status": "missing_followup",
-        "issue": "#288",
-        "note": "Keyword autotargeting settings have no typed update flags.",
     },
     ("feeds", "add", "FileFeed"): {
         "status": "missing_followup",


### PR DESCRIPTION
## Summary
- add explicit `--autotargeting-settings-*` YES/NO flags to `keywords add` and `keywords update`
- build top-level `AutotargetingSettings` payloads with nested `Categories` and `BrandOptions` objects
- reject settings flags in `keywords add` batch modes and reject mixing settings flags with legacy `--autotargeting-category` / `--autotargeting-brand-option`
- update README examples, dry-run coverage, help coverage, and WSDL optional-field audit support rows

## Docs / Contract Checked
- Yandex `keywords.add` / `keywords.update` docs place `AutotargetingSettings` directly under `KeywordAddItem` / `KeywordUpdateItem`.
- `AutotargetingSettings.Categories` exposes `Exact`, `Narrow`, `Alternative`, `Accessory`, and `Broader` YES/NO fields.
- `AutotargetingSettings.BrandOptions` exposes `WithoutBrands`, `WithAdvertiserBrand`, and `WithCompetitorsBrand` YES/NO fields.
- Docs state `AutotargetingCategories` must not be sent together with `AutotargetingSettings`; this PR also blocks mixing with the legacy top-level brand option flag to avoid conflicting old/new autotargeting forms.

## Verification
- `python3 -m pytest tests/test_dry_run.py -k "keywords and autotargeting"`
- `python3 -m pytest tests/test_cli.py -k "keywords and autotargeting"`
- `python3 scripts/build_wsdl_optional_field_audit.py --check`
- `python3 -m pytest tests/test_wsdl_parity_gate.py`
- `python3 -m pytest tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py`
- `mypy .`

Closes #288