### PR TITLE
feat(strategies): expose nested field names on strategies get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,20 @@
   `--fields` (mapping to `FieldNames`) was available, so the
   per-adjustment projections could not be controlled from CLI.
   Closes #408.
+- `direct strategies get` now exposes sixteen additional
+  `--strategy-*-field-names` flags for the separate WSDL
+  `*FieldNames` request parameters declared by `StrategiesGetRequest`,
+  including `--strategy-average-cpa-field-names`,
+  `--strategy-average-cpa-multiple-goals-field-names`,
+  `--strategy-average-cpc-field-names`,
+  `--strategy-maximum-clicks-field-names`,
+  `--strategy-maximum-conversion-rate-field-names`,
+  `--strategy-pay-for-conversion-field-names`, and the remaining
+  per-campaign / per-filter strategy projections. The command also
+  gains `--dry-run` for read-path payload tests. Previously only the
+  top-level `--fields` (mapping to `FieldNames`) was available, so
+  per-strategy-subtype projections could not be controlled from CLI.
+  Closes #414.
 
 Closes #360.
 

--- a/direct_cli/commands/strategies.py
+++ b/direct_cli/commands/strategies.py
@@ -2,6 +2,8 @@
 Strategies commands
 """
 
+from typing import Optional
+
 import click
 
 from ..api import create_client
@@ -406,7 +408,9 @@ def strategies():
     """Manage strategies"""
 
 
-def _parse_field_names_option(wsdl_key: str, raw_value: str | None) -> list[str] | None:
+def _parse_field_names_option(
+    wsdl_key: str, raw_value: Optional[str]
+) -> Optional[list[str]]:
     """Parse a field-name projection and reject explicitly empty CSV."""
     parsed = parse_csv_strings(raw_value)
     if raw_value is not None and not parsed:

--- a/direct_cli/commands/strategies.py
+++ b/direct_cli/commands/strategies.py
@@ -9,6 +9,7 @@ from ..output import format_output, print_error
 from ..utils import (
     MICRO_RUBLES,
     get_default_fields,
+    parse_csv_strings,
     parse_ids,
     validate_priority_goal_value,
 )
@@ -405,6 +406,14 @@ def strategies():
     """Manage strategies"""
 
 
+def _parse_field_names_option(wsdl_key: str, raw_value: str | None) -> list[str] | None:
+    """Parse a field-name projection and reject explicitly empty CSV."""
+    parsed = parse_csv_strings(raw_value)
+    if raw_value is not None and not parsed:
+        raise click.UsageError(f"Provide a non-empty comma-separated {wsdl_key} list.")
+    return parsed
+
+
 @strategies.command()
 @click.option("--ids", help="Comma-separated strategy IDs")
 @click.option(
@@ -421,17 +430,224 @@ def strategies():
 @click.option("--format", "output_format", default="json", help="Output format")
 @click.option("--output", help="Output file")
 @click.option("--fields", help="Comma-separated field names")
+@click.option(
+    "--strategy-average-cpa-field-names",
+    help=(
+        "Comma-separated StrategyAverageCpaFieldNames "
+        "(e.g. AverageCpa,GoalId). Sent as separate top-level request "
+        "parameter per the StrategiesGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--strategy-average-cpa-multiple-goals-field-names",
+    help=(
+        "Comma-separated StrategyAverageCpaMultipleGoalsFieldNames "
+        "(e.g. WeeklySpendLimit,BidCeiling,PriorityGoals). Sent as separate "
+        "top-level request parameter per the StrategiesGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--strategy-average-cpa-per-campaign-field-names",
+    help=(
+        "Comma-separated StrategyAverageCpaPerCampaignFieldNames "
+        "(e.g. AverageCpa,GoalId). Sent as separate top-level request "
+        "parameter per the StrategiesGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--strategy-average-cpa-per-filter-field-names",
+    help=(
+        "Comma-separated StrategyAverageCpaPerFilterFieldNames "
+        "(e.g. AverageCpa,GoalId). Sent as separate top-level request "
+        "parameter per the StrategiesGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--strategy-average-cpc-field-names",
+    help=(
+        "Comma-separated StrategyAverageCpcFieldNames "
+        "(e.g. AverageCpc,WeeklySpendLimit). Sent as separate top-level "
+        "request parameter per the StrategiesGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--strategy-average-cpc-per-campaign-field-names",
+    help=(
+        "Comma-separated StrategyAverageCpcPerCampaignFieldNames "
+        "(e.g. AverageCpc,WeeklySpendLimit). Sent as separate top-level "
+        "request parameter per the StrategiesGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--strategy-average-cpc-per-filter-field-names",
+    help=(
+        "Comma-separated StrategyAverageCpcPerFilterFieldNames "
+        "(e.g. AverageCpc,WeeklySpendLimit). Sent as separate top-level "
+        "request parameter per the StrategiesGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--strategy-average-crr-field-names",
+    help=(
+        "Comma-separated StrategyAverageCrrFieldNames "
+        "(e.g. AverageCrr,GoalId). Sent as separate top-level request "
+        "parameter per the StrategiesGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--strategy-max-profit-field-names",
+    help=(
+        "Comma-separated StrategyMaxProfitFieldNames "
+        "(e.g. WeeklySpendLimit,BidCeiling). Sent as separate top-level "
+        "request parameter per the StrategiesGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--strategy-maximum-clicks-field-names",
+    help=(
+        "Comma-separated StrategyMaximumClicksFieldNames "
+        "(e.g. WeeklySpendLimit,BidCeiling). Sent as separate top-level "
+        "request parameter per the StrategiesGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--strategy-maximum-conversion-rate-field-names",
+    help=(
+        "Comma-separated StrategyMaximumConversionRateFieldNames "
+        "(e.g. WeeklySpendLimit,GoalId). Sent as separate top-level "
+        "request parameter per the StrategiesGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--strategy-pay-for-conversion-crr-field-names",
+    help=(
+        "Comma-separated StrategyPayForConversionCrrFieldNames "
+        "(e.g. Crr,GoalId). Sent as separate top-level request parameter "
+        "per the StrategiesGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--strategy-pay-for-conversion-field-names",
+    help=(
+        "Comma-separated StrategyPayForConversionFieldNames "
+        "(e.g. Cpa,GoalId). Sent as separate top-level request parameter "
+        "per the StrategiesGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--strategy-pay-for-conversion-multiple-goals-field-names",
+    help=(
+        "Comma-separated StrategyPayForConversionMultipleGoalsFieldNames "
+        "(e.g. WeeklySpendLimit,PriorityGoals). Sent as separate top-level "
+        "request parameter per the StrategiesGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--strategy-pay-for-conversion-per-campaign-field-names",
+    help=(
+        "Comma-separated StrategyPayForConversionPerCampaignFieldNames "
+        "(e.g. Cpa,GoalId). Sent as separate top-level request parameter "
+        "per the StrategiesGetRequest WSDL."
+    ),
+)
+@click.option(
+    "--strategy-pay-for-conversion-per-filter-field-names",
+    help=(
+        "Comma-separated StrategyPayForConversionPerFilterFieldNames "
+        "(e.g. Cpa,GoalId). Sent as separate top-level request parameter "
+        "per the StrategiesGetRequest WSDL."
+    ),
+)
+@click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def get(ctx, ids, types, is_archived, limit, fetch_all, output_format, output, fields):
+def get(
+    ctx,
+    ids,
+    types,
+    is_archived,
+    limit,
+    fetch_all,
+    output_format,
+    output,
+    fields,
+    strategy_average_cpa_field_names,
+    strategy_average_cpa_multiple_goals_field_names,
+    strategy_average_cpa_per_campaign_field_names,
+    strategy_average_cpa_per_filter_field_names,
+    strategy_average_cpc_field_names,
+    strategy_average_cpc_per_campaign_field_names,
+    strategy_average_cpc_per_filter_field_names,
+    strategy_average_crr_field_names,
+    strategy_max_profit_field_names,
+    strategy_maximum_clicks_field_names,
+    strategy_maximum_conversion_rate_field_names,
+    strategy_pay_for_conversion_crr_field_names,
+    strategy_pay_for_conversion_field_names,
+    strategy_pay_for_conversion_multiple_goals_field_names,
+    strategy_pay_for_conversion_per_campaign_field_names,
+    strategy_pay_for_conversion_per_filter_field_names,
+    dry_run,
+):
     """Get strategies"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
-
         field_names = fields.split(",") if fields else get_default_fields("strategies")
+
+        raw_nested = (
+            ("StrategyAverageCpaFieldNames", strategy_average_cpa_field_names),
+            (
+                "StrategyAverageCpaMultipleGoalsFieldNames",
+                strategy_average_cpa_multiple_goals_field_names,
+            ),
+            (
+                "StrategyAverageCpaPerCampaignFieldNames",
+                strategy_average_cpa_per_campaign_field_names,
+            ),
+            (
+                "StrategyAverageCpaPerFilterFieldNames",
+                strategy_average_cpa_per_filter_field_names,
+            ),
+            ("StrategyAverageCpcFieldNames", strategy_average_cpc_field_names),
+            (
+                "StrategyAverageCpcPerCampaignFieldNames",
+                strategy_average_cpc_per_campaign_field_names,
+            ),
+            (
+                "StrategyAverageCpcPerFilterFieldNames",
+                strategy_average_cpc_per_filter_field_names,
+            ),
+            ("StrategyAverageCrrFieldNames", strategy_average_crr_field_names),
+            ("StrategyMaxProfitFieldNames", strategy_max_profit_field_names),
+            ("StrategyMaximumClicksFieldNames", strategy_maximum_clicks_field_names),
+            (
+                "StrategyMaximumConversionRateFieldNames",
+                strategy_maximum_conversion_rate_field_names,
+            ),
+            (
+                "StrategyPayForConversionCrrFieldNames",
+                strategy_pay_for_conversion_crr_field_names,
+            ),
+            (
+                "StrategyPayForConversionFieldNames",
+                strategy_pay_for_conversion_field_names,
+            ),
+            (
+                "StrategyPayForConversionMultipleGoalsFieldNames",
+                strategy_pay_for_conversion_multiple_goals_field_names,
+            ),
+            (
+                "StrategyPayForConversionPerCampaignFieldNames",
+                strategy_pay_for_conversion_per_campaign_field_names,
+            ),
+            (
+                "StrategyPayForConversionPerFilterFieldNames",
+                strategy_pay_for_conversion_per_filter_field_names,
+            ),
+        )
+        parsed_nested = {}
+        for wsdl_key, raw_value in raw_nested:
+            parsed = _parse_field_names_option(wsdl_key, raw_value)
+            if parsed:
+                parsed_nested[wsdl_key] = parsed
 
         criteria = {}
         if ids:
@@ -442,10 +658,20 @@ def get(ctx, ids, types, is_archived, limit, fetch_all, output_format, output, f
             criteria["IsArchived"] = is_archived.upper()
 
         params = {"SelectionCriteria": criteria, "FieldNames": field_names}
+        params.update(parsed_nested)
         if limit:
             params["Page"] = {"Limit": limit}
 
         body = {"method": "get", "params": params}
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = create_client(
+            token=ctx.obj.get("token"),
+            login=ctx.obj.get("login"),
+            sandbox=ctx.obj.get("sandbox"),
+        )
         result = client.strategies().post(data=body)
 
         if fetch_all:

--- a/tests/api_coverage_payloads.py
+++ b/tests/api_coverage_payloads.py
@@ -33,6 +33,7 @@ DRY_RUN_PAYLOAD_EXCLUSIONS = {
     "dynamicfeedadtargets.suspend": "Covered by test_dry_run.py::test_dynamicfeedadtargets_suspend_payload.",
     "strategies.add": "Covered by test_dry_run.py::test_strategies_add_payload.",
     "strategies.archive": "Covered by test_dry_run.py::test_strategies_archive_payload.",
+    "strategies.get": "Covered by test_dry_run.py::test_strategies_get_default_field_names_payload.",
     "strategies.unarchive": "Covered by test_dry_run.py::test_strategies_unarchive_payload.",
     "strategies.update": "Covered by test_dry_run.py::test_strategies_update_payload.",
     "reports.get": "Reports API uses a custom TSV endpoint; payload contract is covered by test_reports_request_builder_contract.",

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -2489,22 +2489,6 @@ NESTED_FIELDNAMES_EXCLUSIONS: dict[tuple[str, str, str], str] = {
     ("ads", "get", "TextAdFieldNames"): "#402",
     ("ads", "get", "TextAdPriceExtensionFieldNames"): "#402",
     ("ads", "get", "TextImageAdFieldNames"): "#402",
-    ("strategies", "get", "StrategyAverageCpaFieldNames"): "#402",
-    ("strategies", "get", "StrategyAverageCpaMultipleGoalsFieldNames"): "#402",
-    ("strategies", "get", "StrategyAverageCpaPerCampaignFieldNames"): "#402",
-    ("strategies", "get", "StrategyAverageCpaPerFilterFieldNames"): "#402",
-    ("strategies", "get", "StrategyAverageCpcFieldNames"): "#402",
-    ("strategies", "get", "StrategyAverageCpcPerCampaignFieldNames"): "#402",
-    ("strategies", "get", "StrategyAverageCpcPerFilterFieldNames"): "#402",
-    ("strategies", "get", "StrategyAverageCrrFieldNames"): "#402",
-    ("strategies", "get", "StrategyMaxProfitFieldNames"): "#402",
-    ("strategies", "get", "StrategyMaximumClicksFieldNames"): "#402",
-    ("strategies", "get", "StrategyMaximumConversionRateFieldNames"): "#402",
-    ("strategies", "get", "StrategyPayForConversionCrrFieldNames"): "#402",
-    ("strategies", "get", "StrategyPayForConversionFieldNames"): "#402",
-    ("strategies", "get", "StrategyPayForConversionMultipleGoalsFieldNames"): "#402",
-    ("strategies", "get", "StrategyPayForConversionPerCampaignFieldNames"): "#402",
-    ("strategies", "get", "StrategyPayForConversionPerFilterFieldNames"): "#402",
 }
 
 

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -17725,6 +17725,111 @@ def test_dynamicfeedadtargets_set_bids_payload():
 # ----------------------------------------------------------------------
 
 
+STRATEGIES_GET_NESTED_FIELD_NAME_OPTIONS = [
+    ("--strategy-average-cpa-field-names", "StrategyAverageCpaFieldNames"),
+    (
+        "--strategy-average-cpa-multiple-goals-field-names",
+        "StrategyAverageCpaMultipleGoalsFieldNames",
+    ),
+    (
+        "--strategy-average-cpa-per-campaign-field-names",
+        "StrategyAverageCpaPerCampaignFieldNames",
+    ),
+    (
+        "--strategy-average-cpa-per-filter-field-names",
+        "StrategyAverageCpaPerFilterFieldNames",
+    ),
+    ("--strategy-average-cpc-field-names", "StrategyAverageCpcFieldNames"),
+    (
+        "--strategy-average-cpc-per-campaign-field-names",
+        "StrategyAverageCpcPerCampaignFieldNames",
+    ),
+    (
+        "--strategy-average-cpc-per-filter-field-names",
+        "StrategyAverageCpcPerFilterFieldNames",
+    ),
+    ("--strategy-average-crr-field-names", "StrategyAverageCrrFieldNames"),
+    ("--strategy-max-profit-field-names", "StrategyMaxProfitFieldNames"),
+    ("--strategy-maximum-clicks-field-names", "StrategyMaximumClicksFieldNames"),
+    (
+        "--strategy-maximum-conversion-rate-field-names",
+        "StrategyMaximumConversionRateFieldNames",
+    ),
+    (
+        "--strategy-pay-for-conversion-crr-field-names",
+        "StrategyPayForConversionCrrFieldNames",
+    ),
+    (
+        "--strategy-pay-for-conversion-field-names",
+        "StrategyPayForConversionFieldNames",
+    ),
+    (
+        "--strategy-pay-for-conversion-multiple-goals-field-names",
+        "StrategyPayForConversionMultipleGoalsFieldNames",
+    ),
+    (
+        "--strategy-pay-for-conversion-per-campaign-field-names",
+        "StrategyPayForConversionPerCampaignFieldNames",
+    ),
+    (
+        "--strategy-pay-for-conversion-per-filter-field-names",
+        "StrategyPayForConversionPerFilterFieldNames",
+    ),
+]
+
+
+def test_strategies_get_default_field_names_payload():
+    body = _read_dry_run("strategies", "get", "--ids", "123")
+
+    assert body["method"] == "get"
+    assert body["params"]["SelectionCriteria"] == {"Ids": [123]}
+    assert body["params"]["FieldNames"] == get_default_fields("strategies")
+    assert "StrategyAverageCpaFieldNames" not in body["params"]
+
+
+def test_strategies_get_nested_field_names_payload():
+    body = _read_dry_run(
+        "strategies",
+        "get",
+        "--ids",
+        "123",
+        "--strategy-average-cpa-field-names",
+        "AverageCpa,GoalId",
+        "--strategy-maximum-clicks-field-names",
+        "WeeklySpendLimit,BidCeiling",
+        "--strategy-pay-for-conversion-multiple-goals-field-names",
+        "WeeklySpendLimit,PriorityGoals",
+    )
+
+    params = body["params"]
+    assert params["StrategyAverageCpaFieldNames"] == ["AverageCpa", "GoalId"]
+    assert params["StrategyMaximumClicksFieldNames"] == [
+        "WeeklySpendLimit",
+        "BidCeiling",
+    ]
+    assert params["StrategyPayForConversionMultipleGoalsFieldNames"] == [
+        "WeeklySpendLimit",
+        "PriorityGoals",
+    ]
+
+
+def test_strategies_get_help_exposes_nested_field_names_options():
+    result = CliRunner().invoke(cli, ["strategies", "get", "--help"])
+
+    assert result.exit_code == 0
+    assert "--dry-run" in result.output
+    for flag, _ in STRATEGIES_GET_NESTED_FIELD_NAME_OPTIONS:
+        assert flag in result.output
+
+
+@pytest.mark.parametrize("flag,wsdl_key", STRATEGIES_GET_NESTED_FIELD_NAME_OPTIONS)
+def test_strategies_get_rejects_empty_nested_field_names(flag, wsdl_key):
+    result = CliRunner().invoke(cli, ["strategies", "get", flag, ",", "--dry-run"])
+
+    assert result.exit_code != 0
+    assert f"Provide a non-empty comma-separated {wsdl_key} list." in result.output
+
+
 def test_strategies_add_payload():
     body = _dry_run(
         "strategies",


### PR DESCRIPTION
## Summary

- Add all 16 strategy-specific WSDL nested `*FieldNames` flags to `direct strategies get` for Average CPA/CPC/CRR, maximum clicks/conversion rate, max profit, and pay-for-conversion strategy subtypes.
- Add `--dry-run` to `direct strategies get` so read-path payload tests can cover the new request parameters without contacting the API.
- Remove the corresponding `strategies/get` rows from `NESTED_FIELDNAMES_EXCLUSIONS` so the nested FieldNames coverage gate enforces the new CLI surface.

Closes #414. Tenth PR in Wave 2 milestone 0.3.14.

## Test plan

- [x] `pytest tests/test_dry_run.py -k strategies_get`
- [x] `pytest tests/test_api_coverage.py::test_every_nested_fieldnames_param_has_cli_option`
- [x] `python -m direct_cli.cli strategies get --help`

Made with [Cursor](https://cursor.com)