### PR TITLE
feat(keywords): expose AutotargetingSettings*FieldNames on keywords get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,18 @@
   one has a matching kebab-case CLI option. Acknowledged remaining
   gaps are tracked in `NESTED_FIELDNAMES_EXCLUSIONS` and #402 so
   future additions cannot silently slip in.
+- `direct keywords get` now exposes
+  `--autotargeting-settings-brand-options-field-names`
+  (`AutotargetingBrandOptionsFieldEnum`: `WithoutBrands`,
+  `WithAdvertiserBrand`, `WithCompetitorsBrand`) and
+  `--autotargeting-settings-categories-field-names`
+  (`AutotargetingCategoriesFieldEnum`: `Exact`, `Narrow`,
+  `Alternative`, `Accessory`, `Broader`) for the separate WSDL
+  `*FieldNames` request parameters declared by
+  `KeywordsGetRequest`. Previously only the top-level `--fields`
+  (mapping to `FieldNames`) was available, so the nested
+  `AutotargetingSettings.BrandOptions` / `Categories` projections
+  could not be controlled from CLI. Closes #413.
 
 Closes #360.
 

--- a/direct_cli/commands/keywords.py
+++ b/direct_cli/commands/keywords.py
@@ -15,7 +15,13 @@ from ..output import (
     print_error,
     raise_for_api_result_errors,
 )
-from ..utils import add_criteria_csv, parse_ids, get_default_fields, MICRO_RUBLES
+from ..utils import (
+    MICRO_RUBLES,
+    add_criteria_csv,
+    get_default_fields,
+    parse_csv_strings,
+    parse_ids,
+)
 
 # Yandex Direct API "keywords.add" caps a single AddItems request at 10
 # items; the WSDL declares maxOccurs="unbounded", so this limit comes from
@@ -368,6 +374,24 @@ def keywords():
 @click.option("--format", "output_format", default="json", help="Output format")
 @click.option("--output", help="Output file")
 @click.option("--fields", help="Comma-separated field names")
+@click.option(
+    "--autotargeting-settings-brand-options-field-names",
+    help=(
+        "Comma-separated AutotargetingSettingsBrandOptionsFieldNames "
+        "(e.g. WithoutBrands,WithAdvertiserBrand,WithCompetitorsBrand). "
+        "Sent as separate top-level request parameter per the "
+        "KeywordsGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--autotargeting-settings-categories-field-names",
+    help=(
+        "Comma-separated AutotargetingSettingsCategoriesFieldNames "
+        "(e.g. Exact,Narrow,Alternative,Accessory,Broader). "
+        "Sent as separate top-level request parameter per the "
+        "KeywordsGetRequest WSDL."
+    ),
+)
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
 def get(
@@ -385,6 +409,8 @@ def get(
     output_format,
     output,
     fields,
+    autotargeting_settings_brand_options_field_names,
+    autotargeting_settings_categories_field_names,
     dry_run,
 ):
     """Get keywords"""
@@ -399,6 +425,30 @@ def get(
         )
 
         field_names = fields.split(",") if fields else get_default_fields("keywords")
+
+        parsed_brand_options = parse_csv_strings(
+            autotargeting_settings_brand_options_field_names
+        )
+        if (
+            autotargeting_settings_brand_options_field_names is not None
+            and not parsed_brand_options
+        ):
+            raise click.UsageError(
+                "Provide a non-empty comma-separated "
+                "AutotargetingSettingsBrandOptionsFieldNames list."
+            )
+
+        parsed_categories = parse_csv_strings(
+            autotargeting_settings_categories_field_names
+        )
+        if (
+            autotargeting_settings_categories_field_names is not None
+            and not parsed_categories
+        ):
+            raise click.UsageError(
+                "Provide a non-empty comma-separated "
+                "AutotargetingSettingsCategoriesFieldNames list."
+            )
 
         criteria = {}
         if ids:
@@ -416,6 +466,12 @@ def get(
         add_criteria_csv(criteria, "ServingStatuses", serving_statuses, upper=True)
 
         params = {"SelectionCriteria": criteria, "FieldNames": field_names}
+        if parsed_brand_options:
+            params["AutotargetingSettingsBrandOptionsFieldNames"] = (
+                parsed_brand_options
+            )
+        if parsed_categories:
+            params["AutotargetingSettingsCategoriesFieldNames"] = parsed_categories
 
         if limit:
             params["Page"] = {"Limit": limit}
@@ -437,6 +493,8 @@ def get(
             data = result().extract()
             format_output(data, output_format, output)
 
+    except click.UsageError:
+        raise
     except Exception as e:
         print_error(str(e))
         raise click.Abort()

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -2536,8 +2536,6 @@ NESTED_FIELDNAMES_EXCLUSIONS: dict[tuple[str, str, str], str] = {
     ("creatives", "get", "VideoExtensionCreativeFieldNames"): "#402",
     ("feeds", "get", "FileFeedFieldNames"): "#402",
     ("feeds", "get", "UrlFeedFieldNames"): "#402",
-    ("keywords", "get", "AutotargetingSettingsBrandOptionsFieldNames"): "#402",
-    ("keywords", "get", "AutotargetingSettingsCategoriesFieldNames"): "#402",
     ("strategies", "get", "StrategyAverageCpaFieldNames"): "#402",
     ("strategies", "get", "StrategyAverageCpaMultipleGoalsFieldNames"): "#402",
     ("strategies", "get", "StrategyAverageCpaPerCampaignFieldNames"): "#402",

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -22009,3 +22009,96 @@ def test_keywordbids_get_rejects_empty_fields():
 
     assert result.exit_code != 0
     assert "Provide a non-empty comma-separated FieldNames list." in result.output
+
+
+# ----------------------------------------------------------------------
+# keywords.get: separate AutotargetingSettings*FieldNames (issue #413)
+# ----------------------------------------------------------------------
+
+
+def test_keywords_get_nested_field_names_payload():
+    # KeywordsGetRequest (WSDL tests/wsdl_cache/keywords.xml) declares two
+    # nested top-level *FieldNames parameters separate from FieldNames:
+    # AutotargetingSettingsBrandOptionsFieldNames
+    # (AutotargetingBrandOptionsFieldEnum: WithoutBrands,
+    # WithAdvertiserBrand, WithCompetitorsBrand) and
+    # AutotargetingSettingsCategoriesFieldNames
+    # (AutotargetingCategoriesFieldEnum: Exact, Narrow, Alternative,
+    # Accessory, Broader).
+    body = _read_dry_run(
+        "keywords",
+        "get",
+        "--autotargeting-settings-brand-options-field-names",
+        "WithoutBrands,WithAdvertiserBrand,WithCompetitorsBrand",
+        "--autotargeting-settings-categories-field-names",
+        "Exact,Narrow,Alternative",
+    )
+
+    params = body["params"]
+    assert params["AutotargetingSettingsBrandOptionsFieldNames"] == [
+        "WithoutBrands",
+        "WithAdvertiserBrand",
+        "WithCompetitorsBrand",
+    ]
+    assert params["AutotargetingSettingsCategoriesFieldNames"] == [
+        "Exact",
+        "Narrow",
+        "Alternative",
+    ]
+
+
+def test_keywords_get_omits_nested_field_names_by_default():
+    body = _read_dry_run("keywords", "get")
+
+    assert "AutotargetingSettingsBrandOptionsFieldNames" not in body["params"]
+    assert "AutotargetingSettingsCategoriesFieldNames" not in body["params"]
+
+
+def test_keywords_get_help_exposes_nested_field_names():
+    result = CliRunner().invoke(cli, ["keywords", "get", "--help"])
+
+    assert result.exit_code == 0
+    assert "--autotargeting-settings-brand-options-field-names" in result.output
+    assert "--autotargeting-settings-categories-field-names" in result.output
+
+
+def test_keywords_get_rejects_empty_brand_options_field_names_csv():
+    result = CliRunner().invoke(
+        cli,
+        [
+            "keywords",
+            "get",
+            "--autotargeting-settings-brand-options-field-names",
+            ",",
+            "--dry-run",
+        ],
+        env={"YANDEX_DIRECT_TOKEN": "test-token", "YANDEX_DIRECT_LOGIN": ""},
+    )
+
+    assert result.exit_code != 0
+    assert (
+        "Provide a non-empty comma-separated "
+        "AutotargetingSettingsBrandOptionsFieldNames list."
+        in result.output
+    )
+
+
+def test_keywords_get_rejects_empty_categories_field_names_csv():
+    result = CliRunner().invoke(
+        cli,
+        [
+            "keywords",
+            "get",
+            "--autotargeting-settings-categories-field-names",
+            ",",
+            "--dry-run",
+        ],
+        env={"YANDEX_DIRECT_TOKEN": "test-token", "YANDEX_DIRECT_LOGIN": ""},
+    )
+
+    assert result.exit_code != 0
+    assert (
+        "Provide a non-empty comma-separated "
+        "AutotargetingSettingsCategoriesFieldNames list."
+        in result.output
+    )


### PR DESCRIPTION
## Summary

- Add `--autotargeting-settings-brand-options-field-names` (`AutotargetingBrandOptionsFieldEnum`: `WithoutBrands`, `WithAdvertiserBrand`, `WithCompetitorsBrand`) and `--autotargeting-settings-categories-field-names` (`AutotargetingCategoriesFieldEnum`: `Exact`, `Narrow`, `Alternative`, `Accessory`, `Broader`) to `direct keywords get`.
- Mirrors Wave 1 sitelinks pattern (PR #403) and the #412 feeds PR (#415): parse CSV via `parse_csv_strings`, reject empty input with `click.UsageError`, only inject the WSDL key when non-empty (Yandex falls back to server-side defaults otherwise).
- Remove the two corresponding rows from `NESTED_FIELDNAMES_EXCLUSIONS`.

The same two enum types resurface on `direct adgroups get` per #405 — sample values and help wording stay consistent for follow-up parity.

Closes #413. Second PR in Wave 2 milestone 0.3.14.

## Test plan

- [x] `pytest tests/test_api_coverage.py::test_every_nested_fieldnames_param_has_cli_option` — passes after row removal.
- [x] `pytest tests/test_dry_run.py -k keywords_get` — 5 new tests pass.
- [x] `pytest tests/test_api_coverage.py tests/test_cli.py tests/test_comprehensive.py` — 68 tests pass.
- [x] `direct keywords get --help | grep autotargeting` — both flags visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)