### PR TITLE
Add ResponsiveAd typed flags for ads add

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ direct ads get --adgroup-ids 45678 --format table
 direct ads add --adgroup-id 12345 --type TEXT_AD --title "Title" --text "Ad text" --href "https://example.com" --dry-run
 direct ads add --adgroup-id 12345 --type TEXT_AD --title "Title" --text "Ad text" --href "https://example.com" --title2 "Second headline" --display-url-path "deals" --mobile YES --vcard-id 111 --sitelink-set-id 222 --turbo-page-id 333 --ad-extensions "444,555" --dry-run
 direct ads add --adgroup-id 12345 --type TEXT_AD --title "Title" --text "Ad text" --href "https://example.com" --final-url "https://final.example.com" --video-extension-creative-id 777 --price-extension-price 123.45 --price-extension-price-qualifier FROM --price-extension-price-currency RUB --business-id 777 --prefer-vcard-over-business NO --erir-ad-description "Text ad object" --dry-run
+direct ads add --adgroup-id 12345 --type RESPONSIVE_AD --texts "Text one,Text two" --titles "Title one,Title two" --image-hashes hash1,hash2 --video-extension-ids 111,222 --href "https://example.com" --price-extension-price 123.45 --price-extension-price-qualifier FROM --price-extension-price-currency RUB --business-id 777 --erir-ad-description "Responsive ad object" --dry-run
 direct ads add --adgroup-id 12345 --type TEXT_IMAGE_AD --image-hash abcdefghijklmnopqrst --href "https://example.com" --turbo-page-id 555 --dry-run
 direct ads update --id 99999 --type TEXT_AD --title "New Title" --text "New text" --href "https://example.com"
 direct ads update --id 99999 --type TEXT_AD --image-hash abcdefghijklmnopqrst
@@ -448,6 +449,11 @@ managed through the `--callouts-*` flags above. TEXT_IMAGE_AD additionally
 accepts `--turbo-page-id`, `--final-url`, and `--erir-ad-description`.
 DYNAMIC_TEXT_AD update supports `--text`, `--image-hash`, `--vcard-id`,
 `--sitelink-set-id`, and `--callouts-*`.
+RESPONSIVE_AD `ads add` uses `--texts` and `--titles` as required
+comma-separated lists; optional creation flags include `--image-hashes`,
+`--video-extension-ids`, `--href`, `--age-label`, `--display-url-path`,
+`--sitelink-set-id`, `--ad-extensions`, `--price-extension-*`,
+`--business-id`, and `--erir-ad-description`.
 MOBILE_APP_AD update supports `--mobile-app-feature FEATURE=YES|NO`,
 `--video-extension-creative-id`, and `--erir-ad-description`.
 RESPONSIVE_AD update supports `--texts`, `--titles`, `--image-hashes`,
@@ -1171,6 +1177,7 @@ direct ads get --adgroup-ids 45678 --format table
 direct ads add --adgroup-id 12345 --type TEXT_AD --title "Заголовок" --text "Текст объявления" --href "https://example.com" --dry-run
 direct ads add --adgroup-id 12345 --type TEXT_AD --title "Заголовок" --text "Текст" --href "https://example.com" --title2 "Второй заголовок" --display-url-path "deals" --mobile YES --vcard-id 111 --sitelink-set-id 222 --turbo-page-id 333 --ad-extensions "444,555" --dry-run
 direct ads add --adgroup-id 12345 --type TEXT_AD --title "Заголовок" --text "Текст объявления" --href "https://example.com" --final-url "https://final.example.com" --video-extension-creative-id 777 --price-extension-price 123.45 --price-extension-price-qualifier FROM --price-extension-price-currency RUB --business-id 777 --prefer-vcard-over-business NO --erir-ad-description "Объект текстового объявления" --dry-run
+direct ads add --adgroup-id 12345 --type RESPONSIVE_AD --texts "Текст один,Текст два" --titles "Заголовок один,Заголовок два" --image-hashes hash1,hash2 --video-extension-ids 111,222 --href "https://example.com" --price-extension-price 123.45 --price-extension-price-qualifier FROM --price-extension-price-currency RUB --business-id 777 --erir-ad-description "Объект адаптивного объявления" --dry-run
 direct ads add --adgroup-id 12345 --type TEXT_IMAGE_AD --image-hash abcdefghijklmnopqrst --href "https://example.com" --turbo-page-id 555 --dry-run
 direct ads update --id 99999 --type TEXT_AD --title "Новый заголовок" --text "Новый текст" --href "https://example.com"
 direct ads update --id 99999 --type TEXT_AD --image-hash abcdefghijklmnopqrst
@@ -1213,6 +1220,11 @@ direct ads delete --id 99999
 `--turbo-page-id`, `--final-url` и `--erir-ad-description`. Для
 DYNAMIC_TEXT_AD в `ads update` доступны `--text`, `--image-hash`,
 `--vcard-id`, `--sitelink-set-id` и `--callouts-*`.
+Для RESPONSIVE_AD в `ads add` обязательны `--texts` и `--titles` как списки
+через запятую; дополнительные флаги создания: `--image-hashes`,
+`--video-extension-ids`, `--href`, `--age-label`, `--display-url-path`,
+`--sitelink-set-id`, `--ad-extensions`, `--price-extension-*`,
+`--business-id` и `--erir-ad-description`.
 Для MOBILE_APP_AD в `ads update` доступны `--mobile-app-feature FEATURE=YES|NO`,
 `--video-extension-creative-id` и `--erir-ad-description`.
 Для RESPONSIVE_AD в `ads update` доступны `--texts`, `--titles`,

--- a/README.md
+++ b/README.md
@@ -450,10 +450,10 @@ accepts `--turbo-page-id`, `--final-url`, and `--erir-ad-description`.
 DYNAMIC_TEXT_AD update supports `--text`, `--image-hash`, `--vcard-id`,
 `--sitelink-set-id`, and `--callouts-*`.
 RESPONSIVE_AD `ads add` uses `--texts` and `--titles` as required
-comma-separated lists; optional creation flags include `--image-hashes`,
-`--video-extension-ids`, `--href`, `--age-label`, `--display-url-path`,
-`--sitelink-set-id`, `--ad-extensions`, `--price-extension-*`,
-`--business-id`, and `--erir-ad-description`.
+comma-separated lists and also requires `--href`, `--business-id`, or both.
+Optional creation flags include `--image-hashes`, `--video-extension-ids`,
+`--age-label`, `--display-url-path`, `--sitelink-set-id`, `--ad-extensions`,
+`--price-extension-*`, and `--erir-ad-description`.
 MOBILE_APP_AD update supports `--mobile-app-feature FEATURE=YES|NO`,
 `--video-extension-creative-id`, and `--erir-ad-description`.
 RESPONSIVE_AD update supports `--texts`, `--titles`, `--image-hashes`,
@@ -1221,10 +1221,10 @@ direct ads delete --id 99999
 DYNAMIC_TEXT_AD в `ads update` доступны `--text`, `--image-hash`,
 `--vcard-id`, `--sitelink-set-id` и `--callouts-*`.
 Для RESPONSIVE_AD в `ads add` обязательны `--texts` и `--titles` как списки
-через запятую; дополнительные флаги создания: `--image-hashes`,
-`--video-extension-ids`, `--href`, `--age-label`, `--display-url-path`,
-`--sitelink-set-id`, `--ad-extensions`, `--price-extension-*`,
-`--business-id` и `--erir-ad-description`.
+через запятую, а также `--href`, `--business-id` или оба флага. Дополнительные
+флаги создания: `--image-hashes`, `--video-extension-ids`, `--age-label`,
+`--display-url-path`, `--sitelink-set-id`, `--ad-extensions`,
+`--price-extension-*` и `--erir-ad-description`.
 Для MOBILE_APP_AD в `ads update` доступны `--mobile-app-feature FEATURE=YES|NO`,
 `--video-extension-creative-id` и `--erir-ad-description`.
 Для RESPONSIVE_AD в `ads update` доступны `--texts`, `--titles`,

--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -1009,6 +1009,10 @@ def add(
                 raise click.UsageError(
                     "RESPONSIVE_AD requires " + ", ".join(missing_fields)
                 )
+            if not href and business_id is None:
+                raise click.UsageError(
+                    "RESPONSIVE_AD requires either --href or --business-id."
+                )
 
             parsed_texts = _parse_required_csv_strings(texts, "--texts")
             parsed_titles = _parse_required_csv_strings(titles, "--titles")

--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -247,6 +247,7 @@ def _build_price_extension_add(
     price_extension_old_price,
     price_extension_price_qualifier,
     price_extension_price_currency,
+    container_name="TextAd",
 ):
     """Build TextAd.PriceExtension add payload from typed flags."""
     provided = (
@@ -267,7 +268,7 @@ def _build_price_extension_add(
         missing.append("--price-extension-price-currency")
     if missing:
         raise click.UsageError(
-            "TextAd.PriceExtension add requires " + ", ".join(missing)
+            f"{container_name}.PriceExtension add requires " + ", ".join(missing)
         )
 
     price_extension = {
@@ -657,20 +658,29 @@ def get(
     "--type",
     "ad_type",
     default="TEXT_AD",
-    help="Ad type",
+    help="Ad type: TEXT_AD | TEXT_IMAGE_AD | MOBILE_APP_AD | RESPONSIVE_AD",
 )
 @click.option("--title", help="Ad title (TEXT_AD / MOBILE_APP_AD)")
 @click.option("--text", help="Ad text (TEXT_AD / MOBILE_APP_AD)")
-@click.option("--href", help="Ad URL (TEXT_AD / TEXT_IMAGE_AD)")
+@click.option("--titles", help="Comma-separated ResponsiveAd.Titles values")
+@click.option("--texts", help="Comma-separated ResponsiveAd.Texts values")
+@click.option("--href", help="Ad URL (TEXT_AD / TEXT_IMAGE_AD / RESPONSIVE_AD)")
 @click.option("--image-hash", help="Ad image hash (TEXT_IMAGE_AD / MOBILE_APP_AD)")
+@click.option(
+    "--image-hashes",
+    help="Comma-separated ResponsiveAd.AdImageHashes values",
+)
 @click.option(
     "--action",
     help="MOBILE_APP_AD call-to-action (MobileAppAdActionEnum, e.g. INSTALL)",
 )
 @click.option("--tracking-url", help="MOBILE_APP_AD tracking URL")
-@click.option("--age-label", help="MOBILE_APP_AD age label (MobAppAgeLabelEnum)")
+@click.option(
+    "--age-label",
+    help="Age label (MOBILE_APP_AD MobAppAgeLabelEnum / RESPONSIVE_AD AgeLabelEnum)",
+)
 @click.option("--title2", help="Second headline (TEXT_AD)")
-@click.option("--display-url-path", help="Display URL path (TEXT_AD)")
+@click.option("--display-url-path", help="Display URL path (TEXT_AD / RESPONSIVE_AD)")
 @click.option(
     "--mobile",
     type=click.Choice(["YES", "NO"], case_sensitive=False),
@@ -678,11 +688,16 @@ def get(
     help="Mobile-targeted flag (TEXT_AD)",
 )
 @click.option("--vcard-id", type=int, help="VCard ID (TEXT_AD)")
-@click.option("--sitelink-set-id", type=int, help="Sitelink set ID (TEXT_AD)")
+@click.option(
+    "--sitelink-set-id", type=int, help="Sitelink set ID (TEXT_AD / RESPONSIVE_AD)"
+)
 @click.option(
     "--turbo-page-id", type=int, help="Turbo page ID (TEXT_AD / TEXT_IMAGE_AD)"
 )
-@click.option("--ad-extensions", help="Comma-separated ad extension IDs (TEXT_AD)")
+@click.option(
+    "--ad-extensions",
+    help="Comma-separated ad extension IDs (TEXT_AD / RESPONSIVE_AD)",
+)
 @click.option("--final-url", help="TextAd.FinalUrl (TEXT_AD)")
 @click.option(
     "--video-extension-creative-id",
@@ -692,14 +707,14 @@ def get(
 @click.option(
     "--price-extension-price",
     help=(
-        "TextAd.PriceExtension.Price as human-readable money. "
+        "TextAd/ResponsiveAd.PriceExtension.Price as human-readable money. "
         "Required whenever any PriceExtension flag is used."
     ),
 )
 @click.option(
     "--price-extension-old-price",
     help=(
-        "TextAd.PriceExtension.OldPrice as human-readable money. "
+        "TextAd/ResponsiveAd.PriceExtension.OldPrice as human-readable money. "
         "Optional; if supplied, PriceExtension add also requires "
         "--price-extension-price, --price-extension-price-qualifier, "
         "and --price-extension-price-currency."
@@ -709,7 +724,7 @@ def get(
     "--price-extension-price-qualifier",
     type=click.Choice(["FROM", "UP_TO", "NONE"], case_sensitive=False),
     help=(
-        "TextAd.PriceExtension.PriceQualifier: FROM, UP_TO, or NONE. "
+        "TextAd/ResponsiveAd.PriceExtension.PriceQualifier: FROM, UP_TO, or NONE. "
         "Required whenever any PriceExtension flag is used."
     ),
 )
@@ -720,17 +735,28 @@ def get(
         case_sensitive=False,
     ),
     help=(
-        "TextAd.PriceExtension.PriceCurrency enum value. "
+        "TextAd/ResponsiveAd.PriceExtension.PriceCurrency enum value. "
         "Required whenever any PriceExtension flag is used."
     ),
 )
-@click.option("--business-id", type=int, help="TextAd.BusinessId (TEXT_AD)")
+@click.option(
+    "--video-extension-ids",
+    help="Comma-separated ResponsiveAd.VideoExtensionIds values",
+)
+@click.option(
+    "--business-id",
+    type=int,
+    help="TextAd/ResponsiveAd.BusinessId (TEXT_AD / RESPONSIVE_AD)",
+)
 @click.option(
     "--prefer-vcard-over-business",
     type=click.Choice(["YES", "NO"], case_sensitive=False),
     help="TextAd.PreferVCardOverBusiness value: YES or NO",
 )
-@click.option("--erir-ad-description", help="TextAd.ErirAdDescription (TEXT_AD)")
+@click.option(
+    "--erir-ad-description",
+    help="TextAd/ResponsiveAd.ErirAdDescription (TEXT_AD / RESPONSIVE_AD)",
+)
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
 def add(
@@ -739,8 +765,11 @@ def add(
     ad_type,
     title,
     text,
+    titles,
+    texts,
     href,
     image_hash,
+    image_hashes,
     action,
     tracking_url,
     age_label,
@@ -757,6 +786,7 @@ def add(
     price_extension_old_price,
     price_extension_price_qualifier,
     price_extension_price_currency,
+    video_extension_ids,
     business_id,
     prefer_vcard_over_business,
     erir_ad_description,
@@ -765,12 +795,12 @@ def add(
     """Add new ad"""
     try:
         ad_type_norm = (ad_type or "TEXT_AD").upper().replace("-", "_")
-        supported_types = {"TEXT_AD", "TEXT_IMAGE_AD", "MOBILE_APP_AD"}
+        supported_types = {"TEXT_AD", "TEXT_IMAGE_AD", "MOBILE_APP_AD", "RESPONSIVE_AD"}
         if ad_type_norm not in supported_types:
             raise click.UsageError(
                 "Invalid value for '--type': "
                 f"{ad_type!r} is not one of "
-                "'TEXT_AD', 'TEXT_IMAGE_AD', 'MOBILE_APP_AD'."
+                "'TEXT_AD', 'TEXT_IMAGE_AD', 'MOBILE_APP_AD', 'RESPONSIVE_AD'."
             )
 
         # --mobile has a Click default of "NO" so the value is always present
@@ -809,6 +839,23 @@ def add(
                 "erir_ad_description",
             },
             "TEXT_IMAGE_AD": {"href", "image_hash", "turbo_page_id"},
+            "RESPONSIVE_AD": {
+                "texts",
+                "titles",
+                "href",
+                "age_label",
+                "display_url_path",
+                "image_hashes",
+                "sitelink_set_id",
+                "ad_extensions",
+                "video_extension_ids",
+                "price_extension_price",
+                "price_extension_old_price",
+                "price_extension_price_qualifier",
+                "price_extension_price_currency",
+                "business_id",
+                "erir_ad_description",
+            },
             "MOBILE_APP_AD": {
                 "title",
                 "text",
@@ -821,8 +868,11 @@ def add(
         provided = {
             "title": title,
             "text": text,
+            "titles": titles,
+            "texts": texts,
             "href": href,
             "image_hash": image_hash,
+            "image_hashes": image_hashes,
             "action": action,
             "tracking_url": tracking_url,
             "age_label": age_label,
@@ -839,6 +889,7 @@ def add(
             "price_extension_old_price": price_extension_old_price,
             "price_extension_price_qualifier": price_extension_price_qualifier,
             "price_extension_price_currency": price_extension_price_currency,
+            "video_extension_ids": video_extension_ids,
             "business_id": business_id,
             "prefer_vcard_over_business": prefer_vcard_over_business,
             "erir_ad_description": erir_ad_description,
@@ -846,8 +897,11 @@ def add(
         flag_for = {
             "title": "--title",
             "text": "--text",
+            "titles": "--titles",
+            "texts": "--texts",
             "href": "--href",
             "image_hash": "--image-hash",
+            "image_hashes": "--image-hashes",
             "action": "--action",
             "tracking_url": "--tracking-url",
             "age_label": "--age-label",
@@ -864,6 +918,7 @@ def add(
             "price_extension_old_price": "--price-extension-old-price",
             "price_extension_price_qualifier": "--price-extension-price-qualifier",
             "price_extension_price_currency": "--price-extension-price-currency",
+            "video_extension_ids": "--video-extension-ids",
             "business_id": "--business-id",
             "prefer_vcard_over_business": "--prefer-vcard-over-business",
             "erir_ad_description": "--erir-ad-description",
@@ -941,6 +996,60 @@ def add(
             if turbo_page_id:
                 text_image_ad["TurboPageId"] = turbo_page_id
             ad_data["TextImageAd"] = text_image_ad
+        elif ad_type_norm == "RESPONSIVE_AD":
+            missing_fields = [
+                option_name
+                for option_name, value in (
+                    ("--texts", texts),
+                    ("--titles", titles),
+                )
+                if value is None
+            ]
+            if missing_fields:
+                raise click.UsageError(
+                    "RESPONSIVE_AD requires " + ", ".join(missing_fields)
+                )
+
+            parsed_texts = _parse_required_csv_strings(texts, "--texts")
+            parsed_titles = _parse_required_csv_strings(titles, "--titles")
+            responsive_ad = {
+                "Texts": parsed_texts,
+                "Titles": parsed_titles,
+            }
+            parsed_image_hashes = _parse_required_csv_strings(
+                image_hashes, "--image-hashes"
+            )
+            if parsed_image_hashes:
+                responsive_ad["AdImageHashes"] = parsed_image_hashes
+            parsed_video_extension_ids = _parse_required_ids(
+                video_extension_ids, "--video-extension-ids"
+            )
+            if parsed_video_extension_ids:
+                responsive_ad["VideoExtensionIds"] = parsed_video_extension_ids
+            if sitelink_set_id is not None:
+                responsive_ad["SitelinkSetId"] = sitelink_set_id
+            if ad_extensions:
+                responsive_ad["AdExtensionIds"] = parse_ids(ad_extensions)
+            if href:
+                responsive_ad["Href"] = href
+            if age_label:
+                responsive_ad["AgeLabel"] = age_label.upper()
+            if display_url_path:
+                responsive_ad["DisplayUrlPath"] = display_url_path
+            price_extension = _build_price_extension_add(
+                price_extension_price,
+                price_extension_old_price,
+                price_extension_price_qualifier,
+                price_extension_price_currency,
+                container_name="ResponsiveAd",
+            )
+            if price_extension:
+                responsive_ad["PriceExtension"] = price_extension
+            if business_id is not None:
+                responsive_ad["BusinessId"] = business_id
+            if erir_ad_description:
+                responsive_ad["ErirAdDescription"] = erir_ad_description
+            ad_data["ResponsiveAd"] = responsive_ad
         elif ad_type_norm == "MOBILE_APP_AD":
             if href:
                 raise click.UsageError(

--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -249,7 +249,7 @@ def _build_price_extension_add(
     price_extension_price_currency,
     container_name="TextAd",
 ):
-    """Build TextAd.PriceExtension add payload from typed flags."""
+    """Build PriceExtension add payload for an ad subtype from typed flags."""
     provided = (
         price_extension_price is not None
         or price_extension_old_price is not None

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,9 +11,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 2490 |
+| `missing_followup` | 2473 |
 | `not_applicable` | 23 |
-| `supported` | 728 |
+| `supported` | 745 |
 
 ## Confirmed Follow-Ups
 
@@ -42,23 +42,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `adgroups.update` | `DynamicTextFeedAdGroup.AutotargetingSettings.BrandOptions.WithAdvertiserBrand` | Official adgroups.update docs for DynamicTextFeedAdGroupUpdate list AutotargetingCategories only. [#281](https://github.com/axisrow/direct-cli/issues/281); inherited from `DynamicTextFeedAdGroup.AutotargetingSettings` |
 | `adgroups.update` | `DynamicTextFeedAdGroup.AutotargetingSettings.BrandOptions.WithCompetitorsBrand` | Official adgroups.update docs for DynamicTextFeedAdGroupUpdate list AutotargetingCategories only. [#281](https://github.com/axisrow/direct-cli/issues/281); inherited from `DynamicTextFeedAdGroup.AutotargetingSettings` |
 | `adgroups.update` | `DynamicTextFeedAdGroup.FeedId` | Official adgroups.update docs for DynamicTextFeedAdGroupUpdate do not list FeedId. [#281](https://github.com/axisrow/direct-cli/issues/281) |
-| `ads.add` | `ResponsiveAd` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274) |
-| `ads.add` | `ResponsiveAd.Texts` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
-| `ads.add` | `ResponsiveAd.Titles` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
-| `ads.add` | `ResponsiveAd.AdImageHashes` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
-| `ads.add` | `ResponsiveAd.VideoExtensionIds` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
-| `ads.add` | `ResponsiveAd.Href` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
-| `ads.add` | `ResponsiveAd.AgeLabel` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
-| `ads.add` | `ResponsiveAd.DisplayUrlPath` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
-| `ads.add` | `ResponsiveAd.SitelinkSetId` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
-| `ads.add` | `ResponsiveAd.AdExtensionIds` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
-| `ads.add` | `ResponsiveAd.PriceExtension` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
-| `ads.add` | `ResponsiveAd.PriceExtension.Price` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
-| `ads.add` | `ResponsiveAd.PriceExtension.OldPrice` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
-| `ads.add` | `ResponsiveAd.PriceExtension.PriceQualifier` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
-| `ads.add` | `ResponsiveAd.PriceExtension.PriceCurrency` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
-| `ads.add` | `ResponsiveAd.BusinessId` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
-| `ads.add` | `ResponsiveAd.ErirAdDescription` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
 | `ads.add` | `DynamicTextAd` | DYNAMIC_TEXT_AD add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277) |
 | `ads.add` | `DynamicTextAd.VCardId` | DYNAMIC_TEXT_AD add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `DynamicTextAd` |
 | `ads.add` | `DynamicTextAd.AdImageHash` | DYNAMIC_TEXT_AD add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `DynamicTextAd` |
@@ -2677,23 +2660,23 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `ads.add` | `ads.add` | `TextAd.BusinessId` | `long` | 0 | 1 | `supported` | --business-id |
 | `ads.add` | `ads.add` | `TextAd.PreferVCardOverBusiness` | `YesNoEnum` | 0 | 1 | `supported` | --prefer-vcard-over-business |
 | `ads.add` | `ads.add` | `TextAd.ErirAdDescription` | `string` | 0 | 1 | `supported` | --erir-ad-description |
-| `ads.add` | `ads.add` | `ResponsiveAd` | `ResponsiveAdAdd` | 0 | 1 | `missing_followup` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274) |
-| `ads.add` | `ads.add` | `ResponsiveAd.Texts` | `string` | 1 | unbounded | `missing_followup` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
-| `ads.add` | `ads.add` | `ResponsiveAd.Titles` | `string` | 1 | unbounded | `missing_followup` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
-| `ads.add` | `ads.add` | `ResponsiveAd.AdImageHashes` | `string` | 0 | unbounded | `missing_followup` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
-| `ads.add` | `ads.add` | `ResponsiveAd.VideoExtensionIds` | `long` | 0 | unbounded | `missing_followup` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
-| `ads.add` | `ads.add` | `ResponsiveAd.Href` | `string` | 0 | 1 | `missing_followup` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
-| `ads.add` | `ads.add` | `ResponsiveAd.AgeLabel` | `AgeLabelEnum` | 0 | 1 | `missing_followup` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
-| `ads.add` | `ads.add` | `ResponsiveAd.DisplayUrlPath` | `string` | 0 | 1 | `missing_followup` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
-| `ads.add` | `ads.add` | `ResponsiveAd.SitelinkSetId` | `long` | 0 | 1 | `missing_followup` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
-| `ads.add` | `ads.add` | `ResponsiveAd.AdExtensionIds` | `long` | 0 | unbounded | `missing_followup` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
-| `ads.add` | `ads.add` | `ResponsiveAd.PriceExtension` | `PriceExtensionAddItem` | 0 | 1 | `missing_followup` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
-| `ads.add` | `ads.add` | `ResponsiveAd.PriceExtension.Price` | `long` | 1 | 1 | `missing_followup` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
-| `ads.add` | `ads.add` | `ResponsiveAd.PriceExtension.OldPrice` | `long` | 0 | 1 | `missing_followup` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
-| `ads.add` | `ads.add` | `ResponsiveAd.PriceExtension.PriceQualifier` | `PriceQualifierEnum` | 1 | 1 | `missing_followup` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
-| `ads.add` | `ads.add` | `ResponsiveAd.PriceExtension.PriceCurrency` | `PriceCurrencyEnum` | 1 | 1 | `missing_followup` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
-| `ads.add` | `ads.add` | `ResponsiveAd.BusinessId` | `long` | 0 | 1 | `missing_followup` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
-| `ads.add` | `ads.add` | `ResponsiveAd.ErirAdDescription` | `string` | 0 | 1 | `missing_followup` | RESPONSIVE_AD add fields need typed support or N/A. [#274](https://github.com/axisrow/direct-cli/issues/274); inherited from `ResponsiveAd` |
+| `ads.add` | `ads.add` | `ResponsiveAd` | `ResponsiveAdAdd` | 0 | 1 | `supported` | --type |
+| `ads.add` | `ads.add` | `ResponsiveAd.Texts` | `string` | 1 | unbounded | `supported` | --texts |
+| `ads.add` | `ads.add` | `ResponsiveAd.Titles` | `string` | 1 | unbounded | `supported` | --titles |
+| `ads.add` | `ads.add` | `ResponsiveAd.AdImageHashes` | `string` | 0 | unbounded | `supported` | --image-hashes |
+| `ads.add` | `ads.add` | `ResponsiveAd.VideoExtensionIds` | `long` | 0 | unbounded | `supported` | --video-extension-ids |
+| `ads.add` | `ads.add` | `ResponsiveAd.Href` | `string` | 0 | 1 | `supported` | --href |
+| `ads.add` | `ads.add` | `ResponsiveAd.AgeLabel` | `AgeLabelEnum` | 0 | 1 | `supported` | --age-label |
+| `ads.add` | `ads.add` | `ResponsiveAd.DisplayUrlPath` | `string` | 0 | 1 | `supported` | --display-url-path |
+| `ads.add` | `ads.add` | `ResponsiveAd.SitelinkSetId` | `long` | 0 | 1 | `supported` | --sitelink-set-id |
+| `ads.add` | `ads.add` | `ResponsiveAd.AdExtensionIds` | `long` | 0 | unbounded | `supported` | --ad-extensions |
+| `ads.add` | `ads.add` | `ResponsiveAd.PriceExtension` | `PriceExtensionAddItem` | 0 | 1 | `supported` | --price-extension-old-price, --price-extension-price, --price-extension-price-currency, --price-extension-price-qualifier |
+| `ads.add` | `ads.add` | `ResponsiveAd.PriceExtension.Price` | `long` | 1 | 1 | `supported` | --price-extension-price |
+| `ads.add` | `ads.add` | `ResponsiveAd.PriceExtension.OldPrice` | `long` | 0 | 1 | `supported` | --price-extension-old-price |
+| `ads.add` | `ads.add` | `ResponsiveAd.PriceExtension.PriceQualifier` | `PriceQualifierEnum` | 1 | 1 | `supported` | --price-extension-price-qualifier |
+| `ads.add` | `ads.add` | `ResponsiveAd.PriceExtension.PriceCurrency` | `PriceCurrencyEnum` | 1 | 1 | `supported` | --price-extension-price-currency |
+| `ads.add` | `ads.add` | `ResponsiveAd.BusinessId` | `long` | 0 | 1 | `supported` | --business-id |
+| `ads.add` | `ads.add` | `ResponsiveAd.ErirAdDescription` | `string` | 0 | 1 | `supported` | --erir-ad-description |
 | `ads.add` | `ads.add` | `DynamicTextAd` | `DynamicTextAdAdd` | 0 | 1 | `missing_followup` | DYNAMIC_TEXT_AD add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277) |
 | `ads.add` | `ads.add` | `DynamicTextAd.VCardId` | `long` | 0 | 1 | `missing_followup` | DYNAMIC_TEXT_AD add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `DynamicTextAd` |
 | `ads.add` | `ads.add` | `DynamicTextAd.AdImageHash` | `string` | 0 | 1 | `missing_followup` | DYNAMIC_TEXT_AD add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `DynamicTextAd` |

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -265,15 +265,34 @@ class TestCLI(unittest.TestCase):
         result = self.runner.invoke(cli, ["ads", "add", "--help"])
         self.assertEqual(result.exit_code, 0)
         collapsed = " ".join(result.output.split())
+        self.assertIn(
+            "Ad type: TEXT_AD | TEXT_IMAGE_AD | MOBILE_APP_AD | RESPONSIVE_AD",
+            collapsed,
+        )
+        self.assertIn("Comma-separated ResponsiveAd.Titles values", collapsed)
+        self.assertIn("Comma-separated ResponsiveAd.Texts values", collapsed)
+        self.assertIn("Comma-separated ResponsiveAd.AdImageHashes values", collapsed)
+        self.assertIn(
+            "Comma-separated ResponsiveAd.VideoExtensionIds values", collapsed
+        )
         self.assertIn("TextAd.FinalUrl (TEXT_AD)", collapsed)
         self.assertIn("TextAd.VideoExtension.CreativeId (TEXT_AD)", collapsed)
-        self.assertIn("TextAd.PriceExtension.Price as human-readable money", collapsed)
+        self.assertIn(
+            "TextAd/ResponsiveAd.PriceExtension.Price as human-readable money",
+            collapsed,
+        )
         self.assertIn(
             "Optional; if supplied, PriceExtension add also requires", collapsed
         )
-        self.assertIn("TextAd.BusinessId (TEXT_AD)", collapsed)
+        self.assertIn(
+            "TextAd/ResponsiveAd.BusinessId (TEXT_AD / RESPONSIVE_AD)",
+            collapsed,
+        )
         self.assertIn("TextAd.PreferVCardOverBusiness value: YES or NO", collapsed)
-        self.assertIn("TextAd.ErirAdDescription (TEXT_AD)", collapsed)
+        self.assertIn(
+            "TextAd/ResponsiveAd.ErirAdDescription (TEXT_AD / RESPONSIVE_AD)",
+            collapsed,
+        )
 
     def test_ads_update_help_documents_text_ad_image_hash(self):
         result = self.runner.invoke(cli, ["ads", "update", "--help"])

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1094,6 +1094,148 @@ def test_ads_add_text_image_ad_default_mobile_does_not_leak():
     assert "Mobile" not in ad["TextImageAd"]
 
 
+def test_ads_add_responsive_ad_payload():
+    """Issue #274: RESPONSIVE_AD add builds the documented ResponsiveAd block."""
+    body = _dry_run(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "12345",
+        "--type",
+        "RESPONSIVE_AD",
+        "--texts",
+        "Text one,Text two",
+        "--titles",
+        "Title one,Title two",
+        "--image-hashes",
+        "hash-one,hash-two",
+        "--video-extension-ids",
+        "101,102",
+        "--sitelink-set-id",
+        "0",
+        "--ad-extensions",
+        "333,444",
+        "--href",
+        "https://example.com",
+        "--age-label",
+        "age_18",
+        "--display-url-path",
+        "deals",
+        "--price-extension-price",
+        "123.45",
+        "--price-extension-old-price",
+        "150.00",
+        "--price-extension-price-qualifier",
+        "from",
+        "--price-extension-price-currency",
+        "rub",
+        "--business-id",
+        "0",
+        "--erir-ad-description",
+        "Promoted object",
+    )
+    ad = body["params"]["Ads"][0]
+    assert "Type" not in ad
+    assert ad == {
+        "AdGroupId": 12345,
+        "ResponsiveAd": {
+            "Texts": ["Text one", "Text two"],
+            "Titles": ["Title one", "Title two"],
+            "AdImageHashes": ["hash-one", "hash-two"],
+            "VideoExtensionIds": [101, 102],
+            "SitelinkSetId": 0,
+            "AdExtensionIds": [333, 444],
+            "Href": "https://example.com",
+            "AgeLabel": "AGE_18",
+            "DisplayUrlPath": "deals",
+            "PriceExtension": {
+                "Price": 123450000,
+                "OldPrice": 150000000,
+                "PriceQualifier": "FROM",
+                "PriceCurrency": "RUB",
+            },
+            "BusinessId": 0,
+            "ErirAdDescription": "Promoted object",
+        },
+    }
+
+
+def test_ads_add_responsive_ad_requires_texts_and_titles():
+    """Issue #274: ResponsiveAdAdd requires Texts and Titles."""
+    result = _rejected(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "12345",
+        "--type",
+        "RESPONSIVE_AD",
+        "--texts",
+        "Text one",
+    )
+    assert "RESPONSIVE_AD requires --titles" in result.output
+
+
+def test_ads_add_responsive_ad_empty_texts_rejected():
+    """Issue #274: explicit empty list flags are rejected locally."""
+    result = _rejected(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "12345",
+        "--type",
+        "RESPONSIVE_AD",
+        "--texts",
+        "",
+        "--titles",
+        "Title one",
+    )
+    assert "--texts must contain at least one value." in result.output
+
+
+def test_ads_add_responsive_ad_price_extension_requires_mandatory_fields():
+    """Issue #274: ResponsiveAd.PriceExtension add has required children."""
+    result = _rejected(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "12345",
+        "--type",
+        "RESPONSIVE_AD",
+        "--texts",
+        "Text one",
+        "--titles",
+        "Title one",
+        "--price-extension-old-price",
+        "150.00",
+    )
+    assert "ResponsiveAd.PriceExtension add requires" in result.output
+    assert "--price-extension-price" in result.output
+    assert "--price-extension-price-qualifier" in result.output
+    assert "--price-extension-price-currency" in result.output
+
+
+def test_ads_add_responsive_ad_rejects_other_subtype_flags():
+    """Issue #274: RESPONSIVE_AD add flags must honor subtype allow-lists."""
+    result = _rejected(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "12345",
+        "--type",
+        "RESPONSIVE_AD",
+        "--texts",
+        "Text one",
+        "--titles",
+        "Title one",
+        "--video-extension-creative-id",
+        "777",
+    )
+    assert (
+        "--video-extension-creative-id is not compatible with --type RESPONSIVE_AD"
+        in result.output
+    )
+
+
 def test_ads_update_rejects_status_flag():
     """``--status`` is not part of WSDL ``AdUpdateItem`` (regression for #183).
 

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1188,8 +1188,50 @@ def test_ads_add_responsive_ad_empty_texts_rejected():
         "",
         "--titles",
         "Title one",
+        "--href",
+        "https://example.com",
     )
     assert "--texts must contain at least one value." in result.output
+
+
+def test_ads_add_responsive_ad_requires_href_or_business_id():
+    """Issue #274: ResponsiveAdAdd requires Href, BusinessId, or both."""
+    result = _rejected(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "12345",
+        "--type",
+        "RESPONSIVE_AD",
+        "--texts",
+        "Text one",
+        "--titles",
+        "Title one",
+    )
+    assert "RESPONSIVE_AD requires either --href or --business-id." in result.output
+
+
+def test_ads_add_responsive_ad_accepts_business_id_without_href():
+    """Issue #274: BusinessId alone satisfies the ResponsiveAd destination rule."""
+    body = _dry_run(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "12345",
+        "--type",
+        "RESPONSIVE_AD",
+        "--texts",
+        "Text one",
+        "--titles",
+        "Title one",
+        "--business-id",
+        "777",
+    )
+    assert body["params"]["Ads"][0]["ResponsiveAd"] == {
+        "Texts": ["Text one"],
+        "Titles": ["Title one"],
+        "BusinessId": 777,
+    }
 
 
 def test_ads_add_responsive_ad_price_extension_requires_mandatory_fields():
@@ -1205,6 +1247,8 @@ def test_ads_add_responsive_ad_price_extension_requires_mandatory_fields():
         "Text one",
         "--titles",
         "Title one",
+        "--href",
+        "https://example.com",
         "--price-extension-old-price",
         "150.00",
     )
@@ -1227,6 +1271,8 @@ def test_ads_add_responsive_ad_rejects_other_subtype_flags():
         "Text one",
         "--titles",
         "Title one",
+        "--href",
+        "https://example.com",
         "--video-extension-creative-id",
         "777",
     )

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -953,6 +953,34 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     ("ads", "add", "TextImageAd.AdImageHash"): {"--image-hash"},
     ("ads", "add", "TextImageAd.Href"): {"--href"},
     ("ads", "add", "TextImageAd.TurboPageId"): {"--turbo-page-id"},
+    ("ads", "add", "ResponsiveAd"): {"--type"},
+    ("ads", "add", "ResponsiveAd.Texts"): {"--texts"},
+    ("ads", "add", "ResponsiveAd.Titles"): {"--titles"},
+    ("ads", "add", "ResponsiveAd.AdImageHashes"): {"--image-hashes"},
+    ("ads", "add", "ResponsiveAd.VideoExtensionIds"): {"--video-extension-ids"},
+    ("ads", "add", "ResponsiveAd.Href"): {"--href"},
+    ("ads", "add", "ResponsiveAd.AgeLabel"): {"--age-label"},
+    ("ads", "add", "ResponsiveAd.DisplayUrlPath"): {"--display-url-path"},
+    ("ads", "add", "ResponsiveAd.SitelinkSetId"): {"--sitelink-set-id"},
+    ("ads", "add", "ResponsiveAd.AdExtensionIds"): {"--ad-extensions"},
+    ("ads", "add", "ResponsiveAd.PriceExtension"): {
+        "--price-extension-price",
+        "--price-extension-old-price",
+        "--price-extension-price-qualifier",
+        "--price-extension-price-currency",
+    },
+    ("ads", "add", "ResponsiveAd.PriceExtension.Price"): {"--price-extension-price"},
+    ("ads", "add", "ResponsiveAd.PriceExtension.OldPrice"): {
+        "--price-extension-old-price"
+    },
+    ("ads", "add", "ResponsiveAd.PriceExtension.PriceQualifier"): {
+        "--price-extension-price-qualifier"
+    },
+    ("ads", "add", "ResponsiveAd.PriceExtension.PriceCurrency"): {
+        "--price-extension-price-currency"
+    },
+    ("ads", "add", "ResponsiveAd.BusinessId"): {"--business-id"},
+    ("ads", "add", "ResponsiveAd.ErirAdDescription"): {"--erir-ad-description"},
     ("ads", "update", "TextAd"): {"--type"},
     ("ads", "update", "TextAd.VCardId"): {"--vcard-id"},
     ("ads", "update", "TextAd.AdImageHash"): {"--image-hash"},
@@ -1858,11 +1886,6 @@ OPTIONAL_FIELD_DEFAULT_FOLLOWUPS: dict[tuple[str, str], dict[str, str]] = {
 }
 
 OPTIONAL_FIELD_CHILD_PREFIX_FOLLOWUPS: dict[tuple[str, str, str], dict[str, str]] = {
-    ("ads", "add", "ResponsiveAd"): {
-        "status": "missing_followup",
-        "issue": "#274",
-        "note": "RESPONSIVE_AD add fields need typed support or N/A.",
-    },
     ("ads", "add", "ShoppingAd"): {
         "status": "missing_followup",
         "issue": "#275",


### PR DESCRIPTION
## Summary
- add `ads add --type RESPONSIVE_AD` typed flags for `Titles`, `Texts`, images, video extension IDs, sitelinks/extensions, price extension, business ID, ERIR description, and related scalar fields
- build the documented `ResponsiveAd` add payload with flat add arrays and required `--texts` / `--titles` validation
- update dry-run/help/README examples and WSDL optional-field parity audit

## Docs
- Official Yandex Direct `ads.add` request structure lists these fields under `ResponsiveAd`: https://yandex.ru/dev/direct/doc/en/ads/add

## Verification
- `python3 -m pytest tests/test_dry_run.py -k "ads_add and responsive"`
- `python3 -m pytest tests/test_cli.py -k ads_add_help`
- `python3 scripts/build_wsdl_optional_field_audit.py --check`
- `python3 -m pytest tests/test_wsdl_parity_gate.py`
- `python3 -m pytest tests/test_cli_contract.py -k "json or readme_direct_examples"`
- `python3 -m pytest tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py`
- `mypy .`
- `git diff --check`

Closes #274