### PR TITLE
docs(v4): document AdImageAssociation Get/Set contracts (closes #436)

### DIFF
--- a/direct_cli/v4_contracts.py
+++ b/direct_cli/v4_contracts.py
@@ -464,11 +464,38 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
     "AdImageAssociation": V4MethodContract(
         method="AdImageAssociation",
         group="ad_image",
-        param_shape=PARAM_UNDOCUMENTED,
-        login_placement="unknown",
-        safety=SAFETY_WRITE,
-        source_status=SOURCE_UNDOCUMENTED,
+        param_shape=PARAM_OBJECT,
+        login_placement=(
+            "param contains Action and either SelectionCriteria (Get) or "
+            "AdImageAssociations[] (Set); global --login uses Client-Login "
+            "header"
+        ),
+        safety=SAFETY_MIXED,
+        source_status=SOURCE_DOCS,
         live_probe_allowed=False,
+        example_param={
+            "Action": "Get",
+            "SelectionCriteria": {
+                "Logins": ["client-login"],
+                "AdImageHashes": ["hash"],
+                "StatusAdImageModerate": ["Yes"],
+                "AdIDS": [123],
+                "CampaignIDS": [456],
+                "Limit": 20,
+                "Offset": 0,
+            },
+        },
+        notes=(
+            "Docs-verified 2026-05-28 against dg-v4/live/AdImageAssociation: "
+            "Action in {Get, Set}. Get reads ad-to-image associations via "
+            "param.SelectionCriteria with optional Logins/AdImageHashes/"
+            "StatusAdImageModerate/AdIDS/CampaignIDS/Limit/Offset (empty "
+            "SelectionCriteria returns up to 10000 associations). Set "
+            "writes param.AdImageAssociations[] (max 10000) with required "
+            "AdID and optional AdImageHash; omitting AdImageHash detaches "
+            "the image. No CLI command is exposed yet; this row only "
+            "records the contract."
+        ),
     ),
     "GetKeywordsSuggestion": V4MethodContract(
         method="GetKeywordsSuggestion",


### PR DESCRIPTION
## Summary

Fetched the official v4 docs for `AdImageAssociation` (overview + Get + Set sub-pages) and recorded the documented request shape in `direct_cli/v4_contracts.py:AdImageAssociation`.

## Findings

The method is action-discriminated like `AccountManagement`:

**Get** (read-only):
```json
{ "method": "AdImageAssociation",
  "param": { "Action": "Get",
             "SelectionCriteria": {
               "Logins": [...], "AdImageHashes": [...],
               "StatusAdImageModerate": [...], "AdIDS": [...],
               "CampaignIDS": [...], "Limit": ..., "Offset": ... } } }
```

**Set** (write):
```json
{ "method": "AdImageAssociation",
  "param": { "Action": "Set",
             "AdImageAssociations": [
               { "AdID": 2571700, "AdImageHash": "..." },
               { "AdID": 2571745 } ] } }
```

`AdImageHash` is optional on Set — omitting it (or passing null) detaches the image from the ad.

## Changes

| Field | Before | After |
|---|---|---|
| `param_shape` | `PARAM_UNDOCUMENTED` | `PARAM_OBJECT` |
| `safety` | `SAFETY_WRITE` | `SAFETY_MIXED` (Get=read, Set=write) |
| `source_status` | `SOURCE_UNDOCUMENTED` | `SOURCE_DOCS` |
| `example_param` | absent | Get-form payload with SelectionCriteria |
| `notes` | absent | full Get/Set field reference, max-10000 cap |

No CLI command is exposed yet; this row only records the contract.

## Test plan

- [x] `pytest tests/test_v4_live_contracts.py tests/test_comprehensive.py` — 21 passing, 11 skipped (live tests).

Closes #436. Part of milestone 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)