### PR TITLE
[codex] Add adextensions CalloutFieldNames flag

### DIFF
--- a/direct_cli/commands/adextensions.py
+++ b/direct_cli/commands/adextensions.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import create_client
 from ..output import format_output, print_error
-from ..utils import add_criteria_csv, get_default_fields, parse_ids
+from ..utils import add_criteria_csv, get_default_fields, parse_csv_strings, parse_ids
 
 
 @click.group()
@@ -25,6 +25,10 @@ def adextensions():
 @click.option("--format", "output_format", default="json", help="Output format")
 @click.option("--output", help="Output file")
 @click.option("--fields", help="Comma-separated field names")
+@click.option(
+    "--callout-field-names",
+    help="Comma-separated CalloutFieldNames (e.g. CalloutText)",
+)
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
 def get(
@@ -39,6 +43,7 @@ def get(
     output_format,
     output,
     fields,
+    callout_field_names,
     dry_run,
 ):
     """Get ad extensions"""
@@ -49,9 +54,12 @@ def get(
             sandbox=ctx.obj.get("sandbox"),
         )
 
-        field_names = (
-            fields.split(",") if fields else get_default_fields("adextensions")
-        )
+        field_names = parse_csv_strings(fields) or get_default_fields("adextensions")
+        parsed_callout_field_names = parse_csv_strings(callout_field_names)
+        if callout_field_names is not None and not parsed_callout_field_names:
+            raise click.UsageError(
+                "Provide a non-empty comma-separated CalloutFieldNames list."
+            )
 
         criteria = {}
         if ids:
@@ -64,6 +72,8 @@ def get(
             criteria["ModifiedSince"] = modified_since
 
         params = {"SelectionCriteria": criteria, "FieldNames": field_names}
+        if parsed_callout_field_names:
+            params["CalloutFieldNames"] = parsed_callout_field_names
 
         if limit:
             params["Page"] = {"Limit": limit}
@@ -85,6 +95,8 @@ def get(
             data = result().extract()
             format_output(data, output_format, output)
 
+    except click.UsageError:
+        raise
     except Exception as e:
         print_error(str(e))
         raise click.Abort()

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -9334,6 +9334,50 @@ def test_vcards_add_point_on_map_partial_rejected():
 # ----------------------------------------------------------------------
 
 
+def test_adextensions_get_callout_field_names_payload():
+    body = _read_dry_run(
+        "adextensions",
+        "get",
+        "--types",
+        "CALLOUT",
+        "--fields",
+        "Id,Type,State,Status",
+        "--callout-field-names",
+        "CalloutText",
+    )
+
+    assert body["params"]["SelectionCriteria"] == {"Types": ["CALLOUT"]}
+    assert body["params"]["FieldNames"] == ["Id", "Type", "State", "Status"]
+    assert "CalloutText" not in body["params"]["FieldNames"]
+    assert body["params"]["CalloutFieldNames"] == ["CalloutText"]
+
+
+def test_adextensions_get_help_exposes_callout_field_names():
+    result = CliRunner().invoke(cli, ["adextensions", "get", "--help"])
+
+    assert result.exit_code == 0
+    assert "--callout-field-names" in result.output
+
+
+def test_adextensions_get_rejects_empty_callout_field_names():
+    result = CliRunner().invoke(
+        cli,
+        [
+            "adextensions",
+            "get",
+            "--callout-field-names",
+            ",",
+            "--dry-run",
+        ],
+        env={"YANDEX_DIRECT_TOKEN": "test-token", "YANDEX_DIRECT_LOGIN": ""},
+    )
+
+    assert result.exit_code != 0
+    assert (
+        "Provide a non-empty comma-separated CalloutFieldNames list." in result.output
+    )
+
+
 def test_adextensions_add_does_not_send_type_field():
     body = _dry_run(
         "adextensions",


### PR DESCRIPTION
## Summary

Adds strict Yandex Direct API contract support for `AdExtensions.get` `CalloutFieldNames`.

## Changes

- Adds `direct adextensions get --callout-field-names` as the kebab-case CLI projection of API `CalloutFieldNames`.
- Keeps `--fields` scoped to top-level `FieldNames`; `CalloutText` is emitted only under `CalloutFieldNames`.
- Uses the shared CSV parser and rejects explicit empty `--callout-field-names` input.
- Adds dry-run and help regression coverage.

## Validation

- `python3 -m black --check direct_cli/commands/adextensions.py tests/test_dry_run.py`
- `python3 -m ruff check direct_cli/commands/adextensions.py tests/test_dry_run.py`
- `python3 -m pytest tests/test_dry_run.py tests/test_cli.py -q`
- `python3 -m pytest -q`
- `direct adextensions get --types CALLOUT --fields Id,Type,State,Status --callout-field-names CalloutText --format json --dry-run`
- `git diff --check`