### PR TITLE
docs(v4): document DeleteOfflineReport contract (closes #437)

### DIFF
--- a/direct_cli/v4_contracts.py
+++ b/direct_cli/v4_contracts.py
@@ -374,11 +374,22 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
     "DeleteOfflineReport": V4MethodContract(
         method="DeleteOfflineReport",
         group="offline_reports",
-        param_shape=PARAM_UNDOCUMENTED,
-        login_placement="unknown",
+        param_shape=PARAM_SCALAR,
+        login_placement=(
+            "param is a scalar int (report ID); global --login uses "
+            "Client-Login header"
+        ),
         safety=SAFETY_WRITE,
-        source_status=SOURCE_UNDOCUMENTED,
+        source_status=SOURCE_DOCS,
         live_probe_allowed=False,
+        example_param=12345,
+        notes=(
+            "Docs-verified 2026-05-28 against dg-v4/live/DeleteOfflineReport: "
+            "param is the integer report ID. Response on success: "
+            "{\"data\": 1}. Method is disabled per official docs "
+            "(\"Метод отключен. Используйте API версии 5\"); v5 reports "
+            "API supersedes it. No CLI command is exposed."
+        ),
     ),
     "DeleteReport": V4MethodContract(
         method="DeleteReport",


### PR DESCRIPTION
## Summary

Fetched https://yandex.ru/dev/direct/doc/dg-v4/live/DeleteOfflineReport and recorded the contract in `direct_cli/v4_contracts.py:DeleteOfflineReport`.

## Findings

```json
{ "method": "DeleteOfflineReport", "param": <int> }
```

`param` is the integer report ID. Response on success: `{"data": 1}`. Docs explicitly mark the method as disabled: «Метод отключен. Используйте API версии 5».

## Changes

| Field | Before | After |
|---|---|---|
| `param_shape` | `PARAM_UNDOCUMENTED` | `PARAM_SCALAR` |
| `source_status` | `SOURCE_UNDOCUMENTED` | `SOURCE_DOCS` |
| `example_param` | absent | `12345` |
| `notes` | absent | `Docs-verified 2026-05-28 ...` |

No CLI command is exposed.

## Test plan

- [x] `pytest tests/test_v4_live_contracts.py tests/test_comprehensive.py` — 21 passing, 11 skipped.

Closes #437. Part of milestone 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)