### PR TITLE
Resolve residual ads update fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,8 +413,11 @@ direct ads update --id 99999 --type TEXT_AD --title2 "New second headline" --vca
 direct ads update --id 99999 --type TEXT_AD --callouts-add "111,222" --callouts-remove "333"
 direct ads update --id 99999 --type TEXT_AD --callouts-set "444,555"
 direct ads update --id 99999 --type TEXT_AD --video-extension-creative-id 777 --price-extension-price 123450000 --price-extension-price-qualifier FROM --price-extension-price-currency RUB
+direct ads update --id 99999 --type TEXT_AD --final-url "https://final.example.com" --age-label AGE_18 --business-id 777 --prefer-vcard-over-business NO --erir-ad-description "Text ad object"
 direct ads update --id 99999 --type DYNAMIC_TEXT_AD --text "Updated dynamic text" --callouts-add "111,222"
+direct ads update --id 99999 --type MOBILE_APP_AD --mobile-app-feature PRICE=YES --mobile-app-feature CUSTOMER_RATING=NO --video-extension-creative-id 777 --erir-ad-description "Mobile app object"
 direct ads update --id 99999 --type RESPONSIVE_AD --texts "Text one,Text two" --titles "Title one,Title two" --image-hashes hash1,hash2 --video-extension-ids 111,222 --href "https://example.com" --price-extension-price 123450000 --price-extension-price-qualifier FROM --price-extension-price-currency RUB
+direct ads update --id 99999 --type TEXT_IMAGE_AD --final-url "https://final.example.com" --erir-ad-description "Image ad object"
 direct ads update --id 99999 --type SHOPPING_AD --sitelink-set-id 222 --callouts-set "444,555" --business-id 777 --feed-filter-condition "CATEGORY:EQUALS_ANY:shoes|boots" --title-sources NAME,BRAND --text-sources DESCRIPTION --default-texts "Default product text"
 direct ads update --id 99999 --type MOBILE_APP_IMAGE_AD --image-hash abcdefghijklmnopqrst --tracking-url "https://track.example.com" --erir-ad-description "Mobile image ad"
 direct ads update --id 99999 --type TEXT_AD_BUILDER_AD --creative-id 123 --creative-erir-ad-description "Creative object" --href "https://example.com" --turbo-page-id 456
@@ -432,12 +435,17 @@ existing ad — `--callouts-set` replaces the whole callout list and is mutually
 exclusive with the incremental `--callouts-add` / `--callouts-remove` pair.
 It also exposes `--video-extension-creative-id` and `--price-extension-*` flags
 for `TextAd.VideoExtension` and `TextAd.PriceExtension`; price values use the
-Yandex Direct API long-unit format (price multiplied by 1,000,000).
+Yandex Direct API long-unit format (price multiplied by 1,000,000). Residual
+TEXT_AD update fields are available through `--final-url`, `--age-label`,
+`--business-id`, `--prefer-vcard-over-business`, and `--erir-ad-description`.
 `--mobile` (default `NO`) and `--ad-extensions` are `ads add`-only —
 `TextAdUpdate` does not contain `Mobile`, and on update ad-extensions are
 managed through the `--callouts-*` flags above. TEXT_IMAGE_AD additionally
-accepts `--turbo-page-id`. DYNAMIC_TEXT_AD update supports `--text`,
-`--image-hash`, `--vcard-id`, `--sitelink-set-id`, and `--callouts-*`.
+accepts `--turbo-page-id`, `--final-url`, and `--erir-ad-description`.
+DYNAMIC_TEXT_AD update supports `--text`, `--image-hash`, `--vcard-id`,
+`--sitelink-set-id`, and `--callouts-*`.
+MOBILE_APP_AD update supports `--mobile-app-feature FEATURE=YES|NO`,
+`--video-extension-creative-id`, and `--erir-ad-description`.
 RESPONSIVE_AD update supports `--texts`, `--titles`, `--image-hashes`,
 `--video-extension-ids`, `--href`, `--age-label`, `--display-url-path`,
 `--sitelink-set-id`, `--callouts-*`, `--price-extension-*`, `--business-id`,
@@ -1165,8 +1173,11 @@ direct ads update --id 99999 --type TEXT_AD --title2 "Новый второй з
 direct ads update --id 99999 --type TEXT_AD --callouts-add "111,222" --callouts-remove "333"
 direct ads update --id 99999 --type TEXT_AD --callouts-set "444,555"
 direct ads update --id 99999 --type TEXT_AD --video-extension-creative-id 777 --price-extension-price 123450000 --price-extension-price-qualifier FROM --price-extension-price-currency RUB
+direct ads update --id 99999 --type TEXT_AD --final-url "https://final.example.com" --age-label AGE_18 --business-id 777 --prefer-vcard-over-business NO --erir-ad-description "Объект текстового объявления"
 direct ads update --id 99999 --type DYNAMIC_TEXT_AD --text "Обновленный динамический текст" --callouts-add "111,222"
+direct ads update --id 99999 --type MOBILE_APP_AD --mobile-app-feature PRICE=YES --mobile-app-feature CUSTOMER_RATING=NO --video-extension-creative-id 777 --erir-ad-description "Объект мобильного объявления"
 direct ads update --id 99999 --type RESPONSIVE_AD --texts "Текст один,Текст два" --titles "Заголовок один,Заголовок два" --image-hashes hash1,hash2 --video-extension-ids 111,222 --href "https://example.com" --price-extension-price 123450000 --price-extension-price-qualifier FROM --price-extension-price-currency RUB
+direct ads update --id 99999 --type TEXT_IMAGE_AD --final-url "https://final.example.com" --erir-ad-description "Объект графического объявления"
 direct ads update --id 99999 --type SHOPPING_AD --sitelink-set-id 222 --callouts-set "444,555" --business-id 777 --feed-filter-condition "CATEGORY:EQUALS_ANY:shoes|boots" --title-sources NAME,BRAND --text-sources DESCRIPTION --default-texts "Текст по умолчанию"
 direct ads update --id 99999 --type MOBILE_APP_IMAGE_AD --image-hash abcdefghijklmnopqrst --tracking-url "https://track.example.com" --erir-ad-description "Мобильное графическое объявление"
 direct ads update --id 99999 --type TEXT_AD_BUILDER_AD --creative-id 123 --creative-erir-ad-description "Объект креатива" --href "https://example.com" --turbo-page-id 456
@@ -1185,13 +1196,18 @@ direct ads delete --id 99999
 `--callouts-add` / `--callouts-remove`. Также доступны
 `--video-extension-creative-id` и флаги `--price-extension-*` для
 `TextAd.VideoExtension` и `TextAd.PriceExtension`; цены передаются в формате
-long-единиц API Яндекс Директа (цена, умноженная на 1 000 000). `--mobile`
-(default `NO`) и
+long-единиц API Яндекс Директа (цена, умноженная на 1 000 000). Остальные
+поля TEXT_AD в `ads update` доступны через `--final-url`, `--age-label`,
+`--business-id`, `--prefer-vcard-over-business` и `--erir-ad-description`.
+`--mobile` (default `NO`) и
 `--ad-extensions` доступны только в `ads add` — WSDL `TextAdUpdate` не
 содержит `Mobile`, а в `ads update` расширения управляются через флаги
 `--callouts-*` выше. Для TEXT_IMAGE_AD дополнительно доступен
-`--turbo-page-id`. Для DYNAMIC_TEXT_AD в `ads update` доступны `--text`,
-`--image-hash`, `--vcard-id`, `--sitelink-set-id` и `--callouts-*`.
+`--turbo-page-id`, `--final-url` и `--erir-ad-description`. Для
+DYNAMIC_TEXT_AD в `ads update` доступны `--text`, `--image-hash`,
+`--vcard-id`, `--sitelink-set-id` и `--callouts-*`.
+Для MOBILE_APP_AD в `ads update` доступны `--mobile-app-feature FEATURE=YES|NO`,
+`--video-extension-creative-id` и `--erir-ad-description`.
 Для RESPONSIVE_AD в `ads update` доступны `--texts`, `--titles`,
 `--image-hashes`, `--video-extension-ids`, `--href`, `--age-label`,
 `--display-url-path`, `--sitelink-set-id`, `--callouts-*`,

--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -22,6 +22,8 @@ def ads():
     """Manage ads"""
 
 
+MOBILE_APP_FEATURES = ("PRICE", "ICON", "CUSTOMER_RATING", "RATINGS")
+
 FEED_BASED_UPDATE_FIELDS = {
     "sitelink_set_id",
     "callouts_add",
@@ -34,6 +36,51 @@ FEED_BASED_UPDATE_FIELDS = {
     "default_texts",
 }
 
+
+TEXT_AD_UPDATE_FIELDS = {
+    "title",
+    "text",
+    "href",
+    "image_hash",
+    "title2",
+    "display_url_path",
+    "vcard_id",
+    "sitelink_set_id",
+    "turbo_page_id",
+    "callouts_add",
+    "callouts_remove",
+    "callouts_set",
+    "video_extension_creative_id",
+    "price_extension_price",
+    "price_extension_old_price",
+    "price_extension_price_qualifier",
+    "price_extension_price_currency",
+    "final_url",
+    "age_label",
+    "business_id",
+    "prefer_vcard_over_business",
+    "erir_ad_description",
+}
+
+MOBILE_APP_AD_UPDATE_FIELDS = {
+    "title",
+    "text",
+    "image_hash",
+    "action",
+    "tracking_url",
+    "age_label",
+    "mobile_app_features",
+    "video_extension_creative_id",
+    "erir_ad_description",
+}
+
+TEXT_IMAGE_AD_UPDATE_FIELDS = {
+    "image_hash",
+    "final_url",
+    "href",
+    "turbo_page_id",
+    "erir_ad_description",
+}
 
 MOBILE_APP_IMAGE_UPDATE_FIELDS = {
     "image_hash",
@@ -195,6 +242,41 @@ def _parse_required_ids(
     if not ids:
         raise click.UsageError(f"{flag_name} must contain at least one ID.")
     return ids
+
+
+def _parse_mobile_app_features(
+    raw_values: tuple[str, ...],
+) -> Optional[list[dict[str, str]]]:
+    """Parse repeatable MobileAppAd.Features items as FEATURE=YES|NO."""
+    if not raw_values:
+        return None
+
+    items: list[dict[str, str]] = []
+    allowed_features = ", ".join(MOBILE_APP_FEATURES)
+    for raw_value in raw_values:
+        feature_raw, separator, enabled_raw = raw_value.strip().partition("=")
+        if not separator:
+            raise click.UsageError(
+                "--mobile-app-feature expects FEATURE=YES|NO "
+                "(for example PRICE=YES)."
+            )
+
+        feature = feature_raw.strip().upper()
+        enabled = enabled_raw.strip().upper()
+        if feature not in MOBILE_APP_FEATURES:
+            raise click.UsageError(
+                "Invalid --mobile-app-feature feature "
+                f"{feature_raw!r}; allowed: {allowed_features}."
+            )
+        if enabled not in {"YES", "NO"}:
+            raise click.UsageError(
+                "Invalid --mobile-app-feature value "
+                f"{enabled_raw!r}; expected YES or NO."
+            )
+
+        items.append({"Feature": feature, "Enabled": enabled})
+
+    return items
 
 
 def _build_responsive_ad_update(
@@ -802,7 +884,19 @@ def add(
 )
 @click.option(
     "--age-label",
-    help="Age label (MOBILE_APP_AD MobAppAgeLabelEnum / RESPONSIVE_AD AgeLabelEnum)",
+    help=(
+        "Age label (TEXT_AD / RESPONSIVE_AD AgeLabelEnum; "
+        "MOBILE_APP_AD MobAppAgeLabelEnum)"
+    ),
+)
+@click.option(
+    "--mobile-app-feature",
+    "mobile_app_features",
+    multiple=True,
+    help=(
+        "Repeatable MobileAppAd.Features item as FEATURE=YES|NO. "
+        "Features: PRICE, ICON, CUSTOMER_RATING, RATINGS."
+    ),
 )
 @click.option("--title2", help="Second headline (TEXT_AD)")
 @click.option("--display-url-path", help="Display URL path (TEXT_AD / RESPONSIVE_AD)")
@@ -852,7 +946,10 @@ def add(
 @click.option(
     "--video-extension-creative-id",
     type=int,
-    help="Video extension CreativeId for TextAd.VideoExtension. TEXT_AD only.",
+    help=(
+        "Video extension CreativeId for TextAd/MobileAppAd.VideoExtension. "
+        "TEXT_AD / MOBILE_APP_AD only."
+    ),
 )
 @click.option(
     "--video-extension-ids",
@@ -893,13 +990,19 @@ def add(
 @click.option(
     "--business-id",
     type=int,
-    help="BusinessId (RESPONSIVE_AD / SHOPPING_AD / LISTING_AD)",
+    help="BusinessId (TEXT_AD / RESPONSIVE_AD / SHOPPING_AD / LISTING_AD)",
+)
+@click.option(
+    "--prefer-vcard-over-business",
+    type=click.Choice(["YES", "NO"], case_sensitive=False),
+    help="TextAd.PreferVCardOverBusiness value: YES or NO",
 )
 @click.option(
     "--erir-ad-description",
     help=(
-        "ErirAdDescription for RESPONSIVE_AD, MOBILE_APP_IMAGE_AD, "
-        "SMART_AD_BUILDER_AD, and AdBuilder update subtypes"
+        "ErirAdDescription for TEXT_AD, TEXT_IMAGE_AD, MOBILE_APP_AD, "
+        "RESPONSIVE_AD, MOBILE_APP_IMAGE_AD, SMART_AD_BUILDER_AD, "
+        "and AdBuilder update subtypes"
     ),
 )
 @click.option(
@@ -917,7 +1020,7 @@ def add(
 )
 @click.option(
     "--final-url",
-    help="TextAdBuilderAd.FinalUrl",
+    help="FinalUrl (TEXT_AD / TEXT_IMAGE_AD / TEXT_AD_BUILDER_AD)",
 )
 @click.option(
     "--tracking-pixels",
@@ -961,6 +1064,7 @@ def update(
     action,
     tracking_url,
     age_label,
+    mobile_app_features,
     title2,
     display_url_path,
     vcard_id,
@@ -976,6 +1080,7 @@ def update(
     price_extension_price_qualifier,
     price_extension_price_currency,
     business_id,
+    prefer_vcard_over_business,
     erir_ad_description,
     logo_extension_hash,
     creative_id,
@@ -1026,25 +1131,7 @@ def update(
     # reject up front so the user sees the conflict instead of a no-op
     # (issue #198 H2).
     type_fields = {
-        "TEXT_AD": {
-            "title",
-            "text",
-            "href",
-            "image_hash",
-            "title2",
-            "display_url_path",
-            "vcard_id",
-            "sitelink_set_id",
-            "turbo_page_id",
-            "callouts_add",
-            "callouts_remove",
-            "callouts_set",
-            "video_extension_creative_id",
-            "price_extension_price",
-            "price_extension_old_price",
-            "price_extension_price_qualifier",
-            "price_extension_price_currency",
-        },
+        "TEXT_AD": TEXT_AD_UPDATE_FIELDS,
         "DYNAMIC_TEXT_AD": {
             "text",
             "image_hash",
@@ -1054,15 +1141,8 @@ def update(
             "callouts_remove",
             "callouts_set",
         },
-        "TEXT_IMAGE_AD": {"image_hash", "href", "turbo_page_id"},
-        "MOBILE_APP_AD": {
-            "title",
-            "text",
-            "image_hash",
-            "action",
-            "tracking_url",
-            "age_label",
-        },
+        "TEXT_IMAGE_AD": TEXT_IMAGE_AD_UPDATE_FIELDS,
+        "MOBILE_APP_AD": MOBILE_APP_AD_UPDATE_FIELDS,
         "MOBILE_APP_IMAGE_AD": MOBILE_APP_IMAGE_UPDATE_FIELDS,
         "RESPONSIVE_AD": {
             "texts",
@@ -1099,6 +1179,7 @@ def update(
         "action": action,
         "tracking_url": tracking_url,
         "age_label": age_label,
+        "mobile_app_features": mobile_app_features,
         "title2": title2,
         "display_url_path": display_url_path,
         "vcard_id": vcard_id,
@@ -1114,6 +1195,7 @@ def update(
         "price_extension_price_qualifier": price_extension_price_qualifier,
         "price_extension_price_currency": price_extension_price_currency,
         "business_id": business_id,
+        "prefer_vcard_over_business": prefer_vcard_over_business,
         "erir_ad_description": erir_ad_description,
         "logo_extension_hash": logo_extension_hash,
         "creative_id": creative_id,
@@ -1136,6 +1218,7 @@ def update(
         "action": "--action",
         "tracking_url": "--tracking-url",
         "age_label": "--age-label",
+        "mobile_app_features": "--mobile-app-feature",
         "title2": "--title2",
         "display_url_path": "--display-url-path",
         "vcard_id": "--vcard-id",
@@ -1151,6 +1234,7 @@ def update(
         "price_extension_price_qualifier": "--price-extension-price-qualifier",
         "price_extension_price_currency": "--price-extension-price-currency",
         "business_id": "--business-id",
+        "prefer_vcard_over_business": "--prefer-vcard-over-business",
         "erir_ad_description": "--erir-ad-description",
         "logo_extension_hash": "--logo-extension-hash",
         "creative_id": "--creative-id",
@@ -1184,6 +1268,7 @@ def update(
         price_extension_price_qualifier,
         price_extension_price_currency,
     )
+    parsed_mobile_app_features = _parse_mobile_app_features(mobile_app_features)
 
     ad_data = {"Id": ad_id}
 
@@ -1202,14 +1287,24 @@ def update(
             text_ad["Href"] = href
         if title2:
             text_ad["Title2"] = title2
+        if final_url:
+            text_ad["FinalUrl"] = final_url
         if display_url_path:
             text_ad["DisplayUrlPath"] = display_url_path
-        if turbo_page_id:
+        if age_label:
+            text_ad["AgeLabel"] = age_label.upper()
+        if turbo_page_id is not None:
             text_ad["TurboPageId"] = turbo_page_id
         if video_extension_creative_id is not None:
             text_ad["VideoExtension"] = {"CreativeId": video_extension_creative_id}
         if price_extension:
             text_ad["PriceExtension"] = price_extension
+        if business_id is not None:
+            text_ad["BusinessId"] = business_id
+        if prefer_vcard_over_business:
+            text_ad["PreferVCardOverBusiness"] = prefer_vcard_over_business.upper()
+        if erir_ad_description:
+            text_ad["ErirAdDescription"] = erir_ad_description
         if text_ad:
             ad_data["TextAd"] = text_ad
     elif ad_type_norm == "DYNAMIC_TEXT_AD":
@@ -1227,10 +1322,14 @@ def update(
         text_image_ad = {}
         if image_hash:
             text_image_ad["AdImageHash"] = image_hash
+        if final_url:
+            text_image_ad["FinalUrl"] = final_url
         if href:
             text_image_ad["Href"] = href
-        if turbo_page_id:
+        if turbo_page_id is not None:
             text_image_ad["TurboPageId"] = turbo_page_id
+        if erir_ad_description:
+            text_image_ad["ErirAdDescription"] = erir_ad_description
         if text_image_ad:
             ad_data["TextImageAd"] = text_image_ad
     elif ad_type_norm == "MOBILE_APP_AD":
@@ -1245,8 +1344,16 @@ def update(
             mobile_app_ad["Action"] = action.upper()
         if tracking_url:
             mobile_app_ad["TrackingUrl"] = tracking_url
+        if parsed_mobile_app_features:
+            mobile_app_ad["Features"] = parsed_mobile_app_features
         if age_label:
             mobile_app_ad["AgeLabel"] = age_label.upper()
+        if video_extension_creative_id is not None:
+            mobile_app_ad["VideoExtension"] = {
+                "CreativeId": video_extension_creative_id
+            }
+        if erir_ad_description:
+            mobile_app_ad["ErirAdDescription"] = erir_ad_description
         if mobile_app_ad:
             ad_data["MobileAppAd"] = mobile_app_ad
     elif ad_type_norm == "MOBILE_APP_IMAGE_AD":

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,9 +11,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 2517 |
+| `missing_followup` | 2501 |
 | `not_applicable` | 23 |
-| `supported` | 701 |
+| `supported` | 717 |
 
 ## Confirmed Follow-Ups
 
@@ -153,22 +153,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `ads.add` | `ListingAd.TitleSources` | LISTING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ListingAd` |
 | `ads.add` | `ListingAd.TextSources` | LISTING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ListingAd` |
 | `ads.add` | `ListingAd.DefaultTexts` | LISTING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ListingAd` |
-| `ads.update` | `TextAd.CalloutSetting.AdExtensions` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
-| `ads.update` | `TextAd.CalloutSetting.AdExtensions.AdExtensionId` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
-| `ads.update` | `TextAd.CalloutSetting.AdExtensions.Operation` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
-| `ads.update` | `TextAd.FinalUrl` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
-| `ads.update` | `TextAd.AgeLabel` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
-| `ads.update` | `TextAd.BusinessId` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
-| `ads.update` | `TextAd.PreferVCardOverBusiness` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
-| `ads.update` | `TextAd.ErirAdDescription` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
-| `ads.update` | `MobileAppAd.ErirAdDescription` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
-| `ads.update` | `MobileAppAd.Features` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
-| `ads.update` | `MobileAppAd.Features.Feature` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
-| `ads.update` | `MobileAppAd.Features.Enabled` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
-| `ads.update` | `MobileAppAd.VideoExtension` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
-| `ads.update` | `MobileAppAd.VideoExtension.CreativeId` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
-| `ads.update` | `TextImageAd.ErirAdDescription` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
-| `ads.update` | `TextImageAd.FinalUrl` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
 | `campaigns.add` | `ClientInfo` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
 | `campaigns.add` | `Notification` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
 | `campaigns.add` | `Notification.SmsSettings` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
@@ -2821,15 +2805,15 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `ads.update` | `ads.update` | `TextAd.AdImageHash` | `string` | 0 | 1 | `supported` | --image-hash |
 | `ads.update` | `ads.update` | `TextAd.SitelinkSetId` | `long` | 0 | 1 | `supported` | --sitelink-set-id |
 | `ads.update` | `ads.update` | `TextAd.CalloutSetting` | `AdExtensionSetting` | 0 | 1 | `supported` | --callouts-add, --callouts-remove, --callouts-set |
-| `ads.update` | `ads.update` | `TextAd.CalloutSetting.AdExtensions` | `AdExtensionSettingItem` | 1 | unbounded | `missing_followup` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
-| `ads.update` | `ads.update` | `TextAd.CalloutSetting.AdExtensions.AdExtensionId` | `long` | 1 | 1 | `missing_followup` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
-| `ads.update` | `ads.update` | `TextAd.CalloutSetting.AdExtensions.Operation` | `OperationEnum` | 1 | 1 | `missing_followup` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
+| `ads.update` | `ads.update` | `TextAd.CalloutSetting.AdExtensions` | `AdExtensionSettingItem` | 1 | unbounded | `supported` | --callouts-add, --callouts-remove, --callouts-set |
+| `ads.update` | `ads.update` | `TextAd.CalloutSetting.AdExtensions.AdExtensionId` | `long` | 1 | 1 | `supported` | --callouts-add, --callouts-remove, --callouts-set |
+| `ads.update` | `ads.update` | `TextAd.CalloutSetting.AdExtensions.Operation` | `OperationEnum` | 1 | 1 | `supported` | --callouts-add, --callouts-remove, --callouts-set |
 | `ads.update` | `ads.update` | `TextAd.Text` | `string` | 0 | 1 | `supported` | --text |
 | `ads.update` | `ads.update` | `TextAd.Title` | `string` | 0 | 1 | `supported` | --title |
 | `ads.update` | `ads.update` | `TextAd.Title2` | `string` | 0 | 1 | `supported` | --title2 |
-| `ads.update` | `ads.update` | `TextAd.FinalUrl` | `string` | 0 | 1 | `missing_followup` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
+| `ads.update` | `ads.update` | `TextAd.FinalUrl` | `string` | 0 | 1 | `supported` | --final-url |
 | `ads.update` | `ads.update` | `TextAd.Href` | `string` | 0 | 1 | `supported` | --href |
-| `ads.update` | `ads.update` | `TextAd.AgeLabel` | `AgeLabelEnum` | 0 | 1 | `missing_followup` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
+| `ads.update` | `ads.update` | `TextAd.AgeLabel` | `AgeLabelEnum` | 0 | 1 | `supported` | --age-label |
 | `ads.update` | `ads.update` | `TextAd.DisplayUrlPath` | `string` | 0 | 1 | `supported` | --display-url-path |
 | `ads.update` | `ads.update` | `TextAd.VideoExtension` | `VideoExtensionUpdateItem` | 0 | 1 | `supported` | --video-extension-creative-id |
 | `ads.update` | `ads.update` | `TextAd.VideoExtension.CreativeId` | `long` | 0 | 1 | `supported` | --video-extension-creative-id |
@@ -2839,9 +2823,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `ads.update` | `ads.update` | `TextAd.PriceExtension.PriceQualifier` | `PriceQualifierEnum` | 0 | 1 | `supported` | --price-extension-price-qualifier |
 | `ads.update` | `ads.update` | `TextAd.PriceExtension.PriceCurrency` | `PriceCurrencyEnum` | 0 | 1 | `supported` | --price-extension-price-currency |
 | `ads.update` | `ads.update` | `TextAd.TurboPageId` | `long` | 0 | 1 | `supported` | --turbo-page-id |
-| `ads.update` | `ads.update` | `TextAd.BusinessId` | `long` | 0 | 1 | `missing_followup` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
-| `ads.update` | `ads.update` | `TextAd.PreferVCardOverBusiness` | `YesNoEnum` | 0 | 1 | `missing_followup` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
-| `ads.update` | `ads.update` | `TextAd.ErirAdDescription` | `string` | 0 | 1 | `missing_followup` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
+| `ads.update` | `ads.update` | `TextAd.BusinessId` | `long` | 0 | 1 | `supported` | --business-id |
+| `ads.update` | `ads.update` | `TextAd.PreferVCardOverBusiness` | `YesNoEnum` | 0 | 1 | `supported` | --prefer-vcard-over-business |
+| `ads.update` | `ads.update` | `TextAd.ErirAdDescription` | `string` | 0 | 1 | `supported` | --erir-ad-description |
 | `ads.update` | `ads.update` | `ResponsiveAd` | `ResponsiveAdUpdate` | 0 | 1 | `supported` | --type |
 | `ads.update` | `ads.update` | `ResponsiveAd.Texts` | `string` | 0 | unbounded | `supported` | --texts |
 | `ads.update` | `ads.update` | `ResponsiveAd.Titles` | `string` | 0 | unbounded | `supported` | --titles |
@@ -2879,17 +2863,17 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `ads.update` | `ads.update` | `MobileAppAd.TrackingUrl` | `string` | 0 | 1 | `supported` | --tracking-url |
 | `ads.update` | `ads.update` | `MobileAppAd.Action` | `MobileAppAdActionEnum` | 0 | 1 | `supported` | --action |
 | `ads.update` | `ads.update` | `MobileAppAd.AdImageHash` | `string` | 0 | 1 | `supported` | --image-hash |
-| `ads.update` | `ads.update` | `MobileAppAd.ErirAdDescription` | `string` | 0 | 1 | `missing_followup` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
-| `ads.update` | `ads.update` | `MobileAppAd.Features` | `MobileAppAdFeatureItem` | 0 | unbounded | `missing_followup` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
-| `ads.update` | `ads.update` | `MobileAppAd.Features.Feature` | `MobileAppFeatureEnum` | 1 | 1 | `missing_followup` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
-| `ads.update` | `ads.update` | `MobileAppAd.Features.Enabled` | `YesNoEnum` | 1 | 1 | `missing_followup` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
+| `ads.update` | `ads.update` | `MobileAppAd.ErirAdDescription` | `string` | 0 | 1 | `supported` | --erir-ad-description |
+| `ads.update` | `ads.update` | `MobileAppAd.Features` | `MobileAppAdFeatureItem` | 0 | unbounded | `supported` | --mobile-app-feature |
+| `ads.update` | `ads.update` | `MobileAppAd.Features.Feature` | `MobileAppFeatureEnum` | 1 | 1 | `supported` | --mobile-app-feature |
+| `ads.update` | `ads.update` | `MobileAppAd.Features.Enabled` | `YesNoEnum` | 1 | 1 | `supported` | --mobile-app-feature |
 | `ads.update` | `ads.update` | `MobileAppAd.AgeLabel` | `MobAppAgeLabelEnum` | 0 | 1 | `supported` | --age-label |
-| `ads.update` | `ads.update` | `MobileAppAd.VideoExtension` | `VideoExtensionUpdateItem` | 0 | 1 | `missing_followup` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
-| `ads.update` | `ads.update` | `MobileAppAd.VideoExtension.CreativeId` | `long` | 0 | 1 | `missing_followup` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
+| `ads.update` | `ads.update` | `MobileAppAd.VideoExtension` | `VideoExtensionUpdateItem` | 0 | 1 | `supported` | --video-extension-creative-id |
+| `ads.update` | `ads.update` | `MobileAppAd.VideoExtension.CreativeId` | `long` | 0 | 1 | `supported` | --video-extension-creative-id |
 | `ads.update` | `ads.update` | `TextImageAd` | `TextImageAdUpdate` | 0 | 1 | `supported` | --type |
 | `ads.update` | `ads.update` | `TextImageAd.AdImageHash` | `string` | 0 | 1 | `supported` | --image-hash |
-| `ads.update` | `ads.update` | `TextImageAd.ErirAdDescription` | `string` | 0 | 1 | `missing_followup` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
-| `ads.update` | `ads.update` | `TextImageAd.FinalUrl` | `string` | 0 | 1 | `missing_followup` | ads.update residual optional WSDL path needs typed support or N/A. [#272](https://github.com/axisrow/direct-cli/issues/272) |
+| `ads.update` | `ads.update` | `TextImageAd.ErirAdDescription` | `string` | 0 | 1 | `supported` | --erir-ad-description |
+| `ads.update` | `ads.update` | `TextImageAd.FinalUrl` | `string` | 0 | 1 | `supported` | --final-url |
 | `ads.update` | `ads.update` | `TextImageAd.Href` | `string` | 0 | 1 | `supported` | --href |
 | `ads.update` | `ads.update` | `TextImageAd.TurboPageId` | `long` | 0 | 1 | `supported` | --turbo-page-id |
 | `ads.update` | `ads.update` | `MobileAppImageAd` | `MobileAppImageAdUpdate` | 0 | 1 | `supported` | --type |

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -292,6 +292,13 @@ class TestCLI(unittest.TestCase):
             "Repeatable ShoppingAd/ListingAd FeedFilterConditions item", collapsed
         )
         self.assertIn(
+            "FinalUrl (TEXT_AD / TEXT_IMAGE_AD / TEXT_AD_BUILDER_AD)", collapsed
+        )
+        self.assertIn("TextAd.PreferVCardOverBusiness value: YES or NO", collapsed)
+        self.assertIn(
+            "Repeatable MobileAppAd.Features item as FEATURE=YES|NO", collapsed
+        )
+        self.assertIn(
             "Comma-separated ShoppingAd/ListingAd.TitleSources.Items values",
             collapsed,
         )

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1953,6 +1953,143 @@ def test_ads_update_smart_ad_builder_noop_rejected():
     ) in result.output
 
 
+def test_ads_update_text_ad_residual_optional_payload():
+    """Issue #272: residual TextAdUpdate fields build top-level TextAd keys."""
+    body = _dry_run(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "TEXT_AD",
+        "--final-url",
+        "https://final.example.com",
+        "--age-label",
+        "age_18",
+        "--business-id",
+        "0",
+        "--prefer-vcard-over-business",
+        "yes",
+        "--erir-ad-description",
+        "Text ad object",
+    )
+    assert body["params"]["Ads"][0] == {
+        "Id": 999,
+        "TextAd": {
+            "FinalUrl": "https://final.example.com",
+            "AgeLabel": "AGE_18",
+            "BusinessId": 0,
+            "PreferVCardOverBusiness": "YES",
+            "ErirAdDescription": "Text ad object",
+        },
+    }
+
+
+def test_ads_update_text_image_ad_residual_optional_payload():
+    """Issue #272: TextImageAdUpdate supports FinalUrl and ErirAdDescription."""
+    body = _dry_run(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "TEXT_IMAGE_AD",
+        "--final-url",
+        "https://final.example.com",
+        "--erir-ad-description",
+        "Image ad object",
+        "--turbo-page-id",
+        "0",
+    )
+    assert body["params"]["Ads"][0] == {
+        "Id": 999,
+        "TextImageAd": {
+            "FinalUrl": "https://final.example.com",
+            "ErirAdDescription": "Image ad object",
+            "TurboPageId": 0,
+        },
+    }
+
+
+def test_ads_update_mobile_app_ad_residual_optional_payload():
+    """Issue #272: MobileAppAdUpdate supports Features, VideoExtension, and ERIR."""
+    body = _dry_run(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "MOBILE_APP_AD",
+        "--mobile-app-feature",
+        "PRICE=YES",
+        "--mobile-app-feature",
+        "ratings=no",
+        "--video-extension-creative-id",
+        "0",
+        "--erir-ad-description",
+        "Mobile app object",
+    )
+    assert body["params"]["Ads"][0] == {
+        "Id": 999,
+        "MobileAppAd": {
+            "Features": [
+                {"Feature": "PRICE", "Enabled": "YES"},
+                {"Feature": "RATINGS", "Enabled": "NO"},
+            ],
+            "VideoExtension": {"CreativeId": 0},
+            "ErirAdDescription": "Mobile app object",
+        },
+    }
+
+
+def test_ads_update_mobile_app_feature_invalid_format_rejected():
+    """Issue #272: MobileAppAd.Features uses explicit FEATURE=YES|NO grammar."""
+    result = _rejected(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "MOBILE_APP_AD",
+        "--mobile-app-feature",
+        "PRICE",
+    )
+    assert "--mobile-app-feature expects FEATURE=YES|NO" in result.output
+
+
+def test_ads_update_mobile_app_feature_invalid_value_rejected():
+    """Issue #272: MobileAppAd.Features validates YesNoEnum values locally."""
+    result = _rejected(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "MOBILE_APP_AD",
+        "--mobile-app-feature",
+        "PRICE=MAYBE",
+    )
+    assert "Invalid --mobile-app-feature value" in result.output
+
+
+def test_ads_update_residual_flags_reject_unrelated_subtypes():
+    """Issue #272: residual typed flags still honor per-subtype allow-lists."""
+    result = _rejected(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "TEXT_AD",
+        "--mobile-app-feature",
+        "PRICE=YES",
+    )
+    assert "--mobile-app-feature is not compatible with --type TEXT_AD" in (
+        result.output
+    )
+    assert "does not convert an ad between subtypes" in result.output
+
+
 def test_ads_update_text_ad_with_turbo_page_id():
     """Issue #202: update sets TurboPageId in TextAd."""
     body = _dry_run(

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -946,6 +946,23 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
         "--callouts-remove",
         "--callouts-set",
     },
+    ("ads", "update", "TextAd.CalloutSetting.AdExtensions"): {
+        "--callouts-add",
+        "--callouts-remove",
+        "--callouts-set",
+    },
+    ("ads", "update", "TextAd.CalloutSetting.AdExtensions.AdExtensionId"): {
+        "--callouts-add",
+        "--callouts-remove",
+        "--callouts-set",
+    },
+    ("ads", "update", "TextAd.CalloutSetting.AdExtensions.Operation"): {
+        "--callouts-add",
+        "--callouts-remove",
+        "--callouts-set",
+    },
+    ("ads", "update", "TextAd.FinalUrl"): {"--final-url"},
+    ("ads", "update", "TextAd.AgeLabel"): {"--age-label"},
     ("ads", "update", "TextAd.VideoExtension"): {"--video-extension-creative-id"},
     ("ads", "update", "TextAd.VideoExtension.CreativeId"): {
         "--video-extension-creative-id"
@@ -966,6 +983,11 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     ("ads", "update", "TextAd.PriceExtension.PriceCurrency"): {
         "--price-extension-price-currency"
     },
+    ("ads", "update", "TextAd.BusinessId"): {"--business-id"},
+    ("ads", "update", "TextAd.PreferVCardOverBusiness"): {
+        "--prefer-vcard-over-business"
+    },
+    ("ads", "update", "TextAd.ErirAdDescription"): {"--erir-ad-description"},
     ("ads", "update", "DynamicTextAd"): {"--type"},
     ("ads", "update", "DynamicTextAd.VCardId"): {"--vcard-id"},
     ("ads", "update", "DynamicTextAd.AdImageHash"): {"--image-hash"},
@@ -997,9 +1019,19 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     ("ads", "update", "MobileAppAd.Title"): {"--title"},
     ("ads", "update", "MobileAppAd.TrackingUrl"): {"--tracking-url"},
     ("ads", "update", "MobileAppAd.Action"): {"--action"},
+    ("ads", "update", "MobileAppAd.ErirAdDescription"): {"--erir-ad-description"},
+    ("ads", "update", "MobileAppAd.Features"): {"--mobile-app-feature"},
+    ("ads", "update", "MobileAppAd.Features.Feature"): {"--mobile-app-feature"},
+    ("ads", "update", "MobileAppAd.Features.Enabled"): {"--mobile-app-feature"},
     ("ads", "update", "MobileAppAd.AgeLabel"): {"--age-label"},
+    ("ads", "update", "MobileAppAd.VideoExtension"): {"--video-extension-creative-id"},
+    ("ads", "update", "MobileAppAd.VideoExtension.CreativeId"): {
+        "--video-extension-creative-id"
+    },
     ("ads", "update", "TextImageAd"): {"--type"},
     ("ads", "update", "TextImageAd.AdImageHash"): {"--image-hash"},
+    ("ads", "update", "TextImageAd.ErirAdDescription"): {"--erir-ad-description"},
+    ("ads", "update", "TextImageAd.FinalUrl"): {"--final-url"},
     ("ads", "update", "TextImageAd.Href"): {"--href"},
     ("ads", "update", "TextImageAd.TurboPageId"): {"--turbo-page-id"},
     ("ads", "update", "ResponsiveAd"): {"--type"},


### PR DESCRIPTION
Closes #272

Summary:
- Adds typed ads update flags for residual TextAd, TextImageAd, and MobileAppAd optional fields: FinalUrl, AgeLabel, BusinessId, PreferVCardOverBusiness, ErirAdDescription, MobileAppAd.Features, and MobileAppAd.VideoExtension.
- Routes nested TextAd.CalloutSetting paths to existing callout flags and marks all #272 WSDL audit rows supported.
- Adds focused dry-run/help tests and README EN/RU single-line examples.

Docs/WSDL checked:
- https://yandex.ru/dev/direct/doc/en/ads/update
- tests/wsdl_cache/ads.xml

Validation:
- python3 -m pytest tests/test_dry_run.py -k "ads_update and (residual or mobile_app_feature)"
- python3 -m pytest tests/test_cli.py -k ads_update_help
- python3 scripts/build_wsdl_optional_field_audit.py --check
- python3 -m pytest tests/test_wsdl_parity_gate.py
- python3 -m pytest tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py
- python3 -m pytest tests/test_cli_contract.py -k "json or readme_direct_examples"
- mypy .
- git diff --check