### PR TITLE
feat(clients): expose five nested *FieldNames on clients get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,17 @@
   one has a matching kebab-case CLI option. Acknowledged remaining
   gaps are tracked in `NESTED_FIELDNAMES_EXCLUSIONS` and #402 so
   future additions cannot silently slip in.
+- `direct clients get` now exposes `--contract-field-names`,
+  `--contragent-field-names`, `--contragent-tin-info-field-names`,
+  `--organization-field-names`, and `--tin-info-field-names` for
+  the five nested WSDL `*FieldNames` request parameters declared
+  by `ClientsGetRequest` (`ContractInfoFieldEnum`,
+  `ContragentInfoFieldEnum`, `TinInfoFieldEnum`,
+  `OrgInfoFieldEnum`, `TinInfoFieldEnum`). The command also gains
+  `--dry-run` for parity with other read-path commands.
+  Previously only the top-level `--fields` (mapping to `FieldNames`)
+  was available, so the per-subtype ERIR projections could not be
+  controlled from CLI. Closes #410.
 
 Closes #360.
 

--- a/direct_cli/commands/clients.py
+++ b/direct_cli/commands/clients.py
@@ -18,6 +18,7 @@ from ..utils import (
     CONTRACT_TYPES,
     get_default_fields,
     parse_client_setting_specs,
+    parse_csv_strings,
     parse_email_subscription_specs,
     parse_ids,
     parse_positive_decimal_amount,
@@ -37,8 +38,66 @@ def clients():
 @click.option("--format", "output_format", default="json", help="Output format")
 @click.option("--output", help="Output file")
 @click.option("--fields", help="Comma-separated field names")
+@click.option(
+    "--contract-field-names",
+    help=(
+        "Comma-separated ContractFieldNames "
+        "(e.g. Number,Date,Price,Type,ActionType). "
+        "Sent as separate top-level request parameter per the "
+        "ClientsGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--contragent-field-names",
+    help=(
+        "Comma-separated ContragentFieldNames "
+        "(e.g. Name,Phone,EpayNumber,RegNumber). "
+        "Sent as separate top-level request parameter per the "
+        "ClientsGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--contragent-tin-info-field-names",
+    help=(
+        "Comma-separated ContragentTinInfoFieldNames (e.g. TinType,Tin). "
+        "Sent as separate top-level request parameter per the "
+        "ClientsGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--organization-field-names",
+    help=(
+        "Comma-separated OrganizationFieldNames "
+        "(e.g. Name,EpayNumber,RegNumber,OkvedCode). "
+        "Sent as separate top-level request parameter per the "
+        "ClientsGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--tin-info-field-names",
+    help=(
+        "Comma-separated TinInfoFieldNames (e.g. TinType,Tin). "
+        "Sent as separate top-level request parameter per the "
+        "ClientsGetRequest WSDL."
+    ),
+)
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def get(ctx, ids, limit, fetch_all, output_format, output, fields):
+def get(
+    ctx,
+    ids,
+    limit,
+    fetch_all,
+    output_format,
+    output,
+    fields,
+    contract_field_names,
+    contragent_field_names,
+    contragent_tin_info_field_names,
+    organization_field_names,
+    tin_info_field_names,
+    dry_run,
+):
     """Get clients"""
     try:
         client = create_client(
@@ -49,6 +108,23 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields):
 
         field_names = fields.split(",") if fields else get_default_fields("clients")
 
+        raw_nested = (
+            ("ContractFieldNames", contract_field_names),
+            ("ContragentFieldNames", contragent_field_names),
+            ("ContragentTinInfoFieldNames", contragent_tin_info_field_names),
+            ("OrganizationFieldNames", organization_field_names),
+            ("TinInfoFieldNames", tin_info_field_names),
+        )
+        parsed_nested = {}
+        for wsdl_key, raw_value in raw_nested:
+            parsed = parse_csv_strings(raw_value)
+            if raw_value is not None and not parsed:
+                raise click.UsageError(
+                    f"Provide a non-empty comma-separated {wsdl_key} list."
+                )
+            if parsed:
+                parsed_nested[wsdl_key] = parsed
+
         criteria = {}
         if ids:
             criteria["ClientIds"] = parse_ids(ids)
@@ -58,10 +134,16 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields):
         if criteria:
             params["SelectionCriteria"] = criteria
 
+        params.update(parsed_nested)
+
         if limit:
             params["Page"] = {"Limit": limit}
 
         body = {"method": "get", "params": params}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
 
         result = client.clients().post(data=body)
 
@@ -74,6 +156,8 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields):
             data = result().extract()
             format_output(data, output_format, output)
 
+    except click.UsageError:
+        raise
     except Exception as e:
         print_error(str(e))
         raise click.Abort()

--- a/tests/api_coverage_payloads.py
+++ b/tests/api_coverage_payloads.py
@@ -10,6 +10,7 @@ DRY_RUN_PAYLOAD_EXCLUSIONS = {
     "bids.get": "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria tests.",
     "businesses.get": "Read path omits optional SelectionCriteria when --ids is absent.",
     "campaigns.get": "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria tests.",
+    "clients.get": "Read path omits optional SelectionCriteria when --ids is absent.",
     "creatives.get": "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria tests.",
     "dynamicads.get": "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria tests.",
     "dynamicfeedadtargets.get": "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria tests.",

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -2525,11 +2525,6 @@ NESTED_FIELDNAMES_EXCLUSIONS: dict[tuple[str, str, str], str] = {
     ("campaigns", "get", "UnifiedCampaignFieldNames"): "#402",
     ("campaigns", "get", "UnifiedCampaignPackageBiddingStrategyPlatformsFieldNames"): "#402",  # noqa: E501
     ("campaigns", "get", "UnifiedCampaignSearchStrategyPlacementTypesFieldNames"): "#402",  # noqa: E501
-    ("clients", "get", "ContractFieldNames"): "#402",
-    ("clients", "get", "ContragentFieldNames"): "#402",
-    ("clients", "get", "ContragentTinInfoFieldNames"): "#402",
-    ("clients", "get", "OrganizationFieldNames"): "#402",
-    ("clients", "get", "TinInfoFieldNames"): "#402",
     ("creatives", "get", "CpcVideoCreativeFieldNames"): "#402",
     ("creatives", "get", "CpmVideoCreativeFieldNames"): "#402",
     ("creatives", "get", "SmartCreativeFieldNames"): "#402",

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -22009,3 +22009,76 @@ def test_keywordbids_get_rejects_empty_fields():
 
     assert result.exit_code != 0
     assert "Provide a non-empty comma-separated FieldNames list." in result.output
+
+
+# ----------------------------------------------------------------------
+# clients.get: separate Contract/Contragent/Organization/TinInfo
+# *FieldNames (issue #410)
+# ----------------------------------------------------------------------
+
+
+_CLIENTS_GET_NESTED_FIELD_FLAGS = [
+    ("--contract-field-names", "ContractFieldNames", "Number,Date,Price"),
+    ("--contragent-field-names", "ContragentFieldNames", "Name,Phone,EpayNumber"),
+    (
+        "--contragent-tin-info-field-names",
+        "ContragentTinInfoFieldNames",
+        "TinType,Tin",
+    ),
+    (
+        "--organization-field-names",
+        "OrganizationFieldNames",
+        "Name,EpayNumber,OkvedCode",
+    ),
+    ("--tin-info-field-names", "TinInfoFieldNames", "TinType,Tin"),
+]
+
+
+def test_clients_get_nested_field_names_payload():
+    # ClientsGetRequest (WSDL tests/wsdl_cache/clients.xml) declares five
+    # nested top-level *FieldNames parameters separate from FieldNames:
+    # ContractFieldNames (ContractInfoFieldEnum), ContragentFieldNames
+    # (ContragentInfoFieldEnum), ContragentTinInfoFieldNames
+    # (TinInfoFieldEnum), OrganizationFieldNames (OrgInfoFieldEnum), and
+    # TinInfoFieldNames (TinInfoFieldEnum). The same five enums are reused
+    # on agencyclients.get per #407.
+    argv = ["clients", "get"]
+    expected = {}
+    for flag, wsdl_key, sample in _CLIENTS_GET_NESTED_FIELD_FLAGS:
+        argv.extend([flag, sample])
+        expected[wsdl_key] = sample.split(",")
+
+    body = _read_dry_run(*argv)
+
+    for wsdl_key, values in expected.items():
+        assert body["params"][wsdl_key] == values
+
+
+def test_clients_get_omits_nested_field_names_by_default():
+    body = _read_dry_run("clients", "get")
+
+    for _, wsdl_key, _ in _CLIENTS_GET_NESTED_FIELD_FLAGS:
+        assert wsdl_key not in body["params"]
+
+
+def test_clients_get_help_exposes_nested_field_names():
+    result = CliRunner().invoke(cli, ["clients", "get", "--help"])
+
+    assert result.exit_code == 0
+    for flag, _, _ in _CLIENTS_GET_NESTED_FIELD_FLAGS:
+        assert flag in result.output
+
+
+@pytest.mark.parametrize(
+    "flag,wsdl_key",
+    [(flag, key) for flag, key, _ in _CLIENTS_GET_NESTED_FIELD_FLAGS],
+)
+def test_clients_get_rejects_empty_nested_field_names_csv(flag, wsdl_key):
+    result = CliRunner().invoke(
+        cli,
+        ["clients", "get", flag, ",", "--dry-run"],
+        env={"YANDEX_DIRECT_TOKEN": "test-token", "YANDEX_DIRECT_LOGIN": ""},
+    )
+
+    assert result.exit_code != 0
+    assert f"Provide a non-empty comma-separated {wsdl_key} list." in result.output


### PR DESCRIPTION
## Summary

- Add five `--*-field-names` flags to `direct clients get` for the nested WSDL `*FieldNames` parameters declared by `ClientsGetRequest`:
  - `--contract-field-names` (`ContractInfoFieldEnum`)
  - `--contragent-field-names` (`ContragentInfoFieldEnum`)
  - `--contragent-tin-info-field-names` (`TinInfoFieldEnum`)
  - `--organization-field-names` (`OrgInfoFieldEnum`)
  - `--tin-info-field-names` (`TinInfoFieldEnum`)
- Add `--dry-run` to `clients get` for parity with every other read-path command (and the matching rationale in `DRY_RUN_PAYLOAD_EXCLUSIONS`).
- Same five enum types resurface on `direct agencyclients get` per #407 — sample values and help wording stay consistent.
- Remove the five corresponding rows from `NESTED_FIELDNAMES_EXCLUSIONS`.

Closes #410. Fourth PR in Wave 2 milestone 0.3.14.

## Test plan

- [x] `pytest tests/test_api_coverage.py::test_every_nested_fieldnames_param_has_cli_option` — passes after row removal.
- [x] `pytest tests/test_dry_run.py -k clients_get` — 8 new tests pass (payload, default-omission, --help, 5 parametrized empty-CSV).
- [x] `pytest tests/test_api_coverage.py tests/test_cli.py tests/test_comprehensive.py` — 247 tests pass.
- [x] `direct clients get --help | grep field-names` — 5 new flags + existing `--fields` visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)