### PR TITLE
feat(v4)!: drop --currency from transfer-money to match docs 1:1 (closes #432)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.3.15
+
+**BREAKING CHANGES:**
+
+- `direct v4finance transfer-money` no longer accepts `--currency`, and
+  the wire-body no longer carries `Currency` on `FromCampaigns`/
+  `ToCampaigns` items. The official v4 docs
+  (`dg-v4/reference/TransferMoney`) define `PayCampElement` with only
+  `CampaignID` and `Sum`; `Sum` is in conventional units. The CLI now
+  matches the docs 1:1. Closes #432.
+
 ## 0.3.14
 
 **Fixed:**

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ direct v4finance get-clients-units --logins client-login,other-client --format t
 direct v4finance get-credit-limits --master-token MASTER_TOKEN --operation-num 123 --finance-login agency-login
 direct v4finance create-invoice --payment 123=100.50 --payment 456=25 --currency RUB --master-token MASTER_TOKEN --operation-num 124 --finance-login agency-login --dry-run
 direct v4finance check-payment --custom-transaction-id A123456789012345678901234567890B
-direct v4finance transfer-money --from-campaign-id 123 --to-campaign-id 456 --amount 100.50 --currency RUB --master-token MASTER_TOKEN --operation-num 123 --finance-login agency-login --dry-run
+direct v4finance transfer-money --from-campaign-id 123 --to-campaign-id 456 --amount 100.50 --master-token MASTER_TOKEN --operation-num 123 --finance-login agency-login --dry-run
 direct v4finance pay-campaigns --campaign-ids 123,456 --amount 100.50 --currency RUB --contract-id CONTRACT_ID --pay-method Bank --master-token MASTER_TOKEN --operation-num 123 --finance-login agency-login --dry-run
 ```
 

--- a/direct_cli/commands/v4finance.py
+++ b/direct_cli/commands/v4finance.py
@@ -439,13 +439,6 @@ def create_invoice(
 )
 @click.option("--amount", required=True, help="Positive amount, for example 100.50")
 @click.option(
-    "--currency",
-    default="RUB",
-    show_default=True,
-    type=click.Choice(V4_FINANCE_CURRENCIES, case_sensitive=False),
-    help="Payment currency",
-)
-@click.option(
     "--finance-token",
     envvar="YANDEX_DIRECT_FINANCE_TOKEN",
     help="Precomputed financial token for this method",
@@ -480,7 +473,6 @@ def transfer_money(
     from_campaign_id,
     to_campaign_id,
     amount,
-    currency,
     finance_token,
     master_token,
     operation_num,
@@ -498,20 +490,17 @@ def transfer_money(
         ctx.obj.get("login"),
     )
     parsed_amount = parse_v4_money_sum(amount)
-    currency = currency.upper()
     param = {
         "FromCampaigns": [
             {
                 "CampaignID": from_campaign_id,
                 "Sum": parsed_amount,
-                "Currency": currency,
             },
         ],
         "ToCampaigns": [
             {
                 "CampaignID": to_campaign_id,
                 "Sum": parsed_amount,
-                "Currency": currency,
             },
         ],
     }

--- a/direct_cli/v4_contracts.py
+++ b/direct_cli/v4_contracts.py
@@ -92,12 +92,10 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
         },
         notes=(
             "Docs-verified 2026-05-28 against dg-v4/reference/TransferMoney: "
-            "PayCampElement carries only CampaignID and Sum. Sum is in "
-            "conventional units (условные единицы); no Currency field anywhere "
-            "in the request. Total from-sum must equal total to-sum or the "
-            "API returns error_code=353. CLI dropped the prior --currency "
-            "option to match docs exactly. This CLI exposes dry-run only; "
-            "the method is not live-probed."
+            "PayCampElement carries only CampaignID and Sum (conventional "
+            "units, условные единицы). Total from-sum must equal total "
+            "to-sum or the API returns error_code=353. This CLI exposes "
+            "dry-run only; the method is not live-probed."
         ),
     ),
     "PayCampaigns": V4MethodContract(

--- a/direct_cli/v4_contracts.py
+++ b/direct_cli/v4_contracts.py
@@ -87,13 +87,17 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
         source_status=SOURCE_DOCS,
         live_probe_allowed=False,
         example_param={
-            "FromCampaigns": [{"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"}],
-            "ToCampaigns": [{"CampaignID": 456, "Sum": 100.5, "Currency": "RUB"}],
+            "FromCampaigns": [{"CampaignID": 123, "Sum": 100.5}],
+            "ToCampaigns": [{"CampaignID": 456, "Sum": 100.5}],
         },
         notes=(
-            "Official v4 docs define campaign-to-campaign transfer with "
-            "Currency on each transfer item. "
-            "This CLI exposes dry-run only; the method is not live-probed."
+            "Docs-verified 2026-05-28 against dg-v4/reference/TransferMoney: "
+            "PayCampElement carries only CampaignID and Sum. Sum is in "
+            "conventional units (условные единицы); no Currency field anywhere "
+            "in the request. Total from-sum must equal total to-sum or the "
+            "API returns error_code=353. CLI dropped the prior --currency "
+            "option to match docs exactly. This CLI exposes dry-run only; "
+            "the method is not live-probed."
         ),
     ),
     "PayCampaigns": V4MethodContract(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "direct-cli"
-version = "0.3.14"
+version = "0.3.15"
 description = "Command-line interface for Yandex Direct API"
 readme = "README.md"
 license = {text = "MIT"}

--- a/scripts/test_dangerous_commands.sh
+++ b/scripts/test_dangerous_commands.sh
@@ -21,7 +21,7 @@ Local credential mutations:
   - direct auth use ...
 
 V4 Live finance money mutations (0.3.3 exposes dry-run-only previews):
-  - direct v4finance transfer-money --from-campaign-id ... --to-campaign-id ... --amount ... --currency ... --dry-run
+  - direct v4finance transfer-money --from-campaign-id ... --to-campaign-id ... --amount ... --dry-run
   - direct v4finance pay-campaigns --campaign-ids ... --amount ... --contract-id ... --pay-method ... --dry-run
 
 Production commands that are only allowed in automated smoke tests with --sandbox:

--- a/tests/API_COVERAGE.md
+++ b/tests/API_COVERAGE.md
@@ -59,8 +59,9 @@ The public v4/Live4 finance docs found during milestone 0.3.3 list
 No official `CheckPayment` page or `PaymentID` contract was found.
 Financial methods use an additional `finance_token`, computed from the
 master token, operation number, method name, and normalized login. Public
-dry-run examples mask the computed token. The docs-backed `PayCampaigns` and
-`TransferMoney` contracts require `Currency` on each payment/transfer item.
+dry-run examples mask the computed token. The docs-backed `PayCampaigns`
+contract requires `Currency` on each payment item; `TransferMoney`'s
+`PayCampElement` carries only `CampaignID` and `Sum` (no `Currency`).
 `CreateInvoice` is exposed as `v4finance create-invoice` with repeated
 `--payment CAMPAIGN_ID=AMOUNT` flags and sends docs-backed
 `Payments[].CampaignID/Sum/Currency`; its live write test is opt-in via

--- a/tests/test_v4_contracts.py
+++ b/tests/test_v4_contracts.py
@@ -198,8 +198,8 @@ def test_v4finance_money_contracts_are_docs_backed_dangerous_objects():
     assert build_v4_body("TransferMoney", transfer.example_param) == {
         "method": "TransferMoney",
         "param": {
-            "FromCampaigns": [{"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"}],
-            "ToCampaigns": [{"CampaignID": 456, "Sum": 100.5, "Currency": "RUB"}],
+            "FromCampaigns": [{"CampaignID": 123, "Sum": 100.5}],
+            "ToCampaigns": [{"CampaignID": 456, "Sum": 100.5}],
         },
     }
 

--- a/tests/test_v4finance_money.py
+++ b/tests/test_v4finance_money.py
@@ -89,8 +89,8 @@ def test_transfer_money_dry_run_uses_campaign_arrays_and_masks_finance_token():
     assert json.loads(result.output) == {
         "method": "TransferMoney",
         "param": {
-            "FromCampaigns": [{"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"}],
-            "ToCampaigns": [{"CampaignID": 456, "Sum": 100.5, "Currency": "RUB"}],
+            "FromCampaigns": [{"CampaignID": 123, "Sum": 100.5}],
+            "ToCampaigns": [{"CampaignID": 456, "Sum": 100.5}],
         },
         "finance_token": "<redacted>",
         "operation_num": 42,


### PR DESCRIPTION
## Summary

**BREAKING CHANGE.** Fetched https://yandex.ru/dev/direct/doc/dg-v4/reference/TransferMoney and confirmed that `PayCampElement` carries only `CampaignID` and `Sum` (in conventional units / условные единицы). No `Currency` field exists anywhere in the docs-defined request body.

The prior CLI implementation sent `Currency` on every `FromCampaigns`/`ToCampaigns` item, which is **not part of the docs-defined wire-shape**. To match the docs 1:1, this PR removes `--currency` from the command and drops `Currency` from the wire-body items.

## Changes

- Remove `--currency` option from `direct v4finance transfer-money`.
- Drop `Currency` from `FromCampaigns`/`ToCampaigns` items.
- Update `direct_cli/v4_contracts.py:TransferMoney` `example_param` and `notes` (`Docs-verified 2026-05-28`).
- Update `tests/test_v4finance_money.py:test_transfer_money_dry_run_*`.
- README example no longer passes `--currency`.
- Bump version to 0.3.15; CHANGELOG entry under BREAKING CHANGES.

## Migration

Before:

```
direct v4finance transfer-money --from-campaign-id 123 --to-campaign-id 456 --amount 100.50 --currency RUB --finance-token TOKEN --operation-num 42 --dry-run
```

After:

```
direct v4finance transfer-money --from-campaign-id 123 --to-campaign-id 456 --amount 100.50 --finance-token TOKEN --operation-num 42 --dry-run
```

The API takes `Sum` in conventional units; the currency is implied by the campaign, not by the CLI option.

## Test plan

- [x] `pytest tests/test_v4finance_money.py -k transfer_money` — 3 passing.
- [x] `pytest tests/test_v4finance_money.py tests/test_v4finance_read.py tests/test_comprehensive.py tests/test_cli.py` — 129 passing.
- [x] `direct v4finance transfer-money --help` — `--currency` absent.

## Verification

Live API was not re-verified due to absence of finance credentials in this session. If the API turns out to also accept the extra `Currency` field silently, no regression — but the docs-canonical shape is now what we send.

Closes #432. Part of milestone 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)