### PR TITLE
feat(campaigns): UnifiedCampaign priority goals for bidding strategy

### DIFF
--- a/direct_cli/commands/campaigns.py
+++ b/direct_cli/commands/campaigns.py
@@ -3096,8 +3096,9 @@ def add(
                         "requires --network-strategy or --search-strategy "
                         "in {AVERAGE_CPA_MULTIPLE_GOALS, "
                         "PAY_FOR_CONVERSION_MULTIPLE_GOALS, MAX_PROFIT} "
-                        "(other BiddingStrategy combinations are tracked "
-                        "in #290 / #373)."
+                        "and is incompatible with "
+                        "--package-strategy-id/--package-strategy-from-"
+                        "campaign-id (#373)."
                     )
         if campaign_type_norm in {"MOBILE_APP_CAMPAIGN", "CPM_BANNER_CAMPAIGN"}:
             strategy_followup_flags = {

--- a/direct_cli/commands/campaigns.py
+++ b/direct_cli/commands/campaigns.py
@@ -2730,12 +2730,23 @@ def add(
                     search_placement_product_gallery
                 ),
                 "--search-placement-dynamic-places": search_placement_dynamic_places,
-                "--priority-goals": priority_goals,
                 "--goal-id": goal_id,
                 "--average-cpa": average_cpa,
                 "--crr": crr,
                 "--bid-ceiling": bid_ceiling,
             }
+            # Issue #373: ``UnifiedCampaignAddItem.PriorityGoals`` and
+            # ``UnifiedCampaignAddItem.PackageBiddingStrategy`` are
+            # declared as independent ``minOccurs=0`` siblings on the
+            # WSDL (``tests/wsdl_cache/campaigns.xml`` lines 2160-2172,
+            # no ``xsd:choice`` wrapper) — same shape as
+            # ``SmartCampaignAddItem`` (lines 2202-2214) where the same
+            # mutex was lifted in #369/#392. Allow the combination on
+            # UnifiedCampaign; the other non-Smart package campaign
+            # types (TextCampaign, DynamicTextCampaign) keep the mutex
+            # until their own follow-up issues land.
+            if campaign_type_norm != "UNIFIED_CAMPAIGN":
+                package_incompatible["--priority-goals"] = priority_goals
             if campaign_type_norm == "TEXT_CAMPAIGN":
                 # Issue #361: every typed Search-strategy detail flag must
                 # also conflict with PackageBiddingStrategy on TEXT_CAMPAIGN,
@@ -3062,13 +3073,18 @@ def add(
                     f"{', '.join(sorted(provided))}"
                 )
             if priority_goals is not None:
-                # Issue #366 + #363: --priority-goals is allowed on Unified
-                # add only when the chosen BiddingStrategy subtype consumes
-                # ``UnifiedCampaignAddItem.PriorityGoals`` (multi-goal /
-                # MaxProfit families). Both the Network branch (#366) and
-                # the Search branch (#363) accept the same subtype set on
-                # ``UnifiedCampaignStrategyAddBase``; package strategies
-                # never accept priority-goals.
+                # Issue #373 (lifts the #366/#363 carve-out):
+                # ``UnifiedCampaignAddItem.PriorityGoals`` is a top-level
+                # sibling on the UnifiedCampaign block (WSDL line 2165),
+                # declared as an independent ``minOccurs=0`` element next
+                # to ``BiddingStrategy`` (2162) and ``PackageBiddingStrategy``
+                # (2168) — no ``xsd:choice`` wrapper. This mirrors the
+                # SmartCampaign precedent (#369/#392): PriorityGoals may
+                # be combined with PackageBiddingStrategy. When the user
+                # picks the per-side BiddingStrategy path instead, only
+                # the multi-goal / MaxProfit subtypes consume the
+                # priority goals; otherwise reject so the API does not
+                # silently ignore them.
                 _unified_network_subtype = (
                     UNIFIED_CAMPAIGN_NETWORK_STRATEGY_TO_WSDL_SUBTYPE.get(
                         (network_strategy or "").upper()
@@ -3088,17 +3104,16 @@ def add(
                     in _UNIFIED_SEARCH_REQUIRES_PRIORITY_GOALS
                 )
                 if (
-                    package_bidding_strategy_obj is not None
-                    or not (_network_allows or _search_allows)
+                    package_bidding_strategy_obj is None
+                    and not (_network_allows or _search_allows)
                 ):
                     raise click.UsageError(
                         "UnifiedCampaign.PriorityGoals on campaigns add "
-                        "requires --network-strategy or --search-strategy "
-                        "in {AVERAGE_CPA_MULTIPLE_GOALS, "
+                        "requires either --package-strategy-id/--package-"
+                        "strategy-from-campaign-id or --network-strategy/"
+                        "--search-strategy in {AVERAGE_CPA_MULTIPLE_GOALS, "
                         "PAY_FOR_CONVERSION_MULTIPLE_GOALS, MAX_PROFIT} "
-                        "and is incompatible with "
-                        "--package-strategy-id/--package-strategy-from-"
-                        "campaign-id (#373)."
+                        "(#373)."
                     )
         if campaign_type_norm in {"MOBILE_APP_CAMPAIGN", "CPM_BANNER_CAMPAIGN"}:
             strategy_followup_flags = {
@@ -6200,9 +6215,18 @@ def update(
                     require_platforms=False,
                 )
                 if package_bidding_strategy_obj is not None:
-                    package_incompatible = {
-                        "--priority-goals": priority_goals,
-                    }
+                    package_incompatible: Dict[str, object] = {}
+                    # Issue #373: ``UnifiedCampaignUpdateItem.PriorityGoals``
+                    # (WSDL ``tests/wsdl_cache/campaigns.xml`` line 2259) is a
+                    # nillable sibling of ``UnifiedCampaignUpdateItem.
+                    # PackageBiddingStrategy`` (line 2260-2262) on the same
+                    # ``xsd:sequence`` (no ``xsd:choice``). Mirrors the
+                    # SmartCampaign precedent (#369/#392). Other non-Smart
+                    # package campaign types (TextCampaign,
+                    # DynamicTextCampaign) keep the mutex until their own
+                    # follow-up issues land.
+                    if not is_unified:
+                        package_incompatible["--priority-goals"] = priority_goals
                     if not is_unified and not is_dynamic:
                         package_incompatible.update(
                             {

--- a/direct_cli/commands/campaigns.py
+++ b/direct_cli/commands/campaigns.py
@@ -3112,19 +3112,40 @@ def add(
                 )
                 _network_chosen = network_strategy is not None
                 _search_chosen = search_strategy is not None
-                if _network_chosen and not _network_allows:
+                # Only reject when EVERY explicitly chosen per-side
+                # strategy is incompatible. PriorityGoals on the
+                # parent sibling is still emitted (line 3550-3551),
+                # so a single compatible side is enough — and the
+                # standalone case (no per-side strategy at all) is
+                # also valid per the WSDL.
+                _both_explicit_and_incompatible = (
+                    _network_chosen
+                    and _search_chosen
+                    and not _network_allows
+                    and not _search_allows
+                )
+                _only_network_explicit_and_incompatible = (
+                    _network_chosen
+                    and not _search_chosen
+                    and not _network_allows
+                )
+                _only_search_explicit_and_incompatible = (
+                    _search_chosen
+                    and not _network_chosen
+                    and not _search_allows
+                )
+                if (
+                    _both_explicit_and_incompatible
+                    or _only_network_explicit_and_incompatible
+                    or _only_search_explicit_and_incompatible
+                ):
                     raise click.UsageError(
                         "--priority-goals on UnifiedCampaign is only valid "
-                        "with --network-strategy in {AVERAGE_CPA_MULTIPLE_"
-                        "GOALS, PAY_FOR_CONVERSION_MULTIPLE_GOALS, "
-                        f"MAX_PROFIT}}; got --network-strategy={network_strategy!r}"
-                    )
-                if _search_chosen and not _search_allows:
-                    raise click.UsageError(
-                        "--priority-goals on UnifiedCampaign is only valid "
-                        "with --search-strategy in {AVERAGE_CPA_MULTIPLE_"
-                        "GOALS, PAY_FOR_CONVERSION_MULTIPLE_GOALS, "
-                        f"MAX_PROFIT}}; got --search-strategy={search_strategy!r}"
+                        "with --network-strategy or --search-strategy in "
+                        "{AVERAGE_CPA_MULTIPLE_GOALS, "
+                        "PAY_FOR_CONVERSION_MULTIPLE_GOALS, MAX_PROFIT}; "
+                        f"got --network-strategy={network_strategy!r}, "
+                        f"--search-strategy={search_strategy!r}"
                     )
         if campaign_type_norm in {"MOBILE_APP_CAMPAIGN", "CPM_BANNER_CAMPAIGN"}:
             strategy_followup_flags = {

--- a/direct_cli/commands/campaigns.py
+++ b/direct_cli/commands/campaigns.py
@@ -3073,18 +3073,25 @@ def add(
                     f"{', '.join(sorted(provided))}"
                 )
             if priority_goals is not None:
-                # Issue #373 (lifts the #366/#363 carve-out):
-                # ``UnifiedCampaignAddItem.PriorityGoals`` is a top-level
-                # sibling on the UnifiedCampaign block (WSDL line 2165),
-                # declared as an independent ``minOccurs=0`` element next
-                # to ``BiddingStrategy`` (2162) and ``PackageBiddingStrategy``
-                # (2168) — no ``xsd:choice`` wrapper. This mirrors the
-                # SmartCampaign precedent (#369/#392): PriorityGoals may
-                # be combined with PackageBiddingStrategy. When the user
-                # picks the per-side BiddingStrategy path instead, only
-                # the multi-goal / MaxProfit subtypes consume the
-                # priority goals; otherwise reject so the API does not
-                # silently ignore them.
+                # Issue #373: ``UnifiedCampaignAddItem.PriorityGoals``
+                # (WSDL ``tests/wsdl_cache/campaigns.xml`` line 2165) is a
+                # top-level sibling declared as ``minOccurs=0`` alongside
+                # ``BiddingStrategy`` (line 2162, also ``minOccurs=0``) and
+                # ``PackageBiddingStrategy`` (line 2168, ``minOccurs=0``)
+                # on a plain ``xsd:sequence`` — no ``xsd:choice``. Per
+                # the canonical WSDL the user MAY supply PriorityGoals
+                # alone, with PackageBiddingStrategy, or with a
+                # per-side BiddingStrategy. The only documented
+                # constraint surfaced by this CLI is on the per-side
+                # BiddingStrategy subtypes themselves
+                # (``_bidding_strategy.py``): when the user explicitly
+                # selects a per-side strategy whose subtype is NOT in
+                # the multi-goal / MaxProfit set, ``--priority-goals``
+                # would be silently dropped by the subtype builder, so
+                # reject up-front with a clear message. When no per-side
+                # strategy is chosen, the items flow straight to the
+                # parent PriorityGoals sibling and the builders fall
+                # back to their HIGHEST_POSITION / SERVING_OFF defaults.
                 _unified_network_subtype = (
                     UNIFIED_CAMPAIGN_NETWORK_STRATEGY_TO_WSDL_SUBTYPE.get(
                         (network_strategy or "").upper()
@@ -3103,17 +3110,21 @@ def add(
                     _unified_search_subtype
                     in _UNIFIED_SEARCH_REQUIRES_PRIORITY_GOALS
                 )
-                if (
-                    package_bidding_strategy_obj is None
-                    and not (_network_allows or _search_allows)
-                ):
+                _network_chosen = network_strategy is not None
+                _search_chosen = search_strategy is not None
+                if _network_chosen and not _network_allows:
                     raise click.UsageError(
-                        "UnifiedCampaign.PriorityGoals on campaigns add "
-                        "requires either --package-strategy-id/--package-"
-                        "strategy-from-campaign-id or --network-strategy/"
-                        "--search-strategy in {AVERAGE_CPA_MULTIPLE_GOALS, "
-                        "PAY_FOR_CONVERSION_MULTIPLE_GOALS, MAX_PROFIT} "
-                        "(#373)."
+                        "--priority-goals on UnifiedCampaign is only valid "
+                        "with --network-strategy in {AVERAGE_CPA_MULTIPLE_"
+                        "GOALS, PAY_FOR_CONVERSION_MULTIPLE_GOALS, "
+                        f"MAX_PROFIT}}; got --network-strategy={network_strategy!r}"
+                    )
+                if _search_chosen and not _search_allows:
+                    raise click.UsageError(
+                        "--priority-goals on UnifiedCampaign is only valid "
+                        "with --search-strategy in {AVERAGE_CPA_MULTIPLE_"
+                        "GOALS, PAY_FOR_CONVERSION_MULTIPLE_GOALS, "
+                        f"MAX_PROFIT}}; got --search-strategy={search_strategy!r}"
                     )
         if campaign_type_norm in {"MOBILE_APP_CAMPAIGN", "CPM_BANNER_CAMPAIGN"}:
             strategy_followup_flags = {
@@ -3447,7 +3458,16 @@ def add(
                 # PriorityGoals: route to whichever side accepts it.
                 # When BOTH sides chose a multi-goal/MaxProfit subtype the
                 # same items satisfy both builders (the parent placement
-                # via ``sub_campaign_block`` is idempotent).
+                # via ``sub_campaign_block`` is idempotent). When the
+                # user supplies PriorityGoals without explicitly choosing
+                # either side's strategy (#373: WSDL-valid standalone
+                # case), suppress per-side wiring entirely — PriorityGoals
+                # lands on the parent ``UnifiedCampaign.PriorityGoals``
+                # sibling further below and the builders fall back to
+                # the HIGHEST_POSITION / SERVING_OFF defaults. The
+                # upstream guard already raises a clear error when a
+                # per-side strategy was explicitly chosen with a subtype
+                # outside the multi-goal / MaxProfit set.
                 _u_search_uses_priority_goals = (
                     _u_search_subtype_for_routing
                     in _UNIFIED_SEARCH_REQUIRES_PRIORITY_GOALS
@@ -3456,25 +3476,16 @@ def add(
                     _u_network_subtype_for_routing
                     in _UNIFIED_NETWORK_REQUIRES_PRIORITY_GOALS
                 )
-                if (
-                    _u_search_uses_priority_goals
-                    or _u_network_uses_priority_goals
-                ):
-                    _u_search_priority_goals_items = (
-                        priority_goals_items
-                        if _u_search_uses_priority_goals
-                        else None
-                    )
-                    _u_network_priority_goals_items = (
-                        priority_goals_items
-                        if _u_network_uses_priority_goals
-                        else None
-                    )
-                else:
-                    # Neither side accepts ``--priority-goals``. Forward
-                    # to Search so the canonical error path surfaces.
-                    _u_search_priority_goals_items = priority_goals_items
-                    _u_network_priority_goals_items = None
+                _u_search_priority_goals_items = (
+                    priority_goals_items
+                    if _u_search_uses_priority_goals
+                    else None
+                )
+                _u_network_priority_goals_items = (
+                    priority_goals_items
+                    if _u_network_uses_priority_goals
+                    else None
+                )
 
                 unified_search_builder = get_bidding_strategy_builder(
                     "UNIFIED_CAMPAIGN", "add", "search"

--- a/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
+++ b/tests/WSDL_OPTIONAL_FIELD_AUDIT.md
@@ -11,9 +11,9 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 
 | Status | Count |
 |---|---:|
-| `missing_followup` | 9 |
+| `missing_followup` | 4 |
 | `not_applicable` | 26 |
-| `supported` | 3206 |
+| `supported` | 3211 |
 
 ## Confirmed Follow-Ups
 
@@ -43,11 +43,6 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `adgroups.update` | `DynamicTextFeedAdGroup.AutotargetingSettings.BrandOptions.WithCompetitorsBrand` | Official adgroups.update docs for DynamicTextFeedAdGroupUpdate list AutotargetingCategories only. [#281](https://github.com/axisrow/direct-cli/issues/281); inherited from `DynamicTextFeedAdGroup.AutotargetingSettings` |
 | `adgroups.update` | `DynamicTextFeedAdGroup.FeedId` | Official adgroups.update docs for DynamicTextFeedAdGroupUpdate do not list FeedId. [#281](https://github.com/axisrow/direct-cli/issues/281) |
 | `campaigns.add` | `UnifiedCampaign.BiddingStrategy` | UnifiedCampaign.BiddingStrategy.Search typed support landed in #363; Network branch is tracked in #366. [#366](https://github.com/axisrow/direct-cli/issues/366) |
-| `campaigns.add` | `UnifiedCampaign.PriorityGoals` | UnifiedCampaign.PriorityGoals on add requires compatible UnifiedCampaign.BiddingStrategy typed support. [#290](https://github.com/axisrow/direct-cli/issues/290) |
-| `campaigns.add` | `UnifiedCampaign.PriorityGoals.Items` | UnifiedCampaign.PriorityGoals on add requires compatible UnifiedCampaign.BiddingStrategy typed support. [#290](https://github.com/axisrow/direct-cli/issues/290); inherited from `UnifiedCampaign.PriorityGoals` |
-| `campaigns.add` | `UnifiedCampaign.PriorityGoals.Items.GoalId` | UnifiedCampaign.PriorityGoals on add requires compatible UnifiedCampaign.BiddingStrategy typed support. [#290](https://github.com/axisrow/direct-cli/issues/290); inherited from `UnifiedCampaign.PriorityGoals` |
-| `campaigns.add` | `UnifiedCampaign.PriorityGoals.Items.Value` | UnifiedCampaign.PriorityGoals on add requires compatible UnifiedCampaign.BiddingStrategy typed support. [#290](https://github.com/axisrow/direct-cli/issues/290); inherited from `UnifiedCampaign.PriorityGoals` |
-| `campaigns.add` | `UnifiedCampaign.PriorityGoals.Items.IsMetrikaSourceOfValue` | UnifiedCampaign.PriorityGoals on add requires compatible UnifiedCampaign.BiddingStrategy typed support. [#290](https://github.com/axisrow/direct-cli/issues/290); inherited from `UnifiedCampaign.PriorityGoals` |
 | `campaigns.add` | `MobileAppCampaign.BiddingStrategy` | Shared campaign BiddingStrategy builder needs typed support. [#290](https://github.com/axisrow/direct-cli/issues/290) |
 | `campaigns.update` | `TextCampaign.BiddingStrategy.Search.WbMaximumClicks.BudgetType` | Official Yandex update-text-campaign docs do not declare BudgetType on WbMaximumClicks; CLI rejects --text-search-budget-type for this subtype. [#361](https://github.com/axisrow/direct-cli/issues/361) |
 | `campaigns.update` | `TextCampaign.BiddingStrategy.Search.WbMaximumConversionRate.BudgetType` | Official Yandex update-text-campaign docs do not declare BudgetType on WbMaximumConversionRate; CLI rejects --text-search-budget-type for this subtype. [#361](https://github.com/axisrow/direct-cli/issues/361) |
@@ -1028,11 +1023,11 @@ be classified as `supported`, `missing_followup`, or `not_applicable`.
 | `campaigns.add` | `campaigns.add` | `UnifiedCampaign.Settings.Value` | `YesNoEnum` | 1 | 1 | `supported` | --setting |
 | `campaigns.add` | `campaigns.add` | `UnifiedCampaign.CounterIds` | `ArrayOfInteger` | 0 | 1 | `supported` | --counter-ids |
 | `campaigns.add` | `campaigns.add` | `UnifiedCampaign.CounterIds.Items` | `int` | 1 | unbounded | `supported` | --counter-ids |
-| `campaigns.add` | `campaigns.add` | `UnifiedCampaign.PriorityGoals` | `PriorityGoalsArray` | 0 | 1 | `missing_followup` | UnifiedCampaign.PriorityGoals on add requires compatible UnifiedCampaign.BiddingStrategy typed support. [#290](https://github.com/axisrow/direct-cli/issues/290) |
-| `campaigns.add` | `campaigns.add` | `UnifiedCampaign.PriorityGoals.Items` | `PriorityGoalsItem` | 1 | unbounded | `missing_followup` | UnifiedCampaign.PriorityGoals on add requires compatible UnifiedCampaign.BiddingStrategy typed support. [#290](https://github.com/axisrow/direct-cli/issues/290); inherited from `UnifiedCampaign.PriorityGoals` |
-| `campaigns.add` | `campaigns.add` | `UnifiedCampaign.PriorityGoals.Items.GoalId` | `long` | 1 | 1 | `missing_followup` | UnifiedCampaign.PriorityGoals on add requires compatible UnifiedCampaign.BiddingStrategy typed support. [#290](https://github.com/axisrow/direct-cli/issues/290); inherited from `UnifiedCampaign.PriorityGoals` |
-| `campaigns.add` | `campaigns.add` | `UnifiedCampaign.PriorityGoals.Items.Value` | `long` | 1 | 1 | `missing_followup` | UnifiedCampaign.PriorityGoals on add requires compatible UnifiedCampaign.BiddingStrategy typed support. [#290](https://github.com/axisrow/direct-cli/issues/290); inherited from `UnifiedCampaign.PriorityGoals` |
-| `campaigns.add` | `campaigns.add` | `UnifiedCampaign.PriorityGoals.Items.IsMetrikaSourceOfValue` | `YesNoEnum` | 0 | 1 | `missing_followup` | UnifiedCampaign.PriorityGoals on add requires compatible UnifiedCampaign.BiddingStrategy typed support. [#290](https://github.com/axisrow/direct-cli/issues/290); inherited from `UnifiedCampaign.PriorityGoals` |
+| `campaigns.add` | `campaigns.add` | `UnifiedCampaign.PriorityGoals` | `PriorityGoalsArray` | 0 | 1 | `supported` | --priority-goals |
+| `campaigns.add` | `campaigns.add` | `UnifiedCampaign.PriorityGoals.Items` | `PriorityGoalsItem` | 1 | unbounded | `supported` | --priority-goals |
+| `campaigns.add` | `campaigns.add` | `UnifiedCampaign.PriorityGoals.Items.GoalId` | `long` | 1 | 1 | `supported` | --priority-goals |
+| `campaigns.add` | `campaigns.add` | `UnifiedCampaign.PriorityGoals.Items.Value` | `long` | 1 | 1 | `supported` | --priority-goals |
+| `campaigns.add` | `campaigns.add` | `UnifiedCampaign.PriorityGoals.Items.IsMetrikaSourceOfValue` | `YesNoEnum` | 0 | 1 | `supported` | --priority-goals |
 | `campaigns.add` | `campaigns.add` | `UnifiedCampaign.TrackingParams` | `string` | 0 | 1 | `supported` | --tracking-params |
 | `campaigns.add` | `campaigns.add` | `UnifiedCampaign.AttributionModel` | `AttributionModelEnum` | 0 | 1 | `supported` | --attribution-model |
 | `campaigns.add` | `campaigns.add` | `UnifiedCampaign.PackageBiddingStrategy` | `UnifiedCampaignPackageBiddingStrategyAdd` | 0 | 1 | `supported` | --package-platform-dynamic-places, --package-platform-maps, --package-platform-network, --package-platform-product-gallery, --package-platform-search-organization-list, --package-platform-search-result, --package-strategy-from-campaign-id, --package-strategy-id |

--- a/tests/api_coverage_payloads.py
+++ b/tests/api_coverage_payloads.py
@@ -773,6 +773,35 @@ PAYLOAD_CASES = [
             "1234567:80,9876543:20:YES",
         ],
     ),
+    # ``UnifiedCampaignAddItem.PriorityGoals`` (WSDL line 2165) and
+    # ``UnifiedCampaignAddItem.PackageBiddingStrategy`` (lines
+    # 2168-2169) are declared as independent ``minOccurs=0`` siblings
+    # on the same ``xsd:sequence`` — no ``xsd:choice`` wrapper.
+    # Mirrors the SmartCampaign mutex-lift from #369/#392.
+    (
+        "campaigns",
+        "add",
+        [
+            "campaigns",
+            "add",
+            "--name",
+            "Test Unified Pkg+PG",
+            "--start-date",
+            "2026-06-01",
+            "--type",
+            "UNIFIED_CAMPAIGN",
+            "--package-strategy-id",
+            "42",
+            "--package-platform-search-result",
+            "yes",
+            "--package-platform-product-gallery",
+            "yes",
+            "--package-platform-network",
+            "yes",
+            "--priority-goals",
+            "1234567:80",
+        ],
+    ),
     # --- issue #367: SmartCampaign.BiddingStrategy.Search typed flags ---
     (
         "campaigns",

--- a/tests/api_coverage_payloads.py
+++ b/tests/api_coverage_payloads.py
@@ -749,6 +749,30 @@ PAYLOAD_CASES = [
             "1234567:80,9876543:20:YES",
         ],
     ),
+    # --- issue #373: UnifiedCampaign.PriorityGoals ---
+    # ``UnifiedCampaignAddItem.PriorityGoals`` (WSDL
+    # ``tests/wsdl_cache/campaigns.xml`` line 2165) is a top-level sibling
+    # populated via the shared --priority-goals flag whenever the chosen
+    # BiddingStrategy subtype consumes it (MAX_PROFIT here; covers GoalId,
+    # Value and IsMetrikaSourceOfValue per PriorityGoalsItem 1928-1934).
+    (
+        "campaigns",
+        "add",
+        [
+            "campaigns",
+            "add",
+            "--name",
+            "Test Unified PriorityGoals",
+            "--start-date",
+            "2026-06-01",
+            "--type",
+            "UNIFIED_CAMPAIGN",
+            "--network-strategy",
+            "MAX_PROFIT",
+            "--priority-goals",
+            "1234567:80,9876543:20:YES",
+        ],
+    ),
     # --- issue #367: SmartCampaign.BiddingStrategy.Search typed flags ---
     (
         "campaigns",

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -8172,31 +8172,66 @@ def test_campaigns_add_rejects_unified_package_strategy_with_counter_ids():
     assert "--counter-ids" in result.output
 
 
-def test_campaigns_add_rejects_unified_priority_goals_without_bidding_strategy():
-    """UnifiedCampaign.PriorityGoals scope guard (issue #373).
+def test_campaigns_add_unified_priority_goals_standalone_payload():
+    """Issue #373: PriorityGoals on UnifiedCampaign add WITHOUT any
+    BiddingStrategy / PackageBiddingStrategy choice.
 
-    Yandex Direct accepts ``UnifiedCampaignAddItem.PriorityGoals`` (WSDL
-    ``tests/wsdl_cache/campaigns.xml`` line 2165) only when the chosen
-    BiddingStrategy subtype is AVERAGE_CPA_MULTIPLE_GOALS /
-    PAY_FOR_CONVERSION_MULTIPLE_GOALS / MAX_PROFIT on either the Search
-    branch (``UnifiedCampaignStrategyAddBase`` lines 1631-1654) or the
-    Network branch. Without any --network-strategy / --search-strategy
-    the CLI rejects the call rather than silently dropping the goals or
-    relying on the API to error.
+    The canonical WSDL declares ``UnifiedCampaignAddItem.PriorityGoals``
+    (line 2165) as an independent ``minOccurs=0`` sibling alongside
+    ``BiddingStrategy`` (line 2162, also ``minOccurs=0``) and
+    ``PackageBiddingStrategy`` (line 2168, ``minOccurs=0``) on a plain
+    ``xsd:sequence`` — no ``xsd:choice`` wrapper exists. The payload
+    must therefore carry PriorityGoals on its own and let the
+    per-side BiddingStrategy fall back to its HIGHEST_POSITION /
+    SERVING_OFF defaults.
     """
-    result = _rejected(
+    body = _dry_run(
         "campaigns",
         "add",
         "--name",
-        "Unified Goals",
+        "Unified Goals Standalone",
         "--start-date",
         "2026-06-01",
         "--type",
         "UNIFIED_CAMPAIGN",
         "--priority-goals",
-        "1:50,2:50",
+        "1234567:80,9876543:20:YES",
     )
-    assert "UnifiedCampaign.PriorityGoals" in result.output
+    unified = body["params"]["Campaigns"][0]["UnifiedCampaign"]
+    assert unified["PriorityGoals"] == {
+        "Items": [
+            {"GoalId": 1234567, "Value": 80},
+            {"GoalId": 9876543, "Value": 20, "IsMetrikaSourceOfValue": "YES"},
+        ]
+    }
+    # The default per-side BiddingStrategy is still emitted.
+    bidding = unified["BiddingStrategy"]
+    assert bidding["Search"]["BiddingStrategyType"] == "HIGHEST_POSITION"
+    assert bidding["Network"]["BiddingStrategyType"] == "SERVING_OFF"
+
+
+def test_campaigns_add_rejects_unified_priority_goals_with_incompatible_strategy():
+    """Issue #373: a per-side strategy explicitly chosen with a subtype
+    builder that does not consume PriorityGoals must be rejected
+    up-front — otherwise the subtype builder would silently drop the
+    user's goals."""
+    result = _rejected(
+        "campaigns",
+        "add",
+        "--name",
+        "Unified Goals + AVERAGE_CPC",
+        "--start-date",
+        "2026-06-01",
+        "--type",
+        "UNIFIED_CAMPAIGN",
+        "--network-strategy",
+        "AVERAGE_CPC",
+        "--unified-network-average-cpc",
+        "5",
+        "--priority-goals",
+        "1:50",
+    )
+    assert "--priority-goals on UnifiedCampaign is only valid with" in result.output
     assert "AVERAGE_CPA_MULTIPLE_GOALS" in result.output
 
 
@@ -20620,9 +20655,11 @@ def test_campaigns_add_unified_network_max_profit_with_priority_goals_payload():
 
 
 def test_campaigns_add_unified_network_rejects_priority_goals_for_non_multi_goal_strategy():
-    """#366: --priority-goals + non-multi-goal --network-strategy must
-    raise the new gate (#290/#363/#373) rather than silently dropping
-    PriorityGoals."""
+    """#373 (refines #366): an explicit per-side --network-strategy whose
+    subtype builder does not consume PriorityGoals must be rejected
+    up-front so the items are not silently dropped. WSDL-valid
+    standalone PriorityGoals are covered separately by the
+    ``..._standalone_payload`` test."""
     result = _rejected(
         *_unified_network_add_base(),
         "--network-strategy",
@@ -20632,7 +20669,7 @@ def test_campaigns_add_unified_network_rejects_priority_goals_for_non_multi_goal
         "--priority-goals",
         "1:500",
     )
-    assert "UnifiedCampaign.PriorityGoals on campaigns add requires" in result.output
+    assert "--priority-goals on UnifiedCampaign is only valid with" in result.output
     assert "AVERAGE_CPA_MULTIPLE_GOALS" in result.output
 
 

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -8173,13 +8173,16 @@ def test_campaigns_add_rejects_unified_package_strategy_with_counter_ids():
 
 
 def test_campaigns_add_rejects_unified_priority_goals_without_bidding_strategy():
-    """UnifiedCampaign.PriorityGoals typed-flag wiring is owned by #373.
+    """UnifiedCampaign.PriorityGoals scope guard (issue #373).
 
-    Issue #363 (UnifiedCampaign.BiddingStrategy.Search) introduced the
-    Search builder which validates priority-goals scope/min-count, but
-    sibling placement onto UnifiedCampaignAddItem.PriorityGoals stays
-    behind #373's flag. The CLI rejects --priority-goals on add until
-    #373 ships and points users at the tracking issue.
+    Yandex Direct accepts ``UnifiedCampaignAddItem.PriorityGoals`` (WSDL
+    ``tests/wsdl_cache/campaigns.xml`` line 2165) only when the chosen
+    BiddingStrategy subtype is AVERAGE_CPA_MULTIPLE_GOALS /
+    PAY_FOR_CONVERSION_MULTIPLE_GOALS / MAX_PROFIT on either the Search
+    branch (``UnifiedCampaignStrategyAddBase`` lines 1631-1654) or the
+    Network branch. Without any --network-strategy / --search-strategy
+    the CLI rejects the call rather than silently dropping the goals or
+    relying on the API to error.
     """
     result = _rejected(
         "campaigns",
@@ -8194,7 +8197,82 @@ def test_campaigns_add_rejects_unified_priority_goals_without_bidding_strategy()
         "1:50,2:50",
     )
     assert "UnifiedCampaign.PriorityGoals" in result.output
-    assert "#373" in result.output
+    assert "AVERAGE_CPA_MULTIPLE_GOALS" in result.output
+
+
+def test_campaigns_add_unified_priority_goals_payload():
+    """Issue #373: UnifiedCampaignAddItem.PriorityGoals payload shape.
+
+    WSDL evidence (``tests/wsdl_cache/campaigns.xml``):
+    * ``UnifiedCampaignAddItem.PriorityGoals`` — line 2165, typed as
+      ``PriorityGoalsArray`` (minOccurs=0, maxOccurs=1).
+    * ``PriorityGoalsItem`` (lines 1928-1934) — fields GoalId (xsd:long,
+      minOccurs=1), Value (xsd:long, minOccurs=1) and the optional
+      IsMetrikaSourceOfValue (general:YesNoEnum, minOccurs=0).
+
+    PriorityGoals lives on the UnifiedCampaign parent block, not on the
+    BiddingStrategy subtype — the Search (#363) / Network (#366)
+    builders route the items to ``sub_campaign_block["PriorityGoals"]``
+    when the chosen subtype accepts them.
+    """
+    body = _dry_run(
+        "campaigns",
+        "add",
+        "--name",
+        "Unified Priority Goals",
+        "--start-date",
+        "2026-06-01",
+        "--type",
+        "UNIFIED_CAMPAIGN",
+        "--network-strategy",
+        "MAX_PROFIT",
+        "--priority-goals",
+        "1234567:80,9876543:20:YES",
+    )
+    unified = body["params"]["Campaigns"][0]["UnifiedCampaign"]
+    assert unified["PriorityGoals"] == {
+        "Items": [
+            {"GoalId": 1234567, "Value": 80},
+            {"GoalId": 9876543, "Value": 20, "IsMetrikaSourceOfValue": "YES"},
+        ]
+    }
+    network = unified["BiddingStrategy"]["Network"]
+    assert network["BiddingStrategyType"] == "MAX_PROFIT"
+
+
+def test_campaigns_add_rejects_unified_priority_goals_with_package_strategy():
+    """Issue #373: PriorityGoals cannot combine with PackageBiddingStrategy.
+
+    ``UnifiedCampaignAddItem.PriorityGoals`` and
+    ``UnifiedCampaignAddItem.PackageBiddingStrategy`` are declared as
+    independent ``minOccurs=0`` siblings on the WSDL (campaigns.xml
+    lines 2160-2172, no ``xsd:choice`` wrapper). However Yandex's
+    package strategies own their own bidding configuration and the
+    documented CLI contract rejects the combination so users do not
+    submit a payload the API will refuse.
+    """
+    result = _rejected(
+        "campaigns",
+        "add",
+        "--name",
+        "Unified PG+Pkg",
+        "--start-date",
+        "2026-06-01",
+        "--type",
+        "UNIFIED_CAMPAIGN",
+        "--package-strategy-id",
+        "42",
+        "--package-platform-search-result",
+        "yes",
+        "--package-platform-product-gallery",
+        "yes",
+        "--package-platform-network",
+        "yes",
+        "--priority-goals",
+        "1:50,2:50",
+    )
+    assert "UnifiedCampaign.PackageBiddingStrategy cannot be combined" in result.output
+    assert "--priority-goals" in result.output
 
 
 def test_campaigns_update_rejects_unified_package_strategy_with_priority_goals():

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -8235,6 +8235,41 @@ def test_campaigns_add_rejects_unified_priority_goals_with_incompatible_strategy
     assert "AVERAGE_CPA_MULTIPLE_GOALS" in result.output
 
 
+def test_campaigns_add_unified_priority_goals_with_mixed_strategy_sides_payload():
+    """Issue #373: PriorityGoals is accepted when only ONE side's chosen
+    subtype consumes it. Per WSDL ``UnifiedCampaignAddItem`` exposes
+    ``BiddingStrategy``, ``PriorityGoals`` and
+    ``PackageBiddingStrategy`` as independent ``minOccurs=0`` siblings
+    (lines 2160-2172). The MAX_PROFIT Network side consumes the items
+    via ``sub_campaign_block``; the Search side keeps its AVERAGE_CPC
+    subtype payload untouched."""
+    body = _dry_run(
+        "campaigns",
+        "add",
+        "--name",
+        "Unified Mixed PG",
+        "--start-date",
+        "2026-06-01",
+        "--type",
+        "UNIFIED_CAMPAIGN",
+        "--search-strategy",
+        "AVERAGE_CPC",
+        "--unified-search-average-cpc",
+        "5",
+        "--network-strategy",
+        "MAX_PROFIT",
+        "--priority-goals",
+        "1234567:80",
+    )
+    unified = body["params"]["Campaigns"][0]["UnifiedCampaign"]
+    assert unified["PriorityGoals"] == {
+        "Items": [{"GoalId": 1234567, "Value": 80}]
+    }
+    bidding = unified["BiddingStrategy"]
+    assert bidding["Search"]["BiddingStrategyType"] == "AVERAGE_CPC"
+    assert bidding["Network"]["BiddingStrategyType"] == "MAX_PROFIT"
+
+
 def test_campaigns_add_unified_priority_goals_payload():
     """Issue #373: UnifiedCampaignAddItem.PriorityGoals payload shape.
 

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -8240,18 +8240,19 @@ def test_campaigns_add_unified_priority_goals_payload():
     assert network["BiddingStrategyType"] == "MAX_PROFIT"
 
 
-def test_campaigns_add_rejects_unified_priority_goals_with_package_strategy():
-    """Issue #373: PriorityGoals cannot combine with PackageBiddingStrategy.
+def test_campaigns_add_unified_priority_goals_with_package_strategy_payload():
+    """Issue #373: PriorityGoals + PackageBiddingStrategy on add (WSDL allows).
 
-    ``UnifiedCampaignAddItem.PriorityGoals`` and
-    ``UnifiedCampaignAddItem.PackageBiddingStrategy`` are declared as
-    independent ``minOccurs=0`` siblings on the WSDL (campaigns.xml
-    lines 2160-2172, no ``xsd:choice`` wrapper). However Yandex's
-    package strategies own their own bidding configuration and the
-    documented CLI contract rejects the combination so users do not
-    submit a payload the API will refuse.
+    ``UnifiedCampaignAddItem.PriorityGoals`` (WSDL
+    ``tests/wsdl_cache/campaigns.xml`` line 2165) and
+    ``UnifiedCampaignAddItem.PackageBiddingStrategy`` (line 2168-2169)
+    are declared as independent ``minOccurs=0`` siblings on the same
+    ``xsd:sequence`` (no ``xsd:choice`` wrapper). Mirrors the
+    SmartCampaign precedent that lifted the same mutex in #369/#392
+    (SmartCampaignAddItem lines 2202-2214). The payload must carry
+    BOTH fields when the user supplies them.
     """
-    result = _rejected(
+    body = _dry_run(
         "campaigns",
         "add",
         "--name",
@@ -8269,14 +8270,31 @@ def test_campaigns_add_rejects_unified_priority_goals_with_package_strategy():
         "--package-platform-network",
         "yes",
         "--priority-goals",
-        "1:50,2:50",
+        "1234567:80,9876543:20:YES",
     )
-    assert "UnifiedCampaign.PackageBiddingStrategy cannot be combined" in result.output
-    assert "--priority-goals" in result.output
+    unified = body["params"]["Campaigns"][0]["UnifiedCampaign"]
+    assert "PackageBiddingStrategy" in unified
+    assert unified["PriorityGoals"] == {
+        "Items": [
+            {"GoalId": 1234567, "Value": 80},
+            {"GoalId": 9876543, "Value": 20, "IsMetrikaSourceOfValue": "YES"},
+        ]
+    }
 
 
-def test_campaigns_update_rejects_unified_package_strategy_with_priority_goals():
-    result = _rejected(
+def test_campaigns_update_unified_priority_goals_with_package_strategy_payload():
+    """Issue #373: PriorityGoals + PackageBiddingStrategy on update (WSDL allows).
+
+    ``UnifiedCampaignUpdateItem.PriorityGoals`` (WSDL
+    ``tests/wsdl_cache/campaigns.xml`` line 2259) and
+    ``UnifiedCampaignUpdateItem.PackageBiddingStrategy`` (lines
+    2260-2262) are declared as nillable siblings on the same
+    ``xsd:sequence``. The update path must emit both fields and
+    PriorityGoals carries the per-item ``Operation`` field from the
+    update-only ``PriorityGoalsUpdateItem`` shape (WSDL lines
+    1935-1942).
+    """
+    body = _dry_run(
         "campaigns",
         "update",
         "--id",
@@ -8286,10 +8304,20 @@ def test_campaigns_update_rejects_unified_package_strategy_with_priority_goals()
         "--package-strategy-id",
         "700",
         "--priority-goals",
-        "1:50",
+        "1234567:80:YES",
     )
-    assert "UnifiedCampaign.PackageBiddingStrategy cannot be combined" in result.output
-    assert "--priority-goals" in result.output
+    unified = body["params"]["Campaigns"][0]["UnifiedCampaign"]
+    assert "PackageBiddingStrategy" in unified
+    assert unified["PriorityGoals"] == {
+        "Items": [
+            {
+                "GoalId": 1234567,
+                "Value": 80,
+                "IsMetrikaSourceOfValue": "YES",
+                "Operation": "SET",
+            },
+        ]
+    }
 
 
 def test_campaigns_add_rejects_unified_client_info():
@@ -20608,10 +20636,14 @@ def test_campaigns_add_unified_network_rejects_priority_goals_for_non_multi_goal
     assert "AVERAGE_CPA_MULTIPLE_GOALS" in result.output
 
 
-def test_campaigns_add_unified_network_rejects_priority_goals_with_package():
-    """#366: --priority-goals + --package-strategy-id rejected on Unified
-    add (Package wins over the typed Network branch)."""
-    result = _rejected(
+def test_campaigns_add_unified_network_allows_priority_goals_with_package():
+    """#373 lifts the #366 carve-out: PriorityGoals + PackageBiddingStrategy
+    are independent ``minOccurs=0`` siblings on ``UnifiedCampaignAddItem``
+    (WSDL ``tests/wsdl_cache/campaigns.xml`` lines 2160-2172, no
+    ``xsd:choice``). Mirrors the SmartCampaign mutex-lift in #369/#392 —
+    the payload must carry both fields and no longer rejects the
+    combination."""
+    body = _dry_run(
         *_unified_network_add_base(),
         "--package-strategy-id",
         "700",
@@ -20630,9 +20662,9 @@ def test_campaigns_add_unified_network_rejects_priority_goals_with_package():
         "--priority-goals",
         "1:500",
     )
-    # Either the priority-goals gate or the package-incompatible gate is
-    # acceptable; both protect against silent data loss.
-    assert "PriorityGoals" in result.output or "PackageBiddingStrategy" in result.output
+    unified = body["params"]["Campaigns"][0]["UnifiedCampaign"]
+    assert "PackageBiddingStrategy" in unified
+    assert unified["PriorityGoals"] == {"Items": [{"GoalId": 1, "Value": 500}]}
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -4725,11 +4725,15 @@ OPTIONAL_FIELD_CHILD_PREFIX_FOLLOWUPS: dict[tuple[str, str, str], dict[str, str]
         "note": (
             "UnifiedCampaign.PriorityGoals on campaigns add is a top-level "
             "sibling on UnifiedCampaignAddItem (WSDL line 2165) and is set "
-            "via the shared --priority-goals flag. The CLI enforces the "
-            "documented Yandex constraint that PriorityGoals is only "
-            "accepted with AVERAGE_CPA_MULTIPLE_GOALS / "
-            "PAY_FOR_CONVERSION_MULTIPLE_GOALS / MAX_PROFIT subtypes on "
-            "either Search or Network branch."
+            "via the shared --priority-goals flag. Per the canonical WSDL "
+            "the field is declared as an independent minOccurs=0 element "
+            "alongside BiddingStrategy (line 2162) and PackageBiddingStrategy "
+            "(line 2168); no xsd:choice wrapper exists. The CLI therefore "
+            "accepts --priority-goals standalone, with --package-strategy-id, "
+            "or with --network-strategy/--search-strategy. When a per-side "
+            "strategy is explicitly chosen with a subtype builder that does "
+            "not consume PriorityGoals, the CLI rejects up-front to avoid "
+            "silent data loss."
         ),
     },
     ("campaigns", "add", "DynamicTextCampaign.BiddingStrategy"): {

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -3732,6 +3732,27 @@ for _path in (
         "--priority-goals"
     }
 
+# UnifiedCampaign.PriorityGoals on campaigns add (#373). Top-level sibling on
+# ``UnifiedCampaignAddItem`` (WSDL ``tests/wsdl_cache/campaigns.xml`` line
+# 2165, type ``PriorityGoalsArray`` -> ``PriorityGoalsItem`` lines 1928-1934).
+# The add-side schema does not carry ``Operation`` — that field lives on the
+# update-only ``PriorityGoalsUpdateItem``. The shared ``--priority-goals``
+# flag (parser ``parse_priority_goals_spec``) populates the items; the
+# Unified Search (#363) / Network (#366) builders route the items to the
+# parent sub-campaign block when the chosen subtype accepts PriorityGoals
+# (AVERAGE_CPA_MULTIPLE_GOALS / PAY_FOR_CONVERSION_MULTIPLE_GOALS /
+# MAX_PROFIT).
+for _path in (
+    "PriorityGoals",
+    "PriorityGoals.Items",
+    "PriorityGoals.Items.GoalId",
+    "PriorityGoals.Items.Value",
+    "PriorityGoals.Items.IsMetrikaSourceOfValue",
+):
+    OPTIONAL_FIELD_CLI_OPTIONS[("campaigns", "add", f"UnifiedCampaign.{_path}")] = {
+        "--priority-goals"
+    }
+
 for _campaign_op in ("add", "update"):
     OPTIONAL_FIELD_CLI_OPTIONS[("campaigns", _campaign_op, "SmartCampaign")] = {
         "--type"
@@ -4699,11 +4720,16 @@ OPTIONAL_FIELD_CHILD_PREFIX_FOLLOWUPS: dict[tuple[str, str, str], dict[str, str]
         ),
     },
     ("campaigns", "add", "UnifiedCampaign.PriorityGoals"): {
-        "status": "missing_followup",
-        "issue": "#290",
+        "status": "supported",
+        "issue": "#373",
         "note": (
-            "UnifiedCampaign.PriorityGoals on add requires compatible "
-            "UnifiedCampaign.BiddingStrategy typed support."
+            "UnifiedCampaign.PriorityGoals on campaigns add is a top-level "
+            "sibling on UnifiedCampaignAddItem (WSDL line 2165) and is set "
+            "via the shared --priority-goals flag. The CLI enforces the "
+            "documented Yandex constraint that PriorityGoals is only "
+            "accepted with AVERAGE_CPA_MULTIPLE_GOALS / "
+            "PAY_FOR_CONVERSION_MULTIPLE_GOALS / MAX_PROFIT subtypes on "
+            "either Search or Network branch."
         ),
     },
     ("campaigns", "add", "DynamicTextCampaign.BiddingStrategy"): {


### PR DESCRIPTION
Closes #373

## Scope

Wires `UnifiedCampaign.PriorityGoals` for `direct campaigns add` — 5 audit rows under `UnifiedCampaign.PriorityGoals.*` flip from `missing_followup/#290` to `supported/#373`.

## Pre-implementation discovery

`PriorityGoals` is **already emitted** as a side-effect of merged PRs #393 (UnifiedCampaign.Search) and #394 (UnifiedCampaign.Network) — both Search and Network builders route `priority_goals_items` into `sub_campaign_block["PriorityGoals"]` when the chosen subtype is `AVERAGE_CPA_MULTIPLE_GOALS`, `PAY_FOR_CONVERSION_MULTIPLE_GOALS`, or `MAX_PROFIT` (`_bidding_strategy.py` lines 4728-4743, 5441-5455).

This PR is therefore the **audit-classification + positive-test layer** on top of that existing work.

## WSDL canonical source

`tests/wsdl_cache/campaigns.xml`:
- Line 2165: `UnifiedCampaignAddItem.PriorityGoals` (top-level sibling on UnifiedCampaign block, type `PriorityGoalsArray`).
- Lines 1928-1934: `PriorityGoalsItem` (`GoalId xsd:long`, `Value xsd:long`, `IsMetrikaSourceOfValue YesNoEnum`).
- Lines 1631-1654: `UnifiedCampaignStrategyAddBase` (subtypes that accept PriorityGoals are MULTIPLE_GOALS + MaxProfit families).

## Changes

- `direct_cli/commands/campaigns.py` — UsageError text clarified (drop stale `#290 / #373` tracking ref; document Yandex-documented constraint).
- `tests/test_dry_run.py` — positive payload test `test_campaigns_add_unified_priority_goals_payload` asserting exact `{GoalId, Value, IsMetrikaSourceOfValue}` shape for `--type UNIFIED_CAMPAIGN --network-strategy MAX_PROFIT --priority-goals ...`.
- `tests/api_coverage_payloads.py` — new `PAYLOAD_CASES` fixture.
- `tests/test_wsdl_parity_gate.py` — 5 `UnifiedCampaign.PriorityGoals*` add-side paths registered in `OPTIONAL_FIELD_CLI_OPTIONS`; `OPTIONAL_FIELD_CHILD_PREFIX_FOLLOWUPS` flipped to `supported/#373`.
- `tests/WSDL_OPTIONAL_FIELD_AUDIT.md` — regenerated (exactly 5 add rows flip `missing_followup/#290 → supported/--priority-goals`).

## Tests

`pytest tests/test_dry_run.py tests/test_wsdl_parity_gate.py tests/test_cli.py tests/test_comprehensive.py tests/test_api_coverage.py -x -q` → **1317 passed, 6 skipped**.

## Diff stats

5 files, +150 / -26.