### PR TITLE
[codex] Add CPM adgroup subtype flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,9 @@ direct adgroups get --campaign-ids 1,2,3 --limit 50
 direct adgroups add --name "Group 1" --campaign-id 12345 --region-ids 1,225 --negative-keywords "repair,used" --tracking-params "utm_source=direct" --dry-run
 direct adgroups add --name "Dynamic Group" --campaign-id 12345 --type DYNAMIC_TEXT_AD_GROUP --region-ids 1,225 --domain-url example.com --autotargeting-category EXACT=YES --dry-run
 direct adgroups add --name "Dynamic Feed Group" --campaign-id 12345 --type DYNAMIC_TEXT_FEED_AD_GROUP --region-ids 1,225 --feed-id 170 --autotargeting-category EXACT=YES --dry-run
+direct adgroups add --name "CPM Keywords Group" --campaign-id 12345 --type CPM_BANNER_KEYWORDS_AD_GROUP --region-ids 1,225 --dry-run
+direct adgroups add --name "CPM User Profile Group" --campaign-id 12345 --type CPM_BANNER_USER_PROFILE_AD_GROUP --region-ids 1,225 --dry-run
+direct adgroups add --name "CPM Video Group" --campaign-id 12345 --type CPM_VIDEO_AD_GROUP --region-ids 1,225 --dry-run
 direct adgroups add --name "Smart Group" --campaign-id 12345 --type SMART_AD_GROUP --region-ids 1,225 --feed-id 170 --ad-title-source FEED_NAME --ad-body-source FEED_NAME --dry-run
 direct adgroups add --name "Mobile App Group" --campaign-id 12345 --type MOBILE_APP_AD_GROUP --region-ids 1,225 --store-url https://apps.apple.com/app/id123456789 --target-device-types DEVICE_TYPE_MOBILE,DEVICE_TYPE_TABLET --target-carrier WI_FI_AND_CELLULAR --target-operating-system-version 14.0 --dry-run
 direct adgroups update --id 67890 --negative-keyword-shared-set-ids 10,11 --tracking-params "utm_source=direct"
@@ -1104,6 +1107,9 @@ direct adgroups get --campaign-ids 1,2,3 --limit 50
 direct adgroups add --name "Группа 1" --campaign-id 12345 --region-ids 1,225 --negative-keywords "ремонт,б/у" --tracking-params "utm_source=direct" --dry-run
 direct adgroups add --name "Динамическая группа" --campaign-id 12345 --type DYNAMIC_TEXT_AD_GROUP --region-ids 1,225 --domain-url example.com --autotargeting-category EXACT=YES --dry-run
 direct adgroups add --name "Динамическая группа с фидом" --campaign-id 12345 --type DYNAMIC_TEXT_FEED_AD_GROUP --region-ids 1,225 --feed-id 170 --autotargeting-category EXACT=YES --dry-run
+direct adgroups add --name "CPM группа с ключевыми фразами" --campaign-id 12345 --type CPM_BANNER_KEYWORDS_AD_GROUP --region-ids 1,225 --dry-run
+direct adgroups add --name "CPM группа с профилем пользователя" --campaign-id 12345 --type CPM_BANNER_USER_PROFILE_AD_GROUP --region-ids 1,225 --dry-run
+direct adgroups add --name "CPM видео группа" --campaign-id 12345 --type CPM_VIDEO_AD_GROUP --region-ids 1,225 --dry-run
 direct adgroups add --name "Смарт-группа" --campaign-id 12345 --type SMART_AD_GROUP --region-ids 1,225 --feed-id 170 --ad-title-source FEED_NAME --ad-body-source FEED_NAME --dry-run
 direct adgroups add --name "Группа мобильного приложения" --campaign-id 12345 --type MOBILE_APP_AD_GROUP --region-ids 1,225 --store-url https://apps.apple.com/app/id123456789 --target-device-types DEVICE_TYPE_MOBILE,DEVICE_TYPE_TABLET --target-carrier WI_FI_AND_CELLULAR --target-operating-system-version 14.0 --dry-run
 direct adgroups update --id 67890 --negative-keyword-shared-set-ids 10,11 --tracking-params "utm_source=direct"

--- a/direct_cli/commands/adgroups.py
+++ b/direct_cli/commands/adgroups.py
@@ -92,11 +92,9 @@ def _reject_unsupported_negative_keywords(
         return
 
     unsupported_flags = []
-    if parse_csv_strings(negative_keywords):
+    if negative_keywords is not None:
         unsupported_flags.append("--negative-keywords")
-    if _parse_ids_option(
-        negative_keyword_shared_set_ids, "--negative-keyword-shared-set-ids"
-    ):
+    if negative_keyword_shared_set_ids is not None:
         unsupported_flags.append("--negative-keyword-shared-set-ids")
 
     if unsupported_flags:
@@ -606,13 +604,17 @@ def get(
 )
 @click.option(
     "--negative-keywords",
-    help="Comma-separated ad-group negative keywords for NegativeKeywords.Items",
+    help=(
+        "Comma-separated ad-group negative keywords for NegativeKeywords.Items; "
+        "not compatible with CPM user-profile or video groups"
+    ),
 )
 @click.option(
     "--negative-keyword-shared-set-ids",
     help=(
         "Comma-separated negative keyword shared set IDs for "
-        "NegativeKeywordSharedSetIds.Items"
+        "NegativeKeywordSharedSetIds.Items; not compatible with CPM "
+        "user-profile or video groups"
     ),
 )
 @click.option(

--- a/direct_cli/commands/adgroups.py
+++ b/direct_cli/commands/adgroups.py
@@ -20,9 +20,16 @@ _SUPPORTED_ADGROUP_TYPES = (
     "TEXT_AD_GROUP",
     "DYNAMIC_TEXT_AD_GROUP",
     "DYNAMIC_TEXT_FEED_AD_GROUP",
+    "CPM_BANNER_KEYWORDS_AD_GROUP",
+    "CPM_BANNER_USER_PROFILE_AD_GROUP",
+    "CPM_VIDEO_AD_GROUP",
     "SMART_AD_GROUP",
     "MOBILE_APP_AD_GROUP",
 )
+_NEGATIVE_KEYWORDS_UNSUPPORTED_ADGROUP_TYPES = {
+    "CPM_BANNER_USER_PROFILE_AD_GROUP",
+    "CPM_VIDEO_AD_GROUP",
+}
 _TARGET_DEVICE_TYPES = ("DEVICE_TYPE_MOBILE", "DEVICE_TYPE_TABLET")
 _TARGET_CARRIERS = ("WI_FI_ONLY", "WI_FI_AND_CELLULAR")
 _AUTOTARGETING_CATEGORIES = (
@@ -71,6 +78,31 @@ def _validate_tracking_params(tracking_params: Optional[str]) -> None:
         raise click.UsageError(
             "--tracking-params must be at most "
             f"{_TRACKING_PARAMS_MAX_LENGTH} characters"
+        )
+
+
+def _reject_unsupported_negative_keywords(
+    group_type: str,
+    *,
+    negative_keywords: Optional[str],
+    negative_keyword_shared_set_ids: Optional[str],
+) -> None:
+    """Reject negative keyword flags for ad group types that docs disallow."""
+    if group_type not in _NEGATIVE_KEYWORDS_UNSUPPORTED_ADGROUP_TYPES:
+        return
+
+    unsupported_flags = []
+    if parse_csv_strings(negative_keywords):
+        unsupported_flags.append("--negative-keywords")
+    if _parse_ids_option(
+        negative_keyword_shared_set_ids, "--negative-keyword-shared-set-ids"
+    ):
+        unsupported_flags.append("--negative-keyword-shared-set-ids")
+
+    if unsupported_flags:
+        raise click.UsageError(
+            f"{', '.join(unsupported_flags)} is not compatible with --type "
+            f"{group_type}."
         )
 
 
@@ -480,7 +512,9 @@ def get(
     default="TEXT_AD_GROUP",
     help=(
         "Ad group type: TEXT_AD_GROUP, DYNAMIC_TEXT_AD_GROUP, "
-        "DYNAMIC_TEXT_FEED_AD_GROUP, SMART_AD_GROUP, or MOBILE_APP_AD_GROUP"
+        "DYNAMIC_TEXT_FEED_AD_GROUP, CPM_BANNER_KEYWORDS_AD_GROUP, "
+        "CPM_BANNER_USER_PROFILE_AD_GROUP, CPM_VIDEO_AD_GROUP, "
+        "SMART_AD_GROUP, or MOBILE_APP_AD_GROUP"
     ),
 )
 @click.option(
@@ -634,6 +668,9 @@ def add(
             "TEXT_AD_GROUP": set(),
             "DYNAMIC_TEXT_AD_GROUP": _DYNAMIC_TEXT_ADGROUP_FLAGS,
             "DYNAMIC_TEXT_FEED_AD_GROUP": _DYNAMIC_TEXT_FEED_ADGROUP_FLAGS,
+            "CPM_BANNER_KEYWORDS_AD_GROUP": set(),
+            "CPM_BANNER_USER_PROFILE_AD_GROUP": set(),
+            "CPM_VIDEO_AD_GROUP": set(),
             "SMART_AD_GROUP": {"--feed-id", "--ad-title-source", "--ad-body-source"},
             "MOBILE_APP_AD_GROUP": {
                 "--store-url",
@@ -674,6 +711,11 @@ def add(
                 "--target-carrier": target_carrier,
                 "--target-operating-system-version": target_operating_system_version,
             },
+        )
+        _reject_unsupported_negative_keywords(
+            group_type_norm,
+            negative_keywords=negative_keywords,
+            negative_keyword_shared_set_ids=negative_keyword_shared_set_ids,
         )
 
         adgroup_data = {"Name": name, "CampaignId": campaign_id}
@@ -723,6 +765,12 @@ def add(
             )
             if dynamic_text_feed_adgroup:
                 adgroup_data["DynamicTextFeedAdGroup"] = dynamic_text_feed_adgroup
+        elif group_type_norm == "CPM_BANNER_KEYWORDS_AD_GROUP":
+            adgroup_data["CpmBannerKeywordsAdGroup"] = {}
+        elif group_type_norm == "CPM_BANNER_USER_PROFILE_AD_GROUP":
+            adgroup_data["CpmBannerUserProfileAdGroup"] = {}
+        elif group_type_norm == "CPM_VIDEO_AD_GROUP":
+            adgroup_data["CpmVideoAdGroup"] = {}
         elif group_type_norm == "SMART_AD_GROUP":
             if feed_id is None:
                 raise click.UsageError("--feed-id is required for SMART_AD_GROUP")

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,9 +11,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 2652 |
+| `missing_followup` | 2649 |
 | `not_applicable` | 23 |
-| `supported` | 566 |
+| `supported` | 569 |
 
 ## Confirmed Follow-Ups
 
@@ -30,9 +30,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `adgroups.add` | `DynamicTextFeedAdGroup.AutotargetingSettings.BrandOptions.WithoutBrands` | Official adgroups.add docs for DynamicTextFeedAdGroupAdd list FeedId and AutotargetingCategories only. [#281](https://github.com/axisrow/direct-cli/issues/281); inherited from `DynamicTextFeedAdGroup.AutotargetingSettings` |
 | `adgroups.add` | `DynamicTextFeedAdGroup.AutotargetingSettings.BrandOptions.WithAdvertiserBrand` | Official adgroups.add docs for DynamicTextFeedAdGroupAdd list FeedId and AutotargetingCategories only. [#281](https://github.com/axisrow/direct-cli/issues/281); inherited from `DynamicTextFeedAdGroup.AutotargetingSettings` |
 | `adgroups.add` | `DynamicTextFeedAdGroup.AutotargetingSettings.BrandOptions.WithCompetitorsBrand` | Official adgroups.add docs for DynamicTextFeedAdGroupAdd list FeedId and AutotargetingCategories only. [#281](https://github.com/axisrow/direct-cli/issues/281); inherited from `DynamicTextFeedAdGroup.AutotargetingSettings` |
-| `adgroups.add` | `CpmBannerKeywordsAdGroup` | Rare ad group subtype block is not exposed by --type. [#282](https://github.com/axisrow/direct-cli/issues/282) |
-| `adgroups.add` | `CpmBannerUserProfileAdGroup` | Rare ad group subtype block is not exposed by --type. [#282](https://github.com/axisrow/direct-cli/issues/282) |
-| `adgroups.add` | `CpmVideoAdGroup` | Rare ad group subtype block is not exposed by --type. [#282](https://github.com/axisrow/direct-cli/issues/282) |
 | `adgroups.add` | `UnifiedAdGroup` | Rare ad group subtype block is not exposed by --type. [#283](https://github.com/axisrow/direct-cli/issues/283) |
 | `adgroups.add` | `UnifiedAdGroup.OfferRetargeting` | Rare ad group subtype block is not exposed by --type. [#283](https://github.com/axisrow/direct-cli/issues/283); inherited from `UnifiedAdGroup` |
 | `adgroups.add` | `TextAdGroupFeedParams` | Rare ad group feed params block has no typed add flags. [#284](https://github.com/axisrow/direct-cli/issues/284) |
@@ -2746,9 +2743,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `adgroups.add` | `adgroups.add` | `DynamicTextFeedAdGroup.AutotargetingSettings.BrandOptions.WithAdvertiserBrand` | `YesNoEnum` | 0 | 1 | `not_applicable` | Official adgroups.add docs for DynamicTextFeedAdGroupAdd list FeedId and AutotargetingCategories only. [#281](https://github.com/axisrow/direct-cli/issues/281); inherited from `DynamicTextFeedAdGroup.AutotargetingSettings` |
 | `adgroups.add` | `adgroups.add` | `DynamicTextFeedAdGroup.AutotargetingSettings.BrandOptions.WithCompetitorsBrand` | `YesNoEnum` | 0 | 1 | `not_applicable` | Official adgroups.add docs for DynamicTextFeedAdGroupAdd list FeedId and AutotargetingCategories only. [#281](https://github.com/axisrow/direct-cli/issues/281); inherited from `DynamicTextFeedAdGroup.AutotargetingSettings` |
 | `adgroups.add` | `adgroups.add` | `DynamicTextFeedAdGroup.FeedId` | `long` | 1 | 1 | `supported` | --feed-id |
-| `adgroups.add` | `adgroups.add` | `CpmBannerKeywordsAdGroup` | `CpmBannerKeywordsAdGroupAdd` | 0 | 1 | `missing_followup` | Rare ad group subtype block is not exposed by --type. [#282](https://github.com/axisrow/direct-cli/issues/282) |
-| `adgroups.add` | `adgroups.add` | `CpmBannerUserProfileAdGroup` | `CpmBannerUserProfileAdGroupAdd` | 0 | 1 | `missing_followup` | Rare ad group subtype block is not exposed by --type. [#282](https://github.com/axisrow/direct-cli/issues/282) |
-| `adgroups.add` | `adgroups.add` | `CpmVideoAdGroup` | `CpmVideoAdGroupAdd` | 0 | 1 | `missing_followup` | Rare ad group subtype block is not exposed by --type. [#282](https://github.com/axisrow/direct-cli/issues/282) |
+| `adgroups.add` | `adgroups.add` | `CpmBannerKeywordsAdGroup` | `CpmBannerKeywordsAdGroupAdd` | 0 | 1 | `supported` | --type |
+| `adgroups.add` | `adgroups.add` | `CpmBannerUserProfileAdGroup` | `CpmBannerUserProfileAdGroupAdd` | 0 | 1 | `supported` | --type |
+| `adgroups.add` | `adgroups.add` | `CpmVideoAdGroup` | `CpmVideoAdGroupAdd` | 0 | 1 | `supported` | --type |
 | `adgroups.add` | `adgroups.add` | `SmartAdGroup` | `SmartAdGroupAdd` | 0 | 1 | `supported` | --type |
 | `adgroups.add` | `adgroups.add` | `SmartAdGroup.FeedId` | `long` | 1 | 1 | `supported` | --feed-id |
 | `adgroups.add` | `adgroups.add` | `SmartAdGroup.AdTitleSource` | `string` | 0 | 1 | `supported` | --ad-title-source |

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1951,6 +1951,30 @@ def test_adgroups_add_cpm_banner_keywords_payload_omits_type():
     assert group["CpmBannerKeywordsAdGroup"] == {}
 
 
+def test_adgroups_add_cpm_banner_keywords_accepts_negative_keywords():
+    """Issue #282: CPM banner keyword groups still accept negative keywords."""
+    body = _dry_run(
+        "adgroups",
+        "add",
+        "--name",
+        "CPM Keywords Group",
+        "--campaign-id",
+        "111",
+        "--type",
+        "CPM_BANNER_KEYWORDS_AD_GROUP",
+        "--region-ids",
+        "225",
+        "--negative-keywords",
+        "used,repair",
+        "--negative-keyword-shared-set-ids",
+        "10",
+    )
+    group = body["params"]["AdGroups"][0]
+    assert group["CpmBannerKeywordsAdGroup"] == {}
+    assert group["NegativeKeywords"] == {"Items": ["used", "repair"]}
+    assert group["NegativeKeywordSharedSetIds"] == {"Items": [10]}
+
+
 def test_adgroups_add_cpm_banner_user_profile_payload_omits_type():
     """Issue #282: CPM user-profile subtype sends an empty block."""
     body = _dry_run(
@@ -1969,6 +1993,28 @@ def test_adgroups_add_cpm_banner_user_profile_payload_omits_type():
     assert "Type" not in group
     assert group["RegionIds"] == [1, 225]
     assert group["CpmBannerUserProfileAdGroup"] == {}
+
+
+def test_adgroups_add_cpm_user_profile_rejects_empty_negative_keyword_flag():
+    """Issue #282: disallowed negative keyword flags reject even empty values."""
+    result = _rejected(
+        "adgroups",
+        "add",
+        "--name",
+        "CPM User Profile Group",
+        "--campaign-id",
+        "111",
+        "--type",
+        "CPM_BANNER_USER_PROFILE_AD_GROUP",
+        "--region-ids",
+        "225",
+        "--negative-keywords",
+        "",
+    )
+    assert (
+        "--negative-keywords is not compatible with --type "
+        "CPM_BANNER_USER_PROFILE_AD_GROUP"
+    ) in result.output
 
 
 def test_adgroups_add_cpm_video_payload_omits_type():
@@ -2033,6 +2079,29 @@ def test_adgroups_add_cpm_video_rejects_negative_keyword_shared_sets():
         "--negative-keyword-shared-set-ids is not compatible with --type "
         "CPM_VIDEO_AD_GROUP"
     ) in result.output
+
+
+def test_adgroups_add_cpm_video_rejects_negative_keyword_shared_sets_before_parse():
+    """Issue #282: type incompatibility wins over shared-set ID parsing."""
+    result = _rejected(
+        "adgroups",
+        "add",
+        "--name",
+        "CPM Video Group",
+        "--campaign-id",
+        "111",
+        "--type",
+        "CPM_VIDEO_AD_GROUP",
+        "--region-ids",
+        "225",
+        "--negative-keyword-shared-set-ids",
+        "notanumber",
+    )
+    assert (
+        "--negative-keyword-shared-set-ids is not compatible with --type "
+        "CPM_VIDEO_AD_GROUP"
+    ) in result.output
+    assert "Invalid ID" not in result.output
 
 
 def test_adgroups_add_smart_payload_omits_type():

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1931,6 +1931,110 @@ def test_adgroups_add_dynamic_feed_rejects_undocumented_settings():
     ) in result.output
 
 
+def test_adgroups_add_cpm_banner_keywords_payload_omits_type():
+    """Issue #282: CPM banner keyword subtype sends an empty block."""
+    body = _dry_run(
+        "adgroups",
+        "add",
+        "--name",
+        "CPM Keywords Group",
+        "--campaign-id",
+        "111",
+        "--type",
+        "CPM_BANNER_KEYWORDS_AD_GROUP",
+        "--region-ids",
+        "1,225",
+    )
+    group = body["params"]["AdGroups"][0]
+    assert "Type" not in group
+    assert group["RegionIds"] == [1, 225]
+    assert group["CpmBannerKeywordsAdGroup"] == {}
+
+
+def test_adgroups_add_cpm_banner_user_profile_payload_omits_type():
+    """Issue #282: CPM user-profile subtype sends an empty block."""
+    body = _dry_run(
+        "adgroups",
+        "add",
+        "--name",
+        "CPM User Profile Group",
+        "--campaign-id",
+        "111",
+        "--type",
+        "CPM_BANNER_USER_PROFILE_AD_GROUP",
+        "--region-ids",
+        "1,225",
+    )
+    group = body["params"]["AdGroups"][0]
+    assert "Type" not in group
+    assert group["RegionIds"] == [1, 225]
+    assert group["CpmBannerUserProfileAdGroup"] == {}
+
+
+def test_adgroups_add_cpm_video_payload_omits_type():
+    """Issue #282: CPM video subtype sends an empty block."""
+    body = _dry_run(
+        "adgroups",
+        "add",
+        "--name",
+        "CPM Video Group",
+        "--campaign-id",
+        "111",
+        "--type",
+        "CPM_VIDEO_AD_GROUP",
+        "--region-ids",
+        "1,225",
+    )
+    group = body["params"]["AdGroups"][0]
+    assert "Type" not in group
+    assert group["RegionIds"] == [1, 225]
+    assert group["CpmVideoAdGroup"] == {}
+
+
+def test_adgroups_add_cpm_user_profile_rejects_negative_keywords():
+    """Issue #282: docs disallow negative keywords for user-profile CPM groups."""
+    result = _rejected(
+        "adgroups",
+        "add",
+        "--name",
+        "CPM User Profile Group",
+        "--campaign-id",
+        "111",
+        "--type",
+        "CPM_BANNER_USER_PROFILE_AD_GROUP",
+        "--region-ids",
+        "225",
+        "--negative-keywords",
+        "used",
+    )
+    assert (
+        "--negative-keywords is not compatible with --type "
+        "CPM_BANNER_USER_PROFILE_AD_GROUP"
+    ) in result.output
+
+
+def test_adgroups_add_cpm_video_rejects_negative_keyword_shared_sets():
+    """Issue #282: docs disallow negative keyword sets for CPM video groups."""
+    result = _rejected(
+        "adgroups",
+        "add",
+        "--name",
+        "CPM Video Group",
+        "--campaign-id",
+        "111",
+        "--type",
+        "CPM_VIDEO_AD_GROUP",
+        "--region-ids",
+        "225",
+        "--negative-keyword-shared-set-ids",
+        "10",
+    )
+    assert (
+        "--negative-keyword-shared-set-ids is not compatible with --type "
+        "CPM_VIDEO_AD_GROUP"
+    ) in result.output
+
+
 def test_adgroups_add_smart_payload_omits_type():
     body = _dry_run(
         "adgroups",
@@ -2147,6 +2251,20 @@ def test_adgroups_add_rejects_incompatible_subtype_flags():
         "--feed-id",
         "77",
     )
+    cpm_result = _rejected(
+        "adgroups",
+        "add",
+        "--name",
+        "CPM Keywords Group",
+        "--campaign-id",
+        "111",
+        "--region-ids",
+        "225",
+        "--type",
+        "CPM_BANNER_KEYWORDS_AD_GROUP",
+        "--domain-url",
+        "example.com",
+    )
 
     assert (
         "--domain-url is not compatible with --type TEXT_AD_GROUP" in text_result.output
@@ -2170,6 +2288,10 @@ def test_adgroups_add_rejects_incompatible_subtype_flags():
     assert (
         "--feed-id is not compatible with --type MOBILE_APP_AD_GROUP"
         in mobile_result.output
+    )
+    assert (
+        "--domain-url is not compatible with --type CPM_BANNER_KEYWORDS_AD_GROUP"
+        in cpm_result.output
     )
 
 

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -680,6 +680,9 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     ("adgroups", "add", "DynamicTextFeedAdGroup.AutotargetingCategories.Value"): {
         "--autotargeting-category"
     },
+    ("adgroups", "add", "CpmBannerKeywordsAdGroup"): {"--type"},
+    ("adgroups", "add", "CpmBannerUserProfileAdGroup"): {"--type"},
+    ("adgroups", "add", "CpmVideoAdGroup"): {"--type"},
     ("adgroups", "add", "SmartAdGroup"): {"--type"},
     ("adgroups", "add", "SmartAdGroup.FeedId"): {"--feed-id"},
     ("adgroups", "add", "SmartAdGroup.AdTitleSource"): {"--ad-title-source"},
@@ -1810,21 +1813,6 @@ OPTIONAL_FIELD_AUDIT: dict[tuple[str, str, str], dict[str, str]] = {
             "Official adgroups.add docs for DynamicTextFeedAdGroupAdd list "
             "FeedId and AutotargetingCategories only."
         ),
-    },
-    ("adgroups", "add", "CpmBannerKeywordsAdGroup"): {
-        "status": "missing_followup",
-        "issue": "#282",
-        "note": "Rare ad group subtype block is not exposed by --type.",
-    },
-    ("adgroups", "add", "CpmBannerUserProfileAdGroup"): {
-        "status": "missing_followup",
-        "issue": "#282",
-        "note": "Rare ad group subtype block is not exposed by --type.",
-    },
-    ("adgroups", "add", "CpmVideoAdGroup"): {
-        "status": "missing_followup",
-        "issue": "#282",
-        "note": "Rare ad group subtype block is not exposed by --type.",
     },
     ("adgroups", "add", "UnifiedAdGroup"): {
         "status": "missing_followup",


### PR DESCRIPTION
## Summary
- add canonical typed `--type` values for `CPM_BANNER_KEYWORDS_AD_GROUP`, `CPM_BANNER_USER_PROFILE_AD_GROUP`, and `CPM_VIDEO_AD_GROUP`
- emit the documented top-level empty `CpmBannerKeywordsAdGroup`, `CpmBannerUserProfileAdGroup`, and `CpmVideoAdGroup` add blocks without public `--json`
- reject negative keyword flags for CPM user-profile/video groups where the docs disallow them
- update dry-run tests, WSDL parity routing/audit, and single-line README examples

## Docs boundary
- `adgroups.add` docs list these CPM add subtype blocks as empty objects: https://yandex.com/dev/direct/doc/en/adgroups/add
- `adgroups.update` / cached WSDL do not expose CPM banner/video update subtype blocks, so this PR is add-only for #282.

## Validation
- `python3 -m pytest tests/test_dry_run.py -k "adgroups and cpm"`
- `python3 -m pytest tests/test_dry_run.py -k adgroups`
- `python3 scripts/build_wsdl_optional_field_audit.py --check`
- `python3 -m pytest tests/test_wsdl_parity_gate.py`
- `python3 -m pytest tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py`
- `mypy .`
- `git diff --check`

Closes #282