### PR TITLE
feat(v4): expose all documented GetEventsLog & CreateNewForecast input fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ direct v4tags update-banners --banner-ids 2571700 --clear-tags --dry-run
 ```bash
 direct v4events get-events-log --from 2026-04-14T00:00:00 --to 2026-04-15T00:00:00
 direct v4events get-events-log --from 2026-04-14T00:00:00 --to 2026-04-15T00:00:00 --currency RUB --limit 100 --offset 0 --format table
+direct v4events get-events-log --from 2026-04-14T00:00:00 --to 2026-04-15T00:00:00 --last-event-only Yes --with-text-description Yes --filter-campaign-ids 123,456 --filter-event-type MoneyOut,MoneyIn
 ```
 
 ### V4 Live Wordstat Reports
@@ -166,6 +167,7 @@ the forecast is ready.
 
 ```bash
 direct v4forecast create --phrases "buy laptop,buy desktop" --geo-ids 213 --currency RUB
+direct v4forecast create --phrases "buy laptop" --geo-ids 213 --auction-bids Yes --common-minus-words "used,broken"
 direct v4forecast list --format table
 direct v4forecast get --forecast-id 123 --format table
 direct v4forecast delete --forecast-id 123

--- a/direct_cli/commands/v4events.py
+++ b/direct_cli/commands/v4events.py
@@ -8,12 +8,62 @@ import click
 
 from ..api import create_v4_client
 from ..output import format_output, print_error
+from ..utils import parse_csv_strings, parse_ids
 from ..v4 import build_v4_body, call_v4
 from ..v4_contracts import v4_method_contract
 from .v4shells import V4_EPILOG
 
 V4_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S"
 V4_DATETIME_RE = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}")
+
+# Documented GetEventsLogFilter.EventType enum (dg-v4/live/GetEventsLog).
+EVENT_TYPES = [
+    "BannerModerated",
+    "CampaignFinished",
+    "LowCTR",
+    "MoneyOut",
+    "MoneyWarning",
+    "MoneyIn",
+    "PausedByDayBudget",
+    "WarnMinPrice",
+    "WarnPlace",
+]
+
+
+def _events_log_filter(
+    campaign_ids: Optional[str],
+    banner_ids: Optional[str],
+    phrase_ids: Optional[str],
+    account_ids: Optional[str],
+    event_type: Optional[str],
+) -> Optional[dict]:
+    """Build the GetEventsLogFilter object; None when no filter is provided."""
+    filter_obj: dict = {}
+    for option_name, raw, key in (
+        ("--filter-campaign-ids", campaign_ids, "CampaignIDS"),
+        ("--filter-banner-ids", banner_ids, "BannerIDS"),
+        ("--filter-phrase-ids", phrase_ids, "PhraseIDS"),
+        ("--filter-account-ids", account_ids, "AccountIDS"),
+    ):
+        if not raw:
+            continue
+        try:
+            parsed = parse_ids(raw)
+        except ValueError as exc:
+            raise click.UsageError(f"{option_name}: {exc}") from exc
+        if parsed:
+            filter_obj[key] = parsed
+    if event_type:
+        types = parse_csv_strings(event_type)
+        if types:
+            unknown = [value for value in types if value not in EVENT_TYPES]
+            if unknown:
+                raise click.UsageError(
+                    "--filter-event-type has unknown values: "
+                    f"{', '.join(unknown)}. Valid values: {', '.join(EVENT_TYPES)}"
+                )
+            filter_obj["EventType"] = types
+    return filter_obj or None
 
 
 def _parse_v4_datetime(value: str, option_name: str) -> datetime:
@@ -36,6 +86,14 @@ def _events_log_param(
     currency: str,
     limit: Optional[int],
     offset: Optional[int],
+    last_event_only: Optional[str] = None,
+    with_text_description: Optional[str] = None,
+    logins: Optional[str] = None,
+    campaign_ids: Optional[str] = None,
+    banner_ids: Optional[str] = None,
+    phrase_ids: Optional[str] = None,
+    account_ids: Optional[str] = None,
+    event_type: Optional[str] = None,
 ) -> dict:
     """Build the v4 Live GetEventsLog parameter."""
     from_dt = _parse_v4_datetime(timestamp_from, "--from")
@@ -48,6 +106,19 @@ def _events_log_param(
         "TimestampTo": timestamp_to,
         "Currency": currency,
     }
+    if last_event_only:
+        param["LastEventOnly"] = last_event_only
+    if with_text_description:
+        param["WithTextDescription"] = with_text_description
+    if logins:
+        login_list = parse_csv_strings(logins)
+        if login_list:
+            param["Logins"] = login_list
+    filter_obj = _events_log_filter(
+        campaign_ids, banner_ids, phrase_ids, account_ids, event_type
+    )
+    if filter_obj is not None:
+        param["Filter"] = filter_obj
     if limit is not None:
         param["Limit"] = limit
     if offset is not None:
@@ -74,7 +145,26 @@ def v4events():
     required=True,
     help="End timestamp in YYYY-MM-DDTHH:MM:SS format",
 )
+@click.option(
+    "--last-event-only",
+    type=click.Choice(["Yes", "No"]),
+    help="Return only the latest record per event type — Yes/No",
+)
+@click.option(
+    "--with-text-description",
+    type=click.Choice(["Yes", "No"]),
+    help="Include event text descriptions in the response — Yes/No",
+)
 @click.option("--currency", default="RUB", show_default=True, help="Currency")
+@click.option("--logins", help="Comma-separated client logins")
+@click.option("--filter-campaign-ids", help="Filter: comma-separated campaign IDs")
+@click.option("--filter-banner-ids", help="Filter: comma-separated banner IDs")
+@click.option("--filter-phrase-ids", help="Filter: comma-separated phrase IDs")
+@click.option("--filter-account-ids", help="Filter: comma-separated account IDs")
+@click.option(
+    "--filter-event-type",
+    help="Filter: comma-separated event types (" + ", ".join(EVENT_TYPES) + ")",
+)
 @click.option("--limit", type=click.IntRange(min=0), help="Result limit")
 @click.option("--offset", type=click.IntRange(min=0), help="Result offset")
 @click.option(
@@ -91,7 +181,15 @@ def get_events_log(
     ctx,
     timestamp_from,
     timestamp_to,
+    last_event_only,
+    with_text_description,
     currency,
+    logins,
+    filter_campaign_ids,
+    filter_banner_ids,
+    filter_phrase_ids,
+    filter_account_ids,
+    filter_event_type,
     limit,
     offset,
     output_format,
@@ -99,7 +197,21 @@ def get_events_log(
     dry_run,
 ):
     """Get v4 Live events log entries."""
-    param = _events_log_param(timestamp_from, timestamp_to, currency, limit, offset)
+    param = _events_log_param(
+        timestamp_from,
+        timestamp_to,
+        currency,
+        limit,
+        offset,
+        last_event_only=last_event_only,
+        with_text_description=with_text_description,
+        logins=logins,
+        campaign_ids=filter_campaign_ids,
+        banner_ids=filter_banner_ids,
+        phrase_ids=filter_phrase_ids,
+        account_ids=filter_account_ids,
+        event_type=filter_event_type,
+    )
     if dry_run:
         format_output(build_v4_body("GetEventsLog", param), "json", None)
         return

--- a/direct_cli/commands/v4forecast.py
+++ b/direct_cli/commands/v4forecast.py
@@ -13,7 +13,12 @@ from .v4shells import V4_EPILOG
 
 
 def _forecast_param(
-    phrases: str, geo_ids: Optional[str], currency: str
+    phrases: str,
+    geo_ids: Optional[str],
+    currency: str,
+    categories: Optional[str] = None,
+    auction_bids: Optional[str] = None,
+    common_minus_words: Optional[str] = None,
 ) -> dict[str, object]:
     """Build the v4 Live CreateNewForecast parameter."""
     phrase_list = parse_csv_strings(phrases)
@@ -26,6 +31,13 @@ def _forecast_param(
         "Phrases": phrase_list,
         "Currency": currency,
     }
+    if categories:
+        try:
+            parsed_categories = parse_ids(categories)
+        except ValueError as exc:
+            raise click.UsageError(str(exc)) from exc
+        if parsed_categories:
+            param["Categories"] = parsed_categories
     if geo_ids:
         try:
             parsed_geo_ids = parse_ids(geo_ids)
@@ -33,6 +45,12 @@ def _forecast_param(
             raise click.UsageError(str(exc)) from exc
         if parsed_geo_ids:
             param["GeoID"] = parsed_geo_ids
+    if auction_bids:
+        param["AuctionBids"] = auction_bids
+    if common_minus_words:
+        minus_words = parse_csv_strings(common_minus_words)
+        if minus_words:
+            param["CommonMinusWords"] = minus_words
     return param
 
 
@@ -68,12 +86,25 @@ def v4forecast():
 @v4_method_contract("CreateNewForecast")
 @v4forecast.command()
 @click.option("--phrases", required=True, help="Comma-separated phrases, up to 100")
+@click.option(
+    "--categories",
+    help="Comma-separated Yandex Catalog category IDs (ignored by the API per docs)",
+)
 @click.option("--geo-ids", help="Comma-separated geo region IDs")
 @click.option(
     "--currency",
     default="RUB",
     show_default=True,
     help="Forecast currency",
+)
+@click.option(
+    "--auction-bids",
+    type=click.Choice(["Yes", "No"]),
+    help="Include auction results in the report — Yes/No (API default: No)",
+)
+@click.option(
+    "--common-minus-words",
+    help="Comma-separated common negative keywords",
 )
 @click.option(
     "--format",
@@ -85,9 +116,27 @@ def v4forecast():
 @click.option("--output", help="Output file")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
-def create(ctx, phrases, geo_ids, currency, output_format, output, dry_run):
+def create(
+    ctx,
+    phrases,
+    categories,
+    geo_ids,
+    currency,
+    auction_bids,
+    common_minus_words,
+    output_format,
+    output,
+    dry_run,
+):
     """Create a v4 Live budget forecast."""
-    param = _forecast_param(phrases, geo_ids, currency)
+    param = _forecast_param(
+        phrases,
+        geo_ids,
+        currency,
+        categories=categories,
+        auction_bids=auction_bids,
+        common_minus_words=common_minus_words,
+    )
     if dry_run:
         format_output(build_v4_body("CreateNewForecast", param), "json", None)
         return

--- a/direct_cli/v4_contracts.py
+++ b/direct_cli/v4_contracts.py
@@ -87,12 +87,8 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
         source_status=SOURCE_DOCS,
         live_probe_allowed=False,
         example_param={
-            "FromCampaigns": [
-                {"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"}
-            ],
-            "ToCampaigns": [
-                {"CampaignID": 456, "Sum": 100.5, "Currency": "RUB"}
-            ],
+            "FromCampaigns": [{"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"}],
+            "ToCampaigns": [{"CampaignID": 456, "Sum": 100.5, "Currency": "RUB"}],
         },
         notes=(
             "Docs-verified 2026-05-29 against dg-v4/live/TransferMoney: "
@@ -115,9 +111,7 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
         source_status=SOURCE_DOCS,
         live_probe_allowed=False,
         example_param={
-            "Payments": [
-                {"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"}
-            ],
+            "Payments": [{"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"}],
             "ContractID": "contract-id",
             "PayMethod": "Bank",
         },
@@ -173,9 +167,7 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
         source_status=SOURCE_DOCS,
         live_probe_allowed=False,
         example_param={
-            "Payments": [
-                {"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"}
-            ],
+            "Payments": [{"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"}],
         },
         notes=(
             "Docs-verified 2026-05-29 against dg-v4/live/CreateInvoice: "
@@ -233,7 +225,8 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
         group="events",
         param_shape=PARAM_OBJECT,
         login_placement=(
-            "param contains timestamps, Currency, and optional Limit/Offset; "
+            "param contains timestamps, LastEventOnly, WithTextDescription, "
+            "Currency, Logins, a nested Filter object, and optional Limit/Offset; "
             "global --login uses Client-Login header"
         ),
         safety=SAFETY_READ,
@@ -242,9 +235,29 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
         example_param={
             "TimestampFrom": "2026-04-14T00:00:00",
             "TimestampTo": "2026-04-14T01:00:00",
+            "LastEventOnly": "No",
+            "WithTextDescription": "Yes",
             "Currency": "RUB",
+            "Logins": ["client-login"],
+            "Filter": {
+                "CampaignIDS": [123],
+                "BannerIDS": [456],
+                "PhraseIDS": [789],
+                "AccountIDS": [12],
+                "EventType": ["MoneyOut"],
+            },
+            "Limit": 100,
+            "Offset": 0,
         },
-        notes="Currency is required by live API; omitting it returns error_code=245.",
+        notes=(
+            "Docs-verified 2026-05-29 against dg-v4/live/GetEventsLog: "
+            "GetEventsLogRequest declares TimestampFrom/TimestampTo, "
+            "LastEventOnly (Yes/No), WithTextDescription (Yes/No), Currency, "
+            "Logins[], a nested GetEventsLogFilter "
+            "(CampaignIDS[], BannerIDS[], PhraseIDS[], AccountIDS[], "
+            "EventType[]), Limit, and Offset. Currency is required by the live "
+            "API; omitting it returns error_code=245."
+        ),
     ),
     "GetStatGoals": V4MethodContract(
         method="GetStatGoals",
@@ -335,21 +348,28 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
         group="forecast",
         param_shape=PARAM_OBJECT,
         login_placement=(
-            "param contains documented Phrases, Currency, optional GeoID, "
-            "and optional AuctionBids; global --login uses Client-Login header"
+            "param contains documented Phrases, Categories, GeoID, Currency, "
+            "AuctionBids, and CommonMinusWords; global --login uses Client-Login "
+            "header"
         ),
         safety=SAFETY_ASYNC,
         source_status=SOURCE_DOCS,
         live_probe_allowed=False,
         example_param={
             "Phrases": ["buy laptop"],
-            "Currency": "RUB",
+            "Categories": [10732],
             "GeoID": [213],
+            "Currency": "RUB",
+            "AuctionBids": "No",
+            "CommonMinusWords": ["used"],
         },
         notes=(
-            "Creates an asynchronous budget forecast. The CLI performs one API "
-            "call only, does not poll for readiness, and omits AuctionBids so "
-            "the API default applies."
+            "Docs-verified 2026-05-29 against dg-v4/live/CreateNewForecast: "
+            "NewForecastInfo declares Phrases (required, <=100), Categories, "
+            "GeoID, Currency (required), AuctionBids (Yes/No, default No), and "
+            "CommonMinusWords. Categories is accepted but ignored by the API per "
+            "the docs. Creates an asynchronous forecast; the CLI performs one "
+            "API call only and does not poll for readiness."
         ),
     ),
     "GetForecastList": V4MethodContract(
@@ -404,8 +424,8 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
         notes=(
             "Docs-verified 2026-05-28 against dg-v4/live/DeleteOfflineReport: "
             "param is the integer report ID. Response on success: "
-            "{\"data\": 1}. Method is disabled per official docs "
-            "(\"Метод отключен. Используйте API версии 5\"); v5 reports "
+            '{"data": 1}. Method is disabled per official docs '
+            '("Метод отключен. Используйте API версии 5"); v5 reports '
             "API supersedes it. No CLI command is exposed."
         ),
     ),
@@ -424,9 +444,9 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
         notes=(
             "Docs-verified 2026-05-28 against dg-v4/reference/DeleteReport: "
             "param is the integer report ID obtained via GetReportList. "
-            "Response on success: {\"data\": 1}. Reports are auto-removed "
+            'Response on success: {"data": 1}. Reports are auto-removed '
             "after 5 hours. Method is listed under disabled methods "
-            "(\"Отключенные методы\") in official docs; distinct entry "
+            '("Отключенные методы") in official docs; distinct entry '
             "from DeleteOfflineReport (same wire shape, separate v4 "
             "reference page). No CLI command is exposed."
         ),
@@ -544,8 +564,7 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
         group="keywords",
         param_shape=PARAM_OBJECT,
         login_placement=(
-            "param contains Keywords array; global --login uses "
-            "Client-Login header"
+            "param contains Keywords array; global --login uses " "Client-Login header"
         ),
         safety=SAFETY_READ,
         source_status=SOURCE_DOCS,

--- a/tests/test_v4_contracts.py
+++ b/tests/test_v4_contracts.py
@@ -198,12 +198,8 @@ def test_v4finance_money_contracts_are_docs_backed_dangerous_objects():
     assert build_v4_body("TransferMoney", transfer.example_param) == {
         "method": "TransferMoney",
         "param": {
-            "FromCampaigns": [
-                {"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"}
-            ],
-            "ToCampaigns": [
-                {"CampaignID": 456, "Sum": 100.5, "Currency": "RUB"}
-            ],
+            "FromCampaigns": [{"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"}],
+            "ToCampaigns": [{"CampaignID": 456, "Sum": 100.5, "Currency": "RUB"}],
         },
     }
 
@@ -213,9 +209,7 @@ def test_v4finance_money_contracts_are_docs_backed_dangerous_objects():
     assert build_v4_body("PayCampaigns", pay.example_param) == {
         "method": "PayCampaigns",
         "param": {
-            "Payments": [
-                {"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"}
-            ],
+            "Payments": [{"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"}],
             "ContractID": "contract-id",
             "PayMethod": "Bank",
         },
@@ -229,9 +223,7 @@ def test_v4finance_money_contracts_are_docs_backed_dangerous_objects():
     assert build_v4_body("CreateInvoice", create_invoice.example_param) == {
         "method": "CreateInvoice",
         "param": {
-            "Payments": [
-                {"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"}
-            ],
+            "Payments": [{"CampaignID": 123, "Sum": 100.5, "Currency": "RUB"}],
         },
     }
 
@@ -293,8 +285,11 @@ def test_v4forecast_contracts_are_docs_backed_objects_and_scalars():
     assert create.source_status == SOURCE_DOCS
     assert create.example_param == {
         "Phrases": ["buy laptop"],
-        "Currency": "RUB",
+        "Categories": [10732],
         "GeoID": [213],
+        "Currency": "RUB",
+        "AuctionBids": "No",
+        "CommonMinusWords": ["used"],
     }
     assert build_v4_body("CreateNewForecast", create.example_param) == {
         "method": "CreateNewForecast",
@@ -343,7 +338,19 @@ def test_get_events_log_contract_uses_timestamp_object_with_currency():
     assert contract.example_param == {
         "TimestampFrom": "2026-04-14T00:00:00",
         "TimestampTo": "2026-04-14T01:00:00",
+        "LastEventOnly": "No",
+        "WithTextDescription": "Yes",
         "Currency": "RUB",
+        "Logins": ["client-login"],
+        "Filter": {
+            "CampaignIDS": [123],
+            "BannerIDS": [456],
+            "PhraseIDS": [789],
+            "AccountIDS": [12],
+            "EventType": ["MoneyOut"],
+        },
+        "Limit": 100,
+        "Offset": 0,
     }
     assert build_v4_body("GetEventsLog", contract.example_param) == {
         "method": "GetEventsLog",

--- a/tests/test_v4events.py
+++ b/tests/test_v4events.py
@@ -66,6 +66,116 @@ def test_get_events_log_dry_run_adds_optional_pagination_when_passed():
     }
 
 
+def test_get_events_log_dry_run_builds_full_body_with_nested_filter():
+    result = _invoke(
+        "v4events",
+        "get-events-log",
+        "--from",
+        "2026-04-14T00:00:00",
+        "--to",
+        "2026-04-14T01:00:00",
+        "--last-event-only",
+        "No",
+        "--with-text-description",
+        "Yes",
+        "--currency",
+        "RUB",
+        "--logins",
+        "client-login,other-client",
+        "--filter-campaign-ids",
+        "123,456",
+        "--filter-banner-ids",
+        "789",
+        "--filter-phrase-ids",
+        "1011",
+        "--filter-account-ids",
+        "12",
+        "--filter-event-type",
+        "MoneyOut,MoneyIn",
+        "--limit",
+        "50",
+        "--offset",
+        "10",
+        "--dry-run",
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "method": "GetEventsLog",
+        "param": {
+            "TimestampFrom": "2026-04-14T00:00:00",
+            "TimestampTo": "2026-04-14T01:00:00",
+            "LastEventOnly": "No",
+            "WithTextDescription": "Yes",
+            "Currency": "RUB",
+            "Logins": ["client-login", "other-client"],
+            "Filter": {
+                "CampaignIDS": [123, 456],
+                "BannerIDS": [789],
+                "PhraseIDS": [1011],
+                "AccountIDS": [12],
+                "EventType": ["MoneyOut", "MoneyIn"],
+            },
+            "Limit": 50,
+            "Offset": 10,
+        },
+    }
+
+
+def test_get_events_log_omits_filter_when_no_filter_options():
+    result = _invoke(
+        "v4events",
+        "get-events-log",
+        "--from",
+        "2026-04-14T00:00:00",
+        "--to",
+        "2026-04-14T01:00:00",
+        "--logins",
+        "client-login",
+        "--dry-run",
+    )
+
+    assert result.exit_code == 0
+    param = json.loads(result.output)["param"]
+    assert "Filter" not in param
+    assert param["Logins"] == ["client-login"]
+
+
+def test_get_events_log_rejects_unknown_event_type():
+    result = _invoke(
+        "v4events",
+        "get-events-log",
+        "--from",
+        "2026-04-14T00:00:00",
+        "--to",
+        "2026-04-14T01:00:00",
+        "--filter-event-type",
+        "MoneyOut,Bogus",
+        "--dry-run",
+    )
+
+    assert result.exit_code != 0
+    assert "unknown values: Bogus" in result.output
+
+
+def test_get_events_log_rejects_invalid_filter_id_before_api_call():
+    with patch("direct_cli.commands.v4events.create_v4_client") as create_client:
+        result = _invoke(
+            "v4events",
+            "get-events-log",
+            "--from",
+            "2026-04-14T00:00:00",
+            "--to",
+            "2026-04-14T01:00:00",
+            "--filter-campaign-ids",
+            "123,abc",
+        )
+
+    assert result.exit_code != 0
+    assert "--filter-campaign-ids" in result.output
+    create_client.assert_not_called()
+
+
 @pytest.mark.parametrize(
     "timestamp",
     [

--- a/tests/test_v4forecast.py
+++ b/tests/test_v4forecast.py
@@ -62,6 +62,70 @@ def test_create_dry_run_adds_geo_ids():
     }
 
 
+def test_create_dry_run_adds_all_documented_fields():
+    result = _invoke(
+        "v4forecast",
+        "create",
+        "--phrases",
+        "buy laptop",
+        "--categories",
+        "10732,10733",
+        "--geo-ids",
+        "213",
+        "--currency",
+        "RUB",
+        "--auction-bids",
+        "Yes",
+        "--common-minus-words",
+        "used,broken",
+        "--dry-run",
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "method": "CreateNewForecast",
+        "param": {
+            "Phrases": ["buy laptop"],
+            "Categories": [10732, 10733],
+            "GeoID": [213],
+            "Currency": "RUB",
+            "AuctionBids": "Yes",
+            "CommonMinusWords": ["used", "broken"],
+        },
+    }
+
+
+def test_create_rejects_invalid_auction_bids():
+    result = _invoke(
+        "v4forecast",
+        "create",
+        "--phrases",
+        "buy laptop",
+        "--auction-bids",
+        "maybe",
+        "--dry-run",
+    )
+
+    assert result.exit_code != 0
+    assert "auction-bids" in result.output
+
+
+def test_create_invalid_categories_fail_before_api_call():
+    with patch("direct_cli.commands.v4forecast.create_v4_client") as create_client:
+        result = _invoke(
+            "v4forecast",
+            "create",
+            "--phrases",
+            "buy laptop",
+            "--categories",
+            "10732,abc",
+        )
+
+    assert result.exit_code != 0
+    assert "Invalid ID: 'abc'" in result.output
+    create_client.assert_not_called()
+
+
 def test_create_parses_three_phrase_entries():
     result = _invoke(
         "v4forecast",
@@ -227,8 +291,11 @@ def test_v4forecast_contracts_are_docs_backed():
     assert create.source_status == SOURCE_DOCS
     assert create.example_param == {
         "Phrases": ["buy laptop"],
-        "Currency": "RUB",
+        "Categories": [10732],
         "GeoID": [213],
+        "Currency": "RUB",
+        "AuctionBids": "No",
+        "CommonMinusWords": ["used"],
     }
     assert list_forecasts.param_shape == PARAM_OPTIONAL_OBJECT
     assert list_forecasts.source_status == SOURCE_DOCS


### PR DESCRIPTION
Closes #452
Closes #453

## Summary

Resolves the two v4 docs-drift findings from the 2026-05-29 wire-shape audit (#451). **Additive** — only new optional flags; existing flags and behaviour unchanged.

### #452 — `v4events get-events-log` (was 5/13 documented fields)
Adds the 8 missing inputs, all verified against `dg-v4/live/GetEventsLog`:
- `--last-event-only`, `--with-text-description` (`Yes`/`No`)
- `--logins` (comma-separated)
- nested `Filter` object: `--filter-campaign-ids`, `--filter-banner-ids`, `--filter-phrase-ids`, `--filter-account-ids` (WSDL keys `CampaignIDS`/`BannerIDS`/`PhraseIDS`/`AccountIDS`) and `--filter-event-type` (validated against the documented 9-value enum before any API call).

### #453 — `v4forecast create` (was 3/6 documented fields)
Adds `--categories`, `--auction-bids` (`Yes`/`No`), `--common-minus-words`. `Categories` is accepted but **ignored by the API per docs** (noted in help + contract).

## Contract-source compliance
All field names and enums verified against official `dg-v4/live` docs. Contracts in `v4_contracts.py` updated (`example_param`, `notes` → `Docs-verified 2026-05-29`, `login_placement`).

## Test plan
- [x] `audit_wire_shape.py --v4 --methods GetEventsLog,CreateNewForecast` → **0 findings**
- [x] new dry-run tests assert exact request bodies incl. nested `Filter` and unknown-enum / invalid-id rejection before API calls
- [x] full unit suite green (1419 passed in the focused run)
- [x] `black --check`, `flake8` (new code clean)

Diff ≈ 400 lines (within the 1000-line limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
