### PR TITLE
feat(ads)!: expose nested field names on ads get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 **Breaking changes:**
 
+- `direct ads get` flag `--text-ad-fields` is **renamed** to the
+  WSDL-canonical `--text-ad-field-names` form matching the
+  `TextAdFieldNames` request parameter declared by `AdsGetRequest`.
+  The old `--text-ad-fields` form is no longer accepted — update
+  scripts and automation accordingly. Closes #406.
 - `direct campaigns add` / `direct campaigns update` and `direct
   strategies add` / `direct strategies update` now reject `--priority-goals`
   / `--priority-goal` values below 100,000 (0.1 unit in micro-currency).
@@ -103,6 +108,25 @@
   `--fields` (mapping to `FieldNames`) was available, so the
   per-subtype ad-group projections could not be controlled from
   CLI. Closes #405.
+- `direct ads get` now exposes sixteen additional `--*-field-names`
+  flags for the separate WSDL `*FieldNames` request parameters
+  declared by `AdsGetRequest`: `--cpc-video-ad-builder-ad-field-names`,
+  `--cpm-banner-ad-builder-ad-field-names`,
+  `--cpm-video-ad-builder-ad-field-names`,
+  `--dynamic-text-ad-field-names`, `--listing-ad-field-names`,
+  `--mobile-app-ad-builder-ad-field-names`,
+  `--mobile-app-ad-field-names`,
+  `--mobile-app-cpc-video-ad-builder-ad-field-names`,
+  `--mobile-app-image-ad-field-names`,
+  `--responsive-ad-field-names`, `--shopping-ad-field-names`,
+  `--smart-ad-builder-ad-field-names`,
+  `--text-ad-builder-ad-field-names`,
+  `--text-ad-field-names`,
+  `--text-ad-price-extension-field-names`, and
+  `--text-image-ad-field-names`. Previously only the top-level
+  `--fields` (mapping to `FieldNames`) and non-canonical
+  `--text-ad-fields` were available, so the per-ad-subtype projections
+  could not be controlled from CLI. Closes #406.
 
 **BREAKING CHANGES:**
 

--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -23,6 +23,16 @@ def ads():
     """Manage ads"""
 
 
+def _parse_field_names_option(
+    wsdl_key: str, raw_value: Optional[str]
+) -> Optional[list[str]]:
+    """Parse a field-name projection and reject explicitly empty CSV."""
+    parsed = parse_csv_strings(raw_value)
+    if raw_value is not None and not parsed:
+        raise click.UsageError(f"Provide a non-empty comma-separated {wsdl_key} list.")
+    return parsed
+
+
 MOBILE_APP_FEATURES = ("PRICE", "ICON", "CUSTOMER_RATING", "RATINGS")
 
 FEED_BASED_UPDATE_FIELDS = {
@@ -740,7 +750,132 @@ def _build_smart_ad_builder_ad_update(
 @click.option("--output", help="Output file")
 @click.option("--fields", help="Comma-separated top-level field names")
 @click.option(
-    "--text-ad-fields", help="Comma-separated TextAd field names (e.g. Title,Text,Href)"
+    "--cpc-video-ad-builder-ad-field-names",
+    help=(
+        "Comma-separated CpcVideoAdBuilderAdFieldNames "
+        "(e.g. CreativeId,Href). Sent as separate top-level request "
+        "parameter per the AdsGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--cpm-banner-ad-builder-ad-field-names",
+    help=(
+        "Comma-separated CpmBannerAdBuilderAdFieldNames "
+        "(e.g. CreativeId,Href). Sent as separate top-level request "
+        "parameter per the AdsGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--cpm-video-ad-builder-ad-field-names",
+    help=(
+        "Comma-separated CpmVideoAdBuilderAdFieldNames "
+        "(e.g. CreativeId,Href). Sent as separate top-level request "
+        "parameter per the AdsGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--dynamic-text-ad-field-names",
+    help=(
+        "Comma-separated DynamicTextAdFieldNames (e.g. Title,Text,Href). "
+        "Sent as separate top-level request parameter per the "
+        "AdsGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--listing-ad-field-names",
+    help=(
+        "Comma-separated ListingAdFieldNames (e.g. Title,Text,Href). "
+        "Sent as separate top-level request parameter per the "
+        "AdsGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--mobile-app-ad-builder-ad-field-names",
+    help=(
+        "Comma-separated MobileAppAdBuilderAdFieldNames "
+        "(e.g. CreativeId,TrackingUrl). Sent as separate top-level "
+        "request parameter per the AdsGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--mobile-app-ad-field-names",
+    help=(
+        "Comma-separated MobileAppAdFieldNames (e.g. Title,Text,TrackingUrl). "
+        "Sent as separate top-level request parameter per the "
+        "AdsGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--mobile-app-cpc-video-ad-builder-ad-field-names",
+    help=(
+        "Comma-separated MobileAppCpcVideoAdBuilderAdFieldNames "
+        "(e.g. CreativeId,TrackingUrl). Sent as separate top-level "
+        "request parameter per the AdsGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--mobile-app-image-ad-field-names",
+    help=(
+        "Comma-separated MobileAppImageAdFieldNames (e.g. ImageHash,TrackingUrl). "
+        "Sent as separate top-level request parameter per the "
+        "AdsGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--responsive-ad-field-names",
+    help=(
+        "Comma-separated ResponsiveAdFieldNames (e.g. Titles,Texts,Href). "
+        "Sent as separate top-level request parameter per the "
+        "AdsGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--shopping-ad-field-names",
+    help=(
+        "Comma-separated ShoppingAdFieldNames (e.g. Titles,Texts,Href). "
+        "Sent as separate top-level request parameter per the "
+        "AdsGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--smart-ad-builder-ad-field-names",
+    help=(
+        "Comma-separated SmartAdBuilderAdFieldNames (e.g. CreativeId). "
+        "Sent as separate top-level request parameter per the "
+        "AdsGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--text-ad-builder-ad-field-names",
+    help=(
+        "Comma-separated TextAdBuilderAdFieldNames (e.g. CreativeId,Href). "
+        "Sent as separate top-level request parameter per the "
+        "AdsGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--text-ad-field-names",
+    help=(
+        "Comma-separated TextAdFieldNames (e.g. Title,Text,Href). "
+        "Sent as separate top-level request parameter per the "
+        "AdsGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--text-ad-price-extension-field-names",
+    help=(
+        "Comma-separated TextAdPriceExtensionFieldNames "
+        "(e.g. Price,OldPrice,PriceQualifier). Sent as separate top-level "
+        "request parameter per the AdsGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--text-image-ad-field-names",
+    help=(
+        "Comma-separated TextImageAdFieldNames (e.g. Href,ImageHash). "
+        "Sent as separate top-level request parameter per the "
+        "AdsGetRequest WSDL."
+    ),
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
@@ -766,7 +901,22 @@ def get(
     output_format,
     output,
     fields,
-    text_ad_fields,
+    cpc_video_ad_builder_ad_field_names,
+    cpm_banner_ad_builder_ad_field_names,
+    cpm_video_ad_builder_ad_field_names,
+    dynamic_text_ad_field_names,
+    listing_ad_field_names,
+    mobile_app_ad_builder_ad_field_names,
+    mobile_app_ad_field_names,
+    mobile_app_cpc_video_ad_builder_ad_field_names,
+    mobile_app_image_ad_field_names,
+    responsive_ad_field_names,
+    shopping_ad_field_names,
+    smart_ad_builder_ad_field_names,
+    text_ad_builder_ad_field_names,
+    text_ad_field_names,
+    text_ad_price_extension_field_names,
+    text_image_ad_field_names,
     dry_run,
 ):
     """Get ads"""
@@ -778,10 +928,46 @@ def get(
             fields.split(",") if fields else get_default_fields("ads", "FieldNames")
         )
 
-        text_ad_field_names = (
-            text_ad_fields.split(",")
-            if text_ad_fields
-            else get_default_fields("ads", "TextAdFieldNames")
+        raw_nested = (
+            (
+                "CpcVideoAdBuilderAdFieldNames",
+                cpc_video_ad_builder_ad_field_names,
+            ),
+            (
+                "CpmBannerAdBuilderAdFieldNames",
+                cpm_banner_ad_builder_ad_field_names,
+            ),
+            (
+                "CpmVideoAdBuilderAdFieldNames",
+                cpm_video_ad_builder_ad_field_names,
+            ),
+            ("DynamicTextAdFieldNames", dynamic_text_ad_field_names),
+            ("ListingAdFieldNames", listing_ad_field_names),
+            ("MobileAppAdBuilderAdFieldNames", mobile_app_ad_builder_ad_field_names),
+            ("MobileAppAdFieldNames", mobile_app_ad_field_names),
+            (
+                "MobileAppCpcVideoAdBuilderAdFieldNames",
+                mobile_app_cpc_video_ad_builder_ad_field_names,
+            ),
+            ("MobileAppImageAdFieldNames", mobile_app_image_ad_field_names),
+            ("ResponsiveAdFieldNames", responsive_ad_field_names),
+            ("ShoppingAdFieldNames", shopping_ad_field_names),
+            ("SmartAdBuilderAdFieldNames", smart_ad_builder_ad_field_names),
+            ("TextAdBuilderAdFieldNames", text_ad_builder_ad_field_names),
+            ("TextAdFieldNames", text_ad_field_names),
+            (
+                "TextAdPriceExtensionFieldNames",
+                text_ad_price_extension_field_names,
+            ),
+            ("TextImageAdFieldNames", text_image_ad_field_names),
+        )
+        parsed_nested = {}
+        for wsdl_key, raw_value in raw_nested:
+            parsed = _parse_field_names_option(wsdl_key, raw_value)
+            if parsed:
+                parsed_nested[wsdl_key] = parsed
+        parsed_nested.setdefault(
+            "TextAdFieldNames", get_default_fields("ads", "TextAdFieldNames")
         )
 
         criteria = {}
@@ -818,8 +1004,8 @@ def get(
         params = {
             "SelectionCriteria": criteria,
             "FieldNames": field_names,
-            "TextAdFieldNames": text_ad_field_names,
         }
+        params.update(parsed_nested)
 
         if limit:
             params["Page"] = {"Limit": limit}

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -255,9 +255,9 @@ def _assert_body_matches_wsdl(body: dict, service: str, operation: str):
             continue
         value = body["params"][field["name"]]
         if field["max_occurs"] == "unbounded":
-            assert isinstance(value, list), (
-                f"{service}.{operation}.{field['name']} must be a list"
-            )
+            assert isinstance(
+                value, list
+            ), f"{service}.{operation}.{field['name']} must be a list"
             if value and field["item_fields"]:
                 required = {
                     item["name"]
@@ -305,15 +305,13 @@ class TestApiCoverage:
 
     def test_non_wsdl_services_have_explicit_coverage_policy(self):
         for service_name, policy in sorted(NON_WSDL_SERVICE_POLICIES.items()):
-            assert service_name in cli.commands, (
-                f"Non-WSDL service {service_name} is missing from the CLI"
-            )
+            assert (
+                service_name in cli.commands
+            ), f"Non-WSDL service {service_name} is missing from the CLI"
             assert policy["coverage"] in (
                 "contract-tests",
                 "contract-tests+spec-snapshot",
-            ), (
-                f"Unexpected coverage policy for non-WSDL service {service_name}: {policy}"
-            )
+            ), f"Unexpected coverage policy for non-WSDL service {service_name}: {policy}"
 
     def test_service_method_coverage(self):
         failures = []
@@ -2143,9 +2141,9 @@ class TestApiCoverage:
             }
         }
         violations = find_nested_schema_violations(bad_body, schema)
-        assert any("BogusNestedKey" in v for v in violations), (
-            f"Expected BogusNestedKey to be flagged, got: {violations}"
-        )
+        assert any(
+            "BogusNestedKey" in v for v in violations
+        ), f"Expected BogusNestedKey to be flagged, got: {violations}"
 
 
 @pytest.mark.api_coverage
@@ -2237,9 +2235,9 @@ class TestReportsCoverage:
         assert opt is not None, "--processing-mode flag missing"
         cli_choices = set(opt.type.choices)
         spec_modes = set(spec["processing_modes"])
-        assert cli_choices == spec_modes, (
-            f"--processing-mode choices differ: CLI={cli_choices}, spec={spec_modes}"
-        )
+        assert (
+            cli_choices == spec_modes
+        ), f"--processing-mode choices differ: CLI={cli_choices}, spec={spec_modes}"
 
     def test_cli_request_headers_flags_exist(self):
         """CLI must expose flags for each request header from spec."""
@@ -2261,9 +2259,9 @@ class TestReportsCoverage:
         from direct_cli.wsdl_coverage import NON_WSDL_SERVICE_POLICIES
 
         policy = NON_WSDL_SERVICE_POLICIES["reports"]
-        assert policy["coverage"] == "contract-tests+spec-snapshot", (
-            "reports policy must use 'contract-tests+spec-snapshot' coverage type"
-        )
+        assert (
+            policy["coverage"] == "contract-tests+spec-snapshot"
+        ), "reports policy must use 'contract-tests+spec-snapshot' coverage type"
         assert "spec_snapshot" in policy
         assert "drift_script" in policy
         assert "refresh_script" in policy
@@ -2473,22 +2471,6 @@ class TestReportsBuildRequestExtra:
 # tracking issue — do not silently exclude a gap. To close a row,
 # add the corresponding kebab-case CLI option and delete the entry.
 NESTED_FIELDNAMES_EXCLUSIONS: dict[tuple[str, str, str], str] = {
-    ("ads", "get", "CpcVideoAdBuilderAdFieldNames"): "#402",
-    ("ads", "get", "CpmBannerAdBuilderAdFieldNames"): "#402",
-    ("ads", "get", "CpmVideoAdBuilderAdFieldNames"): "#402",
-    ("ads", "get", "DynamicTextAdFieldNames"): "#402",
-    ("ads", "get", "ListingAdFieldNames"): "#402",
-    ("ads", "get", "MobileAppAdBuilderAdFieldNames"): "#402",
-    ("ads", "get", "MobileAppAdFieldNames"): "#402",
-    ("ads", "get", "MobileAppCpcVideoAdBuilderAdFieldNames"): "#402",
-    ("ads", "get", "MobileAppImageAdFieldNames"): "#402",
-    ("ads", "get", "ResponsiveAdFieldNames"): "#402",
-    ("ads", "get", "ShoppingAdFieldNames"): "#402",
-    ("ads", "get", "SmartAdBuilderAdFieldNames"): "#402",
-    ("ads", "get", "TextAdBuilderAdFieldNames"): "#402",
-    ("ads", "get", "TextAdFieldNames"): "#402",
-    ("ads", "get", "TextAdPriceExtensionFieldNames"): "#402",
-    ("ads", "get", "TextImageAdFieldNames"): "#402",
     ("strategies", "get", "StrategyAverageCpaFieldNames"): "#402",
     ("strategies", "get", "StrategyAverageCpaMultipleGoalsFieldNames"): "#402",
     ("strategies", "get", "StrategyAverageCpaPerCampaignFieldNames"): "#402",

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -3515,6 +3515,29 @@ def test_ads_update_rejects_title2_on_text_image_ad():
     assert "--title2 is not compatible with --type TEXT_IMAGE_AD" in result.output
 
 
+ADS_GET_NESTED_FIELD_NAME_OPTIONS = [
+    ("--cpc-video-ad-builder-ad-field-names", "CpcVideoAdBuilderAdFieldNames"),
+    ("--cpm-banner-ad-builder-ad-field-names", "CpmBannerAdBuilderAdFieldNames"),
+    ("--cpm-video-ad-builder-ad-field-names", "CpmVideoAdBuilderAdFieldNames"),
+    ("--dynamic-text-ad-field-names", "DynamicTextAdFieldNames"),
+    ("--listing-ad-field-names", "ListingAdFieldNames"),
+    ("--mobile-app-ad-builder-ad-field-names", "MobileAppAdBuilderAdFieldNames"),
+    ("--mobile-app-ad-field-names", "MobileAppAdFieldNames"),
+    (
+        "--mobile-app-cpc-video-ad-builder-ad-field-names",
+        "MobileAppCpcVideoAdBuilderAdFieldNames",
+    ),
+    ("--mobile-app-image-ad-field-names", "MobileAppImageAdFieldNames"),
+    ("--responsive-ad-field-names", "ResponsiveAdFieldNames"),
+    ("--shopping-ad-field-names", "ShoppingAdFieldNames"),
+    ("--smart-ad-builder-ad-field-names", "SmartAdBuilderAdFieldNames"),
+    ("--text-ad-builder-ad-field-names", "TextAdBuilderAdFieldNames"),
+    ("--text-ad-field-names", "TextAdFieldNames"),
+    ("--text-ad-price-extension-field-names", "TextAdPriceExtensionFieldNames"),
+    ("--text-image-ad-field-names", "TextImageAdFieldNames"),
+]
+
+
 def test_ads_get_default_fieldnames():
     """Default FieldNames includes basic top-level fields, plus TextAdFieldNames."""
     body = _dry_run("ads", "get", "--campaign-ids", "12345")
@@ -3526,7 +3549,7 @@ def test_ads_get_default_fieldnames():
 
 
 def test_ads_get_with_fields_overrides_defaults():
-    """--fields and --text-ad-fields override the defaults."""
+    """--fields and --text-ad-field-names override the defaults."""
     body = _dry_run(
         "ads",
         "get",
@@ -3534,7 +3557,7 @@ def test_ads_get_with_fields_overrides_defaults():
         "12345",
         "--fields",
         "Id,State",
-        "--text-ad-fields",
+        "--text-ad-field-names",
         "Title",
     )
     assert body["params"]["FieldNames"] == ["Id", "State"]
@@ -3552,6 +3575,65 @@ def test_ads_get_with_ids_and_status():
     }
     assert body["params"]["Page"] == {"Limit": 10}
     assert "TextAdFieldNames" in body["params"]
+
+
+def test_ads_get_nested_field_names_payload():
+    """Nested AdsGetRequest FieldNames options are sent independently."""
+    body = _dry_run(
+        "ads",
+        "get",
+        "--campaign-ids",
+        "12345",
+        "--dynamic-text-ad-field-names",
+        "Title,Text,Href",
+        "--responsive-ad-field-names",
+        "Titles,Texts",
+        "--text-ad-price-extension-field-names",
+        "Price,OldPrice",
+    )
+
+    params = body["params"]
+    assert params["DynamicTextAdFieldNames"] == ["Title", "Text", "Href"]
+    assert params["ResponsiveAdFieldNames"] == ["Titles", "Texts"]
+    assert params["TextAdPriceExtensionFieldNames"] == ["Price", "OldPrice"]
+
+
+def test_ads_get_default_omits_non_text_nested_field_names():
+    """Unspecified nested projections are omitted so Yandex applies defaults."""
+    body = _dry_run("ads", "get", "--campaign-ids", "12345")
+
+    assert "DynamicTextAdFieldNames" not in body["params"]
+    assert "ResponsiveAdFieldNames" not in body["params"]
+    # TextAdFieldNames existed before the rename and keeps its default payload.
+    assert body["params"]["TextAdFieldNames"] == get_default_fields(
+        "ads", "TextAdFieldNames"
+    )
+
+
+def test_ads_get_help_exposes_nested_field_names_options():
+    result = CliRunner().invoke(cli, ["ads", "get", "--help"])
+
+    assert result.exit_code == 0
+    for flag, _ in ADS_GET_NESTED_FIELD_NAME_OPTIONS:
+        assert flag in result.output
+    assert "--text-ad-fields" not in result.output
+
+
+@pytest.mark.parametrize("flag,wsdl_key", ADS_GET_NESTED_FIELD_NAME_OPTIONS)
+def test_ads_get_rejects_empty_nested_field_names(flag, wsdl_key):
+    result = CliRunner().invoke(cli, ["ads", "get", flag, ",", "--dry-run"])
+
+    assert result.exit_code != 0
+    assert f"Provide a non-empty comma-separated {wsdl_key} list." in result.output
+
+
+def test_ads_get_legacy_text_ad_fields_alias_removed():
+    result = CliRunner().invoke(
+        cli, ["ads", "get", "--campaign-ids", "12345", "--text-ad-fields", "Title"]
+    )
+
+    assert result.exit_code != 0
+    assert "No such option '--text-ad-fields'" in result.output
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -3633,7 +3633,8 @@ def test_ads_get_legacy_text_ad_fields_alias_removed():
     )
 
     assert result.exit_code != 0
-    assert "No such option '--text-ad-fields'" in result.output
+    assert "No such option" in result.output
+    assert "--text-ad-fields" in result.output
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_low_coverage_payloads.py
+++ b/tests/test_low_coverage_payloads.py
@@ -861,7 +861,7 @@ def test_ads_get_builds_full_typed_filter_payload():
         "10",
         "--fields",
         "Id,Type",
-        "--text-ad-fields",
+        "--text-ad-field-names",
         "Title,Text",
     )
 


### PR DESCRIPTION
## Summary

- Add all 16 WSDL nested `*FieldNames` flags to `direct ads get`, including per-ad-subtype projections such as `--dynamic-text-ad-field-names`, `--responsive-ad-field-names`, and `--text-ad-price-extension-field-names`.
- Rename `--text-ad-fields` to the WSDL-canonical `--text-ad-field-names` form and reject the removed legacy alias.
- Remove the corresponding `ads/get` rows from `NESTED_FIELDNAMES_EXCLUSIONS` so the nested FieldNames coverage gate enforces the new CLI surface.

Closes #406. Ninth PR in Wave 2 milestone 0.3.14.

## Test plan

- [x] `pytest tests/test_dry_run.py -k ads_get`
- [x] `pytest tests/test_api_coverage.py::test_every_nested_fieldnames_param_has_cli_option`
- [x] `python -m direct_cli.cli ads get --help`

Made with [Cursor](https://cursor.com)