### PR TITLE
[codex] Require timezone for Changes timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,10 +304,12 @@ lines with `\`.
 
 #### Datetime Rules
 
-- Changes timestamps must match Yandex Direct API format `YYYY-MM-DDTHH:MM:SSZ`.
+- Changes timestamps must include an explicit timezone: `YYYY-MM-DDTHH:MM:SSZ`
+  or an offset such as `YYYY-MM-DDTHH:MM:SS+03:00`.
 - Other datetime parameters use their method-specific documented format.
 - Datetime values must be passed as a single shell token.
-- Canonical `changes` examples must use the `Z` suffix.
+- Canonical `changes` examples should use the `Z` suffix; explicit offsets are
+  accepted and normalized to UTC.
 - Canonical examples must not use quoted space-separated datetime values.
 
 Use:
@@ -316,8 +318,8 @@ Use:
 direct changes check-campaigns --timestamp 2026-04-14T00:00:00Z
 ```
 
-Do not use: a `changes` timestamp without the `Z` suffix, or a quoted timestamp
-that contains a space between the date and time.
+Do not use: a `changes` timestamp without a timezone suffix, or a quoted
+timestamp that contains a space between the date and time.
 
 #### Documentation Contract
 
@@ -340,7 +342,7 @@ direct dictionaries get-geo-regions --name Moscow --region-ids 225,187 --exact-n
 ```
 
 Invalid examples include command lines that pass raw JSON flags, use shell
-line continuations, omit the `Z` suffix from `changes` datetimes, or quote
+line continuations, omit the timezone suffix from `changes` datetimes, or quote
 space-separated datetime values.
 
 #### Campaigns
@@ -1125,10 +1127,12 @@ lines with `\`.
 
 #### Datetime Rules
 
-- Changes timestamps must match Yandex Direct API format `YYYY-MM-DDTHH:MM:SSZ`.
+- Changes timestamps must include an explicit timezone: `YYYY-MM-DDTHH:MM:SSZ`
+  or an offset such as `YYYY-MM-DDTHH:MM:SS+03:00`.
 - Other datetime parameters use their method-specific documented format.
 - Datetime values must be passed as a single shell token.
-- Canonical `changes` examples must use the `Z` suffix.
+- Canonical `changes` examples should use the `Z` suffix; explicit offsets are
+  accepted and normalized to UTC.
 - Canonical examples must not use quoted space-separated datetime values.
 
 Use:
@@ -1137,8 +1141,8 @@ Use:
 direct changes check-campaigns --timestamp 2026-04-14T00:00:00Z
 ```
 
-Do not use: a `changes` timestamp without the `Z` suffix, or a quoted timestamp
-that contains a space between the date and time.
+Do not use: a `changes` timestamp without a timezone suffix, or a quoted
+timestamp that contains a space between the date and time.
 
 #### Documentation Contract
 
@@ -1160,7 +1164,7 @@ direct dictionaries get-geo-regions --region-ids 225 --fields GeoRegionId,GeoReg
 ```
 
 Invalid examples include command lines that pass raw JSON flags, use shell
-line continuations, omit the `Z` suffix from `changes` datetimes, or quote
+line continuations, omit the timezone suffix from `changes` datetimes, or quote
 space-separated datetime values.
 
 #### Кампании

--- a/direct_cli/commands/changes.py
+++ b/direct_cli/commands/changes.py
@@ -36,7 +36,10 @@ _CHECK_FIELD_NAMES = frozenset({"CampaignIds", "AdGroupIds", "AdIds", "Campaigns
 @click.option(
     "--timestamp",
     required=True,
-    help="Timestamp for Changes.check (YYYY-MM-DDTHH:MM:SSZ)",
+    help=(
+        "Timestamp for Changes.check "
+        "(YYYY-MM-DDTHH:MM:SSZ or YYYY-MM-DDTHH:MM:SS+03:00)"
+    ),
 )
 @click.option(
     "--fields",
@@ -126,7 +129,10 @@ def check(
 @click.option(
     "--timestamp",
     required=True,
-    help="Timestamp for Changes.checkCampaigns (YYYY-MM-DDTHH:MM:SSZ)",
+    help=(
+        "Timestamp for Changes.checkCampaigns "
+        "(YYYY-MM-DDTHH:MM:SSZ or YYYY-MM-DDTHH:MM:SS+03:00)"
+    ),
 )
 @click.option("--format", "output_format", default="json", help="Output format")
 @click.option("--output", help="Output file")

--- a/direct_cli/utils.py
+++ b/direct_cli/utils.py
@@ -6,7 +6,7 @@ import base64
 import json
 import math
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
 from typing import Any, Dict, Iterable, List, Optional, Union
 
@@ -168,12 +168,24 @@ def parse_date(date_str: str) -> str:
 
 def parse_changes_datetime(datetime_str: str) -> str:
     """Parse Yandex Direct Changes datetime in API wire format."""
+    if not re.fullmatch(
+        r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(Z|[+-]\d{2}:\d{2})",
+        datetime_str,
+    ):
+        raise ValueError(
+            f"Invalid datetime format: {datetime_str}. "
+            "Expected: YYYY-MM-DDTHH:MM:SSZ or YYYY-MM-DDTHH:MM:SS+03:00"
+        )
     try:
-        datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M:%SZ")
-        return datetime_str
+        if datetime_str.endswith("Z"):
+            datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M:%SZ")
+            return datetime_str
+        parsed = datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M:%S%z")
+        return parsed.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     except ValueError:
         raise ValueError(
-            f"Invalid datetime format: {datetime_str}. Expected: YYYY-MM-DDTHH:MM:SSZ"
+            f"Invalid datetime format: {datetime_str}. "
+            "Expected: YYYY-MM-DDTHH:MM:SSZ or YYYY-MM-DDTHH:MM:SS+03:00"
         )
 
 

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -85,6 +85,10 @@ def test_parse_changes_datetime_accepts_yandex_changes_timestamp():
     assert parse_changes_datetime("2026-04-14T00:00:00Z") == "2026-04-14T00:00:00Z"
 
 
+def test_parse_changes_datetime_normalizes_explicit_offset_to_utc():
+    assert parse_changes_datetime("2025-06-01T00:00:00+03:00") == "2025-05-31T21:00:00Z"
+
+
 def test_parse_changes_datetime_rejects_bare_timestamp():
     try:
         parse_changes_datetime("2026-04-14T00:00:00")


### PR DESCRIPTION
## Summary

- Require explicit timezone input for `direct changes` timestamps.
- Accept `...Z` as-is and accept explicit offsets like `+03:00`, normalizing offsets to UTC `...Z` for the API payload.
- Keep bare `YYYY-MM-DDTHH:MM:SS` rejected and update help/README/tests to match.

Closes #383

## Validation

- `python3 -m pytest tests/test_changes.py tests/test_low_coverage_payloads.py -q` -> `69 passed`
- `python3 -m pytest -m "not integration" -q` -> `1344 passed, 44 skipped, 32 deselected, 30 subtasks passed`
- `python3 -m ruff check direct_cli/commands/changes.py direct_cli/utils.py tests/test_changes.py tests/test_low_coverage_payloads.py` -> clean
- `python3 -m ruff format --check direct_cli/commands/changes.py direct_cli/utils.py tests/test_changes.py` -> clean