### PR TITLE
Add AdBuilder update flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,8 @@ direct ads update --id 99999 --type TEXT_AD --video-extension-creative-id 777 --
 direct ads update --id 99999 --type DYNAMIC_TEXT_AD --text "Updated dynamic text" --callouts-add "111,222"
 direct ads update --id 99999 --type RESPONSIVE_AD --texts "Text one,Text two" --titles "Title one,Title two" --image-hashes hash1,hash2 --video-extension-ids 111,222 --href "https://example.com" --price-extension-price 123450000 --price-extension-price-qualifier FROM --price-extension-price-currency RUB
 direct ads update --id 99999 --type SHOPPING_AD --sitelink-set-id 222 --callouts-set "444,555" --business-id 777 --feed-filter-condition "CATEGORY:EQUALS_ANY:shoes|boots" --title-sources NAME,BRAND --text-sources DESCRIPTION --default-texts "Default product text"
+direct ads update --id 99999 --type TEXT_AD_BUILDER_AD --creative-id 123 --creative-erir-ad-description "Creative object" --href "https://example.com" --turbo-page-id 456
+direct ads update --id 99999 --type CPM_BANNER_AD_BUILDER_AD --creative-id 123 --href "https://example.com" --tracking-pixels "https://pixel.example.com/a,https://pixel.example.com/b"
 direct ads delete --id 99999
 ```
 
@@ -442,6 +444,9 @@ SHOPPING_AD and LISTING_AD update support `--sitelink-set-id`,
 `--callouts-*`, `--business-id`, repeatable `--feed-filter-condition`
 (`OPERAND:OPERATOR:ARG1|ARG2`), `--title-sources`, `--text-sources`, and
 `--default-texts`.
+AdBuilder update subtypes support `--creative-id`, `--creative-erir-ad-description`,
+`--erir-ad-description`, and subtype-specific `--final-url`, `--href`,
+`--turbo-page-id`, `--tracking-url`, and `--tracking-pixels`.
 
 #### Keywords
 
@@ -1158,6 +1163,8 @@ direct ads update --id 99999 --type TEXT_AD --video-extension-creative-id 777 --
 direct ads update --id 99999 --type DYNAMIC_TEXT_AD --text "Обновленный динамический текст" --callouts-add "111,222"
 direct ads update --id 99999 --type RESPONSIVE_AD --texts "Текст один,Текст два" --titles "Заголовок один,Заголовок два" --image-hashes hash1,hash2 --video-extension-ids 111,222 --href "https://example.com" --price-extension-price 123450000 --price-extension-price-qualifier FROM --price-extension-price-currency RUB
 direct ads update --id 99999 --type SHOPPING_AD --sitelink-set-id 222 --callouts-set "444,555" --business-id 777 --feed-filter-condition "CATEGORY:EQUALS_ANY:shoes|boots" --title-sources NAME,BRAND --text-sources DESCRIPTION --default-texts "Текст по умолчанию"
+direct ads update --id 99999 --type TEXT_AD_BUILDER_AD --creative-id 123 --creative-erir-ad-description "Объект креатива" --href "https://example.com" --turbo-page-id 456
+direct ads update --id 99999 --type CPM_BANNER_AD_BUILDER_AD --creative-id 123 --href "https://example.com" --tracking-pixels "https://pixel.example.com/a,https://pixel.example.com/b"
 direct ads delete --id 99999
 ```
 
@@ -1186,6 +1193,10 @@ long-единиц API Яндекс Директа (цена, умноженна�
 `--callouts-*`, `--business-id`, повторяемый `--feed-filter-condition`
 (`OPERAND:OPERATOR:ARG1|ARG2`), `--title-sources`, `--text-sources` и
 `--default-texts`.
+Для AdBuilder subtype в `ads update` доступны `--creative-id`,
+`--creative-erir-ad-description`, `--erir-ad-description` и subtype-specific
+`--final-url`, `--href`, `--turbo-page-id`, `--tracking-url`,
+`--tracking-pixels`.
 
 #### Ключевые слова
 

--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -35,6 +35,36 @@ FEED_BASED_UPDATE_FIELDS = {
 }
 
 
+AD_BUILDER_BASE_UPDATE_FIELDS = {
+    "creative_id",
+    "creative_erir_ad_description",
+    "erir_ad_description",
+}
+
+AD_BUILDER_TYPE_FIELDS = {
+    "TEXT_AD_BUILDER_AD": AD_BUILDER_BASE_UPDATE_FIELDS
+    | {"final_url", "href", "turbo_page_id"},
+    "MOBILE_APP_AD_BUILDER_AD": AD_BUILDER_BASE_UPDATE_FIELDS | {"tracking_url"},
+    "MOBILE_APP_CPC_VIDEO_AD_BUILDER_AD": AD_BUILDER_BASE_UPDATE_FIELDS
+    | {"tracking_url"},
+    "CPC_VIDEO_AD_BUILDER_AD": AD_BUILDER_BASE_UPDATE_FIELDS
+    | {"href", "turbo_page_id"},
+    "CPM_BANNER_AD_BUILDER_AD": AD_BUILDER_BASE_UPDATE_FIELDS
+    | {"href", "tracking_pixels", "turbo_page_id"},
+    "CPM_VIDEO_AD_BUILDER_AD": AD_BUILDER_BASE_UPDATE_FIELDS
+    | {"href", "tracking_pixels", "turbo_page_id"},
+}
+
+AD_BUILDER_UPDATE_BLOCKS = {
+    "TEXT_AD_BUILDER_AD": "TextAdBuilderAd",
+    "MOBILE_APP_AD_BUILDER_AD": "MobileAppAdBuilderAd",
+    "MOBILE_APP_CPC_VIDEO_AD_BUILDER_AD": "MobileAppCpcVideoAdBuilderAd",
+    "CPC_VIDEO_AD_BUILDER_AD": "CpcVideoAdBuilderAd",
+    "CPM_BANNER_AD_BUILDER_AD": "CpmBannerAdBuilderAd",
+    "CPM_VIDEO_AD_BUILDER_AD": "CpmVideoAdBuilderAd",
+}
+
+
 def _reject_incompatible_flags(
     ad_type: str,
     allowed_fields: set[str],
@@ -242,6 +272,47 @@ def _build_feed_based_ad_update(
     parsed_default_texts = _parse_required_csv_strings(default_texts, "--default-texts")
     if parsed_default_texts:
         ad_payload["DefaultTexts"] = parsed_default_texts
+
+    return ad_payload
+
+
+def _build_ad_builder_update(
+    creative_id: Optional[int],
+    creative_erir_ad_description: Optional[str],
+    erir_ad_description: Optional[str],
+    final_url: Optional[str],
+    href: Optional[str],
+    turbo_page_id: Optional[int],
+    tracking_url: Optional[str],
+    tracking_pixels: Optional[str],
+) -> dict[str, object]:
+    """Build an AdBuilder*Update payload from typed flags."""
+    ad_payload: dict[str, object] = {}
+
+    if creative_erir_ad_description and creative_id is None:
+        raise click.UsageError("--creative-erir-ad-description requires --creative-id.")
+    if creative_id is not None:
+        creative: dict[str, object] = {"CreativeId": creative_id}
+        if creative_erir_ad_description:
+            creative["ErirAdDescription"] = creative_erir_ad_description
+        ad_payload["Creative"] = creative
+
+    if erir_ad_description:
+        ad_payload["ErirAdDescription"] = erir_ad_description
+    if final_url:
+        ad_payload["FinalUrl"] = final_url
+    if href:
+        ad_payload["Href"] = href
+    if turbo_page_id is not None:
+        ad_payload["TurboPageId"] = turbo_page_id
+    if tracking_url:
+        ad_payload["TrackingUrl"] = tracking_url
+
+    parsed_tracking_pixels = _parse_required_csv_strings(
+        tracking_pixels, "--tracking-pixels"
+    )
+    if parsed_tracking_pixels:
+        ad_payload["TrackingPixels"] = {"Items": parsed_tracking_pixels}
 
     return ad_payload
 
@@ -637,7 +708,10 @@ def add(
     required=True,
     help=(
         "Ad subtype: TEXT_AD | TEXT_IMAGE_AD | MOBILE_APP_AD | "
-        "DYNAMIC_TEXT_AD | RESPONSIVE_AD | SHOPPING_AD | LISTING_AD"
+        "DYNAMIC_TEXT_AD | RESPONSIVE_AD | SHOPPING_AD | LISTING_AD | "
+        "TEXT_AD_BUILDER_AD | MOBILE_APP_AD_BUILDER_AD | "
+        "MOBILE_APP_CPC_VIDEO_AD_BUILDER_AD | CPC_VIDEO_AD_BUILDER_AD | "
+        "CPM_BANNER_AD_BUILDER_AD | CPM_VIDEO_AD_BUILDER_AD"
     ),
 )
 @click.option(
@@ -651,7 +725,14 @@ def add(
 @click.option("--text", help="Text (TEXT_AD / MOBILE_APP_AD / DYNAMIC_TEXT_AD)")
 @click.option("--titles", help="Comma-separated ResponsiveAd.Titles values")
 @click.option("--texts", help="Comma-separated ResponsiveAd.Texts values")
-@click.option("--href", help="URL (TEXT_AD / TEXT_IMAGE_AD / RESPONSIVE_AD)")
+@click.option(
+    "--href",
+    help=(
+        "URL (TEXT_AD / TEXT_IMAGE_AD / RESPONSIVE_AD / "
+        "TEXT_AD_BUILDER_AD / CPC_VIDEO_AD_BUILDER_AD / "
+        "CPM_BANNER_AD_BUILDER_AD / CPM_VIDEO_AD_BUILDER_AD)"
+    ),
+)
 @click.option(
     "--image-hash",
     help="Image hash (TEXT_AD / TEXT_IMAGE_AD / MOBILE_APP_AD / DYNAMIC_TEXT_AD)",
@@ -664,7 +745,13 @@ def add(
     "--action",
     help="MOBILE_APP_AD call-to-action (MobileAppAdActionEnum, e.g. INSTALL)",
 )
-@click.option("--tracking-url", help="MOBILE_APP_AD tracking URL")
+@click.option(
+    "--tracking-url",
+    help=(
+        "Tracking URL (MOBILE_APP_AD / MOBILE_APP_AD_BUILDER_AD / "
+        "MOBILE_APP_CPC_VIDEO_AD_BUILDER_AD)"
+    ),
+)
 @click.option(
     "--age-label",
     help="Age label (MOBILE_APP_AD MobAppAgeLabelEnum / RESPONSIVE_AD AgeLabelEnum)",
@@ -681,7 +768,13 @@ def add(
     ),
 )
 @click.option(
-    "--turbo-page-id", type=int, help="Turbo page ID (TEXT_AD / TEXT_IMAGE_AD)"
+    "--turbo-page-id",
+    type=int,
+    help=(
+        "Turbo page ID (TEXT_AD / TEXT_IMAGE_AD / TEXT_AD_BUILDER_AD / "
+        "CPC_VIDEO_AD_BUILDER_AD / CPM_BANNER_AD_BUILDER_AD / "
+        "CPM_VIDEO_AD_BUILDER_AD)"
+    ),
 )
 @click.option(
     "--callouts-add",
@@ -756,7 +849,24 @@ def add(
 )
 @click.option(
     "--erir-ad-description",
-    help="ResponsiveAd.ErirAdDescription",
+    help="ErirAdDescription for RESPONSIVE_AD and AdBuilder update subtypes",
+)
+@click.option(
+    "--creative-id",
+    type=int,
+    help="AdBuilder Creative.CreativeId for AdBuilder update subtypes",
+)
+@click.option(
+    "--creative-erir-ad-description",
+    help="AdBuilder Creative.ErirAdDescription; requires --creative-id",
+)
+@click.option(
+    "--final-url",
+    help="TextAdBuilderAd.FinalUrl",
+)
+@click.option(
+    "--tracking-pixels",
+    help="Comma-separated AdBuilder TrackingPixels.Items values",
 )
 @click.option(
     "--feed-filter-condition",
@@ -812,6 +922,10 @@ def update(
     price_extension_price_currency,
     business_id,
     erir_ad_description,
+    creative_id,
+    creative_erir_ad_description,
+    final_url,
+    tracking_pixels,
     feed_filter_conditions,
     title_sources,
     text_sources,
@@ -834,13 +948,17 @@ def update(
         "RESPONSIVE_AD",
         "SHOPPING_AD",
         "LISTING_AD",
+        *AD_BUILDER_UPDATE_BLOCKS,
     }
     if ad_type_norm not in supported_types:
         raise click.UsageError(
             "Invalid value for '--type': "
             f"{ad_type!r} is not one of "
             "'TEXT_AD', 'TEXT_IMAGE_AD', 'MOBILE_APP_AD', 'DYNAMIC_TEXT_AD', "
-            "'RESPONSIVE_AD', 'SHOPPING_AD', 'LISTING_AD'."
+            "'RESPONSIVE_AD', 'SHOPPING_AD', 'LISTING_AD', "
+            "'TEXT_AD_BUILDER_AD', 'MOBILE_APP_AD_BUILDER_AD', "
+            "'MOBILE_APP_CPC_VIDEO_AD_BUILDER_AD', 'CPC_VIDEO_AD_BUILDER_AD', "
+            "'CPM_BANNER_AD_BUILDER_AD', 'CPM_VIDEO_AD_BUILDER_AD'."
         )
 
     # Per-WSDL-subtype field allow-list: each --type accepts only the
@@ -907,6 +1025,7 @@ def update(
         },
         "SHOPPING_AD": FEED_BASED_UPDATE_FIELDS,
         "LISTING_AD": FEED_BASED_UPDATE_FIELDS,
+        **AD_BUILDER_TYPE_FIELDS,
     }
     provided = {
         "title": title,
@@ -935,6 +1054,10 @@ def update(
         "price_extension_price_currency": price_extension_price_currency,
         "business_id": business_id,
         "erir_ad_description": erir_ad_description,
+        "creative_id": creative_id,
+        "creative_erir_ad_description": creative_erir_ad_description,
+        "final_url": final_url,
+        "tracking_pixels": tracking_pixels,
         "feed_filter_conditions": feed_filter_conditions,
         "title_sources": title_sources,
         "text_sources": text_sources,
@@ -967,6 +1090,10 @@ def update(
         "price_extension_price_currency": "--price-extension-price-currency",
         "business_id": "--business-id",
         "erir_ad_description": "--erir-ad-description",
+        "creative_id": "--creative-id",
+        "creative_erir_ad_description": "--creative-erir-ad-description",
+        "final_url": "--final-url",
+        "tracking_pixels": "--tracking-pixels",
         "feed_filter_conditions": "--feed-filter-condition",
         "title_sources": "--title-sources",
         "text_sources": "--text-sources",
@@ -1089,6 +1216,19 @@ def update(
         if feed_based_ad:
             field_name = "ShoppingAd" if ad_type_norm == "SHOPPING_AD" else "ListingAd"
             ad_data[field_name] = feed_based_ad
+    elif ad_type_norm in AD_BUILDER_UPDATE_BLOCKS:
+        ad_builder_ad = _build_ad_builder_update(
+            creative_id,
+            creative_erir_ad_description,
+            erir_ad_description,
+            final_url,
+            href,
+            turbo_page_id,
+            tracking_url,
+            tracking_pixels,
+        )
+        if ad_builder_ad:
+            ad_data[AD_BUILDER_UPDATE_BLOCKS[ad_type_norm]] = ad_builder_ad
 
     # Reject empty-subtype no-ops: ``{Id: N}`` with no subtype block
     # is a silent no-op on the live API (issue #198 H1).

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,9 +11,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 2569 |
+| `missing_followup` | 2524 |
 | `not_applicable` | 23 |
-| `supported` | 649 |
+| `supported` | 694 |
 
 ## Confirmed Follow-Ups
 
@@ -173,51 +173,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `ads.update` | `MobileAppImageAd.AdImageHash` | MOBILE_APP_IMAGE_AD update fields need typed support or N/A. [#271](https://github.com/axisrow/direct-cli/issues/271); inherited from `MobileAppImageAd` |
 | `ads.update` | `MobileAppImageAd.ErirAdDescription` | MOBILE_APP_IMAGE_AD update fields need typed support or N/A. [#271](https://github.com/axisrow/direct-cli/issues/271); inherited from `MobileAppImageAd` |
 | `ads.update` | `MobileAppImageAd.TrackingUrl` | MOBILE_APP_IMAGE_AD update fields need typed support or N/A. [#271](https://github.com/axisrow/direct-cli/issues/271); inherited from `MobileAppImageAd` |
-| `ads.update` | `MobileAppCpcVideoAdBuilderAd` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270) |
-| `ads.update` | `MobileAppCpcVideoAdBuilderAd.Creative` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `MobileAppCpcVideoAdBuilderAd` |
-| `ads.update` | `MobileAppCpcVideoAdBuilderAd.Creative.CreativeId` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `MobileAppCpcVideoAdBuilderAd` |
-| `ads.update` | `MobileAppCpcVideoAdBuilderAd.Creative.ErirAdDescription` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `MobileAppCpcVideoAdBuilderAd` |
-| `ads.update` | `MobileAppCpcVideoAdBuilderAd.ErirAdDescription` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `MobileAppCpcVideoAdBuilderAd` |
-| `ads.update` | `MobileAppCpcVideoAdBuilderAd.TrackingUrl` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `MobileAppCpcVideoAdBuilderAd` |
-| `ads.update` | `TextAdBuilderAd` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270) |
-| `ads.update` | `TextAdBuilderAd.Creative` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `TextAdBuilderAd` |
-| `ads.update` | `TextAdBuilderAd.Creative.CreativeId` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `TextAdBuilderAd` |
-| `ads.update` | `TextAdBuilderAd.Creative.ErirAdDescription` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `TextAdBuilderAd` |
-| `ads.update` | `TextAdBuilderAd.ErirAdDescription` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `TextAdBuilderAd` |
-| `ads.update` | `TextAdBuilderAd.FinalUrl` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `TextAdBuilderAd` |
-| `ads.update` | `TextAdBuilderAd.Href` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `TextAdBuilderAd` |
-| `ads.update` | `TextAdBuilderAd.TurboPageId` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `TextAdBuilderAd` |
-| `ads.update` | `MobileAppAdBuilderAd` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270) |
-| `ads.update` | `MobileAppAdBuilderAd.Creative` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `MobileAppAdBuilderAd` |
-| `ads.update` | `MobileAppAdBuilderAd.Creative.CreativeId` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `MobileAppAdBuilderAd` |
-| `ads.update` | `MobileAppAdBuilderAd.Creative.ErirAdDescription` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `MobileAppAdBuilderAd` |
-| `ads.update` | `MobileAppAdBuilderAd.ErirAdDescription` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `MobileAppAdBuilderAd` |
-| `ads.update` | `MobileAppAdBuilderAd.TrackingUrl` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `MobileAppAdBuilderAd` |
-| `ads.update` | `CpcVideoAdBuilderAd` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270) |
-| `ads.update` | `CpcVideoAdBuilderAd.Creative` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpcVideoAdBuilderAd` |
-| `ads.update` | `CpcVideoAdBuilderAd.Creative.CreativeId` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpcVideoAdBuilderAd` |
-| `ads.update` | `CpcVideoAdBuilderAd.Creative.ErirAdDescription` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpcVideoAdBuilderAd` |
-| `ads.update` | `CpcVideoAdBuilderAd.ErirAdDescription` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpcVideoAdBuilderAd` |
-| `ads.update` | `CpcVideoAdBuilderAd.Href` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpcVideoAdBuilderAd` |
-| `ads.update` | `CpcVideoAdBuilderAd.TurboPageId` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpcVideoAdBuilderAd` |
-| `ads.update` | `CpmBannerAdBuilderAd` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270) |
-| `ads.update` | `CpmBannerAdBuilderAd.Creative` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmBannerAdBuilderAd` |
-| `ads.update` | `CpmBannerAdBuilderAd.Creative.CreativeId` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmBannerAdBuilderAd` |
-| `ads.update` | `CpmBannerAdBuilderAd.Creative.ErirAdDescription` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmBannerAdBuilderAd` |
-| `ads.update` | `CpmBannerAdBuilderAd.ErirAdDescription` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmBannerAdBuilderAd` |
-| `ads.update` | `CpmBannerAdBuilderAd.Href` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmBannerAdBuilderAd` |
-| `ads.update` | `CpmBannerAdBuilderAd.TrackingPixels` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmBannerAdBuilderAd` |
-| `ads.update` | `CpmBannerAdBuilderAd.TrackingPixels.Items` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmBannerAdBuilderAd` |
-| `ads.update` | `CpmBannerAdBuilderAd.TurboPageId` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmBannerAdBuilderAd` |
-| `ads.update` | `CpmVideoAdBuilderAd` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270) |
-| `ads.update` | `CpmVideoAdBuilderAd.Creative` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmVideoAdBuilderAd` |
-| `ads.update` | `CpmVideoAdBuilderAd.Creative.CreativeId` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmVideoAdBuilderAd` |
-| `ads.update` | `CpmVideoAdBuilderAd.Creative.ErirAdDescription` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmVideoAdBuilderAd` |
-| `ads.update` | `CpmVideoAdBuilderAd.ErirAdDescription` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmVideoAdBuilderAd` |
-| `ads.update` | `CpmVideoAdBuilderAd.Href` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmVideoAdBuilderAd` |
-| `ads.update` | `CpmVideoAdBuilderAd.TrackingPixels` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmVideoAdBuilderAd` |
-| `ads.update` | `CpmVideoAdBuilderAd.TrackingPixels.Items` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmVideoAdBuilderAd` |
-| `ads.update` | `CpmVideoAdBuilderAd.TurboPageId` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmVideoAdBuilderAd` |
 | `ads.update` | `SmartAdBuilderAd` | SMART_AD_BUILDER_AD update fields need typed support or N/A. [#271](https://github.com/axisrow/direct-cli/issues/271) |
 | `ads.update` | `SmartAdBuilderAd.LogoExtensionHash` | SMART_AD_BUILDER_AD update fields need typed support or N/A. [#271](https://github.com/axisrow/direct-cli/issues/271); inherited from `SmartAdBuilderAd` |
 | `ads.update` | `SmartAdBuilderAd.ErirAdDescription` | SMART_AD_BUILDER_AD update fields need typed support or N/A. [#271](https://github.com/axisrow/direct-cli/issues/271); inherited from `SmartAdBuilderAd` |
@@ -2948,51 +2903,51 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `ads.update` | `ads.update` | `MobileAppImageAd.AdImageHash` | `string` | 0 | 1 | `missing_followup` | MOBILE_APP_IMAGE_AD update fields need typed support or N/A. [#271](https://github.com/axisrow/direct-cli/issues/271); inherited from `MobileAppImageAd` |
 | `ads.update` | `ads.update` | `MobileAppImageAd.ErirAdDescription` | `string` | 0 | 1 | `missing_followup` | MOBILE_APP_IMAGE_AD update fields need typed support or N/A. [#271](https://github.com/axisrow/direct-cli/issues/271); inherited from `MobileAppImageAd` |
 | `ads.update` | `ads.update` | `MobileAppImageAd.TrackingUrl` | `string` | 0 | 1 | `missing_followup` | MOBILE_APP_IMAGE_AD update fields need typed support or N/A. [#271](https://github.com/axisrow/direct-cli/issues/271); inherited from `MobileAppImageAd` |
-| `ads.update` | `ads.update` | `MobileAppCpcVideoAdBuilderAd` | `MobileAppCpcVideoAdBuilderAdUpdate` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270) |
-| `ads.update` | `ads.update` | `MobileAppCpcVideoAdBuilderAd.Creative` | `AdBuilderAdUpdateItem` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `MobileAppCpcVideoAdBuilderAd` |
-| `ads.update` | `ads.update` | `MobileAppCpcVideoAdBuilderAd.Creative.CreativeId` | `long` | 1 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `MobileAppCpcVideoAdBuilderAd` |
-| `ads.update` | `ads.update` | `MobileAppCpcVideoAdBuilderAd.Creative.ErirAdDescription` | `string` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `MobileAppCpcVideoAdBuilderAd` |
-| `ads.update` | `ads.update` | `MobileAppCpcVideoAdBuilderAd.ErirAdDescription` | `string` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `MobileAppCpcVideoAdBuilderAd` |
-| `ads.update` | `ads.update` | `MobileAppCpcVideoAdBuilderAd.TrackingUrl` | `string` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `MobileAppCpcVideoAdBuilderAd` |
-| `ads.update` | `ads.update` | `TextAdBuilderAd` | `TextAdBuilderAdUpdate` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270) |
-| `ads.update` | `ads.update` | `TextAdBuilderAd.Creative` | `AdBuilderAdUpdateItem` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `TextAdBuilderAd` |
-| `ads.update` | `ads.update` | `TextAdBuilderAd.Creative.CreativeId` | `long` | 1 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `TextAdBuilderAd` |
-| `ads.update` | `ads.update` | `TextAdBuilderAd.Creative.ErirAdDescription` | `string` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `TextAdBuilderAd` |
-| `ads.update` | `ads.update` | `TextAdBuilderAd.ErirAdDescription` | `string` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `TextAdBuilderAd` |
-| `ads.update` | `ads.update` | `TextAdBuilderAd.FinalUrl` | `string` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `TextAdBuilderAd` |
-| `ads.update` | `ads.update` | `TextAdBuilderAd.Href` | `string` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `TextAdBuilderAd` |
-| `ads.update` | `ads.update` | `TextAdBuilderAd.TurboPageId` | `long` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `TextAdBuilderAd` |
-| `ads.update` | `ads.update` | `MobileAppAdBuilderAd` | `MobileAppAdBuilderAdUpdate` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270) |
-| `ads.update` | `ads.update` | `MobileAppAdBuilderAd.Creative` | `AdBuilderAdUpdateItem` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `MobileAppAdBuilderAd` |
-| `ads.update` | `ads.update` | `MobileAppAdBuilderAd.Creative.CreativeId` | `long` | 1 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `MobileAppAdBuilderAd` |
-| `ads.update` | `ads.update` | `MobileAppAdBuilderAd.Creative.ErirAdDescription` | `string` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `MobileAppAdBuilderAd` |
-| `ads.update` | `ads.update` | `MobileAppAdBuilderAd.ErirAdDescription` | `string` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `MobileAppAdBuilderAd` |
-| `ads.update` | `ads.update` | `MobileAppAdBuilderAd.TrackingUrl` | `string` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `MobileAppAdBuilderAd` |
-| `ads.update` | `ads.update` | `CpcVideoAdBuilderAd` | `CpcVideoAdBuilderAdUpdate` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270) |
-| `ads.update` | `ads.update` | `CpcVideoAdBuilderAd.Creative` | `AdBuilderAdUpdateItem` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpcVideoAdBuilderAd` |
-| `ads.update` | `ads.update` | `CpcVideoAdBuilderAd.Creative.CreativeId` | `long` | 1 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpcVideoAdBuilderAd` |
-| `ads.update` | `ads.update` | `CpcVideoAdBuilderAd.Creative.ErirAdDescription` | `string` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpcVideoAdBuilderAd` |
-| `ads.update` | `ads.update` | `CpcVideoAdBuilderAd.ErirAdDescription` | `string` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpcVideoAdBuilderAd` |
-| `ads.update` | `ads.update` | `CpcVideoAdBuilderAd.Href` | `string` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpcVideoAdBuilderAd` |
-| `ads.update` | `ads.update` | `CpcVideoAdBuilderAd.TurboPageId` | `long` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpcVideoAdBuilderAd` |
-| `ads.update` | `ads.update` | `CpmBannerAdBuilderAd` | `CpmBannerAdBuilderAdUpdate` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270) |
-| `ads.update` | `ads.update` | `CpmBannerAdBuilderAd.Creative` | `AdBuilderAdUpdateItem` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmBannerAdBuilderAd` |
-| `ads.update` | `ads.update` | `CpmBannerAdBuilderAd.Creative.CreativeId` | `long` | 1 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmBannerAdBuilderAd` |
-| `ads.update` | `ads.update` | `CpmBannerAdBuilderAd.Creative.ErirAdDescription` | `string` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmBannerAdBuilderAd` |
-| `ads.update` | `ads.update` | `CpmBannerAdBuilderAd.ErirAdDescription` | `string` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmBannerAdBuilderAd` |
-| `ads.update` | `ads.update` | `CpmBannerAdBuilderAd.Href` | `string` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmBannerAdBuilderAd` |
-| `ads.update` | `ads.update` | `CpmBannerAdBuilderAd.TrackingPixels` | `ArrayOfString` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmBannerAdBuilderAd` |
-| `ads.update` | `ads.update` | `CpmBannerAdBuilderAd.TrackingPixels.Items` | `string` | 1 | unbounded | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmBannerAdBuilderAd` |
-| `ads.update` | `ads.update` | `CpmBannerAdBuilderAd.TurboPageId` | `long` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmBannerAdBuilderAd` |
-| `ads.update` | `ads.update` | `CpmVideoAdBuilderAd` | `CpmVideoAdBuilderAdUpdate` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270) |
-| `ads.update` | `ads.update` | `CpmVideoAdBuilderAd.Creative` | `AdBuilderAdUpdateItem` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmVideoAdBuilderAd` |
-| `ads.update` | `ads.update` | `CpmVideoAdBuilderAd.Creative.CreativeId` | `long` | 1 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmVideoAdBuilderAd` |
-| `ads.update` | `ads.update` | `CpmVideoAdBuilderAd.Creative.ErirAdDescription` | `string` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmVideoAdBuilderAd` |
-| `ads.update` | `ads.update` | `CpmVideoAdBuilderAd.ErirAdDescription` | `string` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmVideoAdBuilderAd` |
-| `ads.update` | `ads.update` | `CpmVideoAdBuilderAd.Href` | `string` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmVideoAdBuilderAd` |
-| `ads.update` | `ads.update` | `CpmVideoAdBuilderAd.TrackingPixels` | `ArrayOfString` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmVideoAdBuilderAd` |
-| `ads.update` | `ads.update` | `CpmVideoAdBuilderAd.TrackingPixels.Items` | `string` | 1 | unbounded | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmVideoAdBuilderAd` |
-| `ads.update` | `ads.update` | `CpmVideoAdBuilderAd.TurboPageId` | `long` | 0 | 1 | `missing_followup` | AdBuilder update subtype fields need typed support or N/A. [#270](https://github.com/axisrow/direct-cli/issues/270); inherited from `CpmVideoAdBuilderAd` |
+| `ads.update` | `ads.update` | `MobileAppCpcVideoAdBuilderAd` | `MobileAppCpcVideoAdBuilderAdUpdate` | 0 | 1 | `supported` | --type |
+| `ads.update` | `ads.update` | `MobileAppCpcVideoAdBuilderAd.Creative` | `AdBuilderAdUpdateItem` | 0 | 1 | `supported` | --creative-erir-ad-description, --creative-id |
+| `ads.update` | `ads.update` | `MobileAppCpcVideoAdBuilderAd.Creative.CreativeId` | `long` | 1 | 1 | `supported` | --creative-id |
+| `ads.update` | `ads.update` | `MobileAppCpcVideoAdBuilderAd.Creative.ErirAdDescription` | `string` | 0 | 1 | `supported` | --creative-erir-ad-description |
+| `ads.update` | `ads.update` | `MobileAppCpcVideoAdBuilderAd.ErirAdDescription` | `string` | 0 | 1 | `supported` | --erir-ad-description |
+| `ads.update` | `ads.update` | `MobileAppCpcVideoAdBuilderAd.TrackingUrl` | `string` | 0 | 1 | `supported` | --tracking-url |
+| `ads.update` | `ads.update` | `TextAdBuilderAd` | `TextAdBuilderAdUpdate` | 0 | 1 | `supported` | --type |
+| `ads.update` | `ads.update` | `TextAdBuilderAd.Creative` | `AdBuilderAdUpdateItem` | 0 | 1 | `supported` | --creative-erir-ad-description, --creative-id |
+| `ads.update` | `ads.update` | `TextAdBuilderAd.Creative.CreativeId` | `long` | 1 | 1 | `supported` | --creative-id |
+| `ads.update` | `ads.update` | `TextAdBuilderAd.Creative.ErirAdDescription` | `string` | 0 | 1 | `supported` | --creative-erir-ad-description |
+| `ads.update` | `ads.update` | `TextAdBuilderAd.ErirAdDescription` | `string` | 0 | 1 | `supported` | --erir-ad-description |
+| `ads.update` | `ads.update` | `TextAdBuilderAd.FinalUrl` | `string` | 0 | 1 | `supported` | --final-url |
+| `ads.update` | `ads.update` | `TextAdBuilderAd.Href` | `string` | 0 | 1 | `supported` | --href |
+| `ads.update` | `ads.update` | `TextAdBuilderAd.TurboPageId` | `long` | 0 | 1 | `supported` | --turbo-page-id |
+| `ads.update` | `ads.update` | `MobileAppAdBuilderAd` | `MobileAppAdBuilderAdUpdate` | 0 | 1 | `supported` | --type |
+| `ads.update` | `ads.update` | `MobileAppAdBuilderAd.Creative` | `AdBuilderAdUpdateItem` | 0 | 1 | `supported` | --creative-erir-ad-description, --creative-id |
+| `ads.update` | `ads.update` | `MobileAppAdBuilderAd.Creative.CreativeId` | `long` | 1 | 1 | `supported` | --creative-id |
+| `ads.update` | `ads.update` | `MobileAppAdBuilderAd.Creative.ErirAdDescription` | `string` | 0 | 1 | `supported` | --creative-erir-ad-description |
+| `ads.update` | `ads.update` | `MobileAppAdBuilderAd.ErirAdDescription` | `string` | 0 | 1 | `supported` | --erir-ad-description |
+| `ads.update` | `ads.update` | `MobileAppAdBuilderAd.TrackingUrl` | `string` | 0 | 1 | `supported` | --tracking-url |
+| `ads.update` | `ads.update` | `CpcVideoAdBuilderAd` | `CpcVideoAdBuilderAdUpdate` | 0 | 1 | `supported` | --type |
+| `ads.update` | `ads.update` | `CpcVideoAdBuilderAd.Creative` | `AdBuilderAdUpdateItem` | 0 | 1 | `supported` | --creative-erir-ad-description, --creative-id |
+| `ads.update` | `ads.update` | `CpcVideoAdBuilderAd.Creative.CreativeId` | `long` | 1 | 1 | `supported` | --creative-id |
+| `ads.update` | `ads.update` | `CpcVideoAdBuilderAd.Creative.ErirAdDescription` | `string` | 0 | 1 | `supported` | --creative-erir-ad-description |
+| `ads.update` | `ads.update` | `CpcVideoAdBuilderAd.ErirAdDescription` | `string` | 0 | 1 | `supported` | --erir-ad-description |
+| `ads.update` | `ads.update` | `CpcVideoAdBuilderAd.Href` | `string` | 0 | 1 | `supported` | --href |
+| `ads.update` | `ads.update` | `CpcVideoAdBuilderAd.TurboPageId` | `long` | 0 | 1 | `supported` | --turbo-page-id |
+| `ads.update` | `ads.update` | `CpmBannerAdBuilderAd` | `CpmBannerAdBuilderAdUpdate` | 0 | 1 | `supported` | --type |
+| `ads.update` | `ads.update` | `CpmBannerAdBuilderAd.Creative` | `AdBuilderAdUpdateItem` | 0 | 1 | `supported` | --creative-erir-ad-description, --creative-id |
+| `ads.update` | `ads.update` | `CpmBannerAdBuilderAd.Creative.CreativeId` | `long` | 1 | 1 | `supported` | --creative-id |
+| `ads.update` | `ads.update` | `CpmBannerAdBuilderAd.Creative.ErirAdDescription` | `string` | 0 | 1 | `supported` | --creative-erir-ad-description |
+| `ads.update` | `ads.update` | `CpmBannerAdBuilderAd.ErirAdDescription` | `string` | 0 | 1 | `supported` | --erir-ad-description |
+| `ads.update` | `ads.update` | `CpmBannerAdBuilderAd.Href` | `string` | 0 | 1 | `supported` | --href |
+| `ads.update` | `ads.update` | `CpmBannerAdBuilderAd.TrackingPixels` | `ArrayOfString` | 0 | 1 | `supported` | --tracking-pixels |
+| `ads.update` | `ads.update` | `CpmBannerAdBuilderAd.TrackingPixels.Items` | `string` | 1 | unbounded | `supported` | --tracking-pixels |
+| `ads.update` | `ads.update` | `CpmBannerAdBuilderAd.TurboPageId` | `long` | 0 | 1 | `supported` | --turbo-page-id |
+| `ads.update` | `ads.update` | `CpmVideoAdBuilderAd` | `CpmVideoAdBuilderAdUpdate` | 0 | 1 | `supported` | --type |
+| `ads.update` | `ads.update` | `CpmVideoAdBuilderAd.Creative` | `AdBuilderAdUpdateItem` | 0 | 1 | `supported` | --creative-erir-ad-description, --creative-id |
+| `ads.update` | `ads.update` | `CpmVideoAdBuilderAd.Creative.CreativeId` | `long` | 1 | 1 | `supported` | --creative-id |
+| `ads.update` | `ads.update` | `CpmVideoAdBuilderAd.Creative.ErirAdDescription` | `string` | 0 | 1 | `supported` | --creative-erir-ad-description |
+| `ads.update` | `ads.update` | `CpmVideoAdBuilderAd.ErirAdDescription` | `string` | 0 | 1 | `supported` | --erir-ad-description |
+| `ads.update` | `ads.update` | `CpmVideoAdBuilderAd.Href` | `string` | 0 | 1 | `supported` | --href |
+| `ads.update` | `ads.update` | `CpmVideoAdBuilderAd.TrackingPixels` | `ArrayOfString` | 0 | 1 | `supported` | --tracking-pixels |
+| `ads.update` | `ads.update` | `CpmVideoAdBuilderAd.TrackingPixels.Items` | `string` | 1 | unbounded | `supported` | --tracking-pixels |
+| `ads.update` | `ads.update` | `CpmVideoAdBuilderAd.TurboPageId` | `long` | 0 | 1 | `supported` | --turbo-page-id |
 | `ads.update` | `ads.update` | `SmartAdBuilderAd` | `SmartAdBuilderAdUpdate` | 0 | 1 | `missing_followup` | SMART_AD_BUILDER_AD update fields need typed support or N/A. [#271](https://github.com/axisrow/direct-cli/issues/271) |
 | `ads.update` | `ads.update` | `SmartAdBuilderAd.LogoExtensionHash` | `string` | 0 | 1 | `missing_followup` | SMART_AD_BUILDER_AD update fields need typed support or N/A. [#271](https://github.com/axisrow/direct-cli/issues/271); inherited from `SmartAdBuilderAd` |
 | `ads.update` | `ads.update` | `SmartAdBuilderAd.ErirAdDescription` | `string` | 0 | 1 | `missing_followup` | SMART_AD_BUILDER_AD update fields need typed support or N/A. [#271](https://github.com/axisrow/direct-cli/issues/271); inherited from `SmartAdBuilderAd` |

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -273,7 +273,7 @@ class TestCLI(unittest.TestCase):
         )
         self.assertIn(
             "TEXT_AD | TEXT_IMAGE_AD | MOBILE_APP_AD | DYNAMIC_TEXT_AD | "
-            "RESPONSIVE_AD | SHOPPING_AD | LISTING_AD",
+            "RESPONSIVE_AD | SHOPPING_AD | LISTING_AD | TEXT_AD_BUILDER_AD",
             collapsed,
         )
         self.assertIn("Comma-separated ResponsiveAd.Titles values", collapsed)
@@ -287,6 +287,10 @@ class TestCLI(unittest.TestCase):
         self.assertIn(
             "Comma-separated ShoppingAd/ListingAd.TitleSources.Items values",
             collapsed,
+        )
+        self.assertIn("AdBuilder Creative.CreativeId", collapsed)
+        self.assertIn(
+            "Comma-separated AdBuilder TrackingPixels.Items values", collapsed
         )
 
     def test_clients_update_help_documents_erir_organization_flags(self):

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1577,6 +1577,264 @@ def test_ads_update_shopping_ad_zero_ids_are_not_silently_dropped():
     }
 
 
+def test_ads_update_text_ad_builder_ad_payload():
+    """Issue #270: TEXT_AD_BUILDER_AD update builds TextAdBuilderAd block."""
+    body = _dry_run(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "TEXT_AD_BUILDER_AD",
+        "--creative-id",
+        "111",
+        "--creative-erir-ad-description",
+        "Creative object",
+        "--erir-ad-description",
+        "Ad object",
+        "--final-url",
+        "https://final.example.com",
+        "--href",
+        "https://example.com",
+        "--turbo-page-id",
+        "222",
+    )
+    ad = body["params"]["Ads"][0]
+    assert ad == {
+        "Id": 999,
+        "TextAdBuilderAd": {
+            "Creative": {
+                "CreativeId": 111,
+                "ErirAdDescription": "Creative object",
+            },
+            "ErirAdDescription": "Ad object",
+            "FinalUrl": "https://final.example.com",
+            "Href": "https://example.com",
+            "TurboPageId": 222,
+        },
+    }
+    assert "TextAd" not in ad
+
+
+def test_ads_update_mobile_app_ad_builder_ad_payload():
+    """Issue #270: MOBILE_APP_AD_BUILDER_AD update supports TrackingUrl."""
+    body = _dry_run(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "MOBILE_APP_AD_BUILDER_AD",
+        "--creative-id",
+        "111",
+        "--tracking-url",
+        "https://track.example.com",
+        "--erir-ad-description",
+        "Mobile builder",
+    )
+    assert body["params"]["Ads"][0] == {
+        "Id": 999,
+        "MobileAppAdBuilderAd": {
+            "Creative": {"CreativeId": 111},
+            "ErirAdDescription": "Mobile builder",
+            "TrackingUrl": "https://track.example.com",
+        },
+    }
+
+
+def test_ads_update_mobile_app_cpc_video_ad_builder_ad_payload():
+    """Issue #270: MOBILE_APP_CPC_VIDEO_AD_BUILDER_AD uses its own block."""
+    body = _dry_run(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "MOBILE_APP_CPC_VIDEO_AD_BUILDER_AD",
+        "--creative-id",
+        "111",
+        "--tracking-url",
+        "https://track.example.com",
+    )
+    assert body["params"]["Ads"][0] == {
+        "Id": 999,
+        "MobileAppCpcVideoAdBuilderAd": {
+            "Creative": {"CreativeId": 111},
+            "TrackingUrl": "https://track.example.com",
+        },
+    }
+
+
+def test_ads_update_cpc_video_ad_builder_ad_payload():
+    """Issue #270: CPC_VIDEO_AD_BUILDER_AD supports href and TurboPageId."""
+    body = _dry_run(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "CPC_VIDEO_AD_BUILDER_AD",
+        "--creative-id",
+        "111",
+        "--href",
+        "https://example.com",
+        "--turbo-page-id",
+        "222",
+    )
+    assert body["params"]["Ads"][0] == {
+        "Id": 999,
+        "CpcVideoAdBuilderAd": {
+            "Creative": {"CreativeId": 111},
+            "Href": "https://example.com",
+            "TurboPageId": 222,
+        },
+    }
+
+
+def test_ads_update_cpm_banner_ad_builder_ad_payload():
+    """Issue #270: CPM_BANNER_AD_BUILDER_AD wraps TrackingPixels.Items."""
+    body = _dry_run(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "CPM_BANNER_AD_BUILDER_AD",
+        "--creative-id",
+        "111",
+        "--href",
+        "https://example.com",
+        "--tracking-pixels",
+        "https://pixel.example.com/a,https://pixel.example.com/b",
+        "--turbo-page-id",
+        "222",
+    )
+    assert body["params"]["Ads"][0] == {
+        "Id": 999,
+        "CpmBannerAdBuilderAd": {
+            "Creative": {"CreativeId": 111},
+            "Href": "https://example.com",
+            "TrackingPixels": {
+                "Items": [
+                    "https://pixel.example.com/a",
+                    "https://pixel.example.com/b",
+                ]
+            },
+            "TurboPageId": 222,
+        },
+    }
+
+
+def test_ads_update_cpm_video_ad_builder_ad_payload():
+    """Issue #270: CPM_VIDEO_AD_BUILDER_AD wraps TrackingPixels.Items."""
+    body = _dry_run(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "CPM_VIDEO_AD_BUILDER_AD",
+        "--creative-id",
+        "111",
+        "--tracking-pixels",
+        "https://pixel.example.com/a",
+    )
+    assert body["params"]["Ads"][0] == {
+        "Id": 999,
+        "CpmVideoAdBuilderAd": {
+            "Creative": {"CreativeId": 111},
+            "TrackingPixels": {"Items": ["https://pixel.example.com/a"]},
+        },
+    }
+
+
+def test_ads_update_ad_builder_creative_erir_requires_creative_id():
+    """Issue #270: nested Creative.ErirAdDescription requires CreativeId."""
+    result = _rejected(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "TEXT_AD_BUILDER_AD",
+        "--creative-erir-ad-description",
+        "Creative object",
+    )
+    assert "--creative-erir-ad-description requires --creative-id" in result.output
+
+
+def test_ads_update_ad_builder_rejects_unrelated_flag():
+    """Issue #270: AdBuilder subtypes must not silently drop unrelated flags."""
+    result = _rejected(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "MOBILE_APP_AD_BUILDER_AD",
+        "--href",
+        "https://example.com",
+    )
+    assert (
+        "--href is not compatible with --type MOBILE_APP_AD_BUILDER_AD" in result.output
+    )
+    assert "does not convert an ad between subtypes" in result.output
+
+
+def test_ads_update_ad_builder_empty_tracking_pixels_rejected():
+    """Issue #270: explicit empty TrackingPixels does not create a no-op."""
+    result = _rejected(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "CPM_VIDEO_AD_BUILDER_AD",
+        "--tracking-pixels",
+        "",
+    )
+    assert "--tracking-pixels must contain at least one value." in result.output
+
+
+def test_ads_update_ad_builder_noop_rejected():
+    """Issue #270: AdBuilder update without fields stays a no-op error."""
+    result = _rejected(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "CPM_BANNER_AD_BUILDER_AD",
+    )
+    assert (
+        "ads update requires at least one updatable field for "
+        "--type CPM_BANNER_AD_BUILDER_AD"
+    ) in result.output
+
+
+def test_ads_update_ad_builder_zero_ids_are_not_silently_dropped():
+    """Issue #270: nullable long flags use presence, not truthiness."""
+    body = _dry_run(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "TEXT_AD_BUILDER_AD",
+        "--creative-id",
+        "0",
+        "--turbo-page-id",
+        "0",
+    )
+    assert body["params"]["Ads"][0] == {
+        "Id": 999,
+        "TextAdBuilderAd": {
+            "Creative": {"CreativeId": 0},
+            "TurboPageId": 0,
+        },
+    }
+
+
 def test_ads_update_text_ad_with_turbo_page_id():
     """Issue #202: update sets TurboPageId in TextAd."""
     body = _dry_run(

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -1135,6 +1135,99 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     ("ads", "update", "ListingAd.TextSources"): {"--text-sources"},
     ("ads", "update", "ListingAd.TextSources.Items"): {"--text-sources"},
     ("ads", "update", "ListingAd.DefaultTexts"): {"--default-texts"},
+    ("ads", "update", "MobileAppCpcVideoAdBuilderAd"): {"--type"},
+    ("ads", "update", "MobileAppCpcVideoAdBuilderAd.Creative"): {
+        "--creative-id",
+        "--creative-erir-ad-description",
+    },
+    ("ads", "update", "MobileAppCpcVideoAdBuilderAd.Creative.CreativeId"): {
+        "--creative-id"
+    },
+    (
+        "ads",
+        "update",
+        "MobileAppCpcVideoAdBuilderAd.Creative.ErirAdDescription",
+    ): {"--creative-erir-ad-description"},
+    ("ads", "update", "MobileAppCpcVideoAdBuilderAd.ErirAdDescription"): {
+        "--erir-ad-description"
+    },
+    ("ads", "update", "MobileAppCpcVideoAdBuilderAd.TrackingUrl"): {"--tracking-url"},
+    ("ads", "update", "TextAdBuilderAd"): {"--type"},
+    ("ads", "update", "TextAdBuilderAd.Creative"): {
+        "--creative-id",
+        "--creative-erir-ad-description",
+    },
+    ("ads", "update", "TextAdBuilderAd.Creative.CreativeId"): {"--creative-id"},
+    ("ads", "update", "TextAdBuilderAd.Creative.ErirAdDescription"): {
+        "--creative-erir-ad-description"
+    },
+    ("ads", "update", "TextAdBuilderAd.ErirAdDescription"): {"--erir-ad-description"},
+    ("ads", "update", "TextAdBuilderAd.FinalUrl"): {"--final-url"},
+    ("ads", "update", "TextAdBuilderAd.Href"): {"--href"},
+    ("ads", "update", "TextAdBuilderAd.TurboPageId"): {"--turbo-page-id"},
+    ("ads", "update", "MobileAppAdBuilderAd"): {"--type"},
+    ("ads", "update", "MobileAppAdBuilderAd.Creative"): {
+        "--creative-id",
+        "--creative-erir-ad-description",
+    },
+    ("ads", "update", "MobileAppAdBuilderAd.Creative.CreativeId"): {"--creative-id"},
+    ("ads", "update", "MobileAppAdBuilderAd.Creative.ErirAdDescription"): {
+        "--creative-erir-ad-description"
+    },
+    ("ads", "update", "MobileAppAdBuilderAd.ErirAdDescription"): {
+        "--erir-ad-description"
+    },
+    ("ads", "update", "MobileAppAdBuilderAd.TrackingUrl"): {"--tracking-url"},
+    ("ads", "update", "CpcVideoAdBuilderAd"): {"--type"},
+    ("ads", "update", "CpcVideoAdBuilderAd.Creative"): {
+        "--creative-id",
+        "--creative-erir-ad-description",
+    },
+    ("ads", "update", "CpcVideoAdBuilderAd.Creative.CreativeId"): {"--creative-id"},
+    ("ads", "update", "CpcVideoAdBuilderAd.Creative.ErirAdDescription"): {
+        "--creative-erir-ad-description"
+    },
+    ("ads", "update", "CpcVideoAdBuilderAd.ErirAdDescription"): {
+        "--erir-ad-description"
+    },
+    ("ads", "update", "CpcVideoAdBuilderAd.Href"): {"--href"},
+    ("ads", "update", "CpcVideoAdBuilderAd.TurboPageId"): {"--turbo-page-id"},
+    ("ads", "update", "CpmBannerAdBuilderAd"): {"--type"},
+    ("ads", "update", "CpmBannerAdBuilderAd.Creative"): {
+        "--creative-id",
+        "--creative-erir-ad-description",
+    },
+    ("ads", "update", "CpmBannerAdBuilderAd.Creative.CreativeId"): {"--creative-id"},
+    ("ads", "update", "CpmBannerAdBuilderAd.Creative.ErirAdDescription"): {
+        "--creative-erir-ad-description"
+    },
+    ("ads", "update", "CpmBannerAdBuilderAd.ErirAdDescription"): {
+        "--erir-ad-description"
+    },
+    ("ads", "update", "CpmBannerAdBuilderAd.Href"): {"--href"},
+    ("ads", "update", "CpmBannerAdBuilderAd.TrackingPixels"): {"--tracking-pixels"},
+    ("ads", "update", "CpmBannerAdBuilderAd.TrackingPixels.Items"): {
+        "--tracking-pixels"
+    },
+    ("ads", "update", "CpmBannerAdBuilderAd.TurboPageId"): {"--turbo-page-id"},
+    ("ads", "update", "CpmVideoAdBuilderAd"): {"--type"},
+    ("ads", "update", "CpmVideoAdBuilderAd.Creative"): {
+        "--creative-id",
+        "--creative-erir-ad-description",
+    },
+    ("ads", "update", "CpmVideoAdBuilderAd.Creative.CreativeId"): {"--creative-id"},
+    ("ads", "update", "CpmVideoAdBuilderAd.Creative.ErirAdDescription"): {
+        "--creative-erir-ad-description"
+    },
+    ("ads", "update", "CpmVideoAdBuilderAd.ErirAdDescription"): {
+        "--erir-ad-description"
+    },
+    ("ads", "update", "CpmVideoAdBuilderAd.Href"): {"--href"},
+    ("ads", "update", "CpmVideoAdBuilderAd.TrackingPixels"): {"--tracking-pixels"},
+    ("ads", "update", "CpmVideoAdBuilderAd.TrackingPixels.Items"): {
+        "--tracking-pixels"
+    },
+    ("ads", "update", "CpmVideoAdBuilderAd.TurboPageId"): {"--turbo-page-id"},
     ("campaigns", "add", "DailyBudget"): {"--budget"},
     ("campaigns", "add", "DailyBudget.Amount"): {"--budget"},
     ("campaigns", "add", "DailyBudget.Mode"): {"--budget"},
@@ -1773,36 +1866,6 @@ OPTIONAL_FIELD_CHILD_PREFIX_FOLLOWUPS: dict[tuple[str, str, str], dict[str, str]
         "status": "missing_followup",
         "issue": "#278",
         "note": "SMART_AD_BUILDER_AD add fields need typed support or N/A.",
-    },
-    ("ads", "update", "TextAdBuilderAd"): {
-        "status": "missing_followup",
-        "issue": "#270",
-        "note": "AdBuilder update subtype fields need typed support or N/A.",
-    },
-    ("ads", "update", "MobileAppAdBuilderAd"): {
-        "status": "missing_followup",
-        "issue": "#270",
-        "note": "AdBuilder update subtype fields need typed support or N/A.",
-    },
-    ("ads", "update", "CpcVideoAdBuilderAd"): {
-        "status": "missing_followup",
-        "issue": "#270",
-        "note": "AdBuilder update subtype fields need typed support or N/A.",
-    },
-    ("ads", "update", "CpmBannerAdBuilderAd"): {
-        "status": "missing_followup",
-        "issue": "#270",
-        "note": "AdBuilder update subtype fields need typed support or N/A.",
-    },
-    ("ads", "update", "CpmVideoAdBuilderAd"): {
-        "status": "missing_followup",
-        "issue": "#270",
-        "note": "AdBuilder update subtype fields need typed support or N/A.",
-    },
-    ("ads", "update", "MobileAppCpcVideoAdBuilderAd"): {
-        "status": "missing_followup",
-        "issue": "#270",
-        "note": "AdBuilder update subtype fields need typed support or N/A.",
     },
     ("ads", "update", "SmartAdBuilderAd"): {
         "status": "missing_followup",


### PR DESCRIPTION
Closes #270

Summary:
- Adds typed ads update flags for the AdBuilder subtype family: creative fields, subtype URLs, tracking URLs, turbo page IDs, and tracking pixels.
- Builds exact top-level AdBuilder update blocks from WSDL and rejects unrelated/no-op flag combinations.
- Updates dry-run/help tests, WSDL parity routing/audit, and README EN/RU single-line examples.

Docs/WSDL checked:
- https://yandex.ru/dev/direct/doc/en/ads/update
- tests/wsdl_cache/ads.xml

Validation:
- python3 -m pytest tests/test_dry_run.py -k "ads_update and ad_builder"
- python3 -m pytest tests/test_cli.py -k ads_update_help
- python3 scripts/build_wsdl_optional_field_audit.py --check
- python3 -m pytest tests/test_wsdl_parity_gate.py
- python3 -m pytest tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py
- mypy .
- git diff --check