### PR TITLE
Add ShoppingAd and ListingAd typed flags for ads add

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,8 @@ direct ads add --adgroup-id 12345 --type TEXT_AD --title "Title" --text "Ad text
 direct ads add --adgroup-id 12345 --type TEXT_AD --title "Title" --text "Ad text" --href "https://example.com" --title2 "Second headline" --display-url-path "deals" --mobile YES --vcard-id 111 --sitelink-set-id 222 --turbo-page-id 333 --ad-extensions "444,555" --dry-run
 direct ads add --adgroup-id 12345 --type TEXT_AD --title "Title" --text "Ad text" --href "https://example.com" --final-url "https://final.example.com" --video-extension-creative-id 777 --price-extension-price 123.45 --price-extension-price-qualifier FROM --price-extension-price-currency RUB --business-id 777 --prefer-vcard-over-business NO --erir-ad-description "Text ad object" --dry-run
 direct ads add --adgroup-id 12345 --type RESPONSIVE_AD --texts "Text one,Text two" --titles "Title one,Title two" --image-hashes hash1,hash2 --video-extension-ids 111,222 --href "https://example.com" --price-extension-price 123.45 --price-extension-price-qualifier FROM --price-extension-price-currency RUB --business-id 777 --erir-ad-description "Responsive ad object" --dry-run
+direct ads add --adgroup-id 12345 --type SHOPPING_AD --feed-id 170 --default-texts "Default product text" --sitelink-set-id 222 --ad-extensions "333,444" --business-id 777 --feed-filter-condition "CATEGORY:EQUALS_ANY:shoes|boots" --title-sources NAME,BRAND --text-sources DESCRIPTION --dry-run
+direct ads add --adgroup-id 12345 --type LISTING_AD --feed-id 171 --default-texts "Default listing text" --feed-filter-condition "CATEGORY:EQUALS_ANY:appliances" --title-sources TITLE --text-sources DESCRIPTION --dry-run
 direct ads add --adgroup-id 12345 --type TEXT_IMAGE_AD --image-hash abcdefghijklmnopqrst --href "https://example.com" --turbo-page-id 555 --dry-run
 direct ads update --id 99999 --type TEXT_AD --title "New Title" --text "New text" --href "https://example.com"
 direct ads update --id 99999 --type TEXT_AD --image-hash abcdefghijklmnopqrst
@@ -454,6 +456,10 @@ comma-separated lists and also requires `--href`, `--business-id`, or both.
 Optional creation flags include `--image-hashes`, `--video-extension-ids`,
 `--age-label`, `--display-url-path`, `--sitelink-set-id`, `--ad-extensions`,
 `--price-extension-*`, and `--erir-ad-description`.
+SHOPPING_AD and LISTING_AD `ads add` require `--feed-id` and one
+`--default-texts` value. Optional creation flags include `--sitelink-set-id`,
+`--ad-extensions`, `--business-id`, repeatable `--feed-filter-condition`
+(`OPERAND:OPERATOR:ARG1|ARG2`), `--title-sources`, and `--text-sources`.
 MOBILE_APP_AD update supports `--mobile-app-feature FEATURE=YES|NO`,
 `--video-extension-creative-id`, and `--erir-ad-description`.
 RESPONSIVE_AD update supports `--texts`, `--titles`, `--image-hashes`,
@@ -1178,6 +1184,8 @@ direct ads add --adgroup-id 12345 --type TEXT_AD --title "Заголовок" --
 direct ads add --adgroup-id 12345 --type TEXT_AD --title "Заголовок" --text "Текст" --href "https://example.com" --title2 "Второй заголовок" --display-url-path "deals" --mobile YES --vcard-id 111 --sitelink-set-id 222 --turbo-page-id 333 --ad-extensions "444,555" --dry-run
 direct ads add --adgroup-id 12345 --type TEXT_AD --title "Заголовок" --text "Текст объявления" --href "https://example.com" --final-url "https://final.example.com" --video-extension-creative-id 777 --price-extension-price 123.45 --price-extension-price-qualifier FROM --price-extension-price-currency RUB --business-id 777 --prefer-vcard-over-business NO --erir-ad-description "Объект текстового объявления" --dry-run
 direct ads add --adgroup-id 12345 --type RESPONSIVE_AD --texts "Текст один,Текст два" --titles "Заголовок один,Заголовок два" --image-hashes hash1,hash2 --video-extension-ids 111,222 --href "https://example.com" --price-extension-price 123.45 --price-extension-price-qualifier FROM --price-extension-price-currency RUB --business-id 777 --erir-ad-description "Объект адаптивного объявления" --dry-run
+direct ads add --adgroup-id 12345 --type SHOPPING_AD --feed-id 170 --default-texts "Текст по умолчанию" --sitelink-set-id 222 --ad-extensions "333,444" --business-id 777 --feed-filter-condition "CATEGORY:EQUALS_ANY:shoes|boots" --title-sources NAME,BRAND --text-sources DESCRIPTION --dry-run
+direct ads add --adgroup-id 12345 --type LISTING_AD --feed-id 171 --default-texts "Текст листинга по умолчанию" --feed-filter-condition "CATEGORY:EQUALS_ANY:appliances" --title-sources TITLE --text-sources DESCRIPTION --dry-run
 direct ads add --adgroup-id 12345 --type TEXT_IMAGE_AD --image-hash abcdefghijklmnopqrst --href "https://example.com" --turbo-page-id 555 --dry-run
 direct ads update --id 99999 --type TEXT_AD --title "Новый заголовок" --text "Новый текст" --href "https://example.com"
 direct ads update --id 99999 --type TEXT_AD --image-hash abcdefghijklmnopqrst
@@ -1225,6 +1233,11 @@ DYNAMIC_TEXT_AD в `ads update` доступны `--text`, `--image-hash`,
 флаги создания: `--image-hashes`, `--video-extension-ids`, `--age-label`,
 `--display-url-path`, `--sitelink-set-id`, `--ad-extensions`,
 `--price-extension-*` и `--erir-ad-description`.
+Для SHOPPING_AD и LISTING_AD в `ads add` обязательны `--feed-id` и одно
+значение `--default-texts`. Дополнительные флаги создания:
+`--sitelink-set-id`, `--ad-extensions`, `--business-id`, повторяемый
+`--feed-filter-condition` (`OPERAND:OPERATOR:ARG1|ARG2`), `--title-sources` и
+`--text-sources`.
 Для MOBILE_APP_AD в `ads update` доступны `--mobile-app-feature FEATURE=YES|NO`,
 `--video-extension-creative-id` и `--erir-ad-description`.
 Для RESPONSIVE_AD в `ads update` доступны `--texts`, `--titles`,

--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -470,15 +470,13 @@ def _build_feed_based_ad_add(
             f"{container_name} requires " + ", ".join(missing_fields)
         )
 
-    parsed_default_texts = _parse_required_csv_strings(default_texts, "--default-texts")
-    if parsed_default_texts and len(parsed_default_texts) != 1:
-        raise click.UsageError(
-            f"{container_name}.DefaultTexts accepts exactly one value."
-        )
+    default_text = default_texts.strip() if default_texts else ""
+    if not default_text:
+        raise click.UsageError("--default-texts must contain a value.")
 
     ad_payload: dict[str, object] = {
         "FeedId": feed_id,
-        "DefaultTexts": parsed_default_texts,
+        "DefaultTexts": [default_text],
     }
 
     if sitelink_set_id is not None:

--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -37,6 +37,17 @@ FEED_BASED_UPDATE_FIELDS = {
     "default_texts",
 }
 
+FEED_BASED_ADD_FIELDS = {
+    "sitelink_set_id",
+    "ad_extensions",
+    "business_id",
+    "feed_id",
+    "feed_filter_conditions",
+    "title_sources",
+    "text_sources",
+    "default_texts",
+}
+
 
 TEXT_AD_UPDATE_FIELDS = {
     "title",
@@ -437,6 +448,68 @@ def _build_feed_based_ad_update(
     return ad_payload
 
 
+def _build_feed_based_ad_add(
+    feed_id: Optional[int],
+    default_texts: Optional[str],
+    sitelink_set_id: Optional[int],
+    ad_extensions: Optional[str],
+    business_id: Optional[int],
+    feed_filter_conditions: tuple[str, ...],
+    title_sources: Optional[str],
+    text_sources: Optional[str],
+    container_name: str,
+) -> dict[str, object]:
+    """Build ShoppingAdAdd / ListingAdAdd payload from typed flags."""
+    missing_fields = []
+    if feed_id is None:
+        missing_fields.append("--feed-id")
+    if default_texts is None:
+        missing_fields.append("--default-texts")
+    if missing_fields:
+        raise click.UsageError(
+            f"{container_name} requires " + ", ".join(missing_fields)
+        )
+
+    parsed_default_texts = _parse_required_csv_strings(default_texts, "--default-texts")
+    if parsed_default_texts and len(parsed_default_texts) != 1:
+        raise click.UsageError(
+            f"{container_name}.DefaultTexts accepts exactly one value."
+        )
+
+    ad_payload: dict[str, object] = {
+        "FeedId": feed_id,
+        "DefaultTexts": parsed_default_texts,
+    }
+
+    if sitelink_set_id is not None:
+        ad_payload["SitelinkSetId"] = sitelink_set_id
+    parsed_ad_extensions = _parse_required_ids(ad_extensions, "--ad-extensions")
+    if parsed_ad_extensions:
+        ad_payload["AdExtensionIds"] = parsed_ad_extensions
+    if business_id is not None:
+        ad_payload["BusinessId"] = business_id
+    if feed_filter_conditions:
+        if len(feed_filter_conditions) > 30:
+            raise click.UsageError(
+                f"{container_name}.FeedFilterConditions accepts at most 30 filters."
+            )
+        try:
+            parsed_conditions = parse_condition_specs(list(feed_filter_conditions))
+        except ValueError as exc:
+            raise click.UsageError(f"--feed-filter-condition: {exc}")
+        if parsed_conditions:
+            ad_payload["FeedFilterConditions"] = parsed_conditions
+
+    parsed_title_sources = _parse_required_csv_strings(title_sources, "--title-sources")
+    if parsed_title_sources:
+        ad_payload["TitleSources"] = parsed_title_sources
+    parsed_text_sources = _parse_required_csv_strings(text_sources, "--text-sources")
+    if parsed_text_sources:
+        ad_payload["TextSources"] = parsed_text_sources
+
+    return ad_payload
+
+
 def _build_ad_builder_update(
     creative_id: Optional[int],
     creative_erir_ad_description: Optional[str],
@@ -658,7 +731,10 @@ def get(
     "--type",
     "ad_type",
     default="TEXT_AD",
-    help="Ad type: TEXT_AD | TEXT_IMAGE_AD | MOBILE_APP_AD | RESPONSIVE_AD",
+    help=(
+        "Ad type: TEXT_AD | TEXT_IMAGE_AD | MOBILE_APP_AD | RESPONSIVE_AD | "
+        "SHOPPING_AD | LISTING_AD"
+    ),
 )
 @click.option("--title", help="Ad title (TEXT_AD / MOBILE_APP_AD)")
 @click.option("--text", help="Ad text (TEXT_AD / MOBILE_APP_AD)")
@@ -689,14 +765,19 @@ def get(
 )
 @click.option("--vcard-id", type=int, help="VCard ID (TEXT_AD)")
 @click.option(
-    "--sitelink-set-id", type=int, help="Sitelink set ID (TEXT_AD / RESPONSIVE_AD)"
+    "--sitelink-set-id",
+    type=int,
+    help="Sitelink set ID (TEXT_AD / RESPONSIVE_AD / SHOPPING_AD / LISTING_AD)",
 )
 @click.option(
     "--turbo-page-id", type=int, help="Turbo page ID (TEXT_AD / TEXT_IMAGE_AD)"
 )
 @click.option(
     "--ad-extensions",
-    help="Comma-separated ad extension IDs (TEXT_AD / RESPONSIVE_AD)",
+    help=(
+        "Comma-separated ad extension IDs "
+        "(TEXT_AD / RESPONSIVE_AD / SHOPPING_AD / LISTING_AD)"
+    ),
 )
 @click.option("--final-url", help="TextAd.FinalUrl (TEXT_AD)")
 @click.option(
@@ -746,7 +827,7 @@ def get(
 @click.option(
     "--business-id",
     type=int,
-    help="TextAd/ResponsiveAd.BusinessId (TEXT_AD / RESPONSIVE_AD)",
+    help="BusinessId (TEXT_AD / RESPONSIVE_AD / SHOPPING_AD / LISTING_AD)",
 )
 @click.option(
     "--prefer-vcard-over-business",
@@ -756,6 +837,32 @@ def get(
 @click.option(
     "--erir-ad-description",
     help="TextAd/ResponsiveAd.ErirAdDescription (TEXT_AD / RESPONSIVE_AD)",
+)
+@click.option(
+    "--feed-id",
+    type=int,
+    help="ShoppingAd/ListingAd.FeedId (SHOPPING_AD / LISTING_AD)",
+)
+@click.option(
+    "--feed-filter-condition",
+    "feed_filter_conditions",
+    multiple=True,
+    help=(
+        "Repeatable ShoppingAd/ListingAd.FeedFilterConditions item as "
+        "OPERAND:OPERATOR:ARG1|ARG2"
+    ),
+)
+@click.option(
+    "--title-sources",
+    help="Comma-separated ShoppingAd/ListingAd.TitleSources values",
+)
+@click.option(
+    "--text-sources",
+    help="Comma-separated ShoppingAd/ListingAd.TextSources values",
+)
+@click.option(
+    "--default-texts",
+    help="ShoppingAd/ListingAd.DefaultTexts value (required for SHOPPING_AD/LISTING_AD)",
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
@@ -790,17 +897,30 @@ def add(
     business_id,
     prefer_vcard_over_business,
     erir_ad_description,
+    feed_id,
+    feed_filter_conditions,
+    title_sources,
+    text_sources,
+    default_texts,
     dry_run,
 ):
     """Add new ad"""
     try:
         ad_type_norm = (ad_type or "TEXT_AD").upper().replace("-", "_")
-        supported_types = {"TEXT_AD", "TEXT_IMAGE_AD", "MOBILE_APP_AD", "RESPONSIVE_AD"}
+        supported_types = {
+            "TEXT_AD",
+            "TEXT_IMAGE_AD",
+            "MOBILE_APP_AD",
+            "RESPONSIVE_AD",
+            "SHOPPING_AD",
+            "LISTING_AD",
+        }
         if ad_type_norm not in supported_types:
             raise click.UsageError(
                 "Invalid value for '--type': "
                 f"{ad_type!r} is not one of "
-                "'TEXT_AD', 'TEXT_IMAGE_AD', 'MOBILE_APP_AD', 'RESPONSIVE_AD'."
+                "'TEXT_AD', 'TEXT_IMAGE_AD', 'MOBILE_APP_AD', 'RESPONSIVE_AD', "
+                "'SHOPPING_AD', 'LISTING_AD'."
             )
 
         # --mobile has a Click default of "NO" so the value is always present
@@ -856,6 +976,8 @@ def add(
                 "business_id",
                 "erir_ad_description",
             },
+            "SHOPPING_AD": FEED_BASED_ADD_FIELDS,
+            "LISTING_AD": FEED_BASED_ADD_FIELDS,
             "MOBILE_APP_AD": {
                 "title",
                 "text",
@@ -893,6 +1015,11 @@ def add(
             "business_id": business_id,
             "prefer_vcard_over_business": prefer_vcard_over_business,
             "erir_ad_description": erir_ad_description,
+            "feed_id": feed_id,
+            "feed_filter_conditions": feed_filter_conditions,
+            "title_sources": title_sources,
+            "text_sources": text_sources,
+            "default_texts": default_texts,
         }
         flag_for = {
             "title": "--title",
@@ -922,6 +1049,11 @@ def add(
             "business_id": "--business-id",
             "prefer_vcard_over_business": "--prefer-vcard-over-business",
             "erir_ad_description": "--erir-ad-description",
+            "feed_id": "--feed-id",
+            "feed_filter_conditions": "--feed-filter-condition",
+            "title_sources": "--title-sources",
+            "text_sources": "--text-sources",
+            "default_texts": "--default-texts",
         }
         _reject_incompatible_flags(
             ad_type_norm, type_fields[ad_type_norm], provided, flag_for
@@ -1054,6 +1186,19 @@ def add(
             if erir_ad_description:
                 responsive_ad["ErirAdDescription"] = erir_ad_description
             ad_data["ResponsiveAd"] = responsive_ad
+        elif ad_type_norm in {"SHOPPING_AD", "LISTING_AD"}:
+            field_name = "ShoppingAd" if ad_type_norm == "SHOPPING_AD" else "ListingAd"
+            ad_data[field_name] = _build_feed_based_ad_add(
+                feed_id,
+                default_texts,
+                sitelink_set_id,
+                ad_extensions,
+                business_id,
+                feed_filter_conditions,
+                title_sources,
+                text_sources,
+                field_name,
+            )
         elif ad_type_norm == "MOBILE_APP_AD":
             if href:
                 raise click.UsageError(

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,9 +11,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 2473 |
+| `missing_followup` | 2449 |
 | `not_applicable` | 23 |
-| `supported` | 745 |
+| `supported` | 769 |
 
 ## Confirmed Follow-Ups
 
@@ -101,30 +101,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `ads.add` | `CpmVideoAdBuilderAd.TurboPageId` | AdBuilder add subtype fields need typed support or N/A. [#276](https://github.com/axisrow/direct-cli/issues/276); inherited from `CpmVideoAdBuilderAd` |
 | `ads.add` | `SmartAdBuilderAd` | SMART_AD_BUILDER_AD add fields need typed support or N/A. [#278](https://github.com/axisrow/direct-cli/issues/278) |
 | `ads.add` | `SmartAdBuilderAd.LogoExtensionHash` | SMART_AD_BUILDER_AD add fields need typed support or N/A. [#278](https://github.com/axisrow/direct-cli/issues/278); inherited from `SmartAdBuilderAd` |
-| `ads.add` | `ShoppingAd` | SHOPPING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275) |
-| `ads.add` | `ShoppingAd.SitelinkSetId` | SHOPPING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ShoppingAd` |
-| `ads.add` | `ShoppingAd.AdExtensionIds` | SHOPPING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ShoppingAd` |
-| `ads.add` | `ShoppingAd.BusinessId` | SHOPPING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ShoppingAd` |
-| `ads.add` | `ShoppingAd.FeedId` | SHOPPING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ShoppingAd` |
-| `ads.add` | `ShoppingAd.FeedFilterConditions` | SHOPPING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ShoppingAd` |
-| `ads.add` | `ShoppingAd.FeedFilterConditions.Operand` | SHOPPING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ShoppingAd` |
-| `ads.add` | `ShoppingAd.FeedFilterConditions.Operator` | SHOPPING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ShoppingAd` |
-| `ads.add` | `ShoppingAd.FeedFilterConditions.Arguments` | SHOPPING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ShoppingAd` |
-| `ads.add` | `ShoppingAd.TitleSources` | SHOPPING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ShoppingAd` |
-| `ads.add` | `ShoppingAd.TextSources` | SHOPPING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ShoppingAd` |
-| `ads.add` | `ShoppingAd.DefaultTexts` | SHOPPING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ShoppingAd` |
-| `ads.add` | `ListingAd` | LISTING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275) |
-| `ads.add` | `ListingAd.SitelinkSetId` | LISTING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ListingAd` |
-| `ads.add` | `ListingAd.AdExtensionIds` | LISTING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ListingAd` |
-| `ads.add` | `ListingAd.BusinessId` | LISTING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ListingAd` |
-| `ads.add` | `ListingAd.FeedId` | LISTING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ListingAd` |
-| `ads.add` | `ListingAd.FeedFilterConditions` | LISTING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ListingAd` |
-| `ads.add` | `ListingAd.FeedFilterConditions.Operand` | LISTING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ListingAd` |
-| `ads.add` | `ListingAd.FeedFilterConditions.Operator` | LISTING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ListingAd` |
-| `ads.add` | `ListingAd.FeedFilterConditions.Arguments` | LISTING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ListingAd` |
-| `ads.add` | `ListingAd.TitleSources` | LISTING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ListingAd` |
-| `ads.add` | `ListingAd.TextSources` | LISTING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ListingAd` |
-| `ads.add` | `ListingAd.DefaultTexts` | LISTING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ListingAd` |
 | `campaigns.add` | `ClientInfo` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
 | `campaigns.add` | `Notification` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
 | `campaigns.add` | `Notification.SmsSettings` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
@@ -2747,30 +2723,30 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `ads.add` | `ads.add` | `CpmVideoAdBuilderAd.TurboPageId` | `long` | 0 | 1 | `missing_followup` | AdBuilder add subtype fields need typed support or N/A. [#276](https://github.com/axisrow/direct-cli/issues/276); inherited from `CpmVideoAdBuilderAd` |
 | `ads.add` | `ads.add` | `SmartAdBuilderAd` | `SmartAdBuilderAdAdd` | 0 | 1 | `missing_followup` | SMART_AD_BUILDER_AD add fields need typed support or N/A. [#278](https://github.com/axisrow/direct-cli/issues/278) |
 | `ads.add` | `ads.add` | `SmartAdBuilderAd.LogoExtensionHash` | `string` | 0 | 1 | `missing_followup` | SMART_AD_BUILDER_AD add fields need typed support or N/A. [#278](https://github.com/axisrow/direct-cli/issues/278); inherited from `SmartAdBuilderAd` |
-| `ads.add` | `ads.add` | `ShoppingAd` | `ShoppingAdAdd` | 0 | 1 | `missing_followup` | SHOPPING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275) |
-| `ads.add` | `ads.add` | `ShoppingAd.SitelinkSetId` | `long` | 0 | 1 | `missing_followup` | SHOPPING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ShoppingAd` |
-| `ads.add` | `ads.add` | `ShoppingAd.AdExtensionIds` | `long` | 0 | unbounded | `missing_followup` | SHOPPING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ShoppingAd` |
-| `ads.add` | `ads.add` | `ShoppingAd.BusinessId` | `long` | 0 | 1 | `missing_followup` | SHOPPING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ShoppingAd` |
-| `ads.add` | `ads.add` | `ShoppingAd.FeedId` | `long` | 1 | 1 | `missing_followup` | SHOPPING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ShoppingAd` |
-| `ads.add` | `ads.add` | `ShoppingAd.FeedFilterConditions` | `FeedFilterConditionItem` | 0 | unbounded | `missing_followup` | SHOPPING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ShoppingAd` |
-| `ads.add` | `ads.add` | `ShoppingAd.FeedFilterConditions.Operand` | `string` | 1 | 1 | `missing_followup` | SHOPPING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ShoppingAd` |
-| `ads.add` | `ads.add` | `ShoppingAd.FeedFilterConditions.Operator` | `StringConditionOperatorEnum` | 1 | 1 | `missing_followup` | SHOPPING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ShoppingAd` |
-| `ads.add` | `ads.add` | `ShoppingAd.FeedFilterConditions.Arguments` | `string` | 1 | unbounded | `missing_followup` | SHOPPING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ShoppingAd` |
-| `ads.add` | `ads.add` | `ShoppingAd.TitleSources` | `string` | 0 | unbounded | `missing_followup` | SHOPPING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ShoppingAd` |
-| `ads.add` | `ads.add` | `ShoppingAd.TextSources` | `string` | 0 | unbounded | `missing_followup` | SHOPPING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ShoppingAd` |
-| `ads.add` | `ads.add` | `ShoppingAd.DefaultTexts` | `string` | 1 | unbounded | `missing_followup` | SHOPPING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ShoppingAd` |
-| `ads.add` | `ads.add` | `ListingAd` | `ListingAdAdd` | 0 | 1 | `missing_followup` | LISTING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275) |
-| `ads.add` | `ads.add` | `ListingAd.SitelinkSetId` | `long` | 0 | 1 | `missing_followup` | LISTING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ListingAd` |
-| `ads.add` | `ads.add` | `ListingAd.AdExtensionIds` | `long` | 0 | unbounded | `missing_followup` | LISTING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ListingAd` |
-| `ads.add` | `ads.add` | `ListingAd.BusinessId` | `long` | 0 | 1 | `missing_followup` | LISTING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ListingAd` |
-| `ads.add` | `ads.add` | `ListingAd.FeedId` | `long` | 1 | 1 | `missing_followup` | LISTING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ListingAd` |
-| `ads.add` | `ads.add` | `ListingAd.FeedFilterConditions` | `FeedFilterConditionItem` | 0 | unbounded | `missing_followup` | LISTING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ListingAd` |
-| `ads.add` | `ads.add` | `ListingAd.FeedFilterConditions.Operand` | `string` | 1 | 1 | `missing_followup` | LISTING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ListingAd` |
-| `ads.add` | `ads.add` | `ListingAd.FeedFilterConditions.Operator` | `StringConditionOperatorEnum` | 1 | 1 | `missing_followup` | LISTING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ListingAd` |
-| `ads.add` | `ads.add` | `ListingAd.FeedFilterConditions.Arguments` | `string` | 1 | unbounded | `missing_followup` | LISTING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ListingAd` |
-| `ads.add` | `ads.add` | `ListingAd.TitleSources` | `string` | 0 | unbounded | `missing_followup` | LISTING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ListingAd` |
-| `ads.add` | `ads.add` | `ListingAd.TextSources` | `string` | 0 | unbounded | `missing_followup` | LISTING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ListingAd` |
-| `ads.add` | `ads.add` | `ListingAd.DefaultTexts` | `string` | 1 | unbounded | `missing_followup` | LISTING_AD add fields need typed support or N/A. [#275](https://github.com/axisrow/direct-cli/issues/275); inherited from `ListingAd` |
+| `ads.add` | `ads.add` | `ShoppingAd` | `ShoppingAdAdd` | 0 | 1 | `supported` | --type |
+| `ads.add` | `ads.add` | `ShoppingAd.SitelinkSetId` | `long` | 0 | 1 | `supported` | --sitelink-set-id |
+| `ads.add` | `ads.add` | `ShoppingAd.AdExtensionIds` | `long` | 0 | unbounded | `supported` | --ad-extensions |
+| `ads.add` | `ads.add` | `ShoppingAd.BusinessId` | `long` | 0 | 1 | `supported` | --business-id |
+| `ads.add` | `ads.add` | `ShoppingAd.FeedId` | `long` | 1 | 1 | `supported` | --feed-id |
+| `ads.add` | `ads.add` | `ShoppingAd.FeedFilterConditions` | `FeedFilterConditionItem` | 0 | unbounded | `supported` | --feed-filter-condition |
+| `ads.add` | `ads.add` | `ShoppingAd.FeedFilterConditions.Operand` | `string` | 1 | 1 | `supported` | --feed-filter-condition |
+| `ads.add` | `ads.add` | `ShoppingAd.FeedFilterConditions.Operator` | `StringConditionOperatorEnum` | 1 | 1 | `supported` | --feed-filter-condition |
+| `ads.add` | `ads.add` | `ShoppingAd.FeedFilterConditions.Arguments` | `string` | 1 | unbounded | `supported` | --feed-filter-condition |
+| `ads.add` | `ads.add` | `ShoppingAd.TitleSources` | `string` | 0 | unbounded | `supported` | --title-sources |
+| `ads.add` | `ads.add` | `ShoppingAd.TextSources` | `string` | 0 | unbounded | `supported` | --text-sources |
+| `ads.add` | `ads.add` | `ShoppingAd.DefaultTexts` | `string` | 1 | unbounded | `supported` | --default-texts |
+| `ads.add` | `ads.add` | `ListingAd` | `ListingAdAdd` | 0 | 1 | `supported` | --type |
+| `ads.add` | `ads.add` | `ListingAd.SitelinkSetId` | `long` | 0 | 1 | `supported` | --sitelink-set-id |
+| `ads.add` | `ads.add` | `ListingAd.AdExtensionIds` | `long` | 0 | unbounded | `supported` | --ad-extensions |
+| `ads.add` | `ads.add` | `ListingAd.BusinessId` | `long` | 0 | 1 | `supported` | --business-id |
+| `ads.add` | `ads.add` | `ListingAd.FeedId` | `long` | 1 | 1 | `supported` | --feed-id |
+| `ads.add` | `ads.add` | `ListingAd.FeedFilterConditions` | `FeedFilterConditionItem` | 0 | unbounded | `supported` | --feed-filter-condition |
+| `ads.add` | `ads.add` | `ListingAd.FeedFilterConditions.Operand` | `string` | 1 | 1 | `supported` | --feed-filter-condition |
+| `ads.add` | `ads.add` | `ListingAd.FeedFilterConditions.Operator` | `StringConditionOperatorEnum` | 1 | 1 | `supported` | --feed-filter-condition |
+| `ads.add` | `ads.add` | `ListingAd.FeedFilterConditions.Arguments` | `string` | 1 | unbounded | `supported` | --feed-filter-condition |
+| `ads.add` | `ads.add` | `ListingAd.TitleSources` | `string` | 0 | unbounded | `supported` | --title-sources |
+| `ads.add` | `ads.add` | `ListingAd.TextSources` | `string` | 0 | unbounded | `supported` | --text-sources |
+| `ads.add` | `ads.add` | `ListingAd.DefaultTexts` | `string` | 1 | unbounded | `supported` | --default-texts |
 | `ads.update` | `ads.update` | `Id` | `long` | 1 | 1 | `supported` | covered by minOccurs>=1 parity gate |
 | `ads.update` | `ads.update` | `TextAd` | `TextAdUpdate` | 0 | 1 | `supported` | --type |
 | `ads.update` | `ads.update` | `TextAd.VCardId` | `long` | 0 | 1 | `supported` | --vcard-id |

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -266,7 +266,8 @@ class TestCLI(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         collapsed = " ".join(result.output.split())
         self.assertIn(
-            "Ad type: TEXT_AD | TEXT_IMAGE_AD | MOBILE_APP_AD | RESPONSIVE_AD",
+            "Ad type: TEXT_AD | TEXT_IMAGE_AD | MOBILE_APP_AD | RESPONSIVE_AD | "
+            "SHOPPING_AD | LISTING_AD",
             collapsed,
         )
         self.assertIn("Comma-separated ResponsiveAd.Titles values", collapsed)
@@ -285,12 +286,26 @@ class TestCLI(unittest.TestCase):
             "Optional; if supplied, PriceExtension add also requires", collapsed
         )
         self.assertIn(
-            "TextAd/ResponsiveAd.BusinessId (TEXT_AD / RESPONSIVE_AD)",
+            "BusinessId (TEXT_AD / RESPONSIVE_AD / SHOPPING_AD / LISTING_AD)",
             collapsed,
         )
         self.assertIn("TextAd.PreferVCardOverBusiness value: YES or NO", collapsed)
         self.assertIn(
             "TextAd/ResponsiveAd.ErirAdDescription (TEXT_AD / RESPONSIVE_AD)",
+            collapsed,
+        )
+        self.assertIn(
+            "ShoppingAd/ListingAd.FeedId (SHOPPING_AD / LISTING_AD)",
+            collapsed,
+        )
+        self.assertIn(
+            "Repeatable ShoppingAd/ListingAd.FeedFilterConditions item as "
+            "OPERAND:OPERATOR:ARG1|ARG2",
+            collapsed,
+        )
+        self.assertIn(
+            "ShoppingAd/ListingAd.DefaultTexts value "
+            "(required for SHOPPING_AD/LISTING_AD)",
             collapsed,
         )
 

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1389,8 +1389,25 @@ def test_ads_add_shopping_ad_requires_feed_id_and_default_texts():
     assert "ShoppingAd requires --feed-id, --default-texts" in result.output
 
 
-def test_ads_add_listing_ad_default_texts_single_value_only():
-    """Issue #275: DefaultTexts is required but accepts only one value."""
+def test_ads_add_listing_ad_default_texts_preserves_commas():
+    """Issue #275: DefaultTexts is one raw text value, not a CSV list."""
+    body = _dry_run(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "12345",
+        "--type",
+        "LISTING_AD",
+        "--feed-id",
+        "171",
+        "--default-texts",
+        "Sale, today",
+    )
+    assert body["params"]["Ads"][0]["ListingAd"]["DefaultTexts"] == ["Sale, today"]
+
+
+def test_ads_add_listing_ad_empty_default_texts_rejected():
+    """Issue #275: required DefaultTexts must be a meaningful text value."""
     result = _rejected(
         "ads",
         "add",
@@ -1401,9 +1418,9 @@ def test_ads_add_listing_ad_default_texts_single_value_only():
         "--feed-id",
         "171",
         "--default-texts",
-        "One,Two",
+        "",
     )
-    assert "ListingAd.DefaultTexts accepts exactly one value." in result.output
+    assert "--default-texts must contain a value." in result.output
 
 
 def test_ads_add_shopping_ad_rejects_invalid_feed_filter_condition():

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1282,6 +1282,169 @@ def test_ads_add_responsive_ad_rejects_other_subtype_flags():
     )
 
 
+def test_ads_add_shopping_ad_payload():
+    """Issue #275: SHOPPING_AD add builds the documented ShoppingAd block."""
+    body = _dry_run(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "12345",
+        "--type",
+        "SHOPPING_AD",
+        "--feed-id",
+        "170",
+        "--default-texts",
+        "Default product text",
+        "--sitelink-set-id",
+        "0",
+        "--ad-extensions",
+        "333,444",
+        "--business-id",
+        "0",
+        "--feed-filter-condition",
+        "CATEGORY:EQUALS_ANY:shoes|boots",
+        "--feed-filter-condition",
+        "PRICE:GREATER_THAN:100",
+        "--title-sources",
+        "NAME,BRAND",
+        "--text-sources",
+        "DESCRIPTION",
+    )
+    ad = body["params"]["Ads"][0]
+    assert "Type" not in ad
+    assert ad == {
+        "AdGroupId": 12345,
+        "ShoppingAd": {
+            "FeedId": 170,
+            "DefaultTexts": ["Default product text"],
+            "SitelinkSetId": 0,
+            "AdExtensionIds": [333, 444],
+            "BusinessId": 0,
+            "FeedFilterConditions": [
+                {
+                    "Operand": "CATEGORY",
+                    "Operator": "EQUALS_ANY",
+                    "Arguments": ["shoes", "boots"],
+                },
+                {
+                    "Operand": "PRICE",
+                    "Operator": "GREATER_THAN",
+                    "Arguments": ["100"],
+                },
+            ],
+            "TitleSources": ["NAME", "BRAND"],
+            "TextSources": ["DESCRIPTION"],
+        },
+    }
+
+
+def test_ads_add_listing_ad_payload():
+    """Issue #275: LISTING_AD add builds the documented ListingAd block."""
+    body = _dry_run(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "12345",
+        "--type",
+        "LISTING_AD",
+        "--feed-id",
+        "171",
+        "--default-texts",
+        "Default listing text",
+        "--feed-filter-condition",
+        "CATEGORY:EQUALS_ANY:appliances",
+        "--title-sources",
+        "TITLE",
+        "--text-sources",
+        "DESCRIPTION",
+    )
+    assert body["params"]["Ads"][0] == {
+        "AdGroupId": 12345,
+        "ListingAd": {
+            "FeedId": 171,
+            "DefaultTexts": ["Default listing text"],
+            "FeedFilterConditions": [
+                {
+                    "Operand": "CATEGORY",
+                    "Operator": "EQUALS_ANY",
+                    "Arguments": ["appliances"],
+                }
+            ],
+            "TitleSources": ["TITLE"],
+            "TextSources": ["DESCRIPTION"],
+        },
+    }
+
+
+def test_ads_add_shopping_ad_requires_feed_id_and_default_texts():
+    """Issue #275: documented ShoppingAdAdd required fields are local errors."""
+    result = _rejected(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "12345",
+        "--type",
+        "SHOPPING_AD",
+    )
+    assert "ShoppingAd requires --feed-id, --default-texts" in result.output
+
+
+def test_ads_add_listing_ad_default_texts_single_value_only():
+    """Issue #275: DefaultTexts is required but accepts only one value."""
+    result = _rejected(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "12345",
+        "--type",
+        "LISTING_AD",
+        "--feed-id",
+        "171",
+        "--default-texts",
+        "One,Two",
+    )
+    assert "ListingAd.DefaultTexts accepts exactly one value." in result.output
+
+
+def test_ads_add_shopping_ad_rejects_invalid_feed_filter_condition():
+    """Issue #275: feed filter conditions keep the typed grammar."""
+    result = _rejected(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "12345",
+        "--type",
+        "SHOPPING_AD",
+        "--feed-id",
+        "170",
+        "--default-texts",
+        "Default product text",
+        "--feed-filter-condition",
+        "CATEGORY",
+    )
+    assert "--feed-filter-condition: Invalid condition" in result.output
+    assert "Expected format: OPERAND:OPERATOR:ARG1|ARG2" in result.output
+
+
+def test_ads_add_listing_ad_rejects_other_subtype_flags():
+    """Issue #275: LISTING_AD add flags must honor subtype allow-lists."""
+    result = _rejected(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "12345",
+        "--type",
+        "LISTING_AD",
+        "--feed-id",
+        "171",
+        "--default-texts",
+        "Default listing text",
+        "--href",
+        "https://example.com",
+    )
+    assert "--href is not compatible with --type LISTING_AD" in result.output
+
+
 def test_ads_update_rejects_status_flag():
     """``--status`` is not part of WSDL ``AdUpdateItem`` (regression for #183).
 

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -981,6 +981,42 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     },
     ("ads", "add", "ResponsiveAd.BusinessId"): {"--business-id"},
     ("ads", "add", "ResponsiveAd.ErirAdDescription"): {"--erir-ad-description"},
+    ("ads", "add", "ShoppingAd"): {"--type"},
+    ("ads", "add", "ShoppingAd.SitelinkSetId"): {"--sitelink-set-id"},
+    ("ads", "add", "ShoppingAd.AdExtensionIds"): {"--ad-extensions"},
+    ("ads", "add", "ShoppingAd.BusinessId"): {"--business-id"},
+    ("ads", "add", "ShoppingAd.FeedId"): {"--feed-id"},
+    ("ads", "add", "ShoppingAd.FeedFilterConditions"): {"--feed-filter-condition"},
+    ("ads", "add", "ShoppingAd.FeedFilterConditions.Operand"): {
+        "--feed-filter-condition"
+    },
+    ("ads", "add", "ShoppingAd.FeedFilterConditions.Operator"): {
+        "--feed-filter-condition"
+    },
+    ("ads", "add", "ShoppingAd.FeedFilterConditions.Arguments"): {
+        "--feed-filter-condition"
+    },
+    ("ads", "add", "ShoppingAd.TitleSources"): {"--title-sources"},
+    ("ads", "add", "ShoppingAd.TextSources"): {"--text-sources"},
+    ("ads", "add", "ShoppingAd.DefaultTexts"): {"--default-texts"},
+    ("ads", "add", "ListingAd"): {"--type"},
+    ("ads", "add", "ListingAd.SitelinkSetId"): {"--sitelink-set-id"},
+    ("ads", "add", "ListingAd.AdExtensionIds"): {"--ad-extensions"},
+    ("ads", "add", "ListingAd.BusinessId"): {"--business-id"},
+    ("ads", "add", "ListingAd.FeedId"): {"--feed-id"},
+    ("ads", "add", "ListingAd.FeedFilterConditions"): {"--feed-filter-condition"},
+    ("ads", "add", "ListingAd.FeedFilterConditions.Operand"): {
+        "--feed-filter-condition"
+    },
+    ("ads", "add", "ListingAd.FeedFilterConditions.Operator"): {
+        "--feed-filter-condition"
+    },
+    ("ads", "add", "ListingAd.FeedFilterConditions.Arguments"): {
+        "--feed-filter-condition"
+    },
+    ("ads", "add", "ListingAd.TitleSources"): {"--title-sources"},
+    ("ads", "add", "ListingAd.TextSources"): {"--text-sources"},
+    ("ads", "add", "ListingAd.DefaultTexts"): {"--default-texts"},
     ("ads", "update", "TextAd"): {"--type"},
     ("ads", "update", "TextAd.VCardId"): {"--vcard-id"},
     ("ads", "update", "TextAd.AdImageHash"): {"--image-hash"},
@@ -1886,16 +1922,6 @@ OPTIONAL_FIELD_DEFAULT_FOLLOWUPS: dict[tuple[str, str], dict[str, str]] = {
 }
 
 OPTIONAL_FIELD_CHILD_PREFIX_FOLLOWUPS: dict[tuple[str, str, str], dict[str, str]] = {
-    ("ads", "add", "ShoppingAd"): {
-        "status": "missing_followup",
-        "issue": "#275",
-        "note": "SHOPPING_AD add fields need typed support or N/A.",
-    },
-    ("ads", "add", "ListingAd"): {
-        "status": "missing_followup",
-        "issue": "#275",
-        "note": "LISTING_AD add fields need typed support or N/A.",
-    },
     ("ads", "add", "TextAdBuilderAd"): {
         "status": "missing_followup",
         "issue": "#276",


### PR DESCRIPTION
## Summary
- add typed SHOPPING_AD and LISTING_AD support to direct ads add
- build documented top-level ShoppingAd / ListingAd payloads with flat add arrays, required FeedId, and one DefaultTexts value
- mark the matching WSDL audit rows supported and add README/help/dry-run coverage

## Verification
- python3 -m pytest tests/test_dry_run.py -k "ads_add and (shopping or listing)"
- python3 -m pytest tests/test_cli.py -k ads_add_help
- python3 scripts/build_wsdl_optional_field_audit.py --check
- python3 -m pytest tests/test_wsdl_parity_gate.py
- python3 -m pytest tests/test_cli_contract.py -k "json or readme_direct_examples"
- python3 -m pytest tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py
- mypy .
- git diff --check

Official docs checked: https://yandex.ru/dev/direct/doc/en/ads/add

Closes #275