### PR TITLE
[codex] Fix changes timestamp Z format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,21 +73,21 @@ direct dictionaries get-geo-regions \
 
 ### Datetime Rules
 
-- Datetime parameters must be passed in the format `YYYY-MM-DDTHH:MM:SS`.
+- Changes timestamps must match Yandex Direct API format `YYYY-MM-DDTHH:MM:SSZ`.
+- Other datetime parameters use their method-specific documented format.
 - Datetime values must be passed as a single shell token.
-- Canonical examples must not use timezone suffixes like `Z`.
+- Canonical `changes` examples must use the `Z` suffix.
 - Canonical examples must not use quoted space-separated datetime values.
 
 Use:
 
 ```bash
-direct changes check-campaigns --timestamp 2026-04-14T00:00:00
+direct changes check-campaigns --timestamp 2026-04-14T00:00:00Z
 ```
 
 Do not use:
 
 ```bash
-direct changes check-campaigns --timestamp 2026-04-14T00:00:00Z
 direct changes check-campaigns --timestamp "2026-04-14 00:00:00"
 ```
 
@@ -104,7 +104,7 @@ Valid canonical examples:
 
 ```bash
 direct campaigns get --ids 1,2,3
-direct changes check-campaigns --timestamp 2026-04-14T00:00:00
+direct changes check-campaigns --timestamp 2026-04-14T00:00:00Z
 direct keywordsresearch has-search-volume --keywords "buy laptop,buy desktop"
 direct smartadtargets update --id 456 --priority HIGH
 direct dynamicads set-bids --id 789 --bid 12.5
@@ -119,7 +119,6 @@ direct dynamicads set-bids --id 789 --bid 12.5 --json '{"StrategyPriority":"HIGH
 direct dictionaries get-geo-regions \
   --region-ids 225 \
   --fields GeoRegionId,GeoRegionName
-direct changes check-campaigns --timestamp 2026-04-14T00:00:00Z
 direct changes check-campaigns --timestamp "2026-04-14 00:00:00"
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,7 @@ direct changes check-campaigns --timestamp 2026-04-14T00:00:00Z
 Do not use:
 
 ```bash
+direct changes check-campaigns --timestamp 2026-04-14T00:00:00
 direct changes check-campaigns --timestamp "2026-04-14 00:00:00"
 ```
 

--- a/README.md
+++ b/README.md
@@ -304,19 +304,20 @@ lines with `\`.
 
 #### Datetime Rules
 
-- Datetime parameters must be passed in the format `YYYY-MM-DDTHH:MM:SS`.
+- Changes timestamps must match Yandex Direct API format `YYYY-MM-DDTHH:MM:SSZ`.
+- Other datetime parameters use their method-specific documented format.
 - Datetime values must be passed as a single shell token.
-- Canonical examples must not use timezone suffixes like `Z`.
+- Canonical `changes` examples must use the `Z` suffix.
 - Canonical examples must not use quoted space-separated datetime values.
 
 Use:
 
 ```bash
-direct changes check-campaigns --timestamp 2026-04-14T00:00:00
+direct changes check-campaigns --timestamp 2026-04-14T00:00:00Z
 ```
 
-Do not use: a timestamp with a `Z` suffix, or a quoted timestamp that contains
-a space between the date and time.
+Do not use: a `changes` timestamp without the `Z` suffix, or a quoted timestamp
+that contains a space between the date and time.
 
 #### Documentation Contract
 
@@ -331,7 +332,7 @@ Valid canonical examples:
 
 ```bash
 direct campaigns get --ids 1,2,3
-direct changes check-campaigns --timestamp 2026-04-14T00:00:00
+direct changes check-campaigns --timestamp 2026-04-14T00:00:00Z
 direct keywordsresearch has-search-volume --keywords "buy laptop,buy desktop"
 direct smartadtargets update --id 456 --priority HIGH
 direct dynamicads set-bids --id 789 --bid 12500000 --context-bid 9000000 --priority HIGH
@@ -339,7 +340,7 @@ direct dictionaries get-geo-regions --name Moscow --region-ids 225,187 --exact-n
 ```
 
 Invalid examples include command lines that pass raw JSON flags, use shell
-line continuations, add timezone suffixes to CLI datetimes, or quote
+line continuations, omit the `Z` suffix from `changes` datetimes, or quote
 space-separated datetime values.
 
 #### Campaigns
@@ -580,8 +581,8 @@ direct dictionaries get-geo-regions --name Moscow --region-ids 225,187 --exact-n
 direct clients get --fields ClientId,Login,Currency
 
 # Changes
-direct changes check --campaign-ids 1,2,3 --timestamp 2026-04-14T00:00:00 --fields CampaignIds,AdGroupIds,AdIds,CampaignsStat
-direct changes check-campaigns --timestamp 2026-04-14T00:00:00
+direct changes check --campaign-ids 1,2,3 --timestamp 2026-04-14T00:00:00Z --fields CampaignIds,AdGroupIds,AdIds,CampaignsStat
+direct changes check-campaigns --timestamp 2026-04-14T00:00:00Z
 direct changes check-dictionaries
 
 # Keyword research and retargeting
@@ -1124,19 +1125,20 @@ lines with `\`.
 
 #### Datetime Rules
 
-- Datetime parameters must be passed in the format `YYYY-MM-DDTHH:MM:SS`.
+- Changes timestamps must match Yandex Direct API format `YYYY-MM-DDTHH:MM:SSZ`.
+- Other datetime parameters use their method-specific documented format.
 - Datetime values must be passed as a single shell token.
-- Canonical examples must not use timezone suffixes like `Z`.
+- Canonical `changes` examples must use the `Z` suffix.
 - Canonical examples must not use quoted space-separated datetime values.
 
 Use:
 
 ```bash
-direct changes check-campaigns --timestamp 2026-04-14T00:00:00
+direct changes check-campaigns --timestamp 2026-04-14T00:00:00Z
 ```
 
-Do not use: a timestamp with a `Z` suffix, or a quoted timestamp that contains
-a space between the date and time.
+Do not use: a `changes` timestamp without the `Z` suffix, or a quoted timestamp
+that contains a space between the date and time.
 
 #### Documentation Contract
 
@@ -1151,14 +1153,14 @@ Valid canonical examples:
 
 ```bash
 direct campaigns get --ids 1,2,3
-direct changes check-campaigns --timestamp 2026-04-14T00:00:00
+direct changes check-campaigns --timestamp 2026-04-14T00:00:00Z
 direct keywordsresearch has-search-volume --keywords "buy laptop,buy desktop"
 direct dynamicads set-bids --id 789 --bid 12500000
 direct dictionaries get-geo-regions --region-ids 225 --fields GeoRegionId,GeoRegionName
 ```
 
 Invalid examples include command lines that pass raw JSON flags, use shell
-line continuations, add timezone suffixes to CLI datetimes, or quote
+line continuations, omit the `Z` suffix from `changes` datetimes, or quote
 space-separated datetime values.
 
 #### Кампании
@@ -1402,8 +1404,8 @@ direct dictionaries get-geo-regions --name Москва --region-ids 225,187 --e
 direct clients get --fields ClientId,Login,Currency
 
 # Изменения
-direct changes check --campaign-ids 1,2,3 --timestamp 2026-04-14T00:00:00 --fields CampaignIds,AdGroupIds,AdIds,CampaignsStat
-direct changes check-campaigns --timestamp 2026-04-14T00:00:00
+direct changes check --campaign-ids 1,2,3 --timestamp 2026-04-14T00:00:00Z --fields CampaignIds,AdGroupIds,AdIds,CampaignsStat
+direct changes check-campaigns --timestamp 2026-04-14T00:00:00Z
 direct changes check-dictionaries
 
 # Исследование ключевых слов и ретаргетинг

--- a/direct_cli/commands/changes.py
+++ b/direct_cli/commands/changes.py
@@ -36,7 +36,7 @@ _CHECK_FIELD_NAMES = frozenset({"CampaignIds", "AdGroupIds", "AdIds", "Campaigns
 @click.option(
     "--timestamp",
     required=True,
-    help="Timestamp for changes check (YYYY-MM-DDTHH:MM:SS)",
+    help="Timestamp for changes check (YYYY-MM-DDTHH:MM:SSZ)",
 )
 @click.option(
     "--fields",
@@ -126,7 +126,7 @@ def check(
 @click.option(
     "--timestamp",
     required=True,
-    help="Timestamp for changes check (YYYY-MM-DDTHH:MM:SS)",
+    help="Timestamp for changes check (YYYY-MM-DDTHH:MM:SSZ)",
 )
 @click.option("--format", "output_format", default="json", help="Output format")
 @click.option("--output", help="Output file")

--- a/direct_cli/commands/changes.py
+++ b/direct_cli/commands/changes.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import create_client
 from ..output import format_output, print_error
-from ..utils import get_default_fields, parse_datetime, parse_ids
+from ..utils import get_default_fields, parse_changes_datetime, parse_ids
 
 
 @click.group()
@@ -36,7 +36,7 @@ _CHECK_FIELD_NAMES = frozenset({"CampaignIds", "AdGroupIds", "AdIds", "Campaigns
 @click.option(
     "--timestamp",
     required=True,
-    help="Timestamp for changes check (YYYY-MM-DDTHH:MM:SSZ)",
+    help="Timestamp for Changes.check (YYYY-MM-DDTHH:MM:SSZ)",
 )
 @click.option(
     "--fields",
@@ -108,7 +108,7 @@ def check(
 
         params = {
             id_field: id_value,
-            "Timestamp": parse_datetime(timestamp),
+            "Timestamp": parse_changes_datetime(timestamp),
             "FieldNames": field_names,
         }
 
@@ -126,7 +126,7 @@ def check(
 @click.option(
     "--timestamp",
     required=True,
-    help="Timestamp for changes check (YYYY-MM-DDTHH:MM:SSZ)",
+    help="Timestamp for Changes.checkCampaigns (YYYY-MM-DDTHH:MM:SSZ)",
 )
 @click.option("--format", "output_format", default="json", help="Output format")
 @click.option("--output", help="Output file")
@@ -140,7 +140,7 @@ def check_campaigns(ctx, timestamp, output_format, output):
             sandbox=ctx.obj.get("sandbox"),
         )
 
-        params = {"Timestamp": parse_datetime(timestamp)}
+        params = {"Timestamp": parse_changes_datetime(timestamp)}
 
         body = {"method": "checkCampaigns", "params": params}
 

--- a/direct_cli/utils.py
+++ b/direct_cli/utils.py
@@ -167,13 +167,13 @@ def parse_date(date_str: str) -> str:
 
 
 def parse_datetime(datetime_str: str) -> str:
-    """Parse canonical CLI datetime and normalize it for the API."""
+    """Parse Yandex Direct Changes datetime in API wire format."""
     try:
-        datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M:%S")
-        return f"{datetime_str}Z"
+        datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M:%SZ")
+        return datetime_str
     except ValueError:
         raise ValueError(
-            f"Invalid datetime format: {datetime_str}. Expected: YYYY-MM-DDTHH:MM:SS"
+            f"Invalid datetime format: {datetime_str}. Expected: YYYY-MM-DDTHH:MM:SSZ"
         )
 
 

--- a/direct_cli/utils.py
+++ b/direct_cli/utils.py
@@ -166,7 +166,7 @@ def parse_date(date_str: str) -> str:
         raise ValueError(f"Invalid date format: {date_str}. Expected: YYYY-MM-DD")
 
 
-def parse_datetime(datetime_str: str) -> str:
+def parse_changes_datetime(datetime_str: str) -> str:
     """Parse Yandex Direct Changes datetime in API wire format."""
     try:
         datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M:%SZ")

--- a/scripts/build_api_coverage_report.py
+++ b/scripts/build_api_coverage_report.py
@@ -37,7 +37,7 @@ FIELD_OPERATION_CAPTURE_OPTION_FIXTURES = {
         "--campaign-ids",
         "1",
         "--timestamp",
-        "2026-04-14T00:00:00",
+        "2026-04-14T00:00:00Z",
     ],
     ("dictionaries", "getGeoRegions"): ["--fields", "GeoRegionId"],
     ("dynamicfeedadtargets", "get"): ["--ids", "1"],

--- a/scripts/test_safe_commands.sh
+++ b/scripts/test_safe_commands.sh
@@ -302,7 +302,7 @@ run_v4forecast_contracts
 run_v4tags_contracts
 
 if [ -n "$CAMPAIGN_ID" ]; then
-  run_test "changes check-campaigns (env auth)"    direct changes check-campaigns --timestamp 2026-04-23T00:00:00
+  run_test "changes check-campaigns (env auth)"    direct changes check-campaigns --timestamp 2026-04-23T00:00:00Z
   run_test "dynamicads get (env auth)"             direct dynamicads get --adgroup-ids "${ADGROUP_ID:-0}"
   run_test "v4goals get-stat-goals (env auth)"     direct v4goals get-stat-goals --campaign-ids "$CAMPAIGN_ID"
   run_test "v4goals get-retargeting-goals (env auth)" direct v4goals get-retargeting-goals --campaign-ids "$CAMPAIGN_ID"

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 from click.testing import CliRunner
 
 from direct_cli.cli import cli
-from direct_cli.utils import parse_datetime
+from direct_cli.utils import parse_changes_datetime
 
 TIMESTAMP = "2026-05-21T12:00:00Z"
 
@@ -81,22 +81,22 @@ def test_check_with_campaign_ids_sends_campaign_ids_field():
     assert body["params"]["Timestamp"] == TIMESTAMP
 
 
-def test_parse_datetime_accepts_yandex_changes_timestamp():
-    assert parse_datetime("2026-04-14T00:00:00Z") == "2026-04-14T00:00:00Z"
+def test_parse_changes_datetime_accepts_yandex_changes_timestamp():
+    assert parse_changes_datetime("2026-04-14T00:00:00Z") == "2026-04-14T00:00:00Z"
 
 
-def test_parse_datetime_rejects_bare_timestamp():
+def test_parse_changes_datetime_rejects_bare_timestamp():
     try:
-        parse_datetime("2026-04-14T00:00:00")
+        parse_changes_datetime("2026-04-14T00:00:00")
     except ValueError as exc:
         assert "Expected: YYYY-MM-DDTHH:MM:SSZ" in str(exc)
     else:
         raise AssertionError("bare timestamp must be rejected")
 
 
-def test_parse_datetime_rejects_malformed_timestamp():
+def test_parse_changes_datetime_rejects_malformed_timestamp():
     try:
-        parse_datetime("2026-04-14 00:00:00Z")
+        parse_changes_datetime("2026-04-14 00:00:00Z")
     except ValueError as exc:
         assert "Expected: YYYY-MM-DDTHH:MM:SSZ" in str(exc)
     else:

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -5,8 +5,9 @@ from unittest.mock import MagicMock, patch
 from click.testing import CliRunner
 
 from direct_cli.cli import cli
+from direct_cli.utils import parse_datetime
 
-TIMESTAMP = "2026-05-21T12:00:00"
+TIMESTAMP = "2026-05-21T12:00:00Z"
 
 
 def _invoke(*extra_args):
@@ -77,7 +78,29 @@ def test_check_with_campaign_ids_sends_campaign_ids_field():
     assert body["params"]["CampaignIds"] == [1, 2]
     assert "AdGroupIds" not in body["params"]
     assert "AdIds" not in body["params"]
-    assert body["params"]["Timestamp"].endswith("Z")
+    assert body["params"]["Timestamp"] == TIMESTAMP
+
+
+def test_parse_datetime_accepts_yandex_changes_timestamp():
+    assert parse_datetime("2026-04-14T00:00:00Z") == "2026-04-14T00:00:00Z"
+
+
+def test_parse_datetime_rejects_bare_timestamp():
+    try:
+        parse_datetime("2026-04-14T00:00:00")
+    except ValueError as exc:
+        assert "Expected: YYYY-MM-DDTHH:MM:SSZ" in str(exc)
+    else:
+        raise AssertionError("bare timestamp must be rejected")
+
+
+def test_parse_datetime_rejects_malformed_timestamp():
+    try:
+        parse_datetime("2026-04-14 00:00:00Z")
+    except ValueError as exc:
+        assert "Expected: YYYY-MM-DDTHH:MM:SSZ" in str(exc)
+    else:
+        raise AssertionError("malformed timestamp must be rejected")
 
 
 def test_check_with_ad_group_ids_sends_ad_group_ids_field():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -749,7 +749,7 @@ class TestCLI(unittest.TestCase):
     def test_changes_help_uses_canonical_datetime_format(self):
         result = self.runner.invoke(cli, ["changes", "check-campaigns", "--help"])
         self.assertEqual(result.exit_code, 0)
-        self.assertIn("YYYY-MM-DDTHH:MM:SS", result.output)
+        self.assertIn("YYYY-MM-DDTHH:MM:SSZ", result.output)
         self.assertNotIn("ISO format", result.output)
 
     def test_keywordsresearch_help_uses_canonical_names(self):

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -11,6 +11,9 @@ from direct_cli.smoke_matrix import SMOKE_MATRIX
 GROUP_NAME_RE = re.compile(r"^[a-z0-9]+$")
 COMMAND_NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 DATETIME_WITH_Z_RE = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z")
+CHANGES_BARE_DATETIME_RE = re.compile(
+    r"^direct changes .*--timestamp \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\s|$)"
+)
 QUOTED_SPACE_DATETIME_RE = re.compile(r'"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}"')
 
 MUTATING_COMMANDS = {
@@ -142,8 +145,10 @@ def test_readme_direct_examples_are_single_line_canonical_commands():
             offenders.append(f"line continuation: {line}")
         if "--json" in line:
             offenders.append(f"json flag: {line}")
-        if DATETIME_WITH_Z_RE.search(line):
+        if DATETIME_WITH_Z_RE.search(line) and not line.startswith("direct changes "):
             offenders.append(f"timezone datetime: {line}")
+        if CHANGES_BARE_DATETIME_RE.search(line):
+            offenders.append(f"bare changes datetime: {line}")
         if QUOTED_SPACE_DATETIME_RE.search(line):
             offenders.append(f"quoted space datetime: {line}")
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -584,7 +584,7 @@ class TestReadOnlyAgencyClients(unittest.TestCase):
 def _recent_timestamp() -> str:
     """Return an ISO timestamp 1 hour in the past for changes.check* probes."""
     ts = datetime.now(timezone.utc) - timedelta(hours=1)
-    return ts.strftime("%Y-%m-%dT%H:%M:%S")
+    return ts.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 @pytest.mark.integration

--- a/tests/test_low_coverage_payloads.py
+++ b/tests/test_low_coverage_payloads.py
@@ -64,7 +64,7 @@ def test_changes_check_builds_canonical_payload():
             "--campaign-ids",
             "1,2",
             "--timestamp",
-            "2026-04-14T00:00:00",
+            "2026-04-14T00:00:00Z",
             "--fields",
             "CampaignIds,CampaignsStat",
         ],
@@ -88,7 +88,7 @@ def test_changes_check_campaigns_builds_canonical_payload():
             "changes",
             "check-campaigns",
             "--timestamp",
-            "2026-04-14T00:00:00",
+            "2026-04-14T00:00:00Z",
         ],
     )
 
@@ -108,16 +108,28 @@ def test_changes_check_dictionaries_builds_canonical_payload():
     assert body == {"method": "checkDictionaries", "params": {}}
 
 
-def test_changes_rejects_noncanonical_datetime():
+def test_changes_rejects_bare_datetime():
     result = _failing_run(
         "changes",
         "check-campaigns",
         "--timestamp",
-        "2026-04-14T00:00:00Z",
+        "2026-04-14T00:00:00",
     )
 
     assert result.exit_code != 0
-    assert "Expected: YYYY-MM-DDTHH:MM:SS" in result.output
+    assert "Expected: YYYY-MM-DDTHH:MM:SSZ" in result.output
+
+
+def test_changes_rejects_malformed_datetime():
+    result = _failing_run(
+        "changes",
+        "check-campaigns",
+        "--timestamp",
+        "2026-04-14 00:00:00Z",
+    )
+
+    assert result.exit_code != 0
+    assert "Expected: YYYY-MM-DDTHH:MM:SSZ" in result.output
 
 
 def test_keywordsresearch_has_search_volume_builds_typed_payload():


### PR DESCRIPTION
## Summary

- Align `changes check` and `changes check-campaigns` timestamp input with Yandex Direct docs: `YYYY-MM-DDTHH:MM:SSZ` only.
- Stop accepting bare `YYYY-MM-DDTHH:MM:SS` for Changes timestamps.
- Update help text, README/AGENTS examples, safe-command fixtures, integration timestamp generation, and regression tests.

## Why

Yandex documents `Changes.check` / `Changes.checkCampaigns` `Timestamp` as `YYYY-MM-DDThh:mm:ssZ`. The CLI previously accepted a bare timestamp and appended `Z` internally, which drifted from the API contract and broke the plugin-side expectation tracked in `axisrow/yandex-direct-mcp-plugin#115`.

Closes #235.

## Validation

- `python3 -m pytest tests/test_low_coverage_payloads.py tests/test_changes.py tests/test_cli.py tests/test_cli_contract.py -q` -> `122 passed, 30 subtests passed`
- `python3 -m pytest -m "not integration" -q` -> `1323 passed, 44 skipped, 32 deselected, 30 subtests passed`
- `git diff --check` -> clean