### PR TITLE
docs(v4): document DeleteReport contract (closes #438)

### DIFF
--- a/direct_cli/v4_contracts.py
+++ b/direct_cli/v4_contracts.py
@@ -383,11 +383,24 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
     "DeleteReport": V4MethodContract(
         method="DeleteReport",
         group="offline_reports",
-        param_shape=PARAM_UNDOCUMENTED,
-        login_placement="unknown",
+        param_shape=PARAM_SCALAR,
+        login_placement=(
+            "param is a scalar int (report ID); global --login uses "
+            "Client-Login header"
+        ),
         safety=SAFETY_WRITE,
-        source_status=SOURCE_UNDOCUMENTED,
+        source_status=SOURCE_DOCS,
         live_probe_allowed=False,
+        example_param=12345,
+        notes=(
+            "Docs-verified 2026-05-28 against dg-v4/reference/DeleteReport: "
+            "param is the integer report ID obtained via GetReportList. "
+            "Response on success: {\"data\": 1}. Reports are auto-removed "
+            "after 5 hours. Method is listed under disabled methods "
+            "(\"Отключенные методы\") in official docs; distinct entry "
+            "from DeleteOfflineReport (same wire shape, separate v4 "
+            "reference page). No CLI command is exposed."
+        ),
     ),
     "GetBannersTags": V4MethodContract(
         method="GetBannersTags",


### PR DESCRIPTION
## Summary

Fetched https://yandex.ru/dev/direct/doc/dg-v4/reference/DeleteReport and recorded the contract in `direct_cli/v4_contracts.py:DeleteReport`.

## Findings

```json
{ "method": "DeleteReport", "param": <int> }
```

- `param` is the integer report ID obtained via `GetReportList`.
- Response on success: `{"data": 1}`.
- Reports are auto-removed after 5 hours.
- Method is listed under disabled methods («Отключенные методы») in official docs.

**Relationship to `DeleteOfflineReport`:** distinct registry entry with the same wire shape, served from a separate v4 reference page. They are not aliases.

## Changes

| Field | Before | After |
|---|---|---|
| `param_shape` | `PARAM_UNDOCUMENTED` | `PARAM_SCALAR` |
| `source_status` | `SOURCE_UNDOCUMENTED` | `SOURCE_DOCS` |
| `example_param` | absent | `12345` |
| `notes` | absent | `Docs-verified 2026-05-28 ...` |

No CLI command is exposed.

## Test plan

- [x] `pytest tests/test_v4_live_contracts.py tests/test_comprehensive.py` — 21 passing, 11 skipped.

Closes #438. Part of milestone 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)