### PR TITLE
fix(v4)!: restore --currency for live finance methods (regression from #441/#442/#443)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.3.16
+
+**BREAKING CHANGES (regression fix — reverts 0.3.15 wire-shape changes):**
+
+- `direct v4finance transfer-money` now requires `--currency` again and
+  re-emits `Currency` on every `FromCampaigns` / `ToCampaigns` item.
+  The 0.3.15 removal verified against `dg-v4/reference/TransferMoney`
+  (legacy v4); the actual Live 4 docs at
+  `dg-v4/live/TransferMoney` define `PayCampElement` with
+  `CampaignID`, `Sum`, and `Currency`, and explicitly mark `Currency` as
+  obligatory in the Live 4 changelog. The CLI now matches the live
+  docs 1:1. See audit comment on #125 for the reproducible diff.
+- `direct v4finance pay-campaigns` now requires `--currency` again and
+  re-emits `Currency` on every `Payments[]` item. Same root cause:
+  `dg-v4/reference/PayCampaigns` (legacy) lacks `Currency`,
+  `dg-v4/live/PayCampaigns` (Live 4) requires it.
+- `direct v4finance pay-campaigns` accepts `--pay-method Overdraft`
+  again. The Live 4 changelog explicitly adds `Overdraft` for direct
+  advertisers (paired with `Bank` for agencies). Only `Bank` keeps the
+  `--contract-id` requirement.
+- `direct v4finance create-invoice` now requires `--currency` again and
+  re-emits `Currency` on every `Payments[]` item, mirroring
+  `dg-v4/live/CreateInvoice`.
+
+This release reverts the wire-shape changes shipped by PRs #441, #442,
+#443 (which closed #432, #433, #434). The CLI lives in the `v4finance`
+Live group and must mirror `dg-v4/live/*`, not `dg-v4/reference/*`.
+
 ## 0.3.15
 
 **BREAKING CHANGES:**

--- a/README.md
+++ b/README.md
@@ -189,10 +189,10 @@ is omitted. Dry-run output masks the financial token.
 ```bash
 direct v4finance get-clients-units --logins client-login,other-client --format table
 direct v4finance get-credit-limits --master-token MASTER_TOKEN --operation-num 123 --finance-login agency-login
-direct v4finance create-invoice --payment 123=100.50 --payment 456=25 --master-token MASTER_TOKEN --operation-num 124 --finance-login agency-login --dry-run
+direct v4finance create-invoice --payment 123=100.50 --payment 456=25 --currency RUB --master-token MASTER_TOKEN --operation-num 124 --finance-login agency-login --dry-run
 direct v4finance check-payment --custom-transaction-id A123456789012345678901234567890B
-direct v4finance transfer-money --from-campaign-id 123 --to-campaign-id 456 --amount 100.50 --master-token MASTER_TOKEN --operation-num 123 --finance-login agency-login --dry-run
-direct v4finance pay-campaigns --campaign-ids 123,456 --amount 100.50 --contract-id CONTRACT_ID --pay-method Bank --master-token MASTER_TOKEN --operation-num 123 --finance-login agency-login --dry-run
+direct v4finance transfer-money --from-campaign-id 123 --to-campaign-id 456 --amount 100.50 --currency RUB --master-token MASTER_TOKEN --operation-num 123 --finance-login agency-login --dry-run
+direct v4finance pay-campaigns --campaign-ids 123,456 --amount 100.50 --contract-id CONTRACT_ID --pay-method Bank --currency RUB --master-token MASTER_TOKEN --operation-num 123 --finance-login agency-login --dry-run
 ```
 
 ### V4 Live Shared Account

--- a/direct_cli/commands/v4finance.py
+++ b/direct_cli/commands/v4finance.py
@@ -15,7 +15,8 @@ from .v4shells import V4_EPILOG
 
 FINANCE_TOKEN_MASK = "<redacted>"
 CUSTOM_TRANSACTION_ID_RE = re.compile(r"[A-Za-z0-9]{32}")
-V4_PAY_METHODS = ["Bank"]
+V4_PAY_METHODS = ["Bank", "Overdraft"]
+V4_FINANCE_CURRENCIES = ("RUB", "CHF", "EUR", "KZT", "TRY", "UAH", "USD", "BYN")
 FINANCE_HELP_EPILOG = (
     "To issue a master token in the Yandex Direct UI, open Tools -> API -> "
     "Financial operations, enable the 'Allow financial operations' checkbox, "
@@ -33,11 +34,12 @@ def _logins_param(logins: str) -> list[str]:
     return login_list
 
 
-def _invoice_payments_param(payments: tuple[str, ...]) -> dict:
+def _invoice_payments_param(payments: tuple[str, ...], currency: str) -> dict:
     """Build the v4 Live CreateInvoice payment object parameter."""
     if not payments:
         raise click.UsageError("--payment is required")
 
+    normalized_currency = currency.upper()
     parsed_payments = []
     seen_campaign_ids = set()
     for payment in payments:
@@ -62,6 +64,7 @@ def _invoice_payments_param(payments: tuple[str, ...]) -> dict:
             {
                 "CampaignID": campaign_id,
                 "Sum": parse_v4_money_sum(amount_text),
+                "Currency": normalized_currency,
             }
         )
 
@@ -331,6 +334,12 @@ def check_payment(
     help="Invoice payment as CAMPAIGN_ID=AMOUNT; repeat for multiple campaigns",
 )
 @click.option(
+    "--currency",
+    required=True,
+    type=click.Choice(V4_FINANCE_CURRENCIES, case_sensitive=False),
+    help="Payment currency (RUB/CHF/EUR/KZT/TRY/UAH/USD/BYN)",
+)
+@click.option(
     "--finance-token",
     envvar="YANDEX_DIRECT_FINANCE_TOKEN",
     help="Precomputed financial token for this method",
@@ -367,6 +376,7 @@ def check_payment(
 def create_invoice(
     ctx,
     payments,
+    currency,
     finance_token,
     master_token,
     operation_num,
@@ -384,7 +394,7 @@ def create_invoice(
         "CreateInvoice",
         ctx.obj.get("login"),
     )
-    param = _invoice_payments_param(payments)
+    param = _invoice_payments_param(payments, currency)
 
     if dry_run:
         format_output(
@@ -428,6 +438,12 @@ def create_invoice(
 )
 @click.option("--amount", required=True, help="Positive amount, for example 100.50")
 @click.option(
+    "--currency",
+    required=True,
+    type=click.Choice(V4_FINANCE_CURRENCIES, case_sensitive=False),
+    help="Transfer currency (RUB/CHF/EUR/KZT/TRY/UAH/USD/BYN)",
+)
+@click.option(
     "--finance-token",
     envvar="YANDEX_DIRECT_FINANCE_TOKEN",
     help="Precomputed financial token for this method",
@@ -462,6 +478,7 @@ def transfer_money(
     from_campaign_id,
     to_campaign_id,
     amount,
+    currency,
     finance_token,
     master_token,
     operation_num,
@@ -479,17 +496,20 @@ def transfer_money(
         ctx.obj.get("login"),
     )
     parsed_amount = parse_v4_money_sum(amount)
+    normalized_currency = currency.upper()
     param = {
         "FromCampaigns": [
             {
                 "CampaignID": from_campaign_id,
                 "Sum": parsed_amount,
+                "Currency": normalized_currency,
             },
         ],
         "ToCampaigns": [
             {
                 "CampaignID": to_campaign_id,
                 "Sum": parsed_amount,
+                "Currency": normalized_currency,
             },
         ],
     }
@@ -514,7 +534,13 @@ def transfer_money(
     "--pay-method",
     required=True,
     type=click.Choice(V4_PAY_METHODS, case_sensitive=False),
-    help="Payment method",
+    help="Payment method: Bank (agency credit) or Overdraft (direct advertiser)",
+)
+@click.option(
+    "--currency",
+    required=True,
+    type=click.Choice(V4_FINANCE_CURRENCIES, case_sensitive=False),
+    help="Payment currency (RUB/CHF/EUR/KZT/TRY/UAH/USD/BYN)",
 )
 @click.option(
     "--finance-token",
@@ -552,6 +578,7 @@ def pay_campaigns(
     amount,
     contract_id,
     pay_method,
+    currency,
     finance_token,
     master_token,
     operation_num,
@@ -571,12 +598,17 @@ def pay_campaigns(
     parsed_amount = parse_v4_money_sum(amount)
     parsed_campaign_ids = _campaign_ids_param(campaign_ids)
     pay_method = _non_empty_option(pay_method, "--pay-method")
+    normalized_currency = currency.upper()
     contract_id = (contract_id or "").strip()
     if pay_method == "Bank" and not contract_id:
         raise click.UsageError("--contract-id is required when --pay-method Bank")
     param = {
         "Payments": [
-            {"CampaignID": campaign_id, "Sum": parsed_amount}
+            {
+                "CampaignID": campaign_id,
+                "Sum": parsed_amount,
+                "Currency": normalized_currency,
+            }
             for campaign_id in parsed_campaign_ids
         ],
         "PayMethod": pay_method,

--- a/direct_cli/v4_contracts.py
+++ b/direct_cli/v4_contracts.py
@@ -87,15 +87,20 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
         source_status=SOURCE_DOCS,
         live_probe_allowed=False,
         example_param={
-            "FromCampaigns": [{"CampaignID": 123, "Sum": 100.5}],
-            "ToCampaigns": [{"CampaignID": 456, "Sum": 100.5}],
+            "FromCampaigns": [
+                {"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"}
+            ],
+            "ToCampaigns": [
+                {"CampaignID": 456, "Sum": 100.5, "Currency": "RUB"}
+            ],
         },
         notes=(
-            "Docs-verified 2026-05-28 against dg-v4/reference/TransferMoney: "
-            "PayCampElement carries only CampaignID and Sum (conventional "
-            "units, условные единицы). Total from-sum must equal total "
-            "to-sum or the API returns error_code=353. This CLI exposes "
-            "dry-run only; the method is not live-probed."
+            "Docs-verified 2026-05-29 against dg-v4/live/TransferMoney: "
+            "PayCampElement carries CampaignID, Sum, and Currency; the Live 4 "
+            "changelog explicitly marks Currency as a newly required input "
+            "field. Total from-sum must equal total to-sum or the API "
+            "returns error_code=353. This CLI exposes dry-run only; the "
+            "method is not live-probed."
         ),
     ),
     "PayCampaigns": V4MethodContract(
@@ -110,17 +115,19 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
         source_status=SOURCE_DOCS,
         live_probe_allowed=False,
         example_param={
-            "Payments": [{"CampaignID": 123, "Sum": 100.5}],
+            "Payments": [
+                {"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"}
+            ],
             "ContractID": "contract-id",
             "PayMethod": "Bank",
         },
         notes=(
-            "Docs-verified 2026-05-28 against dg-v4/reference/PayCampaigns: "
-            "PayCampElement carries only CampaignID and Sum (conventional "
-            "units); PayMethod currently accepts 'Bank' only. The CLI "
-            "dropped --currency and the undocumented 'Overdraft' PayMethod "
-            "value in 0.3.15 (BREAKING) to mirror docs 1:1. This CLI "
-            "exposes dry-run only; the method is not live-probed."
+            "Docs-verified 2026-05-29 against dg-v4/live/PayCampaigns: "
+            "PayCampElement carries CampaignID, Sum, and Currency (Currency "
+            "marked obligatory in the Live 4 changelog). PayMethod accepts "
+            "'Bank' (agency credit) and 'Overdraft' (direct advertiser), "
+            "both listed in the Live 4 changelog. This CLI exposes dry-run "
+            "only; the method is not live-probed."
         ),
     ),
     "PayCampaignsByCard": V4MethodContract(
@@ -166,14 +173,15 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
         source_status=SOURCE_DOCS,
         live_probe_allowed=False,
         example_param={
-            "Payments": [{"CampaignID": 123, "Sum": 100.5}],
+            "Payments": [
+                {"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"}
+            ],
         },
         notes=(
-            "Docs-verified 2026-05-28 against dg-v4/reference/CreateInvoice: "
-            "PayCampElement carries only CampaignID and Sum (conventional "
-            "units). The CLI dropped --currency in 0.3.15 (BREAKING) to "
-            "mirror docs 1:1. The method has no v5 equivalent and requires "
-            "finance_token plus operation_num."
+            "Docs-verified 2026-05-29 against dg-v4/live/CreateInvoice: "
+            "PayCampElement carries CampaignID, Sum, and Currency (Currency "
+            "marked obligatory in the Live 4 changelog). The method has no "
+            "v5 equivalent and requires finance_token plus operation_num."
         ),
     ),
     "AccountManagement": V4MethodContract(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "direct-cli"
-version = "0.3.15"
+version = "0.3.16"
 description = "Command-line interface for Yandex Direct API"
 readme = "README.md"
 license = {text = "MIT"}

--- a/scripts/test_dangerous_commands.sh
+++ b/scripts/test_dangerous_commands.sh
@@ -21,8 +21,8 @@ Local credential mutations:
   - direct auth use ...
 
 V4 Live finance money mutations (0.3.3 exposes dry-run-only previews):
-  - direct v4finance transfer-money --from-campaign-id ... --to-campaign-id ... --amount ... --dry-run
-  - direct v4finance pay-campaigns --campaign-ids ... --amount ... --contract-id ... --pay-method ... --dry-run
+  - direct v4finance transfer-money --from-campaign-id ... --to-campaign-id ... --amount ... --currency RUB --dry-run
+  - direct v4finance pay-campaigns --campaign-ids ... --amount ... --contract-id ... --pay-method Bank --currency RUB --dry-run
 
 Production commands that are only allowed in automated smoke tests with --sandbox:
   - direct bids set ...

--- a/tests/API_COVERAGE.md
+++ b/tests/API_COVERAGE.md
@@ -60,12 +60,17 @@ No official `CheckPayment` page or `PaymentID` contract was found.
 Financial methods use an additional `finance_token`, computed from the
 master token, operation number, method name, and normalized login. Public
 dry-run examples mask the computed token. The docs-backed `PayCampaigns`,
-`TransferMoney`, and `CreateInvoice` `PayCampElement` carries only
-`CampaignID` and `Sum` (no `Currency`); `PayCampaigns.PayMethod` is
-`'Bank'` only. `CreateInvoice` is exposed as `v4finance create-invoice`
-with repeated `--payment CAMPAIGN_ID=AMOUNT` flags and sends docs-backed
-`Payments[].CampaignID/Sum`; its live write test is opt-in via
-`YANDEX_DIRECT_LIVE_FINANCE_WRITE=1`.
+`TransferMoney`, and `CreateInvoice` `PayCampElement` carries
+`CampaignID`, `Sum`, and `Currency` per `dg-v4/live/*` — the Live 4
+changelog explicitly marks `Currency` as obligatory and `PayCampaigns`
+adds `Overdraft` as a valid `PayMethod` alongside `Bank` (only `Bank`
+requires `--contract-id`). `CreateInvoice` is exposed as `v4finance
+create-invoice` with repeated `--payment CAMPAIGN_ID=AMOUNT` flags plus
+a single `--currency` flag and sends docs-backed
+`Payments[].CampaignID/Sum/Currency`; its live write test is opt-in via
+`YANDEX_DIRECT_LIVE_FINANCE_WRITE=1`. The `dg-v4/reference/*` (legacy
+v4) pages omit `Currency` and are NOT the source of truth for these
+Live 4 commands — see audit comment on #125 for the reproducible diff.
 
 Sandbox v4 Live probes on 2026-04-30 confirmed the runtime request shape for
 `CheckPayment`:

--- a/tests/test_v4_contracts.py
+++ b/tests/test_v4_contracts.py
@@ -198,8 +198,12 @@ def test_v4finance_money_contracts_are_docs_backed_dangerous_objects():
     assert build_v4_body("TransferMoney", transfer.example_param) == {
         "method": "TransferMoney",
         "param": {
-            "FromCampaigns": [{"CampaignID": 123, "Sum": 100.5}],
-            "ToCampaigns": [{"CampaignID": 456, "Sum": 100.5}],
+            "FromCampaigns": [
+                {"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"}
+            ],
+            "ToCampaigns": [
+                {"CampaignID": 456, "Sum": 100.5, "Currency": "RUB"}
+            ],
         },
     }
 
@@ -209,7 +213,9 @@ def test_v4finance_money_contracts_are_docs_backed_dangerous_objects():
     assert build_v4_body("PayCampaigns", pay.example_param) == {
         "method": "PayCampaigns",
         "param": {
-            "Payments": [{"CampaignID": 123, "Sum": 100.5}],
+            "Payments": [
+                {"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"}
+            ],
             "ContractID": "contract-id",
             "PayMethod": "Bank",
         },
@@ -223,7 +229,9 @@ def test_v4finance_money_contracts_are_docs_backed_dangerous_objects():
     assert build_v4_body("CreateInvoice", create_invoice.example_param) == {
         "method": "CreateInvoice",
         "param": {
-            "Payments": [{"CampaignID": 123, "Sum": 100.5}],
+            "Payments": [
+                {"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"}
+            ],
         },
     }
 

--- a/tests/test_v4_live_contracts.py
+++ b/tests/test_v4_live_contracts.py
@@ -199,6 +199,7 @@ def test_v4_live_create_invoice_contract_opt_in_write():
                 {
                     "CampaignID": parsed_campaign_id,
                     "Sum": 1.0,
+                    "Currency": "RUB",
                 }
             ]
         },

--- a/tests/test_v4finance_money.py
+++ b/tests/test_v4finance_money.py
@@ -77,6 +77,8 @@ def test_transfer_money_dry_run_uses_campaign_arrays_and_masks_finance_token():
         "456",
         "--amount",
         "100.50",
+        "--currency",
+        "RUB",
         "--finance-token",
         "secret-finance-token",
         "--operation-num",
@@ -89,8 +91,12 @@ def test_transfer_money_dry_run_uses_campaign_arrays_and_masks_finance_token():
     assert json.loads(result.output) == {
         "method": "TransferMoney",
         "param": {
-            "FromCampaigns": [{"CampaignID": 123, "Sum": 100.5}],
-            "ToCampaigns": [{"CampaignID": 456, "Sum": 100.5}],
+            "FromCampaigns": [
+                {"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"}
+            ],
+            "ToCampaigns": [
+                {"CampaignID": 456, "Sum": 100.5, "Currency": "RUB"}
+            ],
         },
         "finance_token": "<redacted>",
         "operation_num": 42,
@@ -109,6 +115,8 @@ def test_pay_campaigns_dry_run_uses_payment_object_and_masks_finance_token():
         "contract-id",
         "--pay-method",
         "Bank",
+        "--currency",
+        "RUB",
         "--finance-token",
         "secret-finance-token",
         "--operation-num",
@@ -122,8 +130,8 @@ def test_pay_campaigns_dry_run_uses_payment_object_and_masks_finance_token():
         "method": "PayCampaigns",
         "param": {
             "Payments": [
-                {"CampaignID": 123, "Sum": 100.5},
-                {"CampaignID": 456, "Sum": 100.5},
+                {"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"},
+                {"CampaignID": 456, "Sum": 100.5, "Currency": "RUB"},
             ],
             "ContractID": "contract-id",
             "PayMethod": "Bank",
@@ -139,6 +147,8 @@ def test_create_invoice_dry_run_uses_payment_object_and_masks_finance_token():
         "create-invoice",
         "--payment",
         "123=100.50",
+        "--currency",
+        "RUB",
         "--finance-token",
         "secret-finance-token",
         "--operation-num",
@@ -152,7 +162,7 @@ def test_create_invoice_dry_run_uses_payment_object_and_masks_finance_token():
         "method": "CreateInvoice",
         "param": {
             "Payments": [
-                {"CampaignID": 123, "Sum": 100.5},
+                {"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"},
             ],
         },
         "finance_token": "<redacted>",
@@ -168,6 +178,8 @@ def test_create_invoice_dry_run_accepts_multiple_payments():
         "123=100.50",
         "--payment",
         "456=1",
+        "--currency",
+        "RUB",
         "--finance-token",
         "secret-finance-token",
         "--operation-num",
@@ -178,8 +190,8 @@ def test_create_invoice_dry_run_accepts_multiple_payments():
     assert result.exit_code == 0
     assert json.loads(result.output)["param"] == {
         "Payments": [
-            {"CampaignID": 123, "Sum": 100.5},
-            {"CampaignID": 456, "Sum": 1.0},
+            {"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"},
+            {"CampaignID": 456, "Sum": 1.0, "Currency": "RUB"},
         ],
     }
 
@@ -194,6 +206,8 @@ def test_transfer_money_uses_finance_env_fallback_for_dry_run():
         "456",
         "--amount",
         "100.50",
+        "--currency",
+        "RUB",
         "--dry-run",
         env={
             "YANDEX_DIRECT_FINANCE_TOKEN": "env-finance-token",
@@ -218,6 +232,8 @@ def test_transfer_money_can_compute_finance_token_from_master_token():
             "456",
             "--amount",
             "100.50",
+            "--currency",
+            "RUB",
             "--master-token",
             "master-token",
             "--operation-num",
@@ -245,6 +261,8 @@ def test_create_invoice_can_compute_finance_token_from_master_token():
             "create-invoice",
             "--payment",
             "123=100.50",
+            "--currency",
+            "RUB",
             "--master-token",
             "master-token",
             "--operation-num",
@@ -274,6 +292,8 @@ def test_finance_credentials_reject_token_and_master_token_conflict():
         "456",
         "--amount",
         "100.50",
+        "--currency",
+        "RUB",
         "--finance-token",
         "finance-token",
         "--master-token",
@@ -297,6 +317,8 @@ def test_master_token_requires_finance_login_without_login_fallback():
         "456",
         "--amount",
         "100.50",
+        "--currency",
+        "RUB",
         "--master-token",
         "master-token",
         "--operation-num",
@@ -321,6 +343,8 @@ def test_v4finance_money_commands_require_dry_run_before_api_call():
             "456",
             "--amount",
             "100.50",
+            "--currency",
+            "RUB",
             "--finance-token",
             "finance-token",
             "--operation-num",
@@ -347,6 +371,8 @@ def test_v4finance_money_commands_require_finance_credentials_before_api_call():
             "contract-id",
             "--pay-method",
             "Bank",
+            "--currency",
+            "RUB",
             "--dry-run",
         )
 
@@ -366,6 +392,8 @@ def test_v4finance_money_commands_validate_amount_before_api_call():
             "456",
             "--amount",
             "0",
+            "--currency",
+            "RUB",
             "--finance-token",
             "finance-token",
             "--operation-num",
@@ -398,6 +426,8 @@ def test_create_invoice_rejects_invalid_payment_specs_before_api_call(
             "create-invoice",
             "--payment",
             payment,
+            "--currency",
+            "RUB",
             "--finance-token",
             "finance-token",
             "--operation-num",
@@ -419,6 +449,8 @@ def test_create_invoice_rejects_duplicate_campaign_ids_before_api_call():
             "123=100",
             "--payment",
             "123=200",
+            "--currency",
+            "RUB",
             "--finance-token",
             "finance-token",
             "--operation-num",
@@ -443,6 +475,8 @@ def test_v4finance_money_commands_reject_blank_string_options():
         "contract-id",
         "--pay-method",
         "Invalid",
+        "--currency",
+        "RUB",
         "--finance-token",
         "finance-token",
         "--operation-num",
@@ -464,6 +498,8 @@ def test_pay_campaigns_requires_contract_for_bank():
         "100.50",
         "--pay-method",
         "Bank",
+        "--currency",
+        "RUB",
         "--finance-token",
         "finance-token",
         "--operation-num",
@@ -487,6 +523,8 @@ def test_pay_campaigns_rejects_non_positive_campaign_ids():
         "contract-id",
         "--pay-method",
         "Bank",
+        "--currency",
+        "RUB",
         "--finance-token",
         "finance-token",
         "--operation-num",
@@ -498,7 +536,9 @@ def test_pay_campaigns_rejects_non_positive_campaign_ids():
     assert "--campaign-ids must contain only positive integers" in result.output
 
 
-def test_pay_campaigns_rejects_undocumented_pay_method():
+def test_pay_campaigns_accepts_overdraft_pay_method_for_direct_advertisers():
+    # Live 4 changelog explicitly added "Overdraft" as a valid PayMethod for
+    # direct advertisers; only Bank requires --contract-id.
     result = _invoke(
         "v4finance",
         "pay-campaigns",
@@ -508,6 +548,36 @@ def test_pay_campaigns_rejects_undocumented_pay_method():
         "100.50",
         "--pay-method",
         "Overdraft",
+        "--currency",
+        "RUB",
+        "--finance-token",
+        "finance-token",
+        "--operation-num",
+        "42",
+        "--dry-run",
+    )
+
+    assert result.exit_code == 0
+    body = json.loads(result.output)
+    assert body["param"]["PayMethod"] == "Overdraft"
+    assert "ContractID" not in body["param"]
+    assert body["param"]["Payments"] == [
+        {"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"},
+    ]
+
+
+def test_pay_campaigns_rejects_undocumented_pay_method():
+    result = _invoke(
+        "v4finance",
+        "pay-campaigns",
+        "--campaign-ids",
+        "123",
+        "--amount",
+        "100.50",
+        "--pay-method",
+        "CreditCard",
+        "--currency",
+        "RUB",
         "--finance-token",
         "finance-token",
         "--operation-num",
@@ -610,6 +680,8 @@ def test_create_invoice_formats_mocked_response_as_json():
                 "create-invoice",
                 "--payment",
                 "123=100.50",
+                "--currency",
+                "RUB",
                 "--finance-token",
                 "finance-token",
                 "--operation-num",
@@ -631,7 +703,7 @@ def test_create_invoice_formats_mocked_response_as_json():
         "CreateInvoice",
         {
             "Payments": [
-                {"CampaignID": 123, "Sum": 100.5},
+                {"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"},
             ],
         },
     )


### PR DESCRIPTION
## Summary

- Restores `--currency` (required) and `Currency` wire-field on `v4finance transfer-money` / `pay-campaigns` / `create-invoice` after they were dropped in PRs #441/#442/#443 as «docs 1:1». The docs source those PRs cited was `dg-v4/reference/<Method>` (legacy v4 pre-Live), while the CLI lives in the `v4finance` Live group and must mirror `dg-v4/live/<Method>` — where `Currency` is explicitly marked obligatory in the Live 4 changelog.
- Re-enables `Overdraft` as a valid `--pay-method` for `pay-campaigns` (Live 4 changelog adds it for direct advertisers; `--contract-id` stays required only for `Bank`).
- Updates `v4_contracts.py` `example_param` and `notes` to point at the live URLs and the 2026-05-29 verification.
- Bumps to `0.3.16` with a `BREAKING CHANGES` section in CHANGELOG that explicitly frames the change as a revert.

## Root cause (verified, reproducible)

```bash
curl -sL https://yandex.ru/dev/direct/doc/dg-v4/live/PayCampaigns.html \\
  | grep -oE 'PayCampElement[^}]+\\}' | head -1
# → PayCampElement */ "CampaignID" : (int), "Sum" : (float), "Currency" : (string) }
```

Live pages for all three methods (TransferMoney / PayCampaigns / CreateInvoice) contain:

1. JSON request schema with `Currency: (string)` inside `PayCampElement`.
2. Parameter table row `Currency → required: Да`.
3. Changelog «Новое в версии Live 4: Входной параметр Currency стал обязательным».
4. Request examples with `'Currency': 'RUB'`.

Reference URLs lack all four — they describe v4 before Live 4.

Full root-cause diff and per-URL comparison table is in the issue audit comment: https://github.com/axisrow/direct-cli/issues/125#issuecomment-4567992962

## Test plan

- [x] `pytest tests/` — 1908 passed, 84 skipped (existing skips: opt-in live writes).
- [x] `direct v4finance transfer-money --from-campaign-id 1 --to-campaign-id 2 --amount 100.50 --currency RUB --finance-token X --operation-num 1 --dry-run` — JSON contains `Currency: "RUB"` in both items.
- [x] `direct v4finance pay-campaigns --pay-method Overdraft ...` accepted (without `--contract-id`).
- [x] `direct v4finance create-invoice --payment 1=10 --currency RUB ...` emits Currency in each `Payments[]` item.
- [ ] Opt-in live verification under `YANDEX_DIRECT_LIVE_FINANCE_WRITE=1` once a sandbox campaign is available (test body already updated to include `Currency: "RUB"`).

## Audit comment posted to #125

https://github.com/axisrow/direct-cli/issues/125#issuecomment-4567992962