### PR TITLE
ads update: add DYNAMIC_TEXT_AD typed support

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,7 @@ direct ads update --id 99999 --type TEXT_AD --title2 "New second headline" --vca
 direct ads update --id 99999 --type TEXT_AD --callouts-add "111,222" --callouts-remove "333"
 direct ads update --id 99999 --type TEXT_AD --callouts-set "444,555"
 direct ads update --id 99999 --type TEXT_AD --video-extension-creative-id 777 --price-extension-price 123450000 --price-extension-price-qualifier FROM --price-extension-price-currency RUB
+direct ads update --id 99999 --type DYNAMIC_TEXT_AD --text "Updated dynamic text" --callouts-add "111,222"
 direct ads delete --id 99999
 ```
 
@@ -429,7 +430,8 @@ Yandex Direct API long-unit format (price multiplied by 1,000,000).
 `--mobile` (default `NO`) and `--ad-extensions` are `ads add`-only —
 `TextAdUpdate` does not contain `Mobile`, and on update ad-extensions are
 managed through the `--callouts-*` flags above. TEXT_IMAGE_AD additionally
-accepts `--turbo-page-id`.
+accepts `--turbo-page-id`. DYNAMIC_TEXT_AD update supports `--text`,
+`--image-hash`, `--vcard-id`, `--sitelink-set-id`, and `--callouts-*`.
 
 #### Keywords
 
@@ -1143,6 +1145,7 @@ direct ads update --id 99999 --type TEXT_AD --title2 "Новый второй з
 direct ads update --id 99999 --type TEXT_AD --callouts-add "111,222" --callouts-remove "333"
 direct ads update --id 99999 --type TEXT_AD --callouts-set "444,555"
 direct ads update --id 99999 --type TEXT_AD --video-extension-creative-id 777 --price-extension-price 123450000 --price-extension-price-qualifier FROM --price-extension-price-currency RUB
+direct ads update --id 99999 --type DYNAMIC_TEXT_AD --text "Обновленный динамический текст" --callouts-add "111,222"
 direct ads delete --id 99999
 ```
 
@@ -1161,7 +1164,8 @@ long-единиц API Яндекс Директа (цена, умноженна�
 `--ad-extensions` доступны только в `ads add` — WSDL `TextAdUpdate` не
 содержит `Mobile`, а в `ads update` расширения управляются через флаги
 `--callouts-*` выше. Для TEXT_IMAGE_AD дополнительно доступен
-`--turbo-page-id`.
+`--turbo-page-id`. Для DYNAMIC_TEXT_AD в `ads update` доступны `--text`,
+`--image-hash`, `--vcard-id`, `--sitelink-set-id` и `--callouts-*`.
 
 #### Ключевые слова
 

--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -80,11 +80,11 @@ def _build_text_ad_update_base(
 ) -> dict[str, object]:
     """Build fields inherited from WSDL TextAdUpdateBase."""
     text_ad_base: dict[str, object] = {}
-    if vcard_id:
+    if vcard_id is not None:
         text_ad_base["VCardId"] = vcard_id
     if image_hash:
         text_ad_base["AdImageHash"] = image_hash
-    if sitelink_set_id:
+    if sitelink_set_id is not None:
         text_ad_base["SitelinkSetId"] = sitelink_set_id
     if callout_setting:
         text_ad_base["CalloutSetting"] = callout_setting

--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -2,6 +2,8 @@
 Ads commands
 """
 
+from typing import Optional
+
 import click
 
 from ..api import create_client
@@ -35,7 +37,7 @@ def _reject_incompatible_flags(
 
 
 def _build_callout_setting(callouts_add, callouts_remove, callouts_set):
-    """Build TextAdUpdateBase.CalloutSetting (ext:AdExtensionSetting).
+    """Build AdExtensionSetting for text-like ad update payloads.
 
     SET is mutually exclusive with ADD/REMOVE per WSDL OperationEnum
     semantics. Returns None when no callout flag was provided.
@@ -68,6 +70,25 @@ def _build_callout_setting(callouts_add, callouts_remove, callouts_set):
     if not items:
         return None
     return {"AdExtensions": items}
+
+
+def _build_text_ad_update_base(
+    vcard_id: Optional[int],
+    image_hash: Optional[str],
+    sitelink_set_id: Optional[int],
+    callout_setting: Optional[dict[str, object]],
+) -> dict[str, object]:
+    """Build fields inherited from WSDL TextAdUpdateBase."""
+    text_ad_base: dict[str, object] = {}
+    if vcard_id:
+        text_ad_base["VCardId"] = vcard_id
+    if image_hash:
+        text_ad_base["AdImageHash"] = image_hash
+    if sitelink_set_id:
+        text_ad_base["SitelinkSetId"] = sitelink_set_id
+    if callout_setting:
+        text_ad_base["CalloutSetting"] = callout_setting
+    return text_ad_base
 
 
 def _build_price_extension(
@@ -478,7 +499,7 @@ def add(
     "--type",
     "ad_type",
     required=True,
-    help="Ad subtype: TEXT_AD | TEXT_IMAGE_AD | MOBILE_APP_AD",
+    help="Ad subtype: TEXT_AD | TEXT_IMAGE_AD | MOBILE_APP_AD | DYNAMIC_TEXT_AD",
 )
 @click.option(
     "--status",
@@ -488,10 +509,11 @@ def add(
     ),
 )
 @click.option("--title", help="Title (TEXT_AD / MOBILE_APP_AD)")
-@click.option("--text", help="Text (TEXT_AD / MOBILE_APP_AD)")
+@click.option("--text", help="Text (TEXT_AD / MOBILE_APP_AD / DYNAMIC_TEXT_AD)")
 @click.option("--href", help="URL (TEXT_AD / TEXT_IMAGE_AD)")
 @click.option(
-    "--image-hash", help="Image hash (TEXT_AD / TEXT_IMAGE_AD / MOBILE_APP_AD)"
+    "--image-hash",
+    help="Image hash (TEXT_AD / TEXT_IMAGE_AD / MOBILE_APP_AD / DYNAMIC_TEXT_AD)",
 )
 @click.option(
     "--action",
@@ -501,8 +523,12 @@ def add(
 @click.option("--age-label", help="MOBILE_APP_AD age label (MobAppAgeLabelEnum)")
 @click.option("--title2", help="Second headline (TEXT_AD)")
 @click.option("--display-url-path", help="Display URL path (TEXT_AD)")
-@click.option("--vcard-id", type=int, help="VCard ID (TEXT_AD)")
-@click.option("--sitelink-set-id", type=int, help="Sitelink set ID (TEXT_AD)")
+@click.option("--vcard-id", type=int, help="VCard ID (TEXT_AD / DYNAMIC_TEXT_AD)")
+@click.option(
+    "--sitelink-set-id",
+    type=int,
+    help="Sitelink set ID (TEXT_AD / DYNAMIC_TEXT_AD)",
+)
 @click.option(
     "--turbo-page-id", type=int, help="Turbo page ID (TEXT_AD / TEXT_IMAGE_AD)"
 )
@@ -510,14 +536,14 @@ def add(
     "--callouts-add",
     help=(
         "Comma-separated CALLOUT ad-extension IDs to attach "
-        "(Operation=ADD). TEXT_AD only."
+        "(Operation=ADD). TEXT_AD / DYNAMIC_TEXT_AD only."
     ),
 )
 @click.option(
     "--callouts-remove",
     help=(
         "Comma-separated CALLOUT ad-extension IDs to detach "
-        "(Operation=REMOVE). TEXT_AD only."
+        "(Operation=REMOVE). TEXT_AD / DYNAMIC_TEXT_AD only."
     ),
 )
 @click.option(
@@ -525,7 +551,7 @@ def add(
     help=(
         "Comma-separated CALLOUT ad-extension IDs that REPLACE the ad's "
         "current callout list (Operation=SET). Mutually exclusive with "
-        "--callouts-add / --callouts-remove. TEXT_AD only."
+        "--callouts-add / --callouts-remove. TEXT_AD / DYNAMIC_TEXT_AD only."
     ),
 )
 @click.option(
@@ -599,12 +625,12 @@ def update(
         )
 
     ad_type_norm = ad_type.upper().replace("-", "_")
-    supported_types = {"TEXT_AD", "TEXT_IMAGE_AD", "MOBILE_APP_AD"}
+    supported_types = {"TEXT_AD", "TEXT_IMAGE_AD", "MOBILE_APP_AD", "DYNAMIC_TEXT_AD"}
     if ad_type_norm not in supported_types:
         raise click.UsageError(
             "Invalid value for '--type': "
             f"{ad_type!r} is not one of "
-            "'TEXT_AD', 'TEXT_IMAGE_AD', 'MOBILE_APP_AD'."
+            "'TEXT_AD', 'TEXT_IMAGE_AD', 'MOBILE_APP_AD', 'DYNAMIC_TEXT_AD'."
         )
 
     # Per-WSDL-subtype field allow-list: each --type accepts only the
@@ -631,6 +657,15 @@ def update(
             "price_extension_old_price",
             "price_extension_price_qualifier",
             "price_extension_price_currency",
+        },
+        "DYNAMIC_TEXT_AD": {
+            "text",
+            "image_hash",
+            "vcard_id",
+            "sitelink_set_id",
+            "callouts_add",
+            "callouts_remove",
+            "callouts_set",
         },
         "TEXT_IMAGE_AD": {"image_hash", "href", "turbo_page_id"},
         "MOBILE_APP_AD": {
@@ -712,33 +747,41 @@ def update(
     ad_data = {"Id": ad_id}
 
     if ad_type_norm == "TEXT_AD":
-        text_ad = {}
+        text_ad = _build_text_ad_update_base(
+            vcard_id,
+            image_hash,
+            sitelink_set_id,
+            callout_setting,
+        )
         if title:
             text_ad["Title"] = title
         if text:
             text_ad["Text"] = text
         if href:
             text_ad["Href"] = href
-        if image_hash:
-            text_ad["AdImageHash"] = image_hash
         if title2:
             text_ad["Title2"] = title2
         if display_url_path:
             text_ad["DisplayUrlPath"] = display_url_path
-        if vcard_id:
-            text_ad["VCardId"] = vcard_id
-        if sitelink_set_id:
-            text_ad["SitelinkSetId"] = sitelink_set_id
         if turbo_page_id:
             text_ad["TurboPageId"] = turbo_page_id
-        if callout_setting:
-            text_ad["CalloutSetting"] = callout_setting
         if video_extension_creative_id is not None:
             text_ad["VideoExtension"] = {"CreativeId": video_extension_creative_id}
         if price_extension:
             text_ad["PriceExtension"] = price_extension
         if text_ad:
             ad_data["TextAd"] = text_ad
+    elif ad_type_norm == "DYNAMIC_TEXT_AD":
+        dynamic_text_ad = _build_text_ad_update_base(
+            vcard_id,
+            image_hash,
+            sitelink_set_id,
+            callout_setting,
+        )
+        if text:
+            dynamic_text_ad["Text"] = text
+        if dynamic_text_ad:
+            ad_data["DynamicTextAd"] = dynamic_text_ad
     elif ad_type_norm == "TEXT_IMAGE_AD":
         text_image_ad = {}
         if image_hash:

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,9 +11,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 2634 |
+| `missing_followup` | 2625 |
 | `not_applicable` | 23 |
-| `supported` | 584 |
+| `supported` | 593 |
 
 ## Confirmed Follow-Ups
 
@@ -183,15 +183,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `ads.update` | `ResponsiveAd.PriceExtension.PriceCurrency` | RESPONSIVE_AD update fields need typed support or N/A. [#268](https://github.com/axisrow/direct-cli/issues/268); inherited from `ResponsiveAd` |
 | `ads.update` | `ResponsiveAd.BusinessId` | RESPONSIVE_AD update fields need typed support or N/A. [#268](https://github.com/axisrow/direct-cli/issues/268); inherited from `ResponsiveAd` |
 | `ads.update` | `ResponsiveAd.ErirAdDescription` | RESPONSIVE_AD update fields need typed support or N/A. [#268](https://github.com/axisrow/direct-cli/issues/268); inherited from `ResponsiveAd` |
-| `ads.update` | `DynamicTextAd` | DYNAMIC_TEXT_AD update fields need typed support or N/A. [#267](https://github.com/axisrow/direct-cli/issues/267) |
-| `ads.update` | `DynamicTextAd.VCardId` | DYNAMIC_TEXT_AD update fields need typed support or N/A. [#267](https://github.com/axisrow/direct-cli/issues/267); inherited from `DynamicTextAd` |
-| `ads.update` | `DynamicTextAd.AdImageHash` | DYNAMIC_TEXT_AD update fields need typed support or N/A. [#267](https://github.com/axisrow/direct-cli/issues/267); inherited from `DynamicTextAd` |
-| `ads.update` | `DynamicTextAd.SitelinkSetId` | DYNAMIC_TEXT_AD update fields need typed support or N/A. [#267](https://github.com/axisrow/direct-cli/issues/267); inherited from `DynamicTextAd` |
-| `ads.update` | `DynamicTextAd.CalloutSetting` | DYNAMIC_TEXT_AD update fields need typed support or N/A. [#267](https://github.com/axisrow/direct-cli/issues/267); inherited from `DynamicTextAd` |
-| `ads.update` | `DynamicTextAd.CalloutSetting.AdExtensions` | DYNAMIC_TEXT_AD update fields need typed support or N/A. [#267](https://github.com/axisrow/direct-cli/issues/267); inherited from `DynamicTextAd` |
-| `ads.update` | `DynamicTextAd.CalloutSetting.AdExtensions.AdExtensionId` | DYNAMIC_TEXT_AD update fields need typed support or N/A. [#267](https://github.com/axisrow/direct-cli/issues/267); inherited from `DynamicTextAd` |
-| `ads.update` | `DynamicTextAd.CalloutSetting.AdExtensions.Operation` | DYNAMIC_TEXT_AD update fields need typed support or N/A. [#267](https://github.com/axisrow/direct-cli/issues/267); inherited from `DynamicTextAd` |
-| `ads.update` | `DynamicTextAd.Text` | DYNAMIC_TEXT_AD update fields need typed support or N/A. [#267](https://github.com/axisrow/direct-cli/issues/267); inherited from `DynamicTextAd` |
 | `ads.update` | `MobileAppAd.ErirAdDescription` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
 | `ads.update` | `MobileAppAd.Features` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
 | `ads.update` | `MobileAppAd.Features.Feature` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
@@ -2981,15 +2972,15 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `ads.update` | `ads.update` | `ResponsiveAd.PriceExtension.PriceCurrency` | `PriceCurrencyEnum` | 0 | 1 | `missing_followup` | RESPONSIVE_AD update fields need typed support or N/A. [#268](https://github.com/axisrow/direct-cli/issues/268); inherited from `ResponsiveAd` |
 | `ads.update` | `ads.update` | `ResponsiveAd.BusinessId` | `long` | 0 | 1 | `missing_followup` | RESPONSIVE_AD update fields need typed support or N/A. [#268](https://github.com/axisrow/direct-cli/issues/268); inherited from `ResponsiveAd` |
 | `ads.update` | `ads.update` | `ResponsiveAd.ErirAdDescription` | `string` | 0 | 1 | `missing_followup` | RESPONSIVE_AD update fields need typed support or N/A. [#268](https://github.com/axisrow/direct-cli/issues/268); inherited from `ResponsiveAd` |
-| `ads.update` | `ads.update` | `DynamicTextAd` | `DynamicTextAdUpdate` | 0 | 1 | `missing_followup` | DYNAMIC_TEXT_AD update fields need typed support or N/A. [#267](https://github.com/axisrow/direct-cli/issues/267) |
-| `ads.update` | `ads.update` | `DynamicTextAd.VCardId` | `long` | 0 | 1 | `missing_followup` | DYNAMIC_TEXT_AD update fields need typed support or N/A. [#267](https://github.com/axisrow/direct-cli/issues/267); inherited from `DynamicTextAd` |
-| `ads.update` | `ads.update` | `DynamicTextAd.AdImageHash` | `string` | 0 | 1 | `missing_followup` | DYNAMIC_TEXT_AD update fields need typed support or N/A. [#267](https://github.com/axisrow/direct-cli/issues/267); inherited from `DynamicTextAd` |
-| `ads.update` | `ads.update` | `DynamicTextAd.SitelinkSetId` | `long` | 0 | 1 | `missing_followup` | DYNAMIC_TEXT_AD update fields need typed support or N/A. [#267](https://github.com/axisrow/direct-cli/issues/267); inherited from `DynamicTextAd` |
-| `ads.update` | `ads.update` | `DynamicTextAd.CalloutSetting` | `AdExtensionSetting` | 0 | 1 | `missing_followup` | DYNAMIC_TEXT_AD update fields need typed support or N/A. [#267](https://github.com/axisrow/direct-cli/issues/267); inherited from `DynamicTextAd` |
-| `ads.update` | `ads.update` | `DynamicTextAd.CalloutSetting.AdExtensions` | `AdExtensionSettingItem` | 1 | unbounded | `missing_followup` | DYNAMIC_TEXT_AD update fields need typed support or N/A. [#267](https://github.com/axisrow/direct-cli/issues/267); inherited from `DynamicTextAd` |
-| `ads.update` | `ads.update` | `DynamicTextAd.CalloutSetting.AdExtensions.AdExtensionId` | `long` | 1 | 1 | `missing_followup` | DYNAMIC_TEXT_AD update fields need typed support or N/A. [#267](https://github.com/axisrow/direct-cli/issues/267); inherited from `DynamicTextAd` |
-| `ads.update` | `ads.update` | `DynamicTextAd.CalloutSetting.AdExtensions.Operation` | `OperationEnum` | 1 | 1 | `missing_followup` | DYNAMIC_TEXT_AD update fields need typed support or N/A. [#267](https://github.com/axisrow/direct-cli/issues/267); inherited from `DynamicTextAd` |
-| `ads.update` | `ads.update` | `DynamicTextAd.Text` | `string` | 0 | 1 | `missing_followup` | DYNAMIC_TEXT_AD update fields need typed support or N/A. [#267](https://github.com/axisrow/direct-cli/issues/267); inherited from `DynamicTextAd` |
+| `ads.update` | `ads.update` | `DynamicTextAd` | `DynamicTextAdUpdate` | 0 | 1 | `supported` | --type |
+| `ads.update` | `ads.update` | `DynamicTextAd.VCardId` | `long` | 0 | 1 | `supported` | --vcard-id |
+| `ads.update` | `ads.update` | `DynamicTextAd.AdImageHash` | `string` | 0 | 1 | `supported` | --image-hash |
+| `ads.update` | `ads.update` | `DynamicTextAd.SitelinkSetId` | `long` | 0 | 1 | `supported` | --sitelink-set-id |
+| `ads.update` | `ads.update` | `DynamicTextAd.CalloutSetting` | `AdExtensionSetting` | 0 | 1 | `supported` | --callouts-add, --callouts-remove, --callouts-set |
+| `ads.update` | `ads.update` | `DynamicTextAd.CalloutSetting.AdExtensions` | `AdExtensionSettingItem` | 1 | unbounded | `supported` | --callouts-add, --callouts-remove, --callouts-set |
+| `ads.update` | `ads.update` | `DynamicTextAd.CalloutSetting.AdExtensions.AdExtensionId` | `long` | 1 | 1 | `supported` | --callouts-add, --callouts-remove, --callouts-set |
+| `ads.update` | `ads.update` | `DynamicTextAd.CalloutSetting.AdExtensions.Operation` | `OperationEnum` | 1 | 1 | `supported` | --callouts-add, --callouts-remove, --callouts-set |
+| `ads.update` | `ads.update` | `DynamicTextAd.Text` | `string` | 0 | 1 | `supported` | --text |
 | `ads.update` | `ads.update` | `MobileAppAd` | `MobileAppAdUpdate` | 0 | 1 | `supported` | --type |
 | `ads.update` | `ads.update` | `MobileAppAd.Title` | `string` | 0 | 1 | `supported` | --title |
 | `ads.update` | `ads.update` | `MobileAppAd.Text` | `string` | 0 | 1 | `supported` | --text |

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -267,7 +267,13 @@ class TestCLI(unittest.TestCase):
         # Click may wrap the help text across lines, so collapse whitespace
         # before searching for the canonical phrase.
         collapsed = " ".join(result.output.split())
-        self.assertIn("Image hash (TEXT_AD / TEXT_IMAGE_AD / MOBILE_APP_AD)", collapsed)
+        self.assertIn(
+            "Image hash (TEXT_AD / TEXT_IMAGE_AD / MOBILE_APP_AD / DYNAMIC_TEXT_AD)",
+            collapsed,
+        )
+        self.assertIn(
+            "TEXT_AD | TEXT_IMAGE_AD | MOBILE_APP_AD | DYNAMIC_TEXT_AD", collapsed
+        )
 
     def test_clients_update_help_documents_erir_organization_flags(self):
         result = self.runner.invoke(cli, ["clients", "update", "--help"])

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1232,6 +1232,26 @@ def test_ads_update_dynamic_text_ad_noop_rejected():
     )
 
 
+def test_ads_update_dynamic_text_ad_zero_ids_are_not_silently_dropped():
+    """Issue #267: integer flags use presence, not truthiness, in the payload."""
+    body = _dry_run(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "DYNAMIC_TEXT_AD",
+        "--vcard-id",
+        "0",
+        "--sitelink-set-id",
+        "0",
+    )
+    assert body["params"]["Ads"][0] == {
+        "Id": 999,
+        "DynamicTextAd": {"VCardId": 0, "SitelinkSetId": 0},
+    }
+
+
 def test_ads_update_text_ad_with_turbo_page_id():
     """Issue #202: update sets TurboPageId in TextAd."""
     body = _dry_run(

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1134,6 +1134,104 @@ def test_ads_update_text_ad_with_vcard_sitelink():
     assert text_ad == {"VCardId": 111, "SitelinkSetId": 222}
 
 
+def test_ads_update_dynamic_text_ad_payload():
+    """Issue #267: DYNAMIC_TEXT_AD update builds DynamicTextAd block only."""
+    body = _dry_run(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "DYNAMIC_TEXT_AD",
+        "--text",
+        "Updated dynamic text",
+        "--vcard-id",
+        "111",
+        "--image-hash",
+        "ygqa6jmlkgsbz7vnewp0",
+        "--sitelink-set-id",
+        "222",
+        "--callouts-add",
+        "333",
+        "--callouts-remove",
+        "444",
+    )
+    ad = body["params"]["Ads"][0]
+    assert ad == {
+        "Id": 999,
+        "DynamicTextAd": {
+            "VCardId": 111,
+            "AdImageHash": "ygqa6jmlkgsbz7vnewp0",
+            "SitelinkSetId": 222,
+            "CalloutSetting": {
+                "AdExtensions": [
+                    {"AdExtensionId": 333, "Operation": "ADD"},
+                    {"AdExtensionId": 444, "Operation": "REMOVE"},
+                ]
+            },
+            "Text": "Updated dynamic text",
+        },
+    }
+    assert "TextAd" not in ad
+
+
+def test_ads_update_dynamic_text_ad_callouts_set_payload():
+    """Issue #267: DynamicTextAd.CalloutSetting supports SET operation."""
+    body = _dry_run(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "DYNAMIC_TEXT_AD",
+        "--callouts-set",
+        "111,222",
+    )
+    assert body["params"]["Ads"][0] == {
+        "Id": 999,
+        "DynamicTextAd": {
+            "CalloutSetting": {
+                "AdExtensions": [
+                    {"AdExtensionId": 111, "Operation": "SET"},
+                    {"AdExtensionId": 222, "Operation": "SET"},
+                ]
+            }
+        },
+    }
+
+
+def test_ads_update_dynamic_text_ad_rejects_text_ad_only_flag():
+    """Issue #267: --type DYNAMIC_TEXT_AD cannot silently drop TextAd fields."""
+    result = _rejected(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "DYNAMIC_TEXT_AD",
+        "--title2",
+        "Text ad only",
+    )
+    assert "--title2 is not compatible with --type DYNAMIC_TEXT_AD" in result.output
+    assert "does not convert an ad between subtypes" in result.output
+
+
+def test_ads_update_dynamic_text_ad_noop_rejected():
+    """Issue #267: DYNAMIC_TEXT_AD update without fields stays a no-op error."""
+    result = _rejected(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "DYNAMIC_TEXT_AD",
+    )
+    assert (
+        "ads update requires at least one updatable field for --type DYNAMIC_TEXT_AD"
+        in result.output
+    )
+
+
 def test_ads_update_text_ad_with_turbo_page_id():
     """Issue #202: update sets TurboPageId in TextAd."""
     body = _dry_run(

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -966,6 +966,31 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     ("ads", "update", "TextAd.PriceExtension.PriceCurrency"): {
         "--price-extension-price-currency"
     },
+    ("ads", "update", "DynamicTextAd"): {"--type"},
+    ("ads", "update", "DynamicTextAd.VCardId"): {"--vcard-id"},
+    ("ads", "update", "DynamicTextAd.AdImageHash"): {"--image-hash"},
+    ("ads", "update", "DynamicTextAd.SitelinkSetId"): {"--sitelink-set-id"},
+    ("ads", "update", "DynamicTextAd.CalloutSetting"): {
+        "--callouts-add",
+        "--callouts-remove",
+        "--callouts-set",
+    },
+    ("ads", "update", "DynamicTextAd.CalloutSetting.AdExtensions"): {
+        "--callouts-add",
+        "--callouts-remove",
+        "--callouts-set",
+    },
+    ("ads", "update", "DynamicTextAd.CalloutSetting.AdExtensions.AdExtensionId"): {
+        "--callouts-add",
+        "--callouts-remove",
+        "--callouts-set",
+    },
+    ("ads", "update", "DynamicTextAd.CalloutSetting.AdExtensions.Operation"): {
+        "--callouts-add",
+        "--callouts-remove",
+        "--callouts-set",
+    },
+    ("ads", "update", "DynamicTextAd.Text"): {"--text"},
     ("ads", "update", "MobileAppAd"): {"--type"},
     ("ads", "update", "MobileAppAd.AdImageHash"): {"--image-hash"},
     ("ads", "update", "MobileAppAd.Text"): {"--text"},
@@ -1615,11 +1640,6 @@ OPTIONAL_FIELD_CHILD_PREFIX_FOLLOWUPS: dict[tuple[str, str, str], dict[str, str]
         "status": "missing_followup",
         "issue": "#278",
         "note": "SMART_AD_BUILDER_AD add fields need typed support or N/A.",
-    },
-    ("ads", "update", "DynamicTextAd"): {
-        "status": "missing_followup",
-        "issue": "#267",
-        "note": "DYNAMIC_TEXT_AD update fields need typed support or N/A.",
     },
     ("ads", "update", "ResponsiveAd"): {
         "status": "missing_followup",


### PR DESCRIPTION
## Summary
- add DYNAMIC_TEXT_AD to `direct ads update --type ...` typed subtype dispatch
- build the documented/WSDL `DynamicTextAd` update block from `--text`, `--image-hash`, `--vcard-id`, `--sitelink-set-id`, and `--callouts-*`
- share TextAdUpdateBase payload construction without changing existing TEXT_AD / TEXT_IMAGE_AD / MOBILE_APP_AD behavior
- move all #267 `ads.update DynamicTextAd*` audit rows to supported

## Docs / Contract
- Official docs: https://yandex.ru/dev/direct/doc/en/ads/update lists `DynamicTextAd` as an `AdUpdateItem` subtype
- Cached WSDL: `tests/wsdl_cache/ads.xml` defines `DynamicTextAdUpdate` as `TextAdUpdateBase` plus `Text`
- Public contract stays typed flags only; no `--json` or blob input

## Verification
- `python3 -m pytest tests/test_dry_run.py -k "ads_update_dynamic_text"`
- `python3 -m pytest tests/test_cli.py -k "ads_update_help"`
- `python3 scripts/build_wsdl_optional_field_audit.py --check`
- `python3 -m pytest tests/test_wsdl_parity_gate.py`
- `python3 -m pytest tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py`
- `mypy .`
- `git diff --check`

Closes #267