### PR TITLE
Add SmartAdBuilder ads add cleanup flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,10 +413,11 @@ direct ads add --adgroup-id 12345 --type LISTING_AD --feed-id 171 --default-text
 direct ads add --adgroup-id 12345 --type TEXT_AD_BUILDER_AD --creative-id 123 --href "https://example.com" --turbo-page-id 456 --erir-ad-description "Builder ad object" --dry-run
 direct ads add --adgroup-id 12345 --type MOBILE_APP_AD_BUILDER_AD --creative-id 123 --tracking-url "https://track.example.com" --erir-ad-description "Mobile builder ad" --dry-run
 direct ads add --adgroup-id 12345 --type CPM_BANNER_AD_BUILDER_AD --creative-id 123 --href "https://example.com" --tracking-pixels "https://pixel.example.com/a,https://pixel.example.com/b" --dry-run
-direct ads add --adgroup-id 12345 --type TEXT_IMAGE_AD --image-hash abcdefghijklmnopqrst --href "https://example.com" --turbo-page-id 555 --dry-run
+direct ads add --adgroup-id 12345 --type TEXT_IMAGE_AD --image-hash abcdefghijklmnopqrst --href "https://example.com" --turbo-page-id 555 --final-url "https://final.example.com" --erir-ad-description "Image ad object" --dry-run
 direct ads add --adgroup-id 12345 --type DYNAMIC_TEXT_AD --text "Dynamic ad text" --image-hash abcdefghijklmnopqrst --vcard-id 111 --sitelink-set-id 222 --ad-extensions "333,444" --dry-run
 direct ads add --adgroup-id 12345 --type MOBILE_APP_AD --title "Install app" --text "App promo text" --action INSTALL --tracking-url "https://track.example.com" --mobile-app-feature PRICE=YES --video-extension-creative-id 777 --erir-ad-description "Mobile app object" --dry-run
 direct ads add --adgroup-id 12345 --type MOBILE_APP_IMAGE_AD --image-hash abcdefghijklmnopqrst --tracking-url "https://track.example.com" --erir-ad-description "Mobile image ad" --dry-run
+direct ads add --adgroup-id 12345 --type SMART_AD_BUILDER_AD --logo-extension-hash logoabcdefghijklmnop --dry-run
 direct ads update --id 99999 --type TEXT_AD --title "New Title" --text "New text" --href "https://example.com"
 direct ads update --id 99999 --type TEXT_AD --image-hash abcdefghijklmnopqrst
 direct ads update --id 99999 --type TEXT_AD --title2 "New second headline" --vcard-id 222
@@ -468,11 +469,12 @@ SHOPPING_AD and LISTING_AD `ads add` require `--feed-id` and one
 `--default-texts` value. Optional creation flags include `--sitelink-set-id`,
 `--ad-extensions`, `--business-id`, repeatable `--feed-filter-condition`
 (`OPERAND:OPERATOR:ARG1|ARG2`), `--title-sources`, and `--text-sources`.
-AdBuilder add subtypes require `--creative-id`. TEXT_AD_BUILDER_AD,
+Non-SMART AdBuilder add subtypes require `--creative-id`. TEXT_AD_BUILDER_AD,
 CPC_VIDEO_AD_BUILDER_AD, CPM_BANNER_AD_BUILDER_AD, and
 CPM_VIDEO_AD_BUILDER_AD require `--href`, `--turbo-page-id`, or both. Mobile app
 builder subtypes use `--tracking-url`. CPM builder subtypes also support
-`--tracking-pixels`; all AdBuilder add subtypes support `--erir-ad-description`.
+`--tracking-pixels`; non-SMART AdBuilder add subtypes support
+`--erir-ad-description`.
 MOBILE_APP_AD add requires `--title`, `--text`, and `--action`; optional add
 fields include `--mobile-app-feature FEATURE=YES|NO`,
 `--video-extension-creative-id`, and `--erir-ad-description`. MOBILE_APP_IMAGE_AD
@@ -488,6 +490,7 @@ SHOPPING_AD and LISTING_AD update support `--sitelink-set-id`,
 `--default-texts`.
 MOBILE_APP_IMAGE_AD update supports `--image-hash`, `--tracking-url`, and
 `--erir-ad-description`.
+SMART_AD_BUILDER_AD add supports `--logo-extension-hash`.
 AdBuilder update subtypes support `--creative-id`, `--creative-erir-ad-description`,
 `--erir-ad-description`, and subtype-specific `--final-url`, `--href`,
 `--turbo-page-id`, `--tracking-url`, and `--tracking-pixels`. SMART_AD_BUILDER_AD
@@ -1205,10 +1208,11 @@ direct ads add --adgroup-id 12345 --type LISTING_AD --feed-id 171 --default-text
 direct ads add --adgroup-id 12345 --type TEXT_AD_BUILDER_AD --creative-id 123 --href "https://example.com" --turbo-page-id 456 --erir-ad-description "Объект объявления из конструктора" --dry-run
 direct ads add --adgroup-id 12345 --type MOBILE_APP_AD_BUILDER_AD --creative-id 123 --tracking-url "https://track.example.com" --erir-ad-description "Мобильное объявление из конструктора" --dry-run
 direct ads add --adgroup-id 12345 --type CPM_BANNER_AD_BUILDER_AD --creative-id 123 --href "https://example.com" --tracking-pixels "https://pixel.example.com/a,https://pixel.example.com/b" --dry-run
-direct ads add --adgroup-id 12345 --type TEXT_IMAGE_AD --image-hash abcdefghijklmnopqrst --href "https://example.com" --turbo-page-id 555 --dry-run
+direct ads add --adgroup-id 12345 --type TEXT_IMAGE_AD --image-hash abcdefghijklmnopqrst --href "https://example.com" --turbo-page-id 555 --final-url "https://final.example.com" --erir-ad-description "Объект графического объявления" --dry-run
 direct ads add --adgroup-id 12345 --type DYNAMIC_TEXT_AD --text "Динамический текст" --image-hash abcdefghijklmnopqrst --vcard-id 111 --sitelink-set-id 222 --ad-extensions "333,444" --dry-run
 direct ads add --adgroup-id 12345 --type MOBILE_APP_AD --title "Установите приложение" --text "Текст приложения" --action INSTALL --tracking-url "https://track.example.com" --mobile-app-feature PRICE=YES --video-extension-creative-id 777 --erir-ad-description "Объект мобильного объявления" --dry-run
 direct ads add --adgroup-id 12345 --type MOBILE_APP_IMAGE_AD --image-hash abcdefghijklmnopqrst --tracking-url "https://track.example.com" --erir-ad-description "Мобильное графическое объявление" --dry-run
+direct ads add --adgroup-id 12345 --type SMART_AD_BUILDER_AD --logo-extension-hash logoabcdefghijklmnop --dry-run
 direct ads update --id 99999 --type TEXT_AD --title "Новый заголовок" --text "Новый текст" --href "https://example.com"
 direct ads update --id 99999 --type TEXT_AD --image-hash abcdefghijklmnopqrst
 direct ads update --id 99999 --type TEXT_AD --title2 "Новый второй заголовок" --vcard-id 222
@@ -1262,12 +1266,12 @@ DYNAMIC_TEXT_AD в `ads add` обязателен `--text`; доступны `--
 `--sitelink-set-id`, `--ad-extensions`, `--business-id`, повторяемый
 `--feed-filter-condition` (`OPERAND:OPERATOR:ARG1|ARG2`), `--title-sources` и
 `--text-sources`.
-Для AdBuilder subtype в `ads add` обязателен `--creative-id`.
+Для non-SMART AdBuilder subtype в `ads add` обязателен `--creative-id`.
 TEXT_AD_BUILDER_AD, CPC_VIDEO_AD_BUILDER_AD, CPM_BANNER_AD_BUILDER_AD и
 CPM_VIDEO_AD_BUILDER_AD требуют `--href`, `--turbo-page-id` или оба флага.
 Mobile app builder subtype используют `--tracking-url`. CPM builder subtype
-также поддерживают `--tracking-pixels`; все AdBuilder subtype в `ads add`
-поддерживают `--erir-ad-description`.
+также поддерживают `--tracking-pixels`; non-SMART AdBuilder subtype в
+`ads add` поддерживают `--erir-ad-description`.
 Для MOBILE_APP_AD в `ads add` обязательны `--title`, `--text` и `--action`;
 дополнительно доступны `--mobile-app-feature FEATURE=YES|NO`,
 `--video-extension-creative-id` и `--erir-ad-description`. Для
@@ -1283,6 +1287,7 @@ MOBILE_APP_IMAGE_AD в `ads add` обязателен `--image-hash`; в add/upd
 `--default-texts`.
 Для MOBILE_APP_IMAGE_AD в `ads update` доступны `--image-hash`,
 `--tracking-url` и `--erir-ad-description`.
+Для SMART_AD_BUILDER_AD в `ads add` доступен `--logo-extension-hash`.
 Для AdBuilder subtype в `ads update` доступны `--creative-id`,
 `--creative-erir-ad-description`, `--erir-ad-description` и subtype-specific
 `--final-url`, `--href`, `--turbo-page-id`, `--tracking-url`,

--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -74,6 +74,8 @@ MOBILE_APP_IMAGE_AD_ADD_FIELDS = {
     "erir_ad_description",
 }
 
+SMART_AD_BUILDER_ADD_FIELDS = {"logo_extension_hash"}
+
 
 TEXT_AD_UPDATE_FIELDS = {
     "title",
@@ -711,6 +713,18 @@ def _build_mobile_app_image_ad_add(
     return mobile_app_image_ad
 
 
+def _build_smart_ad_builder_ad_add(
+    logo_extension_hash: Optional[str],
+) -> dict[str, object]:
+    """Build SmartAdBuilderAdAdd payload from typed flags."""
+    smart_ad_builder_ad: dict[str, object] = {}
+
+    if logo_extension_hash:
+        smart_ad_builder_ad["LogoExtensionHash"] = logo_extension_hash
+
+    return smart_ad_builder_ad
+
+
 def _build_smart_ad_builder_ad_update(
     logo_extension_hash: Optional[str],
     erir_ad_description: Optional[str],
@@ -876,7 +890,7 @@ def get(
     help=(
         "Ad type: TEXT_AD | TEXT_IMAGE_AD | MOBILE_APP_AD | DYNAMIC_TEXT_AD | "
         "MOBILE_APP_IMAGE_AD | RESPONSIVE_AD | SHOPPING_AD | LISTING_AD | "
-        "TEXT_AD_BUILDER_AD | "
+        "SMART_AD_BUILDER_AD | TEXT_AD_BUILDER_AD | "
         "MOBILE_APP_AD_BUILDER_AD | MOBILE_APP_CPC_VIDEO_AD_BUILDER_AD | "
         "CPC_VIDEO_AD_BUILDER_AD | CPM_BANNER_AD_BUILDER_AD | "
         "CPM_VIDEO_AD_BUILDER_AD"
@@ -962,7 +976,10 @@ def get(
         "(TEXT_AD / DYNAMIC_TEXT_AD / RESPONSIVE_AD / SHOPPING_AD / LISTING_AD)"
     ),
 )
-@click.option("--final-url", help="FinalUrl (TEXT_AD / TEXT_AD_BUILDER_AD)")
+@click.option(
+    "--final-url",
+    help="FinalUrl (TEXT_AD / TEXT_IMAGE_AD / TEXT_AD_BUILDER_AD)",
+)
 @click.option(
     "--video-extension-creative-id",
     type=int,
@@ -1020,18 +1037,22 @@ def get(
 @click.option(
     "--erir-ad-description",
     help=(
-        "ErirAdDescription (TEXT_AD / MOBILE_APP_AD / MOBILE_APP_IMAGE_AD / "
-        "RESPONSIVE_AD / AdBuilder add subtypes)"
+        "ErirAdDescription (TEXT_AD / TEXT_IMAGE_AD / MOBILE_APP_AD / "
+        "MOBILE_APP_IMAGE_AD / RESPONSIVE_AD / non-SMART AdBuilder add subtypes)"
     ),
 )
 @click.option(
     "--creative-id",
     type=int,
-    help="AdBuilder Creative.CreativeId for AdBuilder add subtypes",
+    help="AdBuilder Creative.CreativeId for non-SMART AdBuilder add subtypes",
 )
 @click.option(
     "--tracking-pixels",
     help="Comma-separated AdBuilder TrackingPixels.Items values",
+)
+@click.option(
+    "--logo-extension-hash",
+    help="SmartAdBuilderAd.LogoExtensionHash (SMART_AD_BUILDER_AD)",
 )
 @click.option(
     "--feed-id",
@@ -1095,6 +1116,7 @@ def add(
     erir_ad_description,
     creative_id,
     tracking_pixels,
+    logo_extension_hash,
     feed_id,
     feed_filter_conditions,
     title_sources,
@@ -1114,6 +1136,7 @@ def add(
             "RESPONSIVE_AD",
             "SHOPPING_AD",
             "LISTING_AD",
+            "SMART_AD_BUILDER_AD",
             *AD_BUILDER_ADD_BLOCKS,
         }
         if ad_type_norm not in supported_types:
@@ -1122,7 +1145,8 @@ def add(
                 f"{ad_type!r} is not one of "
                 "'TEXT_AD', 'TEXT_IMAGE_AD', 'MOBILE_APP_AD', 'DYNAMIC_TEXT_AD', "
                 "'MOBILE_APP_IMAGE_AD', 'RESPONSIVE_AD', 'SHOPPING_AD', 'LISTING_AD', "
-                "'TEXT_AD_BUILDER_AD', 'MOBILE_APP_AD_BUILDER_AD', "
+                "'SMART_AD_BUILDER_AD', 'TEXT_AD_BUILDER_AD', "
+                "'MOBILE_APP_AD_BUILDER_AD', "
                 "'MOBILE_APP_CPC_VIDEO_AD_BUILDER_AD', 'CPC_VIDEO_AD_BUILDER_AD', "
                 "'CPM_BANNER_AD_BUILDER_AD', 'CPM_VIDEO_AD_BUILDER_AD'."
             )
@@ -1162,7 +1186,13 @@ def add(
                 "prefer_vcard_over_business",
                 "erir_ad_description",
             },
-            "TEXT_IMAGE_AD": {"href", "image_hash", "turbo_page_id"},
+            "TEXT_IMAGE_AD": {
+                "href",
+                "image_hash",
+                "turbo_page_id",
+                "final_url",
+                "erir_ad_description",
+            },
             "RESPONSIVE_AD": {
                 "texts",
                 "titles",
@@ -1186,6 +1216,7 @@ def add(
             "DYNAMIC_TEXT_AD": DYNAMIC_TEXT_AD_ADD_FIELDS,
             "MOBILE_APP_AD": MOBILE_APP_AD_ADD_FIELDS,
             "MOBILE_APP_IMAGE_AD": MOBILE_APP_IMAGE_AD_ADD_FIELDS,
+            "SMART_AD_BUILDER_AD": SMART_AD_BUILDER_ADD_FIELDS,
         }
         provided = {
             "title": title,
@@ -1218,6 +1249,7 @@ def add(
             "erir_ad_description": erir_ad_description,
             "creative_id": creative_id,
             "tracking_pixels": tracking_pixels,
+            "logo_extension_hash": logo_extension_hash,
             "feed_id": feed_id,
             "feed_filter_conditions": feed_filter_conditions,
             "title_sources": title_sources,
@@ -1255,6 +1287,7 @@ def add(
             "erir_ad_description": "--erir-ad-description",
             "creative_id": "--creative-id",
             "tracking_pixels": "--tracking-pixels",
+            "logo_extension_hash": "--logo-extension-hash",
             "feed_id": "--feed-id",
             "feed_filter_conditions": "--feed-filter-condition",
             "title_sources": "--title-sources",
@@ -1329,17 +1362,23 @@ def add(
             if title or text:
                 raise click.UsageError(
                     "--title/--text are only valid for TEXT_AD. "
-                    "For TEXT_IMAGE_AD, use --image-hash and --href."
+                    "For TEXT_IMAGE_AD, use --image-hash and "
+                    "--href / --turbo-page-id."
                 )
-            if not image_hash or not href:
+            if not image_hash:
+                raise click.UsageError("TEXT_IMAGE_AD requires --image-hash")
+            if not href and turbo_page_id is None:
                 raise click.UsageError(
-                    "TEXT_IMAGE_AD requires both --image-hash and --href"
+                    "TEXT_IMAGE_AD requires either --href or --turbo-page-id."
                 )
-            text_image_ad = {
-                "AdImageHash": image_hash,
-                "Href": href,
-            }
-            if turbo_page_id:
+            text_image_ad = {"AdImageHash": image_hash}
+            if erir_ad_description:
+                text_image_ad["ErirAdDescription"] = erir_ad_description
+            if final_url:
+                text_image_ad["FinalUrl"] = final_url
+            if href:
+                text_image_ad["Href"] = href
+            if turbo_page_id is not None:
                 text_image_ad["TurboPageId"] = turbo_page_id
             ad_data["TextImageAd"] = text_image_ad
         elif ad_type_norm == "RESPONSIVE_AD":
@@ -1471,6 +1510,10 @@ def add(
                 image_hash,
                 erir_ad_description,
                 tracking_url,
+            )
+        elif ad_type_norm == "SMART_AD_BUILDER_AD":
+            ad_data["SmartAdBuilderAd"] = _build_smart_ad_builder_ad_add(
+                logo_extension_hash,
             )
 
         body = {"method": "add", "params": {"Ads": [ad_data]}}

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,9 +11,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 2394 |
+| `missing_followup` | 2390 |
 | `not_applicable` | 23 |
-| `supported` | 824 |
+| `supported` | 828 |
 
 ## Confirmed Follow-Ups
 
@@ -42,10 +42,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `adgroups.update` | `DynamicTextFeedAdGroup.AutotargetingSettings.BrandOptions.WithAdvertiserBrand` | Official adgroups.update docs for DynamicTextFeedAdGroupUpdate list AutotargetingCategories only. [#281](https://github.com/axisrow/direct-cli/issues/281); inherited from `DynamicTextFeedAdGroup.AutotargetingSettings` |
 | `adgroups.update` | `DynamicTextFeedAdGroup.AutotargetingSettings.BrandOptions.WithCompetitorsBrand` | Official adgroups.update docs for DynamicTextFeedAdGroupUpdate list AutotargetingCategories only. [#281](https://github.com/axisrow/direct-cli/issues/281); inherited from `DynamicTextFeedAdGroup.AutotargetingSettings` |
 | `adgroups.update` | `DynamicTextFeedAdGroup.FeedId` | Official adgroups.update docs for DynamicTextFeedAdGroupUpdate do not list FeedId. [#281](https://github.com/axisrow/direct-cli/issues/281) |
-| `ads.add` | `TextImageAd.ErirAdDescription` | ads.add residual optional WSDL path needs typed support or N/A. [#278](https://github.com/axisrow/direct-cli/issues/278) |
-| `ads.add` | `TextImageAd.FinalUrl` | ads.add residual optional WSDL path needs typed support or N/A. [#278](https://github.com/axisrow/direct-cli/issues/278) |
-| `ads.add` | `SmartAdBuilderAd` | SMART_AD_BUILDER_AD add fields need typed support or N/A. [#278](https://github.com/axisrow/direct-cli/issues/278) |
-| `ads.add` | `SmartAdBuilderAd.LogoExtensionHash` | SMART_AD_BUILDER_AD add fields need typed support or N/A. [#278](https://github.com/axisrow/direct-cli/issues/278); inherited from `SmartAdBuilderAd` |
 | `campaigns.add` | `ClientInfo` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
 | `campaigns.add` | `Notification` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
 | `campaigns.add` | `Notification.SmsSettings` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
@@ -2619,8 +2615,8 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `ads.add` | `ads.add` | `MobileAppAd.ErirAdDescription` | `string` | 0 | 1 | `supported` | --erir-ad-description |
 | `ads.add` | `ads.add` | `TextImageAd` | `TextImageAdAdd` | 0 | 1 | `supported` | --type |
 | `ads.add` | `ads.add` | `TextImageAd.AdImageHash` | `string` | 1 | 1 | `supported` | --image-hash |
-| `ads.add` | `ads.add` | `TextImageAd.ErirAdDescription` | `string` | 0 | 1 | `missing_followup` | ads.add residual optional WSDL path needs typed support or N/A. [#278](https://github.com/axisrow/direct-cli/issues/278) |
-| `ads.add` | `ads.add` | `TextImageAd.FinalUrl` | `string` | 0 | 1 | `missing_followup` | ads.add residual optional WSDL path needs typed support or N/A. [#278](https://github.com/axisrow/direct-cli/issues/278) |
+| `ads.add` | `ads.add` | `TextImageAd.ErirAdDescription` | `string` | 0 | 1 | `supported` | --erir-ad-description |
+| `ads.add` | `ads.add` | `TextImageAd.FinalUrl` | `string` | 0 | 1 | `supported` | --final-url |
 | `ads.add` | `ads.add` | `TextImageAd.Href` | `string` | 0 | 1 | `supported` | --href |
 | `ads.add` | `ads.add` | `TextImageAd.TurboPageId` | `long` | 0 | 1 | `supported` | --turbo-page-id |
 | `ads.add` | `ads.add` | `MobileAppImageAd` | `MobileAppImageAdAdd` | 0 | 1 | `supported` | --type |
@@ -2666,8 +2662,8 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `ads.add` | `ads.add` | `CpmVideoAdBuilderAd.TrackingPixels` | `ArrayOfString` | 0 | 1 | `supported` | --tracking-pixels |
 | `ads.add` | `ads.add` | `CpmVideoAdBuilderAd.TrackingPixels.Items` | `string` | 1 | unbounded | `supported` | --tracking-pixels |
 | `ads.add` | `ads.add` | `CpmVideoAdBuilderAd.TurboPageId` | `long` | 0 | 1 | `supported` | --turbo-page-id |
-| `ads.add` | `ads.add` | `SmartAdBuilderAd` | `SmartAdBuilderAdAdd` | 0 | 1 | `missing_followup` | SMART_AD_BUILDER_AD add fields need typed support or N/A. [#278](https://github.com/axisrow/direct-cli/issues/278) |
-| `ads.add` | `ads.add` | `SmartAdBuilderAd.LogoExtensionHash` | `string` | 0 | 1 | `missing_followup` | SMART_AD_BUILDER_AD add fields need typed support or N/A. [#278](https://github.com/axisrow/direct-cli/issues/278); inherited from `SmartAdBuilderAd` |
+| `ads.add` | `ads.add` | `SmartAdBuilderAd` | `SmartAdBuilderAdAdd` | 0 | 1 | `supported` | --type |
+| `ads.add` | `ads.add` | `SmartAdBuilderAd.LogoExtensionHash` | `string` | 0 | 1 | `supported` | --logo-extension-hash |
 | `ads.add` | `ads.add` | `ShoppingAd` | `ShoppingAdAdd` | 0 | 1 | `supported` | --type |
 | `ads.add` | `ads.add` | `ShoppingAd.SitelinkSetId` | `long` | 0 | 1 | `supported` | --sitelink-set-id |
 | `ads.add` | `ads.add` | `ShoppingAd.AdExtensionIds` | `long` | 0 | unbounded | `supported` | --ad-extensions |

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -268,7 +268,7 @@ class TestCLI(unittest.TestCase):
         self.assertIn(
             "Ad type: TEXT_AD | TEXT_IMAGE_AD | MOBILE_APP_AD | DYNAMIC_TEXT_AD | "
             "MOBILE_APP_IMAGE_AD | RESPONSIVE_AD | SHOPPING_AD | LISTING_AD | "
-            "TEXT_AD_BUILDER_AD",
+            "SMART_AD_BUILDER_AD | TEXT_AD_BUILDER_AD",
             collapsed,
         )
         self.assertIn("Ad text (TEXT_AD / MOBILE_APP_AD / DYNAMIC_TEXT_AD)", collapsed)
@@ -286,7 +286,9 @@ class TestCLI(unittest.TestCase):
         self.assertIn(
             "Comma-separated ResponsiveAd.VideoExtensionIds values", collapsed
         )
-        self.assertIn("FinalUrl (TEXT_AD / TEXT_AD_BUILDER_AD)", collapsed)
+        self.assertIn(
+            "FinalUrl (TEXT_AD / TEXT_IMAGE_AD / TEXT_AD_BUILDER_AD)", collapsed
+        )
         self.assertIn(
             "TextAd/MobileAppAd.VideoExtension.CreativeId (TEXT_AD / MOBILE_APP_AD)",
             collapsed,
@@ -304,12 +306,15 @@ class TestCLI(unittest.TestCase):
         )
         self.assertIn("TextAd.PreferVCardOverBusiness value: YES or NO", collapsed)
         self.assertIn(
-            "ErirAdDescription (TEXT_AD / MOBILE_APP_AD / MOBILE_APP_IMAGE_AD / "
-            "RESPONSIVE_AD / AdBuilder add subtypes)",
+            "ErirAdDescription (TEXT_AD / TEXT_IMAGE_AD / MOBILE_APP_AD / "
+            "MOBILE_APP_IMAGE_AD / RESPONSIVE_AD / non-SMART AdBuilder add subtypes)",
             collapsed,
         )
         self.assertIn(
-            "AdBuilder Creative.CreativeId for AdBuilder add subtypes",
+            "SmartAdBuilderAd.LogoExtensionHash (SMART_AD_BUILDER_AD)", collapsed
+        )
+        self.assertIn(
+            "AdBuilder Creative.CreativeId for non-SMART AdBuilder add subtypes",
             collapsed,
         )
         self.assertIn(

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -916,8 +916,8 @@ def test_ads_add_text_ad_optional_extension_flags_reject_other_subtypes():
         "abcdefghij",
         "--href",
         "https://example.com",
-        "--final-url",
-        "https://final.example.com",
+        "--prefer-vcard-over-business",
+        "YES",
     )
     mobile_app = _rejected(
         "ads",
@@ -935,8 +935,9 @@ def test_ads_add_text_ad_optional_extension_flags_reject_other_subtypes():
         "--price-extension-price",
         "123.45",
     )
-    assert "--final-url is not compatible with --type TEXT_IMAGE_AD" in (
-        text_image.output
+    assert (
+        "--prefer-vcard-over-business is not compatible with --type TEXT_IMAGE_AD"
+        in text_image.output
     )
     assert "--price-extension-price is not compatible with --type MOBILE_APP_AD" in (
         mobile_app.output
@@ -960,6 +961,62 @@ def test_ads_add_text_image_ad_with_turbo_page_id():
         "777",
     )
     assert body["params"]["Ads"][0]["TextImageAd"]["TurboPageId"] == 777
+
+
+def test_ads_add_text_image_ad_cleanup_fields_payload():
+    """Issue #278: TEXT_IMAGE_AD add supports residual optional fields."""
+    body = _dry_run(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "55",
+        "--type",
+        "TEXT_IMAGE_AD",
+        "--image-hash",
+        "abcdefghij",
+        "--turbo-page-id",
+        "0",
+        "--final-url",
+        "https://final.example.com",
+        "--erir-ad-description",
+        "Image ad object",
+    )
+    assert body["params"]["Ads"][0]["TextImageAd"] == {
+        "AdImageHash": "abcdefghij",
+        "ErirAdDescription": "Image ad object",
+        "FinalUrl": "https://final.example.com",
+        "TurboPageId": 0,
+    }
+
+
+def test_ads_add_text_image_ad_requires_image_hash():
+    """Issue #278: TextImageAdAdd.AdImageHash is required by the WSDL."""
+    result = _rejected(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "55",
+        "--type",
+        "TEXT_IMAGE_AD",
+        "--href",
+        "https://example.com",
+    )
+    assert "TEXT_IMAGE_AD requires --image-hash" in result.output
+
+
+def test_ads_add_text_image_ad_requires_href_or_turbo_page_id():
+    """Issue #278: TextImageAd add needs a destination flag."""
+    result = _rejected(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "55",
+        "--type",
+        "TEXT_IMAGE_AD",
+        "--image-hash",
+        "abcdefghij",
+    )
+    assert "TEXT_IMAGE_AD requires either --href or --turbo-page-id." in result.output
 
 
 def test_ads_add_rejects_title2_on_text_image_ad():
@@ -1817,6 +1874,44 @@ def test_ads_add_cpm_video_ad_builder_ad_payload():
             "TurboPageId": 0,
         },
     }
+
+
+def test_ads_add_smart_ad_builder_ad_payload():
+    """Issue #278: SMART_AD_BUILDER_AD add supports LogoExtensionHash."""
+    body = _dry_run(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "12345",
+        "--type",
+        "SMART_AD_BUILDER_AD",
+        "--logo-extension-hash",
+        "logoabcdefghijklmnop",
+    )
+    assert body["params"]["Ads"][0] == {
+        "AdGroupId": 12345,
+        "SmartAdBuilderAd": {
+            "LogoExtensionHash": "logoabcdefghijklmnop",
+        },
+    }
+
+
+def test_ads_add_smart_ad_builder_ad_rejects_erir_description():
+    """Issue #278: SmartAdBuilderAdAdd exposes LogoExtensionHash only."""
+    result = _rejected(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "12345",
+        "--type",
+        "SMART_AD_BUILDER_AD",
+        "--erir-ad-description",
+        "Smart builder ad",
+    )
+    assert (
+        "--erir-ad-description is not compatible with --type SMART_AD_BUILDER_AD"
+        in result.output
+    )
 
 
 def test_ads_add_ad_builder_requires_creative_id():

--- a/tests/test_low_coverage_payloads.py
+++ b/tests/test_low_coverage_payloads.py
@@ -919,9 +919,12 @@ def test_ads_add_rejects_incomplete_text_image_ad():
     )
 
     assert missing_hash.exit_code != 0
-    assert "TEXT_IMAGE_AD requires both --image-hash and --href" in missing_hash.output
+    assert "TEXT_IMAGE_AD requires --image-hash" in missing_hash.output
     assert missing_href.exit_code != 0
-    assert "TEXT_IMAGE_AD requires both --image-hash and --href" in missing_href.output
+    assert (
+        "TEXT_IMAGE_AD requires either --href or --turbo-page-id."
+        in missing_href.output
+    )
 
 
 def test_ads_update_text_ad_builds_textad_payload():

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -969,6 +969,8 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     ("ads", "add", "MobileAppImageAd.TrackingUrl"): {"--tracking-url"},
     ("ads", "add", "TextImageAd"): {"--type"},
     ("ads", "add", "TextImageAd.AdImageHash"): {"--image-hash"},
+    ("ads", "add", "TextImageAd.ErirAdDescription"): {"--erir-ad-description"},
+    ("ads", "add", "TextImageAd.FinalUrl"): {"--final-url"},
     ("ads", "add", "TextImageAd.Href"): {"--href"},
     ("ads", "add", "TextImageAd.TurboPageId"): {"--turbo-page-id"},
     ("ads", "add", "ResponsiveAd"): {"--type"},
@@ -1078,6 +1080,8 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     ("ads", "add", "CpmVideoAdBuilderAd.TrackingPixels"): {"--tracking-pixels"},
     ("ads", "add", "CpmVideoAdBuilderAd.TrackingPixels.Items"): {"--tracking-pixels"},
     ("ads", "add", "CpmVideoAdBuilderAd.TurboPageId"): {"--turbo-page-id"},
+    ("ads", "add", "SmartAdBuilderAd"): {"--type"},
+    ("ads", "add", "SmartAdBuilderAd.LogoExtensionHash"): {"--logo-extension-hash"},
     ("ads", "update", "TextAd"): {"--type"},
     ("ads", "update", "TextAd.VCardId"): {"--vcard-id"},
     ("ads", "update", "TextAd.AdImageHash"): {"--image-hash"},
@@ -1924,10 +1928,6 @@ OPTIONAL_FIELD_CLI_OPTIONS.update(
 )
 
 OPTIONAL_FIELD_DEFAULT_FOLLOWUPS: dict[tuple[str, str], dict[str, str]] = {
-    ("ads", "add"): {
-        "issue": "#278",
-        "note": "ads.add residual optional WSDL path needs typed support or N/A.",
-    },
     ("ads", "update"): {
         "issue": "#272",
         "note": "ads.update residual optional WSDL path needs typed support or N/A.",
@@ -1983,11 +1983,6 @@ OPTIONAL_FIELD_DEFAULT_FOLLOWUPS: dict[tuple[str, str], dict[str, str]] = {
 }
 
 OPTIONAL_FIELD_CHILD_PREFIX_FOLLOWUPS: dict[tuple[str, str, str], dict[str, str]] = {
-    ("ads", "add", "SmartAdBuilderAd"): {
-        "status": "missing_followup",
-        "issue": "#278",
-        "note": "SMART_AD_BUILDER_AD add fields need typed support or N/A.",
-    },
     ("campaigns", "add", "TextCampaign.BiddingStrategy"): {
         "status": "missing_followup",
         "issue": "#290",


### PR DESCRIPTION
## Summary
- add ads add support for SMART_AD_BUILDER_AD with --logo-extension-hash
- support TextImageAdAdd FinalUrl and ErirAdDescription typed flags
- move #278 WSDL audit rows from missing_followup to supported and update README/help/tests

## Verification
- python3 -m pytest tests/test_dry_run.py -k "ads_add and (text_image_ad or smart_ad_builder_ad)"
- python3 -m pytest tests/test_cli.py -k ads_add_help
- python3 scripts/build_wsdl_optional_field_audit.py --check
- python3 -m pytest tests/test_wsdl_parity_gate.py
- python3 -m pytest tests/test_cli_contract.py -k "json or readme_direct_examples"
- python3 -m pytest tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py
- mypy .
- git diff --check

Closes #278