### PR TITLE
docs(v4): verify GetCreditLimits wire-shape against official docs (closes #430)

### DIFF
--- a/direct_cli/v4_contracts.py
+++ b/direct_cli/v4_contracts.py
@@ -72,7 +72,10 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
             "Official docs (dg-v4/reference/GetCreditLimits) define the "
             "request body as method + finance_token + operation_num only; "
             "no param. Live probe without finance credentials returns "
-            "error_code=350."
+            "error_code=350. "
+            "Docs-verified 2026-05-28 against dg-v4/reference/GetCreditLimits: "
+            "wire-shape matches CLI dry-run output exactly (method + "
+            "finance_token + operation_num, no param)."
         ),
     ),
     "TransferMoney": V4MethodContract(


### PR DESCRIPTION
## Summary

- Fetched https://yandex.ru/dev/direct/doc/dg-v4/reference/GetCreditLimits and confirmed CLI dry-run output matches the docs exactly: request body is `{method, finance_token, operation_num}` with no `param`.
- Stamps `direct_cli/v4_contracts.py:GetCreditLimits.notes` with a `Docs-verified 2026-05-28` line.
- No code changes — implementation in `commands/v4finance.py:200-278` was already correct.

## Verification

Docs-verified against `dg-v4/reference/GetCreditLimits` (response shape too: `{data: {Currency, Limits: [{ContractID, Limit, LimitSpent}]}}`).

Live API behaviour was *not* re-verified due to absence of finance credentials in this session. If actual API drifts from docs, file a follow-up issue tagged `api-status:docs-drift` + `needs:live-verification`.

## Test plan

- [x] `pytest tests/test_v4finance_read.py -k get_credit_limits` — 8 passing.

Closes #430. Part of milestone 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)