### PR TITLE
[codex] Fix cwd dotenv loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,15 +72,18 @@ Credential resolution priority:
 | 1 | Explicit CLI options | `direct --token TOKEN --login LOGIN campaigns get` |
 | 2 | OAuth profile storage | `direct --profile agency1 campaigns get` |
 | 3 | Profile-specific env vars | `YANDEX_DIRECT_TOKEN_AGENCY1`, `YANDEX_DIRECT_LOGIN_AGENCY1` |
-| 4 | Base env vars or project `.env` | `YANDEX_DIRECT_TOKEN`, `YANDEX_DIRECT_LOGIN` |
+| 4 | Base env vars or current working directory `.env` | `YANDEX_DIRECT_TOKEN`, `YANDEX_DIRECT_LOGIN` |
 | 5 | 1Password references | `--op-token-ref`, `YANDEX_DIRECT_OP_TOKEN_REF` |
 | 6 | Bitwarden references | `--bw-token-ref`, `YANDEX_DIRECT_BW_TOKEN_REF` |
 
-The project `.env` file is loaded automatically. If a profile is selected
-with `--profile` or `direct auth use --profile NAME`, Direct CLI does not
-fall back to base `YANDEX_DIRECT_LOGIN`; this prevents mixing a profile token
-with a login from the project `.env`. For multi-account setups, prefer OAuth
-profiles or profile-specific env vars instead of base credentials.
+Direct CLI automatically loads only the `.env` file from the current working
+directory, i.e. the directory where you run `direct`. It does not search for
+`.env` from the installed package or source-code location. If a profile is
+selected with `--profile` or `direct auth use --profile NAME`, Direct CLI does
+not fall back to base `YANDEX_DIRECT_LOGIN`; this prevents mixing a profile
+token with a login from the current working directory `.env`. For multi-account
+setups, prefer OAuth profiles or profile-specific env vars instead of base
+credentials.
 
 > **Tests use the inverted order.** Live-API test suites (e.g. `tests/test_v4_live_contracts.py`) read `YANDEX_DIRECT_TOKEN` / `YANDEX_DIRECT_LOGIN` from the environment first, only then fall back to the active `direct auth` profile, and skip the test if neither is set. This is intentional: a developer machine with an active profile must not silently hit production on a plain `pytest` invocation. See `CLAUDE.md` for the contract.
 
@@ -968,15 +971,17 @@ direct --profile agency1 campaigns get
 | 1 | Явные CLI-опции | `direct --token TOKEN --login LOGIN campaigns get` |
 | 2 | OAuth profile storage | `direct --profile agency1 campaigns get` |
 | 3 | Профильные env vars | `YANDEX_DIRECT_TOKEN_AGENCY1`, `YANDEX_DIRECT_LOGIN_AGENCY1` |
-| 4 | Базовые env vars или project `.env` | `YANDEX_DIRECT_TOKEN`, `YANDEX_DIRECT_LOGIN` |
+| 4 | Базовые env vars или `.env` из папки запуска | `YANDEX_DIRECT_TOKEN`, `YANDEX_DIRECT_LOGIN` |
 | 5 | 1Password references | `--op-token-ref`, `YANDEX_DIRECT_OP_TOKEN_REF` |
 | 6 | Bitwarden references | `--bw-token-ref`, `YANDEX_DIRECT_BW_TOKEN_REF` |
 
-Файл `.env` в проекте загружается автоматически. Если профиль выбран через
-`--profile` или `direct auth use --profile NAME`, Direct CLI не подставляет
-base `YANDEX_DIRECT_LOGIN`; это защищает от смешивания токена из профиля с
-логином из project `.env`. Для нескольких аккаунтов используйте OAuth profiles
-или профильные env vars, а не базовые credentials.
+Direct CLI автоматически читает только `.env` из текущей рабочей папки, то есть
+из папки, где запущена команда `direct`. Он не ищет `.env` от папки
+установленного пакета или исходного кода. Если профиль выбран через `--profile`
+или `direct auth use --profile NAME`, Direct CLI не подставляет base
+`YANDEX_DIRECT_LOGIN`; это защищает от смешивания токена из профиля с логином из
+`.env` текущей рабочей папки. Для нескольких аккаунтов используйте OAuth
+profiles или профильные env vars, а не базовые credentials.
 
 > **В тестах порядок инвертирован.** Live-API тесты (например `tests/test_v4_live_contracts.py`) сначала читают `YANDEX_DIRECT_TOKEN` / `YANDEX_DIRECT_LOGIN` из окружения, затем падают на активный профиль `direct auth`, и скипают тест если ни того ни другого нет. Это сделано специально: на машине разработчика с активным профилем обычный `pytest` не должен молча идти в боевой API. Контракт зафиксирован в `CLAUDE.md`.
 

--- a/direct_cli/auth.py
+++ b/direct_cli/auth.py
@@ -23,7 +23,7 @@ try:
     from dotenv import load_dotenv
 except ImportError:
 
-    def load_dotenv():
+    def load_dotenv(*args: Any, **kwargs: Any) -> None:
         return None
 
 
@@ -108,12 +108,10 @@ def bw_read(item: str, field: str = "password") -> str:
 
 
 def load_env_file(env_path: Optional[str] = None) -> None:
-    """Load environment variables from .env file"""
+    """Load environment variables from an explicit or current-directory .env."""
     if load_dotenv:
-        if env_path:
-            load_dotenv(env_path)
-        else:
-            load_dotenv()
+        dotenv_path = Path(env_path) if env_path else Path.cwd() / ".env"
+        load_dotenv(dotenv_path)
 
 
 def _profile_suffix(profile: str) -> str:

--- a/direct_cli/cli.py
+++ b/direct_cli/cli.py
@@ -4,10 +4,9 @@ Direct CLI - Command-line interface for Yandex Direct API
 """
 
 import click
-from dotenv import load_dotenv
 
 from . import __version__
-from .auth import get_active_profile, get_credentials
+from .auth import get_active_profile, get_credentials, load_env_file
 from .utils import get_docs_url
 
 from .commands.campaigns import campaigns
@@ -52,7 +51,7 @@ from .commands.v4tags import v4tags
 from .commands.v4wordstat import v4wordstat
 
 # Load .env file
-load_dotenv()
+load_env_file()
 
 
 CLI_EPILOG = """\b

--- a/tests/test_env_loading.py
+++ b/tests/test_env_loading.py
@@ -1,0 +1,100 @@
+"""Tests for Direct CLI .env loading rules."""
+
+import os
+from pathlib import Path
+
+from direct_cli import auth
+
+
+def test_load_env_file_uses_cwd_dotenv_by_default(monkeypatch, tmp_path):
+    """Default .env loading is pinned to the command working directory."""
+    calls = []
+
+    def fake_load_dotenv(dotenv_path):
+        calls.append(Path(dotenv_path))
+        return True
+
+    monkeypatch.setattr(auth, "load_dotenv", fake_load_dotenv)
+    monkeypatch.chdir(tmp_path)
+
+    auth.load_env_file()
+
+    assert calls == [tmp_path / ".env"]
+
+
+def test_load_env_file_uses_explicit_path(monkeypatch, tmp_path):
+    """Explicit env paths are respected exactly."""
+    calls = []
+
+    def fake_load_dotenv(dotenv_path):
+        calls.append(Path(dotenv_path))
+        return True
+
+    env_path = tmp_path / "custom.env"
+    monkeypatch.setattr(auth, "load_dotenv", fake_load_dotenv)
+
+    auth.load_env_file(str(env_path))
+
+    assert calls == [env_path]
+
+
+def test_load_env_file_loads_cwd_dotenv(monkeypatch, tmp_path):
+    """A .env in the command working directory is loaded."""
+    monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
+    monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
+    (tmp_path / ".env").write_text(
+        "YANDEX_DIRECT_TOKEN=cwd-token\n" "YANDEX_DIRECT_LOGIN=cwd-login\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    auth.load_env_file()
+
+    assert os.environ["YANDEX_DIRECT_TOKEN"] == "cwd-token"
+    assert os.environ["YANDEX_DIRECT_LOGIN"] == "cwd-login"
+
+
+def test_load_env_file_does_not_search_from_source_location(monkeypatch, tmp_path):
+    """A source-adjacent .env is ignored when the command runs elsewhere."""
+    source_dir = tmp_path / "source"
+    run_dir = tmp_path / "run"
+    source_dir.mkdir()
+    run_dir.mkdir()
+    source_env = source_dir / ".env"
+    source_env.write_text(
+        "YANDEX_DIRECT_TOKEN=source-token\n" "YANDEX_DIRECT_LOGIN=source-login\n",
+        encoding="utf-8",
+    )
+    calls = []
+
+    def fake_load_dotenv(dotenv_path):
+        path = Path(dotenv_path)
+        calls.append(path)
+        if path == source_env:
+            monkeypatch.setenv("YANDEX_DIRECT_TOKEN", "source-token")
+            monkeypatch.setenv("YANDEX_DIRECT_LOGIN", "source-login")
+        return path.exists()
+
+    monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
+    monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
+    monkeypatch.setattr(auth, "load_dotenv", fake_load_dotenv)
+    monkeypatch.chdir(run_dir)
+
+    auth.load_env_file()
+
+    assert calls == [run_dir / ".env"]
+    assert "YANDEX_DIRECT_TOKEN" not in os.environ
+    assert "YANDEX_DIRECT_LOGIN" not in os.environ
+
+
+def test_cli_routes_early_dotenv_loading_through_auth_helper():
+    """cli.py must not call python-dotenv directly."""
+    repo_root = Path(__file__).resolve().parents[1]
+    cli_source = (repo_root / "direct_cli" / "cli.py").read_text(encoding="utf-8")
+
+    assert "from dotenv import load_dotenv" not in cli_source
+    assert (
+        "from .auth import get_active_profile, get_credentials, load_env_file"
+        in cli_source
+    )
+    assert "load_env_file()" in cli_source

--- a/tests/test_env_loading.py
+++ b/tests/test_env_loading.py
@@ -2,6 +2,8 @@
 
 import ast
 import os
+import subprocess
+import sys
 from pathlib import Path
 
 from direct_cli import auth
@@ -39,20 +41,35 @@ def test_load_env_file_uses_explicit_path(monkeypatch, tmp_path):
     assert calls == [env_path]
 
 
-def test_load_env_file_loads_cwd_dotenv(monkeypatch, tmp_path):
+def test_load_env_file_loads_cwd_dotenv(tmp_path):
     """A .env in the command working directory is loaded."""
-    monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
-    monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
+    repo_root = Path(__file__).resolve().parents[1]
     (tmp_path / ".env").write_text(
         "YANDEX_DIRECT_TOKEN=cwd-token\n" "YANDEX_DIRECT_LOGIN=cwd-login\n",
         encoding="utf-8",
     )
-    monkeypatch.chdir(tmp_path)
+    env = os.environ.copy()
+    env.pop("YANDEX_DIRECT_TOKEN", None)
+    env.pop("YANDEX_DIRECT_LOGIN", None)
+    env["PYTHONPATH"] = str(repo_root)
+    script = (
+        "import os\n"
+        "from direct_cli import auth\n"
+        "auth.load_env_file()\n"
+        "print(os.environ.get('YANDEX_DIRECT_TOKEN'))\n"
+        "print(os.environ.get('YANDEX_DIRECT_LOGIN'))\n"
+    )
 
-    auth.load_env_file()
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
 
-    assert os.environ["YANDEX_DIRECT_TOKEN"] == "cwd-token"
-    assert os.environ["YANDEX_DIRECT_LOGIN"] == "cwd-login"
+    assert result.stdout.splitlines() == ["cwd-token", "cwd-login"]
 
 
 def test_load_env_file_does_not_search_from_source_location(monkeypatch, tmp_path):

--- a/tests/test_env_loading.py
+++ b/tests/test_env_loading.py
@@ -1,5 +1,6 @@
 """Tests for Direct CLI .env loading rules."""
 
+import ast
 import os
 from pathlib import Path
 
@@ -91,10 +92,28 @@ def test_cli_routes_early_dotenv_loading_through_auth_helper():
     """cli.py must not call python-dotenv directly."""
     repo_root = Path(__file__).resolve().parents[1]
     cli_source = (repo_root / "direct_cli" / "cli.py").read_text(encoding="utf-8")
+    cli_tree = ast.parse(cli_source)
 
-    assert "from dotenv import load_dotenv" not in cli_source
-    assert (
-        "from .auth import get_active_profile, get_credentials, load_env_file"
-        in cli_source
+    imports_dotenv_loader = any(
+        isinstance(node, ast.ImportFrom)
+        and node.module == "dotenv"
+        and any(alias.name == "load_dotenv" for alias in node.names)
+        for node in ast.walk(cli_tree)
     )
-    assert "load_env_file()" in cli_source
+    imports_auth_env_loader = any(
+        isinstance(node, ast.ImportFrom)
+        and node.level == 1
+        and node.module == "auth"
+        and any(alias.name == "load_env_file" for alias in node.names)
+        for node in ast.walk(cli_tree)
+    )
+    calls_auth_env_loader = any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "load_env_file"
+        for node in ast.walk(cli_tree)
+    )
+
+    assert not imports_dotenv_loader
+    assert imports_auth_env_loader
+    assert calls_auth_env_loader


### PR DESCRIPTION
## Summary

Fixes issue #356 by centralizing .env loading in `direct_cli.auth.load_env_file()` and pinning implicit .env lookup to the current working directory.

## Changes

- Removed direct `python-dotenv` usage from `direct_cli/cli.py`.
- Updated `load_env_file()` so implicit loading uses only `Path.cwd() / ".env"` and never calls `load_dotenv()` without a path.
- Updated README credential docs to describe current-working-directory `.env` behavior.
- Added regression tests covering cwd `.env`, explicit env paths, and source-adjacent `.env` isolation.

## Validation

- `python3 -m pytest tests/test_env_loading.py tests/test_auth_oauth.py tests/test_auth_op.py tests/test_auth_bw.py tests/test_cli.py -q`
- `python3 -m pytest -q`
- `python3 -m black --check direct_cli/auth.py direct_cli/cli.py tests/test_env_loading.py`
- `python3 -m ruff check direct_cli/auth.py direct_cli/cli.py tests/test_env_loading.py`
- `git diff --check`
- Manual import check from `/private/tmp` with `YANDEX_DIRECT_TOKEN` and `YANDEX_DIRECT_LOGIN` unset: `script_like False False`