### PR TITLE
feat(adgroups): support mobile app ad group flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,9 @@ direct adgroups get --campaign-ids 1,2,3 --limit 50
 direct adgroups add --name "Group 1" --campaign-id 12345 --region-ids 1,225 --negative-keywords "repair,used" --tracking-params "utm_source=direct" --dry-run
 direct adgroups add --name "Dynamic Group" --campaign-id 12345 --type DYNAMIC_TEXT_AD_GROUP --region-ids 1,225 --domain-url example.com --dry-run
 direct adgroups add --name "Smart Group" --campaign-id 12345 --type SMART_AD_GROUP --region-ids 1,225 --feed-id 170 --ad-title-source FEED_NAME --ad-body-source FEED_NAME --dry-run
+direct adgroups add --name "Mobile App Group" --campaign-id 12345 --type MOBILE_APP_AD_GROUP --region-ids 1,225 --store-url https://apps.apple.com/app/id123456789 --target-device-types DEVICE_TYPE_MOBILE,DEVICE_TYPE_TABLET --target-carrier WI_FI_AND_CELLULAR --target-operating-system-version 14.0 --dry-run
 direct adgroups update --id 67890 --negative-keyword-shared-set-ids 10,11 --tracking-params "utm_source=direct"
+direct adgroups update --id 67890 --target-device-types DEVICE_TYPE_TABLET --target-carrier WI_FI_ONLY --target-operating-system-version 13.0
 direct adgroups delete --id 67890
 ```
 
@@ -1099,7 +1101,9 @@ direct adgroups get --campaign-ids 1,2,3 --limit 50
 direct adgroups add --name "Группа 1" --campaign-id 12345 --region-ids 1,225 --negative-keywords "ремонт,б/у" --tracking-params "utm_source=direct" --dry-run
 direct adgroups add --name "Динамическая группа" --campaign-id 12345 --type DYNAMIC_TEXT_AD_GROUP --region-ids 1,225 --domain-url example.com --dry-run
 direct adgroups add --name "Смарт-группа" --campaign-id 12345 --type SMART_AD_GROUP --region-ids 1,225 --feed-id 170 --ad-title-source FEED_NAME --ad-body-source FEED_NAME --dry-run
+direct adgroups add --name "Группа мобильного приложения" --campaign-id 12345 --type MOBILE_APP_AD_GROUP --region-ids 1,225 --store-url https://apps.apple.com/app/id123456789 --target-device-types DEVICE_TYPE_MOBILE,DEVICE_TYPE_TABLET --target-carrier WI_FI_AND_CELLULAR --target-operating-system-version 14.0 --dry-run
 direct adgroups update --id 67890 --negative-keyword-shared-set-ids 10,11 --tracking-params "utm_source=direct"
+direct adgroups update --id 67890 --target-device-types DEVICE_TYPE_TABLET --target-carrier WI_FI_ONLY --target-operating-system-version 13.0
 direct adgroups delete --id 67890
 ```
 

--- a/direct_cli/commands/adgroups.py
+++ b/direct_cli/commands/adgroups.py
@@ -16,6 +16,14 @@ from ..utils import (
 )
 
 _TRACKING_PARAMS_MAX_LENGTH = 1024
+_SUPPORTED_ADGROUP_TYPES = (
+    "TEXT_AD_GROUP",
+    "DYNAMIC_TEXT_AD_GROUP",
+    "SMART_AD_GROUP",
+    "MOBILE_APP_AD_GROUP",
+)
+_TARGET_DEVICE_TYPES = ("DEVICE_TYPE_MOBILE", "DEVICE_TYPE_TABLET")
+_TARGET_CARRIERS = ("WI_FI_ONLY", "WI_FI_AND_CELLULAR")
 
 
 @click.group()
@@ -41,6 +49,96 @@ def _parse_ids_option(value: Optional[str], option_name: str) -> Optional[list[i
         return parse_ids(value)
     except ValueError as exc:
         raise click.UsageError(f"{option_name}: {exc}") from exc
+
+
+def _normalize_enum_token(value: str) -> str:
+    """Normalize enum-like CLI tokens to Yandex Direct uppercase constants."""
+    return value.strip().upper().replace("-", "_")
+
+
+def _parse_enum_value(
+    value: Optional[str], option_name: str, allowed_values: tuple[str, ...]
+) -> Optional[str]:
+    """Parse a single enum-like token and report bad input as UsageError."""
+    if not value:
+        return None
+
+    normalized = _normalize_enum_token(value)
+    if not normalized:
+        return None
+
+    if normalized not in allowed_values:
+        raise click.UsageError(
+            f"{option_name} has invalid value {value!r}; allowed values: "
+            f"{', '.join(allowed_values)}"
+        )
+    return normalized
+
+
+def _parse_enum_csv(
+    value: Optional[str], option_name: str, allowed_values: tuple[str, ...]
+) -> Optional[list[str]]:
+    """Parse comma-separated enum-like tokens and report bad input as UsageError."""
+    parsed = parse_csv_strings(value)
+    if not parsed:
+        return None
+
+    normalized_values = []
+    for item in parsed:
+        normalized = _normalize_enum_token(item)
+        if normalized not in allowed_values:
+            raise click.UsageError(
+                f"{option_name} has invalid value {item!r}; allowed values: "
+                f"{', '.join(allowed_values)}"
+            )
+        normalized_values.append(normalized)
+    return normalized_values
+
+
+def _build_mobile_app_adgroup(
+    *,
+    store_url: Optional[str] = None,
+    target_device_types: Optional[str] = None,
+    target_carrier: Optional[str] = None,
+    target_operating_system_version: Optional[str] = None,
+    require_all_fields: bool = False,
+) -> Optional[dict[str, object]]:
+    """Build the MobileAppAdGroup block shared by add/update."""
+    parsed_device_types = _parse_enum_csv(
+        target_device_types, "--target-device-types", _TARGET_DEVICE_TYPES
+    )
+    parsed_carrier = _parse_enum_value(
+        target_carrier, "--target-carrier", _TARGET_CARRIERS
+    )
+
+    if require_all_fields:
+        missing = []
+        if not store_url:
+            missing.append("--store-url")
+        if not parsed_device_types:
+            missing.append("--target-device-types")
+        if not parsed_carrier:
+            missing.append("--target-carrier")
+        if not target_operating_system_version:
+            missing.append("--target-operating-system-version")
+        if missing:
+            raise click.UsageError(
+                f"{', '.join(missing)} required for MOBILE_APP_AD_GROUP"
+            )
+
+    mobile_app_adgroup: dict[str, object] = {}
+    if store_url:
+        mobile_app_adgroup["StoreUrl"] = store_url
+    if parsed_device_types:
+        mobile_app_adgroup["TargetDeviceType"] = parsed_device_types
+    if parsed_carrier:
+        mobile_app_adgroup["TargetCarrier"] = parsed_carrier
+    if target_operating_system_version:
+        mobile_app_adgroup["TargetOperatingSystemVersion"] = (
+            target_operating_system_version
+        )
+
+    return mobile_app_adgroup or None
 
 
 def _reject_incompatible_flags(
@@ -169,7 +267,10 @@ def get(
     "--type",
     "group_type",
     default="TEXT_AD_GROUP",
-    help="Ad group type",
+    help=(
+        "Ad group type: TEXT_AD_GROUP, DYNAMIC_TEXT_AD_GROUP, SMART_AD_GROUP, "
+        "or MOBILE_APP_AD_GROUP"
+    ),
 )
 @click.option(
     "--region-ids",
@@ -180,6 +281,25 @@ def get(
 @click.option("--feed-id", type=int, help="Smart ad group feed ID")
 @click.option("--ad-title-source", help="Smart ad group title source")
 @click.option("--ad-body-source", help="Smart ad group body source")
+@click.option(
+    "--store-url",
+    help="Mobile app ad group app store URL for MobileAppAdGroup.StoreUrl",
+)
+@click.option(
+    "--target-device-types",
+    help=(
+        "Comma-separated MobileAppAdGroup.TargetDeviceType values: "
+        "DEVICE_TYPE_MOBILE, DEVICE_TYPE_TABLET"
+    ),
+)
+@click.option(
+    "--target-carrier",
+    help=("MobileAppAdGroup.TargetCarrier value: " "WI_FI_ONLY or WI_FI_AND_CELLULAR"),
+)
+@click.option(
+    "--target-operating-system-version",
+    help="Minimum OS version for MobileAppAdGroup.TargetOperatingSystemVersion",
+)
 @click.option(
     "--negative-keywords",
     help="Comma-separated ad-group negative keywords for NegativeKeywords.Items",
@@ -211,6 +331,10 @@ def add(
     feed_id,
     ad_title_source,
     ad_body_source,
+    store_url,
+    target_device_types,
+    target_carrier,
+    target_operating_system_version,
     negative_keywords,
     negative_keyword_shared_set_ids,
     tracking_params,
@@ -221,21 +345,22 @@ def add(
         _validate_tracking_params(tracking_params)
 
         group_type_norm = (group_type or "TEXT_AD_GROUP").upper().replace("-", "_")
-        supported_types = {
-            "TEXT_AD_GROUP",
-            "DYNAMIC_TEXT_AD_GROUP",
-            "SMART_AD_GROUP",
-        }
-        if group_type_norm not in supported_types:
+        if group_type_norm not in _SUPPORTED_ADGROUP_TYPES:
             raise click.UsageError(
                 "Invalid value for '--type': "
                 f"{group_type!r} is not one of "
-                "'TEXT_AD_GROUP', 'DYNAMIC_TEXT_AD_GROUP', 'SMART_AD_GROUP'."
+                f"{', '.join(repr(value) for value in _SUPPORTED_ADGROUP_TYPES)}."
             )
         allowed_flags_by_type = {
             "TEXT_AD_GROUP": set(),
             "DYNAMIC_TEXT_AD_GROUP": {"--domain-url"},
             "SMART_AD_GROUP": {"--feed-id", "--ad-title-source", "--ad-body-source"},
+            "MOBILE_APP_AD_GROUP": {
+                "--store-url",
+                "--target-device-types",
+                "--target-carrier",
+                "--target-operating-system-version",
+            },
         }
         _reject_incompatible_flags(
             group_type_norm,
@@ -245,6 +370,10 @@ def add(
                 "--feed-id": feed_id,
                 "--ad-title-source": ad_title_source,
                 "--ad-body-source": ad_body_source,
+                "--store-url": store_url,
+                "--target-device-types": target_device_types,
+                "--target-carrier": target_carrier,
+                "--target-operating-system-version": target_operating_system_version,
             },
         )
 
@@ -280,6 +409,16 @@ def add(
             if ad_body_source:
                 smart_ad_group["AdBodySource"] = ad_body_source
             adgroup_data["SmartAdGroup"] = smart_ad_group
+        elif group_type_norm == "MOBILE_APP_AD_GROUP":
+            mobile_app_adgroup = _build_mobile_app_adgroup(
+                store_url=store_url,
+                target_device_types=target_device_types,
+                target_carrier=target_carrier,
+                target_operating_system_version=target_operating_system_version,
+                require_all_fields=True,
+            )
+            if mobile_app_adgroup:
+                adgroup_data["MobileAppAdGroup"] = mobile_app_adgroup
 
         body = {"method": "add", "params": {"AdGroups": [adgroup_data]}}
 
@@ -327,6 +466,21 @@ def add(
         "(max 1024 chars)"
     ),
 )
+@click.option(
+    "--target-device-types",
+    help=(
+        "Comma-separated MobileAppAdGroup.TargetDeviceType values: "
+        "DEVICE_TYPE_MOBILE, DEVICE_TYPE_TABLET"
+    ),
+)
+@click.option(
+    "--target-carrier",
+    help=("MobileAppAdGroup.TargetCarrier value: " "WI_FI_ONLY or WI_FI_AND_CELLULAR"),
+)
+@click.option(
+    "--target-operating-system-version",
+    help="Minimum OS version for MobileAppAdGroup.TargetOperatingSystemVersion",
+)
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
 def update(
@@ -338,6 +492,9 @@ def update(
     negative_keywords,
     negative_keyword_shared_set_ids,
     tracking_params,
+    target_device_types,
+    target_carrier,
+    target_operating_system_version,
     dry_run,
 ):
     """Update ad group"""
@@ -364,13 +521,22 @@ def update(
         }
     if tracking_params:
         adgroup_data["TrackingParams"] = tracking_params
+    mobile_app_adgroup = _build_mobile_app_adgroup(
+        target_device_types=target_device_types,
+        target_carrier=target_carrier,
+        target_operating_system_version=target_operating_system_version,
+    )
+    if mobile_app_adgroup:
+        adgroup_data["MobileAppAdGroup"] = mobile_app_adgroup
 
     # Reject empty-payload no-op (issue #198 H5).
     if len(adgroup_data) == 1:
         raise click.UsageError(
             "adgroups update requires at least one updatable field "
             "(--name, --status, --region-ids, --negative-keywords, "
-            "--negative-keyword-shared-set-ids, or --tracking-params)."
+            "--negative-keyword-shared-set-ids, --tracking-params, "
+            "--target-device-types, --target-carrier, or "
+            "--target-operating-system-version)."
         )
 
     try:

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,18 +11,13 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 2723 |
-| `supported` | 518 |
+| `missing_followup` | 2714 |
+| `supported` | 527 |
 
 ## Confirmed Follow-Ups
 
 | CLI command | WSDL path | Issue / note |
 |---|---|---|
-| `adgroups.add` | `MobileAppAdGroup` | Rare ad group subtype block is not exposed by --type. [#279](https://github.com/axisrow/direct-cli/issues/279) |
-| `adgroups.add` | `MobileAppAdGroup.StoreUrl` | Rare ad group subtype block is not exposed by --type. [#279](https://github.com/axisrow/direct-cli/issues/279); inherited from `MobileAppAdGroup` |
-| `adgroups.add` | `MobileAppAdGroup.TargetDeviceType` | Rare ad group subtype block is not exposed by --type. [#279](https://github.com/axisrow/direct-cli/issues/279); inherited from `MobileAppAdGroup` |
-| `adgroups.add` | `MobileAppAdGroup.TargetCarrier` | Rare ad group subtype block is not exposed by --type. [#279](https://github.com/axisrow/direct-cli/issues/279); inherited from `MobileAppAdGroup` |
-| `adgroups.add` | `MobileAppAdGroup.TargetOperatingSystemVersion` | Rare ad group subtype block is not exposed by --type. [#279](https://github.com/axisrow/direct-cli/issues/279); inherited from `MobileAppAdGroup` |
 | `adgroups.add` | `DynamicTextAdGroup.AutotargetingCategories` | Dynamic text ad group autotargeting categories are not exposed. [#280](https://github.com/axisrow/direct-cli/issues/280) |
 | `adgroups.add` | `DynamicTextAdGroup.AutotargetingCategories.Category` | Dynamic text ad group autotargeting categories are not exposed. [#280](https://github.com/axisrow/direct-cli/issues/280); inherited from `DynamicTextAdGroup.AutotargetingCategories` |
 | `adgroups.add` | `DynamicTextAdGroup.AutotargetingCategories.Value` | Dynamic text ad group autotargeting categories are not exposed. [#280](https://github.com/axisrow/direct-cli/issues/280); inherited from `DynamicTextAdGroup.AutotargetingCategories` |
@@ -62,10 +57,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `adgroups.add` | `TextAdGroupFeedParams.FeedId` | Rare ad group feed params block has no typed add flags. [#284](https://github.com/axisrow/direct-cli/issues/284); inherited from `TextAdGroupFeedParams` |
 | `adgroups.add` | `TextAdGroupFeedParams.FeedCategoryIds` | Rare ad group feed params block has no typed add flags. [#284](https://github.com/axisrow/direct-cli/issues/284); inherited from `TextAdGroupFeedParams` |
 | `adgroups.add` | `TextAdGroupFeedParams.FeedCategoryIds.Items` | Rare ad group feed params block has no typed add flags. [#284](https://github.com/axisrow/direct-cli/issues/284); inherited from `TextAdGroupFeedParams` |
-| `adgroups.update` | `MobileAppAdGroup` | Rare ad group subtype block is not exposed by update. [#279](https://github.com/axisrow/direct-cli/issues/279) |
-| `adgroups.update` | `MobileAppAdGroup.TargetDeviceType` | Rare ad group subtype block is not exposed by update. [#279](https://github.com/axisrow/direct-cli/issues/279); inherited from `MobileAppAdGroup` |
-| `adgroups.update` | `MobileAppAdGroup.TargetCarrier` | Rare ad group subtype block is not exposed by update. [#279](https://github.com/axisrow/direct-cli/issues/279); inherited from `MobileAppAdGroup` |
-| `adgroups.update` | `MobileAppAdGroup.TargetOperatingSystemVersion` | Rare ad group subtype block is not exposed by update. [#279](https://github.com/axisrow/direct-cli/issues/279); inherited from `MobileAppAdGroup` |
 | `adgroups.update` | `DynamicTextAdGroup` | Dynamic ad group subtype update block has no typed flags. [#280](https://github.com/axisrow/direct-cli/issues/280) |
 | `adgroups.update` | `DynamicTextAdGroup.AutotargetingCategories` | Dynamic ad group subtype update block has no typed flags. [#280](https://github.com/axisrow/direct-cli/issues/280); inherited from `DynamicTextAdGroup` |
 | `adgroups.update` | `DynamicTextAdGroup.AutotargetingCategories.Category` | Dynamic ad group subtype update block has no typed flags. [#280](https://github.com/axisrow/direct-cli/issues/280); inherited from `DynamicTextAdGroup` |
@@ -2756,11 +2747,11 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `adgroups.add` | `adgroups.add` | `NegativeKeywordSharedSetIds` | `ArrayOfLong` | 0 | 1 | `supported` | --negative-keyword-shared-set-ids |
 | `adgroups.add` | `adgroups.add` | `NegativeKeywordSharedSetIds.Items` | `long` | 1 | unbounded | `supported` | --negative-keyword-shared-set-ids |
 | `adgroups.add` | `adgroups.add` | `TrackingParams` | `string` | 0 | 1 | `supported` | --tracking-params |
-| `adgroups.add` | `adgroups.add` | `MobileAppAdGroup` | `MobileAppAdGroupAdd` | 0 | 1 | `missing_followup` | Rare ad group subtype block is not exposed by --type. [#279](https://github.com/axisrow/direct-cli/issues/279) |
-| `adgroups.add` | `adgroups.add` | `MobileAppAdGroup.StoreUrl` | `string` | 1 | 1 | `missing_followup` | Rare ad group subtype block is not exposed by --type. [#279](https://github.com/axisrow/direct-cli/issues/279); inherited from `MobileAppAdGroup` |
-| `adgroups.add` | `adgroups.add` | `MobileAppAdGroup.TargetDeviceType` | `TargetDeviceTypeEnum` | 1 | unbounded | `missing_followup` | Rare ad group subtype block is not exposed by --type. [#279](https://github.com/axisrow/direct-cli/issues/279); inherited from `MobileAppAdGroup` |
-| `adgroups.add` | `adgroups.add` | `MobileAppAdGroup.TargetCarrier` | `TargetCarrierEnum` | 1 | 1 | `missing_followup` | Rare ad group subtype block is not exposed by --type. [#279](https://github.com/axisrow/direct-cli/issues/279); inherited from `MobileAppAdGroup` |
-| `adgroups.add` | `adgroups.add` | `MobileAppAdGroup.TargetOperatingSystemVersion` | `string` | 1 | 1 | `missing_followup` | Rare ad group subtype block is not exposed by --type. [#279](https://github.com/axisrow/direct-cli/issues/279); inherited from `MobileAppAdGroup` |
+| `adgroups.add` | `adgroups.add` | `MobileAppAdGroup` | `MobileAppAdGroupAdd` | 0 | 1 | `supported` | --type |
+| `adgroups.add` | `adgroups.add` | `MobileAppAdGroup.StoreUrl` | `string` | 1 | 1 | `supported` | --store-url |
+| `adgroups.add` | `adgroups.add` | `MobileAppAdGroup.TargetDeviceType` | `TargetDeviceTypeEnum` | 1 | unbounded | `supported` | --target-device-types |
+| `adgroups.add` | `adgroups.add` | `MobileAppAdGroup.TargetCarrier` | `TargetCarrierEnum` | 1 | 1 | `supported` | --target-carrier |
+| `adgroups.add` | `adgroups.add` | `MobileAppAdGroup.TargetOperatingSystemVersion` | `string` | 1 | 1 | `supported` | --target-operating-system-version |
 | `adgroups.add` | `adgroups.add` | `DynamicTextAdGroup` | `DynamicTextAdGroup` | 0 | 1 | `supported` | --type |
 | `adgroups.add` | `adgroups.add` | `DynamicTextAdGroup.AutotargetingCategories` | `AutotargetingCategory` | 0 | unbounded | `missing_followup` | Dynamic text ad group autotargeting categories are not exposed. [#280](https://github.com/axisrow/direct-cli/issues/280) |
 | `adgroups.add` | `adgroups.add` | `DynamicTextAdGroup.AutotargetingCategories.Category` | `AutotargetingCategoriesEnum` | 1 | 1 | `missing_followup` | Dynamic text ad group autotargeting categories are not exposed. [#280](https://github.com/axisrow/direct-cli/issues/280); inherited from `DynamicTextAdGroup.AutotargetingCategories` |
@@ -2814,10 +2805,10 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `adgroups.update` | `adgroups.update` | `TrackingParams` | `string` | 0 | 1 | `supported` | --tracking-params |
 | `adgroups.update` | `adgroups.update` | `Id` | `long` | 1 | 1 | `supported` | covered by minOccurs>=1 parity gate |
 | `adgroups.update` | `adgroups.update` | `Name` | `string` | 0 | 1 | `supported` | --name |
-| `adgroups.update` | `adgroups.update` | `MobileAppAdGroup` | `MobileAppAdGroupUpdate` | 0 | 1 | `missing_followup` | Rare ad group subtype block is not exposed by update. [#279](https://github.com/axisrow/direct-cli/issues/279) |
-| `adgroups.update` | `adgroups.update` | `MobileAppAdGroup.TargetDeviceType` | `TargetDeviceTypeEnum` | 0 | unbounded | `missing_followup` | Rare ad group subtype block is not exposed by update. [#279](https://github.com/axisrow/direct-cli/issues/279); inherited from `MobileAppAdGroup` |
-| `adgroups.update` | `adgroups.update` | `MobileAppAdGroup.TargetCarrier` | `TargetCarrierEnum` | 0 | 1 | `missing_followup` | Rare ad group subtype block is not exposed by update. [#279](https://github.com/axisrow/direct-cli/issues/279); inherited from `MobileAppAdGroup` |
-| `adgroups.update` | `adgroups.update` | `MobileAppAdGroup.TargetOperatingSystemVersion` | `string` | 0 | 1 | `missing_followup` | Rare ad group subtype block is not exposed by update. [#279](https://github.com/axisrow/direct-cli/issues/279); inherited from `MobileAppAdGroup` |
+| `adgroups.update` | `adgroups.update` | `MobileAppAdGroup` | `MobileAppAdGroupUpdate` | 0 | 1 | `supported` | --target-carrier, --target-device-types, --target-operating-system-version |
+| `adgroups.update` | `adgroups.update` | `MobileAppAdGroup.TargetDeviceType` | `TargetDeviceTypeEnum` | 0 | unbounded | `supported` | --target-device-types |
+| `adgroups.update` | `adgroups.update` | `MobileAppAdGroup.TargetCarrier` | `TargetCarrierEnum` | 0 | 1 | `supported` | --target-carrier |
+| `adgroups.update` | `adgroups.update` | `MobileAppAdGroup.TargetOperatingSystemVersion` | `string` | 0 | 1 | `supported` | --target-operating-system-version |
 | `adgroups.update` | `adgroups.update` | `DynamicTextAdGroup` | `DynamicTextAdGroup` | 0 | 1 | `missing_followup` | Dynamic ad group subtype update block has no typed flags. [#280](https://github.com/axisrow/direct-cli/issues/280) |
 | `adgroups.update` | `adgroups.update` | `DynamicTextAdGroup.AutotargetingCategories` | `AutotargetingCategory` | 0 | unbounded | `missing_followup` | Dynamic ad group subtype update block has no typed flags. [#280](https://github.com/axisrow/direct-cli/issues/280); inherited from `DynamicTextAdGroup` |
 | `adgroups.update` | `adgroups.update` | `DynamicTextAdGroup.AutotargetingCategories.Category` | `AutotargetingCategoriesEnum` | 1 | 1 | `missing_followup` | Dynamic ad group subtype update block has no typed flags. [#280](https://github.com/axisrow/direct-cli/issues/280); inherited from `DynamicTextAdGroup` |

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1751,6 +1751,97 @@ def test_adgroups_add_smart_payload_omits_type():
     }
 
 
+def test_adgroups_add_mobile_app_payload_omits_type():
+    """Issue #279: add builds top-level MobileAppAdGroup payload."""
+    body = _dry_run(
+        "adgroups",
+        "add",
+        "--name",
+        "Mobile App Group",
+        "--campaign-id",
+        "111",
+        "--type",
+        "MOBILE_APP_AD_GROUP",
+        "--region-ids",
+        "1,225",
+        "--store-url",
+        "https://apps.apple.com/app/id123456789",
+        "--target-device-types",
+        "device-type-mobile,DEVICE_TYPE_TABLET",
+        "--target-carrier",
+        "wi-fi-and-cellular",
+        "--target-operating-system-version",
+        "14.0",
+    )
+    group = body["params"]["AdGroups"][0]
+    assert "Type" not in group
+    assert group["MobileAppAdGroup"] == {
+        "StoreUrl": "https://apps.apple.com/app/id123456789",
+        "TargetDeviceType": ["DEVICE_TYPE_MOBILE", "DEVICE_TYPE_TABLET"],
+        "TargetCarrier": "WI_FI_AND_CELLULAR",
+        "TargetOperatingSystemVersion": "14.0",
+    }
+
+
+def test_adgroups_add_mobile_app_requires_documented_fields():
+    """Issue #279: WSDL minOccurs=1 mobile add fields are locally required."""
+    required_options = [
+        ("--store-url", "https://apps.apple.com/app/id123456789"),
+        ("--target-device-types", "DEVICE_TYPE_MOBILE"),
+        ("--target-carrier", "WI_FI_ONLY"),
+        ("--target-operating-system-version", "14.0"),
+    ]
+
+    for missing_option, _ in required_options:
+        args = [
+            "adgroups",
+            "add",
+            "--name",
+            "Mobile App Group",
+            "--campaign-id",
+            "111",
+            "--type",
+            "MOBILE_APP_AD_GROUP",
+            "--region-ids",
+            "225",
+        ]
+        for option, value in required_options:
+            if option != missing_option:
+                args.extend([option, value])
+
+        result = _rejected(*args)
+        assert missing_option in result.output
+        assert "required for MOBILE_APP_AD_GROUP" in result.output
+
+
+def test_adgroups_add_mobile_app_rejects_invalid_device_type():
+    """Issue #279: TargetDeviceType is validated against the API enum."""
+    result = _rejected(
+        "adgroups",
+        "add",
+        "--name",
+        "Mobile App Group",
+        "--campaign-id",
+        "111",
+        "--type",
+        "MOBILE_APP_AD_GROUP",
+        "--region-ids",
+        "225",
+        "--store-url",
+        "https://apps.apple.com/app/id123456789",
+        "--target-device-types",
+        "DEVICE_TYPE_DESKTOP",
+        "--target-carrier",
+        "WI_FI_ONLY",
+        "--target-operating-system-version",
+        "14.0",
+    )
+    assert "--target-device-types has invalid value 'DEVICE_TYPE_DESKTOP'" in (
+        result.output
+    )
+    assert "DEVICE_TYPE_MOBILE, DEVICE_TYPE_TABLET" in result.output
+
+
 def test_adgroups_add_rejects_incompatible_subtype_flags():
     text_result = _rejected(
         "adgroups",
@@ -1798,6 +1889,42 @@ def test_adgroups_add_rejects_incompatible_subtype_flags():
         "--domain-url",
         "example.com",
     )
+    text_mobile_result = _rejected(
+        "adgroups",
+        "add",
+        "--name",
+        "Group A",
+        "--campaign-id",
+        "111",
+        "--region-ids",
+        "225",
+        "--type",
+        "TEXT_AD_GROUP",
+        "--store-url",
+        "https://apps.apple.com/app/id123456789",
+    )
+    mobile_result = _rejected(
+        "adgroups",
+        "add",
+        "--name",
+        "Mobile App Group",
+        "--campaign-id",
+        "111",
+        "--region-ids",
+        "225",
+        "--type",
+        "MOBILE_APP_AD_GROUP",
+        "--store-url",
+        "https://apps.apple.com/app/id123456789",
+        "--target-device-types",
+        "DEVICE_TYPE_MOBILE",
+        "--target-carrier",
+        "WI_FI_ONLY",
+        "--target-operating-system-version",
+        "14.0",
+        "--feed-id",
+        "77",
+    )
 
     assert (
         "--domain-url is not compatible with --type TEXT_AD_GROUP" in text_result.output
@@ -1809,6 +1936,14 @@ def test_adgroups_add_rejects_incompatible_subtype_flags():
     assert (
         "--domain-url is not compatible with --type SMART_AD_GROUP"
         in smart_result.output
+    )
+    assert (
+        "--store-url is not compatible with --type TEXT_AD_GROUP"
+        in text_mobile_result.output
+    )
+    assert (
+        "--feed-id is not compatible with --type MOBILE_APP_AD_GROUP"
+        in mobile_result.output
     )
 
 
@@ -1830,6 +1965,46 @@ def test_adgroups_update_tracking_params_payload():
     )
     group = body["params"]["AdGroups"][0]
     assert group == {"Id": 222, "TrackingParams": "utm_source=direct"}
+
+
+def test_adgroups_update_mobile_app_payload_without_type():
+    """Issue #279: update sets top-level MobileAppAdGroup without --type."""
+    body = _dry_run(
+        "adgroups",
+        "update",
+        "--id",
+        "222",
+        "--target-device-types",
+        "device-type-tablet",
+        "--target-carrier",
+        "wi-fi-only",
+        "--target-operating-system-version",
+        "13.0",
+    )
+    group = body["params"]["AdGroups"][0]
+    assert group == {
+        "Id": 222,
+        "MobileAppAdGroup": {
+            "TargetDeviceType": ["DEVICE_TYPE_TABLET"],
+            "TargetCarrier": "WI_FI_ONLY",
+            "TargetOperatingSystemVersion": "13.0",
+        },
+    }
+
+
+def test_adgroups_update_mobile_app_rejects_invalid_carrier():
+    """Issue #279: TargetCarrier is validated against the API enum."""
+    result = _rejected(
+        "adgroups",
+        "update",
+        "--id",
+        "222",
+        "--target-carrier",
+        "CELLULAR_ONLY",
+    )
+    assert "--target-carrier has invalid value 'CELLULAR_ONLY'" in result.output
+    assert "WI_FI_ONLY or WI_FI_AND_CELLULAR" not in result.output
+    assert "WI_FI_ONLY, WI_FI_AND_CELLULAR" in result.output
 
 
 def test_adgroups_update_negative_keywords_payload():
@@ -1935,6 +2110,9 @@ def test_adgroups_update_without_tracking_params_or_other_fields_rejected():
     assert "--tracking-params" in result.output
     assert "--negative-keywords" in result.output
     assert "--negative-keyword-shared-set-ids" in result.output
+    assert "--target-device-types" in result.output
+    assert "--target-carrier" in result.output
+    assert "--target-operating-system-version" in result.output
     assert "requires at least one updatable field" in result.output
 
 

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -633,6 +633,13 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     ("adgroups", "add", "SmartAdGroup.FeedId"): {"--feed-id"},
     ("adgroups", "add", "SmartAdGroup.AdTitleSource"): {"--ad-title-source"},
     ("adgroups", "add", "SmartAdGroup.AdBodySource"): {"--ad-body-source"},
+    ("adgroups", "add", "MobileAppAdGroup"): {"--type"},
+    ("adgroups", "add", "MobileAppAdGroup.StoreUrl"): {"--store-url"},
+    ("adgroups", "add", "MobileAppAdGroup.TargetDeviceType"): {"--target-device-types"},
+    ("adgroups", "add", "MobileAppAdGroup.TargetCarrier"): {"--target-carrier"},
+    ("adgroups", "add", "MobileAppAdGroup.TargetOperatingSystemVersion"): {
+        "--target-operating-system-version"
+    },
     ("adgroups", "add", "NegativeKeywords"): {"--negative-keywords"},
     ("adgroups", "add", "NegativeKeywords.Items"): {"--negative-keywords"},
     ("adgroups", "add", "NegativeKeywordSharedSetIds"): {
@@ -653,6 +660,18 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
         "--negative-keyword-shared-set-ids"
     },
     ("adgroups", "update", "TrackingParams"): {"--tracking-params"},
+    ("adgroups", "update", "MobileAppAdGroup"): {
+        "--target-device-types",
+        "--target-carrier",
+        "--target-operating-system-version",
+    },
+    ("adgroups", "update", "MobileAppAdGroup.TargetDeviceType"): {
+        "--target-device-types"
+    },
+    ("adgroups", "update", "MobileAppAdGroup.TargetCarrier"): {"--target-carrier"},
+    ("adgroups", "update", "MobileAppAdGroup.TargetOperatingSystemVersion"): {
+        "--target-operating-system-version"
+    },
     ("ads", "add", "TextAd"): {"--type"},
     ("ads", "add", "TextAd.VCardId"): {"--vcard-id"},
     ("ads", "add", "TextAd.AdImageHash"): {"--image-hash"},
@@ -1593,11 +1612,6 @@ OPTIONAL_FIELD_AUDIT: dict[tuple[str, str, str], dict[str, str]] = {
             "intentionally reject autotargeting fields."
         ),
     },
-    ("adgroups", "add", "MobileAppAdGroup"): {
-        "status": "missing_followup",
-        "issue": "#279",
-        "note": "Rare ad group subtype block is not exposed by --type.",
-    },
     ("adgroups", "add", "DynamicTextFeedAdGroup"): {
         "status": "missing_followup",
         "issue": "#281",
@@ -1627,11 +1641,6 @@ OPTIONAL_FIELD_AUDIT: dict[tuple[str, str, str], dict[str, str]] = {
         "status": "missing_followup",
         "issue": "#284",
         "note": "Rare ad group feed params block has no typed add flags.",
-    },
-    ("adgroups", "update", "MobileAppAdGroup"): {
-        "status": "missing_followup",
-        "issue": "#279",
-        "note": "Rare ad group subtype block is not exposed by update.",
     },
     ("adgroups", "update", "DynamicTextAdGroup"): {
         "status": "missing_followup",


### PR DESCRIPTION
## Summary
- Closes #279.
- Adds `adgroups add --type MOBILE_APP_AD_GROUP` typed flags for `MobileAppAdGroup.StoreUrl`, `TargetDeviceType`, `TargetCarrier`, and `TargetOperatingSystemVersion`.
- Adds `adgroups update` typed flags for the updateable `MobileAppAdGroup` fields without requiring `--type`.
- Moves the #279 WSDL audit rows from `missing_followup` to supported and adds README examples.

## Docs Checked
- `adgroups.add`: https://yandex.com/dev/direct/doc/en/adgroups/add confirms `MobileAppAdGroup` is a top-level `AdGroupAddItem` block and its four fields are required.
- `adgroups.update`: https://yandex.ru/dev/direct/doc/ru/adgroups/update confirms `MobileAppAdGroup` is a top-level update block and only target device/carrier/OS version are updateable.

## Verification
- `python3 -m pytest tests/test_dry_run.py -k "adgroups and mobile"`
- `python3 -m pytest tests/test_dry_run.py -k adgroups`
- `python3 scripts/build_wsdl_optional_field_audit.py --check`
- `python3 -m pytest tests/test_wsdl_parity_gate.py`
- `python3 -m pytest tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py`
- `mypy .`
- `git diff --check`