### PR TITLE
feat(campaigns): SmartCampaign priority goals for bidding strategy

### DIFF
--- a/direct_cli/commands/campaigns.py
+++ b/direct_cli/commands/campaigns.py
@@ -2702,12 +2702,8 @@ def add(
                 "--smart-network-cp-spend-limit": smart_network_cp_spend_limit,
                 "--smart-network-cp-start-date": smart_network_cp_start_date,
                 "--smart-network-cp-end-date": smart_network_cp_end_date,
-                "--smart-network-cp-auto-continue": (
-                    smart_network_cp_auto_continue
-                ),
-                "--smart-network-exploration-min": (
-                    smart_network_exploration_min
-                ),
+                "--smart-network-cp-auto-continue": (smart_network_cp_auto_continue),
+                "--smart-network-exploration-min": (smart_network_exploration_min),
                 "--smart-network-exploration-min-custom": (
                     smart_network_exploration_min_custom
                 ),
@@ -2751,12 +2747,6 @@ def add(
                     "a compatible UnifiedCampaign.BiddingStrategy; shared "
                     "BiddingStrategy support is tracked in #290."
                 )
-        if campaign_type_norm == "SMART_CAMPAIGN" and priority_goals is not None:
-            raise click.UsageError(
-                "SmartCampaign.PriorityGoals on campaigns add requires a compatible "
-                "SmartCampaign.BiddingStrategy; shared BiddingStrategy support is "
-                "tracked in #290."
-            )
         if campaign_type_norm in {"MOBILE_APP_CAMPAIGN", "CPM_BANNER_CAMPAIGN"}:
             strategy_followup_flags = {
                 "--goal-id": goal_id,
@@ -3392,6 +3382,17 @@ def add(
                 }
             if parsed_settings:
                 smart_campaign["Settings"] = parsed_settings
+            # SmartCampaignAddItem.PriorityGoals (#369) — top-level sibling on
+            # the SmartCampaign block (WSDL tests/wsdl_cache/campaigns.xml
+            # line 2209: ``PriorityGoalsArray`` minOccurs=0 maxOccurs=1).
+            # Unlike Text/DynamicText, PriorityGoals on SmartCampaign is NOT
+            # constrained to *_MULTIPLE_GOALS subtypes (no such subtypes exist
+            # in SmartCampaignSearch/NetworkStrategyTypeEnum, lines 396-426):
+            # it is an independent campaign-level setting accepted with any
+            # SmartCampaign.BiddingStrategy. PackageBiddingStrategy already
+            # excludes --priority-goals via the shared guard above.
+            if priority_goals_items is not None:
+                smart_campaign["PriorityGoals"] = {"Items": priority_goals_items}
             if attribution_model:
                 smart_campaign["AttributionModel"] = attribution_model.upper()
             if tracking_params:

--- a/direct_cli/commands/campaigns.py
+++ b/direct_cli/commands/campaigns.py
@@ -750,7 +750,10 @@ def get(
         "Comma-separated goal_id:value[:YES|NO] pairs for "
         "TextCampaign/UnifiedCampaign/DynamicTextCampaign.PriorityGoals "
         "(required for AVERAGE_CPA_MULTIPLE_GOALS / "
-        "PAY_FOR_CONVERSION_MULTIPLE_GOALS)"
+        "PAY_FOR_CONVERSION_MULTIPLE_GOALS); also accepted on "
+        "SmartCampaign.PriorityGoals (#369) as a campaign-level "
+        "setting independent of the SmartCampaign.BiddingStrategy "
+        "subtype"
     ),
 )
 @click.option(
@@ -2648,11 +2651,18 @@ def add(
                     f"{', '.join(sorted(provided))}"
                 )
         if smart_package_bidding_strategy_obj is not None:
+            # SmartCampaign.PriorityGoals (#369) is a top-level sibling on
+            # SmartCampaignAddItem (WSDL line 2209) independent of the
+            # BiddingStrategy / PackageBiddingStrategy choice — both
+            # PriorityGoals and PackageBiddingStrategy are declared as
+            # ``minOccurs=0`` siblings on SmartCampaignAddItem (no
+            # ``xsd:choice``), so combining --priority-goals with
+            # PackageBiddingStrategy is WSDL-valid and intentionally
+            # allowed.
             smart_package_incompatible = {
                 "--search-strategy": search_strategy,
                 "--network-strategy": network_strategy,
                 "--filter-average-cpc": filter_average_cpc,
-                "--priority-goals": priority_goals,
                 "--attribution-model": attribution_model,
                 # SmartCampaign.BiddingStrategy.Search typed flags (#367) —
                 # mutually exclusive with PackageBiddingStrategy. Without these

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,9 +11,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 438 |
+| `missing_followup` | 433 |
 | `not_applicable` | 26 |
-| `supported` | 2777 |
+| `supported` | 2782 |
 
 ## Confirmed Follow-Ups
 
@@ -251,11 +251,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `campaigns.add` | `UnifiedCampaign.PriorityGoals.Items.Value` | UnifiedCampaign.PriorityGoals on add requires compatible UnifiedCampaign.BiddingStrategy typed support. [#290](https://github.com/axisrow/direct-cli/issues/290); inherited from `UnifiedCampaign.PriorityGoals` |
 | `campaigns.add` | `UnifiedCampaign.PriorityGoals.Items.IsMetrikaSourceOfValue` | UnifiedCampaign.PriorityGoals on add requires compatible UnifiedCampaign.BiddingStrategy typed support. [#290](https://github.com/axisrow/direct-cli/issues/290); inherited from `UnifiedCampaign.PriorityGoals` |
 | `campaigns.add` | `MobileAppCampaign.BiddingStrategy` | Shared campaign BiddingStrategy builder needs typed support. [#290](https://github.com/axisrow/direct-cli/issues/290) |
-| `campaigns.add` | `SmartCampaign.PriorityGoals` | SmartCampaign.PriorityGoals on add requires compatible SmartCampaign.BiddingStrategy typed support. [#290](https://github.com/axisrow/direct-cli/issues/290) |
-| `campaigns.add` | `SmartCampaign.PriorityGoals.Items` | SmartCampaign.PriorityGoals on add requires compatible SmartCampaign.BiddingStrategy typed support. [#290](https://github.com/axisrow/direct-cli/issues/290); inherited from `SmartCampaign.PriorityGoals` |
-| `campaigns.add` | `SmartCampaign.PriorityGoals.Items.GoalId` | SmartCampaign.PriorityGoals on add requires compatible SmartCampaign.BiddingStrategy typed support. [#290](https://github.com/axisrow/direct-cli/issues/290); inherited from `SmartCampaign.PriorityGoals` |
-| `campaigns.add` | `SmartCampaign.PriorityGoals.Items.Value` | SmartCampaign.PriorityGoals on add requires compatible SmartCampaign.BiddingStrategy typed support. [#290](https://github.com/axisrow/direct-cli/issues/290); inherited from `SmartCampaign.PriorityGoals` |
-| `campaigns.add` | `SmartCampaign.PriorityGoals.Items.IsMetrikaSourceOfValue` | SmartCampaign.PriorityGoals on add requires compatible SmartCampaign.BiddingStrategy typed support. [#290](https://github.com/axisrow/direct-cli/issues/290); inherited from `SmartCampaign.PriorityGoals` |
 | `campaigns.update` | `TextCampaign.BiddingStrategy.Search.WbMaximumClicks.BudgetType` | Official Yandex update-text-campaign docs do not declare BudgetType on WbMaximumClicks; CLI rejects --text-search-budget-type for this subtype. [#361](https://github.com/axisrow/direct-cli/issues/361) |
 | `campaigns.update` | `TextCampaign.BiddingStrategy.Search.WbMaximumConversionRate.BudgetType` | Official Yandex update-text-campaign docs do not declare BudgetType on WbMaximumConversionRate; CLI rejects --text-search-budget-type for this subtype. [#361](https://github.com/axisrow/direct-cli/issues/361) |
 | `campaigns.update` | `TextCampaign.BiddingStrategy.Search.AverageCpaMultipleGoals.BudgetType` | Official Yandex update-text-campaign docs do not declare BudgetType on AverageCpaMultipleGoals; CLI rejects --text-search-budget-type for this subtype. [#361](https://github.com/axisrow/direct-cli/issues/361) |
@@ -2005,11 +2000,11 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `campaigns.add` | `campaigns.add` | `SmartCampaign.Settings.Option` | `SmartCampaignSettingsEnum` | 1 | 1 | `supported` | --setting |
 | `campaigns.add` | `campaigns.add` | `SmartCampaign.Settings.Value` | `YesNoEnum` | 1 | 1 | `supported` | --setting |
 | `campaigns.add` | `campaigns.add` | `SmartCampaign.CounterId` | `long` | 1 | 1 | `supported` | --counter-id |
-| `campaigns.add` | `campaigns.add` | `SmartCampaign.PriorityGoals` | `PriorityGoalsArray` | 0 | 1 | `missing_followup` | SmartCampaign.PriorityGoals on add requires compatible SmartCampaign.BiddingStrategy typed support. [#290](https://github.com/axisrow/direct-cli/issues/290) |
-| `campaigns.add` | `campaigns.add` | `SmartCampaign.PriorityGoals.Items` | `PriorityGoalsItem` | 1 | unbounded | `missing_followup` | SmartCampaign.PriorityGoals on add requires compatible SmartCampaign.BiddingStrategy typed support. [#290](https://github.com/axisrow/direct-cli/issues/290); inherited from `SmartCampaign.PriorityGoals` |
-| `campaigns.add` | `campaigns.add` | `SmartCampaign.PriorityGoals.Items.GoalId` | `long` | 1 | 1 | `missing_followup` | SmartCampaign.PriorityGoals on add requires compatible SmartCampaign.BiddingStrategy typed support. [#290](https://github.com/axisrow/direct-cli/issues/290); inherited from `SmartCampaign.PriorityGoals` |
-| `campaigns.add` | `campaigns.add` | `SmartCampaign.PriorityGoals.Items.Value` | `long` | 1 | 1 | `missing_followup` | SmartCampaign.PriorityGoals on add requires compatible SmartCampaign.BiddingStrategy typed support. [#290](https://github.com/axisrow/direct-cli/issues/290); inherited from `SmartCampaign.PriorityGoals` |
-| `campaigns.add` | `campaigns.add` | `SmartCampaign.PriorityGoals.Items.IsMetrikaSourceOfValue` | `YesNoEnum` | 0 | 1 | `missing_followup` | SmartCampaign.PriorityGoals on add requires compatible SmartCampaign.BiddingStrategy typed support. [#290](https://github.com/axisrow/direct-cli/issues/290); inherited from `SmartCampaign.PriorityGoals` |
+| `campaigns.add` | `campaigns.add` | `SmartCampaign.PriorityGoals` | `PriorityGoalsArray` | 0 | 1 | `supported` | --priority-goals |
+| `campaigns.add` | `campaigns.add` | `SmartCampaign.PriorityGoals.Items` | `PriorityGoalsItem` | 1 | unbounded | `supported` | --priority-goals |
+| `campaigns.add` | `campaigns.add` | `SmartCampaign.PriorityGoals.Items.GoalId` | `long` | 1 | 1 | `supported` | --priority-goals |
+| `campaigns.add` | `campaigns.add` | `SmartCampaign.PriorityGoals.Items.Value` | `long` | 1 | 1 | `supported` | --priority-goals |
+| `campaigns.add` | `campaigns.add` | `SmartCampaign.PriorityGoals.Items.IsMetrikaSourceOfValue` | `YesNoEnum` | 0 | 1 | `supported` | --priority-goals |
 | `campaigns.add` | `campaigns.add` | `SmartCampaign.TrackingParams` | `string` | 0 | 1 | `supported` | --tracking-params |
 | `campaigns.add` | `campaigns.add` | `SmartCampaign.AttributionModel` | `AttributionModelEnum` | 0 | 1 | `supported` | --attribution-model |
 | `campaigns.add` | `campaigns.add` | `SmartCampaign.PackageBiddingStrategy` | `SmartCampaignPackageBiddingStrategyAdd` | 0 | 1 | `supported` | --package-platform-network, --package-platform-search, --package-strategy-from-campaign-id, --package-strategy-id |

--- a/tests/api_coverage_payloads.py
+++ b/tests/api_coverage_payloads.py
@@ -685,6 +685,27 @@ PAYLOAD_CASES = [
             "5",
         ],
     ),
+    # --- issue #369: SmartCampaign.PriorityGoals ---
+    (
+        "campaigns",
+        "add",
+        [
+            "campaigns",
+            "add",
+            "--name",
+            "Test Smart PriorityGoals",
+            "--start-date",
+            "2026-06-01",
+            "--type",
+            "SMART_CAMPAIGN",
+            "--counter-id",
+            "123",
+            "--filter-average-cpc",
+            "1000000",
+            "--priority-goals",
+            "1234567:80,9876543:20:YES",
+        ],
+    ),
     # --- issue #367: SmartCampaign.BiddingStrategy.Search typed flags ---
     (
         "campaigns",

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -5218,12 +5218,18 @@ def test_campaigns_add_smart_default_network_strategy_no_filter_average_cpc():
     assert network == {"BiddingStrategyType": "AVERAGE_CPC_PER_FILTER"}
 
 
-def test_campaigns_add_rejects_smart_priority_goals_without_bidding_strategy():
-    result = _rejected(
+def test_campaigns_add_smart_priority_goals_payload():
+    # Issue #369: SmartCampaignAddItem.PriorityGoals is a top-level sibling on
+    # the SmartCampaign block (WSDL tests/wsdl_cache/campaigns.xml line 2209
+    # ``PriorityGoals`` typed as ``PriorityGoalsArray`` minOccurs=0). Items
+    # carry GoalId (xsd:long, minOccurs=1), Value (xsd:long, minOccurs=1) and
+    # the optional IsMetrikaSourceOfValue (general:YesNoEnum, minOccurs=0)
+    # per the ``PriorityGoalsItem`` complex type (WSDL lines 1928-1934).
+    body = _dry_run(
         "campaigns",
         "add",
         "--name",
-        "Smart Bad",
+        "Smart Priority Goals",
         "--start-date",
         "2026-06-01",
         "--type",
@@ -5233,10 +5239,47 @@ def test_campaigns_add_rejects_smart_priority_goals_without_bidding_strategy():
         "--filter-average-cpc",
         "1000000",
         "--priority-goals",
-        "1234567:80,9876543:20",
+        "1234567:80,9876543:20:YES",
     )
-    assert "SmartCampaign.PriorityGoals" in result.output
-    assert "#290" in result.output
+    smart = body["params"]["Campaigns"][0]["SmartCampaign"]
+    assert smart["PriorityGoals"] == {
+        "Items": [
+            {"GoalId": 1234567, "Value": 80},
+            {"GoalId": 9876543, "Value": 20, "IsMetrikaSourceOfValue": "YES"},
+        ]
+    }
+    # PriorityGoals is independent of BiddingStrategy — the default
+    # AVERAGE_CPC_PER_FILTER Network branch must still be present.
+    network = smart["BiddingStrategy"]["Network"]
+    assert network["BiddingStrategyType"] == "AVERAGE_CPC_PER_FILTER"
+
+
+def test_campaigns_add_smart_priority_goals_rejected_with_package_strategy():
+    # PackageBiddingStrategy on SmartCampaign already rejects --priority-goals
+    # via the shared guard (smart_package_incompatible). Cover the contract
+    # so the conflict cannot regress with the new top-level placement.
+    result = _rejected(
+        "campaigns",
+        "add",
+        "--name",
+        "Smart Pkg+PG",
+        "--start-date",
+        "2026-06-01",
+        "--type",
+        "SMART_CAMPAIGN",
+        "--counter-id",
+        "123",
+        "--package-strategy-id",
+        "42",
+        "--package-platform-search",
+        "yes",
+        "--package-platform-network",
+        "yes",
+        "--priority-goals",
+        "1234567:80",
+    )
+    assert "SmartCampaign.PackageBiddingStrategy cannot be combined" in result.output
+    assert "--priority-goals" in result.output
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -5254,11 +5254,16 @@ def test_campaigns_add_smart_priority_goals_payload():
     assert network["BiddingStrategyType"] == "AVERAGE_CPC_PER_FILTER"
 
 
-def test_campaigns_add_smart_priority_goals_rejected_with_package_strategy():
-    # PackageBiddingStrategy on SmartCampaign already rejects --priority-goals
-    # via the shared guard (smart_package_incompatible). Cover the contract
-    # so the conflict cannot regress with the new top-level placement.
-    result = _rejected(
+def test_campaigns_add_smart_priority_goals_with_package_strategy_payload():
+    # SmartCampaign.PriorityGoals (#369) and SmartCampaign.PackageBiddingStrategy
+    # are declared as independent ``minOccurs=0`` siblings on the
+    # SmartCampaignAddItem complexType (WSDL tests/wsdl_cache/campaigns.xml
+    # lines 2202-2214 — no ``xsd:choice`` wrapping them), so combining
+    # --priority-goals with --package-strategy-id must produce a payload
+    # carrying BOTH fields. The shared smart_package_incompatible guard
+    # documents the mutex it does enforce and intentionally excludes
+    # --priority-goals.
+    body = _dry_run(
         "campaigns",
         "add",
         "--name",
@@ -5278,8 +5283,9 @@ def test_campaigns_add_smart_priority_goals_rejected_with_package_strategy():
         "--priority-goals",
         "1234567:80",
     )
-    assert "SmartCampaign.PackageBiddingStrategy cannot be combined" in result.output
-    assert "--priority-goals" in result.output
+    smart = body["params"]["Campaigns"][0]["SmartCampaign"]
+    assert "PackageBiddingStrategy" in smart
+    assert smart["PriorityGoals"] == {"Items": [{"GoalId": 1234567, "Value": 80}]}
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -1642,6 +1642,21 @@ OPTIONAL_FIELD_CLI_OPTIONS: dict[tuple[str, str, str], set[str]] = {
     },
     ("campaigns", "add", "SmartCampaign.Settings"): {"--setting"},
     ("campaigns", "add", "SmartCampaign.TrackingParams"): {"--tracking-params"},
+    # SmartCampaign.PriorityGoals (#369): top-level sibling on
+    # SmartCampaignAddItem; reuses the shared --priority-goals parser.
+    ("campaigns", "add", "SmartCampaign.PriorityGoals"): {"--priority-goals"},
+    ("campaigns", "add", "SmartCampaign.PriorityGoals.Items"): {"--priority-goals"},
+    ("campaigns", "add", "SmartCampaign.PriorityGoals.Items.GoalId"): {
+        "--priority-goals"
+    },
+    ("campaigns", "add", "SmartCampaign.PriorityGoals.Items.Value"): {
+        "--priority-goals"
+    },
+    (
+        "campaigns",
+        "add",
+        "SmartCampaign.PriorityGoals.Items.IsMetrikaSourceOfValue",
+    ): {"--priority-goals"},
     ("campaigns", "update", "Name"): {"--name"},
     ("campaigns", "update", "DailyBudget"): {"--budget"},
     ("campaigns", "update", "DailyBudget.Amount"): {"--budget"},
@@ -3296,6 +3311,21 @@ for _path in (
         "--priority-goals"
     }
 
+# SmartCampaign.PriorityGoals on add (#369). The add-side schema
+# (``PriorityGoalsArray`` -> ``PriorityGoalsItem``) does not carry
+# ``Operation`` — that field lives on the update-only
+# ``PriorityGoalsUpdateItem``.
+for _path in (
+    "PriorityGoals",
+    "PriorityGoals.Items",
+    "PriorityGoals.Items.GoalId",
+    "PriorityGoals.Items.Value",
+    "PriorityGoals.Items.IsMetrikaSourceOfValue",
+):
+    OPTIONAL_FIELD_CLI_OPTIONS[("campaigns", "add", f"SmartCampaign.{_path}")] = {
+        "--priority-goals"
+    }
+
 # SmartCampaign.BiddingStrategy.Search typed-flag coverage (issue #367).
 # Mirrors WSDL Strategy*Add subtypes (tests/wsdl_cache/campaigns.xml
 # 1401-1481, get-side Strategy* 851-929, SmartCampaignSearchStrategyTypeEnum
@@ -4216,11 +4246,12 @@ OPTIONAL_FIELD_CHILD_PREFIX_FOLLOWUPS: dict[tuple[str, str, str], dict[str, str]
         "note": "Shared campaign BiddingStrategy builder needs typed support.",
     },
     ("campaigns", "add", "SmartCampaign.PriorityGoals"): {
-        "status": "missing_followup",
-        "issue": "#290",
+        "status": "supported",
+        "issue": "#369",
         "note": (
-            "SmartCampaign.PriorityGoals on add requires compatible "
-            "SmartCampaign.BiddingStrategy typed support."
+            "SmartCampaign.PriorityGoals on campaigns add is a top-level "
+            "sibling on SmartCampaignAddItem (WSDL line 2209) and is set "
+            "via the shared --priority-goals flag."
         ),
     },
     ("campaigns", "add", "MobileAppCampaign.BiddingStrategy"): {


### PR DESCRIPTION
Closes #369

## Summary

Wires `SmartCampaign.PriorityGoals` on `direct campaigns add` through the
existing typed `--priority-goals` flag. The field is a top-level sibling on
`SmartCampaignAddItem` and is independent of the `BiddingStrategy` subtype
choice — SmartCampaign has no `*_MULTIPLE_GOALS` strategy subtypes, so the
Text/Dynamic-style subtype gating does not apply.

### WSDL evidence (canonical source)
Yandex public docs are showcaptcha-blocked; the cached WSDL at
`tests/wsdl_cache/campaigns.xml` is the version-pinned source of truth:

- `PriorityGoalsItem` lines 1928-1934: `GoalId` (xsd:long, minOccurs=1),
  `Value` (xsd:long, minOccurs=1), `IsMetrikaSourceOfValue`
  (general:YesNoEnum, minOccurs=0).
- `PriorityGoalsArray` lines 1943-1947: `Items` minOccurs=1
  maxOccurs=unbounded.
- `SmartCampaignAddItem.PriorityGoals` line 2209: typed as
  `PriorityGoalsArray`, minOccurs=0 maxOccurs=1.
- `SmartCampaignAddItem` lines 2202-2214: `PriorityGoals` and
  `PackageBiddingStrategy` are independent `minOccurs=0` siblings (no
  `xsd:choice`), so combining them is WSDL-valid.

Update path (`SmartCampaignUpdateItem.PriorityGoals`, line 2308) uses
`PriorityGoalsUpdateSetting` with the additional per-item `Operation`
field — out of scope here per the issue (`Operations: campaigns.add`);
the existing `OPTIONAL_FIELD_CLI_OPTIONS` mapping already covers update.

## Changes

- `direct_cli/commands/campaigns.py`:
  - Remove the legacy `UsageError` that rejected `SmartCampaign.PriorityGoals`
    on `campaigns add` (deferring to #290).
  - Emit `SmartCampaign.PriorityGoals = {"Items": [...]}` when
    `--priority-goals` items are present.
  - Drop `--priority-goals` from `smart_package_incompatible` (independent
    siblings per WSDL; PackageBiddingStrategy + PriorityGoals is allowed).
  - Extend `--priority-goals` help text to document the new SmartCampaign
    surface and clarify it is NOT subtype-gated for SmartCampaign.
- `tests/test_dry_run.py`:
  - Replace `test_campaigns_add_rejects_smart_priority_goals_without_bidding_strategy`
    with `test_campaigns_add_smart_priority_goals_payload` — asserts exact
    Yandex payload shape with two items including the optional
    `IsMetrikaSourceOfValue`.
  - Add `test_campaigns_add_smart_priority_goals_with_package_strategy_payload`
    — proves the combined Package + PriorityGoals payload reaches the wire
    intact.
- `tests/api_coverage_payloads.py`: add a `PAYLOAD_CASES` fixture for
  `SMART_CAMPAIGN add --priority-goals`.
- `tests/test_wsdl_parity_gate.py`:
  - Register `SmartCampaign.PriorityGoals*` add paths in `COMMAND_WSDL_MAP`
    and `OPTIONAL_FIELD_CLI_OPTIONS` (mirroring the update-side mapping at
    lines 3287-3297).
  - Flip `OPTIONAL_FIELD_CHILD_PREFIX_FOLLOWUPS[("campaigns", "add",
    "SmartCampaign.PriorityGoals")]` from `missing_followup/#290` to
    `supported/#369`.
- `tests/WSDL_OPTIONAL_FIELD_AUDIT.md`: regenerated; exactly five
  `campaigns.add` rows flip from `missing_followup` to `supported` (totals:
  -5 missing, +5 supported).

## Test plan

- [x] `pytest tests/test_dry_run.py tests/test_wsdl_parity_gate.py tests/test_cli.py tests/test_comprehensive.py tests/test_api_coverage.py -x -q` → 1176 passed, 6 skipped, 30 subtests passed
- [x] `python3 scripts/build_wsdl_optional_field_audit.py --check` → audit current
- [x] `black` clean, `flake8` clean on modified lines
- [x] Adversarial review (`codex-companion adversarial-review`) → approve

## Out of scope

- `SmartCampaignUpdateItem.PriorityGoals` (typed `PriorityGoalsUpdateSetting`
  with the per-item `Operation` field) — tracked under epic #290.
- The `parse_priority_goals_spec` `Value` units issue (#387) — pre-existing,
  not touched here.
- TextCampaign / DynamicTextCampaign Search/Network branches (#367, #368
  already merged); UnifiedCampaign branches (#290 follow-ups).