### PR TITLE
feat(feeds): expose FileFeedFieldNames and UrlFeedFieldNames on feeds get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@
   one has a matching kebab-case CLI option. Acknowledged remaining
   gaps are tracked in `NESTED_FIELDNAMES_EXCLUSIONS` and #402 so
   future additions cannot silently slip in.
+- `direct feeds get` now exposes `--file-feed-field-names` and
+  `--url-feed-field-names` for the separate WSDL `FileFeedFieldNames`
+  (`FileFeedFieldEnum`: `Filename`) and `UrlFeedFieldNames`
+  (`UrlFeedFieldEnum`: `Login`, `Url`, `RemoveUtmTags`) request
+  parameters declared by `FeedsGetRequest`. Previously only the
+  top-level `--fields` (mapping to `FieldNames`) was available, so
+  the nested `FileFeed` / `UrlFeed` projections could not be
+  controlled from CLI. Closes #412.
 
 Closes #360.
 

--- a/direct_cli/commands/feeds.py
+++ b/direct_cli/commands/feeds.py
@@ -10,7 +10,7 @@ import click
 
 from ..api import create_client
 from ..output import format_output, print_error
-from ..utils import get_default_fields, parse_ids
+from ..utils import get_default_fields, parse_csv_strings, parse_ids
 
 _YES_NO = ["YES", "NO"]
 # Yandex Direct docs cap FileFeed.Data by total request size. This
@@ -116,9 +116,36 @@ def feeds():
 @click.option("--format", "output_format", default="json", help="Output format")
 @click.option("--output", help="Output file")
 @click.option("--fields", help="Comma-separated field names")
+@click.option(
+    "--file-feed-field-names",
+    help=(
+        "Comma-separated FileFeedFieldNames (e.g. Filename). "
+        "Sent as separate top-level request parameter per the "
+        "FeedsGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--url-feed-field-names",
+    help=(
+        "Comma-separated UrlFeedFieldNames (e.g. Login,Url,RemoveUtmTags). "
+        "Sent as separate top-level request parameter per the "
+        "FeedsGetRequest WSDL."
+    ),
+)
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
+def get(
+    ctx,
+    ids,
+    limit,
+    fetch_all,
+    output_format,
+    output,
+    fields,
+    file_feed_field_names,
+    url_feed_field_names,
+    dry_run,
+):
     """Get feeds"""
     try:
         client = create_client(
@@ -129,6 +156,18 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
 
         field_names = fields.split(",") if fields else get_default_fields("feeds")
 
+        parsed_file_feed_field_names = parse_csv_strings(file_feed_field_names)
+        if file_feed_field_names is not None and not parsed_file_feed_field_names:
+            raise click.UsageError(
+                "Provide a non-empty comma-separated FileFeedFieldNames list."
+            )
+
+        parsed_url_feed_field_names = parse_csv_strings(url_feed_field_names)
+        if url_feed_field_names is not None and not parsed_url_feed_field_names:
+            raise click.UsageError(
+                "Provide a non-empty comma-separated UrlFeedFieldNames list."
+            )
+
         criteria = {}
         if ids:
             criteria["Ids"] = parse_ids(ids)
@@ -136,6 +175,10 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
         params = {"FieldNames": field_names}
         if criteria:
             params["SelectionCriteria"] = criteria
+        if parsed_file_feed_field_names:
+            params["FileFeedFieldNames"] = parsed_file_feed_field_names
+        if parsed_url_feed_field_names:
+            params["UrlFeedFieldNames"] = parsed_url_feed_field_names
 
         if limit:
             params["Page"] = {"Limit": limit}
@@ -157,6 +200,8 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
             data = result().extract()
             format_output(data, output_format, output)
 
+    except click.UsageError:
+        raise
     except Exception as e:
         print_error(str(e))
         raise click.Abort()

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -2534,8 +2534,6 @@ NESTED_FIELDNAMES_EXCLUSIONS: dict[tuple[str, str, str], str] = {
     ("creatives", "get", "CpmVideoCreativeFieldNames"): "#402",
     ("creatives", "get", "SmartCreativeFieldNames"): "#402",
     ("creatives", "get", "VideoExtensionCreativeFieldNames"): "#402",
-    ("feeds", "get", "FileFeedFieldNames"): "#402",
-    ("feeds", "get", "UrlFeedFieldNames"): "#402",
     ("keywords", "get", "AutotargetingSettingsBrandOptionsFieldNames"): "#402",
     ("keywords", "get", "AutotargetingSettingsCategoriesFieldNames"): "#402",
     ("strategies", "get", "StrategyAverageCpaFieldNames"): "#402",

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -22009,3 +22009,70 @@ def test_keywordbids_get_rejects_empty_fields():
 
     assert result.exit_code != 0
     assert "Provide a non-empty comma-separated FieldNames list." in result.output
+
+
+# ----------------------------------------------------------------------
+# feeds.get: separate File/UrlFeedFieldNames parameters (issue #412)
+# ----------------------------------------------------------------------
+
+
+def test_feeds_get_nested_field_names_payload():
+    # FeedsGetRequest (WSDL tests/wsdl_cache/feeds.xml) declares two
+    # nested top-level *FieldNames parameters separate from FieldNames:
+    # FileFeedFieldNames (FileFeedFieldEnum: Filename) and
+    # UrlFeedFieldNames (UrlFeedFieldEnum: Login, Url, RemoveUtmTags).
+    body = _read_dry_run(
+        "feeds",
+        "get",
+        "--file-feed-field-names",
+        "Filename",
+        "--url-feed-field-names",
+        "Login,Url,RemoveUtmTags",
+    )
+
+    params = body["params"]
+    assert params["FileFeedFieldNames"] == ["Filename"]
+    assert params["UrlFeedFieldNames"] == ["Login", "Url", "RemoveUtmTags"]
+
+
+def test_feeds_get_omits_nested_field_names_by_default():
+    body = _read_dry_run("feeds", "get")
+
+    assert "FileFeedFieldNames" not in body["params"]
+    assert "UrlFeedFieldNames" not in body["params"]
+
+
+def test_feeds_get_help_exposes_nested_field_names():
+    result = CliRunner().invoke(cli, ["feeds", "get", "--help"])
+
+    assert result.exit_code == 0
+    assert "--file-feed-field-names" in result.output
+    assert "--url-feed-field-names" in result.output
+
+
+def test_feeds_get_rejects_empty_file_feed_field_names_csv():
+    result = CliRunner().invoke(
+        cli,
+        ["feeds", "get", "--file-feed-field-names", ",", "--dry-run"],
+        env={"YANDEX_DIRECT_TOKEN": "test-token", "YANDEX_DIRECT_LOGIN": ""},
+    )
+
+    assert result.exit_code != 0
+    assert (
+        "Provide a non-empty comma-separated FileFeedFieldNames list."
+        in result.output
+    )
+
+
+def test_feeds_get_rejects_empty_url_feed_field_names_csv():
+    result = CliRunner().invoke(
+        cli,
+        ["feeds", "get", "--url-feed-field-names", ",", "--dry-run"],
+        env={"YANDEX_DIRECT_TOKEN": "test-token", "YANDEX_DIRECT_LOGIN": ""},
+    )
+
+    assert result.exit_code != 0
+    assert (
+        "Provide a non-empty comma-separated UrlFeedFieldNames list."
+        in result.output
+    )


### PR DESCRIPTION
## Summary

- Add `--file-feed-field-names` and `--url-feed-field-names` to `direct feeds get` for the separate WSDL `FileFeedFieldNames` (`FileFeedFieldEnum`: `Filename`) and `UrlFeedFieldNames` (`UrlFeedFieldEnum`: `Login`, `Url`, `RemoveUtmTags`) request parameters declared by `FeedsGetRequest`.
- Pattern mirrors Wave 1 sitelinks (PR #403): parse CSV via `parse_csv_strings`, reject empty input with `click.UsageError`, only inject the WSDL key when non-empty (Yandex falls back to server-side defaults otherwise).
- Remove the two corresponding rows from `NESTED_FIELDNAMES_EXCLUSIONS` (`tests/test_api_coverage.py`) so `test_every_nested_fieldnames_param_has_cli_option` now enforces both flags unconditionally.

Closes #412. First PR in Wave 2 milestone 0.3.14 (proof-of-pattern for the remaining 9 sub-issues #405–#411, #413, #414).

## Test plan

- [x] `pytest tests/test_api_coverage.py::test_every_nested_fieldnames_param_has_cli_option` — passes (regression unblocks both rows).
- [x] `pytest tests/test_dry_run.py -k feeds_get` — 5 new tests pass: payload, default-omission, `--help` visibility, two empty-CSV rejections.
- [x] `pytest tests/test_api_coverage.py tests/test_cli.py tests/test_comprehensive.py` — 247 tests pass.
- [x] `direct feeds get --help | grep field-names` — both new flags visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)