### PR TITLE
Add feeds FileFeed upload support

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,7 +533,9 @@ direct adextensions add --callout-text "Free shipping" --dry-run
 direct adimages add --name banner.png --image-data BASE64DATA --type ICON --dry-run
 direct creatives add --video-id video-id --dry-run
 direct feeds add --name "Feed A" --url "https://example.com/feed.xml" --business-type RETAIL --remove-utm-tags YES --feed-login feedbot --dry-run
+direct feeds add --name "Feed File" --file-feed-path ./feed.xml --business-type RETAIL --dry-run
 direct feeds update --id 18 --name "Feed A v2" --url "https://example.com/feed-v2.xml" --remove-utm-tags NO --clear-feed-login --clear-feed-password --dry-run
+direct feeds update --id 18 --file-feed-path ./feed-v2.xml --file-feed-filename feed-v2.xml --dry-run
 direct clients update --client-info "Priority client" --phone +70000000000 --notification-email user@example.com --notification-lang EN --email-subscription RECEIVE_RECOMMENDATIONS=YES --setting DISPLAY_STORE_RATING=NO --dry-run
 direct clients update --erir-organization-name "Advertiser LLC" --erir-organization-kpp 770101001 --erir-organization-epay-number epay123 --erir-organization-reg-number 1027700132195 --erir-organization-oksm-number 643 --erir-organization-okved-code 62.01 --dry-run
 direct clients update --erir-contract-number C-2026-01 --erir-contract-date 2026-01-15 --erir-contract-type CONTRACT --erir-contract-action-type COMMERCIAL --erir-contract-subject-type REPRESENTATION --erir-contract-is-agency-payment NO --erir-contract-price-amount 120000.5 --erir-contract-price-including-vat YES --dry-run
@@ -1250,7 +1252,9 @@ direct adextensions add --callout-text "Free shipping" --dry-run
 direct adimages add --name banner.png --image-data BASE64DATA --type ICON --dry-run
 direct creatives add --video-id video-id --dry-run
 direct feeds add --name "Фид A" --url "https://example.com/feed.xml" --business-type RETAIL --remove-utm-tags YES --feed-login feedbot --dry-run
+direct feeds add --name "Фид-файл" --file-feed-path ./feed.xml --business-type RETAIL --dry-run
 direct feeds update --id 18 --name "Фид A v2" --url "https://example.com/feed-v2.xml" --remove-utm-tags NO --clear-feed-login --clear-feed-password --dry-run
+direct feeds update --id 18 --file-feed-path ./feed-v2.xml --file-feed-filename feed-v2.xml --dry-run
 direct clients update --client-info "Приоритетный клиент" --phone +70000000000 --notification-email user@example.com --notification-lang EN --email-subscription RECEIVE_RECOMMENDATIONS=YES --setting DISPLAY_STORE_RATING=NO --dry-run
 direct clients update --erir-organization-name "Рекламодатель ООО" --erir-organization-kpp 770101001 --erir-organization-epay-number epay123 --erir-organization-reg-number 1027700132195 --erir-organization-oksm-number 643 --erir-organization-okved-code 62.01 --dry-run
 direct clients update --erir-contract-number C-2026-01 --erir-contract-date 2026-01-15 --erir-contract-type CONTRACT --erir-contract-action-type COMMERCIAL --erir-contract-subject-type REPRESENTATION --erir-contract-is-agency-payment NO --erir-contract-price-amount 120000.5 --erir-contract-price-including-vat YES --dry-run

--- a/direct_cli/commands/feeds.py
+++ b/direct_cli/commands/feeds.py
@@ -2,6 +2,8 @@
 Feeds commands
 """
 
+import base64
+from pathlib import Path
 from typing import Dict, Optional
 
 import click
@@ -11,6 +13,12 @@ from ..output import format_output, print_error
 from ..utils import get_default_fields, parse_ids
 
 _YES_NO = ["YES", "NO"]
+# Yandex Direct docs cap FileFeed.Data by total request size. This
+# pre-read guard rejects definitely oversized local files; the API remains
+# the final validator for the base64-encoded request envelope.
+_FILE_FEED_MAX_BYTES = 50 * 1024 * 1024
+# feeds.add/update docs define FileFeed.Filename as at most 255 characters.
+_FILE_FEED_MAX_FILENAME_LENGTH = 255
 
 
 def _url_feed_payload(
@@ -35,6 +43,65 @@ def _url_feed_payload(
     elif password:
         payload["Password"] = password
     return payload
+
+
+def _file_feed_payload(
+    file_feed_path: str,
+    file_feed_filename: Optional[str] = None,
+) -> Dict[str, object]:
+    path = Path(file_feed_path)
+    filename = file_feed_filename or path.name
+    if not filename:
+        raise click.UsageError("FileFeed.Filename cannot be empty.")
+    if len(filename) > _FILE_FEED_MAX_FILENAME_LENGTH:
+        raise click.UsageError(
+            "FileFeed.Filename must be at most "
+            f"{_FILE_FEED_MAX_FILENAME_LENGTH} characters."
+        )
+
+    try:
+        file_size = path.stat().st_size
+    except OSError as exc:
+        raise click.UsageError(
+            f"Cannot read --file-feed-path {file_feed_path!r}: {exc}"
+        )
+
+    if file_size > _FILE_FEED_MAX_BYTES:
+        raise click.UsageError(
+            "FileFeed.Data must be at most 50 MiB before base64 encoding."
+        )
+
+    try:
+        data = path.read_bytes()
+    except OSError as exc:
+        raise click.UsageError(
+            f"Cannot read --file-feed-path {file_feed_path!r}: {exc}"
+        )
+
+    return {
+        "Data": base64.b64encode(data).decode("ascii"),
+        "Filename": filename,
+    }
+
+
+def _has_url_feed_options(
+    url: Optional[str],
+    remove_utm_tags: Optional[str],
+    feed_login: Optional[str],
+    feed_password: Optional[str],
+    clear_feed_login: bool = False,
+    clear_feed_password: bool = False,
+) -> bool:
+    return any(
+        (
+            url,
+            remove_utm_tags,
+            feed_login,
+            feed_password,
+            clear_feed_login,
+            clear_feed_password,
+        )
+    )
 
 
 @click.group()
@@ -97,7 +164,16 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
 
 @feeds.command()
 @click.option("--name", required=True, help="Feed name")
-@click.option("--url", required=True, help="Feed URL")
+@click.option("--url", help="Feed URL")
+@click.option(
+    "--file-feed-path",
+    type=click.Path(exists=True, dir_okay=False, readable=True),
+    help="Path to feed file for FileFeed.Data base64 upload.",
+)
+@click.option(
+    "--file-feed-filename",
+    help="FileFeed.Filename; defaults to the basename of --file-feed-path.",
+)
 @click.option(
     "--remove-utm-tags",
     type=click.Choice(_YES_NO, case_sensitive=False),
@@ -117,18 +193,46 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
 def add(
-    ctx, name, url, remove_utm_tags, feed_login, feed_password, business_type, dry_run
+    ctx,
+    name,
+    url,
+    file_feed_path,
+    file_feed_filename,
+    remove_utm_tags,
+    feed_login,
+    feed_password,
+    business_type,
+    dry_run,
 ):
     """Add feed"""
     try:
+        if file_feed_filename and not file_feed_path:
+            raise click.UsageError("--file-feed-filename requires --file-feed-path.")
+        if url and file_feed_path:
+            raise click.UsageError("Use either --url or --file-feed-path, not both.")
+        if not url and not file_feed_path:
+            raise click.UsageError("Provide exactly one of --url or --file-feed-path.")
+        if file_feed_path and _has_url_feed_options(
+            None, remove_utm_tags, feed_login, feed_password
+        ):
+            raise click.UsageError(
+                "--remove-utm-tags, --feed-login, and --feed-password are "
+                "only valid with --url feeds."
+            )
+
         feed_data = {
             "Name": name,
             "BusinessType": business_type.upper(),
-            "SourceType": "URL",
-            "UrlFeed": _url_feed_payload(
-                url, remove_utm_tags, feed_login, feed_password
-            ),
+            "SourceType": "FILE" if file_feed_path else "URL",
         }
+        if file_feed_path:
+            feed_data["FileFeed"] = _file_feed_payload(
+                file_feed_path, file_feed_filename
+            )
+        else:
+            feed_data["UrlFeed"] = _url_feed_payload(
+                url, remove_utm_tags, feed_login, feed_password
+            )
 
         body = {"method": "add", "params": {"Feeds": [feed_data]}}
 
@@ -145,6 +249,8 @@ def add(
         result = client.feeds().post(data=body)
         format_output(result().extract(), "json", None)
 
+    except click.UsageError:
+        raise
     except Exception as e:
         print_error(str(e))
         raise click.Abort()
@@ -153,7 +259,22 @@ def add(
 @feeds.command()
 @click.option("--id", "feed_id", required=True, type=int, help="Feed ID")
 @click.option("--name", help="Feed name")
-@click.option("--url", help="Feed URL")
+@click.option(
+    "--url",
+    help="Feed URL for an existing URL feed; Yandex Direct rejects source switches.",
+)
+@click.option(
+    "--file-feed-path",
+    type=click.Path(exists=True, dir_okay=False, readable=True),
+    help=(
+        "Path to feed file for an existing FILE feed; Yandex Direct rejects "
+        "source switches."
+    ),
+)
+@click.option(
+    "--file-feed-filename",
+    help="FileFeed.Filename; defaults to the basename of --file-feed-path.",
+)
 @click.option(
     "--remove-utm-tags",
     type=click.Choice(_YES_NO, case_sensitive=False),
@@ -172,6 +293,8 @@ def update(
     feed_id,
     name,
     url,
+    file_feed_path,
+    file_feed_filename,
     remove_utm_tags,
     feed_login,
     feed_password,
@@ -189,6 +312,19 @@ def update(
             raise click.UsageError(
                 "Use either --feed-password or --clear-feed-password, not both"
             )
+        if file_feed_filename and not file_feed_path:
+            raise click.UsageError("--file-feed-filename requires --file-feed-path.")
+        if file_feed_path and _has_url_feed_options(
+            url,
+            remove_utm_tags,
+            feed_login,
+            feed_password,
+            clear_feed_login,
+            clear_feed_password,
+        ):
+            raise click.UsageError(
+                "FileFeed options cannot be combined with UrlFeed options."
+            )
 
         feed_data = {"Id": feed_id}
 
@@ -204,11 +340,15 @@ def update(
         )
         if url_feed:
             feed_data["UrlFeed"] = url_feed
+        if file_feed_path:
+            feed_data["FileFeed"] = _file_feed_payload(
+                file_feed_path, file_feed_filename
+            )
         if len(feed_data) == 1:
             raise click.UsageError(
-                "Provide at least one of --name, --url, --remove-utm-tags, "
-                "--feed-login, --feed-password, --clear-feed-login, or "
-                "--clear-feed-password"
+                "Provide at least one of --name, --url, --file-feed-path, "
+                "--remove-utm-tags, --feed-login, --feed-password, "
+                "--clear-feed-login, or --clear-feed-password"
             )
 
         body = {"method": "update", "params": {"Feeds": [feed_data]}}

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,8 +11,8 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 2729 |
-| `supported` | 512 |
+| `missing_followup` | 2723 |
+| `supported` | 518 |
 
 ## Confirmed Follow-Ups
 
@@ -2544,12 +2544,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `campaigns.update` | `TimeTargeting.HolidaysSchedule.BidPercent` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
 | `campaigns.update` | `TimeTargeting.HolidaysSchedule.StartHour` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
 | `campaigns.update` | `TimeTargeting.HolidaysSchedule.EndHour` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `feeds.add` | `FileFeed` | FileFeed upload/base64 CLI support is split from #253. [#264](https://github.com/axisrow/direct-cli/issues/264) |
-| `feeds.add` | `FileFeed.Data` | FileFeed upload/base64 CLI support is split from #253. [#264](https://github.com/axisrow/direct-cli/issues/264); inherited from `FileFeed` |
-| `feeds.add` | `FileFeed.Filename` | FileFeed upload/base64 CLI support is split from #253. [#264](https://github.com/axisrow/direct-cli/issues/264); inherited from `FileFeed` |
-| `feeds.update` | `FileFeed` | FileFeed upload/base64 CLI support is split from #253. [#264](https://github.com/axisrow/direct-cli/issues/264) |
-| `feeds.update` | `FileFeed.Data` | FileFeed upload/base64 CLI support is split from #253. [#264](https://github.com/axisrow/direct-cli/issues/264); inherited from `FileFeed` |
-| `feeds.update` | `FileFeed.Filename` | FileFeed upload/base64 CLI support is split from #253. [#264](https://github.com/axisrow/direct-cli/issues/264); inherited from `FileFeed` |
 | `strategies.add` | `PriorityGoals.Items.GoalId` | strategies.add residual optional WSDL path needs typed support or N/A. [#299](https://github.com/axisrow/direct-cli/issues/299) |
 | `strategies.add` | `PriorityGoals.Items.Value` | strategies.add residual optional WSDL path needs typed support or N/A. [#299](https://github.com/axisrow/direct-cli/issues/299) |
 | `strategies.add` | `PriorityGoals.Items.IsMetrikaSourceOfValue` | strategies.add residual optional WSDL path needs typed support or N/A. [#299](https://github.com/axisrow/direct-cli/issues/299) |
@@ -5517,9 +5511,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `feeds.add` | `feeds.add` | `UrlFeed.Url` | `string` | 1 | 1 | `supported` | --url |
 | `feeds.add` | `feeds.add` | `UrlFeed.Login` | `string` | 0 | 1 | `supported` | --feed-login |
 | `feeds.add` | `feeds.add` | `UrlFeed.Password` | `string` | 0 | 1 | `supported` | --feed-password |
-| `feeds.add` | `feeds.add` | `FileFeed` | `FileFeedAdd` | 0 | 1 | `missing_followup` | FileFeed upload/base64 CLI support is split from #253. [#264](https://github.com/axisrow/direct-cli/issues/264) |
-| `feeds.add` | `feeds.add` | `FileFeed.Data` | `base64Binary` | 1 | 1 | `missing_followup` | FileFeed upload/base64 CLI support is split from #253. [#264](https://github.com/axisrow/direct-cli/issues/264); inherited from `FileFeed` |
-| `feeds.add` | `feeds.add` | `FileFeed.Filename` | `string` | 1 | 1 | `missing_followup` | FileFeed upload/base64 CLI support is split from #253. [#264](https://github.com/axisrow/direct-cli/issues/264); inherited from `FileFeed` |
+| `feeds.add` | `feeds.add` | `FileFeed` | `FileFeedAdd` | 0 | 1 | `supported` | --file-feed-path |
+| `feeds.add` | `feeds.add` | `FileFeed.Data` | `base64Binary` | 1 | 1 | `supported` | --file-feed-path |
+| `feeds.add` | `feeds.add` | `FileFeed.Filename` | `string` | 1 | 1 | `supported` | --file-feed-filename, --file-feed-path |
 | `feeds.update` | `feeds.update` | `Id` | `long` | 1 | 1 | `supported` | covered by minOccurs>=1 parity gate |
 | `feeds.update` | `feeds.update` | `Name` | `string` | 0 | 1 | `supported` | --name |
 | `feeds.update` | `feeds.update` | `UrlFeed` | `UrlFeedUpdate` | 0 | 1 | `supported` | --url |
@@ -5527,9 +5521,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `feeds.update` | `feeds.update` | `UrlFeed.Url` | `string` | 0 | 1 | `supported` | --url |
 | `feeds.update` | `feeds.update` | `UrlFeed.Login` | `string` | 0 | 1 | `supported` | --clear-feed-login, --feed-login |
 | `feeds.update` | `feeds.update` | `UrlFeed.Password` | `string` | 0 | 1 | `supported` | --clear-feed-password, --feed-password |
-| `feeds.update` | `feeds.update` | `FileFeed` | `FileFeedUpdate` | 0 | 1 | `missing_followup` | FileFeed upload/base64 CLI support is split from #253. [#264](https://github.com/axisrow/direct-cli/issues/264) |
-| `feeds.update` | `feeds.update` | `FileFeed.Data` | `base64Binary` | 1 | 1 | `missing_followup` | FileFeed upload/base64 CLI support is split from #253. [#264](https://github.com/axisrow/direct-cli/issues/264); inherited from `FileFeed` |
-| `feeds.update` | `feeds.update` | `FileFeed.Filename` | `string` | 1 | 1 | `missing_followup` | FileFeed upload/base64 CLI support is split from #253. [#264](https://github.com/axisrow/direct-cli/issues/264); inherited from `FileFeed` |
+| `feeds.update` | `feeds.update` | `FileFeed` | `FileFeedUpdate` | 0 | 1 | `supported` | --file-feed-path |
+| `feeds.update` | `feeds.update` | `FileFeed.Data` | `base64Binary` | 1 | 1 | `supported` | --file-feed-path |
+| `feeds.update` | `feeds.update` | `FileFeed.Filename` | `string` | 1 | 1 | `supported` | --file-feed-filename, --file-feed-path |
 | `keywordbids.set` | `keywordbids.set` | `CampaignId` | `long` | 0 | 1 | `supported` | --campaign-id |
 | `keywordbids.set` | `keywordbids.set` | `AdGroupId` | `long` | 0 | 1 | `supported` | --adgroup-id |
 | `keywordbids.set` | `keywordbids.set` | `KeywordId` | `long` | 0 | 1 | `supported` | --keyword-id |

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -48,6 +48,7 @@ commands that now expose ``--dry-run`` (``delete``,
 Part of axisrow/yandex-direct-mcp-plugin#61.
 """
 
+import base64
 import json
 from unittest.mock import patch
 
@@ -4034,6 +4035,124 @@ def test_feeds_add_payload_accepts_urlfeed_details():
     }
 
 
+def test_feeds_add_payload_accepts_filefeed_upload(tmp_path):
+    feed_path = tmp_path / "feed.xml"
+    feed_bytes = b"<yml_catalog><shop /></yml_catalog>"
+    feed_path.write_bytes(feed_bytes)
+
+    body = _dry_run(
+        "feeds",
+        "add",
+        "--name",
+        "Feed A",
+        "--file-feed-path",
+        str(feed_path),
+        "--business-type",
+        "retail",
+    )
+    feed = body["params"]["Feeds"][0]
+    assert feed == {
+        "Name": "Feed A",
+        "BusinessType": "RETAIL",
+        "SourceType": "FILE",
+        "FileFeed": {
+            "Data": base64.b64encode(feed_bytes).decode("ascii"),
+            "Filename": "feed.xml",
+        },
+    }
+
+
+def test_feeds_add_payload_accepts_filefeed_filename_override(tmp_path):
+    feed_path = tmp_path / "source.tmp"
+    feed_path.write_bytes(b"id,name\n1,chair\n")
+
+    body = _dry_run(
+        "feeds",
+        "add",
+        "--name",
+        "Feed A",
+        "--file-feed-path",
+        str(feed_path),
+        "--file-feed-filename",
+        "products.csv",
+        "--business-type",
+        "RETAIL",
+    )
+    feed = body["params"]["Feeds"][0]
+    assert feed["SourceType"] == "FILE"
+    assert feed["FileFeed"]["Filename"] == "products.csv"
+
+
+def test_feeds_add_rejects_url_and_filefeed_mix(tmp_path):
+    feed_path = tmp_path / "feed.xml"
+    feed_path.write_text("<feed />", encoding="utf-8")
+
+    result = _rejected(
+        "feeds",
+        "add",
+        "--name",
+        "Feed A",
+        "--url",
+        "https://example.com/feed.xml",
+        "--file-feed-path",
+        str(feed_path),
+        "--business-type",
+        "RETAIL",
+    )
+    assert "Use either --url or --file-feed-path" in result.output
+
+
+def test_feeds_add_rejects_filefeed_filename_without_path():
+    result = _rejected(
+        "feeds",
+        "add",
+        "--name",
+        "Feed A",
+        "--file-feed-filename",
+        "feed.xml",
+        "--business-type",
+        "RETAIL",
+    )
+    assert "--file-feed-filename requires --file-feed-path" in result.output
+
+
+def test_feeds_add_rejects_overlong_filefeed_filename(tmp_path):
+    feed_path = tmp_path / "feed.xml"
+    feed_path.write_text("<feed />", encoding="utf-8")
+
+    result = _rejected(
+        "feeds",
+        "add",
+        "--name",
+        "Feed A",
+        "--file-feed-path",
+        str(feed_path),
+        "--file-feed-filename",
+        "x" * 256,
+        "--business-type",
+        "RETAIL",
+    )
+    assert "FileFeed.Filename must be at most 255 characters" in result.output
+
+
+def test_feeds_add_rejects_oversized_filefeed_before_reading(tmp_path):
+    feed_path = tmp_path / "huge-feed.xml"
+    with feed_path.open("wb") as fh:
+        fh.truncate((50 * 1024 * 1024) + 1)
+
+    result = _rejected(
+        "feeds",
+        "add",
+        "--name",
+        "Feed A",
+        "--file-feed-path",
+        str(feed_path),
+        "--business-type",
+        "RETAIL",
+    )
+    assert "FileFeed.Data must be at most 50 MiB" in result.output
+
+
 def test_feeds_update_payload_changes_url():
     body = _dry_run(
         "feeds",
@@ -4084,6 +4203,46 @@ def test_feeds_update_payload_can_clear_urlfeed_credentials():
     assert feed == {"Id": 9, "UrlFeed": {"Login": None, "Password": None}}
 
 
+def test_feeds_update_payload_accepts_filefeed_upload(tmp_path):
+    feed_path = tmp_path / "feed.yml"
+    feed_bytes = b"offer: 1\n"
+    feed_path.write_bytes(feed_bytes)
+
+    body = _dry_run(
+        "feeds",
+        "update",
+        "--id",
+        "9",
+        "--file-feed-path",
+        str(feed_path),
+    )
+    feed = body["params"]["Feeds"][0]
+    assert feed == {
+        "Id": 9,
+        "FileFeed": {
+            "Data": base64.b64encode(feed_bytes).decode("ascii"),
+            "Filename": "feed.yml",
+        },
+    }
+
+
+def test_feeds_update_rejects_urlfeed_and_filefeed_mix(tmp_path):
+    feed_path = tmp_path / "feed.xml"
+    feed_path.write_text("<feed />", encoding="utf-8")
+
+    result = _rejected(
+        "feeds",
+        "update",
+        "--id",
+        "9",
+        "--file-feed-path",
+        str(feed_path),
+        "--remove-utm-tags",
+        "YES",
+    )
+    assert "FileFeed options cannot be combined with UrlFeed options" in result.output
+
+
 def test_feeds_update_rejects_setting_and_clearing_login():
     result = CliRunner().invoke(
         cli,
@@ -4122,6 +4281,7 @@ def test_feeds_update_without_fields_errors():
     )
     assert "--name" in combined
     assert "--url" in combined
+    assert "--file-feed-path" in combined
     assert "--remove-utm-tags" in combined
     assert "--clear-feed-login" in combined
 

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -550,7 +550,7 @@ WSDL_FIELD_TO_CLI_OPTION: dict[str, set[str]] = {
     "Name": {"--name"},
     "StartDate": {"--start-date"},
     "BusinessType": {"--business-type"},
-    "SourceType": {"--url"},  # derived inside the command
+    "SourceType": {"--url", "--file-feed-path"},  # derived inside the command
     "Id": {"--id"},
     "Keyword": {"--keyword"},
     "ImageData": {"--image-data", "--image-file"},
@@ -602,6 +602,7 @@ INTERNAL_VALIDATION: dict[tuple[str, str, str], str] = {
     ("creatives", "add", "VideoExtensionCreative"): "Missing option '--video-id'",
     ("keywords", "add", "Keyword"): "Provide exactly one of: --keyword",
     ("keywords", "add", "AdGroupId"): "Provide exactly one of: --keyword",
+    ("feeds", "add", "SourceType"): "Provide exactly one of --url or --file-feed-path",
     ("sitelinks", "add", "Sitelinks"): "Provide exactly one of: --sitelink",
 }
 
@@ -923,6 +924,12 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     ("feeds", "add", "UrlFeed.RemoveUtmTags"): {"--remove-utm-tags"},
     ("feeds", "add", "UrlFeed.Login"): {"--feed-login"},
     ("feeds", "add", "UrlFeed.Password"): {"--feed-password"},
+    ("feeds", "add", "FileFeed"): {"--file-feed-path"},
+    ("feeds", "add", "FileFeed.Data"): {"--file-feed-path"},
+    ("feeds", "add", "FileFeed.Filename"): {
+        "--file-feed-path",
+        "--file-feed-filename",
+    },
     ("feeds", "update", "Name"): {"--name"},
     ("feeds", "update", "UrlFeed"): {"--url"},
     ("feeds", "update", "UrlFeed.Url"): {"--url"},
@@ -931,6 +938,12 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     ("feeds", "update", "UrlFeed.Password"): {
         "--feed-password",
         "--clear-feed-password",
+    },
+    ("feeds", "update", "FileFeed"): {"--file-feed-path"},
+    ("feeds", "update", "FileFeed.Data"): {"--file-feed-path"},
+    ("feeds", "update", "FileFeed.Filename"): {
+        "--file-feed-path",
+        "--file-feed-filename",
     },
     ("creatives", "add", "VideoExtensionCreative.VideoId"): {"--video-id"},
     ("keywords", "add", "Bid"): {"--bid"},
@@ -1250,14 +1263,6 @@ OPTIONAL_FIELD_DEFAULT_FOLLOWUPS: dict[tuple[str, str], dict[str, str]] = {
     ("dynamicfeedadtargets", "add"): {
         "issue": "#303",
         "note": "dynamicfeedadtargets.add optional WSDL path needs typed support or N/A.",
-    },
-    ("feeds", "add"): {
-        "issue": "#264",
-        "note": "feeds.add optional WSDL path needs typed support or N/A.",
-    },
-    ("feeds", "update"): {
-        "issue": "#264",
-        "note": "feeds.update optional WSDL path needs typed support or N/A.",
     },
     ("retargeting", "add"): {
         "issue": "#256",
@@ -1588,16 +1593,6 @@ OPTIONAL_FIELD_AUDIT: dict[tuple[str, str, str], dict[str, str]] = {
             "intentionally reject autotargeting fields."
         ),
     },
-    ("feeds", "add", "FileFeed"): {
-        "status": "missing_followup",
-        "issue": "#264",
-        "note": "FileFeed upload/base64 CLI support is split from #253.",
-    },
-    ("feeds", "update", "FileFeed"): {
-        "status": "missing_followup",
-        "issue": "#264",
-        "note": "FileFeed upload/base64 CLI support is split from #253.",
-    },
     ("adgroups", "add", "MobileAppAdGroup"): {
         "status": "missing_followup",
         "issue": "#279",
@@ -1750,6 +1745,14 @@ INTERNAL_VALIDATION_PROBES: dict[tuple[str, str, str], list[str]] = {
     ("creatives", "add", "VideoExtensionCreative"): ["creatives", "add"],
     ("keywords", "add", "Keyword"): ["keywords", "add"],
     ("keywords", "add", "AdGroupId"): ["keywords", "add"],
+    ("feeds", "add", "SourceType"): [
+        "feeds",
+        "add",
+        "--name",
+        "Feed A",
+        "--business-type",
+        "RETAIL",
+    ],
     ("sitelinks", "add", "Sitelinks"): ["sitelinks", "add"],
 }
 


### PR DESCRIPTION
## Summary
- add typed `--file-feed-path` / `--file-feed-filename` support for `feeds add` and `feeds update`
- encode local feed files into `FileFeed.Data` base64 and set `SourceType: FILE` for add payloads
- prevent mixing `UrlFeed` and `FileFeed` options, update README examples, and mark FileFeed WSDL rows supported

## Docs checked
- Yandex Direct `feeds.add`: `SourceType` is `URL | FILE`; `FileFeed.Data` and `FileFeed.Filename` are required inside `FileFeed`
- Yandex Direct `feeds.update`: `FileFeed.Data` and `FileFeed.Filename` are required inside `FileFeed`; changing source/business type is not allowed

## Verification
- `python3 -m pytest tests/test_dry_run.py -k feeds`
- `python3 scripts/build_wsdl_optional_field_audit.py --check`
- `python3 -m pytest tests/test_wsdl_parity_gate.py`
- `python3 -m pytest tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py`
- `mypy .`
- `git diff --check`

Closes #264