### PR TITLE
[codex] Add text adgroup feed params flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ direct campaigns delete --id 12345
 ```bash
 direct adgroups get --campaign-ids 1,2,3 --limit 50
 direct adgroups add --name "Group 1" --campaign-id 12345 --region-ids 1,225 --negative-keywords "repair,used" --tracking-params "utm_source=direct" --dry-run
+direct adgroups add --name "Text Feed Group" --campaign-id 12345 --region-ids 1,225 --feed-id 170 --feed-category-ids 10,11 --dry-run
 direct adgroups add --name "Dynamic Group" --campaign-id 12345 --type DYNAMIC_TEXT_AD_GROUP --region-ids 1,225 --domain-url example.com --autotargeting-category EXACT=YES --dry-run
 direct adgroups add --name "Dynamic Feed Group" --campaign-id 12345 --type DYNAMIC_TEXT_FEED_AD_GROUP --region-ids 1,225 --feed-id 170 --autotargeting-category EXACT=YES --dry-run
 direct adgroups add --name "CPM Keywords Group" --campaign-id 12345 --type CPM_BANNER_KEYWORDS_AD_GROUP --region-ids 1,225 --dry-run
@@ -389,6 +390,7 @@ direct adgroups add --name "Smart Group" --campaign-id 12345 --type SMART_AD_GRO
 direct adgroups add --name "Unified Group" --campaign-id 12345 --type UNIFIED_AD_GROUP --region-ids 1,225 --offer-retargeting YES --dry-run
 direct adgroups add --name "Mobile App Group" --campaign-id 12345 --type MOBILE_APP_AD_GROUP --region-ids 1,225 --store-url https://apps.apple.com/app/id123456789 --target-device-types DEVICE_TYPE_MOBILE,DEVICE_TYPE_TABLET --target-carrier WI_FI_AND_CELLULAR --target-operating-system-version 14.0 --dry-run
 direct adgroups update --id 67890 --negative-keyword-shared-set-ids 10,11 --tracking-params "utm_source=direct"
+direct adgroups update --id 67890 --feed-id 170 --feed-category-ids 10,11
 direct adgroups update --id 67890 --domain-url example.com --autotargeting-settings-exact YES --autotargeting-settings-without-brands YES --dry-run
 direct adgroups update --id 67890 --dynamic-feed --autotargeting-category EXACT=YES --dry-run
 direct adgroups update --id 67890 --target-device-types DEVICE_TYPE_TABLET --target-carrier WI_FI_ONLY --target-operating-system-version 13.0
@@ -1108,6 +1110,7 @@ direct campaigns delete --id 12345
 ```bash
 direct adgroups get --campaign-ids 1,2,3 --limit 50
 direct adgroups add --name "Группа 1" --campaign-id 12345 --region-ids 1,225 --negative-keywords "ремонт,б/у" --tracking-params "utm_source=direct" --dry-run
+direct adgroups add --name "ТГО-группа с фидом" --campaign-id 12345 --region-ids 1,225 --feed-id 170 --feed-category-ids 10,11 --dry-run
 direct adgroups add --name "Динамическая группа" --campaign-id 12345 --type DYNAMIC_TEXT_AD_GROUP --region-ids 1,225 --domain-url example.com --autotargeting-category EXACT=YES --dry-run
 direct adgroups add --name "Динамическая группа с фидом" --campaign-id 12345 --type DYNAMIC_TEXT_FEED_AD_GROUP --region-ids 1,225 --feed-id 170 --autotargeting-category EXACT=YES --dry-run
 direct adgroups add --name "CPM группа с ключевыми фразами" --campaign-id 12345 --type CPM_BANNER_KEYWORDS_AD_GROUP --region-ids 1,225 --dry-run
@@ -1117,6 +1120,7 @@ direct adgroups add --name "Смарт-группа" --campaign-id 12345 --type 
 direct adgroups add --name "ЕПК-группа" --campaign-id 12345 --type UNIFIED_AD_GROUP --region-ids 1,225 --offer-retargeting YES --dry-run
 direct adgroups add --name "Группа мобильного приложения" --campaign-id 12345 --type MOBILE_APP_AD_GROUP --region-ids 1,225 --store-url https://apps.apple.com/app/id123456789 --target-device-types DEVICE_TYPE_MOBILE,DEVICE_TYPE_TABLET --target-carrier WI_FI_AND_CELLULAR --target-operating-system-version 14.0 --dry-run
 direct adgroups update --id 67890 --negative-keyword-shared-set-ids 10,11 --tracking-params "utm_source=direct"
+direct adgroups update --id 67890 --feed-id 170 --feed-category-ids 10,11
 direct adgroups update --id 67890 --domain-url example.com --autotargeting-settings-exact YES --autotargeting-settings-without-brands YES --dry-run
 direct adgroups update --id 67890 --dynamic-feed --autotargeting-category EXACT=YES --dry-run
 direct adgroups update --id 67890 --target-device-types DEVICE_TYPE_TABLET --target-carrier WI_FI_ONLY --target-operating-system-version 13.0

--- a/direct_cli/commands/adgroups.py
+++ b/direct_cli/commands/adgroups.py
@@ -632,7 +632,8 @@ def get(
     type=int,
     help=(
         "TextAdGroupFeedParams.FeedId, SmartAdGroup.FeedId, or "
-        "DynamicTextFeedAdGroup.FeedId"
+        "DynamicTextFeedAdGroup.FeedId; required for SMART_AD_GROUP and "
+        "DYNAMIC_TEXT_FEED_AD_GROUP"
     ),
 )
 @click.option(

--- a/direct_cli/commands/adgroups.py
+++ b/direct_cli/commands/adgroups.py
@@ -64,6 +64,10 @@ _DYNAMIC_TEXT_FEED_ADGROUP_FLAGS = {
     "--feed-id",
     "--autotargeting-category",
 }
+_TEXT_ADGROUP_FEED_PARAMS_FLAGS = {
+    "--feed-id",
+    "--feed-category-ids",
+}
 
 
 @click.group()
@@ -358,6 +362,28 @@ def _build_dynamic_text_feed_adgroup(
     return dynamic_text_feed_adgroup or None
 
 
+def _build_text_adgroup_feed_params(
+    *,
+    feed_id: Optional[int],
+    feed_category_ids: Optional[str],
+) -> Optional[dict[str, object]]:
+    """Build TextAdGroupFeedParams from typed feed flags."""
+    parsed_feed_category_ids = _parse_ids_option(
+        feed_category_ids,
+        "--feed-category-ids",
+    )
+
+    if feed_id is None and parsed_feed_category_ids:
+        raise click.UsageError("--feed-id is required when --feed-category-ids is used")
+    if feed_id is None:
+        return None
+
+    feed_params: dict[str, object] = {"FeedId": feed_id}
+    if parsed_feed_category_ids:
+        feed_params["FeedCategoryIds"] = {"Items": parsed_feed_category_ids}
+    return feed_params
+
+
 def _reject_incompatible_flags(
     group_type: str,
     allowed_flags: set[str],
@@ -605,9 +631,13 @@ def get(
     "--feed-id",
     type=int,
     help=(
-        "SmartAdGroup.FeedId or DynamicTextFeedAdGroup.FeedId; "
-        "required for SMART_AD_GROUP and DYNAMIC_TEXT_FEED_AD_GROUP"
+        "TextAdGroupFeedParams.FeedId, SmartAdGroup.FeedId, or "
+        "DynamicTextFeedAdGroup.FeedId"
     ),
+)
+@click.option(
+    "--feed-category-ids",
+    help="Comma-separated TextAdGroupFeedParams.FeedCategoryIds item IDs",
 )
 @click.option("--ad-title-source", help="Smart ad group title source")
 @click.option("--ad-body-source", help="Smart ad group body source")
@@ -677,6 +707,7 @@ def add(
     autotargeting_settings_with_advertiser_brand,
     autotargeting_settings_with_competitors_brand,
     feed_id,
+    feed_category_ids,
     ad_title_source,
     ad_body_source,
     offer_retargeting,
@@ -701,7 +732,7 @@ def add(
                 f"{', '.join(repr(value) for value in _SUPPORTED_ADGROUP_TYPES)}."
             )
         allowed_flags_by_type = {
-            "TEXT_AD_GROUP": set(),
+            "TEXT_AD_GROUP": _TEXT_ADGROUP_FEED_PARAMS_FLAGS,
             "DYNAMIC_TEXT_AD_GROUP": _DYNAMIC_TEXT_ADGROUP_FLAGS,
             "DYNAMIC_TEXT_FEED_AD_GROUP": _DYNAMIC_TEXT_FEED_ADGROUP_FLAGS,
             "CPM_BANNER_KEYWORDS_AD_GROUP": set(),
@@ -741,6 +772,7 @@ def add(
                     autotargeting_settings_with_competitors_brand
                 ),
                 "--feed-id": feed_id,
+                "--feed-category-ids": feed_category_ids,
                 "--ad-title-source": ad_title_source,
                 "--ad-body-source": ad_body_source,
                 "--offer-retargeting": offer_retargeting,
@@ -773,7 +805,14 @@ def add(
             }
         if tracking_params:
             adgroup_data["TrackingParams"] = tracking_params
-        if group_type_norm == "DYNAMIC_TEXT_AD_GROUP":
+        if group_type_norm == "TEXT_AD_GROUP":
+            text_adgroup_feed_params = _build_text_adgroup_feed_params(
+                feed_id=feed_id,
+                feed_category_ids=feed_category_ids,
+            )
+            if text_adgroup_feed_params:
+                adgroup_data["TextAdGroupFeedParams"] = text_adgroup_feed_params
+        elif group_type_norm == "DYNAMIC_TEXT_AD_GROUP":
             dynamic_text_adgroup = _build_dynamic_text_adgroup(
                 domain_url=domain_url,
                 autotargeting_categories=autotargeting_categories,
@@ -892,6 +931,15 @@ def add(
         "(max 1024 chars)"
     ),
 )
+@click.option(
+    "--feed-id",
+    type=int,
+    help="TextAdGroupFeedParams.FeedId update value",
+)
+@click.option(
+    "--feed-category-ids",
+    help="Comma-separated TextAdGroupFeedParams.FeedCategoryIds item IDs",
+)
 @click.option("--ad-title-source", help="SmartAdGroup.AdTitleSource update value")
 @click.option("--ad-body-source", help="SmartAdGroup.AdBodySource update value")
 @click.option(
@@ -979,6 +1027,8 @@ def update(
     negative_keywords,
     negative_keyword_shared_set_ids,
     tracking_params,
+    feed_id,
+    feed_category_ids,
     ad_title_source,
     ad_body_source,
     offer_retargeting,
@@ -1036,6 +1086,10 @@ def update(
             "SmartAdGroup": {
                 "--ad-title-source": ad_title_source,
                 "--ad-body-source": ad_body_source,
+            },
+            "TextAdGroupFeedParams": {
+                "--feed-id": feed_id,
+                "--feed-category-ids": feed_category_ids,
             },
             "UnifiedAdGroup": {
                 "--offer-retargeting": offer_retargeting,
@@ -1100,6 +1154,12 @@ def update(
     )
     if mobile_app_adgroup:
         adgroup_data["MobileAppAdGroup"] = mobile_app_adgroup
+    text_adgroup_feed_params = _build_text_adgroup_feed_params(
+        feed_id=feed_id,
+        feed_category_ids=feed_category_ids,
+    )
+    if text_adgroup_feed_params:
+        adgroup_data["TextAdGroupFeedParams"] = text_adgroup_feed_params
     smart_adgroup = {}
     if ad_title_source:
         smart_adgroup["AdTitleSource"] = ad_title_source
@@ -1119,7 +1179,8 @@ def update(
             "--domain-url, --dynamic-feed, --autotargeting-category, "
             "--autotargeting-settings-* flags, --target-device-types, "
             "--target-carrier, --target-operating-system-version, "
-            "--ad-title-source, --ad-body-source, or --offer-retargeting)."
+            "--feed-id, --feed-category-ids, --ad-title-source, "
+            "--ad-body-source, or --offer-retargeting)."
         )
 
     try:

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,9 +11,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 2642 |
+| `missing_followup` | 2634 |
 | `not_applicable` | 23 |
-| `supported` | 576 |
+| `supported` | 584 |
 
 ## Confirmed Follow-Ups
 
@@ -30,10 +30,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `adgroups.add` | `DynamicTextFeedAdGroup.AutotargetingSettings.BrandOptions.WithoutBrands` | Official adgroups.add docs for DynamicTextFeedAdGroupAdd list FeedId and AutotargetingCategories only. [#281](https://github.com/axisrow/direct-cli/issues/281); inherited from `DynamicTextFeedAdGroup.AutotargetingSettings` |
 | `adgroups.add` | `DynamicTextFeedAdGroup.AutotargetingSettings.BrandOptions.WithAdvertiserBrand` | Official adgroups.add docs for DynamicTextFeedAdGroupAdd list FeedId and AutotargetingCategories only. [#281](https://github.com/axisrow/direct-cli/issues/281); inherited from `DynamicTextFeedAdGroup.AutotargetingSettings` |
 | `adgroups.add` | `DynamicTextFeedAdGroup.AutotargetingSettings.BrandOptions.WithCompetitorsBrand` | Official adgroups.add docs for DynamicTextFeedAdGroupAdd list FeedId and AutotargetingCategories only. [#281](https://github.com/axisrow/direct-cli/issues/281); inherited from `DynamicTextFeedAdGroup.AutotargetingSettings` |
-| `adgroups.add` | `TextAdGroupFeedParams` | Rare ad group feed params block has no typed add flags. [#284](https://github.com/axisrow/direct-cli/issues/284) |
-| `adgroups.add` | `TextAdGroupFeedParams.FeedId` | Rare ad group feed params block has no typed add flags. [#284](https://github.com/axisrow/direct-cli/issues/284); inherited from `TextAdGroupFeedParams` |
-| `adgroups.add` | `TextAdGroupFeedParams.FeedCategoryIds` | Rare ad group feed params block has no typed add flags. [#284](https://github.com/axisrow/direct-cli/issues/284); inherited from `TextAdGroupFeedParams` |
-| `adgroups.add` | `TextAdGroupFeedParams.FeedCategoryIds.Items` | Rare ad group feed params block has no typed add flags. [#284](https://github.com/axisrow/direct-cli/issues/284); inherited from `TextAdGroupFeedParams` |
 | `adgroups.update` | `DynamicTextFeedAdGroup.AutotargetingSettings` | Official adgroups.update docs for DynamicTextFeedAdGroupUpdate list AutotargetingCategories only. [#281](https://github.com/axisrow/direct-cli/issues/281) |
 | `adgroups.update` | `DynamicTextFeedAdGroup.AutotargetingSettings.Categories` | Official adgroups.update docs for DynamicTextFeedAdGroupUpdate list AutotargetingCategories only. [#281](https://github.com/axisrow/direct-cli/issues/281); inherited from `DynamicTextFeedAdGroup.AutotargetingSettings` |
 | `adgroups.update` | `DynamicTextFeedAdGroup.AutotargetingSettings.Categories.Exact` | Official adgroups.update docs for DynamicTextFeedAdGroupUpdate list AutotargetingCategories only. [#281](https://github.com/axisrow/direct-cli/issues/281); inherited from `DynamicTextFeedAdGroup.AutotargetingSettings` |
@@ -46,10 +42,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `adgroups.update` | `DynamicTextFeedAdGroup.AutotargetingSettings.BrandOptions.WithAdvertiserBrand` | Official adgroups.update docs for DynamicTextFeedAdGroupUpdate list AutotargetingCategories only. [#281](https://github.com/axisrow/direct-cli/issues/281); inherited from `DynamicTextFeedAdGroup.AutotargetingSettings` |
 | `adgroups.update` | `DynamicTextFeedAdGroup.AutotargetingSettings.BrandOptions.WithCompetitorsBrand` | Official adgroups.update docs for DynamicTextFeedAdGroupUpdate list AutotargetingCategories only. [#281](https://github.com/axisrow/direct-cli/issues/281); inherited from `DynamicTextFeedAdGroup.AutotargetingSettings` |
 | `adgroups.update` | `DynamicTextFeedAdGroup.FeedId` | Official adgroups.update docs for DynamicTextFeedAdGroupUpdate do not list FeedId. [#281](https://github.com/axisrow/direct-cli/issues/281) |
-| `adgroups.update` | `TextAdGroupFeedParams` | Rare ad group feed params block has no typed update flags. [#284](https://github.com/axisrow/direct-cli/issues/284) |
-| `adgroups.update` | `TextAdGroupFeedParams.FeedId` | Rare ad group feed params block has no typed update flags. [#284](https://github.com/axisrow/direct-cli/issues/284); inherited from `TextAdGroupFeedParams` |
-| `adgroups.update` | `TextAdGroupFeedParams.FeedCategoryIds` | Rare ad group feed params block has no typed update flags. [#284](https://github.com/axisrow/direct-cli/issues/284); inherited from `TextAdGroupFeedParams` |
-| `adgroups.update` | `TextAdGroupFeedParams.FeedCategoryIds.Items` | Rare ad group feed params block has no typed update flags. [#284](https://github.com/axisrow/direct-cli/issues/284); inherited from `TextAdGroupFeedParams` |
 | `ads.add` | `TextAd.FinalUrl` | TEXT_AD optional add fields need typed support or N/A. [#273](https://github.com/axisrow/direct-cli/issues/273); inherited from `TextAd` |
 | `ads.add` | `TextAd.VideoExtension` | TEXT_AD optional add fields need typed support or N/A. [#273](https://github.com/axisrow/direct-cli/issues/273); inherited from `TextAd` |
 | `ads.add` | `TextAd.VideoExtension.CreativeId` | TEXT_AD optional add fields need typed support or N/A. [#273](https://github.com/axisrow/direct-cli/issues/273); inherited from `TextAd` |
@@ -2745,10 +2737,10 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `adgroups.add` | `adgroups.add` | `SmartAdGroup.AdBodySource` | `string` | 0 | 1 | `supported` | --ad-body-source |
 | `adgroups.add` | `adgroups.add` | `UnifiedAdGroup` | `UnifiedAdGroupAdd` | 0 | 1 | `supported` | --type |
 | `adgroups.add` | `adgroups.add` | `UnifiedAdGroup.OfferRetargeting` | `YesNoEnum` | 1 | 1 | `supported` | --offer-retargeting |
-| `adgroups.add` | `adgroups.add` | `TextAdGroupFeedParams` | `TextAdGroupFeedParamsAdd` | 0 | 1 | `missing_followup` | Rare ad group feed params block has no typed add flags. [#284](https://github.com/axisrow/direct-cli/issues/284) |
-| `adgroups.add` | `adgroups.add` | `TextAdGroupFeedParams.FeedId` | `long` | 1 | 1 | `missing_followup` | Rare ad group feed params block has no typed add flags. [#284](https://github.com/axisrow/direct-cli/issues/284); inherited from `TextAdGroupFeedParams` |
-| `adgroups.add` | `adgroups.add` | `TextAdGroupFeedParams.FeedCategoryIds` | `ArrayOfLong` | 0 | 1 | `missing_followup` | Rare ad group feed params block has no typed add flags. [#284](https://github.com/axisrow/direct-cli/issues/284); inherited from `TextAdGroupFeedParams` |
-| `adgroups.add` | `adgroups.add` | `TextAdGroupFeedParams.FeedCategoryIds.Items` | `long` | 1 | unbounded | `missing_followup` | Rare ad group feed params block has no typed add flags. [#284](https://github.com/axisrow/direct-cli/issues/284); inherited from `TextAdGroupFeedParams` |
+| `adgroups.add` | `adgroups.add` | `TextAdGroupFeedParams` | `TextAdGroupFeedParamsAdd` | 0 | 1 | `supported` | --feed-category-ids, --feed-id |
+| `adgroups.add` | `adgroups.add` | `TextAdGroupFeedParams.FeedId` | `long` | 1 | 1 | `supported` | --feed-id |
+| `adgroups.add` | `adgroups.add` | `TextAdGroupFeedParams.FeedCategoryIds` | `ArrayOfLong` | 0 | 1 | `supported` | --feed-category-ids |
+| `adgroups.add` | `adgroups.add` | `TextAdGroupFeedParams.FeedCategoryIds.Items` | `long` | 1 | unbounded | `supported` | --feed-category-ids |
 | `adgroups.update` | `adgroups.update` | `RegionIds` | `long` | 0 | unbounded | `supported` | --region-ids |
 | `adgroups.update` | `adgroups.update` | `NegativeKeywords` | `ArrayOfString` | 0 | 1 | `supported` | --negative-keywords |
 | `adgroups.update` | `adgroups.update` | `NegativeKeywords.Items` | `string` | 1 | unbounded | `supported` | --negative-keywords |
@@ -2796,10 +2788,10 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `adgroups.update` | `adgroups.update` | `SmartAdGroup` | `SmartAdGroupUpdate` | 0 | 1 | `supported` | --ad-body-source, --ad-title-source |
 | `adgroups.update` | `adgroups.update` | `SmartAdGroup.AdTitleSource` | `string` | 0 | 1 | `supported` | --ad-title-source |
 | `adgroups.update` | `adgroups.update` | `SmartAdGroup.AdBodySource` | `string` | 0 | 1 | `supported` | --ad-body-source |
-| `adgroups.update` | `adgroups.update` | `TextAdGroupFeedParams` | `TextAdGroupFeedParamsUpdate` | 0 | 1 | `missing_followup` | Rare ad group feed params block has no typed update flags. [#284](https://github.com/axisrow/direct-cli/issues/284) |
-| `adgroups.update` | `adgroups.update` | `TextAdGroupFeedParams.FeedId` | `long` | 1 | 1 | `missing_followup` | Rare ad group feed params block has no typed update flags. [#284](https://github.com/axisrow/direct-cli/issues/284); inherited from `TextAdGroupFeedParams` |
-| `adgroups.update` | `adgroups.update` | `TextAdGroupFeedParams.FeedCategoryIds` | `ArrayOfLong` | 0 | 1 | `missing_followup` | Rare ad group feed params block has no typed update flags. [#284](https://github.com/axisrow/direct-cli/issues/284); inherited from `TextAdGroupFeedParams` |
-| `adgroups.update` | `adgroups.update` | `TextAdGroupFeedParams.FeedCategoryIds.Items` | `long` | 1 | unbounded | `missing_followup` | Rare ad group feed params block has no typed update flags. [#284](https://github.com/axisrow/direct-cli/issues/284); inherited from `TextAdGroupFeedParams` |
+| `adgroups.update` | `adgroups.update` | `TextAdGroupFeedParams` | `TextAdGroupFeedParamsUpdate` | 0 | 1 | `supported` | --feed-category-ids, --feed-id |
+| `adgroups.update` | `adgroups.update` | `TextAdGroupFeedParams.FeedId` | `long` | 1 | 1 | `supported` | --feed-id |
+| `adgroups.update` | `adgroups.update` | `TextAdGroupFeedParams.FeedCategoryIds` | `ArrayOfLong` | 0 | 1 | `supported` | --feed-category-ids |
+| `adgroups.update` | `adgroups.update` | `TextAdGroupFeedParams.FeedCategoryIds.Items` | `long` | 1 | unbounded | `supported` | --feed-category-ids |
 | `adgroups.update` | `adgroups.update` | `UnifiedAdGroup` | `UnifiedAdGroupUpdate` | 0 | 1 | `supported` | --offer-retargeting |
 | `adgroups.update` | `adgroups.update` | `UnifiedAdGroup.OfferRetargeting` | `YesNoEnum` | 0 | 1 | `supported` | --offer-retargeting |
 | `adimages.add` | `adimages.add` | `ImageData` | `base64Binary` | 1 | 1 | `supported` | covered by minOccurs>=1 parity gate |

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1606,6 +1606,65 @@ def test_adgroups_add_payload_omits_type():
     assert group["RegionIds"] == [1, 225]
 
 
+def test_adgroups_add_text_feed_params_payload():
+    """Issue #284: text ad group feed params use a typed top-level block."""
+    body = _dry_run(
+        "adgroups",
+        "add",
+        "--name",
+        "Text Feed Group",
+        "--campaign-id",
+        "111",
+        "--region-ids",
+        "1,225",
+        "--feed-id",
+        "170",
+        "--feed-category-ids",
+        "10,11",
+    )
+    group = body["params"]["AdGroups"][0]
+    assert "Type" not in group
+    assert group["TextAdGroupFeedParams"] == {
+        "FeedId": 170,
+        "FeedCategoryIds": {"Items": [10, 11]},
+    }
+
+
+def test_adgroups_add_text_feed_params_feed_id_only_payload():
+    """Issue #284: category IDs are optional; omitted means all categories."""
+    body = _dry_run(
+        "adgroups",
+        "add",
+        "--name",
+        "Text Feed Group",
+        "--campaign-id",
+        "111",
+        "--region-ids",
+        "225",
+        "--feed-id",
+        "170",
+    )
+    group = body["params"]["AdGroups"][0]
+    assert group["TextAdGroupFeedParams"] == {"FeedId": 170}
+
+
+def test_adgroups_add_text_feed_params_requires_feed_id_for_categories():
+    """Issue #284: FeedId is required when TextAdGroupFeedParams is sent."""
+    result = _rejected(
+        "adgroups",
+        "add",
+        "--name",
+        "Text Feed Group",
+        "--campaign-id",
+        "111",
+        "--region-ids",
+        "225",
+        "--feed-category-ids",
+        "10",
+    )
+    assert "--feed-id is required when --feed-category-ids is used" in result.output
+
+
 def test_adgroups_add_tracking_params_payload():
     body = _dry_run(
         "adgroups",
@@ -2424,6 +2483,30 @@ def test_adgroups_add_rejects_incompatible_subtype_flags():
     )
 
 
+def test_adgroups_add_rejects_text_feed_category_ids_for_dynamic_group():
+    """Issue #284: TextAdGroupFeedParams flags apply only to TEXT_AD_GROUP."""
+    result = _rejected(
+        "adgroups",
+        "add",
+        "--name",
+        "Dynamic Group",
+        "--campaign-id",
+        "111",
+        "--type",
+        "DYNAMIC_TEXT_AD_GROUP",
+        "--region-ids",
+        "225",
+        "--domain-url",
+        "example.com",
+        "--feed-category-ids",
+        "10",
+    )
+    assert (
+        "--feed-category-ids is not compatible with --type DYNAMIC_TEXT_AD_GROUP"
+        in result.output
+    )
+
+
 def test_adgroups_update_payload_name_only():
     body = _dry_run("adgroups", "update", "--id", "222", "--name", "Renamed")
     assert body["method"] == "update"
@@ -2442,6 +2525,55 @@ def test_adgroups_update_tracking_params_payload():
     )
     group = body["params"]["AdGroups"][0]
     assert group == {"Id": 222, "TrackingParams": "utm_source=direct"}
+
+
+def test_adgroups_update_text_feed_params_payload_without_type():
+    """Issue #284: update sets top-level TextAdGroupFeedParams without --type."""
+    body = _dry_run(
+        "adgroups",
+        "update",
+        "--id",
+        "222",
+        "--feed-id",
+        "170",
+        "--feed-category-ids",
+        "10,11",
+    )
+    group = body["params"]["AdGroups"][0]
+    assert group == {
+        "Id": 222,
+        "TextAdGroupFeedParams": {
+            "FeedId": 170,
+            "FeedCategoryIds": {"Items": [10, 11]},
+        },
+    }
+
+
+def test_adgroups_update_text_feed_params_feed_id_only_payload():
+    """Issue #284: TextAdGroupFeedParamsUpdate can update just FeedId."""
+    body = _dry_run(
+        "adgroups",
+        "update",
+        "--id",
+        "222",
+        "--feed-id",
+        "170",
+    )
+    group = body["params"]["AdGroups"][0]
+    assert group == {"Id": 222, "TextAdGroupFeedParams": {"FeedId": 170}}
+
+
+def test_adgroups_update_text_feed_params_requires_feed_id_for_categories():
+    """Issue #284: update cannot send category IDs without FeedId."""
+    result = _rejected(
+        "adgroups",
+        "update",
+        "--id",
+        "222",
+        "--feed-category-ids",
+        "10",
+    )
+    assert "--feed-id is required when --feed-category-ids is used" in result.output
 
 
 def test_adgroups_update_dynamic_domain_url_payload_without_type():
@@ -2734,6 +2866,24 @@ def test_adgroups_update_rejects_mixed_smart_and_unified_subtype_flags():
     assert "--ad-title-source" in result.output
     assert "UnifiedAdGroup update flags" in result.output
     assert "--offer-retargeting" in result.output
+
+
+def test_adgroups_update_rejects_mixed_text_feed_and_smart_subtype_flags():
+    """Issue #284: update must not emit TextAdGroupFeedParams and SmartAdGroup."""
+    result = _rejected(
+        "adgroups",
+        "update",
+        "--id",
+        "222",
+        "--feed-id",
+        "170",
+        "--ad-title-source",
+        "name",
+    )
+    assert "TextAdGroupFeedParams update flags" in result.output
+    assert "--feed-id" in result.output
+    assert "SmartAdGroup update flags" in result.output
+    assert "--ad-title-source" in result.output
 
 
 def test_adgroups_update_negative_keywords_payload():

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -2507,6 +2507,30 @@ def test_adgroups_add_rejects_text_feed_category_ids_for_dynamic_group():
     )
 
 
+def test_adgroups_add_rejects_text_feed_category_ids_for_smart_group():
+    """Issue #284: TextAdGroupFeedParams category IDs do not apply to smart."""
+    result = _rejected(
+        "adgroups",
+        "add",
+        "--name",
+        "Smart Group",
+        "--campaign-id",
+        "111",
+        "--type",
+        "SMART_AD_GROUP",
+        "--region-ids",
+        "225",
+        "--feed-id",
+        "170",
+        "--feed-category-ids",
+        "10",
+    )
+    assert (
+        "--feed-category-ids is not compatible with --type SMART_AD_GROUP"
+        in result.output
+    )
+
+
 def test_adgroups_update_payload_name_only():
     body = _dry_run("adgroups", "update", "--id", "222", "--name", "Renamed")
     assert body["method"] == "update"

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -689,6 +689,17 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     ("adgroups", "add", "SmartAdGroup.AdBodySource"): {"--ad-body-source"},
     ("adgroups", "add", "UnifiedAdGroup"): {"--type"},
     ("adgroups", "add", "UnifiedAdGroup.OfferRetargeting"): {"--offer-retargeting"},
+    ("adgroups", "add", "TextAdGroupFeedParams"): {
+        "--feed-id",
+        "--feed-category-ids",
+    },
+    ("adgroups", "add", "TextAdGroupFeedParams.FeedId"): {"--feed-id"},
+    ("adgroups", "add", "TextAdGroupFeedParams.FeedCategoryIds"): {
+        "--feed-category-ids"
+    },
+    ("adgroups", "add", "TextAdGroupFeedParams.FeedCategoryIds.Items"): {
+        "--feed-category-ids"
+    },
     ("adgroups", "add", "MobileAppAdGroup"): {"--type"},
     ("adgroups", "add", "MobileAppAdGroup.StoreUrl"): {"--store-url"},
     ("adgroups", "add", "MobileAppAdGroup.TargetDeviceType"): {"--target-device-types"},
@@ -886,6 +897,17 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     ("adgroups", "update", "SmartAdGroup.AdBodySource"): {"--ad-body-source"},
     ("adgroups", "update", "UnifiedAdGroup"): {"--offer-retargeting"},
     ("adgroups", "update", "UnifiedAdGroup.OfferRetargeting"): {"--offer-retargeting"},
+    ("adgroups", "update", "TextAdGroupFeedParams"): {
+        "--feed-id",
+        "--feed-category-ids",
+    },
+    ("adgroups", "update", "TextAdGroupFeedParams.FeedId"): {"--feed-id"},
+    ("adgroups", "update", "TextAdGroupFeedParams.FeedCategoryIds"): {
+        "--feed-category-ids"
+    },
+    ("adgroups", "update", "TextAdGroupFeedParams.FeedCategoryIds.Items"): {
+        "--feed-category-ids"
+    },
     ("ads", "add", "TextAd"): {"--type"},
     ("ads", "add", "TextAd.VCardId"): {"--vcard-id"},
     ("ads", "add", "TextAd.AdImageHash"): {"--image-hash"},
@@ -1824,11 +1846,6 @@ OPTIONAL_FIELD_AUDIT: dict[tuple[str, str, str], dict[str, str]] = {
             "FeedId and AutotargetingCategories only."
         ),
     },
-    ("adgroups", "add", "TextAdGroupFeedParams"): {
-        "status": "missing_followup",
-        "issue": "#284",
-        "note": "Rare ad group feed params block has no typed add flags.",
-    },
     ("adgroups", "update", "DynamicTextFeedAdGroup.AutotargetingSettings"): {
         "status": "not_applicable",
         "issue": "#281",
@@ -1844,11 +1861,6 @@ OPTIONAL_FIELD_AUDIT: dict[tuple[str, str, str], dict[str, str]] = {
             "Official adgroups.update docs for DynamicTextFeedAdGroupUpdate "
             "do not list FeedId."
         ),
-    },
-    ("adgroups", "update", "TextAdGroupFeedParams"): {
-        "status": "missing_followup",
-        "issue": "#284",
-        "note": "Rare ad group feed params block has no typed update flags.",
     },
 }
 


### PR DESCRIPTION
## Summary
- add typed `--feed-category-ids` support and reuse `--feed-id` for `TextAdGroupFeedParams` on `adgroups add`
- add `--feed-id` / `--feed-category-ids` support for `TextAdGroupFeedParams` on `adgroups update` without requiring `--type`
- keep subtype payloads mutually exclusive in update, and mark the #284 WSDL audit rows supported
- add README EN/RU single-line examples

## Docs checked
- https://yandex.com/dev/direct/doc/en/adgroups/add
- https://yandex.ru/dev/direct/doc/ru/adgroups/update

## Validation
- `python3 -m pytest tests/test_dry_run.py -k "adgroups and (text_feed or feed_params or feed_category)"`
- `python3 -m pytest tests/test_dry_run.py -k "adgroups"`
- `python3 scripts/build_wsdl_optional_field_audit.py --check`
- `python3 -m pytest tests/test_wsdl_parity_gate.py`
- `python3 -m pytest tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py`
- `mypy .`
- `git diff --check`

Closes #284