### PR TITLE
Add campaign-level typed controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,8 +359,8 @@ direct campaigns add --name "CPA Campaign" --start-date 2026-06-01 --type TEXT_C
 # Multi-goal CPA via PriorityGoals (goal_id:value pairs, WSDL PriorityGoalsItem)
 direct campaigns add --name "Multi-Goal CPA" --start-date 2026-06-01 --type TEXT_CAMPAIGN --search-strategy AVERAGE_CPA_MULTIPLE_GOALS --network-strategy SERVING_OFF --priority-goals 1234567:80,9876543:20 --bid-ceiling 1000000000 --dry-run
 
-# Notification (Sms/Email) and TimeTargeting accept JSON with WSDL CamelCase keys
-direct campaigns add --name "Notify+Schedule" --start-date 2026-06-01 --type TEXT_CAMPAIGN --search-strategy HIGHEST_POSITION --network-strategy SERVING_OFF --notification '{"EmailSettings":{"Email":"ops@example.com","SendWarnings":"YES"}}' --time-targeting '{"Schedule":["1A0123456789ABCDEFGHIJKL"],"ConsiderWorkingWeekends":"YES"}' --dry-run
+# Notification (Sms/Email) and TimeTargeting via typed CLI flags
+direct campaigns add --name "Notify+Schedule" --start-date 2026-06-01 --type TEXT_CAMPAIGN --search-strategy HIGHEST_POSITION --network-strategy SERVING_OFF --notification-email ops@example.com --notification-send-warnings YES --time-targeting-schedule 1A0123456789ABCDEFGHIJKL --consider-working-weekends YES --dry-run
 
 # TrackingParams (campaign-level UTM / tracking query string)
 direct campaigns add --name "UTM" --start-date 2026-06-01 --type TEXT_CAMPAIGN --tracking-params "utm_source=direct&utm_campaign={campaign_id}" --dry-run
@@ -1160,8 +1160,8 @@ direct campaigns add --name "CPA-кампания" --start-date 2026-06-01 --typ
 # Мульти-целевой CPA через PriorityGoals (пары goal_id:value, WSDL PriorityGoalsItem)
 direct campaigns add --name "Мульти-целевой CPA" --start-date 2026-06-01 --type TEXT_CAMPAIGN --search-strategy AVERAGE_CPA_MULTIPLE_GOALS --network-strategy SERVING_OFF --priority-goals 1234567:80,9876543:20 --bid-ceiling 1000000000 --dry-run
 
-# Notification (Sms/Email) и TimeTargeting принимают JSON с CamelCase ключами WSDL
-direct campaigns add --name "Уведомления+Расписание" --start-date 2026-06-01 --type TEXT_CAMPAIGN --search-strategy HIGHEST_POSITION --network-strategy SERVING_OFF --notification '{"EmailSettings":{"Email":"ops@example.com","SendWarnings":"YES"}}' --time-targeting '{"Schedule":["1A0123456789ABCDEFGHIJKL"],"ConsiderWorkingWeekends":"YES"}' --dry-run
+# Notification (Sms/Email) и TimeTargeting через явные CLI-флаги
+direct campaigns add --name "Уведомления+Расписание" --start-date 2026-06-01 --type TEXT_CAMPAIGN --search-strategy HIGHEST_POSITION --network-strategy SERVING_OFF --notification-email ops@example.com --notification-send-warnings YES --time-targeting-schedule 1A0123456789ABCDEFGHIJKL --consider-working-weekends YES --dry-run
 
 # TrackingParams — UTM/трекинг на уровне кампании (TextCampaign/DynamicTextCampaign/SmartCampaign.TrackingParams)
 direct campaigns add --name "UTM" --start-date 2026-06-01 --type TEXT_CAMPAIGN --tracking-params "utm_source=direct&utm_campaign={campaign_id}" --dry-run

--- a/direct_cli/commands/campaigns.py
+++ b/direct_cli/commands/campaigns.py
@@ -2,6 +2,7 @@
 Campaigns commands
 """
 
+import re
 from typing import Dict, List, Optional, Sequence
 
 import click
@@ -76,7 +77,24 @@ BLOCKED_IPS_MAX_ITEMS = 25
 EXCLUDED_SITES_MAX_ITEMS = 1000
 EXCLUDED_SITE_MAX_LENGTH = 255
 TIME_TARGETING_SCHEDULE_MAX_ITEMS = 7
-SMS_TIME_MINUTES = {"00", "15", "30", "45"}
+HH_MM_RE = re.compile(r"^(?:[01]\d|2[0-3]):(?:00|15|30|45)$")
+_DEPRECATED_CAMPAIGNS_STRUCTURED_OPTIONS = {
+    "notification": (
+        "--notification is no longer accepted on 'campaigns add/update'; "
+        "use typed flags such as --sms-events, --notification-email, "
+        "and --notification-send-warnings."
+    ),
+    "time_targeting": (
+        "--time-targeting is no longer accepted on 'campaigns add/update'; "
+        "use typed flags such as --time-targeting-schedule, "
+        "--consider-working-weekends, and --holidays-suspend-on-holidays."
+    ),
+}
+
+
+def _deprecated_campaigns_structured_option(ctx, param, value):
+    if value is not None:
+        raise click.UsageError(_DEPRECATED_CAMPAIGNS_STRUCTURED_OPTIONS[param.name])
 
 
 def _apply_cpa_strategy_fields(
@@ -299,14 +317,7 @@ def _validate_sms_time(option_name: str, value: Optional[str]) -> Optional[str]:
     """Validate documented HH:MM values with 15-minute steps."""
     if value is None:
         return None
-    try:
-        hour_text, minute_text = value.split(":")
-        hour = int(hour_text)
-    except ValueError:
-        raise click.UsageError(
-            f"{option_name} must use HH:MM with minutes 00, 15, 30, or 45"
-        )
-    if not 0 <= hour <= 23 or minute_text not in SMS_TIME_MINUTES:
+    if not HH_MM_RE.fullmatch(value):
         raise click.UsageError(
             f"{option_name} must use HH:MM with minutes 00, 15, 30, or 45"
         )
@@ -705,6 +716,24 @@ def get(
     help="Bid ceiling in micro-rubles for the chosen CPA strategy",
 )
 @click.option(
+    "--notification",
+    default=None,
+    expose_value=False,
+    callback=_deprecated_campaigns_structured_option,
+    is_eager=True,
+    hidden=True,
+    help="Removed: use typed Notification flags",
+)
+@click.option(
+    "--time-targeting",
+    default=None,
+    expose_value=False,
+    callback=_deprecated_campaigns_structured_option,
+    is_eager=True,
+    hidden=True,
+    help="Removed: use typed TimeTargeting flags",
+)
+@click.option(
     "--client-info",
     help="CampaignBase.ClientInfo client name, max 255 characters",
 )
@@ -1098,6 +1127,24 @@ def add(
 @click.option("--budget", type=MICRO_RUBLES, help="New daily budget in micro-rubles")
 @click.option("--start-date", help="New start date (YYYY-MM-DD)")
 @click.option("--end-date", help="New end date (YYYY-MM-DD)")
+@click.option(
+    "--notification",
+    default=None,
+    expose_value=False,
+    callback=_deprecated_campaigns_structured_option,
+    is_eager=True,
+    hidden=True,
+    help="Removed: use typed Notification flags",
+)
+@click.option(
+    "--time-targeting",
+    default=None,
+    expose_value=False,
+    callback=_deprecated_campaigns_structured_option,
+    is_eager=True,
+    hidden=True,
+    help="Removed: use typed TimeTargeting flags",
+)
 @click.option(
     "--client-info",
     help="CampaignBase.ClientInfo client name, max 255 characters",

--- a/direct_cli/commands/campaigns.py
+++ b/direct_cli/commands/campaigns.py
@@ -2,7 +2,7 @@
 Campaigns commands
 """
 
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Sequence
 
 import click
 
@@ -16,7 +16,6 @@ from ..utils import (
     MICRO_RUBLES,
     parse_ids,
     parse_csv_strings,
-    parse_json,
     parse_priority_goals_spec,
     parse_setting_specs,
 )
@@ -70,62 +69,14 @@ _STRATEGY_REQUIRED_TYPED_FLAGS: Dict[str, Dict[str, str]] = {
     "PayForConversionMultipleGoals": {"PriorityGoals": "--priority-goals"},
 }
 
-_NOTIFICATION_KEYS = {"SmsSettings", "EmailSettings"}
-_SMS_SETTINGS_KEYS = {"Events", "TimeFrom", "TimeTo"}
-_EMAIL_SETTINGS_KEYS = {
-    "Email",
-    "CheckPositionInterval",
-    "WarningBalance",
-    "SendAccountNews",
-    "SendWarnings",
-}
-_TIME_TARGETING_KEYS = {
-    "Schedule",
-    "ConsiderWorkingWeekends",
-    "HolidaysSchedule",
-}
-_HOLIDAYS_SCHEDULE_KEYS = {
-    "SuspendOnHolidays",
-    "BidPercent",
-    "StartHour",
-    "EndHour",
-}
-
-
-def _validate_notification_shape(notification: object) -> None:
-    """Reject malformed --notification JSON before sending to API."""
-    if not isinstance(notification, dict) or not notification:
-        raise click.UsageError(
-            "--notification must be a non-empty JSON object with "
-            f"keys from {sorted(_NOTIFICATION_KEYS)}"
-        )
-    unknown = set(notification) - _NOTIFICATION_KEYS
-    if unknown:
-        raise click.UsageError(
-            f"--notification contains unknown key(s) {sorted(unknown)}; "
-            f"allowed: {sorted(_NOTIFICATION_KEYS)}"
-        )
-    sms = notification.get("SmsSettings")
-    if sms is not None:
-        if not isinstance(sms, dict):
-            raise click.UsageError("--notification.SmsSettings must be a JSON object")
-        unknown_sms = set(sms) - _SMS_SETTINGS_KEYS
-        if unknown_sms:
-            raise click.UsageError(
-                "--notification.SmsSettings contains unknown key(s) "
-                f"{sorted(unknown_sms)}; allowed: {sorted(_SMS_SETTINGS_KEYS)}"
-            )
-    email = notification.get("EmailSettings")
-    if email is not None:
-        if not isinstance(email, dict):
-            raise click.UsageError("--notification.EmailSettings must be a JSON object")
-        unknown_email = set(email) - _EMAIL_SETTINGS_KEYS
-        if unknown_email:
-            raise click.UsageError(
-                "--notification.EmailSettings contains unknown key(s) "
-                f"{sorted(unknown_email)}; allowed: "
-                f"{sorted(_EMAIL_SETTINGS_KEYS)}"
-            )
+SMS_EVENTS = {"MONITORING", "MODERATION", "MONEY_IN", "MONEY_OUT", "FINISHED"}
+YES_NO = ["YES", "NO"]
+CLIENT_INFO_MAX_LENGTH = 255
+BLOCKED_IPS_MAX_ITEMS = 25
+EXCLUDED_SITES_MAX_ITEMS = 1000
+EXCLUDED_SITE_MAX_LENGTH = 255
+TIME_TARGETING_SCHEDULE_MAX_ITEMS = 7
+SMS_TIME_MINUTES = {"00", "15", "30", "45"}
 
 
 def _apply_cpa_strategy_fields(
@@ -278,34 +229,6 @@ def _apply_cpa_strategy_fields(
         _place("Network", network_subtype)
 
 
-def _validate_time_targeting_shape(time_targeting: object) -> None:
-    """Reject malformed --time-targeting JSON before sending to API."""
-    if not isinstance(time_targeting, dict) or not time_targeting:
-        raise click.UsageError(
-            "--time-targeting must be a non-empty JSON object with "
-            f"keys from {sorted(_TIME_TARGETING_KEYS)}"
-        )
-    unknown = set(time_targeting) - _TIME_TARGETING_KEYS
-    if unknown:
-        raise click.UsageError(
-            f"--time-targeting contains unknown key(s) {sorted(unknown)}; "
-            f"allowed: {sorted(_TIME_TARGETING_KEYS)}"
-        )
-    holidays = time_targeting.get("HolidaysSchedule")
-    if holidays is not None:
-        if not isinstance(holidays, dict):
-            raise click.UsageError(
-                "--time-targeting.HolidaysSchedule must be a JSON object"
-            )
-        unknown_h = set(holidays) - _HOLIDAYS_SCHEDULE_KEYS
-        if unknown_h:
-            raise click.UsageError(
-                "--time-targeting.HolidaysSchedule contains unknown "
-                f"key(s) {sorted(unknown_h)}; allowed: "
-                f"{sorted(_HOLIDAYS_SCHEDULE_KEYS)}"
-            )
-
-
 @click.group()
 def campaigns():
     """Manage campaigns"""
@@ -317,6 +240,202 @@ def _parse_csv_option(option_name: str, value: Optional[str]) -> Optional[List[s
     if value is not None and not parsed:
         raise click.UsageError(f"{option_name} must contain at least one value")
     return parsed
+
+
+def _array_of_string_option(
+    option_name: str,
+    value: Optional[str],
+    *,
+    max_items: Optional[int] = None,
+    max_item_length: Optional[int] = None,
+) -> Optional[dict]:
+    """Build a WSDL ArrayOfString payload from a comma-separated flag."""
+    parsed = _parse_csv_option(option_name, value)
+    if parsed and max_items is not None and len(parsed) > max_items:
+        raise click.UsageError(f"{option_name} must contain at most {max_items} items")
+    if parsed and max_item_length is not None:
+        too_long = [item for item in parsed if len(item) > max_item_length]
+        if too_long:
+            raise click.UsageError(
+                f"{option_name} items must be at most " f"{max_item_length} characters"
+            )
+    return {"Items": parsed} if parsed else None
+
+
+def _time_targeting_schedule_option(values: Sequence[str]) -> Optional[dict]:
+    """Build TimeTargeting.Schedule without splitting comma-bearing rows."""
+    if not values:
+        return None
+    items = [value.strip() for value in values if value.strip()]
+    if len(items) != len(values):
+        raise click.UsageError(
+            "--time-targeting-schedule must contain at least one value"
+        )
+    if len(items) > TIME_TARGETING_SCHEDULE_MAX_ITEMS:
+        raise click.UsageError(
+            "--time-targeting-schedule must contain at most "
+            f"{TIME_TARGETING_SCHEDULE_MAX_ITEMS} items"
+        )
+    return {"Items": items}
+
+
+def _upper_yes_no(value: Optional[str]) -> Optional[str]:
+    """Normalize Click YesNoEnum values."""
+    return value.upper() if value is not None else None
+
+
+def _validate_max_length(
+    option_name: str,
+    value: Optional[str],
+    max_length: int,
+) -> Optional[str]:
+    """Reject string options longer than the documented maximum."""
+    if value is not None and len(value) > max_length:
+        raise click.UsageError(f"{option_name} must be at most {max_length} characters")
+    return value
+
+
+def _validate_sms_time(option_name: str, value: Optional[str]) -> Optional[str]:
+    """Validate documented HH:MM values with 15-minute steps."""
+    if value is None:
+        return None
+    try:
+        hour_text, minute_text = value.split(":")
+        hour = int(hour_text)
+    except ValueError:
+        raise click.UsageError(
+            f"{option_name} must use HH:MM with minutes 00, 15, 30, or 45"
+        )
+    if not 0 <= hour <= 23 or minute_text not in SMS_TIME_MINUTES:
+        raise click.UsageError(
+            f"{option_name} must use HH:MM with minutes 00, 15, 30, or 45"
+        )
+    return value
+
+
+def _build_notification(
+    sms_events: Optional[str],
+    sms_time_from: Optional[str],
+    sms_time_to: Optional[str],
+    notification_email: Optional[str],
+    notification_check_position_interval: Optional[str],
+    notification_warning_balance: Optional[int],
+    notification_send_account_news: Optional[str],
+    notification_send_warnings: Optional[str],
+) -> Optional[dict]:
+    """Build CampaignBase.Notification from typed flags."""
+    notification: Dict[str, dict] = {}
+
+    sms_settings: dict = {}
+    parsed_sms_events = _parse_csv_option("--sms-events", sms_events)
+    if parsed_sms_events:
+        normalized_events = [event.upper() for event in parsed_sms_events]
+        invalid = sorted(set(normalized_events) - SMS_EVENTS)
+        if invalid:
+            raise click.UsageError(
+                "--sms-events contains invalid value(s) "
+                f"{invalid}; allowed: {sorted(SMS_EVENTS)}"
+            )
+        sms_settings["Events"] = normalized_events
+    validated_sms_time_from = _validate_sms_time("--sms-time-from", sms_time_from)
+    if validated_sms_time_from:
+        sms_settings["TimeFrom"] = validated_sms_time_from
+    validated_sms_time_to = _validate_sms_time("--sms-time-to", sms_time_to)
+    if validated_sms_time_to:
+        sms_settings["TimeTo"] = validated_sms_time_to
+    if sms_settings:
+        notification["SmsSettings"] = sms_settings
+
+    email_settings: dict = {}
+    if notification_email:
+        email_settings["Email"] = notification_email
+    if notification_check_position_interval is not None:
+        email_settings["CheckPositionInterval"] = int(
+            notification_check_position_interval
+        )
+    if notification_warning_balance is not None:
+        email_settings["WarningBalance"] = notification_warning_balance
+    send_account_news = _upper_yes_no(notification_send_account_news)
+    if send_account_news is not None:
+        email_settings["SendAccountNews"] = send_account_news
+    send_warnings = _upper_yes_no(notification_send_warnings)
+    if send_warnings is not None:
+        email_settings["SendWarnings"] = send_warnings
+    if email_settings:
+        notification["EmailSettings"] = email_settings
+
+    return notification or None
+
+
+def _build_time_targeting(
+    time_targeting_schedule: Sequence[str],
+    consider_working_weekends: Optional[str],
+    holidays_suspend_on_holidays: Optional[str],
+    holidays_bid_percent: Optional[int],
+    holidays_start_hour: Optional[int],
+    holidays_end_hour: Optional[int],
+) -> Optional[dict]:
+    """Build CampaignAddItem/UpdateItem.TimeTargeting from typed flags."""
+    schedule = _time_targeting_schedule_option(time_targeting_schedule)
+    has_holidays = any(
+        value is not None
+        for value in (
+            holidays_suspend_on_holidays,
+            holidays_bid_percent,
+            holidays_start_hour,
+            holidays_end_hour,
+        )
+    )
+    has_time_targeting = (
+        schedule is not None or consider_working_weekends is not None or has_holidays
+    )
+    if not has_time_targeting:
+        return None
+    if consider_working_weekends is None:
+        raise click.UsageError(
+            "TimeTargeting requires --consider-working-weekends when any "
+            "time-targeting flag is provided."
+        )
+
+    time_targeting: dict = {
+        "ConsiderWorkingWeekends": consider_working_weekends.upper()
+    }
+    if schedule is not None:
+        time_targeting["Schedule"] = schedule
+
+    if has_holidays:
+        if holidays_suspend_on_holidays is None:
+            raise click.UsageError(
+                "TimeTargeting.HolidaysSchedule requires "
+                "--holidays-suspend-on-holidays when any --holidays-* flag "
+                "is provided."
+            )
+        suspend_on_holidays = holidays_suspend_on_holidays.upper()
+        if suspend_on_holidays == "YES" and any(
+            value is not None
+            for value in (
+                holidays_bid_percent,
+                holidays_start_hour,
+                holidays_end_hour,
+            )
+        ):
+            raise click.UsageError(
+                "--holidays-bid-percent, --holidays-start-hour, and "
+                "--holidays-end-hour can be provided only when "
+                "--holidays-suspend-on-holidays is NO."
+            )
+        if holidays_bid_percent is not None and holidays_bid_percent % 10 != 0:
+            raise click.UsageError("--holidays-bid-percent must be a multiple of 10")
+        holidays: dict = {"SuspendOnHolidays": suspend_on_holidays}
+        if holidays_bid_percent is not None:
+            holidays["BidPercent"] = holidays_bid_percent
+        if holidays_start_hour is not None:
+            holidays["StartHour"] = holidays_start_hour
+        if holidays_end_hour is not None:
+            holidays["EndHour"] = holidays_end_hour
+        time_targeting["HolidaysSchedule"] = holidays
+
+    return time_targeting
 
 
 def _reject_incompatible_flags(
@@ -586,20 +705,69 @@ def get(
     help="Bid ceiling in micro-rubles for the chosen CPA strategy",
 )
 @click.option(
-    "--notification",
-    "notification_json",
-    help=(
-        "JSON for CampaignBase.Notification "
-        '({"SmsSettings":{...}, "EmailSettings":{...}})'
-    ),
+    "--client-info",
+    help="CampaignBase.ClientInfo client name, max 255 characters",
 )
 @click.option(
-    "--time-targeting",
-    "time_targeting_json",
-    help=(
-        "JSON for CampaignAddItem.TimeTargeting "
-        '({"Schedule":[...], "ConsiderWorkingWeekends":"YES|NO", ...})'
-    ),
+    "--sms-events",
+    help="Comma-separated Notification.SmsSettings.Events values",
+)
+@click.option("--sms-time-from", help="Notification.SmsSettings.TimeFrom")
+@click.option("--sms-time-to", help="Notification.SmsSettings.TimeTo")
+@click.option("--notification-email", help="Notification.EmailSettings.Email")
+@click.option(
+    "--notification-check-position-interval",
+    type=click.Choice(["15", "30", "60"]),
+    help="Notification.EmailSettings.CheckPositionInterval",
+)
+@click.option(
+    "--notification-warning-balance",
+    type=click.IntRange(1, 50),
+    help="Notification.EmailSettings.WarningBalance",
+)
+@click.option(
+    "--notification-send-account-news",
+    type=click.Choice(YES_NO, case_sensitive=False),
+    help="Notification.EmailSettings.SendAccountNews: YES or NO",
+)
+@click.option(
+    "--notification-send-warnings",
+    type=click.Choice(YES_NO, case_sensitive=False),
+    help="Notification.EmailSettings.SendWarnings: YES or NO",
+)
+@click.option("--time-zone", help="CampaignBase.TimeZone")
+@click.option("--negative-keywords", help="Comma-separated NegativeKeywords.Items")
+@click.option("--blocked-ips", help="Comma-separated BlockedIps.Items")
+@click.option("--excluded-sites", help="Comma-separated ExcludedSites.Items")
+@click.option(
+    "--time-targeting-schedule",
+    multiple=True,
+    help="Repeatable TimeTargeting.Schedule.Items row",
+)
+@click.option(
+    "--consider-working-weekends",
+    type=click.Choice(YES_NO, case_sensitive=False),
+    help="TimeTargeting.ConsiderWorkingWeekends: YES or NO",
+)
+@click.option(
+    "--holidays-suspend-on-holidays",
+    type=click.Choice(YES_NO, case_sensitive=False),
+    help="TimeTargeting.HolidaysSchedule.SuspendOnHolidays: YES or NO",
+)
+@click.option(
+    "--holidays-bid-percent",
+    type=click.IntRange(0, 200),
+    help="TimeTargeting.HolidaysSchedule.BidPercent",
+)
+@click.option(
+    "--holidays-start-hour",
+    type=click.IntRange(0, 23),
+    help="TimeTargeting.HolidaysSchedule.StartHour",
+)
+@click.option(
+    "--holidays-end-hour",
+    type=click.IntRange(0, 24),
+    help="TimeTargeting.HolidaysSchedule.EndHour",
 )
 @click.option(
     "--tracking-params",
@@ -630,8 +798,25 @@ def add(
     average_cpa,
     crr,
     bid_ceiling,
-    notification_json,
-    time_targeting_json,
+    client_info,
+    sms_events,
+    sms_time_from,
+    sms_time_to,
+    notification_email,
+    notification_check_position_interval,
+    notification_warning_balance,
+    notification_send_account_news,
+    notification_send_warnings,
+    time_zone,
+    negative_keywords,
+    blocked_ips,
+    excluded_sites,
+    time_targeting_schedule,
+    consider_working_weekends,
+    holidays_suspend_on_holidays,
+    holidays_bid_percent,
+    holidays_start_hour,
+    holidays_end_hour,
     tracking_params,
     dry_run,
 ):
@@ -712,23 +897,45 @@ def add(
             },
         )
 
-        # Parse cross-cutting structured inputs up front so any
-        # UsageError fires before we start composing the payload.
-        notification_obj = None
-        if notification_json is not None:
-            try:
-                notification_obj = parse_json(notification_json)
-            except ValueError as exc:
-                raise click.UsageError(f"--notification: {exc}")
-            _validate_notification_shape(notification_obj)
-
-        time_targeting_obj = None
-        if time_targeting_json is not None:
-            try:
-                time_targeting_obj = parse_json(time_targeting_json)
-            except ValueError as exc:
-                raise click.UsageError(f"--time-targeting: {exc}")
-            _validate_time_targeting_shape(time_targeting_obj)
+        # Build cross-cutting structured inputs from typed flags up front so
+        # any UsageError fires before we start composing the payload.
+        notification_obj = _build_notification(
+            sms_events,
+            sms_time_from,
+            sms_time_to,
+            notification_email,
+            notification_check_position_interval,
+            notification_warning_balance,
+            notification_send_account_news,
+            notification_send_warnings,
+        )
+        time_targeting_obj = _build_time_targeting(
+            time_targeting_schedule,
+            consider_working_weekends,
+            holidays_suspend_on_holidays,
+            holidays_bid_percent,
+            holidays_start_hour,
+            holidays_end_hour,
+        )
+        client_info_obj = _validate_max_length(
+            "--client-info",
+            client_info,
+            CLIENT_INFO_MAX_LENGTH,
+        )
+        negative_keywords_obj = _array_of_string_option(
+            "--negative-keywords", negative_keywords
+        )
+        blocked_ips_obj = _array_of_string_option(
+            "--blocked-ips",
+            blocked_ips,
+            max_items=BLOCKED_IPS_MAX_ITEMS,
+        )
+        excluded_sites_obj = _array_of_string_option(
+            "--excluded-sites",
+            excluded_sites,
+            max_items=EXCLUDED_SITES_MAX_ITEMS,
+            max_item_length=EXCLUDED_SITE_MAX_LENGTH,
+        )
 
         counter_ids_list = None
         if counter_ids is not None:
@@ -846,11 +1053,19 @@ def add(
         if end_date:
             campaign_data["EndDate"] = end_date
 
-        # CampaignBase.Notification + CampaignAddItem.TimeTargeting are
-        # campaign-level (siblings of TextCampaign/DynamicTextCampaign/
-        # SmartCampaign), so apply them after the subtype block.
+        # Campaign-level fields are siblings of the subtype block.
+        if client_info_obj:
+            campaign_data["ClientInfo"] = client_info_obj
         if notification_obj is not None:
             campaign_data["Notification"] = notification_obj
+        if time_zone:
+            campaign_data["TimeZone"] = time_zone
+        if negative_keywords_obj is not None:
+            campaign_data["NegativeKeywords"] = negative_keywords_obj
+        if blocked_ips_obj is not None:
+            campaign_data["BlockedIps"] = blocked_ips_obj
+        if excluded_sites_obj is not None:
+            campaign_data["ExcludedSites"] = excluded_sites_obj
         if time_targeting_obj is not None:
             campaign_data["TimeTargeting"] = time_targeting_obj
 
@@ -884,6 +1099,71 @@ def add(
 @click.option("--start-date", help="New start date (YYYY-MM-DD)")
 @click.option("--end-date", help="New end date (YYYY-MM-DD)")
 @click.option(
+    "--client-info",
+    help="CampaignBase.ClientInfo client name, max 255 characters",
+)
+@click.option(
+    "--sms-events",
+    help="Comma-separated Notification.SmsSettings.Events values",
+)
+@click.option("--sms-time-from", help="Notification.SmsSettings.TimeFrom")
+@click.option("--sms-time-to", help="Notification.SmsSettings.TimeTo")
+@click.option("--notification-email", help="Notification.EmailSettings.Email")
+@click.option(
+    "--notification-check-position-interval",
+    type=click.Choice(["15", "30", "60"]),
+    help="Notification.EmailSettings.CheckPositionInterval",
+)
+@click.option(
+    "--notification-warning-balance",
+    type=click.IntRange(1, 50),
+    help="Notification.EmailSettings.WarningBalance",
+)
+@click.option(
+    "--notification-send-account-news",
+    type=click.Choice(YES_NO, case_sensitive=False),
+    help="Notification.EmailSettings.SendAccountNews: YES or NO",
+)
+@click.option(
+    "--notification-send-warnings",
+    type=click.Choice(YES_NO, case_sensitive=False),
+    help="Notification.EmailSettings.SendWarnings: YES or NO",
+)
+@click.option("--time-zone", help="CampaignBase.TimeZone")
+@click.option("--negative-keywords", help="Comma-separated NegativeKeywords.Items")
+@click.option("--blocked-ips", help="Comma-separated BlockedIps.Items")
+@click.option("--excluded-sites", help="Comma-separated ExcludedSites.Items")
+@click.option(
+    "--time-targeting-schedule",
+    multiple=True,
+    help="Repeatable TimeTargeting.Schedule.Items row",
+)
+@click.option(
+    "--consider-working-weekends",
+    type=click.Choice(YES_NO, case_sensitive=False),
+    help="TimeTargeting.ConsiderWorkingWeekends: YES or NO",
+)
+@click.option(
+    "--holidays-suspend-on-holidays",
+    type=click.Choice(YES_NO, case_sensitive=False),
+    help="TimeTargeting.HolidaysSchedule.SuspendOnHolidays: YES or NO",
+)
+@click.option(
+    "--holidays-bid-percent",
+    type=click.IntRange(0, 200),
+    help="TimeTargeting.HolidaysSchedule.BidPercent",
+)
+@click.option(
+    "--holidays-start-hour",
+    type=click.IntRange(0, 23),
+    help="TimeTargeting.HolidaysSchedule.StartHour",
+)
+@click.option(
+    "--holidays-end-hour",
+    type=click.IntRange(0, 24),
+    help="TimeTargeting.HolidaysSchedule.EndHour",
+)
+@click.option(
     "--type",
     "campaign_type",
     help=(
@@ -910,6 +1190,25 @@ def update(
     budget,
     start_date,
     end_date,
+    client_info,
+    sms_events,
+    sms_time_from,
+    sms_time_to,
+    notification_email,
+    notification_check_position_interval,
+    notification_warning_balance,
+    notification_send_account_news,
+    notification_send_warnings,
+    time_zone,
+    negative_keywords,
+    blocked_ips,
+    excluded_sites,
+    time_targeting_schedule,
+    consider_working_weekends,
+    holidays_suspend_on_holidays,
+    holidays_bid_percent,
+    holidays_start_hour,
+    holidays_end_hour,
     campaign_type,
     tracking_params,
     dry_run,
@@ -933,6 +1232,57 @@ def update(
             campaign_data["StartDate"] = start_date
         if end_date:
             campaign_data["EndDate"] = end_date
+        notification_obj = _build_notification(
+            sms_events,
+            sms_time_from,
+            sms_time_to,
+            notification_email,
+            notification_check_position_interval,
+            notification_warning_balance,
+            notification_send_account_news,
+            notification_send_warnings,
+        )
+        time_targeting_obj = _build_time_targeting(
+            time_targeting_schedule,
+            consider_working_weekends,
+            holidays_suspend_on_holidays,
+            holidays_bid_percent,
+            holidays_start_hour,
+            holidays_end_hour,
+        )
+        client_info_obj = _validate_max_length(
+            "--client-info",
+            client_info,
+            CLIENT_INFO_MAX_LENGTH,
+        )
+        negative_keywords_obj = _array_of_string_option(
+            "--negative-keywords", negative_keywords
+        )
+        blocked_ips_obj = _array_of_string_option(
+            "--blocked-ips",
+            blocked_ips,
+            max_items=BLOCKED_IPS_MAX_ITEMS,
+        )
+        excluded_sites_obj = _array_of_string_option(
+            "--excluded-sites",
+            excluded_sites,
+            max_items=EXCLUDED_SITES_MAX_ITEMS,
+            max_item_length=EXCLUDED_SITE_MAX_LENGTH,
+        )
+        if client_info_obj:
+            campaign_data["ClientInfo"] = client_info_obj
+        if notification_obj is not None:
+            campaign_data["Notification"] = notification_obj
+        if time_zone:
+            campaign_data["TimeZone"] = time_zone
+        if negative_keywords_obj is not None:
+            campaign_data["NegativeKeywords"] = negative_keywords_obj
+        if blocked_ips_obj is not None:
+            campaign_data["BlockedIps"] = blocked_ips_obj
+        if excluded_sites_obj is not None:
+            campaign_data["ExcludedSites"] = excluded_sites_obj
+        if time_targeting_obj is not None:
+            campaign_data["TimeTargeting"] = time_targeting_obj
 
         subtype_supported = {
             "TEXT_CAMPAIGN",

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,9 +11,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 2193 |
+| `missing_followup` | 2137 |
 | `not_applicable` | 23 |
-| `supported` | 1025 |
+| `supported` | 1081 |
 
 ## Confirmed Follow-Ups
 
@@ -42,25 +42,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `adgroups.update` | `DynamicTextFeedAdGroup.AutotargetingSettings.BrandOptions.WithAdvertiserBrand` | Official adgroups.update docs for DynamicTextFeedAdGroupUpdate list AutotargetingCategories only. [#281](https://github.com/axisrow/direct-cli/issues/281); inherited from `DynamicTextFeedAdGroup.AutotargetingSettings` |
 | `adgroups.update` | `DynamicTextFeedAdGroup.AutotargetingSettings.BrandOptions.WithCompetitorsBrand` | Official adgroups.update docs for DynamicTextFeedAdGroupUpdate list AutotargetingCategories only. [#281](https://github.com/axisrow/direct-cli/issues/281); inherited from `DynamicTextFeedAdGroup.AutotargetingSettings` |
 | `adgroups.update` | `DynamicTextFeedAdGroup.FeedId` | Official adgroups.update docs for DynamicTextFeedAdGroupUpdate do not list FeedId. [#281](https://github.com/axisrow/direct-cli/issues/281) |
-| `campaigns.add` | `ClientInfo` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `Notification` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `Notification.SmsSettings` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `Notification.SmsSettings.Events` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `Notification.SmsSettings.TimeFrom` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `Notification.SmsSettings.TimeTo` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `Notification.EmailSettings` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `Notification.EmailSettings.Email` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `Notification.EmailSettings.CheckPositionInterval` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `Notification.EmailSettings.WarningBalance` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `Notification.EmailSettings.SendAccountNews` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `Notification.EmailSettings.SendWarnings` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `TimeZone` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `NegativeKeywords` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `NegativeKeywords.Items` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `BlockedIps` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `BlockedIps.Items` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `ExcludedSites` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `ExcludedSites.Items` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
 | `campaigns.add` | `TextCampaign.BiddingStrategy.Search` | Shared campaign BiddingStrategy builder needs typed support. [#290](https://github.com/axisrow/direct-cli/issues/290); inherited from `TextCampaign.BiddingStrategy` |
 | `campaigns.add` | `TextCampaign.BiddingStrategy.Search.WbMaximumClicks` | Shared campaign BiddingStrategy builder needs typed support. [#290](https://github.com/axisrow/direct-cli/issues/290); inherited from `TextCampaign.BiddingStrategy` |
 | `campaigns.add` | `TextCampaign.BiddingStrategy.Search.WbMaximumClicks.WeeklySpendLimit` | Shared campaign BiddingStrategy builder needs typed support. [#290](https://github.com/axisrow/direct-cli/issues/290); inherited from `TextCampaign.BiddingStrategy` |
@@ -1082,34 +1063,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `campaigns.add` | `SmartCampaign.PackageBiddingStrategy.Platforms` | SmartCampaign optional fields need typed support or N/A. [#295](https://github.com/axisrow/direct-cli/issues/295); inherited from `SmartCampaign` |
 | `campaigns.add` | `SmartCampaign.PackageBiddingStrategy.Platforms.Search` | SmartCampaign optional fields need typed support or N/A. [#295](https://github.com/axisrow/direct-cli/issues/295); inherited from `SmartCampaign` |
 | `campaigns.add` | `SmartCampaign.PackageBiddingStrategy.Platforms.Network` | SmartCampaign optional fields need typed support or N/A. [#295](https://github.com/axisrow/direct-cli/issues/295); inherited from `SmartCampaign` |
-| `campaigns.add` | `TimeTargeting` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `TimeTargeting.Schedule` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `TimeTargeting.Schedule.Items` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `TimeTargeting.ConsiderWorkingWeekends` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `TimeTargeting.HolidaysSchedule` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `TimeTargeting.HolidaysSchedule.SuspendOnHolidays` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `TimeTargeting.HolidaysSchedule.BidPercent` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `TimeTargeting.HolidaysSchedule.StartHour` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `TimeTargeting.HolidaysSchedule.EndHour` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `ClientInfo` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `Notification` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `Notification.SmsSettings` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `Notification.SmsSettings.Events` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `Notification.SmsSettings.TimeFrom` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `Notification.SmsSettings.TimeTo` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `Notification.EmailSettings` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `Notification.EmailSettings.Email` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `Notification.EmailSettings.CheckPositionInterval` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `Notification.EmailSettings.WarningBalance` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `Notification.EmailSettings.SendAccountNews` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `Notification.EmailSettings.SendWarnings` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `TimeZone` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `NegativeKeywords` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `NegativeKeywords.Items` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `BlockedIps` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `BlockedIps.Items` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `ExcludedSites` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `ExcludedSites.Items` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
 | `campaigns.update` | `TextCampaign.CounterIds` | TextCampaign optional fields need typed support or N/A. [#292](https://github.com/axisrow/direct-cli/issues/292); inherited from `TextCampaign` |
 | `campaigns.update` | `TextCampaign.CounterIds.Items` | TextCampaign optional fields need typed support or N/A. [#292](https://github.com/axisrow/direct-cli/issues/292); inherited from `TextCampaign` |
 | `campaigns.update` | `TextCampaign.RelevantKeywords` | TextCampaign optional fields need typed support or N/A. [#292](https://github.com/axisrow/direct-cli/issues/292); inherited from `TextCampaign` |
@@ -2226,15 +2179,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `campaigns.update` | `SmartCampaign.PackageBiddingStrategy.Platforms` | SmartCampaign optional fields need typed support or N/A. [#295](https://github.com/axisrow/direct-cli/issues/295); inherited from `SmartCampaign` |
 | `campaigns.update` | `SmartCampaign.PackageBiddingStrategy.Platforms.Search` | SmartCampaign optional fields need typed support or N/A. [#295](https://github.com/axisrow/direct-cli/issues/295); inherited from `SmartCampaign` |
 | `campaigns.update` | `SmartCampaign.PackageBiddingStrategy.Platforms.Network` | SmartCampaign optional fields need typed support or N/A. [#295](https://github.com/axisrow/direct-cli/issues/295); inherited from `SmartCampaign` |
-| `campaigns.update` | `TimeTargeting` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `TimeTargeting.Schedule` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `TimeTargeting.Schedule.Items` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `TimeTargeting.ConsiderWorkingWeekends` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `TimeTargeting.HolidaysSchedule` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `TimeTargeting.HolidaysSchedule.SuspendOnHolidays` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `TimeTargeting.HolidaysSchedule.BidPercent` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `TimeTargeting.HolidaysSchedule.StartHour` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `TimeTargeting.HolidaysSchedule.EndHour` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
 
 ## Field Table
 
@@ -2707,31 +2651,31 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `bids.set` | `bids.set` | `ContextBid` | `long` | 0 | 1 | `supported` | --context-bid |
 | `bids.set` | `bids.set` | `AutotargetingSearchBidIsAuto` | `YesNoEnum` | 0 | 1 | `supported` | --autotargeting-search-bid-is-auto |
 | `bids.set` | `bids.set` | `StrategyPriority` | `PriorityEnum` | 0 | 1 | `supported` | --priority |
-| `campaigns.add` | `campaigns.add` | `ClientInfo` | `string` | 0 | 1 | `missing_followup` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `campaigns.add` | `Notification` | `Notification` | 0 | 1 | `missing_followup` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `campaigns.add` | `Notification.SmsSettings` | `SmsSettings` | 0 | 1 | `missing_followup` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `campaigns.add` | `Notification.SmsSettings.Events` | `SmsEventsEnum` | 0 | unbounded | `missing_followup` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `campaigns.add` | `Notification.SmsSettings.TimeFrom` | `string` | 0 | 1 | `missing_followup` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `campaigns.add` | `Notification.SmsSettings.TimeTo` | `string` | 0 | 1 | `missing_followup` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `campaigns.add` | `Notification.EmailSettings` | `EmailSettings` | 0 | 1 | `missing_followup` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `campaigns.add` | `Notification.EmailSettings.Email` | `string` | 0 | 1 | `missing_followup` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `campaigns.add` | `Notification.EmailSettings.CheckPositionInterval` | `int` | 0 | 1 | `missing_followup` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `campaigns.add` | `Notification.EmailSettings.WarningBalance` | `int` | 0 | 1 | `missing_followup` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `campaigns.add` | `Notification.EmailSettings.SendAccountNews` | `YesNoEnum` | 0 | 1 | `missing_followup` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `campaigns.add` | `Notification.EmailSettings.SendWarnings` | `YesNoEnum` | 0 | 1 | `missing_followup` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `campaigns.add` | `TimeZone` | `string` | 0 | 1 | `missing_followup` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
+| `campaigns.add` | `campaigns.add` | `ClientInfo` | `string` | 0 | 1 | `supported` | --client-info |
+| `campaigns.add` | `campaigns.add` | `Notification` | `Notification` | 0 | 1 | `supported` | --notification-check-position-interval, --notification-email, --notification-send-account-news, --notification-send-warnings, --notification-warning-balance, --sms-events, --sms-time-from, --sms-time-to |
+| `campaigns.add` | `campaigns.add` | `Notification.SmsSettings` | `SmsSettings` | 0 | 1 | `supported` | --sms-events, --sms-time-from, --sms-time-to |
+| `campaigns.add` | `campaigns.add` | `Notification.SmsSettings.Events` | `SmsEventsEnum` | 0 | unbounded | `supported` | --sms-events |
+| `campaigns.add` | `campaigns.add` | `Notification.SmsSettings.TimeFrom` | `string` | 0 | 1 | `supported` | --sms-time-from |
+| `campaigns.add` | `campaigns.add` | `Notification.SmsSettings.TimeTo` | `string` | 0 | 1 | `supported` | --sms-time-to |
+| `campaigns.add` | `campaigns.add` | `Notification.EmailSettings` | `EmailSettings` | 0 | 1 | `supported` | --notification-check-position-interval, --notification-email, --notification-send-account-news, --notification-send-warnings, --notification-warning-balance |
+| `campaigns.add` | `campaigns.add` | `Notification.EmailSettings.Email` | `string` | 0 | 1 | `supported` | --notification-email |
+| `campaigns.add` | `campaigns.add` | `Notification.EmailSettings.CheckPositionInterval` | `int` | 0 | 1 | `supported` | --notification-check-position-interval |
+| `campaigns.add` | `campaigns.add` | `Notification.EmailSettings.WarningBalance` | `int` | 0 | 1 | `supported` | --notification-warning-balance |
+| `campaigns.add` | `campaigns.add` | `Notification.EmailSettings.SendAccountNews` | `YesNoEnum` | 0 | 1 | `supported` | --notification-send-account-news |
+| `campaigns.add` | `campaigns.add` | `Notification.EmailSettings.SendWarnings` | `YesNoEnum` | 0 | 1 | `supported` | --notification-send-warnings |
+| `campaigns.add` | `campaigns.add` | `TimeZone` | `string` | 0 | 1 | `supported` | --time-zone |
 | `campaigns.add` | `campaigns.add` | `Name` | `string` | 1 | 1 | `supported` | covered by minOccurs>=1 parity gate |
 | `campaigns.add` | `campaigns.add` | `StartDate` | `string` | 1 | 1 | `supported` | covered by minOccurs>=1 parity gate |
 | `campaigns.add` | `campaigns.add` | `DailyBudget` | `DailyBudget` | 0 | 1 | `supported` | --budget |
 | `campaigns.add` | `campaigns.add` | `DailyBudget.Amount` | `long` | 1 | 1 | `supported` | --budget |
 | `campaigns.add` | `campaigns.add` | `DailyBudget.Mode` | `DailyBudgetModeEnum` | 1 | 1 | `supported` | --budget |
 | `campaigns.add` | `campaigns.add` | `EndDate` | `string` | 0 | 1 | `supported` | --end-date |
-| `campaigns.add` | `campaigns.add` | `NegativeKeywords` | `ArrayOfString` | 0 | 1 | `missing_followup` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `campaigns.add` | `NegativeKeywords.Items` | `string` | 1 | unbounded | `missing_followup` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `campaigns.add` | `BlockedIps` | `ArrayOfString` | 0 | 1 | `missing_followup` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `campaigns.add` | `BlockedIps.Items` | `string` | 1 | unbounded | `missing_followup` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `campaigns.add` | `ExcludedSites` | `ArrayOfString` | 0 | 1 | `missing_followup` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `campaigns.add` | `ExcludedSites.Items` | `string` | 1 | unbounded | `missing_followup` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
+| `campaigns.add` | `campaigns.add` | `NegativeKeywords` | `ArrayOfString` | 0 | 1 | `supported` | --negative-keywords |
+| `campaigns.add` | `campaigns.add` | `NegativeKeywords.Items` | `string` | 1 | unbounded | `supported` | --negative-keywords |
+| `campaigns.add` | `campaigns.add` | `BlockedIps` | `ArrayOfString` | 0 | 1 | `supported` | --blocked-ips |
+| `campaigns.add` | `campaigns.add` | `BlockedIps.Items` | `string` | 1 | unbounded | `supported` | --blocked-ips |
+| `campaigns.add` | `campaigns.add` | `ExcludedSites` | `ArrayOfString` | 0 | 1 | `supported` | --excluded-sites |
+| `campaigns.add` | `campaigns.add` | `ExcludedSites.Items` | `string` | 1 | unbounded | `supported` | --excluded-sites |
 | `campaigns.add` | `campaigns.add` | `TextCampaign` | `TextCampaignAddItem` | 0 | 1 | `supported` | --type |
 | `campaigns.add` | `campaigns.add` | `TextCampaign.BiddingStrategy` | `TextCampaignStrategyAdd` | 0 | 1 | `supported` | --network-strategy, --search-strategy |
 | `campaigns.add` | `campaigns.add` | `TextCampaign.BiddingStrategy.Search` | `TextCampaignSearchStrategyAdd` | 1 | 1 | `missing_followup` | Shared campaign BiddingStrategy builder needs typed support. [#290](https://github.com/axisrow/direct-cli/issues/290); inherited from `TextCampaign.BiddingStrategy` |
@@ -3770,28 +3714,28 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `campaigns.add` | `campaigns.add` | `SmartCampaign.PackageBiddingStrategy.Platforms` | `SmartCampaignPlatforms` | 1 | 1 | `missing_followup` | SmartCampaign optional fields need typed support or N/A. [#295](https://github.com/axisrow/direct-cli/issues/295); inherited from `SmartCampaign` |
 | `campaigns.add` | `campaigns.add` | `SmartCampaign.PackageBiddingStrategy.Platforms.Search` | `YesNoEnum` | 1 | 1 | `missing_followup` | SmartCampaign optional fields need typed support or N/A. [#295](https://github.com/axisrow/direct-cli/issues/295); inherited from `SmartCampaign` |
 | `campaigns.add` | `campaigns.add` | `SmartCampaign.PackageBiddingStrategy.Platforms.Network` | `YesNoEnum` | 1 | 1 | `missing_followup` | SmartCampaign optional fields need typed support or N/A. [#295](https://github.com/axisrow/direct-cli/issues/295); inherited from `SmartCampaign` |
-| `campaigns.add` | `campaigns.add` | `TimeTargeting` | `TimeTargetingAdd` | 0 | 1 | `missing_followup` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `campaigns.add` | `TimeTargeting.Schedule` | `ArrayOfString` | 0 | 1 | `missing_followup` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `campaigns.add` | `TimeTargeting.Schedule.Items` | `string` | 1 | unbounded | `missing_followup` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `campaigns.add` | `TimeTargeting.ConsiderWorkingWeekends` | `YesNoEnum` | 1 | 1 | `missing_followup` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `campaigns.add` | `TimeTargeting.HolidaysSchedule` | `TimeTargetingOnPublicHolidays` | 0 | 1 | `missing_followup` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `campaigns.add` | `TimeTargeting.HolidaysSchedule.SuspendOnHolidays` | `YesNoEnum` | 1 | 1 | `missing_followup` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `campaigns.add` | `TimeTargeting.HolidaysSchedule.BidPercent` | `int` | 0 | 1 | `missing_followup` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `campaigns.add` | `TimeTargeting.HolidaysSchedule.StartHour` | `int` | 0 | 1 | `missing_followup` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.add` | `campaigns.add` | `TimeTargeting.HolidaysSchedule.EndHour` | `int` | 0 | 1 | `missing_followup` | campaigns.add campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `campaigns.update` | `ClientInfo` | `string` | 0 | 1 | `missing_followup` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `campaigns.update` | `Notification` | `Notification` | 0 | 1 | `missing_followup` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `campaigns.update` | `Notification.SmsSettings` | `SmsSettings` | 0 | 1 | `missing_followup` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `campaigns.update` | `Notification.SmsSettings.Events` | `SmsEventsEnum` | 0 | unbounded | `missing_followup` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `campaigns.update` | `Notification.SmsSettings.TimeFrom` | `string` | 0 | 1 | `missing_followup` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `campaigns.update` | `Notification.SmsSettings.TimeTo` | `string` | 0 | 1 | `missing_followup` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `campaigns.update` | `Notification.EmailSettings` | `EmailSettings` | 0 | 1 | `missing_followup` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `campaigns.update` | `Notification.EmailSettings.Email` | `string` | 0 | 1 | `missing_followup` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `campaigns.update` | `Notification.EmailSettings.CheckPositionInterval` | `int` | 0 | 1 | `missing_followup` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `campaigns.update` | `Notification.EmailSettings.WarningBalance` | `int` | 0 | 1 | `missing_followup` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `campaigns.update` | `Notification.EmailSettings.SendAccountNews` | `YesNoEnum` | 0 | 1 | `missing_followup` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `campaigns.update` | `Notification.EmailSettings.SendWarnings` | `YesNoEnum` | 0 | 1 | `missing_followup` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `campaigns.update` | `TimeZone` | `string` | 0 | 1 | `missing_followup` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
+| `campaigns.add` | `campaigns.add` | `TimeTargeting` | `TimeTargetingAdd` | 0 | 1 | `supported` | --consider-working-weekends, --holidays-bid-percent, --holidays-end-hour, --holidays-start-hour, --holidays-suspend-on-holidays, --time-targeting-schedule |
+| `campaigns.add` | `campaigns.add` | `TimeTargeting.Schedule` | `ArrayOfString` | 0 | 1 | `supported` | --time-targeting-schedule |
+| `campaigns.add` | `campaigns.add` | `TimeTargeting.Schedule.Items` | `string` | 1 | unbounded | `supported` | --time-targeting-schedule |
+| `campaigns.add` | `campaigns.add` | `TimeTargeting.ConsiderWorkingWeekends` | `YesNoEnum` | 1 | 1 | `supported` | --consider-working-weekends |
+| `campaigns.add` | `campaigns.add` | `TimeTargeting.HolidaysSchedule` | `TimeTargetingOnPublicHolidays` | 0 | 1 | `supported` | --holidays-bid-percent, --holidays-end-hour, --holidays-start-hour, --holidays-suspend-on-holidays |
+| `campaigns.add` | `campaigns.add` | `TimeTargeting.HolidaysSchedule.SuspendOnHolidays` | `YesNoEnum` | 1 | 1 | `supported` | --holidays-suspend-on-holidays |
+| `campaigns.add` | `campaigns.add` | `TimeTargeting.HolidaysSchedule.BidPercent` | `int` | 0 | 1 | `supported` | --holidays-bid-percent |
+| `campaigns.add` | `campaigns.add` | `TimeTargeting.HolidaysSchedule.StartHour` | `int` | 0 | 1 | `supported` | --holidays-start-hour |
+| `campaigns.add` | `campaigns.add` | `TimeTargeting.HolidaysSchedule.EndHour` | `int` | 0 | 1 | `supported` | --holidays-end-hour |
+| `campaigns.update` | `campaigns.update` | `ClientInfo` | `string` | 0 | 1 | `supported` | --client-info |
+| `campaigns.update` | `campaigns.update` | `Notification` | `Notification` | 0 | 1 | `supported` | --notification-check-position-interval, --notification-email, --notification-send-account-news, --notification-send-warnings, --notification-warning-balance, --sms-events, --sms-time-from, --sms-time-to |
+| `campaigns.update` | `campaigns.update` | `Notification.SmsSettings` | `SmsSettings` | 0 | 1 | `supported` | --sms-events, --sms-time-from, --sms-time-to |
+| `campaigns.update` | `campaigns.update` | `Notification.SmsSettings.Events` | `SmsEventsEnum` | 0 | unbounded | `supported` | --sms-events |
+| `campaigns.update` | `campaigns.update` | `Notification.SmsSettings.TimeFrom` | `string` | 0 | 1 | `supported` | --sms-time-from |
+| `campaigns.update` | `campaigns.update` | `Notification.SmsSettings.TimeTo` | `string` | 0 | 1 | `supported` | --sms-time-to |
+| `campaigns.update` | `campaigns.update` | `Notification.EmailSettings` | `EmailSettings` | 0 | 1 | `supported` | --notification-check-position-interval, --notification-email, --notification-send-account-news, --notification-send-warnings, --notification-warning-balance |
+| `campaigns.update` | `campaigns.update` | `Notification.EmailSettings.Email` | `string` | 0 | 1 | `supported` | --notification-email |
+| `campaigns.update` | `campaigns.update` | `Notification.EmailSettings.CheckPositionInterval` | `int` | 0 | 1 | `supported` | --notification-check-position-interval |
+| `campaigns.update` | `campaigns.update` | `Notification.EmailSettings.WarningBalance` | `int` | 0 | 1 | `supported` | --notification-warning-balance |
+| `campaigns.update` | `campaigns.update` | `Notification.EmailSettings.SendAccountNews` | `YesNoEnum` | 0 | 1 | `supported` | --notification-send-account-news |
+| `campaigns.update` | `campaigns.update` | `Notification.EmailSettings.SendWarnings` | `YesNoEnum` | 0 | 1 | `supported` | --notification-send-warnings |
+| `campaigns.update` | `campaigns.update` | `TimeZone` | `string` | 0 | 1 | `supported` | --time-zone |
 | `campaigns.update` | `campaigns.update` | `Id` | `long` | 1 | 1 | `supported` | covered by minOccurs>=1 parity gate |
 | `campaigns.update` | `campaigns.update` | `Name` | `string` | 0 | 1 | `supported` | --name |
 | `campaigns.update` | `campaigns.update` | `StartDate` | `string` | 0 | 1 | `supported` | --start-date |
@@ -3799,12 +3743,12 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `campaigns.update` | `campaigns.update` | `DailyBudget.Amount` | `long` | 1 | 1 | `supported` | --budget |
 | `campaigns.update` | `campaigns.update` | `DailyBudget.Mode` | `DailyBudgetModeEnum` | 1 | 1 | `supported` | --budget |
 | `campaigns.update` | `campaigns.update` | `EndDate` | `string` | 0 | 1 | `supported` | --end-date |
-| `campaigns.update` | `campaigns.update` | `NegativeKeywords` | `ArrayOfString` | 0 | 1 | `missing_followup` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `campaigns.update` | `NegativeKeywords.Items` | `string` | 1 | unbounded | `missing_followup` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `campaigns.update` | `BlockedIps` | `ArrayOfString` | 0 | 1 | `missing_followup` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `campaigns.update` | `BlockedIps.Items` | `string` | 1 | unbounded | `missing_followup` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `campaigns.update` | `ExcludedSites` | `ArrayOfString` | 0 | 1 | `missing_followup` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `campaigns.update` | `ExcludedSites.Items` | `string` | 1 | unbounded | `missing_followup` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
+| `campaigns.update` | `campaigns.update` | `NegativeKeywords` | `ArrayOfString` | 0 | 1 | `supported` | --negative-keywords |
+| `campaigns.update` | `campaigns.update` | `NegativeKeywords.Items` | `string` | 1 | unbounded | `supported` | --negative-keywords |
+| `campaigns.update` | `campaigns.update` | `BlockedIps` | `ArrayOfString` | 0 | 1 | `supported` | --blocked-ips |
+| `campaigns.update` | `campaigns.update` | `BlockedIps.Items` | `string` | 1 | unbounded | `supported` | --blocked-ips |
+| `campaigns.update` | `campaigns.update` | `ExcludedSites` | `ArrayOfString` | 0 | 1 | `supported` | --excluded-sites |
+| `campaigns.update` | `campaigns.update` | `ExcludedSites.Items` | `string` | 1 | unbounded | `supported` | --excluded-sites |
 | `campaigns.update` | `campaigns.update` | `TextCampaign` | `TextCampaignUpdateItem` | 0 | 1 | `supported` | --type |
 | `campaigns.update` | `campaigns.update` | `TextCampaign.CounterIds` | `ArrayOfInteger` | 0 | 1 | `missing_followup` | TextCampaign optional fields need typed support or N/A. [#292](https://github.com/axisrow/direct-cli/issues/292); inherited from `TextCampaign` |
 | `campaigns.update` | `campaigns.update` | `TextCampaign.CounterIds.Items` | `int` | 1 | unbounded | `missing_followup` | TextCampaign optional fields need typed support or N/A. [#292](https://github.com/axisrow/direct-cli/issues/292); inherited from `TextCampaign` |
@@ -4927,15 +4871,15 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `campaigns.update` | `campaigns.update` | `SmartCampaign.PackageBiddingStrategy.Platforms` | `SmartCampaignPlatforms` | 0 | 1 | `missing_followup` | SmartCampaign optional fields need typed support or N/A. [#295](https://github.com/axisrow/direct-cli/issues/295); inherited from `SmartCampaign` |
 | `campaigns.update` | `campaigns.update` | `SmartCampaign.PackageBiddingStrategy.Platforms.Search` | `YesNoEnum` | 1 | 1 | `missing_followup` | SmartCampaign optional fields need typed support or N/A. [#295](https://github.com/axisrow/direct-cli/issues/295); inherited from `SmartCampaign` |
 | `campaigns.update` | `campaigns.update` | `SmartCampaign.PackageBiddingStrategy.Platforms.Network` | `YesNoEnum` | 1 | 1 | `missing_followup` | SmartCampaign optional fields need typed support or N/A. [#295](https://github.com/axisrow/direct-cli/issues/295); inherited from `SmartCampaign` |
-| `campaigns.update` | `campaigns.update` | `TimeTargeting` | `TimeTargeting` | 0 | 1 | `missing_followup` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `campaigns.update` | `TimeTargeting.Schedule` | `ArrayOfString` | 0 | 1 | `missing_followup` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `campaigns.update` | `TimeTargeting.Schedule.Items` | `string` | 1 | unbounded | `missing_followup` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `campaigns.update` | `TimeTargeting.ConsiderWorkingWeekends` | `YesNoEnum` | 1 | 1 | `missing_followup` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `campaigns.update` | `TimeTargeting.HolidaysSchedule` | `TimeTargetingOnPublicHolidays` | 0 | 1 | `missing_followup` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `campaigns.update` | `TimeTargeting.HolidaysSchedule.SuspendOnHolidays` | `YesNoEnum` | 1 | 1 | `missing_followup` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `campaigns.update` | `TimeTargeting.HolidaysSchedule.BidPercent` | `int` | 0 | 1 | `missing_followup` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `campaigns.update` | `TimeTargeting.HolidaysSchedule.StartHour` | `int` | 0 | 1 | `missing_followup` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
-| `campaigns.update` | `campaigns.update` | `TimeTargeting.HolidaysSchedule.EndHour` | `int` | 0 | 1 | `missing_followup` | campaigns.update campaign-level optional path needs typed support or N/A. [#291](https://github.com/axisrow/direct-cli/issues/291) |
+| `campaigns.update` | `campaigns.update` | `TimeTargeting` | `TimeTargeting` | 0 | 1 | `supported` | --consider-working-weekends, --holidays-bid-percent, --holidays-end-hour, --holidays-start-hour, --holidays-suspend-on-holidays, --time-targeting-schedule |
+| `campaigns.update` | `campaigns.update` | `TimeTargeting.Schedule` | `ArrayOfString` | 0 | 1 | `supported` | --time-targeting-schedule |
+| `campaigns.update` | `campaigns.update` | `TimeTargeting.Schedule.Items` | `string` | 1 | unbounded | `supported` | --time-targeting-schedule |
+| `campaigns.update` | `campaigns.update` | `TimeTargeting.ConsiderWorkingWeekends` | `YesNoEnum` | 1 | 1 | `supported` | --consider-working-weekends |
+| `campaigns.update` | `campaigns.update` | `TimeTargeting.HolidaysSchedule` | `TimeTargetingOnPublicHolidays` | 0 | 1 | `supported` | --holidays-bid-percent, --holidays-end-hour, --holidays-start-hour, --holidays-suspend-on-holidays |
+| `campaigns.update` | `campaigns.update` | `TimeTargeting.HolidaysSchedule.SuspendOnHolidays` | `YesNoEnum` | 1 | 1 | `supported` | --holidays-suspend-on-holidays |
+| `campaigns.update` | `campaigns.update` | `TimeTargeting.HolidaysSchedule.BidPercent` | `int` | 0 | 1 | `supported` | --holidays-bid-percent |
+| `campaigns.update` | `campaigns.update` | `TimeTargeting.HolidaysSchedule.StartHour` | `int` | 0 | 1 | `supported` | --holidays-start-hour |
+| `campaigns.update` | `campaigns.update` | `TimeTargeting.HolidaysSchedule.EndHour` | `int` | 0 | 1 | `supported` | --holidays-end-hour |
 | `clients.update` | `clients.update` | `ClientInfo` | `string` | 0 | 1 | `supported` | --client-info |
 | `clients.update` | `clients.update` | `Phone` | `string` | 0 | 1 | `supported` | --phone |
 | `clients.update` | `clients.update` | `Notification` | `NotificationUpdate` | 0 | 1 | `supported` | --email-subscription, --notification-email, --notification-lang |

--- a/tests/api_coverage_payloads.py
+++ b/tests/api_coverage_payloads.py
@@ -654,17 +654,20 @@ PAYLOAD_CASES = [
             "HIGHEST_POSITION",
             "--network-strategy",
             "SERVING_OFF",
-            "--notification",
-            (
-                '{"SmsSettings":{"Events":["FINISHED"],"TimeFrom":"09:00",'
-                '"TimeTo":"18:00"},"EmailSettings":'
-                '{"Email":"ops@example.com","SendWarnings":"YES"}}'
-            ),
-            "--time-targeting",
-            (
-                '{"Schedule":["1A0123456789ABCDEFGHIJKL"],'
-                '"ConsiderWorkingWeekends":"YES"}'
-            ),
+            "--sms-events",
+            "FINISHED",
+            "--sms-time-from",
+            "09:00",
+            "--sms-time-to",
+            "18:00",
+            "--notification-email",
+            "ops@example.com",
+            "--notification-send-warnings",
+            "YES",
+            "--time-targeting-schedule",
+            "1A0123456789ABCDEFGHIJKL",
+            "--consider-working-weekends",
+            "YES",
         ],
     ),
     (

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -5282,20 +5282,37 @@ def test_campaigns_add_counter_ids_payload():
 
 
 def test_campaigns_add_notification_payload():
-    notification = (
-        '{"SmsSettings":{"Events":["FINISHED"],"TimeFrom":"09:00","TimeTo":"18:00"},'
-        '"EmailSettings":{"Email":"ops@example.com","SendWarnings":"YES"}}'
+    body = _dry_run(
+        *_cpa_base_args(),
+        "--sms-events",
+        "FINISHED,moderation",
+        "--sms-time-from",
+        "09:00",
+        "--sms-time-to",
+        "18:00",
+        "--notification-email",
+        "ops@example.com",
+        "--notification-check-position-interval",
+        "15",
+        "--notification-warning-balance",
+        "20",
+        "--notification-send-account-news",
+        "no",
+        "--notification-send-warnings",
+        "YES",
     )
-    body = _dry_run(*_cpa_base_args(), "--notification", notification)
     campaign = body["params"]["Campaigns"][0]
     assert campaign["Notification"] == {
         "SmsSettings": {
-            "Events": ["FINISHED"],
+            "Events": ["FINISHED", "MODERATION"],
             "TimeFrom": "09:00",
             "TimeTo": "18:00",
         },
         "EmailSettings": {
             "Email": "ops@example.com",
+            "CheckPositionInterval": 15,
+            "WarningBalance": 20,
+            "SendAccountNews": "NO",
             "SendWarnings": "YES",
         },
     }
@@ -5304,16 +5321,25 @@ def test_campaigns_add_notification_payload():
 
 
 def test_campaigns_add_time_targeting_payload():
-    tt = (
-        '{"Schedule":["1A0123456789ABCDEFGHIJKL"],'
-        '"ConsiderWorkingWeekends":"YES",'
-        '"HolidaysSchedule":{"SuspendOnHolidays":"NO","BidPercent":50,'
-        '"StartHour":10,"EndHour":20}}'
+    schedule_row = "1,0,0,50,50,100,100,150,200,200,150,100,100,80,70,100,100,100,50,50,40,30,0,0,0"
+    body = _dry_run(
+        *_cpa_base_args(),
+        "--time-targeting-schedule",
+        schedule_row,
+        "--consider-working-weekends",
+        "YES",
+        "--holidays-suspend-on-holidays",
+        "no",
+        "--holidays-bid-percent",
+        "50",
+        "--holidays-start-hour",
+        "10",
+        "--holidays-end-hour",
+        "20",
     )
-    body = _dry_run(*_cpa_base_args(), "--time-targeting", tt)
     campaign = body["params"]["Campaigns"][0]
     assert campaign["TimeTargeting"] == {
-        "Schedule": ["1A0123456789ABCDEFGHIJKL"],
+        "Schedule": {"Items": [schedule_row]},
         "ConsiderWorkingWeekends": "YES",
         "HolidaysSchedule": {
             "SuspendOnHolidays": "NO",
@@ -5323,6 +5349,162 @@ def test_campaigns_add_time_targeting_payload():
         },
     }
     assert "TimeTargeting" not in campaign["TextCampaign"]
+
+
+def test_campaigns_add_campaign_level_controls_payload():
+    body = _dry_run(
+        *_cpa_base_args(),
+        "--client-info",
+        "Client A",
+        "--time-zone",
+        "Europe/Moscow",
+        "--negative-keywords",
+        "used,repair",
+        "--blocked-ips",
+        "192.0.2.1,198.51.100.2",
+        "--excluded-sites",
+        "example.com,example.net",
+    )
+    campaign = body["params"]["Campaigns"][0]
+    assert campaign["ClientInfo"] == "Client A"
+    assert campaign["TimeZone"] == "Europe/Moscow"
+    assert campaign["NegativeKeywords"] == {"Items": ["used", "repair"]}
+    assert campaign["BlockedIps"] == {"Items": ["192.0.2.1", "198.51.100.2"]}
+    assert campaign["ExcludedSites"] == {"Items": ["example.com", "example.net"]}
+
+
+def test_campaigns_update_campaign_level_controls_payload():
+    body = _dry_run(
+        "campaigns",
+        "update",
+        "--id",
+        "123",
+        "--client-info",
+        "Client B",
+        "--sms-events",
+        "FINISHED",
+        "--notification-email",
+        "ops@example.com",
+        "--notification-send-warnings",
+        "NO",
+        "--time-zone",
+        "Asia/Bangkok",
+        "--negative-keywords",
+        "used",
+        "--blocked-ips",
+        "192.0.2.1",
+        "--excluded-sites",
+        "example.com",
+        "--time-targeting-schedule",
+        "1A0123456789ABCDEFGHIJKL",
+        "--consider-working-weekends",
+        "NO",
+    )
+    campaign = body["params"]["Campaigns"][0]
+    assert campaign == {
+        "Id": 123,
+        "ClientInfo": "Client B",
+        "Notification": {
+            "SmsSettings": {"Events": ["FINISHED"]},
+            "EmailSettings": {
+                "Email": "ops@example.com",
+                "SendWarnings": "NO",
+            },
+        },
+        "TimeZone": "Asia/Bangkok",
+        "NegativeKeywords": {"Items": ["used"]},
+        "BlockedIps": {"Items": ["192.0.2.1"]},
+        "ExcludedSites": {"Items": ["example.com"]},
+        "TimeTargeting": {
+            "Schedule": {"Items": ["1A0123456789ABCDEFGHIJKL"]},
+            "ConsiderWorkingWeekends": "NO",
+        },
+    }
+
+
+def test_campaigns_time_targeting_requires_consider_working_weekends():
+    result = _rejected(
+        *_cpa_base_args(),
+        "--time-targeting-schedule",
+        "1A0123456789ABCDEFGHIJKL",
+    )
+    assert "--consider-working-weekends" in result.output
+
+
+def test_campaigns_holidays_requires_suspend_on_holidays():
+    result = _rejected(
+        *_cpa_base_args(),
+        "--consider-working-weekends",
+        "YES",
+        "--holidays-bid-percent",
+        "50",
+    )
+    assert "--holidays-suspend-on-holidays" in result.output
+
+
+def test_campaigns_rejects_invalid_sms_events():
+    result = _rejected(*_cpa_base_args(), "--sms-events", "BROKEN")
+    assert "--sms-events" in result.output
+    assert "invalid value" in result.output
+
+
+def test_campaigns_rejects_empty_negative_keywords():
+    result = _rejected(*_cpa_base_args(), "--negative-keywords", ",")
+    assert "--negative-keywords" in result.output
+
+
+def test_campaigns_rejects_too_long_client_info():
+    result = _rejected(*_cpa_base_args(), "--client-info", "x" * 256)
+    assert "--client-info must be at most 255 characters" in result.output
+
+
+def test_campaigns_rejects_invalid_notification_interval():
+    result = _rejected(
+        *_cpa_base_args(),
+        "--notification-check-position-interval",
+        "10",
+    )
+    assert "--notification-check-position-interval" in result.output
+
+
+def test_campaigns_rejects_invalid_sms_time_step():
+    result = _rejected(*_cpa_base_args(), "--sms-time-from", "09:10")
+    assert "--sms-time-from" in result.output
+
+
+def test_campaigns_rejects_too_many_blocked_ips():
+    result = _rejected(
+        *_cpa_base_args(),
+        "--blocked-ips",
+        ",".join(f"192.0.2.{index}" for index in range(26)),
+    )
+    assert "--blocked-ips must contain at most 25 items" in result.output
+
+
+def test_campaigns_rejects_holidays_bid_percent_with_suspend_yes():
+    result = _rejected(
+        *_cpa_base_args(),
+        "--consider-working-weekends",
+        "YES",
+        "--holidays-suspend-on-holidays",
+        "YES",
+        "--holidays-bid-percent",
+        "50",
+    )
+    assert "--holidays-bid-percent" in result.output
+
+
+def test_campaigns_help_exposes_typed_campaign_level_flags_not_json_blobs():
+    for command in ("add", "update"):
+        result = CliRunner().invoke(cli, ["campaigns", command, "--help"])
+        assert result.exit_code == 0
+        assert "--notification " not in result.output
+        assert "--time-targeting " not in result.output
+        assert "--notification-email" in result.output
+        assert "--time-targeting-schedule" in result.output
+        assert "--negative-keywords" in result.output
+        assert "--blocked-ips" in result.output
+        assert "--excluded-sites" in result.output
 
 
 def test_campaigns_add_text_tracking_params_payload():
@@ -5627,67 +5809,6 @@ def test_campaigns_add_rejects_priority_goals_no_separator():
         "1:80,broken",
     )
     assert "--priority-goals" in result.output
-
-
-def test_campaigns_add_rejects_notification_bad_json():
-    result = _rejected(*_cpa_base_args(), "--notification", "not-json")
-    assert "--notification" in result.output
-
-
-def test_campaigns_add_rejects_notification_unknown_top_level_key():
-    result = _rejected(*_cpa_base_args(), "--notification", '{"Foo":1}')
-    assert "--notification" in result.output and "unknown key" in result.output
-
-
-def test_campaigns_add_rejects_notification_empty_object():
-    result = _rejected(*_cpa_base_args(), "--notification", "{}")
-    assert "non-empty" in result.output
-
-
-def test_campaigns_add_rejects_notification_unknown_sms_key():
-    result = _rejected(
-        *_cpa_base_args(),
-        "--notification",
-        '{"SmsSettings":{"Foo":1}}',
-    )
-    assert "SmsSettings" in result.output and "unknown key" in result.output
-
-
-def test_campaigns_add_rejects_notification_unknown_email_key():
-    result = _rejected(
-        *_cpa_base_args(),
-        "--notification",
-        '{"EmailSettings":{"Foo":1}}',
-    )
-    assert "EmailSettings" in result.output and "unknown key" in result.output
-
-
-def test_campaigns_add_rejects_time_targeting_bad_json():
-    result = _rejected(*_cpa_base_args(), "--time-targeting", "x")
-    assert "--time-targeting" in result.output
-
-
-def test_campaigns_add_rejects_time_targeting_unknown_key():
-    result = _rejected(
-        *_cpa_base_args(),
-        "--time-targeting",
-        '{"Foo":1}',
-    )
-    assert "--time-targeting" in result.output and "unknown key" in result.output
-
-
-def test_campaigns_add_rejects_time_targeting_empty():
-    result = _rejected(*_cpa_base_args(), "--time-targeting", "{}")
-    assert "non-empty" in result.output
-
-
-def test_campaigns_add_rejects_time_targeting_unknown_holidays_key():
-    result = _rejected(
-        *_cpa_base_args(),
-        "--time-targeting",
-        '{"HolidaysSchedule":{"Foo":1}}',
-    )
-    assert "HolidaysSchedule" in result.output and "unknown key" in result.output
 
 
 def test_campaigns_add_rejects_counter_ids_for_smart_campaign():

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -5472,6 +5472,30 @@ def test_campaigns_rejects_invalid_sms_time_step():
     assert "--sms-time-from" in result.output
 
 
+def test_campaigns_rejects_non_canonical_sms_time_format():
+    result = _rejected(*_cpa_base_args(), "--sms-time-from", "9:00")
+    assert "--sms-time-from" in result.output
+    assert "HH:MM" in result.output
+
+
+def test_campaigns_rejects_legacy_notification_blob_with_guidance():
+    result = _rejected(*_cpa_base_args(), "--notification", "{}")
+    assert "--notification is no longer accepted" in result.output
+    assert "--notification-email" in result.output
+
+
+def test_campaigns_update_rejects_legacy_notification_blob_with_guidance():
+    result = _rejected("campaigns", "update", "--id", "123", "--notification", "{}")
+    assert "--notification is no longer accepted" in result.output
+    assert "--notification-email" in result.output
+
+
+def test_campaigns_rejects_legacy_time_targeting_blob_with_guidance():
+    result = _rejected(*_cpa_base_args(), "--time-targeting", "{}")
+    assert "--time-targeting is no longer accepted" in result.output
+    assert "--time-targeting-schedule" in result.output
+
+
 def test_campaigns_rejects_too_many_blocked_ips():
     result = _rejected(
         *_cpa_base_args(),

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -1428,6 +1428,83 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     ("campaigns", "add", "DailyBudget.Amount"): {"--budget"},
     ("campaigns", "add", "DailyBudget.Mode"): {"--budget"},
     ("campaigns", "add", "EndDate"): {"--end-date"},
+    ("campaigns", "add", "ClientInfo"): {"--client-info"},
+    ("campaigns", "add", "Notification"): {
+        "--sms-events",
+        "--sms-time-from",
+        "--sms-time-to",
+        "--notification-email",
+        "--notification-check-position-interval",
+        "--notification-warning-balance",
+        "--notification-send-account-news",
+        "--notification-send-warnings",
+    },
+    ("campaigns", "add", "Notification.SmsSettings"): {
+        "--sms-events",
+        "--sms-time-from",
+        "--sms-time-to",
+    },
+    ("campaigns", "add", "Notification.SmsSettings.Events"): {"--sms-events"},
+    ("campaigns", "add", "Notification.SmsSettings.TimeFrom"): {"--sms-time-from"},
+    ("campaigns", "add", "Notification.SmsSettings.TimeTo"): {"--sms-time-to"},
+    ("campaigns", "add", "Notification.EmailSettings"): {
+        "--notification-email",
+        "--notification-check-position-interval",
+        "--notification-warning-balance",
+        "--notification-send-account-news",
+        "--notification-send-warnings",
+    },
+    ("campaigns", "add", "Notification.EmailSettings.Email"): {"--notification-email"},
+    ("campaigns", "add", "Notification.EmailSettings.CheckPositionInterval"): {
+        "--notification-check-position-interval"
+    },
+    ("campaigns", "add", "Notification.EmailSettings.WarningBalance"): {
+        "--notification-warning-balance"
+    },
+    ("campaigns", "add", "Notification.EmailSettings.SendAccountNews"): {
+        "--notification-send-account-news"
+    },
+    ("campaigns", "add", "Notification.EmailSettings.SendWarnings"): {
+        "--notification-send-warnings"
+    },
+    ("campaigns", "add", "TimeZone"): {"--time-zone"},
+    ("campaigns", "add", "NegativeKeywords"): {"--negative-keywords"},
+    ("campaigns", "add", "NegativeKeywords.Items"): {"--negative-keywords"},
+    ("campaigns", "add", "BlockedIps"): {"--blocked-ips"},
+    ("campaigns", "add", "BlockedIps.Items"): {"--blocked-ips"},
+    ("campaigns", "add", "ExcludedSites"): {"--excluded-sites"},
+    ("campaigns", "add", "ExcludedSites.Items"): {"--excluded-sites"},
+    ("campaigns", "add", "TimeTargeting"): {
+        "--time-targeting-schedule",
+        "--consider-working-weekends",
+        "--holidays-suspend-on-holidays",
+        "--holidays-bid-percent",
+        "--holidays-start-hour",
+        "--holidays-end-hour",
+    },
+    ("campaigns", "add", "TimeTargeting.Schedule"): {"--time-targeting-schedule"},
+    ("campaigns", "add", "TimeTargeting.Schedule.Items"): {"--time-targeting-schedule"},
+    ("campaigns", "add", "TimeTargeting.ConsiderWorkingWeekends"): {
+        "--consider-working-weekends"
+    },
+    ("campaigns", "add", "TimeTargeting.HolidaysSchedule"): {
+        "--holidays-suspend-on-holidays",
+        "--holidays-bid-percent",
+        "--holidays-start-hour",
+        "--holidays-end-hour",
+    },
+    ("campaigns", "add", "TimeTargeting.HolidaysSchedule.SuspendOnHolidays"): {
+        "--holidays-suspend-on-holidays"
+    },
+    ("campaigns", "add", "TimeTargeting.HolidaysSchedule.BidPercent"): {
+        "--holidays-bid-percent"
+    },
+    ("campaigns", "add", "TimeTargeting.HolidaysSchedule.StartHour"): {
+        "--holidays-start-hour"
+    },
+    ("campaigns", "add", "TimeTargeting.HolidaysSchedule.EndHour"): {
+        "--holidays-end-hour"
+    },
     ("campaigns", "add", "TextCampaign"): {"--type"},
     ("campaigns", "add", "TextCampaign.BiddingStrategy"): {
         "--search-strategy",
@@ -1461,6 +1538,87 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     ("campaigns", "update", "DailyBudget.Mode"): {"--budget"},
     ("campaigns", "update", "StartDate"): {"--start-date"},
     ("campaigns", "update", "EndDate"): {"--end-date"},
+    ("campaigns", "update", "ClientInfo"): {"--client-info"},
+    ("campaigns", "update", "Notification"): {
+        "--sms-events",
+        "--sms-time-from",
+        "--sms-time-to",
+        "--notification-email",
+        "--notification-check-position-interval",
+        "--notification-warning-balance",
+        "--notification-send-account-news",
+        "--notification-send-warnings",
+    },
+    ("campaigns", "update", "Notification.SmsSettings"): {
+        "--sms-events",
+        "--sms-time-from",
+        "--sms-time-to",
+    },
+    ("campaigns", "update", "Notification.SmsSettings.Events"): {"--sms-events"},
+    ("campaigns", "update", "Notification.SmsSettings.TimeFrom"): {"--sms-time-from"},
+    ("campaigns", "update", "Notification.SmsSettings.TimeTo"): {"--sms-time-to"},
+    ("campaigns", "update", "Notification.EmailSettings"): {
+        "--notification-email",
+        "--notification-check-position-interval",
+        "--notification-warning-balance",
+        "--notification-send-account-news",
+        "--notification-send-warnings",
+    },
+    ("campaigns", "update", "Notification.EmailSettings.Email"): {
+        "--notification-email"
+    },
+    ("campaigns", "update", "Notification.EmailSettings.CheckPositionInterval"): {
+        "--notification-check-position-interval"
+    },
+    ("campaigns", "update", "Notification.EmailSettings.WarningBalance"): {
+        "--notification-warning-balance"
+    },
+    ("campaigns", "update", "Notification.EmailSettings.SendAccountNews"): {
+        "--notification-send-account-news"
+    },
+    ("campaigns", "update", "Notification.EmailSettings.SendWarnings"): {
+        "--notification-send-warnings"
+    },
+    ("campaigns", "update", "TimeZone"): {"--time-zone"},
+    ("campaigns", "update", "NegativeKeywords"): {"--negative-keywords"},
+    ("campaigns", "update", "NegativeKeywords.Items"): {"--negative-keywords"},
+    ("campaigns", "update", "BlockedIps"): {"--blocked-ips"},
+    ("campaigns", "update", "BlockedIps.Items"): {"--blocked-ips"},
+    ("campaigns", "update", "ExcludedSites"): {"--excluded-sites"},
+    ("campaigns", "update", "ExcludedSites.Items"): {"--excluded-sites"},
+    ("campaigns", "update", "TimeTargeting"): {
+        "--time-targeting-schedule",
+        "--consider-working-weekends",
+        "--holidays-suspend-on-holidays",
+        "--holidays-bid-percent",
+        "--holidays-start-hour",
+        "--holidays-end-hour",
+    },
+    ("campaigns", "update", "TimeTargeting.Schedule"): {"--time-targeting-schedule"},
+    ("campaigns", "update", "TimeTargeting.Schedule.Items"): {
+        "--time-targeting-schedule"
+    },
+    ("campaigns", "update", "TimeTargeting.ConsiderWorkingWeekends"): {
+        "--consider-working-weekends"
+    },
+    ("campaigns", "update", "TimeTargeting.HolidaysSchedule"): {
+        "--holidays-suspend-on-holidays",
+        "--holidays-bid-percent",
+        "--holidays-start-hour",
+        "--holidays-end-hour",
+    },
+    ("campaigns", "update", "TimeTargeting.HolidaysSchedule.SuspendOnHolidays"): {
+        "--holidays-suspend-on-holidays"
+    },
+    ("campaigns", "update", "TimeTargeting.HolidaysSchedule.BidPercent"): {
+        "--holidays-bid-percent"
+    },
+    ("campaigns", "update", "TimeTargeting.HolidaysSchedule.StartHour"): {
+        "--holidays-start-hour"
+    },
+    ("campaigns", "update", "TimeTargeting.HolidaysSchedule.EndHour"): {
+        "--holidays-end-hour"
+    },
     ("campaigns", "update", "TextCampaign"): {"--type"},
     ("campaigns", "update", "TextCampaign.TrackingParams"): {"--tracking-params"},
     ("campaigns", "update", "DynamicTextCampaign"): {"--type"},
@@ -1993,14 +2151,6 @@ OPTIONAL_FIELD_DEFAULT_FOLLOWUPS: dict[tuple[str, str], dict[str, str]] = {
     ("bidmodifiers", "add"): {
         "issue": "#254",
         "note": "bidmodifiers.add optional WSDL path needs typed support or N/A.",
-    },
-    ("campaigns", "add"): {
-        "issue": "#291",
-        "note": "campaigns.add campaign-level optional path needs typed support or N/A.",
-    },
-    ("campaigns", "update"): {
-        "issue": "#291",
-        "note": "campaigns.update campaign-level optional path needs typed support or N/A.",
     },
     ("dynamicads", "add"): {
         "issue": "#303",


### PR DESCRIPTION
## Summary
- adds typed `campaigns add/update` flags for campaign-level controls from #291: ClientInfo, Notification, TimeZone, NegativeKeywords, BlockedIps, ExcludedSites, and TimeTargeting
- removes the public `--notification` / `--time-targeting` JSON blob inputs in favor of canonical typed flags
- keeps campaign-level fields at the top level of `CampaignAddItem` / `CampaignUpdateItem`, matching Yandex Direct API docs
- updates WSDL optional-field audit routing and README single-line examples

## Verification
- `python3 scripts/build_wsdl_optional_field_audit.py --check`
- `python3 -m pytest tests/test_dry_run.py -k "campaigns and (notification or time_targeting or campaign_level or sms_events or negative_keywords or client_info or blocked_ips or holidays or help_exposes_typed)"`
- `python3 -m pytest tests/test_wsdl_parity_gate.py`
- `python3 -m pytest tests/test_api_coverage.py`
- `python3 -m pytest tests/test_cli_contract.py -k "json or readme_direct_examples"`
- `python3 -m pytest tests/test_cli.py tests/test_dry_run.py tests/test_wsdl_parity_gate.py`
- `mypy .`
- `git diff --check`
- `python3 -m pytest -m "not integration"`

Closes #291
