### PR TITLE
Add TextAd optional fields for ads add

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ direct ads get --campaign-ids 1,2,3
 direct ads get --adgroup-ids 45678 --format table
 direct ads add --adgroup-id 12345 --type TEXT_AD --title "Title" --text "Ad text" --href "https://example.com" --dry-run
 direct ads add --adgroup-id 12345 --type TEXT_AD --title "Title" --text "Ad text" --href "https://example.com" --title2 "Second headline" --display-url-path "deals" --mobile YES --vcard-id 111 --sitelink-set-id 222 --turbo-page-id 333 --ad-extensions "444,555" --dry-run
+direct ads add --adgroup-id 12345 --type TEXT_AD --title "Title" --text "Ad text" --href "https://example.com" --final-url "https://final.example.com" --video-extension-creative-id 777 --price-extension-price 123450000 --price-extension-price-qualifier FROM --price-extension-price-currency RUB --business-id 777 --prefer-vcard-over-business NO --erir-ad-description "Text ad object" --dry-run
 direct ads add --adgroup-id 12345 --type TEXT_IMAGE_AD --image-hash abcdefghijklmnopqrst --href "https://example.com" --turbo-page-id 555 --dry-run
 direct ads update --id 99999 --type TEXT_AD --title "New Title" --text "New text" --href "https://example.com"
 direct ads update --id 99999 --type TEXT_AD --image-hash abcdefghijklmnopqrst
@@ -428,16 +429,18 @@ direct ads delete --id 99999
 
 Available TEXT_AD typed flags for `ads add` / `ads update`: `--title`, `--text`,
 `--href`, `--image-hash`, `--title2`, `--display-url-path`, `--vcard-id`,
-`--sitelink-set-id`, `--turbo-page-id`. `ads update` additionally exposes
+`--sitelink-set-id`, `--turbo-page-id`, `--final-url`,
+`--video-extension-creative-id`, `--price-extension-*`, `--business-id`,
+`--prefer-vcard-over-business`, and `--erir-ad-description`. For `ads add`,
+`TextAd.PriceExtension` requires `--price-extension-price`,
+`--price-extension-price-qualifier`, and `--price-extension-price-currency`
+when any price-extension flag is used. `ads update` additionally exposes
 `--callouts-add`, `--callouts-remove`, and `--callouts-set` for managing the
 `TextAdUpdateBase.CalloutSetting` (`ext:AdExtensionSetting`) field on an
 existing ad — `--callouts-set` replaces the whole callout list and is mutually
 exclusive with the incremental `--callouts-add` / `--callouts-remove` pair.
-It also exposes `--video-extension-creative-id` and `--price-extension-*` flags
-for `TextAd.VideoExtension` and `TextAd.PriceExtension`; price values use the
-Yandex Direct API long-unit format (price multiplied by 1,000,000). Residual
-TEXT_AD update fields are available through `--final-url`, `--age-label`,
-`--business-id`, `--prefer-vcard-over-business`, and `--erir-ad-description`.
+Price values use the Yandex Direct API long-unit format (price multiplied by
+1,000,000). `ads update` also supports `--age-label`.
 `--mobile` (default `NO`) and `--ad-extensions` are `ads add`-only —
 `TextAdUpdate` does not contain `Mobile`, and on update ad-extensions are
 managed through the `--callouts-*` flags above. TEXT_IMAGE_AD additionally
@@ -1166,6 +1169,7 @@ direct ads get --campaign-ids 1,2,3
 direct ads get --adgroup-ids 45678 --format table
 direct ads add --adgroup-id 12345 --type TEXT_AD --title "Заголовок" --text "Текст объявления" --href "https://example.com" --dry-run
 direct ads add --adgroup-id 12345 --type TEXT_AD --title "Заголовок" --text "Текст" --href "https://example.com" --title2 "Второй заголовок" --display-url-path "deals" --mobile YES --vcard-id 111 --sitelink-set-id 222 --turbo-page-id 333 --ad-extensions "444,555" --dry-run
+direct ads add --adgroup-id 12345 --type TEXT_AD --title "Заголовок" --text "Текст объявления" --href "https://example.com" --final-url "https://final.example.com" --video-extension-creative-id 777 --price-extension-price 123450000 --price-extension-price-qualifier FROM --price-extension-price-currency RUB --business-id 777 --prefer-vcard-over-business NO --erir-ad-description "Объект текстового объявления" --dry-run
 direct ads add --adgroup-id 12345 --type TEXT_IMAGE_AD --image-hash abcdefghijklmnopqrst --href "https://example.com" --turbo-page-id 555 --dry-run
 direct ads update --id 99999 --type TEXT_AD --title "Новый заголовок" --text "Новый текст" --href "https://example.com"
 direct ads update --id 99999 --type TEXT_AD --image-hash abcdefghijklmnopqrst
@@ -1188,18 +1192,19 @@ direct ads delete --id 99999
 
 Доступные типизированные флаги TEXT_AD для `ads add` / `ads update`:
 `--title`, `--text`, `--href`, `--image-hash`, `--title2`, `--display-url-path`,
-`--vcard-id`, `--sitelink-set-id`, `--turbo-page-id`. В `ads update`
-дополнительно доступны `--callouts-add`, `--callouts-remove` и
+`--vcard-id`, `--sitelink-set-id`, `--turbo-page-id`, `--final-url`,
+`--video-extension-creative-id`, `--price-extension-*`, `--business-id`,
+`--prefer-vcard-over-business` и `--erir-ad-description`. Для `ads add`
+`TextAd.PriceExtension` требует `--price-extension-price`,
+`--price-extension-price-qualifier` и `--price-extension-price-currency`, если
+передан любой price-extension флаг. В `ads update` дополнительно доступны
+`--callouts-add`, `--callouts-remove` и
 `--callouts-set` для управления полем `TextAdUpdateBase.CalloutSetting`
 (`ext:AdExtensionSetting`) у существующего объявления — `--callouts-set`
 заменяет весь список выносок и взаимоисключим с инкрементальной парой
-`--callouts-add` / `--callouts-remove`. Также доступны
-`--video-extension-creative-id` и флаги `--price-extension-*` для
-`TextAd.VideoExtension` и `TextAd.PriceExtension`; цены передаются в формате
-long-единиц API Яндекс Директа (цена, умноженная на 1 000 000). Остальные
-поля TEXT_AD в `ads update` доступны через `--final-url`, `--age-label`,
-`--business-id`, `--prefer-vcard-over-business` и `--erir-ad-description`.
-`--mobile` (default `NO`) и
+`--callouts-add` / `--callouts-remove`. Цены передаются в формате long-единиц
+API Яндекс Директа (цена, умноженная на 1 000 000). В `ads update` также
+поддерживается `--age-label`. `--mobile` (по умолчанию `NO`) и
 `--ad-extensions` доступны только в `ads add` — WSDL `TextAdUpdate` не
 содержит `Mobile`, а в `ads update` расширения управляются через флаги
 `--callouts-*` выше. Для TEXT_IMAGE_AD дополнительно доступен

--- a/README.md
+++ b/README.md
@@ -406,18 +406,18 @@ direct ads get --campaign-ids 1,2,3
 direct ads get --adgroup-ids 45678 --format table
 direct ads add --adgroup-id 12345 --type TEXT_AD --title "Title" --text "Ad text" --href "https://example.com" --dry-run
 direct ads add --adgroup-id 12345 --type TEXT_AD --title "Title" --text "Ad text" --href "https://example.com" --title2 "Second headline" --display-url-path "deals" --mobile YES --vcard-id 111 --sitelink-set-id 222 --turbo-page-id 333 --ad-extensions "444,555" --dry-run
-direct ads add --adgroup-id 12345 --type TEXT_AD --title "Title" --text "Ad text" --href "https://example.com" --final-url "https://final.example.com" --video-extension-creative-id 777 --price-extension-price 123450000 --price-extension-price-qualifier FROM --price-extension-price-currency RUB --business-id 777 --prefer-vcard-over-business NO --erir-ad-description "Text ad object" --dry-run
+direct ads add --adgroup-id 12345 --type TEXT_AD --title "Title" --text "Ad text" --href "https://example.com" --final-url "https://final.example.com" --video-extension-creative-id 777 --price-extension-price 123.45 --price-extension-price-qualifier FROM --price-extension-price-currency RUB --business-id 777 --prefer-vcard-over-business NO --erir-ad-description "Text ad object" --dry-run
 direct ads add --adgroup-id 12345 --type TEXT_IMAGE_AD --image-hash abcdefghijklmnopqrst --href "https://example.com" --turbo-page-id 555 --dry-run
 direct ads update --id 99999 --type TEXT_AD --title "New Title" --text "New text" --href "https://example.com"
 direct ads update --id 99999 --type TEXT_AD --image-hash abcdefghijklmnopqrst
 direct ads update --id 99999 --type TEXT_AD --title2 "New second headline" --vcard-id 222
 direct ads update --id 99999 --type TEXT_AD --callouts-add "111,222" --callouts-remove "333"
 direct ads update --id 99999 --type TEXT_AD --callouts-set "444,555"
-direct ads update --id 99999 --type TEXT_AD --video-extension-creative-id 777 --price-extension-price 123450000 --price-extension-price-qualifier FROM --price-extension-price-currency RUB
+direct ads update --id 99999 --type TEXT_AD --video-extension-creative-id 777 --price-extension-price 123.45 --price-extension-price-qualifier FROM --price-extension-price-currency RUB
 direct ads update --id 99999 --type TEXT_AD --final-url "https://final.example.com" --age-label AGE_18 --business-id 777 --prefer-vcard-over-business NO --erir-ad-description "Text ad object"
 direct ads update --id 99999 --type DYNAMIC_TEXT_AD --text "Updated dynamic text" --callouts-add "111,222"
 direct ads update --id 99999 --type MOBILE_APP_AD --mobile-app-feature PRICE=YES --mobile-app-feature CUSTOMER_RATING=NO --video-extension-creative-id 777 --erir-ad-description "Mobile app object"
-direct ads update --id 99999 --type RESPONSIVE_AD --texts "Text one,Text two" --titles "Title one,Title two" --image-hashes hash1,hash2 --video-extension-ids 111,222 --href "https://example.com" --price-extension-price 123450000 --price-extension-price-qualifier FROM --price-extension-price-currency RUB
+direct ads update --id 99999 --type RESPONSIVE_AD --texts "Text one,Text two" --titles "Title one,Title two" --image-hashes hash1,hash2 --video-extension-ids 111,222 --href "https://example.com" --price-extension-price 123.45 --price-extension-price-qualifier FROM --price-extension-price-currency RUB
 direct ads update --id 99999 --type TEXT_IMAGE_AD --final-url "https://final.example.com" --erir-ad-description "Image ad object"
 direct ads update --id 99999 --type SHOPPING_AD --sitelink-set-id 222 --callouts-set "444,555" --business-id 777 --feed-filter-condition "CATEGORY:EQUALS_ANY:shoes|boots" --title-sources NAME,BRAND --text-sources DESCRIPTION --default-texts "Default product text"
 direct ads update --id 99999 --type MOBILE_APP_IMAGE_AD --image-hash abcdefghijklmnopqrst --tracking-url "https://track.example.com" --erir-ad-description "Mobile image ad"
@@ -439,8 +439,9 @@ when any price-extension flag is used. `ads update` additionally exposes
 `TextAdUpdateBase.CalloutSetting` (`ext:AdExtensionSetting`) field on an
 existing ad — `--callouts-set` replaces the whole callout list and is mutually
 exclusive with the incremental `--callouts-add` / `--callouts-remove` pair.
-Price values use the Yandex Direct API long-unit format (price multiplied by
-1,000,000). `ads update` also supports `--age-label`.
+Price-extension values are human-readable money amounts and are converted to
+the Yandex Direct API long-unit format internally. `ads update` also supports
+`--age-label`.
 `--mobile` (default `NO`) and `--ad-extensions` are `ads add`-only —
 `TextAdUpdate` does not contain `Mobile`, and on update ad-extensions are
 managed through the `--callouts-*` flags above. TEXT_IMAGE_AD additionally
@@ -1169,18 +1170,18 @@ direct ads get --campaign-ids 1,2,3
 direct ads get --adgroup-ids 45678 --format table
 direct ads add --adgroup-id 12345 --type TEXT_AD --title "Заголовок" --text "Текст объявления" --href "https://example.com" --dry-run
 direct ads add --adgroup-id 12345 --type TEXT_AD --title "Заголовок" --text "Текст" --href "https://example.com" --title2 "Второй заголовок" --display-url-path "deals" --mobile YES --vcard-id 111 --sitelink-set-id 222 --turbo-page-id 333 --ad-extensions "444,555" --dry-run
-direct ads add --adgroup-id 12345 --type TEXT_AD --title "Заголовок" --text "Текст объявления" --href "https://example.com" --final-url "https://final.example.com" --video-extension-creative-id 777 --price-extension-price 123450000 --price-extension-price-qualifier FROM --price-extension-price-currency RUB --business-id 777 --prefer-vcard-over-business NO --erir-ad-description "Объект текстового объявления" --dry-run
+direct ads add --adgroup-id 12345 --type TEXT_AD --title "Заголовок" --text "Текст объявления" --href "https://example.com" --final-url "https://final.example.com" --video-extension-creative-id 777 --price-extension-price 123.45 --price-extension-price-qualifier FROM --price-extension-price-currency RUB --business-id 777 --prefer-vcard-over-business NO --erir-ad-description "Объект текстового объявления" --dry-run
 direct ads add --adgroup-id 12345 --type TEXT_IMAGE_AD --image-hash abcdefghijklmnopqrst --href "https://example.com" --turbo-page-id 555 --dry-run
 direct ads update --id 99999 --type TEXT_AD --title "Новый заголовок" --text "Новый текст" --href "https://example.com"
 direct ads update --id 99999 --type TEXT_AD --image-hash abcdefghijklmnopqrst
 direct ads update --id 99999 --type TEXT_AD --title2 "Новый второй заголовок" --vcard-id 222
 direct ads update --id 99999 --type TEXT_AD --callouts-add "111,222" --callouts-remove "333"
 direct ads update --id 99999 --type TEXT_AD --callouts-set "444,555"
-direct ads update --id 99999 --type TEXT_AD --video-extension-creative-id 777 --price-extension-price 123450000 --price-extension-price-qualifier FROM --price-extension-price-currency RUB
+direct ads update --id 99999 --type TEXT_AD --video-extension-creative-id 777 --price-extension-price 123.45 --price-extension-price-qualifier FROM --price-extension-price-currency RUB
 direct ads update --id 99999 --type TEXT_AD --final-url "https://final.example.com" --age-label AGE_18 --business-id 777 --prefer-vcard-over-business NO --erir-ad-description "Объект текстового объявления"
 direct ads update --id 99999 --type DYNAMIC_TEXT_AD --text "Обновленный динамический текст" --callouts-add "111,222"
 direct ads update --id 99999 --type MOBILE_APP_AD --mobile-app-feature PRICE=YES --mobile-app-feature CUSTOMER_RATING=NO --video-extension-creative-id 777 --erir-ad-description "Объект мобильного объявления"
-direct ads update --id 99999 --type RESPONSIVE_AD --texts "Текст один,Текст два" --titles "Заголовок один,Заголовок два" --image-hashes hash1,hash2 --video-extension-ids 111,222 --href "https://example.com" --price-extension-price 123450000 --price-extension-price-qualifier FROM --price-extension-price-currency RUB
+direct ads update --id 99999 --type RESPONSIVE_AD --texts "Текст один,Текст два" --titles "Заголовок один,Заголовок два" --image-hashes hash1,hash2 --video-extension-ids 111,222 --href "https://example.com" --price-extension-price 123.45 --price-extension-price-qualifier FROM --price-extension-price-currency RUB
 direct ads update --id 99999 --type TEXT_IMAGE_AD --final-url "https://final.example.com" --erir-ad-description "Объект графического объявления"
 direct ads update --id 99999 --type SHOPPING_AD --sitelink-set-id 222 --callouts-set "444,555" --business-id 777 --feed-filter-condition "CATEGORY:EQUALS_ANY:shoes|boots" --title-sources NAME,BRAND --text-sources DESCRIPTION --default-texts "Текст по умолчанию"
 direct ads update --id 99999 --type MOBILE_APP_IMAGE_AD --image-hash abcdefghijklmnopqrst --tracking-url "https://track.example.com" --erir-ad-description "Мобильное графическое объявление"
@@ -1202,9 +1203,10 @@ direct ads delete --id 99999
 `--callouts-set` для управления полем `TextAdUpdateBase.CalloutSetting`
 (`ext:AdExtensionSetting`) у существующего объявления — `--callouts-set`
 заменяет весь список выносок и взаимоисключим с инкрементальной парой
-`--callouts-add` / `--callouts-remove`. Цены передаются в формате long-единиц
-API Яндекс Директа (цена, умноженная на 1 000 000). В `ads update` также
-поддерживается `--age-label`. `--mobile` (по умолчанию `NO`) и
+`--callouts-add` / `--callouts-remove`. Значения price-extension передаются как
+человекочитаемые суммы и внутри CLI конвертируются в long-единицы API Яндекс
+Директа. В `ads update` также поддерживается `--age-label`.
+`--mobile` (по умолчанию `NO`) и
 `--ad-extensions` доступны только в `ads add` — WSDL `TextAdUpdate` не
 содержит `Mobile`, а в `ads update` расширения управляются через флаги
 `--callouts-*` выше. Для TEXT_IMAGE_AD дополнительно доступен

--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -2,6 +2,7 @@
 Ads commands
 """
 
+from decimal import Decimal, InvalidOperation
 from typing import Optional
 
 import click
@@ -207,14 +208,38 @@ def _build_price_extension(
     """Build TextAd.PriceExtension update payload from typed flags."""
     price_extension = {}
     if price_extension_price is not None:
-        price_extension["Price"] = price_extension_price
+        price_extension["Price"] = _parse_price_extension_amount(
+            price_extension_price, "--price-extension-price"
+        )
     if price_extension_old_price is not None:
-        price_extension["OldPrice"] = price_extension_old_price
+        price_extension["OldPrice"] = _parse_price_extension_amount(
+            price_extension_old_price, "--price-extension-old-price"
+        )
     if price_extension_price_qualifier:
         price_extension["PriceQualifier"] = price_extension_price_qualifier.upper()
     if price_extension_price_currency:
         price_extension["PriceCurrency"] = price_extension_price_currency.upper()
     return price_extension or None
+
+
+def _parse_price_extension_amount(value: str, flag_name: str) -> int:
+    """Convert human-readable price-extension money to API long units."""
+    try:
+        amount = Decimal(value)
+    except (InvalidOperation, ValueError):
+        raise click.UsageError(
+            f"{flag_name} must be a human-readable money value, for example 123.45."
+        )
+
+    if not amount.is_finite():
+        raise click.UsageError(f"{flag_name} must be a finite money value.")
+    if amount < 0:
+        raise click.UsageError(f"{flag_name} must be non-negative.")
+    exponent = amount.as_tuple().exponent
+    if not isinstance(exponent, int) or exponent < -2:
+        raise click.UsageError(f"{flag_name} must have at most two decimal places.")
+
+    return int(amount * Decimal("1000000"))
 
 
 def _build_price_extension_add(
@@ -246,12 +271,16 @@ def _build_price_extension_add(
         )
 
     price_extension = {
-        "Price": price_extension_price,
+        "Price": _parse_price_extension_amount(
+            price_extension_price, "--price-extension-price"
+        ),
         "PriceQualifier": price_extension_price_qualifier.upper(),
         "PriceCurrency": price_extension_price_currency.upper(),
     }
     if price_extension_old_price is not None:
-        price_extension["OldPrice"] = price_extension_old_price
+        price_extension["OldPrice"] = _parse_price_extension_amount(
+            price_extension_old_price, "--price-extension-old-price"
+        )
     return price_extension
 
 
@@ -662,18 +691,18 @@ def get(
 )
 @click.option(
     "--price-extension-price",
-    type=int,
     help=(
-        "TextAd.PriceExtension.Price as API long units "
-        "(price multiplied by 1,000,000). Required with PriceExtension add."
+        "TextAd.PriceExtension.Price as human-readable money. "
+        "Required whenever any PriceExtension flag is used."
     ),
 )
 @click.option(
     "--price-extension-old-price",
-    type=int,
     help=(
-        "TextAd.PriceExtension.OldPrice as API long units "
-        "(price multiplied by 1,000,000). TEXT_AD only."
+        "TextAd.PriceExtension.OldPrice as human-readable money. "
+        "Optional; if supplied, PriceExtension add also requires "
+        "--price-extension-price, --price-extension-price-qualifier, "
+        "and --price-extension-price-currency."
     ),
 )
 @click.option(
@@ -681,7 +710,7 @@ def get(
     type=click.Choice(["FROM", "UP_TO", "NONE"], case_sensitive=False),
     help=(
         "TextAd.PriceExtension.PriceQualifier: FROM, UP_TO, or NONE. "
-        "Required with PriceExtension add."
+        "Required whenever any PriceExtension flag is used."
     ),
 )
 @click.option(
@@ -692,7 +721,7 @@ def get(
     ),
     help=(
         "TextAd.PriceExtension.PriceCurrency enum value. "
-        "Required with PriceExtension add."
+        "Required whenever any PriceExtension flag is used."
     ),
 )
 @click.option("--business-id", type=int, help="TextAd.BusinessId (TEXT_AD)")
@@ -1097,18 +1126,16 @@ def add(
 )
 @click.option(
     "--price-extension-price",
-    type=int,
     help=(
-        "PriceExtension.Price as API long units "
-        "(price multiplied by 1,000,000). TEXT_AD / RESPONSIVE_AD only."
+        "PriceExtension.Price as human-readable money; converted to API long "
+        "units. TEXT_AD / RESPONSIVE_AD only."
     ),
 )
 @click.option(
     "--price-extension-old-price",
-    type=int,
     help=(
-        "PriceExtension.OldPrice as API long units "
-        "(price multiplied by 1,000,000). TEXT_AD / RESPONSIVE_AD only."
+        "PriceExtension.OldPrice as human-readable money; converted to API "
+        "long units. TEXT_AD / RESPONSIVE_AD only."
     ),
 )
 @click.option(

--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -217,6 +217,44 @@ def _build_price_extension(
     return price_extension or None
 
 
+def _build_price_extension_add(
+    price_extension_price,
+    price_extension_old_price,
+    price_extension_price_qualifier,
+    price_extension_price_currency,
+):
+    """Build TextAd.PriceExtension add payload from typed flags."""
+    provided = (
+        price_extension_price is not None
+        or price_extension_old_price is not None
+        or price_extension_price_qualifier
+        or price_extension_price_currency
+    )
+    if not provided:
+        return None
+
+    missing = []
+    if price_extension_price is None:
+        missing.append("--price-extension-price")
+    if not price_extension_price_qualifier:
+        missing.append("--price-extension-price-qualifier")
+    if not price_extension_price_currency:
+        missing.append("--price-extension-price-currency")
+    if missing:
+        raise click.UsageError(
+            "TextAd.PriceExtension add requires " + ", ".join(missing)
+        )
+
+    price_extension = {
+        "Price": price_extension_price,
+        "PriceQualifier": price_extension_price_qualifier.upper(),
+        "PriceCurrency": price_extension_price_currency.upper(),
+    }
+    if price_extension_old_price is not None:
+        price_extension["OldPrice"] = price_extension_old_price
+    return price_extension
+
+
 def _parse_required_csv_strings(
     csv_value: Optional[str], flag_name: str
 ) -> Optional[list[str]]:
@@ -616,6 +654,54 @@ def get(
     "--turbo-page-id", type=int, help="Turbo page ID (TEXT_AD / TEXT_IMAGE_AD)"
 )
 @click.option("--ad-extensions", help="Comma-separated ad extension IDs (TEXT_AD)")
+@click.option("--final-url", help="TextAd.FinalUrl (TEXT_AD)")
+@click.option(
+    "--video-extension-creative-id",
+    type=int,
+    help="TextAd.VideoExtension.CreativeId (TEXT_AD)",
+)
+@click.option(
+    "--price-extension-price",
+    type=int,
+    help=(
+        "TextAd.PriceExtension.Price as API long units "
+        "(price multiplied by 1,000,000). Required with PriceExtension add."
+    ),
+)
+@click.option(
+    "--price-extension-old-price",
+    type=int,
+    help=(
+        "TextAd.PriceExtension.OldPrice as API long units "
+        "(price multiplied by 1,000,000). TEXT_AD only."
+    ),
+)
+@click.option(
+    "--price-extension-price-qualifier",
+    type=click.Choice(["FROM", "UP_TO", "NONE"], case_sensitive=False),
+    help=(
+        "TextAd.PriceExtension.PriceQualifier: FROM, UP_TO, or NONE. "
+        "Required with PriceExtension add."
+    ),
+)
+@click.option(
+    "--price-extension-price-currency",
+    type=click.Choice(
+        ["RUB", "UAH", "BYN", "USD", "EUR", "KZT", "TRY", "CHF", "UZS"],
+        case_sensitive=False,
+    ),
+    help=(
+        "TextAd.PriceExtension.PriceCurrency enum value. "
+        "Required with PriceExtension add."
+    ),
+)
+@click.option("--business-id", type=int, help="TextAd.BusinessId (TEXT_AD)")
+@click.option(
+    "--prefer-vcard-over-business",
+    type=click.Choice(["YES", "NO"], case_sensitive=False),
+    help="TextAd.PreferVCardOverBusiness value: YES or NO",
+)
+@click.option("--erir-ad-description", help="TextAd.ErirAdDescription (TEXT_AD)")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
 def add(
@@ -636,6 +722,15 @@ def add(
     sitelink_set_id,
     turbo_page_id,
     ad_extensions,
+    final_url,
+    video_extension_creative_id,
+    price_extension_price,
+    price_extension_old_price,
+    price_extension_price_qualifier,
+    price_extension_price_currency,
+    business_id,
+    prefer_vcard_over_business,
+    erir_ad_description,
     dry_run,
 ):
     """Add new ad"""
@@ -674,6 +769,15 @@ def add(
                 "sitelink_set_id",
                 "turbo_page_id",
                 "ad_extensions",
+                "final_url",
+                "video_extension_creative_id",
+                "price_extension_price",
+                "price_extension_old_price",
+                "price_extension_price_qualifier",
+                "price_extension_price_currency",
+                "business_id",
+                "prefer_vcard_over_business",
+                "erir_ad_description",
             },
             "TEXT_IMAGE_AD": {"href", "image_hash", "turbo_page_id"},
             "MOBILE_APP_AD": {
@@ -700,6 +804,15 @@ def add(
             "sitelink_set_id": sitelink_set_id,
             "turbo_page_id": turbo_page_id,
             "ad_extensions": ad_extensions,
+            "final_url": final_url,
+            "video_extension_creative_id": video_extension_creative_id,
+            "price_extension_price": price_extension_price,
+            "price_extension_old_price": price_extension_old_price,
+            "price_extension_price_qualifier": price_extension_price_qualifier,
+            "price_extension_price_currency": price_extension_price_currency,
+            "business_id": business_id,
+            "prefer_vcard_over_business": prefer_vcard_over_business,
+            "erir_ad_description": erir_ad_description,
         }
         flag_for = {
             "title": "--title",
@@ -716,6 +829,15 @@ def add(
             "sitelink_set_id": "--sitelink-set-id",
             "turbo_page_id": "--turbo-page-id",
             "ad_extensions": "--ad-extensions",
+            "final_url": "--final-url",
+            "video_extension_creative_id": "--video-extension-creative-id",
+            "price_extension_price": "--price-extension-price",
+            "price_extension_old_price": "--price-extension-old-price",
+            "price_extension_price_qualifier": "--price-extension-price-qualifier",
+            "price_extension_price_currency": "--price-extension-price-currency",
+            "business_id": "--business-id",
+            "prefer_vcard_over_business": "--prefer-vcard-over-business",
+            "erir_ad_description": "--erir-ad-description",
         }
         _reject_incompatible_flags(
             ad_type_norm, type_fields[ad_type_norm], provided, flag_for
@@ -754,6 +876,24 @@ def add(
                 text_ad["TurboPageId"] = turbo_page_id
             if ad_extensions:
                 text_ad["AdExtensionIds"] = parse_ids(ad_extensions)
+            if final_url:
+                text_ad["FinalUrl"] = final_url
+            if video_extension_creative_id is not None:
+                text_ad["VideoExtension"] = {"CreativeId": video_extension_creative_id}
+            price_extension = _build_price_extension_add(
+                price_extension_price,
+                price_extension_old_price,
+                price_extension_price_qualifier,
+                price_extension_price_currency,
+            )
+            if price_extension:
+                text_ad["PriceExtension"] = price_extension
+            if business_id is not None:
+                text_ad["BusinessId"] = business_id
+            if prefer_vcard_over_business:
+                text_ad["PreferVCardOverBusiness"] = prefer_vcard_over_business.upper()
+            if erir_ad_description:
+                text_ad["ErirAdDescription"] = erir_ad_description
             ad_data["TextAd"] = text_ad
         elif ad_type_norm == "TEXT_IMAGE_AD":
             if title or text:

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,9 +11,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 2501 |
+| `missing_followup` | 2490 |
 | `not_applicable` | 23 |
-| `supported` | 717 |
+| `supported` | 728 |
 
 ## Confirmed Follow-Ups
 
@@ -42,17 +42,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `adgroups.update` | `DynamicTextFeedAdGroup.AutotargetingSettings.BrandOptions.WithAdvertiserBrand` | Official adgroups.update docs for DynamicTextFeedAdGroupUpdate list AutotargetingCategories only. [#281](https://github.com/axisrow/direct-cli/issues/281); inherited from `DynamicTextFeedAdGroup.AutotargetingSettings` |
 | `adgroups.update` | `DynamicTextFeedAdGroup.AutotargetingSettings.BrandOptions.WithCompetitorsBrand` | Official adgroups.update docs for DynamicTextFeedAdGroupUpdate list AutotargetingCategories only. [#281](https://github.com/axisrow/direct-cli/issues/281); inherited from `DynamicTextFeedAdGroup.AutotargetingSettings` |
 | `adgroups.update` | `DynamicTextFeedAdGroup.FeedId` | Official adgroups.update docs for DynamicTextFeedAdGroupUpdate do not list FeedId. [#281](https://github.com/axisrow/direct-cli/issues/281) |
-| `ads.add` | `TextAd.FinalUrl` | TEXT_AD optional add fields need typed support or N/A. [#273](https://github.com/axisrow/direct-cli/issues/273); inherited from `TextAd` |
-| `ads.add` | `TextAd.VideoExtension` | TEXT_AD optional add fields need typed support or N/A. [#273](https://github.com/axisrow/direct-cli/issues/273); inherited from `TextAd` |
-| `ads.add` | `TextAd.VideoExtension.CreativeId` | TEXT_AD optional add fields need typed support or N/A. [#273](https://github.com/axisrow/direct-cli/issues/273); inherited from `TextAd` |
-| `ads.add` | `TextAd.PriceExtension` | TEXT_AD optional add fields need typed support or N/A. [#273](https://github.com/axisrow/direct-cli/issues/273); inherited from `TextAd` |
-| `ads.add` | `TextAd.PriceExtension.Price` | TEXT_AD optional add fields need typed support or N/A. [#273](https://github.com/axisrow/direct-cli/issues/273); inherited from `TextAd` |
-| `ads.add` | `TextAd.PriceExtension.OldPrice` | TEXT_AD optional add fields need typed support or N/A. [#273](https://github.com/axisrow/direct-cli/issues/273); inherited from `TextAd` |
-| `ads.add` | `TextAd.PriceExtension.PriceQualifier` | TEXT_AD optional add fields need typed support or N/A. [#273](https://github.com/axisrow/direct-cli/issues/273); inherited from `TextAd` |
-| `ads.add` | `TextAd.PriceExtension.PriceCurrency` | TEXT_AD optional add fields need typed support or N/A. [#273](https://github.com/axisrow/direct-cli/issues/273); inherited from `TextAd` |
-| `ads.add` | `TextAd.BusinessId` | TEXT_AD optional add fields need typed support or N/A. [#273](https://github.com/axisrow/direct-cli/issues/273); inherited from `TextAd` |
-| `ads.add` | `TextAd.PreferVCardOverBusiness` | TEXT_AD optional add fields need typed support or N/A. [#273](https://github.com/axisrow/direct-cli/issues/273); inherited from `TextAd` |
-| `ads.add` | `TextAd.ErirAdDescription` | TEXT_AD optional add fields need typed support or N/A. [#273](https://github.com/axisrow/direct-cli/issues/273); inherited from `TextAd` |
 | `ads.add` | `ResponsiveAd` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274) |
 | `ads.add` | `ResponsiveAd.Texts` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
 | `ads.add` | `ResponsiveAd.Titles` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
@@ -2673,21 +2662,21 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `ads.add` | `ads.add` | `TextAd.Text` | `string` | 1 | 1 | `supported` | --text |
 | `ads.add` | `ads.add` | `TextAd.Title` | `string` | 1 | 1 | `supported` | --title |
 | `ads.add` | `ads.add` | `TextAd.Title2` | `string` | 0 | 1 | `supported` | --title2 |
-| `ads.add` | `ads.add` | `TextAd.FinalUrl` | `string` | 0 | 1 | `missing_followup` | TEXT_AD optional add fields need typed support or N/A. [#273](https://github.com/axisrow/direct-cli/issues/273); inherited from `TextAd` |
+| `ads.add` | `ads.add` | `TextAd.FinalUrl` | `string` | 0 | 1 | `supported` | --final-url |
 | `ads.add` | `ads.add` | `TextAd.Href` | `string` | 0 | 1 | `supported` | --href |
 | `ads.add` | `ads.add` | `TextAd.Mobile` | `YesNoEnum` | 1 | 1 | `supported` | --mobile |
 | `ads.add` | `ads.add` | `TextAd.DisplayUrlPath` | `string` | 0 | 1 | `supported` | --display-url-path |
-| `ads.add` | `ads.add` | `TextAd.VideoExtension` | `VideoExtensionAddItem` | 0 | 1 | `missing_followup` | TEXT_AD optional add fields need typed support or N/A. [#273](https://github.com/axisrow/direct-cli/issues/273); inherited from `TextAd` |
-| `ads.add` | `ads.add` | `TextAd.VideoExtension.CreativeId` | `long` | 0 | 1 | `missing_followup` | TEXT_AD optional add fields need typed support or N/A. [#273](https://github.com/axisrow/direct-cli/issues/273); inherited from `TextAd` |
-| `ads.add` | `ads.add` | `TextAd.PriceExtension` | `PriceExtensionAddItem` | 0 | 1 | `missing_followup` | TEXT_AD optional add fields need typed support or N/A. [#273](https://github.com/axisrow/direct-cli/issues/273); inherited from `TextAd` |
-| `ads.add` | `ads.add` | `TextAd.PriceExtension.Price` | `long` | 1 | 1 | `missing_followup` | TEXT_AD optional add fields need typed support or N/A. [#273](https://github.com/axisrow/direct-cli/issues/273); inherited from `TextAd` |
-| `ads.add` | `ads.add` | `TextAd.PriceExtension.OldPrice` | `long` | 0 | 1 | `missing_followup` | TEXT_AD optional add fields need typed support or N/A. [#273](https://github.com/axisrow/direct-cli/issues/273); inherited from `TextAd` |
-| `ads.add` | `ads.add` | `TextAd.PriceExtension.PriceQualifier` | `PriceQualifierEnum` | 1 | 1 | `missing_followup` | TEXT_AD optional add fields need typed support or N/A. [#273](https://github.com/axisrow/direct-cli/issues/273); inherited from `TextAd` |
-| `ads.add` | `ads.add` | `TextAd.PriceExtension.PriceCurrency` | `PriceCurrencyEnum` | 1 | 1 | `missing_followup` | TEXT_AD optional add fields need typed support or N/A. [#273](https://github.com/axisrow/direct-cli/issues/273); inherited from `TextAd` |
+| `ads.add` | `ads.add` | `TextAd.VideoExtension` | `VideoExtensionAddItem` | 0 | 1 | `supported` | --video-extension-creative-id |
+| `ads.add` | `ads.add` | `TextAd.VideoExtension.CreativeId` | `long` | 0 | 1 | `supported` | --video-extension-creative-id |
+| `ads.add` | `ads.add` | `TextAd.PriceExtension` | `PriceExtensionAddItem` | 0 | 1 | `supported` | --price-extension-old-price, --price-extension-price, --price-extension-price-currency, --price-extension-price-qualifier |
+| `ads.add` | `ads.add` | `TextAd.PriceExtension.Price` | `long` | 1 | 1 | `supported` | --price-extension-price |
+| `ads.add` | `ads.add` | `TextAd.PriceExtension.OldPrice` | `long` | 0 | 1 | `supported` | --price-extension-old-price |
+| `ads.add` | `ads.add` | `TextAd.PriceExtension.PriceQualifier` | `PriceQualifierEnum` | 1 | 1 | `supported` | --price-extension-price-qualifier |
+| `ads.add` | `ads.add` | `TextAd.PriceExtension.PriceCurrency` | `PriceCurrencyEnum` | 1 | 1 | `supported` | --price-extension-price-currency |
 | `ads.add` | `ads.add` | `TextAd.TurboPageId` | `long` | 0 | 1 | `supported` | --turbo-page-id |
-| `ads.add` | `ads.add` | `TextAd.BusinessId` | `long` | 0 | 1 | `missing_followup` | TEXT_AD optional add fields need typed support or N/A. [#273](https://github.com/axisrow/direct-cli/issues/273); inherited from `TextAd` |
-| `ads.add` | `ads.add` | `TextAd.PreferVCardOverBusiness` | `YesNoEnum` | 0 | 1 | `missing_followup` | TEXT_AD optional add fields need typed support or N/A. [#273](https://github.com/axisrow/direct-cli/issues/273); inherited from `TextAd` |
-| `ads.add` | `ads.add` | `TextAd.ErirAdDescription` | `string` | 0 | 1 | `missing_followup` | TEXT_AD optional add fields need typed support or N/A. [#273](https://github.com/axisrow/direct-cli/issues/273); inherited from `TextAd` |
+| `ads.add` | `ads.add` | `TextAd.BusinessId` | `long` | 0 | 1 | `supported` | --business-id |
+| `ads.add` | `ads.add` | `TextAd.PreferVCardOverBusiness` | `YesNoEnum` | 0 | 1 | `supported` | --prefer-vcard-over-business |
+| `ads.add` | `ads.add` | `TextAd.ErirAdDescription` | `string` | 0 | 1 | `supported` | --erir-ad-description |
 | `ads.add` | `ads.add` | `ResponsiveAd` | `ResponsiveAdAdd` | 0 | 1 | `missing_followup` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274) |
 | `ads.add` | `ads.add` | `ResponsiveAd.Texts` | `string` | 1 | unbounded | `missing_followup` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
 | `ads.add` | `ads.add` | `ResponsiveAd.Titles` | `string` | 1 | unbounded | `missing_followup` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -261,6 +261,17 @@ class TestCLI(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertNotIn("Documentation:", result.output)
 
+    def test_ads_add_help_documents_text_ad_optional_extensions(self):
+        result = self.runner.invoke(cli, ["ads", "add", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        collapsed = " ".join(result.output.split())
+        self.assertIn("TextAd.FinalUrl (TEXT_AD)", collapsed)
+        self.assertIn("TextAd.VideoExtension.CreativeId (TEXT_AD)", collapsed)
+        self.assertIn("TextAd.PriceExtension.Price as API long units", collapsed)
+        self.assertIn("TextAd.BusinessId (TEXT_AD)", collapsed)
+        self.assertIn("TextAd.PreferVCardOverBusiness value: YES or NO", collapsed)
+        self.assertIn("TextAd.ErirAdDescription (TEXT_AD)", collapsed)
+
     def test_ads_update_help_documents_text_ad_image_hash(self):
         result = self.runner.invoke(cli, ["ads", "update", "--help"])
         self.assertEqual(result.exit_code, 0)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -267,7 +267,10 @@ class TestCLI(unittest.TestCase):
         collapsed = " ".join(result.output.split())
         self.assertIn("TextAd.FinalUrl (TEXT_AD)", collapsed)
         self.assertIn("TextAd.VideoExtension.CreativeId (TEXT_AD)", collapsed)
-        self.assertIn("TextAd.PriceExtension.Price as API long units", collapsed)
+        self.assertIn("TextAd.PriceExtension.Price as human-readable money", collapsed)
+        self.assertIn(
+            "Optional; if supplied, PriceExtension add also requires", collapsed
+        )
         self.assertIn("TextAd.BusinessId (TEXT_AD)", collapsed)
         self.assertIn("TextAd.PreferVCardOverBusiness value: YES or NO", collapsed)
         self.assertIn("TextAd.ErirAdDescription (TEXT_AD)", collapsed)

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -831,6 +831,118 @@ def test_ads_add_text_ad_with_turbo_page_id():
     assert body["params"]["Ads"][0]["TextAd"]["TurboPageId"] == 333
 
 
+def test_ads_add_text_ad_optional_extension_fields_payload():
+    """Issue #273: TEXT_AD add optional extension fields are top-level TextAd."""
+    body = _dry_run(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "12345",
+        "--type",
+        "TEXT_AD",
+        "--title",
+        "T",
+        "--text",
+        "Body text long enough",
+        "--href",
+        "https://example.com",
+        "--final-url",
+        "https://final.example.com",
+        "--video-extension-creative-id",
+        "0",
+        "--price-extension-price",
+        "123450000",
+        "--price-extension-old-price",
+        "234560000",
+        "--price-extension-price-qualifier",
+        "from",
+        "--price-extension-price-currency",
+        "rub",
+        "--business-id",
+        "0",
+        "--prefer-vcard-over-business",
+        "yes",
+        "--erir-ad-description",
+        "Text ad object",
+    )
+    text_ad = body["params"]["Ads"][0]["TextAd"]
+    assert text_ad["FinalUrl"] == "https://final.example.com"
+    assert text_ad["VideoExtension"] == {"CreativeId": 0}
+    assert text_ad["PriceExtension"] == {
+        "Price": 123450000,
+        "OldPrice": 234560000,
+        "PriceQualifier": "FROM",
+        "PriceCurrency": "RUB",
+    }
+    assert text_ad["BusinessId"] == 0
+    assert text_ad["PreferVCardOverBusiness"] == "YES"
+    assert text_ad["ErirAdDescription"] == "Text ad object"
+
+
+def test_ads_add_text_ad_price_extension_requires_mandatory_fields():
+    """Issue #273: PriceExtensionAddItem has required nested fields."""
+    result = _rejected(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "12345",
+        "--type",
+        "TEXT_AD",
+        "--title",
+        "T",
+        "--text",
+        "Body text long enough",
+        "--href",
+        "https://example.com",
+        "--price-extension-old-price",
+        "234560000",
+    )
+    assert "TextAd.PriceExtension add requires" in result.output
+    assert "--price-extension-price" in result.output
+    assert "--price-extension-price-qualifier" in result.output
+    assert "--price-extension-price-currency" in result.output
+
+
+def test_ads_add_text_ad_optional_extension_flags_reject_other_subtypes():
+    """Issue #273: TEXT_AD add flags must not silently drop on other subtypes."""
+    text_image = _rejected(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "1",
+        "--type",
+        "TEXT_IMAGE_AD",
+        "--image-hash",
+        "abcdefghij",
+        "--href",
+        "https://example.com",
+        "--final-url",
+        "https://final.example.com",
+    )
+    mobile_app = _rejected(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "1",
+        "--type",
+        "MOBILE_APP_AD",
+        "--title",
+        "T",
+        "--text",
+        "Body",
+        "--action",
+        "INSTALL",
+        "--price-extension-price",
+        "123450000",
+    )
+    assert "--final-url is not compatible with --type TEXT_IMAGE_AD" in (
+        text_image.output
+    )
+    assert "--price-extension-price is not compatible with --type MOBILE_APP_AD" in (
+        mobile_app.output
+    )
+
+
 def test_ads_add_text_image_ad_with_turbo_page_id():
     """Issue #202: --turbo-page-id is also valid for TEXT_IMAGE_AD."""
     body = _dry_run(

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -851,9 +851,9 @@ def test_ads_add_text_ad_optional_extension_fields_payload():
         "--video-extension-creative-id",
         "0",
         "--price-extension-price",
-        "123450000",
+        "123.45",
         "--price-extension-old-price",
-        "234560000",
+        "234.56",
         "--price-extension-price-qualifier",
         "from",
         "--price-extension-price-currency",
@@ -895,7 +895,7 @@ def test_ads_add_text_ad_price_extension_requires_mandatory_fields():
         "--href",
         "https://example.com",
         "--price-extension-old-price",
-        "234560000",
+        "234.56",
     )
     assert "TextAd.PriceExtension add requires" in result.output
     assert "--price-extension-price" in result.output
@@ -933,7 +933,7 @@ def test_ads_add_text_ad_optional_extension_flags_reject_other_subtypes():
         "--action",
         "INSTALL",
         "--price-extension-price",
-        "123450000",
+        "123.45",
     )
     assert "--final-url is not compatible with --type TEXT_IMAGE_AD" in (
         text_image.output
@@ -1394,9 +1394,9 @@ def test_ads_update_responsive_ad_payload():
         "--display-url-path",
         "deals",
         "--price-extension-price",
-        "123450000",
+        "123.45",
         "--price-extension-old-price",
-        "150000000",
+        "150.00",
         "--price-extension-price-qualifier",
         "from",
         "--price-extension-price-currency",
@@ -2494,9 +2494,9 @@ def test_ads_update_text_ad_price_extension_payload():
         "--type",
         "TEXT_AD",
         "--price-extension-price",
-        "123450000",
+        "123.45",
         "--price-extension-old-price",
-        "150000000",
+        "150.00",
         "--price-extension-price-qualifier",
         "from",
         "--price-extension-price-currency",
@@ -2513,6 +2513,23 @@ def test_ads_update_text_ad_price_extension_payload():
             }
         },
     }
+
+
+def test_ads_update_text_ad_price_extension_rejects_fractional_cents():
+    """PriceExtension money input is human-readable with two decimal places."""
+    result = _rejected(
+        "ads",
+        "update",
+        "--id",
+        "999",
+        "--type",
+        "TEXT_AD",
+        "--price-extension-price",
+        "123.456",
+    )
+    assert "--price-extension-price must have at most two decimal places" in (
+        result.output
+    )
 
 
 def test_ads_update_text_ad_price_extension_partial_payload():
@@ -2561,7 +2578,7 @@ def test_ads_update_text_ad_price_extension_flags_rejected_for_mobile_app_ad():
         "--type",
         "MOBILE_APP_AD",
         "--price-extension-price",
-        "123450000",
+        "123.45",
     )
     assert (
         "--price-extension-price is not compatible with --type MOBILE_APP_AD"

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -920,6 +920,28 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     ("ads", "add", "TextAd.Mobile"): {"--mobile"},
     ("ads", "add", "TextAd.DisplayUrlPath"): {"--display-url-path"},
     ("ads", "add", "TextAd.TurboPageId"): {"--turbo-page-id"},
+    ("ads", "add", "TextAd.FinalUrl"): {"--final-url"},
+    ("ads", "add", "TextAd.VideoExtension"): {"--video-extension-creative-id"},
+    ("ads", "add", "TextAd.VideoExtension.CreativeId"): {
+        "--video-extension-creative-id"
+    },
+    ("ads", "add", "TextAd.PriceExtension"): {
+        "--price-extension-price",
+        "--price-extension-old-price",
+        "--price-extension-price-qualifier",
+        "--price-extension-price-currency",
+    },
+    ("ads", "add", "TextAd.PriceExtension.Price"): {"--price-extension-price"},
+    ("ads", "add", "TextAd.PriceExtension.OldPrice"): {"--price-extension-old-price"},
+    ("ads", "add", "TextAd.PriceExtension.PriceQualifier"): {
+        "--price-extension-price-qualifier"
+    },
+    ("ads", "add", "TextAd.PriceExtension.PriceCurrency"): {
+        "--price-extension-price-currency"
+    },
+    ("ads", "add", "TextAd.BusinessId"): {"--business-id"},
+    ("ads", "add", "TextAd.PreferVCardOverBusiness"): {"--prefer-vcard-over-business"},
+    ("ads", "add", "TextAd.ErirAdDescription"): {"--erir-ad-description"},
     ("ads", "add", "MobileAppAd"): {"--type"},
     ("ads", "add", "MobileAppAd.AdImageHash"): {"--image-hash"},
     ("ads", "add", "MobileAppAd.Text"): {"--text"},
@@ -1836,11 +1858,6 @@ OPTIONAL_FIELD_DEFAULT_FOLLOWUPS: dict[tuple[str, str], dict[str, str]] = {
 }
 
 OPTIONAL_FIELD_CHILD_PREFIX_FOLLOWUPS: dict[tuple[str, str, str], dict[str, str]] = {
-    ("ads", "add", "TextAd"): {
-        "status": "missing_followup",
-        "issue": "#273",
-        "note": "TEXT_AD optional add fields need typed support or N/A.",
-    },
     ("ads", "add", "ResponsiveAd"): {
         "status": "missing_followup",
         "issue": "#274",


### PR DESCRIPTION
## Summary
- add typed `ads add --type TEXT_AD` flags for `FinalUrl`, `VideoExtension.CreativeId`, `PriceExtension`, `BusinessId`, `PreferVCardOverBusiness`, and `ErirAdDescription`
- validate required nested `PriceExtensionAddItem` fields when any price-extension flag is provided
- update dry-run/help/README examples and WSDL optional-field parity audit

## Docs
- Official Yandex Direct `ads.add` request structure lists these fields under `TextAd`: https://yandex.ru/dev/direct/doc/en/ads/add

## Verification
- `python3 -m pytest tests/test_dry_run.py -k "ads_add and (optional_extension or price_extension)"`
- `python3 -m pytest tests/test_cli.py -k ads_add_help`
- `python3 scripts/build_wsdl_optional_field_audit.py --check`
- `python3 -m pytest tests/test_wsdl_parity_gate.py`
- `python3 -m pytest tests/test_cli_contract.py -k "json or readme_direct_examples"`
- `python3 -m pytest tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py`
- `mypy .`
- `git diff --check`

Closes #273