### PR TITLE
Support strategy PriorityGoals item fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,9 +598,11 @@ direct strategies get --limit 5
 direct strategies add --name "Shared Clicks" --type WbMaximumClicks --weekly-spend-limit 1000000000 --bid-ceiling 30000000 --dry-run
 direct strategies add --name "Custom Period Clicks" --type WbMaximumClicks --custom-period-spend-limit 1000000000 --custom-period-start-date 2026-06-01 --custom-period-end-date 2026-06-30 --custom-period-auto-continue YES --dry-run
 direct strategies add --name "Exploration CPA" --type AverageCpa --average-cpa 4000000 --goal-id 123 --minimum-exploration-budget 200000000 --dry-run
+direct strategies add --name "CRR Goal Values" --type AverageCrr --average-crr 10 --goal-id 123 --priority-goal 123:2000000:YES --dry-run
 direct strategies update --id 42 --type WbMaximumClicks --weekly-spend-limit 35000000 --dry-run
 direct strategies update --id 42 --type WbMaximumClicks --custom-period-spend-limit 35000000 --custom-period-start-date 2026-07-01 --custom-period-end-date 2026-07-31 --custom-period-auto-continue NO --dry-run
 direct strategies update --id 42 --type MaxProfit --minimum-exploration-budget 0 --dry-run
+direct strategies update --id 42 --priority-goal 123:2000000:YES --dry-run
 direct strategies archive --id 42 --dry-run
 
 # Dynamic feed ad targets
@@ -1400,9 +1402,11 @@ direct strategies get --limit 5
 direct strategies add --name "Общая стратегия" --type WbMaximumClicks --weekly-spend-limit 1000000000 --bid-ceiling 30000000 --dry-run
 direct strategies add --name "Периодный бюджет" --type WbMaximumClicks --custom-period-spend-limit 1000000000 --custom-period-start-date 2026-06-01 --custom-period-end-date 2026-06-30 --custom-period-auto-continue YES --dry-run
 direct strategies add --name "Минимальный бюджет CPA" --type AverageCpa --average-cpa 4000000 --goal-id 123 --minimum-exploration-budget 200000000 --dry-run
+direct strategies add --name "CRR по целям" --type AverageCrr --average-crr 10 --goal-id 123 --priority-goal 123:2000000:YES --dry-run
 direct strategies update --id 42 --type WbMaximumClicks --weekly-spend-limit 35000000 --dry-run
 direct strategies update --id 42 --type WbMaximumClicks --custom-period-spend-limit 35000000 --custom-period-start-date 2026-07-01 --custom-period-end-date 2026-07-31 --custom-period-auto-continue NO --dry-run
 direct strategies update --id 42 --type MaxProfit --minimum-exploration-budget 0 --dry-run
+direct strategies update --id 42 --priority-goal 123:2000000:YES --dry-run
 direct strategies archive --id 42 --dry-run
 
 # Динамические таргеты по фиду

--- a/direct_cli/commands/strategies.py
+++ b/direct_cli/commands/strategies.py
@@ -173,6 +173,11 @@ EXPLORATION_BUDGET_STRATEGY_TYPES = {
     "AverageCrr",
     "AverageCpaMultipleGoals",
 }
+PRIORITY_GOAL_FIELD_OPTIONS = {
+    "GoalId": "--priority-goal",
+    "Value": "--priority-goal",
+    "IsMetrikaSourceOfValue": "--priority-goal",
+}
 STRATEGY_FLAG_NAMES = {
     "average_cpc": "--average-cpc",
     "average_cpa": "--average-cpa",
@@ -248,18 +253,32 @@ def _build_exploration_budget(
 
 
 def _parse_priority_goal(spec: str) -> dict:
-    """Parse a priority goal spec in GOAL_ID:VALUE format."""
-    goal_id, separator, value = spec.partition(":")
-    if not separator:
+    """Parse a priority goal spec in GOAL_ID:VALUE[:YES|NO] format."""
+    parts = [part.strip() for part in spec.split(":")]
+    if (
+        len(parts) not in (2, 3)
+        or not parts[0]
+        or not parts[1]
+        or (len(parts) == 3 and not parts[2])
+    ):
         raise click.UsageError(
-            "Invalid --priority-goal. Expected GOAL_ID:VALUE, for example 123:1000000"
+            "Invalid --priority-goal. Expected GOAL_ID:VALUE[:YES|NO], "
+            "for example 123:1000000:YES"
         )
     try:
-        return {"GoalId": int(goal_id.strip()), "Value": int(value.strip())}
+        item = {"GoalId": int(parts[0]), "Value": int(parts[1])}
     except ValueError:
         raise click.UsageError(
             "Invalid --priority-goal. GOAL_ID and VALUE must be integers"
         )
+    if len(parts) == 3:
+        is_metrika_source = parts[2].upper()
+        if is_metrika_source not in {"YES", "NO"}:
+            raise click.UsageError(
+                "Invalid --priority-goal. IsMetrikaSourceOfValue must be YES or NO"
+            )
+        item["IsMetrikaSourceOfValue"] = is_metrika_source
+    return item
 
 
 def _build_strategy_fields(
@@ -485,7 +504,7 @@ def get(ctx, ids, types, is_archived, limit, fetch_all, output_format, output, f
     "--priority-goal",
     "priority_goals",
     multiple=True,
-    help="Priority goal as GOAL_ID:VALUE; may be repeated",
+    help="Priority goal as GOAL_ID:VALUE[:YES|NO]; may be repeated",
 )
 @click.option(
     "--attribution-model",
@@ -623,7 +642,7 @@ def add(
     "--priority-goal",
     "priority_goals",
     multiple=True,
-    help="Priority goal as GOAL_ID:VALUE; may be repeated",
+    help="Priority goal as GOAL_ID:VALUE[:YES|NO]; may be repeated",
 )
 @click.option(
     "--attribution-model",

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,9 +11,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 2199 |
+| `missing_followup` | 2193 |
 | `not_applicable` | 23 |
-| `supported` | 1019 |
+| `supported` | 1025 |
 
 ## Confirmed Follow-Ups
 
@@ -2235,12 +2235,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `campaigns.update` | `TimeTargeting.HolidaysSchedule.BidPercent` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
 | `campaigns.update` | `TimeTargeting.HolidaysSchedule.StartHour` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
 | `campaigns.update` | `TimeTargeting.HolidaysSchedule.EndHour` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `strategies.add` | `PriorityGoals.Items.GoalId` | strategies.add residual optional WSDL path needs typed support or N/A. [#299](https://github.com/axisrow/direct-cli/issues/299) |
-| `strategies.add` | `PriorityGoals.Items.Value` | strategies.add residual optional WSDL path needs typed support or N/A. [#299](https://github.com/axisrow/direct-cli/issues/299) |
-| `strategies.add` | `PriorityGoals.Items.IsMetrikaSourceOfValue` | strategies.add residual optional WSDL path needs typed support or N/A. [#299](https://github.com/axisrow/direct-cli/issues/299) |
-| `strategies.update` | `PriorityGoals.Items.GoalId` | strategies.update residual optional WSDL path needs typed support or N/A. [#300](https://github.com/axisrow/direct-cli/issues/300) |
-| `strategies.update` | `PriorityGoals.Items.Value` | strategies.update residual optional WSDL path needs typed support or N/A. [#300](https://github.com/axisrow/direct-cli/issues/300) |
-| `strategies.update` | `PriorityGoals.Items.IsMetrikaSourceOfValue` | strategies.update residual optional WSDL path needs typed support or N/A. [#300](https://github.com/axisrow/direct-cli/issues/300) |
 
 ## Field Table
 
@@ -5133,9 +5127,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `strategies.add` | `strategies.add` | `CounterIds.Items` | `long` | 1 | unbounded | `supported` | --counter-ids |
 | `strategies.add` | `strategies.add` | `PriorityGoals` | `PriorityGoalsArray` | 0 | 1 | `supported` | --priority-goal |
 | `strategies.add` | `strategies.add` | `PriorityGoals.Items` | `PriorityGoalsItem` | 1 | unbounded | `supported` | --priority-goal |
-| `strategies.add` | `strategies.add` | `PriorityGoals.Items.GoalId` | `long` | 1 | 1 | `missing_followup` | strategies.add residual optional WSDL path needs typed support or N/A. [#299](https://github.com/axisrow/direct-cli/issues/299) |
-| `strategies.add` | `strategies.add` | `PriorityGoals.Items.Value` | `long` | 1 | 1 | `missing_followup` | strategies.add residual optional WSDL path needs typed support or N/A. [#299](https://github.com/axisrow/direct-cli/issues/299) |
-| `strategies.add` | `strategies.add` | `PriorityGoals.Items.IsMetrikaSourceOfValue` | `YesNoEnum` | 0 | 1 | `missing_followup` | strategies.add residual optional WSDL path needs typed support or N/A. [#299](https://github.com/axisrow/direct-cli/issues/299) |
+| `strategies.add` | `strategies.add` | `PriorityGoals.Items.GoalId` | `long` | 1 | 1 | `supported` | --priority-goal |
+| `strategies.add` | `strategies.add` | `PriorityGoals.Items.Value` | `long` | 1 | 1 | `supported` | --priority-goal |
+| `strategies.add` | `strategies.add` | `PriorityGoals.Items.IsMetrikaSourceOfValue` | `YesNoEnum` | 0 | 1 | `supported` | --priority-goal |
 | `strategies.add` | `strategies.add` | `WbMaximumClicks` | `StrategyMaximumClicksAddItem` | 0 | 1 | `supported` | --type |
 | `strategies.add` | `strategies.add` | `WbMaximumClicks.WeeklySpendLimit` | `long` | 0 | 1 | `supported` | --weekly-spend-limit |
 | `strategies.add` | `strategies.add` | `WbMaximumClicks.CustomPeriodBudget` | `CustomPeriodBudget` | 0 | 1 | `supported` | --custom-period-auto-continue, --custom-period-end-date, --custom-period-spend-limit, --custom-period-start-date |
@@ -5302,9 +5296,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `strategies.update` | `strategies.update` | `CounterIds.Items` | `long` | 1 | unbounded | `supported` | --counter-ids |
 | `strategies.update` | `strategies.update` | `PriorityGoals` | `PriorityGoalsArray` | 0 | 1 | `supported` | --priority-goal |
 | `strategies.update` | `strategies.update` | `PriorityGoals.Items` | `PriorityGoalsItem` | 1 | unbounded | `supported` | --priority-goal |
-| `strategies.update` | `strategies.update` | `PriorityGoals.Items.GoalId` | `long` | 1 | 1 | `missing_followup` | strategies.update residual optional WSDL path needs typed support or N/A. [#300](https://github.com/axisrow/direct-cli/issues/300) |
-| `strategies.update` | `strategies.update` | `PriorityGoals.Items.Value` | `long` | 1 | 1 | `missing_followup` | strategies.update residual optional WSDL path needs typed support or N/A. [#300](https://github.com/axisrow/direct-cli/issues/300) |
-| `strategies.update` | `strategies.update` | `PriorityGoals.Items.IsMetrikaSourceOfValue` | `YesNoEnum` | 0 | 1 | `missing_followup` | strategies.update residual optional WSDL path needs typed support or N/A. [#300](https://github.com/axisrow/direct-cli/issues/300) |
+| `strategies.update` | `strategies.update` | `PriorityGoals.Items.GoalId` | `long` | 1 | 1 | `supported` | --priority-goal |
+| `strategies.update` | `strategies.update` | `PriorityGoals.Items.Value` | `long` | 1 | 1 | `supported` | --priority-goal |
+| `strategies.update` | `strategies.update` | `PriorityGoals.Items.IsMetrikaSourceOfValue` | `YesNoEnum` | 0 | 1 | `supported` | --priority-goal |
 | `strategies.update` | `strategies.update` | `WbMaximumClicks` | `StrategyMaximumClicksUpdateItem` | 0 | 1 | `supported` | --type |
 | `strategies.update` | `strategies.update` | `WbMaximumClicks.WeeklySpendLimit` | `long` | 0 | 1 | `supported` | --weekly-spend-limit |
 | `strategies.update` | `strategies.update` | `WbMaximumClicks.CustomPeriodBudget` | `CustomPeriodBudget` | 0 | 1 | `supported` | --custom-period-auto-continue, --custom-period-end-date, --custom-period-spend-limit, --custom-period-start-date |

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -158,6 +158,7 @@ def test_strategies_help_does_not_expose_legacy_json_flags():
         assert "--params" not in result.output
         assert "--priority-goals" not in result.output
         assert "--priority-goal" in result.output
+        assert "GOAL_ID:VALUE[:YES|NO]" in result.output
         assert "--custom-period-spend-limit" in result.output
         assert "--custom-period-start-date" in result.output
         assert "--custom-period-end-date" in result.output

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -9438,6 +9438,38 @@ def test_strategies_add_payload():
     assert s["PriorityGoals"]["Items"] == [{"GoalId": 123, "Value": 2000000}]
 
 
+def test_strategies_add_priority_goal_metrika_source_payload():
+    body = _dry_run(
+        "strategies",
+        "add",
+        "--name",
+        "CRR Strategy",
+        "--type",
+        "AverageCrr",
+        "--average-crr",
+        "10",
+        "--goal-id",
+        "123",
+        "--priority-goal",
+        "123:2000000:YES",
+        "--priority-goal",
+        "456:1000000:no",
+    )
+    s = body["params"]["Strategies"][0]
+    assert s["PriorityGoals"]["Items"] == [
+        {
+            "GoalId": 123,
+            "Value": 2000000,
+            "IsMetrikaSourceOfValue": "YES",
+        },
+        {
+            "GoalId": 456,
+            "Value": 1000000,
+            "IsMetrikaSourceOfValue": "NO",
+        },
+    ]
+
+
 def test_strategies_add_no_type_key_at_root():
     body = _dry_run(
         "strategies",
@@ -9470,6 +9502,44 @@ def test_strategies_update_payload():
     assert s["Id"] == 77
     assert s["Name"] == "Updated"
     assert s["AverageCpc"]["AverageCpc"] == 1500000
+
+
+def test_strategies_update_priority_goal_metrika_source_payload():
+    body = _dry_run(
+        "strategies",
+        "update",
+        "--id",
+        "77",
+        "--priority-goal",
+        "123:2000000:YES",
+    )
+    s = body["params"]["Strategies"][0]
+    assert s == {
+        "Id": 77,
+        "PriorityGoals": {
+            "Items": [
+                {
+                    "GoalId": 123,
+                    "Value": 2000000,
+                    "IsMetrikaSourceOfValue": "YES",
+                }
+            ]
+        },
+    }
+
+
+def test_strategies_rejects_invalid_priority_goal_metrika_source():
+    result = _failing_run(
+        "strategies",
+        "update",
+        "--id",
+        "77",
+        "--priority-goal",
+        "123:2000000:MAYBE",
+        "--dry-run",
+    )
+    assert result.exit_code != 0
+    assert "IsMetrikaSourceOfValue must be YES or NO" in result.output
 
 
 def test_strategies_update_requires_type_for_strategy_specific_fields():

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -45,6 +45,7 @@ from direct_cli.commands.strategies import (
     EXPLORATION_BUDGET_FIELD_OPTIONS,
     EXPLORATION_BUDGET_FLAGS,
     EXPLORATION_BUDGET_STRATEGY_TYPES,
+    PRIORITY_GOAL_FIELD_OPTIONS,
     STRATEGY_FIELD_OPTIONS,
     STRATEGY_FLAG_NAMES,
     STRATEGY_TYPES,
@@ -1899,6 +1900,10 @@ OPTIONAL_FIELD_CLI_OPTIONS.update(
         ("strategies", "add", "CounterIds.Items"): {"--counter-ids"},
         ("strategies", "add", "PriorityGoals"): {"--priority-goal"},
         ("strategies", "add", "PriorityGoals.Items"): {"--priority-goal"},
+        **{
+            ("strategies", "add", f"PriorityGoals.Items.{wsdl_field}"): {flag_name}
+            for wsdl_field, flag_name in PRIORITY_GOAL_FIELD_OPTIONS.items()
+        },
     }
 )
 
@@ -1942,6 +1947,10 @@ OPTIONAL_FIELD_CLI_OPTIONS.update(
         ("strategies", "update", "CounterIds.Items"): {"--counter-ids"},
         ("strategies", "update", "PriorityGoals"): {"--priority-goal"},
         ("strategies", "update", "PriorityGoals.Items"): {"--priority-goal"},
+        **{
+            ("strategies", "update", f"PriorityGoals.Items.{wsdl_field}"): {flag_name}
+            for wsdl_field, flag_name in PRIORITY_GOAL_FIELD_OPTIONS.items()
+        },
     }
 )
 
@@ -2016,14 +2025,6 @@ OPTIONAL_FIELD_DEFAULT_FOLLOWUPS: dict[tuple[str, str], dict[str, str]] = {
     ("smartadtargets", "update"): {
         "issue": "#304",
         "note": "smartadtargets.update optional WSDL path needs typed support or N/A.",
-    },
-    ("strategies", "add"): {
-        "issue": "#299",
-        "note": "strategies.add residual optional WSDL path needs typed support or N/A.",
-    },
-    ("strategies", "update"): {
-        "issue": "#300",
-        "note": "strategies.update residual optional WSDL path needs typed support or N/A.",
     },
 }
 


### PR DESCRIPTION
Summary

- Extends the existing typed --priority-goal flag to accept GOAL_ID:VALUE[:YES|NO].
- Maps GoalId, Value, and IsMetrikaSourceOfValue into PriorityGoals.Items for strategies add/update.
- Updates WSDL parity/audit rows and single-line README/help examples.

Verification

- python3 scripts/build_wsdl_optional_field_audit.py --check
- python3 -m pytest tests/test_dry_run.py -k "strategies and priority_goal"
- python3 -m pytest tests/test_cli_contract.py -k strategies_help
- python3 -m pytest tests/test_wsdl_parity_gate.py
- python3 -m pytest tests/test_low_coverage_payloads.py -k strategies
- python3 -m pytest tests/test_cli_contract.py -k "json or readme_direct_examples"
- python3 -m pytest tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py
- mypy .
- git diff --check
- python3 -m pytest -m "not integration"

Closes #299
Closes #300