### PR TITLE
[codex] Fix dotenv credential precedence

### DIFF
--- a/direct_cli/cli.py
+++ b/direct_cli/cli.py
@@ -4,6 +4,7 @@ Direct CLI - Command-line interface for Yandex Direct API
 """
 
 import click
+from click.core import ParameterSource
 
 from . import __version__
 from .auth import get_active_profile, get_credentials, load_env_file
@@ -65,6 +66,13 @@ API errors:
   Error 8800 usually means the object is not available under the current
   Client-Login/account.
 """
+
+
+def _command_line_option_value(ctx, name, value):
+    """Return only values explicitly supplied on the command line."""
+    if ctx.get_parameter_source(name) is ParameterSource.COMMANDLINE:
+        return value
+    return None
 
 
 def _command_has_option(cmd: click.Command, option_name: str) -> bool:
@@ -214,6 +222,27 @@ def cli(
     if ctx.invoked_subcommand != "auth":
         active_profile = get_active_profile()
 
+    explicit_token = _command_line_option_value(ctx, "token", token)
+    explicit_login = _command_line_option_value(ctx, "login", login)
+    if (
+        explicit_login is None
+        and active_profile is None
+        and ctx.get_parameter_source("login") is ParameterSource.ENVIRONMENT
+    ):
+        explicit_login = login
+    explicit_op_token_ref = _command_line_option_value(
+        ctx, "op_token_ref", op_token_ref
+    )
+    explicit_op_login_ref = _command_line_option_value(
+        ctx, "op_login_ref", op_login_ref
+    )
+    explicit_bw_token_ref = _command_line_option_value(
+        ctx, "bw_token_ref", bw_token_ref
+    )
+    explicit_bw_login_ref = _command_line_option_value(
+        ctx, "bw_login_ref", bw_login_ref
+    )
+
     # Resolve credentials early so all subcommands get the final values
     has_refs = (
         token
@@ -228,13 +257,13 @@ def cli(
     if has_refs:
         try:
             resolved_token, resolved_login = get_credentials(
-                token=token,
-                login=login,
+                token=explicit_token,
+                login=explicit_login,
                 profile=profile,
-                op_token_ref=op_token_ref,
-                op_login_ref=op_login_ref,
-                bw_token_ref=bw_token_ref,
-                bw_login_ref=bw_login_ref,
+                op_token_ref=explicit_op_token_ref,
+                op_login_ref=explicit_op_login_ref,
+                bw_token_ref=explicit_bw_token_ref,
+                bw_login_ref=explicit_bw_login_ref,
             )
             ctx.obj["token"] = resolved_token
             ctx.obj["login"] = resolved_login
@@ -245,11 +274,11 @@ def cli(
                 # Explicit profile selected but not found — surface the error
                 raise click.ClickException(str(e))
             # No credential source at all — let subcommands fail naturally
-            ctx.obj["token"] = token
-            ctx.obj["login"] = login
+            ctx.obj["token"] = explicit_token
+            ctx.obj["login"] = explicit_login
     else:
-        ctx.obj["token"] = token
-        ctx.obj["login"] = login
+        ctx.obj["token"] = explicit_token
+        ctx.obj["login"] = explicit_login
 
 
 def _register_command(command: click.Command) -> None:

--- a/direct_cli/commands/adgroups.py
+++ b/direct_cli/commands/adgroups.py
@@ -660,7 +660,7 @@ def get(
 )
 @click.option(
     "--target-carrier",
-    help=("MobileAppAdGroup.TargetCarrier value: " "WI_FI_ONLY or WI_FI_AND_CELLULAR"),
+    help=("MobileAppAdGroup.TargetCarrier value: WI_FI_ONLY or WI_FI_AND_CELLULAR"),
 )
 @click.option(
     "--target-operating-system-version",
@@ -911,7 +911,7 @@ def add(
 @click.option(
     "--dynamic-feed",
     is_flag=True,
-    help=("Build DynamicTextFeedAdGroup update block for " "--autotargeting-category"),
+    help=("Build DynamicTextFeedAdGroup update block for --autotargeting-category"),
 )
 @click.option(
     "--negative-keywords",
@@ -957,7 +957,7 @@ def add(
 )
 @click.option(
     "--target-carrier",
-    help=("MobileAppAdGroup.TargetCarrier value: " "WI_FI_ONLY or WI_FI_AND_CELLULAR"),
+    help=("MobileAppAdGroup.TargetCarrier value: WI_FI_ONLY or WI_FI_AND_CELLULAR"),
 )
 @click.option(
     "--target-operating-system-version",

--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -394,8 +394,7 @@ def _parse_mobile_app_features(
         feature_raw, separator, enabled_raw = raw_value.strip().partition("=")
         if not separator:
             raise click.UsageError(
-                "--mobile-app-feature expects FEATURE=YES|NO "
-                "(for example PRICE=YES)."
+                "--mobile-app-feature expects FEATURE=YES|NO (for example PRICE=YES)."
             )
 
         feature = feature_raw.strip().upper()

--- a/direct_cli/commands/campaigns.py
+++ b/direct_cli/commands/campaigns.py
@@ -279,7 +279,7 @@ def _array_of_string_option(
         too_long = [item for item in parsed if len(item) > max_item_length]
         if too_long:
             raise click.UsageError(
-                f"{option_name} items must be at most " f"{max_item_length} characters"
+                f"{option_name} items must be at most {max_item_length} characters"
             )
     return {"Items": parsed} if parsed else None
 
@@ -997,7 +997,7 @@ def get(
     "--package-platform-dynamic-places",
     type=click.Choice(YES_NO, case_sensitive=False),
     help=(
-        "TextCampaign/UnifiedCampaign.PackageBiddingStrategy." "Platforms.DynamicPlaces"
+        "TextCampaign/UnifiedCampaign.PackageBiddingStrategy.Platforms.DynamicPlaces"
     ),
 )
 @click.option(
@@ -1900,7 +1900,7 @@ def add(
     "--package-platform-dynamic-places",
     type=click.Choice(YES_NO, case_sensitive=False),
     help=(
-        "TextCampaign/UnifiedCampaign.PackageBiddingStrategy." "Platforms.DynamicPlaces"
+        "TextCampaign/UnifiedCampaign.PackageBiddingStrategy.Platforms.DynamicPlaces"
     ),
 )
 @click.option(
@@ -2340,7 +2340,9 @@ def update(
                 package_label = (
                     "UnifiedCampaign"
                     if is_unified
-                    else "DynamicTextCampaign" if is_dynamic else "TextCampaign"
+                    else "DynamicTextCampaign"
+                    if is_dynamic
+                    else "TextCampaign"
                 )
                 parsed_settings = parse_setting_specs(list(settings))
                 if parsed_settings:

--- a/direct_cli/commands/dynamicads.py
+++ b/direct_cli/commands/dynamicads.py
@@ -268,8 +268,7 @@ def set_bids(
             )
         if not bid_fields:
             raise click.UsageError(
-                "Provide at least one bid field"
-                " (--bid, --context-bid, or --priority)"
+                "Provide at least one bid field (--bid, --context-bid, or --priority)"
             )
 
         body = {"method": "setBids", "params": {"Bids": [bid_data]}}

--- a/direct_cli/commands/keywordbids.py
+++ b/direct_cli/commands/keywordbids.py
@@ -221,9 +221,9 @@ def set_auto(
                 "TargetTrafficVolume": target_traffic_volume
             }
             if increase_percent is not None:
-                bidding_rule["SearchByTrafficVolume"][
-                    "IncreasePercent"
-                ] = increase_percent
+                bidding_rule["SearchByTrafficVolume"]["IncreasePercent"] = (
+                    increase_percent
+                )
             if bid_ceiling is not None:
                 bidding_rule["SearchByTrafficVolume"]["BidCeiling"] = bid_ceiling
         if target_coverage is not None:

--- a/direct_cli/commands/keywords.py
+++ b/direct_cli/commands/keywords.py
@@ -88,8 +88,7 @@ def _coerce_keyword_field(field: str, raw_value: Any, row_index: int) -> Any:
             return int(raw_value)
         except (TypeError, ValueError):
             raise click.UsageError(
-                f"Row {row_index} field {field!r}: expected integer, "
-                f"got {raw_value!r}"
+                f"Row {row_index} field {field!r}: expected integer, got {raw_value!r}"
             )
     if kind == "micro":
         try:

--- a/direct_cli/commands/retargeting.py
+++ b/direct_cli/commands/retargeting.py
@@ -34,7 +34,9 @@ def get(ctx, ids, types, limit, fetch_all, output_format, output, fields):
             sandbox=ctx.obj.get("sandbox"),
         )
 
-        field_names = fields.split(",") if fields else get_default_fields("retargetinglists")
+        field_names = (
+            fields.split(",") if fields else get_default_fields("retargetinglists")
+        )
 
         criteria = {}
         if ids:

--- a/direct_cli/commands/strategies.py
+++ b/direct_cli/commands/strategies.py
@@ -236,7 +236,7 @@ def _build_exploration_budget(
         return None
     if strategy_type not in EXPLORATION_BUDGET_STRATEGY_TYPES:
         raise click.UsageError(
-            "--minimum-exploration-budget is not valid for " f"--type {strategy_type}."
+            f"--minimum-exploration-budget is not valid for --type {strategy_type}."
         )
     if (
         weekly_spend_limit is not None

--- a/direct_cli/commands/v4account.py
+++ b/direct_cli/commands/v4account.py
@@ -219,9 +219,7 @@ def _validate_action(action: str) -> str:
     return normalized
 
 
-def _flag_supplied(
-    ctx: click.Context, name: str, value: Any
-) -> bool:
+def _flag_supplied(ctx: click.Context, name: str, value: Any) -> bool:
     """Detect whether an action-specific Click parameter was supplied by the user.
 
     Values sourced from envvars or defaults are NOT counted as "supplied" —
@@ -249,7 +247,9 @@ def _reject_disallowed_flags(
         if name not in allowed and _flag_supplied(ctx, name, value)
     )
     if offenders:
-        valid_flags = sorted(_PARAM_TO_FLAG[name] for name in allowed if name in _PARAM_TO_FLAG)
+        valid_flags = sorted(
+            _PARAM_TO_FLAG[name] for name in allowed if name in _PARAM_TO_FLAG
+        )
         raise click.UsageError(
             f"{', '.join(offenders)} not valid for --action {action}. "
             f"Valid flags for {action}: {', '.join(valid_flags)}"
@@ -272,9 +272,7 @@ def _account_selection_criteria(
         if not parsed_ids:
             raise click.UsageError("--account-ids must not be empty when provided")
         if any(account_id <= 0 for account_id in parsed_ids):
-            raise click.UsageError(
-                "--account-ids must contain only positive integers"
-            )
+            raise click.UsageError("--account-ids must contain only positive integers")
     else:
         parsed_ids = None
 
@@ -291,9 +289,7 @@ def _account_selection_criteria(
     return criteria or None
 
 
-def _account_get_param(
-    logins: Optional[str], account_ids: Optional[str]
-) -> dict:
+def _account_get_param(logins: Optional[str], account_ids: Optional[str]) -> dict:
     """Build the Get param object."""
     criteria = _account_selection_criteria(logins, account_ids)
     param: dict = {"Action": "Get"}
@@ -366,9 +362,7 @@ def _account_update_param(
     return {"Action": action, "Accounts": [account]}
 
 
-def _parse_account_payments(
-    payments: tuple[str, ...], currency: str
-) -> list[dict]:
+def _parse_account_payments(payments: tuple[str, ...], currency: str) -> list[dict]:
     """Parse repeated --payment ACCOUNT_ID=AMOUNT into PayCampElement-shaped items."""
     if not payments:
         raise click.UsageError("--payment is required")
@@ -425,9 +419,7 @@ def _account_deposit_param(
     return {"Action": "Deposit", "Payments": items}
 
 
-def _account_invoice_param(
-    payments: tuple[str, ...], currency: str
-) -> dict:
+def _account_invoice_param(payments: tuple[str, ...], currency: str) -> dict:
     """Build the Invoice param object."""
     return {
         "Action": "Invoice",
@@ -443,9 +435,7 @@ def _account_transfer_param(
 ) -> dict:
     """Build the TransferMoney param object (single transfer per call)."""
     if from_account_id == to_account_id:
-        raise click.UsageError(
-            "--from-account-id and --to-account-id must differ"
-        )
+        raise click.UsageError("--from-account-id and --to-account-id must differ")
     return {
         "Action": "TransferMoney",
         "Transfers": [
@@ -535,9 +525,7 @@ def enable_shared_account(ctx, client_login, dry_run, output_format, output):
 @click.option(
     "--sms-time-from", help="SMS notification start time, HH:MM (Update only)"
 )
-@click.option(
-    "--sms-time-to", help="SMS notification end time, HH:MM (Update only)"
-)
+@click.option("--sms-time-to", help="SMS notification end time, HH:MM (Update only)")
 @click.option("--email", help="Notification email (Update only)")
 @click.option(
     "--money-warning-value",
@@ -554,8 +542,7 @@ def enable_shared_account(ctx, client_login, dry_run, output_format, output):
     "payments",
     multiple=True,
     help=(
-        "Payment as ACCOUNT_ID=AMOUNT; repeat for multiple accounts "
-        "(Deposit / Invoice)"
+        "Payment as ACCOUNT_ID=AMOUNT; repeat for multiple accounts (Deposit / Invoice)"
     ),
 )
 @click.option(
@@ -579,9 +566,7 @@ def enable_shared_account(ctx, client_login, dry_run, output_format, output):
     type=click.IntRange(min=1),
     help="Destination account ID (TransferMoney only)",
 )
-@click.option(
-    "--amount", help="Positive amount, e.g. 100.50 (TransferMoney only)"
-)
+@click.option("--amount", help="Positive amount, e.g. 100.50 (TransferMoney only)")
 @click.option(
     "--finance-token",
     envvar="YANDEX_DIRECT_FINANCE_TOKEN",
@@ -684,7 +669,9 @@ def account_management(
 
     if action == "Get":
         param = _account_get_param(logins, account_ids)
-        _emit_or_call_v4(ctx, "AccountManagement", param, dry_run, output_format, output)
+        _emit_or_call_v4(
+            ctx, "AccountManagement", param, dry_run, output_format, output
+        )
         return
 
     _require_dry_run_or_sandbox(dry_run, ctx.obj.get("sandbox"))
@@ -704,14 +691,14 @@ def account_management(
             money_warning_value,
             paused_by_day_budget,
         )
-        _emit_or_call_v4(ctx, "AccountManagement", param, dry_run, output_format, output)
+        _emit_or_call_v4(
+            ctx, "AccountManagement", param, dry_run, output_format, output
+        )
         return
 
     # Deposit / Invoice / TransferMoney — financial sub-actions.
     if currency is None:
-        raise click.UsageError(
-            f"--currency is required for --action {action}"
-        )
+        raise click.UsageError(f"--currency is required for --action {action}")
     resolved_token, resolved_op_num = _finance_credentials(
         finance_token,
         master_token,

--- a/direct_cli/utils.py
+++ b/direct_cli/utils.py
@@ -173,7 +173,7 @@ def parse_datetime(datetime_str: str) -> str:
         return f"{datetime_str}Z"
     except ValueError:
         raise ValueError(
-            "Invalid datetime format: " f"{datetime_str}. Expected: YYYY-MM-DDTHH:MM:SS"
+            f"Invalid datetime format: {datetime_str}. Expected: YYYY-MM-DDTHH:MM:SS"
         )
 
 
@@ -239,8 +239,7 @@ def parse_priority_goals_spec(
         pair = pair.strip()
         if not pair:
             raise click.UsageError(
-                "--priority-goals must be a comma-separated list of "
-                "goal_id:value pairs"
+                "--priority-goals must be a comma-separated list of goal_id:value pairs"
             )
         parts = [part.strip() for part in pair.split(":")]
         if len(parts) not in (2, 3):

--- a/direct_cli/v4_contracts.py
+++ b/direct_cli/v4_contracts.py
@@ -350,8 +350,7 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
         group="forecast",
         param_shape=PARAM_SCALAR,
         login_placement=(
-            "param is the scalar forecast ID; global --login uses "
-            "Client-Login header"
+            "param is the scalar forecast ID; global --login uses Client-Login header"
         ),
         safety=SAFETY_READ,
         source_status=SOURCE_DOCS,
@@ -364,8 +363,7 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
         group="forecast",
         param_shape=PARAM_SCALAR,
         login_placement=(
-            "param is the scalar forecast ID; global --login uses "
-            "Client-Login header"
+            "param is the scalar forecast ID; global --login uses Client-Login header"
         ),
         safety=SAFETY_WRITE,
         source_status=SOURCE_DOCS,
@@ -426,8 +424,7 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
         group="tags",
         param_shape=PARAM_ARRAY,
         login_placement=(
-            "param is a list of BannerTagsInfo; global --login uses "
-            "Client-Login header"
+            "param is a list of BannerTagsInfo; global --login uses Client-Login header"
         ),
         safety=SAFETY_WRITE,
         source_status=SOURCE_DOCS,

--- a/scripts/anonymize_cassettes.py
+++ b/scripts/anonymize_cassettes.py
@@ -1,22 +1,20 @@
 #!/usr/bin/env python3
 """Anonymize real client IDs in VCR cassette files."""
+
 import re
 import glob
 import os
 
 REPLACEMENTS = [
     # === Длинные числа первыми (во избежание частичных замен) ===
-
     # Ad IDs (11 цифр)
     ("17692564248", "30000000001"),
     ("17692565308", "30000000002"),
-
     # Keyword/Bid IDs (11 цифр)
     ("57019292002", "40000000001"),
     ("57019292280", "40000000002"),
     ("57019293955", "40000000003"),
     ("57020317358", "40000000004"),
-
     # Ad Group IDs (10 цифр)
     ("5743529158", "2000000001"),
     ("5743529188", "2000000002"),
@@ -27,11 +25,9 @@ REPLACEMENTS = [
     ("5743542755", "2000000007"),
     ("5743542801", "2000000008"),
     ("5743542961", "2000000009"),
-
     # Creative / Sitelinks IDs (10 цифр)
     ("1156472207", "1000000001"),
     ("1472003845", "1000000002"),
-
     # Campaign IDs (9 цифр)
     ("700011014", "100000001"),
     ("700011015", "100000002"),
@@ -54,14 +50,11 @@ REPLACEMENTS = [
     ("709165094", "100000019"),
     ("709165101", "100000020"),
     ("709165115", "100000021"),
-
     # Bid Modifier ID (8 цифр)
     ("10177172", "10000001"),
-
     # Smart Ad Target IDs (7 цифр)
     ("3286108", "1000001"),
     ("3286111", "1000002"),
-
     # Ad Group IDs (7 цифр)
     ("4794478", "2000001"),
     ("4794479", "2000002"),
@@ -69,27 +62,25 @@ REPLACEMENTS = [
     ("4794481", "2000004"),
     ("4794482", "2000005"),
     ("4794483", "2000006"),
-
     # VCard / Negative KW IDs (6 цифр)
     ("340674", "100001"),
     ("420556", "100002"),
-
     # Ad Extension / Retargeting IDs (5 и 4 цифры)
     ("10655", "10001"),
     ("5263", "1001"),
     ("5264", "1002"),
-
     # Feed IDs (3 цифры)
     ("173", "101"),
     ("174", "102"),
-
     # String Video IDs (28 символов)
     ("69e6fcdeaf0e44cf15081eec005", "aabbccdd1122334455667700001"),
     ("69e6fce2af0e44cf1508230e005", "aabbccdd1122334455667700002"),
 ]
 
 REQUEST_ID_RE = re.compile(r"(- ')(\d{19})(')")
-DATE_RE = re.compile(r"(- (?:')?)(Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2} \w+ \d{4} \d{2}:\d{2}:\d{2} GMT('?)")
+DATE_RE = re.compile(
+    r"(- (?:')?)(Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2} \w+ \d{4} \d{2}:\d{2}:\d{2} GMT('?)"
+)
 XACCEL_REQID_RE = re.compile(r"(reqid:)\d+")
 # Matches Content-Length lines in request blocks that have <REDACTED> body
 CONTENT_LENGTH_RE = re.compile(r"(      Content-Length:\n      - ')(\d+)(')")
@@ -124,7 +115,9 @@ def anonymize_file(path: str) -> int:
             return block
         body_str = body_match.group(1)
         new_len = str(len(body_str.encode("utf-8")))
-        block = re.sub(r"(      Content-Length:\n      - ')\d+(')", rf"\g<1>{new_len}\2", block)
+        block = re.sub(
+            r"(      Content-Length:\n      - ')\d+(')", rf"\g<1>{new_len}\2", block
+        )
         return block
 
     content = re.sub(
@@ -133,7 +126,6 @@ def anonymize_file(path: str) -> int:
         content,
         flags=re.DOTALL,
     )
-
 
     if content != original:
         with open(path, "w", encoding="utf-8") as f:

--- a/scripts/build_api_coverage_report.py
+++ b/scripts/build_api_coverage_report.py
@@ -646,9 +646,7 @@ def _validate_runtime_deprecated_methods(deprecated_methods=None) -> list[dict]:
             captured: dict = {}
             try:
                 if original_create_client is not None:
-                    module.create_client = lambda **_: _CapturedClient(
-                        captured
-                    )  # noqa: B023
+                    module.create_client = lambda **_: _CapturedClient(captured)  # noqa: B023
                 result = CliRunner().invoke(cli, argv, standalone_mode=False)
             finally:
                 if original_create_client is not None:

--- a/scripts/check_reports_drift.py
+++ b/scripts/check_reports_drift.py
@@ -86,11 +86,13 @@ def compute_drift(cached: dict, live: dict, missing_cache_count: int = 0) -> dic
     added_headers = sorted(live_headers - cached_headers)
     removed_headers = sorted(cached_headers - live_headers)
     if added_headers or removed_headers:
-        drift.append({
-            "section": "request_headers",
-            "added": added_headers,
-            "removed": removed_headers,
-        })
+        drift.append(
+            {
+                "section": "request_headers",
+                "added": added_headers,
+                "removed": removed_headers,
+            }
+        )
 
     return {
         "sources_checked": len(REPORTS_SPEC_URLS),

--- a/scripts/check_wsdl_drift.py
+++ b/scripts/check_wsdl_drift.py
@@ -98,11 +98,7 @@ def main() -> int:
         "imported_xsd_drift": xsd_drift,
     }
     print(json.dumps(report, indent=2, ensure_ascii=False))
-    return (
-        1
-        if (drift or missing_cache or xsd_drift or xsd_missing_cache)
-        else 0
-    )
+    return 1 if (drift or missing_cache or xsd_drift or xsd_missing_cache) else 0
 
 
 if __name__ == "__main__":

--- a/scripts/patch_vendor_imports.py
+++ b/scripts/patch_vendor_imports.py
@@ -81,8 +81,7 @@ def patch_line(line: str, path: Path, line_number: int, vendor_dir: Path) -> str
         captured = match.group(2)
         _validate_captured(captured, path, line_number, line)
         return (
-            f"from {_relative_from(vendor_dir, path, match.group(1))} "
-            f"import {captured}"
+            f"from {_relative_from(vendor_dir, path, match.group(1))} import {captured}"
         )
 
     if line.startswith("import tapi_yandex_direct"):

--- a/scripts/refresh_wsdl_cache.py
+++ b/scripts/refresh_wsdl_cache.py
@@ -29,7 +29,9 @@ def main():
         print("\nFailed services:")
         for service, exc in sorted(errors.items()):
             print(f"  {service}: {exc}")
-        print(f"\n{len(CANONICAL_API_SERVICES) - len(errors)} succeeded, {len(errors)} failed.")
+        print(
+            f"\n{len(CANONICAL_API_SERVICES) - len(errors)} succeeded, {len(errors)} failed."
+        )
         sys.exit(1)
     else:
         print(f"All {len(CANONICAL_API_SERVICES)} services refreshed successfully.")

--- a/scripts/sandbox_write_live.py
+++ b/scripts/sandbox_write_live.py
@@ -488,7 +488,7 @@ class LiveSandboxRunner:
                 command=matrix_command,
                 status=NOT_COVERED,
                 detail=(
-                    "set YANDEX_DIRECT_V4ACCOUNT_CLIENT_LOGIN or " "YANDEX_DIRECT_LOGIN"
+                    "set YANDEX_DIRECT_V4ACCOUNT_CLIENT_LOGIN or YANDEX_DIRECT_LOGIN"
                 ),
             )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,9 +86,7 @@ def _before_record_request(request):
     body = getattr(request, "body", None)
     redacted = False
     if body and "VideoData" in (body if isinstance(body, str) else ""):
-        request.body = re.sub(
-            r'"VideoData":"[^"]*"', '"VideoData":"<REDACTED>"', body
-        )
+        request.body = re.sub(r'"VideoData":"[^"]*"', '"VideoData":"<REDACTED>"', body)
         redacted = True
     elif isinstance(body, bytes) and b"VideoData" in body:
         request.body = re.sub(
@@ -106,7 +104,9 @@ def _before_record_request(request):
         redacted = True
     if redacted:
         new_body = request.body
-        new_len = str(len(new_body.encode("utf-8") if isinstance(new_body, str) else new_body))
+        new_len = str(
+            len(new_body.encode("utf-8") if isinstance(new_body, str) else new_body)
+        )
         for k in list(request.headers.keys()):
             if k.lower() == "content-length":
                 request.headers[k] = new_len
@@ -119,7 +119,9 @@ def _before_record_response(response):
         body = response.get("body", {})
         data = body.get("string")
         if isinstance(data, bytes):
-            body["string"] = _scrub_login(data.decode("utf-8", errors="replace")).encode("utf-8")
+            body["string"] = _scrub_login(
+                data.decode("utf-8", errors="replace")
+            ).encode("utf-8")
         elif isinstance(data, str):
             body["string"] = _scrub_login(data)
 
@@ -131,7 +133,9 @@ def _before_record_response(response):
             continue
         if low == "x-accel-info":
             headers[key] = [
-                re.sub(r"reqid:\d+", "reqid:0000000000000000000", v) if isinstance(v, str) else v
+                re.sub(r"reqid:\d+", "reqid:0000000000000000000", v)
+                if isinstance(v, str)
+                else v
                 for v in headers[key]
             ]
             continue
@@ -285,8 +289,8 @@ def unique_suffix() -> str:
 _SANDBOX_ERROR_PATTERNS = (
     "Object not found",
     "Operation not supported",  # sandbox returns this for features unavailable in test env
-    "Not supported",            # sandbox returns this for unsupported campaign types
-    "не поддерживается",        # Russian variant of the above
+    "Not supported",  # sandbox returns this for unsupported campaign types
+    "не поддерживается",  # Russian variant of the above
     "Campaign not found",
     "Ad group not found",
     "not accessible",
@@ -294,13 +298,26 @@ _SANDBOX_ERROR_PATTERNS = (
 
 # Named extra_patterns for per-resource sandbox quirks.
 # Import these in tests instead of repeating inline tuples.
-_CAMPAIGN_STATUS_PATTERNS = ("DRAFT", "has not been saved", "is draft", "Invalid object status")
+_CAMPAIGN_STATUS_PATTERNS = (
+    "DRAFT",
+    "has not been saved",
+    "is draft",
+    "Invalid object status",
+)
 _ARCHIVE_PATTERNS = ("Cannot archive", "Cannot unarchive", "Invalid object status")
 _KEYWORD_PATTERNS = ("Keyword not found",)
 _SITELINK_PATTERNS = ("temporarily unavailable",)
 _IMAGE_PATTERNS = ("Invalid format",)
-_SMART_AD_PATTERNS = ("Неподходящий тип группы объявлений", "SelectionCriteria filtration")
-_RETARGETING_PATTERNS = ("required field", "is omitted", "Invalid request", "Not specified")
+_SMART_AD_PATTERNS = (
+    "Неподходящий тип группы объявлений",
+    "SelectionCriteria filtration",
+)
+_RETARGETING_PATTERNS = (
+    "required field",
+    "is omitted",
+    "Invalid request",
+    "Not specified",
+)
 
 
 def _is_sandbox_error(output: str, extra_patterns: tuple = ()) -> bool:
@@ -354,9 +371,12 @@ def sandbox_campaign(unique_suffix):
     """Create a TEXT_CAMPAIGN in sandbox, yield its ID, delete on teardown."""
     name = f"claude-test-{unique_suffix}"
     result = _fixture_invoke(
-        "campaigns", "add",
-        "--name", name,
-        "--start-date", tomorrow(),
+        "campaigns",
+        "add",
+        "--name",
+        name,
+        "--start-date",
+        tomorrow(),
         label="campaigns add",
     )
     campaign_id = _fixture_parse(result)
@@ -371,10 +391,14 @@ def sandbox_adgroup(sandbox_campaign):
     """Create a TEXT_AD_GROUP in sandbox, yield its ID, delete on teardown."""
     campaign_id = sandbox_campaign
     result = _fixture_invoke(
-        "adgroups", "add",
-        "--name", "test-group",
-        "--campaign-id", str(campaign_id),
-        "--region-ids", "1,225",
+        "adgroups",
+        "add",
+        "--name",
+        "test-group",
+        "--campaign-id",
+        str(campaign_id),
+        "--region-ids",
+        "1,225",
         label="adgroups add",
     )
     adgroup_id = _fixture_parse(result)
@@ -389,11 +413,16 @@ def sandbox_ad(sandbox_adgroup):
     """Create a TEXT_AD in sandbox, yield its ID, delete on teardown."""
     adgroup_id = sandbox_adgroup
     result = _fixture_invoke(
-        "ads", "add",
-        "--adgroup-id", str(adgroup_id),
-        "--title", "Test Ad",
-        "--text", "Test ad text",
-        "--href", "https://example.com",
+        "ads",
+        "add",
+        "--adgroup-id",
+        str(adgroup_id),
+        "--title",
+        "Test Ad",
+        "--text",
+        "Test ad text",
+        "--href",
+        "https://example.com",
         label="ads add",
     )
     ad_id = _fixture_parse(result)
@@ -408,9 +437,12 @@ def sandbox_keyword(sandbox_adgroup):
     """Create a keyword in sandbox, yield its ID, delete on teardown."""
     adgroup_id = sandbox_adgroup
     result = _fixture_invoke(
-        "keywords", "add",
-        "--adgroup-id", str(adgroup_id),
-        "--keyword", "тестовое ключевое слово",
+        "keywords",
+        "add",
+        "--adgroup-id",
+        str(adgroup_id),
+        "--keyword",
+        "тестовое ключевое слово",
         label="keywords add",
     )
     keyword_id = _fixture_parse(result)
@@ -424,14 +456,20 @@ def sandbox_keyword(sandbox_adgroup):
 def sandbox_retargeting_list(unique_suffix):
     """Create a retargeting list from typed ``--rule`` flags in sandbox."""
     result = _invoke(
-        "retargeting", "add",
-        "--name", f"test-rtg-{unique_suffix}",
-        "--type", "RETARGETING",
-        "--rule", "ALL:12345:30",
+        "retargeting",
+        "add",
+        "--name",
+        f"test-rtg-{unique_suffix}",
+        "--type",
+        "RETARGETING",
+        "--rule",
+        "ALL:12345:30",
     )
     if result.exit_code != 0:
         if _is_sandbox_error(result.output, extra_patterns=_RETARGETING_PATTERNS):
-            pytest.skip(f"retargeting add not supported (sandbox): {result.output[:200]}")
+            pytest.skip(
+                f"retargeting add not supported (sandbox): {result.output[:200]}"
+            )
         pytest.fail(f"retargeting add failed (CLI regression?): {result.output[:500]}")
 
     # Parse response body — sandbox may return exit 0 with Errors
@@ -459,10 +497,14 @@ def sandbox_retargeting_list(unique_suffix):
 def sandbox_feed(unique_suffix):
     """Create a feed in sandbox, yield its ID, delete on teardown."""
     result = _invoke(
-        "feeds", "add",
-        "--name", f"test-feed-{unique_suffix}",
-        "--url", "https://example.com/feed.xml",
-        "--business-type", "RETAIL",
+        "feeds",
+        "add",
+        "--name",
+        f"test-feed-{unique_suffix}",
+        "--url",
+        "https://example.com/feed.xml",
+        "--business-type",
+        "RETAIL",
     )
     if result.exit_code != 0:
         if _is_sandbox_error(result.output):
@@ -484,25 +526,38 @@ def sandbox_dynamic_adgroup(unique_suffix):
     """
     # Step 1: create DYNAMIC_TEXT_CAMPAIGN
     campaign_result = _fixture_invoke(
-        "campaigns", "add",
-        "--name", f"claude-dynamic-{unique_suffix}",
-        "--start-date", tomorrow(),
-        "--type", "DYNAMIC_TEXT_CAMPAIGN",
-        "--setting", "ADD_METRICA_TAG=NO",
-        "--search-strategy", "HIGHEST_POSITION",
-        "--network-strategy", "SERVING_OFF",
+        "campaigns",
+        "add",
+        "--name",
+        f"claude-dynamic-{unique_suffix}",
+        "--start-date",
+        tomorrow(),
+        "--type",
+        "DYNAMIC_TEXT_CAMPAIGN",
+        "--setting",
+        "ADD_METRICA_TAG=NO",
+        "--search-strategy",
+        "HIGHEST_POSITION",
+        "--network-strategy",
+        "SERVING_OFF",
         label="campaigns add (dynamic)",
     )
     campaign_id = _fixture_parse(campaign_result)
 
     # Step 2: create DYNAMIC_TEXT_AD_GROUP
     adgroup_result = _fixture_invoke(
-        "adgroups", "add",
-        "--name", "dynamic-test-group",
-        "--campaign-id", str(campaign_id),
-        "--region-ids", "1,225",
-        "--type", "DYNAMIC_TEXT_AD_GROUP",
-        "--domain-url", "example.com",
+        "adgroups",
+        "add",
+        "--name",
+        "dynamic-test-group",
+        "--campaign-id",
+        str(campaign_id),
+        "--region-ids",
+        "1,225",
+        "--type",
+        "DYNAMIC_TEXT_AD_GROUP",
+        "--domain-url",
+        "example.com",
         label="adgroups add (dynamic)",
     )
     adgroup_id = _fixture_parse(adgroup_result)
@@ -526,25 +581,38 @@ def sandbox_smart_adgroup(unique_suffix, sandbox_feed):
     # Sandbox accepts any positive integer; replays match on body so the value
     # just needs to be stable.
     campaign_result = _fixture_invoke(
-        "campaigns", "add",
-        "--name", f"claude-smart-{unique_suffix}",
-        "--start-date", tomorrow(),
-        "--type", "SMART_CAMPAIGN",
-        "--counter-id", "12345678",
-        "--network-strategy", "AVERAGE_CPC_PER_FILTER",
-        "--filter-average-cpc", "1000000",
+        "campaigns",
+        "add",
+        "--name",
+        f"claude-smart-{unique_suffix}",
+        "--start-date",
+        tomorrow(),
+        "--type",
+        "SMART_CAMPAIGN",
+        "--counter-id",
+        "12345678",
+        "--network-strategy",
+        "AVERAGE_CPC_PER_FILTER",
+        "--filter-average-cpc",
+        "1000000",
         label="campaigns add (smart)",
     )
     campaign_id = _fixture_parse(campaign_result)
 
     # Step 2: create SMART_AD_GROUP (FeedId is required per API docs)
     adgroup_result = _fixture_invoke(
-        "adgroups", "add",
-        "--name", "smart-test-group",
-        "--campaign-id", str(campaign_id),
-        "--region-ids", "1,225",
-        "--type", "SMART_AD_GROUP",
-        "--feed-id", str(sandbox_feed),
+        "adgroups",
+        "add",
+        "--name",
+        "smart-test-group",
+        "--campaign-id",
+        str(campaign_id),
+        "--region-ids",
+        "1,225",
+        "--type",
+        "SMART_AD_GROUP",
+        "--feed-id",
+        str(sandbox_feed),
         label="adgroups add (smart)",
     )
     adgroup_id = _fixture_parse(adgroup_result)

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -254,9 +254,9 @@ def _assert_body_matches_wsdl(body: dict, service: str, operation: str):
             continue
         value = body["params"][field["name"]]
         if field["max_occurs"] == "unbounded":
-            assert isinstance(
-                value, list
-            ), f"{service}.{operation}.{field['name']} must be a list"
+            assert isinstance(value, list), (
+                f"{service}.{operation}.{field['name']} must be a list"
+            )
             if value and field["item_fields"]:
                 required = {
                     item["name"]
@@ -304,13 +304,15 @@ class TestApiCoverage:
 
     def test_non_wsdl_services_have_explicit_coverage_policy(self):
         for service_name, policy in sorted(NON_WSDL_SERVICE_POLICIES.items()):
-            assert (
-                service_name in cli.commands
-            ), f"Non-WSDL service {service_name} is missing from the CLI"
+            assert service_name in cli.commands, (
+                f"Non-WSDL service {service_name} is missing from the CLI"
+            )
             assert policy["coverage"] in (
                 "contract-tests",
                 "contract-tests+spec-snapshot",
-            ), f"Unexpected coverage policy for non-WSDL service {service_name}: {policy}"
+            ), (
+                f"Unexpected coverage policy for non-WSDL service {service_name}: {policy}"
+            )
 
     def test_service_method_coverage(self):
         failures = []
@@ -2140,9 +2142,9 @@ class TestApiCoverage:
             }
         }
         violations = find_nested_schema_violations(bad_body, schema)
-        assert any(
-            "BogusNestedKey" in v for v in violations
-        ), f"Expected BogusNestedKey to be flagged, got: {violations}"
+        assert any("BogusNestedKey" in v for v in violations), (
+            f"Expected BogusNestedKey to be flagged, got: {violations}"
+        )
 
 
 @pytest.mark.api_coverage
@@ -2234,9 +2236,9 @@ class TestReportsCoverage:
         assert opt is not None, "--processing-mode flag missing"
         cli_choices = set(opt.type.choices)
         spec_modes = set(spec["processing_modes"])
-        assert (
-            cli_choices == spec_modes
-        ), f"--processing-mode choices differ: CLI={cli_choices}, spec={spec_modes}"
+        assert cli_choices == spec_modes, (
+            f"--processing-mode choices differ: CLI={cli_choices}, spec={spec_modes}"
+        )
 
     def test_cli_request_headers_flags_exist(self):
         """CLI must expose flags for each request header from spec."""
@@ -2258,9 +2260,9 @@ class TestReportsCoverage:
         from direct_cli.wsdl_coverage import NON_WSDL_SERVICE_POLICIES
 
         policy = NON_WSDL_SERVICE_POLICIES["reports"]
-        assert (
-            policy["coverage"] == "contract-tests+spec-snapshot"
-        ), "reports policy must use 'contract-tests+spec-snapshot' coverage type"
+        assert policy["coverage"] == "contract-tests+spec-snapshot", (
+            "reports policy must use 'contract-tests+spec-snapshot' coverage type"
+        )
         assert "spec_snapshot" in policy
         assert "drift_script" in policy
         assert "refresh_script" in policy

--- a/tests/test_auth_bw.py
+++ b/tests/test_auth_bw.py
@@ -78,7 +78,9 @@ class TestGetCredentialsBw:
     @patch("direct_cli.auth.load_env_file")
     @patch("direct_cli.auth.get_active_profile", return_value=None)
     @patch("direct_cli.auth.bw_read", return_value="bw-token-value")
-    def test_get_credentials_bw_fallback(self, mock_bw_read, mock_profile, mock_load, monkeypatch):
+    def test_get_credentials_bw_fallback(
+        self, mock_bw_read, mock_profile, mock_load, monkeypatch
+    ):
         monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
         monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
         monkeypatch.delenv("YANDEX_DIRECT_OP_TOKEN_REF", raising=False)

--- a/tests/test_auth_oauth.py
+++ b/tests/test_auth_oauth.py
@@ -2,6 +2,7 @@
 
 import io
 import json
+import os
 import stat
 import urllib.parse
 from urllib.error import HTTPError, URLError
@@ -190,25 +191,28 @@ class TestAuthOAuth:
     def test_cli_command_prefers_active_profile_over_cwd_dotenv(
         self, mock_create_client, isolated_auth_store, monkeypatch, tmp_path
     ):
-        monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
-        monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
-        (tmp_path / ".env").write_text(
-            "YANDEX_DIRECT_TOKEN=dotenv-token\nYANDEX_DIRECT_LOGIN=dotenv-login\n",
-            encoding="utf-8",
-        )
-        monkeypatch.chdir(tmp_path)
-        load_env_file()
-        save_oauth_profile(
-            profile="agency1",
-            token="oauth-token-1",
-            login="client-login-1",
-            refresh_token="refresh-1",
-            expires_at=4_100_000_000.0,
-            client_id=DEFAULT_OAUTH_CLIENT_ID,
-        )
-        runner = CliRunner()
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("YANDEX_DIRECT_TOKEN", None)
+            os.environ.pop("YANDEX_DIRECT_LOGIN", None)
+            (tmp_path / ".env").write_text(
+                "YANDEX_DIRECT_TOKEN=dotenv-token\nYANDEX_DIRECT_LOGIN=dotenv-login\n",
+                encoding="utf-8",
+            )
+            monkeypatch.chdir(tmp_path)
+            load_env_file()
+            save_oauth_profile(
+                profile="agency1",
+                token="oauth-token-1",
+                login="client-login-1",
+                refresh_token="refresh-1",
+                expires_at=4_100_000_000.0,
+                client_id=DEFAULT_OAUTH_CLIENT_ID,
+            )
+            runner = CliRunner()
 
-        result = runner.invoke(cli, ["campaigns", "get", "--ids", "123", "--dry-run"])
+            result = runner.invoke(
+                cli, ["campaigns", "get", "--ids", "123", "--dry-run"]
+            )
 
         assert result.exit_code == 0
         mock_create_client.assert_called_once_with(
@@ -223,17 +227,20 @@ class TestAuthOAuth:
     def test_cli_command_uses_cwd_dotenv_without_active_profile(
         self, mock_create_client, isolated_auth_store, monkeypatch, tmp_path
     ):
-        monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
-        monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
-        (tmp_path / ".env").write_text(
-            "YANDEX_DIRECT_TOKEN=dotenv-token\nYANDEX_DIRECT_LOGIN=dotenv-login\n",
-            encoding="utf-8",
-        )
-        monkeypatch.chdir(tmp_path)
-        load_env_file()
-        runner = CliRunner()
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("YANDEX_DIRECT_TOKEN", None)
+            os.environ.pop("YANDEX_DIRECT_LOGIN", None)
+            (tmp_path / ".env").write_text(
+                "YANDEX_DIRECT_TOKEN=dotenv-token\nYANDEX_DIRECT_LOGIN=dotenv-login\n",
+                encoding="utf-8",
+            )
+            monkeypatch.chdir(tmp_path)
+            load_env_file()
+            runner = CliRunner()
 
-        result = runner.invoke(cli, ["campaigns", "get", "--ids", "123", "--dry-run"])
+            result = runner.invoke(
+                cli, ["campaigns", "get", "--ids", "123", "--dry-run"]
+            )
 
         assert result.exit_code == 0
         mock_create_client.assert_called_once_with(
@@ -246,38 +253,39 @@ class TestAuthOAuth:
     def test_cli_explicit_credentials_override_profile_and_cwd_dotenv(
         self, mock_create_client, isolated_auth_store, monkeypatch, tmp_path
     ):
-        monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
-        monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
-        (tmp_path / ".env").write_text(
-            "YANDEX_DIRECT_TOKEN=dotenv-token\nYANDEX_DIRECT_LOGIN=dotenv-login\n",
-            encoding="utf-8",
-        )
-        monkeypatch.chdir(tmp_path)
-        load_env_file()
-        save_oauth_profile(
-            profile="agency1",
-            token="oauth-token-1",
-            login="client-login-1",
-            refresh_token="refresh-1",
-            expires_at=4_100_000_000.0,
-            client_id=DEFAULT_OAUTH_CLIENT_ID,
-        )
-        runner = CliRunner()
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("YANDEX_DIRECT_TOKEN", None)
+            os.environ.pop("YANDEX_DIRECT_LOGIN", None)
+            (tmp_path / ".env").write_text(
+                "YANDEX_DIRECT_TOKEN=dotenv-token\nYANDEX_DIRECT_LOGIN=dotenv-login\n",
+                encoding="utf-8",
+            )
+            monkeypatch.chdir(tmp_path)
+            load_env_file()
+            save_oauth_profile(
+                profile="agency1",
+                token="oauth-token-1",
+                login="client-login-1",
+                refresh_token="refresh-1",
+                expires_at=4_100_000_000.0,
+                client_id=DEFAULT_OAUTH_CLIENT_ID,
+            )
+            runner = CliRunner()
 
-        result = runner.invoke(
-            cli,
-            [
-                "--token",
-                "cli-token",
-                "--login",
-                "cli-login",
-                "campaigns",
-                "get",
-                "--ids",
-                "123",
-                "--dry-run",
-            ],
-        )
+            result = runner.invoke(
+                cli,
+                [
+                    "--token",
+                    "cli-token",
+                    "--login",
+                    "cli-login",
+                    "campaigns",
+                    "get",
+                    "--ids",
+                    "123",
+                    "--dry-run",
+                ],
+            )
 
         assert result.exit_code == 0
         mock_create_client.assert_called_once_with(

--- a/tests/test_auth_oauth.py
+++ b/tests/test_auth_oauth.py
@@ -14,6 +14,7 @@ from direct_cli.auth import (
     DEFAULT_OAUTH_CLIENT_ID,
     exchange_oauth_code,
     get_credentials,
+    load_env_file,
     load_auth_store,
     refresh_access_token,
     save_auth_store,
@@ -184,6 +185,108 @@ class TestAuthOAuth:
         )
         assert "env-token" not in result.output
         assert "env-login" not in result.output
+
+    @patch("direct_cli.commands.campaigns.create_client")
+    def test_cli_command_prefers_active_profile_over_cwd_dotenv(
+        self, mock_create_client, isolated_auth_store, monkeypatch, tmp_path
+    ):
+        monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
+        (tmp_path / ".env").write_text(
+            "YANDEX_DIRECT_TOKEN=dotenv-token\nYANDEX_DIRECT_LOGIN=dotenv-login\n",
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+        load_env_file()
+        save_oauth_profile(
+            profile="agency1",
+            token="oauth-token-1",
+            login="client-login-1",
+            refresh_token="refresh-1",
+            expires_at=4_100_000_000.0,
+            client_id=DEFAULT_OAUTH_CLIENT_ID,
+        )
+        runner = CliRunner()
+
+        result = runner.invoke(cli, ["campaigns", "get", "--ids", "123", "--dry-run"])
+
+        assert result.exit_code == 0
+        mock_create_client.assert_called_once_with(
+            token="oauth-token-1", login="client-login-1", sandbox=False
+        )
+        assert "dotenv-token" not in result.output
+        assert "dotenv-login" not in result.output
+        assert "oauth-token-1" not in result.output
+        assert "client-login-1" not in result.output
+
+    @patch("direct_cli.commands.campaigns.create_client")
+    def test_cli_command_uses_cwd_dotenv_without_active_profile(
+        self, mock_create_client, isolated_auth_store, monkeypatch, tmp_path
+    ):
+        monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
+        (tmp_path / ".env").write_text(
+            "YANDEX_DIRECT_TOKEN=dotenv-token\nYANDEX_DIRECT_LOGIN=dotenv-login\n",
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+        load_env_file()
+        runner = CliRunner()
+
+        result = runner.invoke(cli, ["campaigns", "get", "--ids", "123", "--dry-run"])
+
+        assert result.exit_code == 0
+        mock_create_client.assert_called_once_with(
+            token="dotenv-token", login="dotenv-login", sandbox=False
+        )
+        assert "dotenv-token" not in result.output
+        assert "dotenv-login" not in result.output
+
+    @patch("direct_cli.commands.campaigns.create_client")
+    def test_cli_explicit_credentials_override_profile_and_cwd_dotenv(
+        self, mock_create_client, isolated_auth_store, monkeypatch, tmp_path
+    ):
+        monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
+        monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
+        (tmp_path / ".env").write_text(
+            "YANDEX_DIRECT_TOKEN=dotenv-token\nYANDEX_DIRECT_LOGIN=dotenv-login\n",
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+        load_env_file()
+        save_oauth_profile(
+            profile="agency1",
+            token="oauth-token-1",
+            login="client-login-1",
+            refresh_token="refresh-1",
+            expires_at=4_100_000_000.0,
+            client_id=DEFAULT_OAUTH_CLIENT_ID,
+        )
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli,
+            [
+                "--token",
+                "cli-token",
+                "--login",
+                "cli-login",
+                "campaigns",
+                "get",
+                "--ids",
+                "123",
+                "--dry-run",
+            ],
+        )
+
+        assert result.exit_code == 0
+        mock_create_client.assert_called_once_with(
+            token="cli-token", login="cli-login", sandbox=False
+        )
+        assert "dotenv-token" not in result.output
+        assert "oauth-token-1" not in result.output
+        assert "cli-token" not in result.output
+        assert "cli-login" not in result.output
 
     def test_auth_login_oauth_token_mode(self, isolated_auth_store):
         runner = CliRunner()

--- a/tests/test_auth_op.py
+++ b/tests/test_auth_op.py
@@ -57,7 +57,9 @@ class TestGetCredentialsOp:
     @patch("direct_cli.auth.load_env_file")
     @patch("direct_cli.auth.get_active_profile", return_value=None)
     @patch("direct_cli.auth.op_read", return_value="op-token-value")
-    def test_get_credentials_op_fallback(self, mock_op_read, mock_profile, mock_load, monkeypatch):
+    def test_get_credentials_op_fallback(
+        self, mock_op_read, mock_profile, mock_load, monkeypatch
+    ):
         monkeypatch.delenv("YANDEX_DIRECT_TOKEN", raising=False)
         monkeypatch.delenv("YANDEX_DIRECT_LOGIN", raising=False)
         monkeypatch.setenv("YANDEX_DIRECT_OP_TOKEN_REF", "op://vault/item/token")

--- a/tests/test_balance.py
+++ b/tests/test_balance.py
@@ -21,9 +21,13 @@ def test_balance_dry_run_with_logins_emits_v4_request_body():
 
 
 def test_balance_omitted_logins_uses_configured_login():
-    result = CliRunner(env={"YANDEX_DIRECT_LOGIN": "client-login"}).invoke(
-        cli, ["balance", "--dry-run"]
-    )
+    with patch("direct_cli.cli.get_active_profile", return_value=None):
+        result = CliRunner(
+            env={
+                "YANDEX_DIRECT_TOKEN": "",
+                "YANDEX_DIRECT_LOGIN": "client-login",
+            }
+        ).invoke(cli, ["balance", "--dry-run"])
 
     assert result.exit_code == 0
     assert json.loads(result.output) == {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -604,7 +604,8 @@ class TestCLI(unittest.TestCase):
         """Earlier chunk OK, later chunk fails: diagnostic shows both. See #211."""
 
         good_chunk_result = [
-            {"Id": idx} for idx in range(1, 11)  # KEYWORDS_ADD_MAX_BATCH = 10
+            {"Id": idx}
+            for idx in range(1, 11)  # KEYWORDS_ADD_MAX_BATCH = 10
         ]
         # Mixed chunk: one item succeeds, one fails. The success item must
         # land in partial-success diagnostic; the failure item must not.

--- a/tests/test_env_loading.py
+++ b/tests/test_env_loading.py
@@ -45,7 +45,7 @@ def test_load_env_file_loads_cwd_dotenv(tmp_path):
     """A .env in the command working directory is loaded."""
     repo_root = Path(__file__).resolve().parents[1]
     (tmp_path / ".env").write_text(
-        "YANDEX_DIRECT_TOKEN=cwd-token\n" "YANDEX_DIRECT_LOGIN=cwd-login\n",
+        "YANDEX_DIRECT_TOKEN=cwd-token\nYANDEX_DIRECT_LOGIN=cwd-login\n",
         encoding="utf-8",
     )
     env = os.environ.copy()
@@ -80,7 +80,7 @@ def test_load_env_file_does_not_search_from_source_location(monkeypatch, tmp_pat
     run_dir.mkdir()
     source_env = source_dir / ".env"
     source_env.write_text(
-        "YANDEX_DIRECT_TOKEN=source-token\n" "YANDEX_DIRECT_LOGIN=source-login\n",
+        "YANDEX_DIRECT_TOKEN=source-token\nYANDEX_DIRECT_LOGIN=source-login\n",
         encoding="utf-8",
     )
     calls = []

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -241,8 +241,7 @@ class TestReadOnlyAds(unittest.TestCase):
             self.assertIn(
                 "TextAd",
                 ad,
-                f"TEXT_AD {ad['Id']} missing TextAd — "
-                "TextAdFieldNames may not be sent",
+                f"TEXT_AD {ad['Id']} missing TextAd — TextAdFieldNames may not be sent",
             )
             self.assertIn("Title", ad["TextAd"])
             self.assertIn("Text", ad["TextAd"])
@@ -661,6 +660,7 @@ class TestReadOnlyBalance(unittest.TestCase):
         # 3500 limitation does not apply to this invocation path.
         result = invoke_get("balance", "--format", "json")
         assert_success(result, "balance")
+
 
 @pytest.mark.integration
 @skip_if_no_token

--- a/tests/test_integration_write.py
+++ b/tests/test_integration_write.py
@@ -571,9 +571,9 @@ class TestWriteBidModifiersSet:
             "bidmodifiers set unexpectedly succeeded without --id; it must "
             "reject the legacy CampaignId + Type shape locally."
         )
-        assert (
-            "legacy --campaign-id/--type shape is not supported" in r.output
-        ), f"Unexpected failure mode from bidmodifiers set: {r.output[:500]}"
+        assert "legacy --campaign-id/--type shape is not supported" in r.output, (
+            f"Unexpected failure mode from bidmodifiers set: {r.output[:500]}"
+        )
 
 
 # ── feeds ────────────────────────────────────────────────────────────────
@@ -610,7 +610,9 @@ class TestWriteFeeds:
             )
             if r.exit_code != 0:
                 if _is_sandbox_error(r.output):
-                    pytest.skip(f"feeds update not supported in sandbox: {r.output[:200]}")
+                    pytest.skip(
+                        f"feeds update not supported in sandbox: {r.output[:200]}"
+                    )
                 pytest.fail(f"feeds update failed (CLI regression?): {r.output[:500]}")
         finally:
             _invoke("feeds", "delete", "--id", str(fid))
@@ -874,9 +876,9 @@ class TestWriteAdImages:
             pytest.fail(f"adimages add failed (CLI regression?): {r.output[:500]}")
 
         data = json.loads(r.output)
-        assert (
-            isinstance(data, list) and data
-        ), f"adimages add returned empty result: {r.output[:200]}"
+        assert isinstance(data, list) and data, (
+            f"adimages add returned empty result: {r.output[:200]}"
+        )
         first = data[0]
         if "Errors" in first and first["Errors"]:
             err_text = str(first["Errors"])

--- a/tests/test_transport_contract.py
+++ b/tests/test_transport_contract.py
@@ -19,9 +19,9 @@ def test_dependency_uses_axisrow_fork():
         Path(__file__).resolve().parent.parent
         / "direct_cli/_vendor/tapi_yandex_direct/__init__.py"
     )
-    assert (
-        vendor_init.exists()
-    ), "Vendored tapi_yandex_direct not found in direct_cli/_vendor/"
+    assert vendor_init.exists(), (
+        "Vendored tapi_yandex_direct not found in direct_cli/_vendor/"
+    )
 
 
 def test_tapi_transport_exposes_cli_resource_executors():

--- a/tests/test_v4_contracts.py
+++ b/tests/test_v4_contracts.py
@@ -138,9 +138,7 @@ def test_account_management_deposit_contract_uses_payments_with_origin():
 def test_account_management_invoice_contract_uses_payments():
     param = {
         "Action": "Invoice",
-        "Payments": [
-            {"AccountID": 1327944, "Amount": 100.5, "Currency": "RUB"}
-        ],
+        "Payments": [{"AccountID": 1327944, "Amount": 100.5, "Currency": "RUB"}],
     }
 
     assert build_v4_body("AccountManagement", param) == {

--- a/tests/test_v4_exit_codes.py
+++ b/tests/test_v4_exit_codes.py
@@ -83,12 +83,15 @@ def test_usage_error_from_call_v4_yields_exit_code_2(module_name, argv):
     """If call_v4 raises UsageError, Click must format it and exit with 2."""
     sentinel = "v4 shape validation failed: bogus"
 
-    with patch(
-        f"direct_cli.commands.{module_name}.call_v4",
-        side_effect=click.UsageError(sentinel),
-    ), patch(
-        f"direct_cli.commands.{module_name}.create_v4_client",
-        return_value=object(),
+    with (
+        patch(
+            f"direct_cli.commands.{module_name}.call_v4",
+            side_effect=click.UsageError(sentinel),
+        ),
+        patch(
+            f"direct_cli.commands.{module_name}.create_v4_client",
+            return_value=object(),
+        ),
     ):
         result = _invoke(*argv)
 
@@ -109,12 +112,15 @@ def test_usage_error_from_call_v4_yields_exit_code_2(module_name, argv):
 )
 def test_runtime_error_from_call_v4_still_exits_with_abort(module_name, argv):
     """Non-Click exceptions must still go through print_error + Abort (exit 1)."""
-    with patch(
-        f"direct_cli.commands.{module_name}.call_v4",
-        side_effect=RuntimeError("boom"),
-    ), patch(
-        f"direct_cli.commands.{module_name}.create_v4_client",
-        return_value=object(),
+    with (
+        patch(
+            f"direct_cli.commands.{module_name}.call_v4",
+            side_effect=RuntimeError("boom"),
+        ),
+        patch(
+            f"direct_cli.commands.{module_name}.create_v4_client",
+            return_value=object(),
+        ),
     ):
         result = _invoke(*argv)
 

--- a/tests/test_v4_live_contracts.py
+++ b/tests/test_v4_live_contracts.py
@@ -282,9 +282,9 @@ def test_v4_live_wordstat_lifecycle_opt_in_write():
         "CreateNewWordstatReport",
         {"Phrases": ["купить ноутбук"], "GeoID": [0]},
     )
-    assert (
-        isinstance(report_id, int) and report_id > 0
-    ), f"unexpected CreateNewWordstatReport response: {report_id!r}"
+    assert isinstance(report_id, int) and report_id > 0, (
+        f"unexpected CreateNewWordstatReport response: {report_id!r}"
+    )
     _orphan_store.add("v4wordstat", report_id)
     try:
         reports = call_v4(client, "GetWordstatReportList")
@@ -320,9 +320,9 @@ def test_v4_live_forecast_lifecycle_opt_in_write():
         "CreateNewForecast",
         {"Phrases": ["купить ноутбук"], "GeoID": [213], "Currency": "RUB"},
     )
-    assert (
-        isinstance(forecast_id, int) and forecast_id > 0
-    ), f"unexpected CreateNewForecast response: {forecast_id!r}"
+    assert isinstance(forecast_id, int) and forecast_id > 0, (
+        f"unexpected CreateNewForecast response: {forecast_id!r}"
+    )
     _orphan_store.add("v4forecast", forecast_id)
     try:
         forecasts = call_v4(client, "GetForecastList")

--- a/tests/test_v4account.py
+++ b/tests/test_v4account.py
@@ -420,9 +420,7 @@ def test_v4account_commands_declare_v4_contracts():
 
 
 def test_account_management_get_dry_run_omits_selection_criteria_when_no_filters():
-    result = _invoke(
-        "v4account", "account-management", "--action", "Get", "--dry-run"
-    )
+    result = _invoke("v4account", "account-management", "--action", "Get", "--dry-run")
 
     assert result.exit_code == 0
     assert json.loads(result.output) == {
@@ -623,9 +621,7 @@ def test_account_management_deposit_dry_run_masks_finance_token():
         "method": "AccountManagement",
         "param": {
             "Action": "Deposit",
-            "Payments": [
-                {"AccountID": 1327944, "Amount": 100.5, "Currency": "RUB"}
-            ],
+            "Payments": [{"AccountID": 1327944, "Amount": 100.5, "Currency": "RUB"}],
         },
         "finance_token": "<redacted>",
         "operation_num": 42,
@@ -918,8 +914,7 @@ def test_account_management_transfer_requires_all_three_flags():
 
     assert result.exit_code != 0
     assert (
-        "--from-account-id, --to-account-id, and --amount are required"
-        in result.output
+        "--from-account-id, --to-account-id, and --amount are required" in result.output
     )
     build_body.assert_not_called()
 

--- a/tests/test_v5_live_write.py
+++ b/tests/test_v5_live_write.py
@@ -164,9 +164,9 @@ def _extract_first_id(output: str, key: str = "AddResults") -> int | str:
 
     assert items, f"No result items in response: {output[:500]}"
     first = items[0]
-    assert (
-        "Errors" not in first or not first["Errors"]
-    ), f"API rejected add: {first.get('Errors')}"
+    assert "Errors" not in first or not first["Errors"], (
+        f"API rejected add: {first.get('Errors')}"
+    )
     assert "Id" in first, f"No Id in add result: {first}"
     raw = first["Id"]
     try:
@@ -188,9 +188,9 @@ def _extract_field(output: str, field: str = "Id", key: str = "AddResults") -> A
 
     assert items, f"No result items in response: {output[:500]}"
     first = items[0]
-    assert (
-        "Errors" not in first or not first["Errors"]
-    ), f"API rejected request: {first.get('Errors')}"
+    assert "Errors" not in first or not first["Errors"], (
+        f"API rejected request: {first.get('Errors')}"
+    )
     assert field in first, f"No {field} in result: {first}"
     return first[field]
 
@@ -284,8 +284,7 @@ def _assert_draft_or_success(result, cmd_label: str) -> None:
     """Assert success or skip if the API rejected a draft-state operation."""
     if result.exit_code != 0 and _is_draft_state_error(result.output):
         pytest.skip(
-            f"{cmd_label} rejected on draft resource (expected): "
-            f"{result.output[:200]}"
+            f"{cmd_label} rejected on draft resource (expected): {result.output[:200]}"
         )
     _assert_success(result, cmd_label)
 
@@ -424,9 +423,9 @@ def test_v5_live_draft_adimages_add_get_delete() -> None:
             result_data = data.get("result", data)
             images = result_data.get("AdImages", [])
         hashes_in_response = {img.get("AdImageHash") for img in images}
-        assert (
-            img_hash in hashes_in_response
-        ), f"Uploaded image hash {img_hash} not found in get response"
+        assert img_hash in hashes_in_response, (
+            f"Uploaded image hash {img_hash} not found in get response"
+        )
     finally:
         r = _invoke_live("adimages", "delete", "--hash", str(img_hash))
         if r.exit_code != 0:
@@ -868,9 +867,9 @@ def test_v5_live_draft_dynamicads_add_delete() -> None:
         else:
             result_data = data.get("result", data)
             targets = result_data.get("DynamicTextAdTargets", [])
-        assert any(
-            t.get("Id") == did for t in targets
-        ), f"Dynamic ad target {did} not found in get response"
+        assert any(t.get("Id") == did for t in targets), (
+            f"Dynamic ad target {did} not found in get response"
+        )
     finally:
         if did is not None:
             _invoke_live("dynamicads", "delete", "--id", str(did))

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -115,7 +115,7 @@ def test_empty_payload_no_op_rejected(
 ) -> None:
     result = CliRunner().invoke(cli, argv + ["--dry-run"])
     assert result.exit_code != 0, (
-        f"{command_key}: empty payload accepted as no-op. " f"Output: {result.output!r}"
+        f"{command_key}: empty payload accepted as no-op. Output: {result.output!r}"
     )
     assert expected_error.lower() in result.output.lower(), (
         f"{command_key}: rejection happened but the error message lacks the "
@@ -517,7 +517,7 @@ def test_silent_data_loss_rejected(
 ) -> None:
     result = CliRunner().invoke(cli, argv + ["--dry-run"])
     assert result.exit_code != 0, (
-        f"{probe_id}: incompatible flag silently dropped. " f"Output: {result.output!r}"
+        f"{probe_id}: incompatible flag silently dropped. Output: {result.output!r}"
     )
     assert expected_error.lower() in result.output.lower(), (
         f"{probe_id}: rejection happened but the error message does not "
@@ -2683,9 +2683,9 @@ OPTIONAL_FIELD_CHILD_PREFIX_FOLLOWUPS: dict[tuple[str, str, str], dict[str, str]
     },
 }
 
-OPTIONAL_FIELD_CHILD_COMPONENT_FOLLOWUPS: dict[tuple[str, str, str], dict[str, str]] = (
-    {}
-)
+OPTIONAL_FIELD_CHILD_COMPONENT_FOLLOWUPS: dict[
+    tuple[str, str, str], dict[str, str]
+] = {}
 
 OPTIONAL_FIELD_AUDIT: dict[tuple[str, str, str], dict[str, str]] = {
     ("keywords", "add", "AutotargetingSearchBidIsAuto"): {
@@ -2883,9 +2883,9 @@ def test_optional_field_audit_entries_reference_real_wsdl_paths() -> None:
                 missing_issues.append((cli_group, cli_op, wsdl_path, issue))
 
     assert not bad_statuses, f"Invalid optional-field audit statuses: {bad_statuses}"
-    assert (
-        not stale_entries
-    ), f"Optional-field audit entries no longer in WSDL: {stale_entries}"
+    assert not stale_entries, (
+        f"Optional-field audit entries no longer in WSDL: {stale_entries}"
+    )
     assert not missing_issues, (
         "Optional-field missing_followup entries must link a GitHub issue: "
         f"{missing_issues}"
@@ -2937,7 +2937,7 @@ def test_optional_field_supported_options_reference_click_options() -> None:
             bad_options.append((cli_group, cli_op, wsdl_path, missing))
 
     assert not stale_paths, (
-        "Optional-field supported entries no longer exist in WSDL: " f"{stale_paths}"
+        f"Optional-field supported entries no longer exist in WSDL: {stale_paths}"
     )
     assert not bad_options, (
         "Optional-field supported entries reference missing Click options: "


### PR DESCRIPTION
## Summary
- keep CWD `.env` loading supported while preventing base `YANDEX_DIRECT_TOKEN` / `YANDEX_DIRECT_LOGIN` from silently overriding an active auth profile
- treat root credential options as explicit overrides only when they come from command-line flags
- add regression coverage for active profile + CWD `.env`, no active profile + CWD `.env`, explicit `--token/--login`, and the balance login-only contract
- apply repository-wide `ruff format` so `ruff format --check .` passes

Fixes #356.

## Validation
- `python3 -m pytest tests/test_env_loading.py tests/test_auth_oauth.py tests/test_cli.py tests/test_balance.py -q` -> 115 passed, 30 subtests passed
- `python3 -m pytest -q` -> 1329 passed, 44 skipped, 30 subtests passed
- `python3 -m ruff format --check .` -> 109 files already formatted
- `python3 -m ruff check .` -> All checks passed
- `mypy .` -> Success: no issues found in 56 source files
- `git diff --check` -> passed
- live read-only `direct adextensions get --types CALLOUT --format json` from both plugin CWD and direct-cli CWD returned the same 3 ids: 19718116, 19718117, 19718118