### PR TITLE
Add Smart and mobile image update flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,9 @@ direct ads update --id 99999 --type TEXT_AD --video-extension-creative-id 777 --
 direct ads update --id 99999 --type DYNAMIC_TEXT_AD --text "Updated dynamic text" --callouts-add "111,222"
 direct ads update --id 99999 --type RESPONSIVE_AD --texts "Text one,Text two" --titles "Title one,Title two" --image-hashes hash1,hash2 --video-extension-ids 111,222 --href "https://example.com" --price-extension-price 123450000 --price-extension-price-qualifier FROM --price-extension-price-currency RUB
 direct ads update --id 99999 --type SHOPPING_AD --sitelink-set-id 222 --callouts-set "444,555" --business-id 777 --feed-filter-condition "CATEGORY:EQUALS_ANY:shoes|boots" --title-sources NAME,BRAND --text-sources DESCRIPTION --default-texts "Default product text"
+direct ads update --id 99999 --type MOBILE_APP_IMAGE_AD --image-hash abcdefghijklmnopqrst --tracking-url "https://track.example.com" --erir-ad-description "Mobile image ad"
 direct ads update --id 99999 --type TEXT_AD_BUILDER_AD --creative-id 123 --creative-erir-ad-description "Creative object" --href "https://example.com" --turbo-page-id 456
+direct ads update --id 99999 --type SMART_AD_BUILDER_AD --logo-extension-hash logoabcdefghijklmnop --erir-ad-description "Smart builder ad"
 direct ads update --id 99999 --type CPM_BANNER_AD_BUILDER_AD --creative-id 123 --href "https://example.com" --tracking-pixels "https://pixel.example.com/a,https://pixel.example.com/b"
 direct ads delete --id 99999
 ```
@@ -444,9 +446,12 @@ SHOPPING_AD and LISTING_AD update support `--sitelink-set-id`,
 `--callouts-*`, `--business-id`, repeatable `--feed-filter-condition`
 (`OPERAND:OPERATOR:ARG1|ARG2`), `--title-sources`, `--text-sources`, and
 `--default-texts`.
+MOBILE_APP_IMAGE_AD update supports `--image-hash`, `--tracking-url`, and
+`--erir-ad-description`.
 AdBuilder update subtypes support `--creative-id`, `--creative-erir-ad-description`,
 `--erir-ad-description`, and subtype-specific `--final-url`, `--href`,
-`--turbo-page-id`, `--tracking-url`, and `--tracking-pixels`.
+`--turbo-page-id`, `--tracking-url`, and `--tracking-pixels`. SMART_AD_BUILDER_AD
+update supports `--logo-extension-hash` and `--erir-ad-description`.
 
 #### Keywords
 
@@ -1163,7 +1168,9 @@ direct ads update --id 99999 --type TEXT_AD --video-extension-creative-id 777 --
 direct ads update --id 99999 --type DYNAMIC_TEXT_AD --text "Обновленный динамический текст" --callouts-add "111,222"
 direct ads update --id 99999 --type RESPONSIVE_AD --texts "Текст один,Текст два" --titles "Заголовок один,Заголовок два" --image-hashes hash1,hash2 --video-extension-ids 111,222 --href "https://example.com" --price-extension-price 123450000 --price-extension-price-qualifier FROM --price-extension-price-currency RUB
 direct ads update --id 99999 --type SHOPPING_AD --sitelink-set-id 222 --callouts-set "444,555" --business-id 777 --feed-filter-condition "CATEGORY:EQUALS_ANY:shoes|boots" --title-sources NAME,BRAND --text-sources DESCRIPTION --default-texts "Текст по умолчанию"
+direct ads update --id 99999 --type MOBILE_APP_IMAGE_AD --image-hash abcdefghijklmnopqrst --tracking-url "https://track.example.com" --erir-ad-description "Mobile image ad"
 direct ads update --id 99999 --type TEXT_AD_BUILDER_AD --creative-id 123 --creative-erir-ad-description "Объект креатива" --href "https://example.com" --turbo-page-id 456
+direct ads update --id 99999 --type SMART_AD_BUILDER_AD --logo-extension-hash logoabcdefghijklmnop --erir-ad-description "Smart builder ad"
 direct ads update --id 99999 --type CPM_BANNER_AD_BUILDER_AD --creative-id 123 --href "https://example.com" --tracking-pixels "https://pixel.example.com/a,https://pixel.example.com/b"
 direct ads delete --id 99999
 ```
@@ -1193,10 +1200,13 @@ long-единиц API Яндекс Директа (цена, умноженна�
 `--callouts-*`, `--business-id`, повторяемый `--feed-filter-condition`
 (`OPERAND:OPERATOR:ARG1|ARG2`), `--title-sources`, `--text-sources` и
 `--default-texts`.
+Для MOBILE_APP_IMAGE_AD в `ads update` доступны `--image-hash`,
+`--tracking-url` и `--erir-ad-description`.
 Для AdBuilder subtype в `ads update` доступны `--creative-id`,
 `--creative-erir-ad-description`, `--erir-ad-description` и subtype-specific
 `--final-url`, `--href`, `--turbo-page-id`, `--tracking-url`,
-`--tracking-pixels`.
+`--tracking-pixels`. Для SMART_AD_BUILDER_AD в `ads update` доступны
+`--logo-extension-hash` и `--erir-ad-description`.
 
 #### Ключевые слова
 

--- a/README.md
+++ b/README.md
@@ -1168,9 +1168,9 @@ direct ads update --id 99999 --type TEXT_AD --video-extension-creative-id 777 --
 direct ads update --id 99999 --type DYNAMIC_TEXT_AD --text "Обновленный динамический текст" --callouts-add "111,222"
 direct ads update --id 99999 --type RESPONSIVE_AD --texts "Текст один,Текст два" --titles "Заголовок один,Заголовок два" --image-hashes hash1,hash2 --video-extension-ids 111,222 --href "https://example.com" --price-extension-price 123450000 --price-extension-price-qualifier FROM --price-extension-price-currency RUB
 direct ads update --id 99999 --type SHOPPING_AD --sitelink-set-id 222 --callouts-set "444,555" --business-id 777 --feed-filter-condition "CATEGORY:EQUALS_ANY:shoes|boots" --title-sources NAME,BRAND --text-sources DESCRIPTION --default-texts "Текст по умолчанию"
-direct ads update --id 99999 --type MOBILE_APP_IMAGE_AD --image-hash abcdefghijklmnopqrst --tracking-url "https://track.example.com" --erir-ad-description "Mobile image ad"
+direct ads update --id 99999 --type MOBILE_APP_IMAGE_AD --image-hash abcdefghijklmnopqrst --tracking-url "https://track.example.com" --erir-ad-description "Мобильное графическое объявление"
 direct ads update --id 99999 --type TEXT_AD_BUILDER_AD --creative-id 123 --creative-erir-ad-description "Объект креатива" --href "https://example.com" --turbo-page-id 456
-direct ads update --id 99999 --type SMART_AD_BUILDER_AD --logo-extension-hash logoabcdefghijklmnop --erir-ad-description "Smart builder ad"
+direct ads update --id 99999 --type SMART_AD_BUILDER_AD --logo-extension-hash logoabcdefghijklmnop --erir-ad-description "Смарт-объявление из конструктора"
 direct ads update --id 99999 --type CPM_BANNER_AD_BUILDER_AD --creative-id 123 --href "https://example.com" --tracking-pixels "https://pixel.example.com/a,https://pixel.example.com/b"
 direct ads delete --id 99999
 ```

--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -35,6 +35,17 @@ FEED_BASED_UPDATE_FIELDS = {
 }
 
 
+MOBILE_APP_IMAGE_UPDATE_FIELDS = {
+    "image_hash",
+    "tracking_url",
+    "erir_ad_description",
+}
+
+SMART_AD_BUILDER_UPDATE_FIELDS = {
+    "logo_extension_hash",
+    "erir_ad_description",
+}
+
 AD_BUILDER_BASE_UPDATE_FIELDS = {
     "creative_id",
     "creative_erir_ad_description",
@@ -315,6 +326,39 @@ def _build_ad_builder_update(
         ad_payload["TrackingPixels"] = {"Items": parsed_tracking_pixels}
 
     return ad_payload
+
+
+def _build_mobile_app_image_ad_update(
+    image_hash: Optional[str],
+    erir_ad_description: Optional[str],
+    tracking_url: Optional[str],
+) -> dict[str, object]:
+    """Build MobileAppImageAdUpdate payload from typed flags."""
+    mobile_app_image_ad: dict[str, object] = {}
+
+    if image_hash:
+        mobile_app_image_ad["AdImageHash"] = image_hash
+    if erir_ad_description:
+        mobile_app_image_ad["ErirAdDescription"] = erir_ad_description
+    if tracking_url:
+        mobile_app_image_ad["TrackingUrl"] = tracking_url
+
+    return mobile_app_image_ad
+
+
+def _build_smart_ad_builder_ad_update(
+    logo_extension_hash: Optional[str],
+    erir_ad_description: Optional[str],
+) -> dict[str, object]:
+    """Build SmartAdBuilderAdUpdate payload from typed flags."""
+    smart_ad_builder_ad: dict[str, object] = {}
+
+    if logo_extension_hash:
+        smart_ad_builder_ad["LogoExtensionHash"] = logo_extension_hash
+    if erir_ad_description:
+        smart_ad_builder_ad["ErirAdDescription"] = erir_ad_description
+
+    return smart_ad_builder_ad
 
 
 @ads.command()
@@ -708,10 +752,11 @@ def add(
     required=True,
     help=(
         "Ad subtype: TEXT_AD | TEXT_IMAGE_AD | MOBILE_APP_AD | "
-        "DYNAMIC_TEXT_AD | RESPONSIVE_AD | SHOPPING_AD | LISTING_AD | "
-        "TEXT_AD_BUILDER_AD | MOBILE_APP_AD_BUILDER_AD | "
-        "MOBILE_APP_CPC_VIDEO_AD_BUILDER_AD | CPC_VIDEO_AD_BUILDER_AD | "
-        "CPM_BANNER_AD_BUILDER_AD | CPM_VIDEO_AD_BUILDER_AD"
+        "DYNAMIC_TEXT_AD | MOBILE_APP_IMAGE_AD | RESPONSIVE_AD | "
+        "SHOPPING_AD | LISTING_AD | SMART_AD_BUILDER_AD | TEXT_AD_BUILDER_AD | "
+        "MOBILE_APP_AD_BUILDER_AD | MOBILE_APP_CPC_VIDEO_AD_BUILDER_AD | "
+        "CPC_VIDEO_AD_BUILDER_AD | CPM_BANNER_AD_BUILDER_AD | "
+        "CPM_VIDEO_AD_BUILDER_AD"
     ),
 )
 @click.option(
@@ -735,7 +780,10 @@ def add(
 )
 @click.option(
     "--image-hash",
-    help="Image hash (TEXT_AD / TEXT_IMAGE_AD / MOBILE_APP_AD / DYNAMIC_TEXT_AD)",
+    help=(
+        "Image hash (TEXT_AD / TEXT_IMAGE_AD / MOBILE_APP_AD / "
+        "DYNAMIC_TEXT_AD / MOBILE_APP_IMAGE_AD)"
+    ),
 )
 @click.option(
     "--image-hashes",
@@ -749,7 +797,7 @@ def add(
     "--tracking-url",
     help=(
         "Tracking URL (MOBILE_APP_AD / MOBILE_APP_AD_BUILDER_AD / "
-        "MOBILE_APP_CPC_VIDEO_AD_BUILDER_AD)"
+        "MOBILE_APP_CPC_VIDEO_AD_BUILDER_AD / MOBILE_APP_IMAGE_AD)"
     ),
 )
 @click.option(
@@ -849,7 +897,14 @@ def add(
 )
 @click.option(
     "--erir-ad-description",
-    help="ErirAdDescription for RESPONSIVE_AD and AdBuilder update subtypes",
+    help=(
+        "ErirAdDescription for RESPONSIVE_AD, MOBILE_APP_IMAGE_AD, "
+        "SMART_AD_BUILDER_AD, and AdBuilder update subtypes"
+    ),
+)
+@click.option(
+    "--logo-extension-hash",
+    help="SmartAdBuilderAd.LogoExtensionHash",
 )
 @click.option(
     "--creative-id",
@@ -922,6 +977,7 @@ def update(
     price_extension_price_currency,
     business_id,
     erir_ad_description,
+    logo_extension_hash,
     creative_id,
     creative_erir_ad_description,
     final_url,
@@ -944,10 +1000,12 @@ def update(
         "TEXT_AD",
         "TEXT_IMAGE_AD",
         "MOBILE_APP_AD",
+        "MOBILE_APP_IMAGE_AD",
         "DYNAMIC_TEXT_AD",
         "RESPONSIVE_AD",
         "SHOPPING_AD",
         "LISTING_AD",
+        "SMART_AD_BUILDER_AD",
         *AD_BUILDER_UPDATE_BLOCKS,
     }
     if ad_type_norm not in supported_types:
@@ -955,7 +1013,8 @@ def update(
             "Invalid value for '--type': "
             f"{ad_type!r} is not one of "
             "'TEXT_AD', 'TEXT_IMAGE_AD', 'MOBILE_APP_AD', 'DYNAMIC_TEXT_AD', "
-            "'RESPONSIVE_AD', 'SHOPPING_AD', 'LISTING_AD', "
+            "'MOBILE_APP_IMAGE_AD', 'RESPONSIVE_AD', 'SHOPPING_AD', 'LISTING_AD', "
+            "'SMART_AD_BUILDER_AD', "
             "'TEXT_AD_BUILDER_AD', 'MOBILE_APP_AD_BUILDER_AD', "
             "'MOBILE_APP_CPC_VIDEO_AD_BUILDER_AD', 'CPC_VIDEO_AD_BUILDER_AD', "
             "'CPM_BANNER_AD_BUILDER_AD', 'CPM_VIDEO_AD_BUILDER_AD'."
@@ -1004,6 +1063,7 @@ def update(
             "tracking_url",
             "age_label",
         },
+        "MOBILE_APP_IMAGE_AD": MOBILE_APP_IMAGE_UPDATE_FIELDS,
         "RESPONSIVE_AD": {
             "texts",
             "titles",
@@ -1025,6 +1085,7 @@ def update(
         },
         "SHOPPING_AD": FEED_BASED_UPDATE_FIELDS,
         "LISTING_AD": FEED_BASED_UPDATE_FIELDS,
+        "SMART_AD_BUILDER_AD": SMART_AD_BUILDER_UPDATE_FIELDS,
         **AD_BUILDER_TYPE_FIELDS,
     }
     provided = {
@@ -1054,6 +1115,7 @@ def update(
         "price_extension_price_currency": price_extension_price_currency,
         "business_id": business_id,
         "erir_ad_description": erir_ad_description,
+        "logo_extension_hash": logo_extension_hash,
         "creative_id": creative_id,
         "creative_erir_ad_description": creative_erir_ad_description,
         "final_url": final_url,
@@ -1090,6 +1152,7 @@ def update(
         "price_extension_price_currency": "--price-extension-price-currency",
         "business_id": "--business-id",
         "erir_ad_description": "--erir-ad-description",
+        "logo_extension_hash": "--logo-extension-hash",
         "creative_id": "--creative-id",
         "creative_erir_ad_description": "--creative-erir-ad-description",
         "final_url": "--final-url",
@@ -1186,6 +1249,14 @@ def update(
             mobile_app_ad["AgeLabel"] = age_label.upper()
         if mobile_app_ad:
             ad_data["MobileAppAd"] = mobile_app_ad
+    elif ad_type_norm == "MOBILE_APP_IMAGE_AD":
+        mobile_app_image_ad = _build_mobile_app_image_ad_update(
+            image_hash,
+            erir_ad_description,
+            tracking_url,
+        )
+        if mobile_app_image_ad:
+            ad_data["MobileAppImageAd"] = mobile_app_image_ad
     elif ad_type_norm == "RESPONSIVE_AD":
         responsive_ad = _build_responsive_ad_update(
             texts,
@@ -1216,6 +1287,13 @@ def update(
         if feed_based_ad:
             field_name = "ShoppingAd" if ad_type_norm == "SHOPPING_AD" else "ListingAd"
             ad_data[field_name] = feed_based_ad
+    elif ad_type_norm == "SMART_AD_BUILDER_AD":
+        smart_ad_builder_ad = _build_smart_ad_builder_ad_update(
+            logo_extension_hash,
+            erir_ad_description,
+        )
+        if smart_ad_builder_ad:
+            ad_data["SmartAdBuilderAd"] = smart_ad_builder_ad
     elif ad_type_norm in AD_BUILDER_UPDATE_BLOCKS:
         ad_builder_ad = _build_ad_builder_update(
             creative_id,

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,9 +11,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 2524 |
+| `missing_followup` | 2517 |
 | `not_applicable` | 23 |
-| `supported` | 694 |
+| `supported` | 701 |
 
 ## Confirmed Follow-Ups
 
@@ -169,13 +169,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `ads.update` | `MobileAppAd.VideoExtension.CreativeId` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
 | `ads.update` | `TextImageAd.ErirAdDescription` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
 | `ads.update` | `TextImageAd.FinalUrl` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
-| `ads.update` | `MobileAppImageAd` | MOBILE_APP_IMAGE_AD update fields need typed support or N/A. [#271](https://github.com/axisrow/direct-cli/issues/271) |
-| `ads.update` | `MobileAppImageAd.AdImageHash` | MOBILE_APP_IMAGE_AD update fields need typed support or N/A. [#271](https://github.com/axisrow/direct-cli/issues/271); inherited from `MobileAppImageAd` |
-| `ads.update` | `MobileAppImageAd.ErirAdDescription` | MOBILE_APP_IMAGE_AD update fields need typed support or N/A. [#271](https://github.com/axisrow/direct-cli/issues/271); inherited from `MobileAppImageAd` |
-| `ads.update` | `MobileAppImageAd.TrackingUrl` | MOBILE_APP_IMAGE_AD update fields need typed support or N/A. [#271](https://github.com/axisrow/direct-cli/issues/271); inherited from `MobileAppImageAd` |
-| `ads.update` | `SmartAdBuilderAd` | SMART_AD_BUILDER_AD update fields need typed support or N/A. [#271](https://github.com/axisrow/direct-cli/issues/271) |
-| `ads.update` | `SmartAdBuilderAd.LogoExtensionHash` | SMART_AD_BUILDER_AD update fields need typed support or N/A. [#271](https://github.com/axisrow/direct-cli/issues/271); inherited from `SmartAdBuilderAd` |
-| `ads.update` | `SmartAdBuilderAd.ErirAdDescription` | SMART_AD_BUILDER_AD update fields need typed support or N/A. [#271](https://github.com/axisrow/direct-cli/issues/271); inherited from `SmartAdBuilderAd` |
 | `campaigns.add` | `ClientInfo` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
 | `campaigns.add` | `Notification` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
 | `campaigns.add` | `Notification.SmsSettings` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
@@ -2899,10 +2892,10 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `ads.update` | `ads.update` | `TextImageAd.FinalUrl` | `string` | 0 | 1 | `missing_followup` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
 | `ads.update` | `ads.update` | `TextImageAd.Href` | `string` | 0 | 1 | `supported` | --href |
 | `ads.update` | `ads.update` | `TextImageAd.TurboPageId` | `long` | 0 | 1 | `supported` | --turbo-page-id |
-| `ads.update` | `ads.update` | `MobileAppImageAd` | `MobileAppImageAdUpdate` | 0 | 1 | `missing_followup` | MOBILE_APP_IMAGE_AD update fields need typed support or N/A. [#271](https://github.com/axisrow/direct-cli/issues/271) |
-| `ads.update` | `ads.update` | `MobileAppImageAd.AdImageHash` | `string` | 0 | 1 | `missing_followup` | MOBILE_APP_IMAGE_AD update fields need typed support or N/A. [#271](https://github.com/axisrow/direct-cli/issues/271); inherited from `MobileAppImageAd` |
-| `ads.update` | `ads.update` | `MobileAppImageAd.ErirAdDescription` | `string` | 0 | 1 | `missing_followup` | MOBILE_APP_IMAGE_AD update fields need typed support or N/A. [#271](https://github.com/axisrow/direct-cli/issues/271); inherited from `MobileAppImageAd` |
-| `ads.update` | `ads.update` | `MobileAppImageAd.TrackingUrl` | `string` | 0 | 1 | `missing_followup` | MOBILE_APP_IMAGE_AD update fields need typed support or N/A. [#271](https://github.com/axisrow/direct-cli/issues/271); inherited from `MobileAppImageAd` |
+| `ads.update` | `ads.update` | `MobileAppImageAd` | `MobileAppImageAdUpdate` | 0 | 1 | `supported` | --type |
+| `ads.update` | `ads.update` | `MobileAppImageAd.AdImageHash` | `string` | 0 | 1 | `supported` | --image-hash |
+| `ads.update` | `ads.update` | `MobileAppImageAd.ErirAdDescription` | `string` | 0 | 1 | `supported` | --erir-ad-description |
+| `ads.update` | `ads.update` | `MobileAppImageAd.TrackingUrl` | `string` | 0 | 1 | `supported` | --tracking-url |
 | `ads.update` | `ads.update` | `MobileAppCpcVideoAdBuilderAd` | `MobileAppCpcVideoAdBuilderAdUpdate` | 0 | 1 | `supported` | --type |
 | `ads.update` | `ads.update` | `MobileAppCpcVideoAdBuilderAd.Creative` | `AdBuilderAdUpdateItem` | 0 | 1 | `supported` | --creative-erir-ad-description, --creative-id |
 | `ads.update` | `ads.update` | `MobileAppCpcVideoAdBuilderAd.Creative.CreativeId` | `long` | 1 | 1 | `supported` | --creative-id |
@@ -2948,9 +2941,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `ads.update` | `ads.update` | `CpmVideoAdBuilderAd.TrackingPixels` | `ArrayOfString` | 0 | 1 | `supported` | --tracking-pixels |
 | `ads.update` | `ads.update` | `CpmVideoAdBuilderAd.TrackingPixels.Items` | `string` | 1 | unbounded | `supported` | --tracking-pixels |
 | `ads.update` | `ads.update` | `CpmVideoAdBuilderAd.TurboPageId` | `long` | 0 | 1 | `supported` | --turbo-page-id |
-| `ads.update` | `ads.update` | `SmartAdBuilderAd` | `SmartAdBuilderAdUpdate` | 0 | 1 | `missing_followup` | SMART_AD_BUILDER_AD update fields need typed support or N/A. [#271](https://github.com/axisrow/direct-cli/issues/271) |
-| `ads.update` | `ads.update` | `SmartAdBuilderAd.LogoExtensionHash` | `string` | 0 | 1 | `missing_followup` | SMART_AD_BUILDER_AD update fields need typed support or N/A. [#271](https://github.com/axisrow/direct-cli/issues/271); inherited from `SmartAdBuilderAd` |
-| `ads.update` | `ads.update` | `SmartAdBuilderAd.ErirAdDescription` | `string` | 0 | 1 | `missing_followup` | SMART_AD_BUILDER_AD update fields need typed support or N/A. [#271](https://github.com/axisrow/direct-cli/issues/271); inherited from `SmartAdBuilderAd` |
+| `ads.update` | `ads.update` | `SmartAdBuilderAd` | `SmartAdBuilderAdUpdate` | 0 | 1 | `supported` | --type |
+| `ads.update` | `ads.update` | `SmartAdBuilderAd.LogoExtensionHash` | `string` | 0 | 1 | `supported` | --logo-extension-hash |
+| `ads.update` | `ads.update` | `SmartAdBuilderAd.ErirAdDescription` | `string` | 0 | 1 | `supported` | --erir-ad-description |
 | `ads.update` | `ads.update` | `ShoppingAd` | `ShoppingAdUpdate` | 0 | 1 | `supported` | --type |
 | `ads.update` | `ads.update` | `ShoppingAd.SitelinkSetId` | `long` | 0 | 1 | `supported` | --sitelink-set-id |
 | `ads.update` | `ads.update` | `ShoppingAd.CalloutSetting` | `AdExtensionSetting` | 0 | 1 | `supported` | --callouts-add, --callouts-remove, --callouts-set |

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -268,12 +268,19 @@ class TestCLI(unittest.TestCase):
         # before searching for the canonical phrase.
         collapsed = " ".join(result.output.split())
         self.assertIn(
-            "Image hash (TEXT_AD / TEXT_IMAGE_AD / MOBILE_APP_AD / DYNAMIC_TEXT_AD)",
+            "Image hash (TEXT_AD / TEXT_IMAGE_AD / MOBILE_APP_AD / "
+            "DYNAMIC_TEXT_AD / MOBILE_APP_IMAGE_AD)",
+            collapsed,
+        )
+        self.assertIn(
+            "Tracking URL (MOBILE_APP_AD / MOBILE_APP_AD_BUILDER_AD / "
+            "MOBILE_APP_CPC_VIDEO_AD_BUILDER_AD / MOBILE_APP_IMAGE_AD)",
             collapsed,
         )
         self.assertIn(
             "TEXT_AD | TEXT_IMAGE_AD | MOBILE_APP_AD | DYNAMIC_TEXT_AD | "
-            "RESPONSIVE_AD | SHOPPING_AD | LISTING_AD | TEXT_AD_BUILDER_AD",
+            "MOBILE_APP_IMAGE_AD | RESPONSIVE_AD | SHOPPING_AD | LISTING_AD | "
+            "SMART_AD_BUILDER_AD | TEXT_AD_BUILDER_AD",
             collapsed,
         )
         self.assertIn("Comma-separated ResponsiveAd.Titles values", collapsed)
@@ -289,6 +296,7 @@ class TestCLI(unittest.TestCase):
             collapsed,
         )
         self.assertIn("AdBuilder Creative.CreativeId", collapsed)
+        self.assertIn("SmartAdBuilderAd.LogoExtensionHash", collapsed)
         self.assertIn(
             "Comma-separated AdBuilder TrackingPixels.Items values", collapsed
         )

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1835,6 +1835,124 @@ def test_ads_update_ad_builder_zero_ids_are_not_silently_dropped():
     }
 
 
+def test_ads_update_mobile_app_image_ad_payload():
+    """Issue #271: MOBILE_APP_IMAGE_AD update builds MobileAppImageAd block."""
+    body = _dry_run(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "MOBILE_APP_IMAGE_AD",
+        "--image-hash",
+        "abcdefghijklmnopqrst",
+        "--tracking-url",
+        "https://track.example.com",
+        "--erir-ad-description",
+        "Mobile image ad",
+    )
+    ad = body["params"]["Ads"][0]
+    assert ad == {
+        "Id": 999,
+        "MobileAppImageAd": {
+            "AdImageHash": "abcdefghijklmnopqrst",
+            "ErirAdDescription": "Mobile image ad",
+            "TrackingUrl": "https://track.example.com",
+        },
+    }
+    assert "MobileAppAd" not in ad
+
+
+def test_ads_update_smart_ad_builder_ad_payload():
+    """Issue #271: SMART_AD_BUILDER_AD update supports compact fields."""
+    body = _dry_run(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "SMART_AD_BUILDER_AD",
+        "--logo-extension-hash",
+        "logoabcdefghijklmnop",
+        "--erir-ad-description",
+        "Smart builder ad",
+    )
+    assert body["params"]["Ads"][0] == {
+        "Id": 999,
+        "SmartAdBuilderAd": {
+            "LogoExtensionHash": "logoabcdefghijklmnop",
+            "ErirAdDescription": "Smart builder ad",
+        },
+    }
+
+
+def test_ads_update_mobile_app_image_rejects_unrelated_flag():
+    """Issue #271: MobileAppImageAd must not silently drop unrelated flags."""
+    result = _rejected(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "MOBILE_APP_IMAGE_AD",
+        "--href",
+        "https://example.com",
+    )
+    assert "--href is not compatible with --type MOBILE_APP_IMAGE_AD" in result.output
+    assert "does not convert an ad between subtypes" in result.output
+
+
+def test_ads_update_smart_ad_builder_rejects_unrelated_flag():
+    """Issue #271: SmartAdBuilderAd has no Creative block in ads.update."""
+    result = _rejected(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "SMART_AD_BUILDER_AD",
+        "--creative-id",
+        "111",
+    )
+    assert (
+        "--creative-id is not compatible with --type SMART_AD_BUILDER_AD"
+        in result.output
+    )
+    assert "does not convert an ad between subtypes" in result.output
+
+
+def test_ads_update_mobile_app_image_noop_rejected():
+    """Issue #271: MobileAppImageAd update without fields stays a no-op error."""
+    result = _rejected(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "MOBILE_APP_IMAGE_AD",
+    )
+    assert (
+        "ads update requires at least one updatable field for "
+        "--type MOBILE_APP_IMAGE_AD"
+    ) in result.output
+
+
+def test_ads_update_smart_ad_builder_noop_rejected():
+    """Issue #271: SmartAdBuilderAd update without fields stays a no-op error."""
+    result = _rejected(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "SMART_AD_BUILDER_AD",
+    )
+    assert (
+        "ads update requires at least one updatable field for "
+        "--type SMART_AD_BUILDER_AD"
+    ) in result.output
+
+
 def test_ads_update_text_ad_with_turbo_page_id():
     """Issue #202: update sets TurboPageId in TextAd."""
     body = _dry_run(

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -1228,6 +1228,13 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
         "--tracking-pixels"
     },
     ("ads", "update", "CpmVideoAdBuilderAd.TurboPageId"): {"--turbo-page-id"},
+    ("ads", "update", "MobileAppImageAd"): {"--type"},
+    ("ads", "update", "MobileAppImageAd.AdImageHash"): {"--image-hash"},
+    ("ads", "update", "MobileAppImageAd.ErirAdDescription"): {"--erir-ad-description"},
+    ("ads", "update", "MobileAppImageAd.TrackingUrl"): {"--tracking-url"},
+    ("ads", "update", "SmartAdBuilderAd"): {"--type"},
+    ("ads", "update", "SmartAdBuilderAd.LogoExtensionHash"): {"--logo-extension-hash"},
+    ("ads", "update", "SmartAdBuilderAd.ErirAdDescription"): {"--erir-ad-description"},
     ("campaigns", "add", "DailyBudget"): {"--budget"},
     ("campaigns", "add", "DailyBudget.Amount"): {"--budget"},
     ("campaigns", "add", "DailyBudget.Mode"): {"--budget"},
@@ -1866,16 +1873,6 @@ OPTIONAL_FIELD_CHILD_PREFIX_FOLLOWUPS: dict[tuple[str, str, str], dict[str, str]
         "status": "missing_followup",
         "issue": "#278",
         "note": "SMART_AD_BUILDER_AD add fields need typed support or N/A.",
-    },
-    ("ads", "update", "SmartAdBuilderAd"): {
-        "status": "missing_followup",
-        "issue": "#271",
-        "note": "SMART_AD_BUILDER_AD update fields need typed support or N/A.",
-    },
-    ("ads", "update", "MobileAppImageAd"): {
-        "status": "missing_followup",
-        "issue": "#271",
-        "note": "MOBILE_APP_IMAGE_AD update fields need typed support or N/A.",
     },
     ("campaigns", "add", "TextCampaign.BiddingStrategy"): {
         "status": "missing_followup",


### PR DESCRIPTION
Closes #271

Summary:
- Adds typed ads update support for MOBILE_APP_IMAGE_AD: AdImageHash, TrackingUrl, and ErirAdDescription.
- Adds typed ads update support for SMART_AD_BUILDER_AD: LogoExtensionHash and ErirAdDescription.
- Preserves subtype no-op and incompatible-flag guards, updates dry-run/help tests, WSDL parity routing/audit, and README EN/RU single-line examples.

Docs/WSDL checked:
- https://yandex.ru/dev/direct/doc/en/ads/update
- tests/wsdl_cache/ads.xml

Validation:
- python3 -m pytest tests/test_dry_run.py -k "ads_update and (mobile_app_image or smart_ad_builder)"
- python3 -m pytest tests/test_cli.py -k ads_update_help
- python3 scripts/build_wsdl_optional_field_audit.py --check
- python3 -m pytest tests/test_wsdl_parity_gate.py
- python3 -m pytest tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py
- mypy .
- git diff --check