### PR TITLE
Add ExplorationBudget strategy flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,8 +597,10 @@ direct dynamicads set-bids --id 789 --bid 12500000 --context-bid 9000000 --prior
 direct strategies get --limit 5
 direct strategies add --name "Shared Clicks" --type WbMaximumClicks --weekly-spend-limit 1000000000 --bid-ceiling 30000000 --dry-run
 direct strategies add --name "Custom Period Clicks" --type WbMaximumClicks --custom-period-spend-limit 1000000000 --custom-period-start-date 2026-06-01 --custom-period-end-date 2026-06-30 --custom-period-auto-continue YES --dry-run
+direct strategies add --name "Exploration CPA" --type AverageCpa --average-cpa 4000000 --goal-id 123 --minimum-exploration-budget 200000000 --dry-run
 direct strategies update --id 42 --type WbMaximumClicks --weekly-spend-limit 35000000 --dry-run
 direct strategies update --id 42 --type WbMaximumClicks --custom-period-spend-limit 35000000 --custom-period-start-date 2026-07-01 --custom-period-end-date 2026-07-31 --custom-period-auto-continue NO --dry-run
+direct strategies update --id 42 --type MaxProfit --minimum-exploration-budget 0 --dry-run
 direct strategies archive --id 42 --dry-run
 
 # Dynamic feed ad targets
@@ -1397,8 +1399,10 @@ direct dynamicads set-bids --id 789 --bid 12500000 --context-bid 9000000 --prior
 direct strategies get --limit 5
 direct strategies add --name "Общая стратегия" --type WbMaximumClicks --weekly-spend-limit 1000000000 --bid-ceiling 30000000 --dry-run
 direct strategies add --name "Периодный бюджет" --type WbMaximumClicks --custom-period-spend-limit 1000000000 --custom-period-start-date 2026-06-01 --custom-period-end-date 2026-06-30 --custom-period-auto-continue YES --dry-run
+direct strategies add --name "Минимальный бюджет CPA" --type AverageCpa --average-cpa 4000000 --goal-id 123 --minimum-exploration-budget 200000000 --dry-run
 direct strategies update --id 42 --type WbMaximumClicks --weekly-spend-limit 35000000 --dry-run
 direct strategies update --id 42 --type WbMaximumClicks --custom-period-spend-limit 35000000 --custom-period-start-date 2026-07-01 --custom-period-end-date 2026-07-31 --custom-period-auto-continue NO --dry-run
+direct strategies update --id 42 --type MaxProfit --minimum-exploration-budget 0 --dry-run
 direct strategies archive --id 42 --dry-run
 
 # Динамические таргеты по фиду

--- a/direct_cli/commands/strategies.py
+++ b/direct_cli/commands/strategies.py
@@ -160,6 +160,19 @@ CUSTOM_PERIOD_BUDGET_FIELD_OPTIONS = {
     "AutoContinue": "--custom-period-auto-continue",
 }
 CUSTOM_PERIOD_BUDGET_FLAGS = set(CUSTOM_PERIOD_BUDGET_FIELD_OPTIONS.values())
+EXPLORATION_BUDGET_FIELD_OPTIONS = {
+    "MinimumExplorationBudget": "--minimum-exploration-budget",
+    "IsMinimumExplorationBudgetCustom": "--minimum-exploration-budget",
+}
+EXPLORATION_BUDGET_FLAGS = set(EXPLORATION_BUDGET_FIELD_OPTIONS.values())
+EXPLORATION_BUDGET_STRATEGY_TYPES = {
+    "AverageCpa",
+    "MaxProfit",
+    "AverageCpaPerCampaign",
+    "AverageCpaPerFilter",
+    "AverageCrr",
+    "AverageCpaMultipleGoals",
+}
 STRATEGY_FLAG_NAMES = {
     "average_cpc": "--average-cpc",
     "average_cpa": "--average-cpa",
@@ -208,6 +221,32 @@ def _build_custom_period_budget(
     }
 
 
+def _build_exploration_budget(
+    strategy_type,
+    minimum_exploration_budget,
+    weekly_spend_limit,
+):
+    """Build ExplorationBudget from typed flags."""
+    if minimum_exploration_budget is None:
+        return None
+    if strategy_type not in EXPLORATION_BUDGET_STRATEGY_TYPES:
+        raise click.UsageError(
+            "--minimum-exploration-budget is not valid for " f"--type {strategy_type}."
+        )
+    if (
+        weekly_spend_limit is not None
+        and minimum_exploration_budget > weekly_spend_limit
+    ):
+        raise click.UsageError(
+            "--minimum-exploration-budget must be less than or equal to "
+            "--weekly-spend-limit when both flags are provided."
+        )
+    return {
+        "MinimumExplorationBudget": minimum_exploration_budget,
+        "IsMinimumExplorationBudgetCustom": "YES",
+    }
+
+
 def _parse_priority_goal(spec: str) -> dict:
     """Parse a priority goal spec in GOAL_ID:VALUE format."""
     goal_id, separator, value = spec.partition(":")
@@ -236,6 +275,7 @@ def _build_strategy_fields(
     custom_period_start_date,
     custom_period_end_date,
     custom_period_auto_continue,
+    minimum_exploration_budget,
     *,
     update=False,
 ):
@@ -258,6 +298,7 @@ def _build_strategy_fields(
                 weekly_spend_limit,
                 bid_ceiling,
                 *custom_period_values,
+                minimum_exploration_budget,
             )
         ):
             raise click.UsageError(
@@ -322,6 +363,13 @@ def _build_strategy_fields(
     )
     if custom_period_budget:
         fields["CustomPeriodBudget"] = custom_period_budget
+    exploration_budget = _build_exploration_budget(
+        strategy_type,
+        minimum_exploration_budget,
+        weekly_spend_limit,
+    )
+    if exploration_budget:
+        fields["ExplorationBudget"] = exploration_budget
     return fields
 
 
@@ -424,6 +472,14 @@ def get(ctx, ids, types, is_archived, limit, fetch_all, output_format, output, f
     type=click.Choice(["YES", "NO"], case_sensitive=False),
     help="CustomPeriodBudget.AutoContinue value: YES or NO",
 )
+@click.option(
+    "--minimum-exploration-budget",
+    type=MICRO_RUBLES,
+    help=(
+        "ExplorationBudget.MinimumExplorationBudget in micro-rubles; "
+        "sets IsMinimumExplorationBudgetCustom=YES"
+    ),
+)
 @click.option("--counter-ids", help="Comma-separated Metrica counter IDs")
 @click.option(
     "--priority-goal",
@@ -456,6 +512,7 @@ def add(
     custom_period_start_date,
     custom_period_end_date,
     custom_period_auto_continue,
+    minimum_exploration_budget,
     counter_ids,
     priority_goals,
     attribution_model,
@@ -478,6 +535,7 @@ def add(
                 custom_period_start_date,
                 custom_period_end_date,
                 custom_period_auto_continue,
+                minimum_exploration_budget,
             ),
         }
         if strategy_type in GOAL_ID_STRATEGY_TYPES and goal_id is None:
@@ -552,6 +610,14 @@ def add(
     type=click.Choice(["YES", "NO"], case_sensitive=False),
     help="CustomPeriodBudget.AutoContinue value: YES or NO",
 )
+@click.option(
+    "--minimum-exploration-budget",
+    type=MICRO_RUBLES,
+    help=(
+        "ExplorationBudget.MinimumExplorationBudget in micro-rubles; "
+        "sets IsMinimumExplorationBudgetCustom=YES"
+    ),
+)
 @click.option("--counter-ids", help="Comma-separated Metrica counter IDs")
 @click.option(
     "--priority-goal",
@@ -585,6 +651,7 @@ def update(
     custom_period_start_date,
     custom_period_end_date,
     custom_period_auto_continue,
+    minimum_exploration_budget,
     counter_ids,
     priority_goals,
     attribution_model,
@@ -608,6 +675,7 @@ def update(
             custom_period_start_date,
             custom_period_end_date,
             custom_period_auto_continue,
+            minimum_exploration_budget,
             update=True,
         )
         if strategy_fields and not strategy_type:

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,9 +11,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 2235 |
+| `missing_followup` | 2199 |
 | `not_applicable` | 23 |
-| `supported` | 983 |
+| `supported` | 1019 |
 
 ## Confirmed Follow-Ups
 
@@ -2238,45 +2238,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `strategies.add` | `PriorityGoals.Items.GoalId` | strategies.add residual optional WSDL path needs typed support or N/A. [#299](https://github.com/axisrow/direct-cli/issues/299) |
 | `strategies.add` | `PriorityGoals.Items.Value` | strategies.add residual optional WSDL path needs typed support or N/A. [#299](https://github.com/axisrow/direct-cli/issues/299) |
 | `strategies.add` | `PriorityGoals.Items.IsMetrikaSourceOfValue` | strategies.add residual optional WSDL path needs typed support or N/A. [#299](https://github.com/axisrow/direct-cli/issues/299) |
-| `strategies.add` | `AverageCpa.ExplorationBudget` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298) |
-| `strategies.add` | `AverageCpa.ExplorationBudget.MinimumExplorationBudget` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpa.ExplorationBudget` |
-| `strategies.add` | `AverageCpa.ExplorationBudget.IsMinimumExplorationBudgetCustom` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpa.ExplorationBudget` |
-| `strategies.add` | `MaxProfit.ExplorationBudget` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298) |
-| `strategies.add` | `MaxProfit.ExplorationBudget.MinimumExplorationBudget` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `MaxProfit.ExplorationBudget` |
-| `strategies.add` | `MaxProfit.ExplorationBudget.IsMinimumExplorationBudgetCustom` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `MaxProfit.ExplorationBudget` |
-| `strategies.add` | `AverageCpaPerCampaign.ExplorationBudget` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298) |
-| `strategies.add` | `AverageCpaPerCampaign.ExplorationBudget.MinimumExplorationBudget` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpaPerCampaign.ExplorationBudget` |
-| `strategies.add` | `AverageCpaPerCampaign.ExplorationBudget.IsMinimumExplorationBudgetCustom` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpaPerCampaign.ExplorationBudget` |
-| `strategies.add` | `AverageCpaPerFilter.ExplorationBudget` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298) |
-| `strategies.add` | `AverageCpaPerFilter.ExplorationBudget.MinimumExplorationBudget` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpaPerFilter.ExplorationBudget` |
-| `strategies.add` | `AverageCpaPerFilter.ExplorationBudget.IsMinimumExplorationBudgetCustom` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpaPerFilter.ExplorationBudget` |
-| `strategies.add` | `AverageCrr.ExplorationBudget` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298) |
-| `strategies.add` | `AverageCrr.ExplorationBudget.MinimumExplorationBudget` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCrr.ExplorationBudget` |
-| `strategies.add` | `AverageCrr.ExplorationBudget.IsMinimumExplorationBudgetCustom` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCrr.ExplorationBudget` |
-| `strategies.add` | `AverageCpaMultipleGoals.ExplorationBudget` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298) |
-| `strategies.add` | `AverageCpaMultipleGoals.ExplorationBudget.MinimumExplorationBudget` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpaMultipleGoals.ExplorationBudget` |
-| `strategies.add` | `AverageCpaMultipleGoals.ExplorationBudget.IsMinimumExplorationBudgetCustom` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpaMultipleGoals.ExplorationBudget` |
 | `strategies.update` | `PriorityGoals.Items.GoalId` | strategies.update residual optional WSDL path needs typed support or N/A. [#300](https://github.com/axisrow/direct-cli/issues/300) |
 | `strategies.update` | `PriorityGoals.Items.Value` | strategies.update residual optional WSDL path needs typed support or N/A. [#300](https://github.com/axisrow/direct-cli/issues/300) |
 | `strategies.update` | `PriorityGoals.Items.IsMetrikaSourceOfValue` | strategies.update residual optional WSDL path needs typed support or N/A. [#300](https://github.com/axisrow/direct-cli/issues/300) |
-| `strategies.update` | `AverageCpa.ExplorationBudget` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298) |
-| `strategies.update` | `AverageCpa.ExplorationBudget.MinimumExplorationBudget` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpa.ExplorationBudget` |
-| `strategies.update` | `AverageCpa.ExplorationBudget.IsMinimumExplorationBudgetCustom` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpa.ExplorationBudget` |
-| `strategies.update` | `MaxProfit.ExplorationBudget` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298) |
-| `strategies.update` | `MaxProfit.ExplorationBudget.MinimumExplorationBudget` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `MaxProfit.ExplorationBudget` |
-| `strategies.update` | `MaxProfit.ExplorationBudget.IsMinimumExplorationBudgetCustom` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `MaxProfit.ExplorationBudget` |
-| `strategies.update` | `AverageCpaPerCampaign.ExplorationBudget` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298) |
-| `strategies.update` | `AverageCpaPerCampaign.ExplorationBudget.MinimumExplorationBudget` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpaPerCampaign.ExplorationBudget` |
-| `strategies.update` | `AverageCpaPerCampaign.ExplorationBudget.IsMinimumExplorationBudgetCustom` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpaPerCampaign.ExplorationBudget` |
-| `strategies.update` | `AverageCpaPerFilter.ExplorationBudget` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298) |
-| `strategies.update` | `AverageCpaPerFilter.ExplorationBudget.MinimumExplorationBudget` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpaPerFilter.ExplorationBudget` |
-| `strategies.update` | `AverageCpaPerFilter.ExplorationBudget.IsMinimumExplorationBudgetCustom` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpaPerFilter.ExplorationBudget` |
-| `strategies.update` | `AverageCrr.ExplorationBudget` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298) |
-| `strategies.update` | `AverageCrr.ExplorationBudget.MinimumExplorationBudget` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCrr.ExplorationBudget` |
-| `strategies.update` | `AverageCrr.ExplorationBudget.IsMinimumExplorationBudgetCustom` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCrr.ExplorationBudget` |
-| `strategies.update` | `AverageCpaMultipleGoals.ExplorationBudget` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298) |
-| `strategies.update` | `AverageCpaMultipleGoals.ExplorationBudget.MinimumExplorationBudget` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpaMultipleGoals.ExplorationBudget` |
-| `strategies.update` | `AverageCpaMultipleGoals.ExplorationBudget.IsMinimumExplorationBudgetCustom` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpaMultipleGoals.ExplorationBudget` |
 
 ## Field Table
 
@@ -5207,9 +5171,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `strategies.add` | `strategies.add` | `AverageCpa.CustomPeriodBudget.EndDate` | `string` | 1 | 1 | `supported` | --custom-period-end-date |
 | `strategies.add` | `strategies.add` | `AverageCpa.CustomPeriodBudget.AutoContinue` | `YesNoEnum` | 1 | 1 | `supported` | --custom-period-auto-continue |
 | `strategies.add` | `strategies.add` | `AverageCpa.BidCeiling` | `long` | 0 | 1 | `supported` | --bid-ceiling |
-| `strategies.add` | `strategies.add` | `AverageCpa.ExplorationBudget` | `ExplorationBudget` | 0 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298) |
-| `strategies.add` | `strategies.add` | `AverageCpa.ExplorationBudget.MinimumExplorationBudget` | `long` | 1 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpa.ExplorationBudget` |
-| `strategies.add` | `strategies.add` | `AverageCpa.ExplorationBudget.IsMinimumExplorationBudgetCustom` | `YesNoEnum` | 1 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpa.ExplorationBudget` |
+| `strategies.add` | `strategies.add` | `AverageCpa.ExplorationBudget` | `ExplorationBudget` | 0 | 1 | `supported` | --minimum-exploration-budget |
+| `strategies.add` | `strategies.add` | `AverageCpa.ExplorationBudget.MinimumExplorationBudget` | `long` | 1 | 1 | `supported` | --minimum-exploration-budget |
+| `strategies.add` | `strategies.add` | `AverageCpa.ExplorationBudget.IsMinimumExplorationBudgetCustom` | `YesNoEnum` | 1 | 1 | `supported` | --minimum-exploration-budget |
 | `strategies.add` | `strategies.add` | `MaxProfit` | `StrategyMaxProfitAddItem` | 0 | 1 | `supported` | --type |
 | `strategies.add` | `strategies.add` | `MaxProfit.WeeklySpendLimit` | `long` | 0 | 1 | `supported` | --weekly-spend-limit |
 | `strategies.add` | `strategies.add` | `MaxProfit.CustomPeriodBudget` | `CustomPeriodBudget` | 0 | 1 | `supported` | --custom-period-auto-continue, --custom-period-end-date, --custom-period-spend-limit, --custom-period-start-date |
@@ -5217,9 +5181,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `strategies.add` | `strategies.add` | `MaxProfit.CustomPeriodBudget.StartDate` | `string` | 1 | 1 | `supported` | --custom-period-start-date |
 | `strategies.add` | `strategies.add` | `MaxProfit.CustomPeriodBudget.EndDate` | `string` | 1 | 1 | `supported` | --custom-period-end-date |
 | `strategies.add` | `strategies.add` | `MaxProfit.CustomPeriodBudget.AutoContinue` | `YesNoEnum` | 1 | 1 | `supported` | --custom-period-auto-continue |
-| `strategies.add` | `strategies.add` | `MaxProfit.ExplorationBudget` | `ExplorationBudget` | 0 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298) |
-| `strategies.add` | `strategies.add` | `MaxProfit.ExplorationBudget.MinimumExplorationBudget` | `long` | 1 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `MaxProfit.ExplorationBudget` |
-| `strategies.add` | `strategies.add` | `MaxProfit.ExplorationBudget.IsMinimumExplorationBudgetCustom` | `YesNoEnum` | 1 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `MaxProfit.ExplorationBudget` |
+| `strategies.add` | `strategies.add` | `MaxProfit.ExplorationBudget` | `ExplorationBudget` | 0 | 1 | `supported` | --minimum-exploration-budget |
+| `strategies.add` | `strategies.add` | `MaxProfit.ExplorationBudget.MinimumExplorationBudget` | `long` | 1 | 1 | `supported` | --minimum-exploration-budget |
+| `strategies.add` | `strategies.add` | `MaxProfit.ExplorationBudget.IsMinimumExplorationBudgetCustom` | `YesNoEnum` | 1 | 1 | `supported` | --minimum-exploration-budget |
 | `strategies.add` | `strategies.add` | `PayForConversion` | `StrategyPayForConversionAddItem` | 0 | 1 | `supported` | --type |
 | `strategies.add` | `strategies.add` | `PayForConversion.Cpa` | `long` | 1 | 1 | `supported` | --average-cpa |
 | `strategies.add` | `strategies.add` | `PayForConversion.GoalId` | `long` | 1 | 1 | `supported` | --goal-id |
@@ -5239,9 +5203,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `strategies.add` | `strategies.add` | `AverageCpaPerCampaign.CustomPeriodBudget.EndDate` | `string` | 1 | 1 | `supported` | --custom-period-end-date |
 | `strategies.add` | `strategies.add` | `AverageCpaPerCampaign.CustomPeriodBudget.AutoContinue` | `YesNoEnum` | 1 | 1 | `supported` | --custom-period-auto-continue |
 | `strategies.add` | `strategies.add` | `AverageCpaPerCampaign.BidCeiling` | `long` | 0 | 1 | `supported` | --bid-ceiling |
-| `strategies.add` | `strategies.add` | `AverageCpaPerCampaign.ExplorationBudget` | `ExplorationBudget` | 0 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298) |
-| `strategies.add` | `strategies.add` | `AverageCpaPerCampaign.ExplorationBudget.MinimumExplorationBudget` | `long` | 1 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpaPerCampaign.ExplorationBudget` |
-| `strategies.add` | `strategies.add` | `AverageCpaPerCampaign.ExplorationBudget.IsMinimumExplorationBudgetCustom` | `YesNoEnum` | 1 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpaPerCampaign.ExplorationBudget` |
+| `strategies.add` | `strategies.add` | `AverageCpaPerCampaign.ExplorationBudget` | `ExplorationBudget` | 0 | 1 | `supported` | --minimum-exploration-budget |
+| `strategies.add` | `strategies.add` | `AverageCpaPerCampaign.ExplorationBudget.MinimumExplorationBudget` | `long` | 1 | 1 | `supported` | --minimum-exploration-budget |
+| `strategies.add` | `strategies.add` | `AverageCpaPerCampaign.ExplorationBudget.IsMinimumExplorationBudgetCustom` | `YesNoEnum` | 1 | 1 | `supported` | --minimum-exploration-budget |
 | `strategies.add` | `strategies.add` | `PayForConversionPerCampaign` | `StrategyPayForConversionPerCampaignAddItem` | 0 | 1 | `supported` | --type |
 | `strategies.add` | `strategies.add` | `PayForConversionPerCampaign.Cpa` | `long` | 1 | 1 | `supported` | --average-cpa |
 | `strategies.add` | `strategies.add` | `PayForConversionPerCampaign.GoalId` | `long` | 1 | 1 | `supported` | --goal-id |
@@ -5270,9 +5234,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `strategies.add` | `strategies.add` | `AverageCpaPerFilter.CustomPeriodBudget.EndDate` | `string` | 1 | 1 | `supported` | --custom-period-end-date |
 | `strategies.add` | `strategies.add` | `AverageCpaPerFilter.CustomPeriodBudget.AutoContinue` | `YesNoEnum` | 1 | 1 | `supported` | --custom-period-auto-continue |
 | `strategies.add` | `strategies.add` | `AverageCpaPerFilter.BidCeiling` | `long` | 0 | 1 | `supported` | --bid-ceiling |
-| `strategies.add` | `strategies.add` | `AverageCpaPerFilter.ExplorationBudget` | `ExplorationBudget` | 0 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298) |
-| `strategies.add` | `strategies.add` | `AverageCpaPerFilter.ExplorationBudget.MinimumExplorationBudget` | `long` | 1 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpaPerFilter.ExplorationBudget` |
-| `strategies.add` | `strategies.add` | `AverageCpaPerFilter.ExplorationBudget.IsMinimumExplorationBudgetCustom` | `YesNoEnum` | 1 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpaPerFilter.ExplorationBudget` |
+| `strategies.add` | `strategies.add` | `AverageCpaPerFilter.ExplorationBudget` | `ExplorationBudget` | 0 | 1 | `supported` | --minimum-exploration-budget |
+| `strategies.add` | `strategies.add` | `AverageCpaPerFilter.ExplorationBudget.MinimumExplorationBudget` | `long` | 1 | 1 | `supported` | --minimum-exploration-budget |
+| `strategies.add` | `strategies.add` | `AverageCpaPerFilter.ExplorationBudget.IsMinimumExplorationBudgetCustom` | `YesNoEnum` | 1 | 1 | `supported` | --minimum-exploration-budget |
 | `strategies.add` | `strategies.add` | `AverageCpcPerCampaign` | `StrategyAverageCpcPerCampaignAddItem` | 0 | 1 | `supported` | --type |
 | `strategies.add` | `strategies.add` | `AverageCpcPerCampaign.AverageCpc` | `long` | 1 | 1 | `supported` | --average-cpc |
 | `strategies.add` | `strategies.add` | `AverageCpcPerCampaign.WeeklySpendLimit` | `long` | 0 | 1 | `supported` | --weekly-spend-limit |
@@ -5300,9 +5264,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `strategies.add` | `strategies.add` | `AverageCrr.CustomPeriodBudget.StartDate` | `string` | 1 | 1 | `supported` | --custom-period-start-date |
 | `strategies.add` | `strategies.add` | `AverageCrr.CustomPeriodBudget.EndDate` | `string` | 1 | 1 | `supported` | --custom-period-end-date |
 | `strategies.add` | `strategies.add` | `AverageCrr.CustomPeriodBudget.AutoContinue` | `YesNoEnum` | 1 | 1 | `supported` | --custom-period-auto-continue |
-| `strategies.add` | `strategies.add` | `AverageCrr.ExplorationBudget` | `ExplorationBudget` | 0 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298) |
-| `strategies.add` | `strategies.add` | `AverageCrr.ExplorationBudget.MinimumExplorationBudget` | `long` | 1 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCrr.ExplorationBudget` |
-| `strategies.add` | `strategies.add` | `AverageCrr.ExplorationBudget.IsMinimumExplorationBudgetCustom` | `YesNoEnum` | 1 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCrr.ExplorationBudget` |
+| `strategies.add` | `strategies.add` | `AverageCrr.ExplorationBudget` | `ExplorationBudget` | 0 | 1 | `supported` | --minimum-exploration-budget |
+| `strategies.add` | `strategies.add` | `AverageCrr.ExplorationBudget.MinimumExplorationBudget` | `long` | 1 | 1 | `supported` | --minimum-exploration-budget |
+| `strategies.add` | `strategies.add` | `AverageCrr.ExplorationBudget.IsMinimumExplorationBudgetCustom` | `YesNoEnum` | 1 | 1 | `supported` | --minimum-exploration-budget |
 | `strategies.add` | `strategies.add` | `PayForConversionCrr` | `StrategyPayForConversionCrrAddItem` | 0 | 1 | `supported` | --type |
 | `strategies.add` | `strategies.add` | `PayForConversionCrr.Crr` | `int` | 1 | 1 | `supported` | --average-crr |
 | `strategies.add` | `strategies.add` | `PayForConversionCrr.GoalId` | `long` | 1 | 1 | `supported` | --goal-id |
@@ -5319,9 +5283,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `strategies.add` | `strategies.add` | `AverageCpaMultipleGoals.CustomPeriodBudget.StartDate` | `string` | 1 | 1 | `supported` | --custom-period-start-date |
 | `strategies.add` | `strategies.add` | `AverageCpaMultipleGoals.CustomPeriodBudget.EndDate` | `string` | 1 | 1 | `supported` | --custom-period-end-date |
 | `strategies.add` | `strategies.add` | `AverageCpaMultipleGoals.CustomPeriodBudget.AutoContinue` | `YesNoEnum` | 1 | 1 | `supported` | --custom-period-auto-continue |
-| `strategies.add` | `strategies.add` | `AverageCpaMultipleGoals.ExplorationBudget` | `ExplorationBudget` | 0 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298) |
-| `strategies.add` | `strategies.add` | `AverageCpaMultipleGoals.ExplorationBudget.MinimumExplorationBudget` | `long` | 1 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpaMultipleGoals.ExplorationBudget` |
-| `strategies.add` | `strategies.add` | `AverageCpaMultipleGoals.ExplorationBudget.IsMinimumExplorationBudgetCustom` | `YesNoEnum` | 1 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpaMultipleGoals.ExplorationBudget` |
+| `strategies.add` | `strategies.add` | `AverageCpaMultipleGoals.ExplorationBudget` | `ExplorationBudget` | 0 | 1 | `supported` | --minimum-exploration-budget |
+| `strategies.add` | `strategies.add` | `AverageCpaMultipleGoals.ExplorationBudget.MinimumExplorationBudget` | `long` | 1 | 1 | `supported` | --minimum-exploration-budget |
+| `strategies.add` | `strategies.add` | `AverageCpaMultipleGoals.ExplorationBudget.IsMinimumExplorationBudgetCustom` | `YesNoEnum` | 1 | 1 | `supported` | --minimum-exploration-budget |
 | `strategies.add` | `strategies.add` | `AverageCpaMultipleGoals.BidCeiling` | `long` | 0 | 1 | `supported` | --bid-ceiling |
 | `strategies.add` | `strategies.add` | `PayForConversionMultipleGoals` | `StrategyPayForConversionMultipleGoalsAddItem` | 0 | 1 | `supported` | --type |
 | `strategies.add` | `strategies.add` | `PayForConversionMultipleGoals.GoalId` | `long` | 1 | 1 | `supported` | --goal-id |
@@ -5371,9 +5335,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `strategies.update` | `strategies.update` | `AverageCpa.GoalId` | `long` | 0 | 1 | `supported` | --goal-id |
 | `strategies.update` | `strategies.update` | `AverageCpa.WeeklySpendLimit` | `long` | 0 | 1 | `supported` | --weekly-spend-limit |
 | `strategies.update` | `strategies.update` | `AverageCpa.BidCeiling` | `long` | 0 | 1 | `supported` | --bid-ceiling |
-| `strategies.update` | `strategies.update` | `AverageCpa.ExplorationBudget` | `ExplorationBudget` | 0 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298) |
-| `strategies.update` | `strategies.update` | `AverageCpa.ExplorationBudget.MinimumExplorationBudget` | `long` | 1 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpa.ExplorationBudget` |
-| `strategies.update` | `strategies.update` | `AverageCpa.ExplorationBudget.IsMinimumExplorationBudgetCustom` | `YesNoEnum` | 1 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpa.ExplorationBudget` |
+| `strategies.update` | `strategies.update` | `AverageCpa.ExplorationBudget` | `ExplorationBudget` | 0 | 1 | `supported` | --minimum-exploration-budget |
+| `strategies.update` | `strategies.update` | `AverageCpa.ExplorationBudget.MinimumExplorationBudget` | `long` | 1 | 1 | `supported` | --minimum-exploration-budget |
+| `strategies.update` | `strategies.update` | `AverageCpa.ExplorationBudget.IsMinimumExplorationBudgetCustom` | `YesNoEnum` | 1 | 1 | `supported` | --minimum-exploration-budget |
 | `strategies.update` | `strategies.update` | `MaxProfit` | `StrategyMaxProfitUpdateItem` | 0 | 1 | `supported` | --type |
 | `strategies.update` | `strategies.update` | `MaxProfit.WeeklySpendLimit` | `long` | 0 | 1 | `supported` | --weekly-spend-limit |
 | `strategies.update` | `strategies.update` | `MaxProfit.CustomPeriodBudget` | `CustomPeriodBudget` | 0 | 1 | `supported` | --custom-period-auto-continue, --custom-period-end-date, --custom-period-spend-limit, --custom-period-start-date |
@@ -5381,9 +5345,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `strategies.update` | `strategies.update` | `MaxProfit.CustomPeriodBudget.StartDate` | `string` | 1 | 1 | `supported` | --custom-period-start-date |
 | `strategies.update` | `strategies.update` | `MaxProfit.CustomPeriodBudget.EndDate` | `string` | 1 | 1 | `supported` | --custom-period-end-date |
 | `strategies.update` | `strategies.update` | `MaxProfit.CustomPeriodBudget.AutoContinue` | `YesNoEnum` | 1 | 1 | `supported` | --custom-period-auto-continue |
-| `strategies.update` | `strategies.update` | `MaxProfit.ExplorationBudget` | `ExplorationBudget` | 0 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298) |
-| `strategies.update` | `strategies.update` | `MaxProfit.ExplorationBudget.MinimumExplorationBudget` | `long` | 1 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `MaxProfit.ExplorationBudget` |
-| `strategies.update` | `strategies.update` | `MaxProfit.ExplorationBudget.IsMinimumExplorationBudgetCustom` | `YesNoEnum` | 1 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `MaxProfit.ExplorationBudget` |
+| `strategies.update` | `strategies.update` | `MaxProfit.ExplorationBudget` | `ExplorationBudget` | 0 | 1 | `supported` | --minimum-exploration-budget |
+| `strategies.update` | `strategies.update` | `MaxProfit.ExplorationBudget.MinimumExplorationBudget` | `long` | 1 | 1 | `supported` | --minimum-exploration-budget |
+| `strategies.update` | `strategies.update` | `MaxProfit.ExplorationBudget.IsMinimumExplorationBudgetCustom` | `YesNoEnum` | 1 | 1 | `supported` | --minimum-exploration-budget |
 | `strategies.update` | `strategies.update` | `PayForConversion` | `StrategyPayForConversionUpdateItem` | 0 | 1 | `supported` | --type |
 | `strategies.update` | `strategies.update` | `PayForConversion.Cpa` | `long` | 0 | 1 | `supported` | --average-cpa |
 | `strategies.update` | `strategies.update` | `PayForConversion.GoalId` | `long` | 0 | 1 | `supported` | --goal-id |
@@ -5403,9 +5367,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `strategies.update` | `strategies.update` | `AverageCpaPerCampaign.CustomPeriodBudget.EndDate` | `string` | 1 | 1 | `supported` | --custom-period-end-date |
 | `strategies.update` | `strategies.update` | `AverageCpaPerCampaign.CustomPeriodBudget.AutoContinue` | `YesNoEnum` | 1 | 1 | `supported` | --custom-period-auto-continue |
 | `strategies.update` | `strategies.update` | `AverageCpaPerCampaign.BidCeiling` | `long` | 0 | 1 | `supported` | --bid-ceiling |
-| `strategies.update` | `strategies.update` | `AverageCpaPerCampaign.ExplorationBudget` | `ExplorationBudget` | 0 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298) |
-| `strategies.update` | `strategies.update` | `AverageCpaPerCampaign.ExplorationBudget.MinimumExplorationBudget` | `long` | 1 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpaPerCampaign.ExplorationBudget` |
-| `strategies.update` | `strategies.update` | `AverageCpaPerCampaign.ExplorationBudget.IsMinimumExplorationBudgetCustom` | `YesNoEnum` | 1 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpaPerCampaign.ExplorationBudget` |
+| `strategies.update` | `strategies.update` | `AverageCpaPerCampaign.ExplorationBudget` | `ExplorationBudget` | 0 | 1 | `supported` | --minimum-exploration-budget |
+| `strategies.update` | `strategies.update` | `AverageCpaPerCampaign.ExplorationBudget.MinimumExplorationBudget` | `long` | 1 | 1 | `supported` | --minimum-exploration-budget |
+| `strategies.update` | `strategies.update` | `AverageCpaPerCampaign.ExplorationBudget.IsMinimumExplorationBudgetCustom` | `YesNoEnum` | 1 | 1 | `supported` | --minimum-exploration-budget |
 | `strategies.update` | `strategies.update` | `PayForConversionPerCampaign` | `StrategyPayForConversionPerCampaignUpdateItem` | 0 | 1 | `supported` | --type |
 | `strategies.update` | `strategies.update` | `PayForConversionPerCampaign.Cpa` | `long` | 0 | 1 | `supported` | --average-cpa |
 | `strategies.update` | `strategies.update` | `PayForConversionPerCampaign.GoalId` | `long` | 0 | 1 | `supported` | --goal-id |
@@ -5434,9 +5398,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `strategies.update` | `strategies.update` | `AverageCpaPerFilter.CustomPeriodBudget.EndDate` | `string` | 1 | 1 | `supported` | --custom-period-end-date |
 | `strategies.update` | `strategies.update` | `AverageCpaPerFilter.CustomPeriodBudget.AutoContinue` | `YesNoEnum` | 1 | 1 | `supported` | --custom-period-auto-continue |
 | `strategies.update` | `strategies.update` | `AverageCpaPerFilter.BidCeiling` | `long` | 0 | 1 | `supported` | --bid-ceiling |
-| `strategies.update` | `strategies.update` | `AverageCpaPerFilter.ExplorationBudget` | `ExplorationBudget` | 0 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298) |
-| `strategies.update` | `strategies.update` | `AverageCpaPerFilter.ExplorationBudget.MinimumExplorationBudget` | `long` | 1 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpaPerFilter.ExplorationBudget` |
-| `strategies.update` | `strategies.update` | `AverageCpaPerFilter.ExplorationBudget.IsMinimumExplorationBudgetCustom` | `YesNoEnum` | 1 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpaPerFilter.ExplorationBudget` |
+| `strategies.update` | `strategies.update` | `AverageCpaPerFilter.ExplorationBudget` | `ExplorationBudget` | 0 | 1 | `supported` | --minimum-exploration-budget |
+| `strategies.update` | `strategies.update` | `AverageCpaPerFilter.ExplorationBudget.MinimumExplorationBudget` | `long` | 1 | 1 | `supported` | --minimum-exploration-budget |
+| `strategies.update` | `strategies.update` | `AverageCpaPerFilter.ExplorationBudget.IsMinimumExplorationBudgetCustom` | `YesNoEnum` | 1 | 1 | `supported` | --minimum-exploration-budget |
 | `strategies.update` | `strategies.update` | `AverageCpcPerCampaign` | `StrategyAverageCpcPerCampaignUpdateItem` | 0 | 1 | `supported` | --type |
 | `strategies.update` | `strategies.update` | `AverageCpcPerCampaign.AverageCpc` | `long` | 0 | 1 | `supported` | --average-cpc |
 | `strategies.update` | `strategies.update` | `AverageCpcPerCampaign.WeeklySpendLimit` | `long` | 0 | 1 | `supported` | --weekly-spend-limit |
@@ -5464,9 +5428,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `strategies.update` | `strategies.update` | `AverageCrr.CustomPeriodBudget.StartDate` | `string` | 1 | 1 | `supported` | --custom-period-start-date |
 | `strategies.update` | `strategies.update` | `AverageCrr.CustomPeriodBudget.EndDate` | `string` | 1 | 1 | `supported` | --custom-period-end-date |
 | `strategies.update` | `strategies.update` | `AverageCrr.CustomPeriodBudget.AutoContinue` | `YesNoEnum` | 1 | 1 | `supported` | --custom-period-auto-continue |
-| `strategies.update` | `strategies.update` | `AverageCrr.ExplorationBudget` | `ExplorationBudget` | 0 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298) |
-| `strategies.update` | `strategies.update` | `AverageCrr.ExplorationBudget.MinimumExplorationBudget` | `long` | 1 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCrr.ExplorationBudget` |
-| `strategies.update` | `strategies.update` | `AverageCrr.ExplorationBudget.IsMinimumExplorationBudgetCustom` | `YesNoEnum` | 1 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCrr.ExplorationBudget` |
+| `strategies.update` | `strategies.update` | `AverageCrr.ExplorationBudget` | `ExplorationBudget` | 0 | 1 | `supported` | --minimum-exploration-budget |
+| `strategies.update` | `strategies.update` | `AverageCrr.ExplorationBudget.MinimumExplorationBudget` | `long` | 1 | 1 | `supported` | --minimum-exploration-budget |
+| `strategies.update` | `strategies.update` | `AverageCrr.ExplorationBudget.IsMinimumExplorationBudgetCustom` | `YesNoEnum` | 1 | 1 | `supported` | --minimum-exploration-budget |
 | `strategies.update` | `strategies.update` | `PayForConversionCrr` | `StrategyPayForConversionCrrUpdateItem` | 0 | 1 | `supported` | --type |
 | `strategies.update` | `strategies.update` | `PayForConversionCrr.Crr` | `int` | 0 | 1 | `supported` | --average-crr |
 | `strategies.update` | `strategies.update` | `PayForConversionCrr.GoalId` | `long` | 0 | 1 | `supported` | --goal-id |
@@ -5483,9 +5447,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `strategies.update` | `strategies.update` | `AverageCpaMultipleGoals.CustomPeriodBudget.StartDate` | `string` | 1 | 1 | `supported` | --custom-period-start-date |
 | `strategies.update` | `strategies.update` | `AverageCpaMultipleGoals.CustomPeriodBudget.EndDate` | `string` | 1 | 1 | `supported` | --custom-period-end-date |
 | `strategies.update` | `strategies.update` | `AverageCpaMultipleGoals.CustomPeriodBudget.AutoContinue` | `YesNoEnum` | 1 | 1 | `supported` | --custom-period-auto-continue |
-| `strategies.update` | `strategies.update` | `AverageCpaMultipleGoals.ExplorationBudget` | `ExplorationBudget` | 0 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298) |
-| `strategies.update` | `strategies.update` | `AverageCpaMultipleGoals.ExplorationBudget.MinimumExplorationBudget` | `long` | 1 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpaMultipleGoals.ExplorationBudget` |
-| `strategies.update` | `strategies.update` | `AverageCpaMultipleGoals.ExplorationBudget.IsMinimumExplorationBudgetCustom` | `YesNoEnum` | 1 | 1 | `missing_followup` | Strategy ExplorationBudget fields need typed support. [#298](https://github.com/axisrow/direct-cli/issues/298); inherited from `AverageCpaMultipleGoals.ExplorationBudget` |
+| `strategies.update` | `strategies.update` | `AverageCpaMultipleGoals.ExplorationBudget` | `ExplorationBudget` | 0 | 1 | `supported` | --minimum-exploration-budget |
+| `strategies.update` | `strategies.update` | `AverageCpaMultipleGoals.ExplorationBudget.MinimumExplorationBudget` | `long` | 1 | 1 | `supported` | --minimum-exploration-budget |
+| `strategies.update` | `strategies.update` | `AverageCpaMultipleGoals.ExplorationBudget.IsMinimumExplorationBudgetCustom` | `YesNoEnum` | 1 | 1 | `supported` | --minimum-exploration-budget |
 | `strategies.update` | `strategies.update` | `AverageCpaMultipleGoals.BidCeiling` | `long` | 0 | 1 | `supported` | --bid-ceiling |
 | `strategies.update` | `strategies.update` | `PayForConversionMultipleGoals` | `StrategyPayForConversionMultipleGoalsUpdateItem` | 0 | 1 | `supported` | --type |
 | `strategies.update` | `strategies.update` | `PayForConversionMultipleGoals.WeeklySpendLimit` | `long` | 0 | 1 | `supported` | --weekly-spend-limit |

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -162,6 +162,7 @@ def test_strategies_help_does_not_expose_legacy_json_flags():
         assert "--custom-period-start-date" in result.output
         assert "--custom-period-end-date" in result.output
         assert "--custom-period-auto-continue" in result.output
+        assert "--minimum-exploration-budget" in result.output
 
 
 def test_readme_bash_blocks_do_not_use_deprecated_direct_cli_executable():

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -9682,6 +9682,106 @@ def test_strategies_custom_period_budget_rejects_weekly_spend_limit():
     )
 
 
+def test_strategies_add_exploration_budget_payload():
+    body = _dry_run(
+        "strategies",
+        "add",
+        "--name",
+        "Exploration",
+        "--type",
+        "AverageCpa",
+        "--average-cpa",
+        "4000000",
+        "--goal-id",
+        "123",
+        "--minimum-exploration-budget",
+        "200000000",
+    )
+    s = body["params"]["Strategies"][0]
+    assert s["AverageCpa"]["ExplorationBudget"] == {
+        "MinimumExplorationBudget": 200000000,
+        "IsMinimumExplorationBudgetCustom": "YES",
+    }
+
+
+def test_strategies_update_exploration_budget_payload_accepts_zero():
+    body = _dry_run(
+        "strategies",
+        "update",
+        "--id",
+        "42",
+        "--type",
+        "MaxProfit",
+        "--minimum-exploration-budget",
+        "0",
+    )
+    s = body["params"]["Strategies"][0]
+    assert s["MaxProfit"] == {
+        "ExplorationBudget": {
+            "MinimumExplorationBudget": 0,
+            "IsMinimumExplorationBudgetCustom": "YES",
+        }
+    }
+
+
+def test_strategies_exploration_budget_requires_type():
+    result = _failing_run(
+        "strategies",
+        "update",
+        "--id",
+        "42",
+        "--minimum-exploration-budget",
+        "200000000",
+        "--dry-run",
+    )
+    assert result.exit_code != 0
+    assert "Provide --type when setting strategy-specific fields" in result.output
+
+
+def test_strategies_exploration_budget_rejects_unsupported_type():
+    result = _failing_run(
+        "strategies",
+        "update",
+        "--id",
+        "42",
+        "--type",
+        "AverageCpc",
+        "--minimum-exploration-budget",
+        "200000000",
+        "--dry-run",
+    )
+    assert result.exit_code != 0
+    assert (
+        "--minimum-exploration-budget is not valid for --type AverageCpc."
+        in result.output
+    )
+
+
+def test_strategies_exploration_budget_rejects_value_above_weekly_budget():
+    result = _failing_run(
+        "strategies",
+        "add",
+        "--name",
+        "Exploration",
+        "--type",
+        "AverageCpa",
+        "--average-cpa",
+        "4000000",
+        "--goal-id",
+        "123",
+        "--weekly-spend-limit",
+        "100000000",
+        "--minimum-exploration-budget",
+        "200000000",
+        "--dry-run",
+    )
+    assert result.exit_code != 0
+    assert (
+        "--minimum-exploration-budget must be less than or equal to "
+        "--weekly-spend-limit"
+    ) in result.output
+
+
 def test_strategies_archive_payload():
     body = _dry_run("strategies", "archive", "--id", "10")
     assert body == {

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -42,6 +42,9 @@ from direct_cli.commands.bidmodifiers import _BIDMODIFIER_TYPE_TO_NESTED
 from direct_cli.commands.strategies import (
     CUSTOM_PERIOD_BUDGET_FIELD_OPTIONS,
     CUSTOM_PERIOD_BUDGET_FLAGS,
+    EXPLORATION_BUDGET_FIELD_OPTIONS,
+    EXPLORATION_BUDGET_FLAGS,
+    EXPLORATION_BUDGET_STRATEGY_TYPES,
     STRATEGY_FIELD_OPTIONS,
     STRATEGY_FLAG_NAMES,
     STRATEGY_TYPES,
@@ -1880,6 +1883,14 @@ for strategy_type, options in STRATEGY_FIELD_OPTIONS.items():
         OPTIONAL_FIELD_CLI_OPTIONS[
             ("strategies", "add", f"{strategy_type}.CustomPeriodBudget.{wsdl_field}")
         ] = {flag_name}
+    if strategy_type in EXPLORATION_BUDGET_STRATEGY_TYPES:
+        OPTIONAL_FIELD_CLI_OPTIONS[
+            ("strategies", "add", f"{strategy_type}.ExplorationBudget")
+        ] = EXPLORATION_BUDGET_FLAGS
+        for wsdl_field, flag_name in EXPLORATION_BUDGET_FIELD_OPTIONS.items():
+            OPTIONAL_FIELD_CLI_OPTIONS[
+                ("strategies", "add", f"{strategy_type}.ExplorationBudget.{wsdl_field}")
+            ] = {flag_name}
 
 OPTIONAL_FIELD_CLI_OPTIONS.update(
     {
@@ -1898,19 +1909,30 @@ for strategy_type, options in STRATEGY_UPDATE_FIELD_OPTIONS.items():
             ("strategies", "update", f"{strategy_type}.{wsdl_field}")
         ] = {STRATEGY_FLAG_NAMES[param_name]}
     # Cached strategies WSDL does not expose this update path for bare AverageCpa.
-    if strategy_type == "AverageCpa":
-        continue
-    OPTIONAL_FIELD_CLI_OPTIONS[
-        ("strategies", "update", f"{strategy_type}.CustomPeriodBudget")
-    ] = CUSTOM_PERIOD_BUDGET_FLAGS
-    for wsdl_field, flag_name in CUSTOM_PERIOD_BUDGET_FIELD_OPTIONS.items():
+    if strategy_type != "AverageCpa":
         OPTIONAL_FIELD_CLI_OPTIONS[
-            (
-                "strategies",
-                "update",
-                f"{strategy_type}.CustomPeriodBudget.{wsdl_field}",
-            )
-        ] = {flag_name}
+            ("strategies", "update", f"{strategy_type}.CustomPeriodBudget")
+        ] = CUSTOM_PERIOD_BUDGET_FLAGS
+        for wsdl_field, flag_name in CUSTOM_PERIOD_BUDGET_FIELD_OPTIONS.items():
+            OPTIONAL_FIELD_CLI_OPTIONS[
+                (
+                    "strategies",
+                    "update",
+                    f"{strategy_type}.CustomPeriodBudget.{wsdl_field}",
+                )
+            ] = {flag_name}
+    if strategy_type in EXPLORATION_BUDGET_STRATEGY_TYPES:
+        OPTIONAL_FIELD_CLI_OPTIONS[
+            ("strategies", "update", f"{strategy_type}.ExplorationBudget")
+        ] = EXPLORATION_BUDGET_FLAGS
+        for wsdl_field, flag_name in EXPLORATION_BUDGET_FIELD_OPTIONS.items():
+            OPTIONAL_FIELD_CLI_OPTIONS[
+                (
+                    "strategies",
+                    "update",
+                    f"{strategy_type}.ExplorationBudget.{wsdl_field}",
+                )
+            ] = {flag_name}
 
 OPTIONAL_FIELD_CLI_OPTIONS.update(
     {
@@ -2128,18 +2150,9 @@ OPTIONAL_FIELD_CHILD_PREFIX_FOLLOWUPS: dict[tuple[str, str, str], dict[str, str]
     },
 }
 
-OPTIONAL_FIELD_CHILD_COMPONENT_FOLLOWUPS: dict[tuple[str, str, str], dict[str, str]] = {
-    ("strategies", "add", "ExplorationBudget"): {
-        "status": "missing_followup",
-        "issue": "#298",
-        "note": "Strategy ExplorationBudget fields need typed support.",
-    },
-    ("strategies", "update", "ExplorationBudget"): {
-        "status": "missing_followup",
-        "issue": "#298",
-        "note": "Strategy ExplorationBudget fields need typed support.",
-    },
-}
+OPTIONAL_FIELD_CHILD_COMPONENT_FOLLOWUPS: dict[tuple[str, str, str], dict[str, str]] = (
+    {}
+)
 
 OPTIONAL_FIELD_AUDIT: dict[tuple[str, str, str], dict[str, str]] = {
     ("keywords", "add", "AutotargetingSearchBidIsAuto"): {


### PR DESCRIPTION
Summary

- Adds typed strategies add/update --minimum-exploration-budget support for ExplorationBudget.
- Builds the Yandex payload under supported strategy subtype blocks and sets IsMinimumExplorationBudgetCustom=YES deterministically.
- Updates WSDL parity gate/audit rows and README examples for the new canonical flag.

Verification

- python3 scripts/build_wsdl_optional_field_audit.py --check
- python3 -m pytest tests/test_dry_run.py -k "strategies and exploration_budget"
- python3 -m pytest tests/test_cli_contract.py -k strategies_help
- python3 -m pytest tests/test_wsdl_parity_gate.py
- python3 -m pytest tests/test_cli_contract.py -k "json or readme_direct_examples"
- python3 -m pytest tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py
- mypy .
- git diff --check
- python3 -m pytest -m "not integration"

Closes #298