### PR TITLE
test: integration suite cleanup — graceful skip, explicit creds, dedupe, dynamic counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,32 @@
 
 Closes #360.
 
+**Tests:**
+
+- `tests/test_integration.py` now gracefully skips the seven read-only
+  classes that rely on live-API probes (`TestReadOnlyAdGroups`,
+  `TestReadOnlyAds`, `TestReadOnlyKeywords`,
+  `TestReadOnlyDynamicFeedAdTargets`, `TestReadOnlyLeads`,
+  `TestReadOnlyBusinesses`, `TestReadOnlyAdVideos`) when the probe
+  raises — previously a temporary API outage crashed `setUpClass`
+  with an opaque traceback.
+- `invoke_get` in `tests/test_integration.py` now passes the resolved
+  test credentials as explicit `--token`/`--login` flags so the
+  integration suite cannot silently fall through to a developer's
+  active `direct auth` profile (priority 1 in the CLI credential
+  chain wins over the profile, matching CLAUDE.md guidance).
+- `tests/test_comprehensive.py` slimmed down: `TestCLIHelp` (full
+  duplicate of `tests/test_cli.py`) removed; the unique
+  `TestCommandsRegistered`, `TestUtils`, `TestOutputFormatters`,
+  `TestAuth`, and `TestErrorHandling` classes are kept.
+- `tests/test_smoke_matrix.py` no longer hard-codes
+  `total_cli_subcommands == 144` or `wsdl_operations == 112`. Counts
+  are derived from the live Click registry and parsed WSDLs.
+- `tests/test_sandbox_write_audit.py` no longer hard-codes
+  `total == 83`. The count derives from `commands_for_category`.
+
+Closes #396.
+
 ## 0.3.13
 
 **Breaking changes:**

--- a/tests/test_comprehensive.py
+++ b/tests/test_comprehensive.py
@@ -1,5 +1,11 @@
 """
-Comprehensive tests for Direct CLI
+Tests for Direct CLI utility surface — command-registry inventory,
+utils parsers, output formatters, and auth credential chain.
+
+Surfaces here are NOT duplicated by ``test_cli.py`` (which focuses on
+help-text and behavior contracts). The previous ``TestCLIHelp`` and
+``test_campaigns_help`` were redundant with ``test_cli.py`` and have
+been removed. See issue #396 for context.
 """
 
 import os
@@ -9,25 +15,6 @@ from click.testing import CliRunner
 
 from direct_cli.cli import cli
 from direct_cli import auth, utils, output
-
-
-class TestCLIHelp(unittest.TestCase):
-    """Test CLI help output"""
-
-    def setUp(self):
-        self.runner = CliRunner()
-
-    def test_cli_help(self):
-        result = self.runner.invoke(cli, ["--help"])
-        self.assertEqual(result.exit_code, 0)
-        self.assertIn("Command-line interface for Yandex Direct API", result.output)
-
-    def test_campaigns_help(self):
-        result = self.runner.invoke(cli, ["campaigns", "--help"])
-        self.assertEqual(result.exit_code, 0)
-        self.assertIn("Manage campaigns", result.output)
-        self.assertIn("get", result.output)
-        self.assertIn("add", result.output)
 
 
 class TestCommandsRegistered(unittest.TestCase):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -35,16 +35,77 @@ from direct_cli.cli import cli
 from direct_cli._smoke_probes import advideo_probe_id
 
 sys.path.insert(0, os.path.dirname(__file__))
-from conftest import skip_if_no_token  # noqa: E402
+from conftest import _REAL_LOGIN, _REAL_TOKEN, skip_if_no_token  # noqa: E402
 
 
 def make_runner():
     return CliRunner()
 
 
+def _invoke_env():
+    """Build the env dict that CliRunner injects into the test process.
+
+    Always pass the resolved test credentials explicitly so the
+    integration suite never depends on shell environment state at
+    process start. This matches the inverted credential-resolution
+    contract in CLAUDE.md (env vars win over active profile inside
+    the test harness).
+    """
+    env = {}
+    if _REAL_TOKEN:
+        env["YANDEX_DIRECT_TOKEN"] = _REAL_TOKEN
+    if _REAL_LOGIN:
+        env["YANDEX_DIRECT_LOGIN"] = _REAL_LOGIN
+    return env
+
+
+def _prepend_credential_flags(args):
+    """Prepend ``--token``/``--login`` to the CLI args.
+
+    The CLI credential chain (``direct_cli/auth.py:get_credentials``)
+    gives the active ``direct auth`` profile priority over the
+    ``YANDEX_DIRECT_TOKEN`` env var, so an env-only injection lets the
+    test silently hit a developer's production profile. Passing the
+    resolved test credentials as explicit ``--token``/``--login``
+    arguments uses priority 1 in the chain and guarantees the test
+    uses exactly the credentials ``conftest._resolve_test_credentials``
+    picked.
+    """
+    if not _REAL_TOKEN:
+        return list(args)
+    flags = ["--token", _REAL_TOKEN]
+    if _REAL_LOGIN:
+        flags += ["--login", _REAL_LOGIN]
+    # Insert credential flags after a leading ``--sandbox`` (which must
+    # stay attached to the top-level group) but before the subcommand
+    # so the global options bind to the right Click group.
+    args = list(args)
+    if args and args[0] == "--sandbox":
+        return [args[0]] + flags + args[1:]
+    return flags + args
+
+
 def invoke_get(*args):
     """Invoke a read-only CLI command and return the result."""
-    return make_runner().invoke(cli, list(args))
+    return make_runner().invoke(
+        cli, _prepend_credential_flags(args), env=_invoke_env()
+    )
+
+
+def _skip_class_on_probe_failure(probe, *, what: str):
+    """Call a probe function inside setUpClass and convert any API error
+    into ``unittest.SkipTest`` so a temporary API outage skips the class
+    instead of crashing with an opaque traceback. Returns the probe value
+    on success (which may itself be ``None`` when the probe simply did
+    not find a resource — the per-test ``skipTest`` calls handle that
+    case).
+    """
+    try:
+        return probe()
+    except Exception as exc:  # noqa: BLE001 — probe may raise any API exc
+        raise unittest.SkipTest(
+            f"setUpClass probe for {what} failed: {exc.__class__.__name__}: {exc}"
+        )
 
 
 def assert_success(result, cmd_label: str):
@@ -178,7 +239,9 @@ class TestReadOnlyCampaigns(unittest.TestCase):
 class TestReadOnlyAdGroups(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.campaign_id = get_first_campaign_id()
+        cls.campaign_id = _skip_class_on_probe_failure(
+            get_first_campaign_id, what="first campaign id"
+        )
 
     def test_get_adgroups(self):
         if not self.campaign_id:
@@ -201,7 +264,9 @@ class TestReadOnlyAdGroups(unittest.TestCase):
 class TestReadOnlyAds(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.campaign_id = get_first_campaign_id()
+        cls.campaign_id = _skip_class_on_probe_failure(
+            get_first_campaign_id, what="first campaign id"
+        )
 
     def test_get_ads(self):
         if not self.campaign_id:
@@ -252,7 +317,9 @@ class TestReadOnlyAds(unittest.TestCase):
 class TestReadOnlyKeywords(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.campaign_id = get_first_campaign_id()
+        cls.campaign_id = _skip_class_on_probe_failure(
+            get_first_campaign_id, what="first campaign id"
+        )
 
     def test_get_keywords(self):
         if not self.campaign_id:
@@ -453,7 +520,9 @@ class TestReadOnlyStrategies(unittest.TestCase):
 class TestReadOnlyDynamicFeedAdTargets(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.campaign_id = get_first_campaign_id()
+        cls.campaign_id = _skip_class_on_probe_failure(
+            get_first_campaign_id, what="first campaign id"
+        )
 
     def test_get_dynamic_feed_ad_targets(self):
         if not self.campaign_id:
@@ -476,7 +545,9 @@ class TestReadOnlyDynamicFeedAdTargets(unittest.TestCase):
 class TestReadOnlyLeads(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.turbo_page_id = get_first_leads_turbopage_id()
+        cls.turbo_page_id = _skip_class_on_probe_failure(
+            get_first_leads_turbopage_id, what="first leads turbo page id"
+        )
 
     def test_get_leads(self):
         if self.turbo_page_id is None:
@@ -507,7 +578,9 @@ class TestReadOnlyTurbopages(unittest.TestCase):
 class TestReadOnlyBusinesses(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.business_id = get_first_business_id()
+        cls.business_id = _skip_class_on_probe_failure(
+            get_first_business_id, what="first business id"
+        )
 
     def test_get_businesses(self):
         if self.business_id is None:
@@ -530,7 +603,9 @@ class TestReadOnlyBusinesses(unittest.TestCase):
 class TestReadOnlyAdVideos(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.advideo_id = get_first_advideo_probe_id()
+        cls.advideo_id = _skip_class_on_probe_failure(
+            get_first_advideo_probe_id, what="first advideo probe id"
+        )
 
     def test_get_advideos(self):
         if self.advideo_id is None:

--- a/tests/test_sandbox_write_audit.py
+++ b/tests/test_sandbox_write_audit.py
@@ -30,10 +30,14 @@ def test_sandbox_write_audit_outputs_markdown_and_json(tmp_path):
     audit = json.loads(json_output.read_text())
     rows = audit["rows"]
 
+    # Issue #396: counts derive from the smoke matrix, not a hard-coded
+    # number. Adding a write-sandbox command should not require updating
+    # a magic constant here — it shows up in commands_for_category
+    # automatically.
+    expected_total = len(commands_for_category(WRITE_SANDBOX))
     assert audit["summary"]["category"] == WRITE_SANDBOX
-    assert audit["summary"]["total"] == len(commands_for_category(WRITE_SANDBOX))
-    assert audit["summary"]["total"] == 83
-    assert len(rows) == 83
+    assert audit["summary"]["total"] == expected_total
+    assert len(rows) == expected_total
     assert {row["status"] for row in rows} <= ALLOWED_STATUSES
 
     not_covered = {row["command"] for row in rows if row["status"] == "NOT_COVERED"}

--- a/tests/test_smoke_matrix.py
+++ b/tests/test_smoke_matrix.py
@@ -57,16 +57,58 @@ def test_smoke_matrix_covers_every_cli_subcommand_once():
     assert set(seen) == actual
 
 
-def test_smoke_matrix_counts_match_current_cli_surface():
+def test_smoke_matrix_counts_are_self_consistent():
+    """Smoke summary counts must agree with what Click and WSDL report.
+
+    Previously these were hard-coded magic numbers (``== 144``,
+    ``== 112``); adding a single new command or WSDL operation broke
+    the test with an opaque message. Issue #396. Now we derive every
+    expected count from the live Click registry and parsed WSDLs and
+    assert the smoke summary matches.
+    """
+    from direct_cli.wsdl_coverage import CANONICAL_API_SERVICES
+
     summary = smoke_summary()
 
-    assert summary["total_cli_groups"] == 40
-    assert summary["total_cli_subcommands"] == 144
-    assert summary["api_cli_subcommands"] == 140
-    assert summary["wsdl_services"] == 29
+    # Top-level Click groups (including ``auth`` and other non-API groups
+    # without ``.commands``). Matches ``len(cli.commands)`` in
+    # smoke_matrix.smoke_summary.
+    expected_cli_groups = len(cli.commands)
+
+    # Subcommands registered everywhere — counts ``group.subcommand`` for
+    # groups with ``.commands`` plus bare top-level commands. Matches
+    # ``_registered_cli_commands()`` in smoke_matrix.
+    expected_cli_subcommands = 0
+    for group in cli.commands.values():
+        if hasattr(group, "commands"):
+            expected_cli_subcommands += len(group.commands)
+        else:
+            expected_cli_subcommands += 1
+
+    # Subcommands that map to an API service (excludes ``auth.*``).
+    expected_api_cli_subcommands = 0
+    for group_name, group in cli.commands.items():
+        if group_name == "auth":
+            continue
+        if hasattr(group, "commands"):
+            expected_api_cli_subcommands += len(group.commands)
+        else:
+            expected_api_cli_subcommands += 1
+
+    expected_wsdl_operations = sum(
+        len(parse_wsdl_operations(fetch_wsdl(service)))
+        for service in CANONICAL_API_SERVICES
+    )
+
+    assert summary["total_cli_groups"] == expected_cli_groups
+    assert summary["total_cli_subcommands"] == expected_cli_subcommands
+    assert summary["api_cli_subcommands"] == expected_api_cli_subcommands
+    assert summary["wsdl_services"] == len(CANONICAL_API_SERVICES)
     assert summary["non_wsdl_services"] == sorted(NON_WSDL_SERVICES)
-    assert summary["api_services_total"] == 30
-    assert summary["wsdl_operations"] == 112
+    assert summary["api_services_total"] == (
+        len(CANONICAL_API_SERVICES) + len(NON_WSDL_SERVICES)
+    )
+    assert summary["wsdl_operations"] == expected_wsdl_operations
 
 
 def test_wsdl_backed_cli_commands_are_classified():


### PR DESCRIPTION
## Summary

Closes #396 — five fixes from the test-suite audit (2 High, 3 Medium):

### High #1: setUpClass crashes on temporary API outage

The seven `TestReadOnly*` classes that probe the live API in
`setUpClass` (`TestReadOnlyAdGroups`, `TestReadOnlyAds`,
`TestReadOnlyKeywords`, `TestReadOnlyDynamicFeedAdTargets`,
`TestReadOnlyLeads`, `TestReadOnlyBusinesses`, `TestReadOnlyAdVideos`)
previously had no try/except — a transient API error gave an opaque
traceback instead of a clean skip. New helper
`_skip_class_on_probe_failure` catches any probe exception and raises
`unittest.SkipTest` (which `setUpClass` honours by skipping the whole
class).

### High #2: invoke_get silently used the active direct-auth profile

`direct_cli/auth.py:get_credentials` gives the active `direct auth`
profile priority over `YANDEX_DIRECT_TOKEN` env var. The integration
suite previously passed no credentials to `CliRunner.invoke`, so on
any developer machine with an active profile the tests silently hit
production with profile creds. `invoke_get` now prepends
`--token`/`--login` (resolved via `conftest._resolve_test_credentials`)
to every CLI call — `--token` is priority 1 in the credential chain
and beats the profile, matching CLAUDE.md's inverted contract.

### Medium #3: test_comprehensive.py partially duplicated test_cli.py

`TestCLIHelp` (and `test_campaigns_help`) were full duplicates of
classes in `test_cli.py` — removed. The remaining classes
(`TestCommandsRegistered`, `TestUtils`, `TestOutputFormatters`,
`TestAuth`, `TestErrorHandling`) cover surfaces NOT touched by
`test_cli.py` — kept.

### Medium #5: hard-coded `== 144` and `== 112` in test_smoke_matrix.py

Adding any CLI command or WSDL operation broke the test with an
opaque message. Replaced with self-consistency checks that derive the
expected counts from the live Click registry and parsed WSDLs.

### Medium #6: hard-coded `== 83` in test_sandbox_write_audit.py

Same pattern: replaced with `len(commands_for_category(WRITE_SANDBOX))`.

## Test plan

- [x] `pytest --ignore=tests/test_integration.py --ignore=tests/test_v5_live_write.py --ignore=tests/test_v4_live_contracts.py` — 1788 passed, 21 skipped, 0 failed.
- [x] `pytest tests/test_integration.py -m integration` — 32 passed against live API (read-only).
- [x] `pytest tests/test_comprehensive.py tests/test_smoke_matrix.py tests/test_sandbox_write_audit.py` — 44 passed.
- [x] `flake8 tests/test_integration.py tests/test_comprehensive.py tests/test_smoke_matrix.py tests/test_sandbox_write_audit.py` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)