### PR TITLE
Resolve keyword batch autotargeting deferral

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,7 @@ Example `keywords.jsonl`:
 ```
 
 - Row keys use WSDL CamelCase: `Keyword`, `AdGroupId`, `Bid`, `ContextBid`, `UserParam1`, `UserParam2`.
+- Autotargeting row fields are intentionally not accepted in batch mode; use single-item typed flags such as `--autotargeting-search-bid-is-auto`, `--priority`, `--autotargeting-category`, `--autotargeting-brand-option`, or `--autotargeting-settings-*`.
 - `--adgroup-id` provides the default group ID; rows can override it via per-row `AdGroupId`.
 - Each effective row must resolve `Keyword` and `AdGroupId`; unknown fields are rejected with the row number.
 - API limit: 10 items per `keywords.add` request — see [Yandex Direct docs](https://yandex.ru/dev/direct/doc/dg/objects/keyword.html). The CLI sends as many chunks as needed and merges `AddResults`.
@@ -1166,6 +1167,7 @@ direct keywords add --keywords-json '[{"Keyword":"купить ноутбук","
 ```
 
 - Ключи строки — WSDL CamelCase: `Keyword`, `AdGroupId`, `Bid`, `ContextBid`, `UserParam1`, `UserParam2`.
+- Поля автотаргетинга намеренно не принимаются в batch-режиме; используйте single-item typed flags: `--autotargeting-search-bid-is-auto`, `--priority`, `--autotargeting-category`, `--autotargeting-brand-option` или `--autotargeting-settings-*`.
 - `--adgroup-id` задаёт значение по умолчанию; в строке можно переопределить через `AdGroupId`.
 - В каждой строке должны разрешаться `Keyword` и `AdGroupId`; неизвестные поля отклоняются с указанием номера строки.
 - API-лимит: 10 элементов на запрос `keywords.add` — см. [документацию Yandex Direct](https://yandex.ru/dev/direct/doc/dg/objects/keyword.html). CLI отправит нужное число чанков и склеит `AddResults`.

--- a/direct_cli/commands/keywords.py
+++ b/direct_cli/commands/keywords.py
@@ -59,6 +59,14 @@ _KEYWORD_ROW_FIELDS: Dict[str, str] = {
     "UserParam2": "str",
 }
 
+_KEYWORD_BATCH_DEFERRED_FIELDS = {
+    "AutotargetingSearchBidIsAuto": "--autotargeting-search-bid-is-auto",
+    "StrategyPriority": "--priority",
+    "AutotargetingCategories": "--autotargeting-category",
+    "AutotargetingBrandOptions": "--autotargeting-brand-option",
+    "AutotargetingSettings": "--autotargeting-settings-* flags",
+}
+
 
 def _coerce_keyword_field(field: str, raw_value: Any, row_index: int) -> Any:
     kind = _KEYWORD_ROW_FIELDS[field]
@@ -101,6 +109,16 @@ def _normalize_keyword_row(
     if not isinstance(row, dict):
         raise click.UsageError(
             f"Row {row_index}: expected JSON object, got {type(row).__name__}"
+        )
+
+    deferred = sorted(set(row) & set(_KEYWORD_BATCH_DEFERRED_FIELDS))
+    if deferred:
+        field = deferred[0]
+        flag = _KEYWORD_BATCH_DEFERRED_FIELDS[field]
+        raise click.UsageError(
+            f"Keyword row {row_index} field {field!r} is intentionally "
+            "unsupported in batch mode; use the single-item typed option "
+            f"{flag} instead."
         )
 
     unknown = sorted(set(row) - set(_KEYWORD_ROW_FIELDS))

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -5540,9 +5540,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `keywords.add` | `keywords.add` | `Keyword` | `string` | 1 | 1 | `supported` | covered by minOccurs>=1 parity gate |
 | `keywords.add` | `keywords.add` | `AdGroupId` | `long` | 1 | 1 | `supported` | covered by minOccurs>=1 parity gate |
 | `keywords.add` | `keywords.add` | `Bid` | `long` | 0 | 1 | `supported` | --bid |
-| `keywords.add` | `keywords.add` | `AutotargetingSearchBidIsAuto` | `YesNoEnum` | 0 | 1 | `supported` | Single-item typed flag is supported; batch/from-file parity is tracked separately. [#289](https://github.com/axisrow/direct-cli/issues/289) |
+| `keywords.add` | `keywords.add` | `AutotargetingSearchBidIsAuto` | `YesNoEnum` | 0 | 1 | `supported` | Single-item typed flag is supported; batch/from-file rows intentionally reject autotargeting fields. [#289](https://github.com/axisrow/direct-cli/issues/289) |
 | `keywords.add` | `keywords.add` | `ContextBid` | `long` | 0 | 1 | `supported` | --context-bid |
-| `keywords.add` | `keywords.add` | `StrategyPriority` | `PriorityEnum` | 0 | 1 | `supported` | Single-item typed flag is supported; batch/from-file parity is tracked separately. [#289](https://github.com/axisrow/direct-cli/issues/289) |
+| `keywords.add` | `keywords.add` | `StrategyPriority` | `PriorityEnum` | 0 | 1 | `supported` | Single-item typed flag is supported; batch/from-file rows intentionally reject autotargeting fields. [#289](https://github.com/axisrow/direct-cli/issues/289) |
 | `keywords.add` | `keywords.add` | `UserParam1` | `string` | 0 | 1 | `supported` | --user-param-1 |
 | `keywords.add` | `keywords.add` | `UserParam2` | `string` | 0 | 1 | `supported` | --user-param-2 |
 | `keywords.add` | `keywords.add` | `AutotargetingCategories` | `AutotargetingCategory` | 0 | unbounded | `supported` | --autotargeting-category |

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -3320,6 +3320,50 @@ def test_keywords_add_rejects_unknown_field_in_row(tmp_path):
     assert "Unknown field 'Foo' in keyword row 1" in result.output
 
 
+def test_keywords_add_rejects_autotargeting_row_fields_in_batch(tmp_path):
+    deferred_fields = {
+        "AutotargetingSearchBidIsAuto": ("YES", "--autotargeting-search-bid-is-auto"),
+        "StrategyPriority": ("HIGH", "--priority"),
+        "AutotargetingCategories": (
+            [{"Category": "EXACT", "Value": "YES"}],
+            "--autotargeting-category",
+        ),
+        "AutotargetingBrandOptions": (
+            [{"Option": "WITHOUT_BRANDS", "Value": "YES"}],
+            "--autotargeting-brand-option",
+        ),
+        "AutotargetingSettings": (
+            {"Categories": {"Exact": "YES"}},
+            "--autotargeting-settings-* flags",
+        ),
+    }
+
+    for field, (value, expected_flag) in deferred_fields.items():
+        path = _write_jsonl(
+            tmp_path,
+            [{"Keyword": "kw", "AdGroupId": 1, field: value}],
+        )
+        result = _rejected("keywords", "add", "--from-file", path)
+        assert f"field '{field}' is intentionally unsupported" in result.output
+        assert "batch mode" in result.output
+        assert expected_flag in result.output
+
+
+def test_keywords_add_rejects_autotargeting_inline_batch_row():
+    inline = json.dumps(
+        [
+            {
+                "Keyword": "kw",
+                "AdGroupId": 1,
+                "AutotargetingSearchBidIsAuto": "YES",
+            }
+        ]
+    )
+    result = _rejected("keywords", "add", "--keywords-json", inline)
+    assert "AutotargetingSearchBidIsAuto" in result.output
+    assert "intentionally unsupported in batch mode" in result.output
+
+
 def test_keywords_add_rejects_invalid_jsonl(tmp_path):
     path = tmp_path / "broken.jsonl"
     path.write_text(

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -1576,16 +1576,16 @@ OPTIONAL_FIELD_AUDIT: dict[tuple[str, str, str], dict[str, str]] = {
         "status": "supported",
         "issue": "#289",
         "note": (
-            "Single-item typed flag is supported; batch/from-file parity is "
-            "tracked separately."
+            "Single-item typed flag is supported; batch/from-file rows "
+            "intentionally reject autotargeting fields."
         ),
     },
     ("keywords", "add", "StrategyPriority"): {
         "status": "supported",
         "issue": "#289",
         "note": (
-            "Single-item typed flag is supported; batch/from-file parity is "
-            "tracked separately."
+            "Single-item typed flag is supported; batch/from-file rows "
+            "intentionally reject autotargeting fields."
         ),
     },
     ("feeds", "add", "FileFeed"): {


### PR DESCRIPTION
## Summary
- add explicit batch-row rejection for keyword autotargeting fields instead of treating them as generic unknown fields
- document that keyword autotargeting remains single-item typed flags only in batch docs
- update #289 WSDL audit notes from tracked-separately to intentionally rejected batch rows

## Verification
- `python3 scripts/build_wsdl_optional_field_audit.py --check`
- `python3 -m pytest tests/test_dry_run.py -k "keywords and batch"`
- `python3 -m pytest tests/test_wsdl_parity_gate.py`
- `python3 -m pytest tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py`
- `mypy .`

Closes #289