### PR TITLE
docs(v4): stamp CheckPayment with docs-absence verification (closes #431)

### DIFF
--- a/direct_cli/v4_contracts.py
+++ b/direct_cli/v4_contracts.py
@@ -143,7 +143,10 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
             "Official public docs were not found. Sandbox v4 Live rejects "
             "PaymentID with error_code=71 and requires CustomTransactionID; "
             "a valid 32-character unknown CustomTransactionID reaches method "
-            "validation and returns error_code=370."
+            "validation and returns error_code=370. "
+            "Docs-verified 2026-05-28: method is absent from the v4 "
+            "_AllMethods index (dg-v4/ru/reference/_AllMethods); sandbox "
+            "behaviour remains the source of truth for the wire shape."
         ),
     ),
     "CreateInvoice": V4MethodContract(


### PR DESCRIPTION
## Summary

- Verified via the v4 _AllMethods index (`dg-v4/ru/reference/_AllMethods`) that CheckPayment is not present on the official Yandex Direct v4 documentation site.
- Existing notes already record that sandbox behaviour (`error_code=71` for `PaymentID`, `error_code=370` for unknown 32-char `CustomTransactionID`) is the source of truth for the wire shape.
- Stamps `direct_cli/v4_contracts.py:CheckPayment.notes` with a `Docs-verified 2026-05-28` line so the verification is explicit and dated.

## Verification

Index page checked: `https://yandex.ru/dev/direct/doc/dg-v4/ru/reference/_AllMethods` — CheckPayment absent. Per the milestone-22 methodology, docs-absence is recorded with a dated stamp; no live re-verification was performed (no finance credentials in this session).

## Test plan

- [x] `pytest tests/test_v4finance_money.py -k check_payment` — 9 passing.

Closes #431. Part of milestone 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)