### PR TITLE
Add dynamic and mobile app ads add flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,9 @@ direct ads add --adgroup-id 12345 --type TEXT_AD_BUILDER_AD --creative-id 123 --
 direct ads add --adgroup-id 12345 --type MOBILE_APP_AD_BUILDER_AD --creative-id 123 --tracking-url "https://track.example.com" --erir-ad-description "Mobile builder ad" --dry-run
 direct ads add --adgroup-id 12345 --type CPM_BANNER_AD_BUILDER_AD --creative-id 123 --href "https://example.com" --tracking-pixels "https://pixel.example.com/a,https://pixel.example.com/b" --dry-run
 direct ads add --adgroup-id 12345 --type TEXT_IMAGE_AD --image-hash abcdefghijklmnopqrst --href "https://example.com" --turbo-page-id 555 --dry-run
+direct ads add --adgroup-id 12345 --type DYNAMIC_TEXT_AD --text "Dynamic ad text" --image-hash abcdefghijklmnopqrst --vcard-id 111 --sitelink-set-id 222 --ad-extensions "333,444" --dry-run
+direct ads add --adgroup-id 12345 --type MOBILE_APP_AD --title "Install app" --text "App promo text" --action INSTALL --tracking-url "https://track.example.com" --mobile-app-feature PRICE=YES --video-extension-creative-id 777 --erir-ad-description "Mobile app object" --dry-run
+direct ads add --adgroup-id 12345 --type MOBILE_APP_IMAGE_AD --image-hash abcdefghijklmnopqrst --tracking-url "https://track.example.com" --erir-ad-description "Mobile image ad" --dry-run
 direct ads update --id 99999 --type TEXT_AD --title "New Title" --text "New text" --href "https://example.com"
 direct ads update --id 99999 --type TEXT_AD --image-hash abcdefghijklmnopqrst
 direct ads update --id 99999 --type TEXT_AD --title2 "New second headline" --vcard-id 222
@@ -452,8 +455,10 @@ the Yandex Direct API long-unit format internally. `ads update` also supports
 `TextAdUpdate` does not contain `Mobile`, and on update ad-extensions are
 managed through the `--callouts-*` flags above. TEXT_IMAGE_AD additionally
 accepts `--turbo-page-id`, `--final-url`, and `--erir-ad-description`.
-DYNAMIC_TEXT_AD update supports `--text`, `--image-hash`, `--vcard-id`,
-`--sitelink-set-id`, and `--callouts-*`.
+DYNAMIC_TEXT_AD add requires `--text` and supports `--image-hash`,
+`--vcard-id`, `--sitelink-set-id`, and `--ad-extensions`; update supports
+`--text`, `--image-hash`, `--vcard-id`, `--sitelink-set-id`, and
+`--callouts-*`.
 RESPONSIVE_AD `ads add` uses `--texts` and `--titles` as required
 comma-separated lists and also requires `--href`, `--business-id`, or both.
 Optional creation flags include `--image-hashes`, `--video-extension-ids`,
@@ -468,8 +473,11 @@ CPC_VIDEO_AD_BUILDER_AD, CPM_BANNER_AD_BUILDER_AD, and
 CPM_VIDEO_AD_BUILDER_AD require `--href`, `--turbo-page-id`, or both. Mobile app
 builder subtypes use `--tracking-url`. CPM builder subtypes also support
 `--tracking-pixels`; all AdBuilder add subtypes support `--erir-ad-description`.
-MOBILE_APP_AD update supports `--mobile-app-feature FEATURE=YES|NO`,
-`--video-extension-creative-id`, and `--erir-ad-description`.
+MOBILE_APP_AD add requires `--title`, `--text`, and `--action`; optional add
+fields include `--mobile-app-feature FEATURE=YES|NO`,
+`--video-extension-creative-id`, and `--erir-ad-description`. MOBILE_APP_IMAGE_AD
+add requires `--image-hash`; add/update support `--tracking-url` and
+`--erir-ad-description`.
 RESPONSIVE_AD update supports `--texts`, `--titles`, `--image-hashes`,
 `--video-extension-ids`, `--href`, `--age-label`, `--display-url-path`,
 `--sitelink-set-id`, `--callouts-*`, `--price-extension-*`, `--business-id`,
@@ -1198,6 +1206,9 @@ direct ads add --adgroup-id 12345 --type TEXT_AD_BUILDER_AD --creative-id 123 --
 direct ads add --adgroup-id 12345 --type MOBILE_APP_AD_BUILDER_AD --creative-id 123 --tracking-url "https://track.example.com" --erir-ad-description "Мобильное объявление из конструктора" --dry-run
 direct ads add --adgroup-id 12345 --type CPM_BANNER_AD_BUILDER_AD --creative-id 123 --href "https://example.com" --tracking-pixels "https://pixel.example.com/a,https://pixel.example.com/b" --dry-run
 direct ads add --adgroup-id 12345 --type TEXT_IMAGE_AD --image-hash abcdefghijklmnopqrst --href "https://example.com" --turbo-page-id 555 --dry-run
+direct ads add --adgroup-id 12345 --type DYNAMIC_TEXT_AD --text "Динамический текст" --image-hash abcdefghijklmnopqrst --vcard-id 111 --sitelink-set-id 222 --ad-extensions "333,444" --dry-run
+direct ads add --adgroup-id 12345 --type MOBILE_APP_AD --title "Установите приложение" --text "Текст приложения" --action INSTALL --tracking-url "https://track.example.com" --mobile-app-feature PRICE=YES --video-extension-creative-id 777 --erir-ad-description "Объект мобильного объявления" --dry-run
+direct ads add --adgroup-id 12345 --type MOBILE_APP_IMAGE_AD --image-hash abcdefghijklmnopqrst --tracking-url "https://track.example.com" --erir-ad-description "Мобильное графическое объявление" --dry-run
 direct ads update --id 99999 --type TEXT_AD --title "Новый заголовок" --text "Новый текст" --href "https://example.com"
 direct ads update --id 99999 --type TEXT_AD --image-hash abcdefghijklmnopqrst
 direct ads update --id 99999 --type TEXT_AD --title2 "Новый второй заголовок" --vcard-id 222
@@ -1237,8 +1248,10 @@ direct ads delete --id 99999
 содержит `Mobile`, а в `ads update` расширения управляются через флаги
 `--callouts-*` выше. Для TEXT_IMAGE_AD дополнительно доступен
 `--turbo-page-id`, `--final-url` и `--erir-ad-description`. Для
-DYNAMIC_TEXT_AD в `ads update` доступны `--text`, `--image-hash`,
-`--vcard-id`, `--sitelink-set-id` и `--callouts-*`.
+DYNAMIC_TEXT_AD в `ads add` обязателен `--text`; доступны `--image-hash`,
+`--vcard-id`, `--sitelink-set-id` и `--ad-extensions`. В `ads update`
+доступны `--text`, `--image-hash`, `--vcard-id`, `--sitelink-set-id` и
+`--callouts-*`.
 Для RESPONSIVE_AD в `ads add` обязательны `--texts` и `--titles` как списки
 через запятую, а также `--href`, `--business-id` или оба флага. Дополнительные
 флаги создания: `--image-hashes`, `--video-extension-ids`, `--age-label`,
@@ -1255,8 +1268,11 @@ CPM_VIDEO_AD_BUILDER_AD требуют `--href`, `--turbo-page-id` или оба
 Mobile app builder subtype используют `--tracking-url`. CPM builder subtype
 также поддерживают `--tracking-pixels`; все AdBuilder subtype в `ads add`
 поддерживают `--erir-ad-description`.
-Для MOBILE_APP_AD в `ads update` доступны `--mobile-app-feature FEATURE=YES|NO`,
-`--video-extension-creative-id` и `--erir-ad-description`.
+Для MOBILE_APP_AD в `ads add` обязательны `--title`, `--text` и `--action`;
+дополнительно доступны `--mobile-app-feature FEATURE=YES|NO`,
+`--video-extension-creative-id` и `--erir-ad-description`. Для
+MOBILE_APP_IMAGE_AD в `ads add` обязателен `--image-hash`; в add/update
+доступны `--tracking-url` и `--erir-ad-description`.
 Для RESPONSIVE_AD в `ads update` доступны `--texts`, `--titles`,
 `--image-hashes`, `--video-extension-ids`, `--href`, `--age-label`,
 `--display-url-path`, `--sitelink-set-id`, `--callouts-*`,

--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -48,6 +48,32 @@ FEED_BASED_ADD_FIELDS = {
     "default_texts",
 }
 
+DYNAMIC_TEXT_AD_ADD_FIELDS = {
+    "text",
+    "image_hash",
+    "vcard_id",
+    "sitelink_set_id",
+    "ad_extensions",
+}
+
+MOBILE_APP_AD_ADD_FIELDS = {
+    "title",
+    "text",
+    "image_hash",
+    "action",
+    "tracking_url",
+    "age_label",
+    "mobile_app_features",
+    "video_extension_creative_id",
+    "erir_ad_description",
+}
+
+MOBILE_APP_IMAGE_AD_ADD_FIELDS = {
+    "image_hash",
+    "tracking_url",
+    "erir_ad_description",
+}
+
 
 TEXT_AD_UPDATE_FIELDS = {
     "title",
@@ -538,6 +564,31 @@ def _build_feed_based_ad_add(
     return ad_payload
 
 
+def _build_dynamic_text_ad_add(
+    text: Optional[str],
+    image_hash: Optional[str],
+    vcard_id: Optional[int],
+    sitelink_set_id: Optional[int],
+    ad_extensions: Optional[str],
+) -> dict[str, object]:
+    """Build DynamicTextAdAdd payload from typed flags."""
+    if not text:
+        raise click.UsageError("DYNAMIC_TEXT_AD requires --text")
+
+    dynamic_text_ad: dict[str, object] = {"Text": text}
+    if image_hash:
+        dynamic_text_ad["AdImageHash"] = image_hash
+    if vcard_id is not None:
+        dynamic_text_ad["VCardId"] = vcard_id
+    if sitelink_set_id is not None:
+        dynamic_text_ad["SitelinkSetId"] = sitelink_set_id
+    parsed_ad_extensions = _parse_required_ids(ad_extensions, "--ad-extensions")
+    if parsed_ad_extensions:
+        dynamic_text_ad["AdExtensionIds"] = parsed_ad_extensions
+
+    return dynamic_text_ad
+
+
 def _build_ad_builder_update(
     creative_id: Optional[int],
     creative_erir_ad_description: Optional[str],
@@ -634,6 +685,24 @@ def _build_mobile_app_image_ad_update(
 
     if image_hash:
         mobile_app_image_ad["AdImageHash"] = image_hash
+    if erir_ad_description:
+        mobile_app_image_ad["ErirAdDescription"] = erir_ad_description
+    if tracking_url:
+        mobile_app_image_ad["TrackingUrl"] = tracking_url
+
+    return mobile_app_image_ad
+
+
+def _build_mobile_app_image_ad_add(
+    image_hash: Optional[str],
+    erir_ad_description: Optional[str],
+    tracking_url: Optional[str],
+) -> dict[str, object]:
+    """Build MobileAppImageAdAdd payload from typed flags."""
+    if not image_hash:
+        raise click.UsageError("MOBILE_APP_IMAGE_AD requires --image-hash")
+
+    mobile_app_image_ad: dict[str, object] = {"AdImageHash": image_hash}
     if erir_ad_description:
         mobile_app_image_ad["ErirAdDescription"] = erir_ad_description
     if tracking_url:
@@ -805,15 +874,16 @@ def get(
     "ad_type",
     default="TEXT_AD",
     help=(
-        "Ad type: TEXT_AD | TEXT_IMAGE_AD | MOBILE_APP_AD | RESPONSIVE_AD | "
-        "SHOPPING_AD | LISTING_AD | TEXT_AD_BUILDER_AD | "
+        "Ad type: TEXT_AD | TEXT_IMAGE_AD | MOBILE_APP_AD | DYNAMIC_TEXT_AD | "
+        "MOBILE_APP_IMAGE_AD | RESPONSIVE_AD | SHOPPING_AD | LISTING_AD | "
+        "TEXT_AD_BUILDER_AD | "
         "MOBILE_APP_AD_BUILDER_AD | MOBILE_APP_CPC_VIDEO_AD_BUILDER_AD | "
         "CPC_VIDEO_AD_BUILDER_AD | CPM_BANNER_AD_BUILDER_AD | "
         "CPM_VIDEO_AD_BUILDER_AD"
     ),
 )
 @click.option("--title", help="Ad title (TEXT_AD / MOBILE_APP_AD)")
-@click.option("--text", help="Ad text (TEXT_AD / MOBILE_APP_AD)")
+@click.option("--text", help="Ad text (TEXT_AD / MOBILE_APP_AD / DYNAMIC_TEXT_AD)")
 @click.option("--titles", help="Comma-separated ResponsiveAd.Titles values")
 @click.option("--texts", help="Comma-separated ResponsiveAd.Texts values")
 @click.option(
@@ -824,7 +894,13 @@ def get(
         "CPM_VIDEO_AD_BUILDER_AD)"
     ),
 )
-@click.option("--image-hash", help="Ad image hash (TEXT_IMAGE_AD / MOBILE_APP_AD)")
+@click.option(
+    "--image-hash",
+    help=(
+        "Ad image hash (TEXT_IMAGE_AD / MOBILE_APP_AD / DYNAMIC_TEXT_AD / "
+        "MOBILE_APP_IMAGE_AD)"
+    ),
+)
 @click.option(
     "--image-hashes",
     help="Comma-separated ResponsiveAd.AdImageHashes values",
@@ -837,12 +913,21 @@ def get(
     "--tracking-url",
     help=(
         "Tracking URL (MOBILE_APP_AD / MOBILE_APP_AD_BUILDER_AD / "
-        "MOBILE_APP_CPC_VIDEO_AD_BUILDER_AD)"
+        "MOBILE_APP_CPC_VIDEO_AD_BUILDER_AD / MOBILE_APP_IMAGE_AD)"
     ),
 )
 @click.option(
     "--age-label",
     help="Age label (MOBILE_APP_AD MobAppAgeLabelEnum / RESPONSIVE_AD AgeLabelEnum)",
+)
+@click.option(
+    "--mobile-app-feature",
+    "mobile_app_features",
+    multiple=True,
+    help=(
+        "Repeatable MobileAppAd.Features item as FEATURE=YES|NO "
+        "(PRICE, ICON, CUSTOMER_RATING, RATINGS)"
+    ),
 )
 @click.option("--title2", help="Second headline (TEXT_AD)")
 @click.option("--display-url-path", help="Display URL path (TEXT_AD / RESPONSIVE_AD)")
@@ -852,11 +937,14 @@ def get(
     default="NO",
     help="Mobile-targeted flag (TEXT_AD)",
 )
-@click.option("--vcard-id", type=int, help="VCard ID (TEXT_AD)")
+@click.option("--vcard-id", type=int, help="VCard ID (TEXT_AD / DYNAMIC_TEXT_AD)")
 @click.option(
     "--sitelink-set-id",
     type=int,
-    help="Sitelink set ID (TEXT_AD / RESPONSIVE_AD / SHOPPING_AD / LISTING_AD)",
+    help=(
+        "Sitelink set ID "
+        "(TEXT_AD / DYNAMIC_TEXT_AD / RESPONSIVE_AD / SHOPPING_AD / LISTING_AD)"
+    ),
 )
 @click.option(
     "--turbo-page-id",
@@ -871,14 +959,14 @@ def get(
     "--ad-extensions",
     help=(
         "Comma-separated ad extension IDs "
-        "(TEXT_AD / RESPONSIVE_AD / SHOPPING_AD / LISTING_AD)"
+        "(TEXT_AD / DYNAMIC_TEXT_AD / RESPONSIVE_AD / SHOPPING_AD / LISTING_AD)"
     ),
 )
 @click.option("--final-url", help="FinalUrl (TEXT_AD / TEXT_AD_BUILDER_AD)")
 @click.option(
     "--video-extension-creative-id",
     type=int,
-    help="TextAd.VideoExtension.CreativeId (TEXT_AD)",
+    help="TextAd/MobileAppAd.VideoExtension.CreativeId (TEXT_AD / MOBILE_APP_AD)",
 )
 @click.option(
     "--price-extension-price",
@@ -931,7 +1019,10 @@ def get(
 )
 @click.option(
     "--erir-ad-description",
-    help=("ErirAdDescription (TEXT_AD / RESPONSIVE_AD / AdBuilder add subtypes)"),
+    help=(
+        "ErirAdDescription (TEXT_AD / MOBILE_APP_AD / MOBILE_APP_IMAGE_AD / "
+        "RESPONSIVE_AD / AdBuilder add subtypes)"
+    ),
 )
 @click.option(
     "--creative-id",
@@ -984,6 +1075,7 @@ def add(
     action,
     tracking_url,
     age_label,
+    mobile_app_features,
     title2,
     display_url_path,
     mobile,
@@ -1017,6 +1109,8 @@ def add(
             "TEXT_AD",
             "TEXT_IMAGE_AD",
             "MOBILE_APP_AD",
+            "DYNAMIC_TEXT_AD",
+            "MOBILE_APP_IMAGE_AD",
             "RESPONSIVE_AD",
             "SHOPPING_AD",
             "LISTING_AD",
@@ -1026,8 +1120,8 @@ def add(
             raise click.UsageError(
                 "Invalid value for '--type': "
                 f"{ad_type!r} is not one of "
-                "'TEXT_AD', 'TEXT_IMAGE_AD', 'MOBILE_APP_AD', 'RESPONSIVE_AD', "
-                "'SHOPPING_AD', 'LISTING_AD', "
+                "'TEXT_AD', 'TEXT_IMAGE_AD', 'MOBILE_APP_AD', 'DYNAMIC_TEXT_AD', "
+                "'MOBILE_APP_IMAGE_AD', 'RESPONSIVE_AD', 'SHOPPING_AD', 'LISTING_AD', "
                 "'TEXT_AD_BUILDER_AD', 'MOBILE_APP_AD_BUILDER_AD', "
                 "'MOBILE_APP_CPC_VIDEO_AD_BUILDER_AD', 'CPC_VIDEO_AD_BUILDER_AD', "
                 "'CPM_BANNER_AD_BUILDER_AD', 'CPM_VIDEO_AD_BUILDER_AD'."
@@ -1089,14 +1183,9 @@ def add(
             "SHOPPING_AD": FEED_BASED_ADD_FIELDS,
             "LISTING_AD": FEED_BASED_ADD_FIELDS,
             **AD_BUILDER_ADD_TYPE_FIELDS,
-            "MOBILE_APP_AD": {
-                "title",
-                "text",
-                "image_hash",
-                "action",
-                "tracking_url",
-                "age_label",
-            },
+            "DYNAMIC_TEXT_AD": DYNAMIC_TEXT_AD_ADD_FIELDS,
+            "MOBILE_APP_AD": MOBILE_APP_AD_ADD_FIELDS,
+            "MOBILE_APP_IMAGE_AD": MOBILE_APP_IMAGE_AD_ADD_FIELDS,
         }
         provided = {
             "title": title,
@@ -1109,6 +1198,7 @@ def add(
             "action": action,
             "tracking_url": tracking_url,
             "age_label": age_label,
+            "mobile_app_features": mobile_app_features,
             "title2": title2,
             "display_url_path": display_url_path,
             "mobile": mobile_provided,
@@ -1145,6 +1235,7 @@ def add(
             "action": "--action",
             "tracking_url": "--tracking-url",
             "age_label": "--age-label",
+            "mobile_app_features": "--mobile-app-feature",
             "title2": "--title2",
             "display_url_path": "--display-url-path",
             "mobile": "--mobile",
@@ -1226,6 +1317,14 @@ def add(
             if erir_ad_description:
                 text_ad["ErirAdDescription"] = erir_ad_description
             ad_data["TextAd"] = text_ad
+        elif ad_type_norm == "DYNAMIC_TEXT_AD":
+            ad_data["DynamicTextAd"] = _build_dynamic_text_ad_add(
+                text,
+                image_hash,
+                vcard_id,
+                sitelink_set_id,
+                ad_extensions,
+            )
         elif ad_type_norm == "TEXT_IMAGE_AD":
             if title or text:
                 raise click.UsageError(
@@ -1357,7 +1456,22 @@ def add(
                 mobile_app_ad["TrackingUrl"] = tracking_url
             if age_label:
                 mobile_app_ad["AgeLabel"] = age_label.upper()
+            parsed_features = _parse_mobile_app_features(mobile_app_features)
+            if parsed_features:
+                mobile_app_ad["Features"] = parsed_features
+            if video_extension_creative_id is not None:
+                mobile_app_ad["VideoExtension"] = {
+                    "CreativeId": video_extension_creative_id
+                }
+            if erir_ad_description:
+                mobile_app_ad["ErirAdDescription"] = erir_ad_description
             ad_data["MobileAppAd"] = mobile_app_ad
+        elif ad_type_norm == "MOBILE_APP_IMAGE_AD":
+            ad_data["MobileAppImageAd"] = _build_mobile_app_image_ad_add(
+                image_hash,
+                erir_ad_description,
+                tracking_url,
+            )
 
         body = {"method": "add", "params": {"Ads": [ad_data]}}
 

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,9 +11,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 2410 |
+| `missing_followup` | 2394 |
 | `not_applicable` | 23 |
-| `supported` | 808 |
+| `supported` | 824 |
 
 ## Confirmed Follow-Ups
 
@@ -42,24 +42,8 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `adgroups.update` | `DynamicTextFeedAdGroup.AutotargetingSettings.BrandOptions.WithAdvertiserBrand` | Official adgroups.update docs for DynamicTextFeedAdGroupUpdate list AutotargetingCategories only. [#281](https://github.com/axisrow/direct-cli/issues/281); inherited from `DynamicTextFeedAdGroup.AutotargetingSettings` |
 | `adgroups.update` | `DynamicTextFeedAdGroup.AutotargetingSettings.BrandOptions.WithCompetitorsBrand` | Official adgroups.update docs for DynamicTextFeedAdGroupUpdate list AutotargetingCategories only. [#281](https://github.com/axisrow/direct-cli/issues/281); inherited from `DynamicTextFeedAdGroup.AutotargetingSettings` |
 | `adgroups.update` | `DynamicTextFeedAdGroup.FeedId` | Official adgroups.update docs for DynamicTextFeedAdGroupUpdate do not list FeedId. [#281](https://github.com/axisrow/direct-cli/issues/281) |
-| `ads.add` | `DynamicTextAd` | DYNAMIC_TEXT_AD add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277) |
-| `ads.add` | `DynamicTextAd.VCardId` | DYNAMIC_TEXT_AD add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `DynamicTextAd` |
-| `ads.add` | `DynamicTextAd.AdImageHash` | DYNAMIC_TEXT_AD add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `DynamicTextAd` |
-| `ads.add` | `DynamicTextAd.SitelinkSetId` | DYNAMIC_TEXT_AD add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `DynamicTextAd` |
-| `ads.add` | `DynamicTextAd.AdExtensionIds` | DYNAMIC_TEXT_AD add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `DynamicTextAd` |
-| `ads.add` | `DynamicTextAd.Text` | DYNAMIC_TEXT_AD add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `DynamicTextAd` |
-| `ads.add` | `MobileAppAd.Features` | Mobile app ad add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `MobileAppAd` |
-| `ads.add` | `MobileAppAd.Features.Feature` | Mobile app ad add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `MobileAppAd` |
-| `ads.add` | `MobileAppAd.Features.Enabled` | Mobile app ad add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `MobileAppAd` |
-| `ads.add` | `MobileAppAd.VideoExtension` | Mobile app ad add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `MobileAppAd` |
-| `ads.add` | `MobileAppAd.VideoExtension.CreativeId` | Mobile app ad add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `MobileAppAd` |
-| `ads.add` | `MobileAppAd.ErirAdDescription` | Mobile app ad add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `MobileAppAd` |
 | `ads.add` | `TextImageAd.ErirAdDescription` | ads.add residual optional WSDL path needs typed support or N/A. [#278](https://github.com/axisrow/direct-cli/issues/278) |
 | `ads.add` | `TextImageAd.FinalUrl` | ads.add residual optional WSDL path needs typed support or N/A. [#278](https://github.com/axisrow/direct-cli/issues/278) |
-| `ads.add` | `MobileAppImageAd` | Mobile app image ad add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277) |
-| `ads.add` | `MobileAppImageAd.AdImageHash` | Mobile app image ad add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `MobileAppImageAd` |
-| `ads.add` | `MobileAppImageAd.ErirAdDescription` | Mobile app image ad add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `MobileAppImageAd` |
-| `ads.add` | `MobileAppImageAd.TrackingUrl` | Mobile app image ad add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `MobileAppImageAd` |
 | `ads.add` | `SmartAdBuilderAd` | SMART_AD_BUILDER_AD add fields need typed support or N/A. [#278](https://github.com/axisrow/direct-cli/issues/278) |
 | `ads.add` | `SmartAdBuilderAd.LogoExtensionHash` | SMART_AD_BUILDER_AD add fields need typed support or N/A. [#278](https://github.com/axisrow/direct-cli/issues/278); inherited from `SmartAdBuilderAd` |
 | `campaigns.add` | `ClientInfo` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
@@ -2614,35 +2598,35 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `ads.add` | `ads.add` | `ResponsiveAd.PriceExtension.PriceCurrency` | `PriceCurrencyEnum` | 1 | 1 | `supported` | --price-extension-price-currency |
 | `ads.add` | `ads.add` | `ResponsiveAd.BusinessId` | `long` | 0 | 1 | `supported` | --business-id |
 | `ads.add` | `ads.add` | `ResponsiveAd.ErirAdDescription` | `string` | 0 | 1 | `supported` | --erir-ad-description |
-| `ads.add` | `ads.add` | `DynamicTextAd` | `DynamicTextAdAdd` | 0 | 1 | `missing_followup` | DYNAMIC_TEXT_AD add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277) |
-| `ads.add` | `ads.add` | `DynamicTextAd.VCardId` | `long` | 0 | 1 | `missing_followup` | DYNAMIC_TEXT_AD add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `DynamicTextAd` |
-| `ads.add` | `ads.add` | `DynamicTextAd.AdImageHash` | `string` | 0 | 1 | `missing_followup` | DYNAMIC_TEXT_AD add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `DynamicTextAd` |
-| `ads.add` | `ads.add` | `DynamicTextAd.SitelinkSetId` | `long` | 0 | 1 | `missing_followup` | DYNAMIC_TEXT_AD add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `DynamicTextAd` |
-| `ads.add` | `ads.add` | `DynamicTextAd.AdExtensionIds` | `long` | 0 | unbounded | `missing_followup` | DYNAMIC_TEXT_AD add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `DynamicTextAd` |
-| `ads.add` | `ads.add` | `DynamicTextAd.Text` | `string` | 1 | 1 | `missing_followup` | DYNAMIC_TEXT_AD add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `DynamicTextAd` |
+| `ads.add` | `ads.add` | `DynamicTextAd` | `DynamicTextAdAdd` | 0 | 1 | `supported` | --type |
+| `ads.add` | `ads.add` | `DynamicTextAd.VCardId` | `long` | 0 | 1 | `supported` | --vcard-id |
+| `ads.add` | `ads.add` | `DynamicTextAd.AdImageHash` | `string` | 0 | 1 | `supported` | --image-hash |
+| `ads.add` | `ads.add` | `DynamicTextAd.SitelinkSetId` | `long` | 0 | 1 | `supported` | --sitelink-set-id |
+| `ads.add` | `ads.add` | `DynamicTextAd.AdExtensionIds` | `long` | 0 | unbounded | `supported` | --ad-extensions |
+| `ads.add` | `ads.add` | `DynamicTextAd.Text` | `string` | 1 | 1 | `supported` | --text |
 | `ads.add` | `ads.add` | `MobileAppAd` | `MobileAppAdAdd` | 0 | 1 | `supported` | --type |
 | `ads.add` | `ads.add` | `MobileAppAd.AdImageHash` | `string` | 0 | 1 | `supported` | --image-hash |
 | `ads.add` | `ads.add` | `MobileAppAd.Text` | `string` | 1 | 1 | `supported` | --text |
 | `ads.add` | `ads.add` | `MobileAppAd.Title` | `string` | 1 | 1 | `supported` | --title |
 | `ads.add` | `ads.add` | `MobileAppAd.TrackingUrl` | `string` | 0 | 1 | `supported` | --tracking-url |
 | `ads.add` | `ads.add` | `MobileAppAd.Action` | `MobileAppAdActionEnum` | 1 | 1 | `supported` | --action |
-| `ads.add` | `ads.add` | `MobileAppAd.Features` | `MobileAppAdFeatureItem` | 0 | unbounded | `missing_followup` | Mobile app ad add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `MobileAppAd` |
-| `ads.add` | `ads.add` | `MobileAppAd.Features.Feature` | `MobileAppFeatureEnum` | 1 | 1 | `missing_followup` | Mobile app ad add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `MobileAppAd` |
-| `ads.add` | `ads.add` | `MobileAppAd.Features.Enabled` | `YesNoEnum` | 1 | 1 | `missing_followup` | Mobile app ad add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `MobileAppAd` |
+| `ads.add` | `ads.add` | `MobileAppAd.Features` | `MobileAppAdFeatureItem` | 0 | unbounded | `supported` | --mobile-app-feature |
+| `ads.add` | `ads.add` | `MobileAppAd.Features.Feature` | `MobileAppFeatureEnum` | 1 | 1 | `supported` | --mobile-app-feature |
+| `ads.add` | `ads.add` | `MobileAppAd.Features.Enabled` | `YesNoEnum` | 1 | 1 | `supported` | --mobile-app-feature |
 | `ads.add` | `ads.add` | `MobileAppAd.AgeLabel` | `MobAppAgeLabelEnum` | 0 | 1 | `supported` | --age-label |
-| `ads.add` | `ads.add` | `MobileAppAd.VideoExtension` | `VideoExtensionAddItem` | 0 | 1 | `missing_followup` | Mobile app ad add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `MobileAppAd` |
-| `ads.add` | `ads.add` | `MobileAppAd.VideoExtension.CreativeId` | `long` | 0 | 1 | `missing_followup` | Mobile app ad add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `MobileAppAd` |
-| `ads.add` | `ads.add` | `MobileAppAd.ErirAdDescription` | `string` | 0 | 1 | `missing_followup` | Mobile app ad add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `MobileAppAd` |
+| `ads.add` | `ads.add` | `MobileAppAd.VideoExtension` | `VideoExtensionAddItem` | 0 | 1 | `supported` | --video-extension-creative-id |
+| `ads.add` | `ads.add` | `MobileAppAd.VideoExtension.CreativeId` | `long` | 0 | 1 | `supported` | --video-extension-creative-id |
+| `ads.add` | `ads.add` | `MobileAppAd.ErirAdDescription` | `string` | 0 | 1 | `supported` | --erir-ad-description |
 | `ads.add` | `ads.add` | `TextImageAd` | `TextImageAdAdd` | 0 | 1 | `supported` | --type |
 | `ads.add` | `ads.add` | `TextImageAd.AdImageHash` | `string` | 1 | 1 | `supported` | --image-hash |
 | `ads.add` | `ads.add` | `TextImageAd.ErirAdDescription` | `string` | 0 | 1 | `missing_followup` | ads.add residual optional WSDL path needs typed support or N/A. [#278](https://github.com/axisrow/direct-cli/issues/278) |
 | `ads.add` | `ads.add` | `TextImageAd.FinalUrl` | `string` | 0 | 1 | `missing_followup` | ads.add residual optional WSDL path needs typed support or N/A. [#278](https://github.com/axisrow/direct-cli/issues/278) |
 | `ads.add` | `ads.add` | `TextImageAd.Href` | `string` | 0 | 1 | `supported` | --href |
 | `ads.add` | `ads.add` | `TextImageAd.TurboPageId` | `long` | 0 | 1 | `supported` | --turbo-page-id |
-| `ads.add` | `ads.add` | `MobileAppImageAd` | `MobileAppImageAdAdd` | 0 | 1 | `missing_followup` | Mobile app image ad add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277) |
-| `ads.add` | `ads.add` | `MobileAppImageAd.AdImageHash` | `string` | 1 | 1 | `missing_followup` | Mobile app image ad add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `MobileAppImageAd` |
-| `ads.add` | `ads.add` | `MobileAppImageAd.ErirAdDescription` | `string` | 0 | 1 | `missing_followup` | Mobile app image ad add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `MobileAppImageAd` |
-| `ads.add` | `ads.add` | `MobileAppImageAd.TrackingUrl` | `string` | 0 | 1 | `missing_followup` | Mobile app image ad add fields need typed support or N/A. [#277](https://github.com/axisrow/direct-cli/issues/277); inherited from `MobileAppImageAd` |
+| `ads.add` | `ads.add` | `MobileAppImageAd` | `MobileAppImageAdAdd` | 0 | 1 | `supported` | --type |
+| `ads.add` | `ads.add` | `MobileAppImageAd.AdImageHash` | `string` | 1 | 1 | `supported` | --image-hash |
+| `ads.add` | `ads.add` | `MobileAppImageAd.ErirAdDescription` | `string` | 0 | 1 | `supported` | --erir-ad-description |
+| `ads.add` | `ads.add` | `MobileAppImageAd.TrackingUrl` | `string` | 0 | 1 | `supported` | --tracking-url |
 | `ads.add` | `ads.add` | `TextAdBuilderAd` | `TextAdBuilderAdAdd` | 0 | 1 | `supported` | --type |
 | `ads.add` | `ads.add` | `TextAdBuilderAd.Creative` | `AdBuilderAdAddItem` | 1 | 1 | `supported` | --creative-id |
 | `ads.add` | `ads.add` | `TextAdBuilderAd.Creative.CreativeId` | `long` | 1 | 1 | `supported` | --creative-id |

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -266,9 +266,19 @@ class TestCLI(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         collapsed = " ".join(result.output.split())
         self.assertIn(
-            "Ad type: TEXT_AD | TEXT_IMAGE_AD | MOBILE_APP_AD | RESPONSIVE_AD | "
-            "SHOPPING_AD | LISTING_AD | TEXT_AD_BUILDER_AD",
+            "Ad type: TEXT_AD | TEXT_IMAGE_AD | MOBILE_APP_AD | DYNAMIC_TEXT_AD | "
+            "MOBILE_APP_IMAGE_AD | RESPONSIVE_AD | SHOPPING_AD | LISTING_AD | "
+            "TEXT_AD_BUILDER_AD",
             collapsed,
+        )
+        self.assertIn("Ad text (TEXT_AD / MOBILE_APP_AD / DYNAMIC_TEXT_AD)", collapsed)
+        self.assertIn(
+            "Ad image hash (TEXT_IMAGE_AD / MOBILE_APP_AD / DYNAMIC_TEXT_AD / "
+            "MOBILE_APP_IMAGE_AD)",
+            collapsed,
+        )
+        self.assertIn(
+            "Repeatable MobileAppAd.Features item as FEATURE=YES|NO", collapsed
         )
         self.assertIn("Comma-separated ResponsiveAd.Titles values", collapsed)
         self.assertIn("Comma-separated ResponsiveAd.Texts values", collapsed)
@@ -277,7 +287,10 @@ class TestCLI(unittest.TestCase):
             "Comma-separated ResponsiveAd.VideoExtensionIds values", collapsed
         )
         self.assertIn("FinalUrl (TEXT_AD / TEXT_AD_BUILDER_AD)", collapsed)
-        self.assertIn("TextAd.VideoExtension.CreativeId (TEXT_AD)", collapsed)
+        self.assertIn(
+            "TextAd/MobileAppAd.VideoExtension.CreativeId (TEXT_AD / MOBILE_APP_AD)",
+            collapsed,
+        )
         self.assertIn(
             "TextAd/ResponsiveAd.PriceExtension.Price as human-readable money",
             collapsed,
@@ -291,7 +304,8 @@ class TestCLI(unittest.TestCase):
         )
         self.assertIn("TextAd.PreferVCardOverBusiness value: YES or NO", collapsed)
         self.assertIn(
-            "ErirAdDescription (TEXT_AD / RESPONSIVE_AD / AdBuilder add subtypes)",
+            "ErirAdDescription (TEXT_AD / MOBILE_APP_AD / MOBILE_APP_IMAGE_AD / "
+            "RESPONSIVE_AD / AdBuilder add subtypes)",
             collapsed,
         )
         self.assertIn(

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1094,6 +1094,194 @@ def test_ads_add_text_image_ad_default_mobile_does_not_leak():
     assert "Mobile" not in ad["TextImageAd"]
 
 
+def test_ads_add_dynamic_text_ad_payload():
+    """Issue #277: DYNAMIC_TEXT_AD add builds DynamicTextAdAdd fields."""
+    body = _dry_run(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "12345",
+        "--type",
+        "DYNAMIC_TEXT_AD",
+        "--text",
+        "Dynamic ad text",
+        "--image-hash",
+        "abcdefghij",
+        "--vcard-id",
+        "0",
+        "--sitelink-set-id",
+        "0",
+        "--ad-extensions",
+        "333,444",
+    )
+    assert body["params"]["Ads"][0] == {
+        "AdGroupId": 12345,
+        "DynamicTextAd": {
+            "Text": "Dynamic ad text",
+            "AdImageHash": "abcdefghij",
+            "VCardId": 0,
+            "SitelinkSetId": 0,
+            "AdExtensionIds": [333, 444],
+        },
+    }
+
+
+def test_ads_add_dynamic_text_ad_requires_text():
+    """Issue #277: DynamicTextAdAdd.Text is required by the WSDL."""
+    result = _rejected(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "12345",
+        "--type",
+        "DYNAMIC_TEXT_AD",
+    )
+    assert "DYNAMIC_TEXT_AD requires --text" in result.output
+
+
+def test_ads_add_dynamic_text_ad_rejects_other_subtype_flags():
+    """Issue #277: DYNAMIC_TEXT_AD add must not silently drop other flags."""
+    result = _rejected(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "12345",
+        "--type",
+        "DYNAMIC_TEXT_AD",
+        "--text",
+        "Dynamic ad text",
+        "--href",
+        "https://example.com",
+    )
+    assert "--href is not compatible with --type DYNAMIC_TEXT_AD" in result.output
+
+
+def test_ads_add_mobile_app_ad_optional_fields_payload():
+    """Issue #277: MOBILE_APP_AD add supports compact optional app fields."""
+    body = _dry_run(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "12345",
+        "--type",
+        "MOBILE_APP_AD",
+        "--title",
+        "Install app",
+        "--text",
+        "App promo text",
+        "--action",
+        "download",
+        "--image-hash",
+        "abcdefghij",
+        "--tracking-url",
+        "https://track.example.com",
+        "--age-label",
+        "age_18",
+        "--mobile-app-feature",
+        "PRICE=YES",
+        "--mobile-app-feature",
+        "CUSTOMER_RATING=NO",
+        "--video-extension-creative-id",
+        "0",
+        "--erir-ad-description",
+        "Mobile app object",
+    )
+    assert body["params"]["Ads"][0] == {
+        "AdGroupId": 12345,
+        "MobileAppAd": {
+            "Title": "Install app",
+            "Text": "App promo text",
+            "Action": "DOWNLOAD",
+            "AdImageHash": "abcdefghij",
+            "TrackingUrl": "https://track.example.com",
+            "AgeLabel": "AGE_18",
+            "Features": [
+                {"Feature": "PRICE", "Enabled": "YES"},
+                {"Feature": "CUSTOMER_RATING", "Enabled": "NO"},
+            ],
+            "VideoExtension": {"CreativeId": 0},
+            "ErirAdDescription": "Mobile app object",
+        },
+    }
+
+
+def test_ads_add_mobile_app_ad_feature_validation():
+    """Issue #277: MobileAppAd.Features keeps the typed FEATURE=YES|NO grammar."""
+    result = _rejected(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "12345",
+        "--type",
+        "MOBILE_APP_AD",
+        "--title",
+        "Install app",
+        "--text",
+        "App promo text",
+        "--action",
+        "INSTALL",
+        "--mobile-app-feature",
+        "PRICE=MAYBE",
+    )
+    assert "Invalid --mobile-app-feature value" in result.output
+
+
+def test_ads_add_mobile_app_image_ad_payload():
+    """Issue #277: MOBILE_APP_IMAGE_AD add builds MobileAppImageAdAdd."""
+    body = _dry_run(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "12345",
+        "--type",
+        "MOBILE_APP_IMAGE_AD",
+        "--image-hash",
+        "abcdefghij",
+        "--tracking-url",
+        "https://track.example.com",
+        "--erir-ad-description",
+        "Mobile image object",
+    )
+    assert body["params"]["Ads"][0] == {
+        "AdGroupId": 12345,
+        "MobileAppImageAd": {
+            "AdImageHash": "abcdefghij",
+            "TrackingUrl": "https://track.example.com",
+            "ErirAdDescription": "Mobile image object",
+        },
+    }
+
+
+def test_ads_add_mobile_app_image_ad_requires_image_hash():
+    """Issue #277: MobileAppImageAdAdd.AdImageHash is required by the WSDL."""
+    result = _rejected(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "12345",
+        "--type",
+        "MOBILE_APP_IMAGE_AD",
+    )
+    assert "MOBILE_APP_IMAGE_AD requires --image-hash" in result.output
+
+
+def test_ads_add_mobile_app_image_ad_rejects_other_subtype_flags():
+    """Issue #277: MOBILE_APP_IMAGE_AD add must reject unrelated typed flags."""
+    result = _rejected(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "12345",
+        "--type",
+        "MOBILE_APP_IMAGE_AD",
+        "--image-hash",
+        "abcdefghij",
+        "--title",
+        "Install app",
+    )
+    assert "--title is not compatible with --type MOBILE_APP_IMAGE_AD" in result.output
+
+
 def test_ads_add_responsive_ad_payload():
     """Issue #274: RESPONSIVE_AD add builds the documented ResponsiveAd block."""
     body = _dry_run(

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -942,13 +942,31 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     ("ads", "add", "TextAd.BusinessId"): {"--business-id"},
     ("ads", "add", "TextAd.PreferVCardOverBusiness"): {"--prefer-vcard-over-business"},
     ("ads", "add", "TextAd.ErirAdDescription"): {"--erir-ad-description"},
+    ("ads", "add", "DynamicTextAd"): {"--type"},
+    ("ads", "add", "DynamicTextAd.VCardId"): {"--vcard-id"},
+    ("ads", "add", "DynamicTextAd.AdImageHash"): {"--image-hash"},
+    ("ads", "add", "DynamicTextAd.SitelinkSetId"): {"--sitelink-set-id"},
+    ("ads", "add", "DynamicTextAd.AdExtensionIds"): {"--ad-extensions"},
+    ("ads", "add", "DynamicTextAd.Text"): {"--text"},
     ("ads", "add", "MobileAppAd"): {"--type"},
     ("ads", "add", "MobileAppAd.AdImageHash"): {"--image-hash"},
     ("ads", "add", "MobileAppAd.Text"): {"--text"},
     ("ads", "add", "MobileAppAd.Title"): {"--title"},
     ("ads", "add", "MobileAppAd.TrackingUrl"): {"--tracking-url"},
     ("ads", "add", "MobileAppAd.Action"): {"--action"},
+    ("ads", "add", "MobileAppAd.Features"): {"--mobile-app-feature"},
+    ("ads", "add", "MobileAppAd.Features.Feature"): {"--mobile-app-feature"},
+    ("ads", "add", "MobileAppAd.Features.Enabled"): {"--mobile-app-feature"},
     ("ads", "add", "MobileAppAd.AgeLabel"): {"--age-label"},
+    ("ads", "add", "MobileAppAd.VideoExtension"): {"--video-extension-creative-id"},
+    ("ads", "add", "MobileAppAd.VideoExtension.CreativeId"): {
+        "--video-extension-creative-id"
+    },
+    ("ads", "add", "MobileAppAd.ErirAdDescription"): {"--erir-ad-description"},
+    ("ads", "add", "MobileAppImageAd"): {"--type"},
+    ("ads", "add", "MobileAppImageAd.AdImageHash"): {"--image-hash"},
+    ("ads", "add", "MobileAppImageAd.ErirAdDescription"): {"--erir-ad-description"},
+    ("ads", "add", "MobileAppImageAd.TrackingUrl"): {"--tracking-url"},
     ("ads", "add", "TextImageAd"): {"--type"},
     ("ads", "add", "TextImageAd.AdImageHash"): {"--image-hash"},
     ("ads", "add", "TextImageAd.Href"): {"--href"},
@@ -1965,21 +1983,6 @@ OPTIONAL_FIELD_DEFAULT_FOLLOWUPS: dict[tuple[str, str], dict[str, str]] = {
 }
 
 OPTIONAL_FIELD_CHILD_PREFIX_FOLLOWUPS: dict[tuple[str, str, str], dict[str, str]] = {
-    ("ads", "add", "DynamicTextAd"): {
-        "status": "missing_followup",
-        "issue": "#277",
-        "note": "DYNAMIC_TEXT_AD add fields need typed support or N/A.",
-    },
-    ("ads", "add", "MobileAppAd"): {
-        "status": "missing_followup",
-        "issue": "#277",
-        "note": "Mobile app ad add fields need typed support or N/A.",
-    },
-    ("ads", "add", "MobileAppImageAd"): {
-        "status": "missing_followup",
-        "issue": "#277",
-        "note": "Mobile app image ad add fields need typed support or N/A.",
-    },
     ("ads", "add", "SmartAdBuilderAd"): {
         "status": "missing_followup",
         "issue": "#278",


### PR DESCRIPTION
## Summary
- add ads add support for DYNAMIC_TEXT_AD and MOBILE_APP_IMAGE_AD
- extend MOBILE_APP_AD add with Features, VideoExtension, and ErirAdDescription typed flags
- move #277 WSDL audit rows from missing_followup to supported and update README/help/tests

## Verification
- python3 -m pytest tests/test_dry_run.py -k "ads_add and (dynamic_text or mobile_app)"
- python3 -m pytest tests/test_cli.py -k ads_add_help
- python3 scripts/build_wsdl_optional_field_audit.py --check
- python3 -m pytest tests/test_wsdl_parity_gate.py
- python3 -m pytest tests/test_cli_contract.py -k "json or readme_direct_examples"
- python3 -m pytest tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py
- mypy .
- git diff --check

Closes #277