### PR TITLE
test(read): v4 Live read cassettes + fix unbounded v4 retry-loop

### DIFF
--- a/direct_cli/_vendor/tapi_yandex_direct/v4/adapter.py
+++ b/direct_cli/_vendor/tapi_yandex_direct/v4/adapter.py
@@ -176,9 +176,15 @@ class V4LiveClientAdapter(JSONAdapterMixin, TapiAdapter):
                 code = 0
 
         if code in (54, 55) and api_params.get("retry_if_exceeded_limit", True):
-            logger.warning("v4 Live limit exceeded (code=%s), retry in 10s", code)
-            time.sleep(10)
-            return True
+            # Bound the limit-exceeded retries with the same attempt budget as
+            # the server-error branch below.  Without this guard the loop is
+            # infinite (sleep 10s, retry, forever) whenever the API keeps
+            # returning code 54/55 — which hangs the caller indefinitely.
+            if repeat_number < api_params.get("retries_if_server_error", 5):
+                logger.warning("v4 Live limit exceeded (code=%s), retry in 10s", code)
+                time.sleep(10)
+                return True
+            return False
 
         if code in (52, 1000, 1001, 1002) or response.status_code == 500:
             if repeat_number < api_params.get("retries_if_server_error", 5):

--- a/tests/cassettes/test_read_cassettes/test_read_command[v4events_get_events_log].yaml
+++ b/tests/cassettes/test_read_cassettes/test_read_command[v4events_get_events_log].yaml
@@ -1,0 +1,52 @@
+interactions:
+- request:
+    body: '{"method":"GetEventsLog","param":{"TimestampFrom":"2026-05-01T00:00:00","TimestampTo":"2026-05-28T00:00:00","Currency":"RUB"},"token":"<REDACTED>","locale":"en"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '161'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      authorization:
+      - REDACTED
+      client-login:
+      - REDACTED
+    method: POST
+    uri: https://api-sandbox.direct.yandex.ru/live/v4/json/
+  response:
+    body:
+      string: '{"data":[]}'
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 29 May 2026 06:39:02 GMT
+      RequestId:
+      - '4348048659933115401'
+      Set-Cookie:
+      - REDACTED
+      Transfer-Encoding:
+      - chunked
+      X-Accel-Info:
+      - reqid:0000000000000000000,cmd:direct.json-api/GetEventsLog
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '11'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_read_cassettes/test_read_command[v4finance_get_clients_units].yaml
+++ b/tests/cassettes/test_read_cassettes/test_read_command[v4finance_get_clients_units].yaml
@@ -1,0 +1,52 @@
+interactions:
+- request:
+    body: '{"method":"GetClientsUnits","param":["REDACTED"],"token":"<REDACTED>","locale":"en"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '84'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      authorization:
+      - REDACTED
+      client-login:
+      - REDACTED
+    method: POST
+    uri: https://api-sandbox.direct.yandex.ru/live/v4/json/
+  response:
+    body:
+      string: '{"data":[{"Login":"REDACTED","UnitsRest":32000}]}'
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 29 May 2026 06:39:04 GMT
+      RequestId:
+      - '4617307722901139995'
+      Set-Cookie:
+      - REDACTED
+      Transfer-Encoding:
+      - chunked
+      X-Accel-Info:
+      - reqid:0000000000000000000,cmd:direct.json-api/GetClientsUnits
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '54'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_read_cassettes/test_read_command[v4forecast_list].yaml
+++ b/tests/cassettes/test_read_cassettes/test_read_command[v4forecast_list].yaml
@@ -1,0 +1,52 @@
+interactions:
+- request:
+    body: '{"method":"GetForecastList","token":"<REDACTED>","locale":"en"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '63'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      authorization:
+      - REDACTED
+      client-login:
+      - REDACTED
+    method: POST
+    uri: https://api-sandbox.direct.yandex.ru/live/v4/json/
+  response:
+    body:
+      string: '{"data":[]}'
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 29 May 2026 06:38:50 GMT
+      RequestId:
+      - '4842807932961601953'
+      Set-Cookie:
+      - REDACTED
+      Transfer-Encoding:
+      - chunked
+      X-Accel-Info:
+      - reqid:0000000000000000000,cmd:direct.json-api/GetForecastList
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '11'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_read_cassettes/test_read_command[v4goals_get_stat_goals].yaml
+++ b/tests/cassettes/test_read_cassettes/test_read_command[v4goals_get_stat_goals].yaml
@@ -1,0 +1,52 @@
+interactions:
+- request:
+    body: '{"method":"GetStatGoals","param":{"CampaignIDS":[700012672]},"token":"<REDACTED>","locale":"en"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '96'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      authorization:
+      - REDACTED
+      client-login:
+      - REDACTED
+    method: POST
+    uri: https://api-sandbox.direct.yandex.ru/live/v4/json/
+  response:
+    body:
+      string: '{"data":[]}'
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 29 May 2026 06:38:06 GMT
+      RequestId:
+      - '1960449532692433252'
+      Set-Cookie:
+      - REDACTED
+      Transfer-Encoding:
+      - chunked
+      X-Accel-Info:
+      - reqid:0000000000000000000,cmd:direct.json-api/GetStatGoals
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '11'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_read_cassettes/test_read_command[v4tags_get_campaigns].yaml
+++ b/tests/cassettes/test_read_cassettes/test_read_command[v4tags_get_campaigns].yaml
@@ -1,0 +1,52 @@
+interactions:
+- request:
+    body: '{"method":"GetCampaignsTags","param":{"CampaignIDS":[700012672]},"token":"<REDACTED>","locale":"en"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '100'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      authorization:
+      - REDACTED
+      client-login:
+      - REDACTED
+    method: POST
+    uri: https://api-sandbox.direct.yandex.ru/live/v4/json/
+  response:
+    body:
+      string: '{"data":[{"Tags":[],"CampaignID":700012672}]}'
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 29 May 2026 06:38:40 GMT
+      RequestId:
+      - '8999091392491883531'
+      Set-Cookie:
+      - REDACTED
+      Transfer-Encoding:
+      - chunked
+      X-Accel-Info:
+      - reqid:0000000000000000000,cmd:direct.json-api/GetCampaignsTags
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '45'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_read_cassettes/test_read_command[v4wordstat_list_reports].yaml
+++ b/tests/cassettes/test_read_cassettes/test_read_command[v4wordstat_list_reports].yaml
@@ -1,0 +1,52 @@
+interactions:
+- request:
+    body: '{"method":"GetWordstatReportList","token":"<REDACTED>","locale":"en"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '69'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      authorization:
+      - REDACTED
+      client-login:
+      - REDACTED
+    method: POST
+    uri: https://api-sandbox.direct.yandex.ru/live/v4/json/
+  response:
+    body:
+      string: '{"data":[]}'
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 29 May 2026 06:38:52 GMT
+      RequestId:
+      - '7228898972265560536'
+      Set-Cookie:
+      - REDACTED
+      Transfer-Encoding:
+      - chunked
+      X-Accel-Info:
+      - reqid:0000000000000000000,cmd:direct.json-api/GetWordstatReportList
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '11'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_read_cassettes/test_v4finance_check_payment_unknown_transaction.yaml
+++ b/tests/cassettes/test_read_cassettes/test_v4finance_check_payment_unknown_transaction.yaml
@@ -1,0 +1,52 @@
+interactions:
+- request:
+    body: '{"method":"CheckPayment","param":{"CustomTransactionID":"abcdef0123456789abcdef0123456789"},"token":"<REDACTED>","locale":"en"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '127'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      authorization:
+      - REDACTED
+      client-login:
+      - REDACTED
+    method: POST
+    uri: https://api-sandbox.direct.yandex.ru/live/v4/json/
+  response:
+    body:
+      string: '{"error_detail":"","error_str":"Transaction does not exist","error_code":370}'
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 29 May 2026 06:39:17 GMT
+      RequestId:
+      - '6315729184206375584'
+      Set-Cookie:
+      - REDACTED
+      Transfer-Encoding:
+      - chunked
+      X-Accel-Info:
+      - reqid:0000000000000000000,cmd:direct.json-api/CheckPayment
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '77'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,6 +140,17 @@ def _before_record_request(request):
             rb'"token":"[^"]*"', b'"token":"<REDACTED>"', request.body
         )
         redacted = True
+    # The login can also be echoed inside the request body — e.g. the v4
+    # `GetClientsUnits` call sends the account login as a `Logins` param.
+    if _REAL_LOGIN and request.body:
+        if isinstance(request.body, str) and _REAL_LOGIN in request.body:
+            request.body = request.body.replace(_REAL_LOGIN, _REDACTED)
+            redacted = True
+        elif isinstance(request.body, bytes) and _REAL_LOGIN.encode() in request.body:
+            request.body = request.body.replace(
+                _REAL_LOGIN.encode(), _REDACTED.encode()
+            )
+            redacted = True
     if redacted:
         new_body = request.body
         new_len = str(
@@ -171,9 +182,11 @@ def _before_record_response(response):
             continue
         if low == "x-accel-info":
             headers[key] = [
-                re.sub(r"reqid:\d+", "reqid:0000000000000000000", v)
-                if isinstance(v, str)
-                else v
+                (
+                    re.sub(r"reqid:\d+", "reqid:0000000000000000000", v)
+                    if isinstance(v, str)
+                    else v
+                )
                 for v in headers[key]
             ]
             continue
@@ -259,9 +272,9 @@ def parse_add_result(result, key: str = "AddResults") -> int:
         items = data.get(key, data.get("SetItems", []))
     assert items, f"No results in add response: {result.output[:500]}"
     first = items[0]
-    assert "Errors" not in first or not first["Errors"], (
-        f"API rejected add: {first.get('Errors')}"
-    )
+    assert (
+        "Errors" not in first or not first["Errors"]
+    ), f"API rejected add: {first.get('Errors')}"
     assert "Id" in first, f"No Id in add result: {first}"
     return first["Id"]
 
@@ -275,9 +288,9 @@ def parse_first_result(result, key: str = "AddResults") -> dict:
         items = data.get(key, data.get("SetItems", []))
     assert items, f"No results in response: {result.output[:500]}"
     first = items[0]
-    assert "Errors" not in first or not first["Errors"], (
-        f"API rejected: {first.get('Errors')}"
-    )
+    assert (
+        "Errors" not in first or not first["Errors"]
+    ), f"API rejected: {first.get('Errors')}"
     return first
 
 

--- a/tests/test_read_cassettes.py
+++ b/tests/test_read_cassettes.py
@@ -28,11 +28,14 @@ Coverage notes — v5 read commands intentionally NOT recorded here:
 
     agencyclients get   — account is not an agency (API error 54)
 
-v4 read commands are NOT covered by this suite: vcrpy cannot intercept the
-vendored v4 Live HTTP client in ``--record-mode=rewrite`` (recording hangs
-indefinitely even for a single v4 case, although each v4 command runs in
-1-2s outside pytest). v4 read paths remain covered by the live
-``test_v4_live_contracts.py`` suite until VCR×v4 is resolved separately.
+v4 read commands ARE covered (see the ``v4*`` cases below). vcrpy records the
+vendored v4 Live client through the same ``requests``/``urllib3`` transport as
+v5 — there is no incompatibility. Earlier recording attempts hung because the
+v4 adapter retried request-limit errors (code 54/55) in an unbounded loop; that
+loop is now bounded (``v4/adapter.py`` ``retry_request``), so ``--record-mode=
+rewrite`` no longer hangs. The ``v4finance check-payment`` case is recorded as a
+*deterministic error* (``error_code=370``, "Transaction does not exist"), so it
+asserts a non-zero exit and the error string instead of success.
 """
 
 from __future__ import annotations
@@ -46,7 +49,7 @@ from click.testing import CliRunner
 from direct_cli.cli import cli
 
 sys.path.insert(0, os.path.dirname(__file__))
-from conftest import _REAL_LOGIN, _REAL_TOKEN  # noqa: E402
+from conftest import _REAL_LOGIN, _REAL_TOKEN, _REDACTED  # noqa: E402
 
 # Stable sandbox fixtures (confirmed live against the recording account).
 SANDBOX_CAMPAIGN_ID = "700012672"
@@ -96,9 +99,12 @@ READ_CASES: list[tuple[str, list[str]]] = [
     (
         "changes_check",
         [
-            "changes", "check",
-            "--campaign-ids", SANDBOX_CAMPAIGN_ID,
-            "--timestamp", "2026-05-29T00:00:00Z",
+            "changes",
+            "check",
+            "--campaign-ids",
+            SANDBOX_CAMPAIGN_ID,
+            "--timestamp",
+            "2026-05-29T00:00:00Z",
         ],
     ),
     (
@@ -109,25 +115,40 @@ READ_CASES: list[tuple[str, list[str]]] = [
     (
         "keywordsresearch_has_search_volume",
         [
-            "keywordsresearch", "has-search-volume",
-            "--keywords", "купить телефон",
-            "--region-ids", "213",
+            "keywordsresearch",
+            "has-search-volume",
+            "--keywords",
+            "купить телефон",
+            "--region-ids",
+            "213",
         ],
     ),
     (
         "keywordsresearch_deduplicate",
-        ["keywordsresearch", "deduplicate", "--keywords", "купить телефон,телефон купить"],
+        [
+            "keywordsresearch",
+            "deduplicate",
+            "--keywords",
+            "купить телефон,телефон купить",
+        ],
     ),
     (
         "reports_get",
         [
-            "reports", "get",
-            "--type", "campaign_performance_report",
-            "--from", "2026-05-01",
-            "--to", "2026-05-28",
-            "--name", "vcr_camp_perf",
-            "--fields", "CampaignId,Impressions,Clicks,Cost",
-            "--campaign-ids", SANDBOX_CAMPAIGN_ID,
+            "reports",
+            "get",
+            "--type",
+            "campaign_performance_report",
+            "--from",
+            "2026-05-01",
+            "--to",
+            "2026-05-28",
+            "--name",
+            "vcr_camp_perf",
+            "--fields",
+            "CampaignId,Impressions,Clicks,Cost",
+            "--campaign-ids",
+            SANDBOX_CAMPAIGN_ID,
         ],
     ),
     ("sitelinks_get", ["sitelinks", "get"]),
@@ -135,7 +156,10 @@ READ_CASES: list[tuple[str, list[str]]] = [
     ("feeds_get", ["feeds", "get"]),
     ("bids_get", ["bids", "get", "--campaign-ids", SANDBOX_CAMPAIGN_ID]),
     ("keywordbids_get", ["keywordbids", "get", "--campaign-ids", SANDBOX_CAMPAIGN_ID]),
-    ("bidmodifiers_get", ["bidmodifiers", "get", "--campaign-ids", SANDBOX_CAMPAIGN_ID]),
+    (
+        "bidmodifiers_get",
+        ["bidmodifiers", "get", "--campaign-ids", SANDBOX_CAMPAIGN_ID],
+    ),
     (
         "audiencetargets_get",
         ["audiencetargets", "get", "--campaign-ids", SANDBOX_CAMPAIGN_ID],
@@ -146,6 +170,35 @@ READ_CASES: list[tuple[str, list[str]]] = [
         ["smartadtargets", "get", "--campaign-ids", SANDBOX_CAMPAIGN_ID],
     ),
     ("negativekeywordsharedsets_get", ["negativekeywordsharedsets", "get"]),
+    # ── v4 Live read commands ──────────────────────────────────────────
+    # All run against --sandbox and return a success body (exit 0). The v4
+    # Live client shares the requests/urllib3 transport vcrpy patches, so
+    # these record and replay exactly like the v5 cases above.
+    (
+        "v4goals_get_stat_goals",
+        ["v4goals", "get-stat-goals", "--campaign-ids", SANDBOX_CAMPAIGN_ID],
+    ),
+    (
+        "v4tags_get_campaigns",
+        ["v4tags", "get-campaigns", "--campaign-ids", SANDBOX_CAMPAIGN_ID],
+    ),
+    ("v4forecast_list", ["v4forecast", "list"]),
+    ("v4wordstat_list_reports", ["v4wordstat", "list-reports"]),
+    (
+        "v4events_get_events_log",
+        [
+            "v4events",
+            "get-events-log",
+            "--from",
+            "2026-05-01T00:00:00",
+            "--to",
+            "2026-05-28T00:00:00",
+        ],
+    ),
+    (
+        "v4finance_get_clients_units",
+        ["v4finance", "get-clients-units", "--logins", _REAL_LOGIN or _REDACTED],
+    ),
 ]
 
 
@@ -165,3 +218,35 @@ def test_read_command(cassette_id: str, args: list[str]) -> None:
     # Output must be present (JSON list/object or TSV report body); an
     # empty sandbox list is valid and still non-empty as text.
     assert result.output.strip() != "", f"[{cassette_id}] produced no output"
+
+
+# A 32-char latin-alphanumeric transaction id that does not exist — the v4
+# Live CheckPayment method answers deterministically with error_code=370
+# ("Transaction does not exist"). This makes a stable, secret-free cassette
+# for the read-only error path that the success-only READ_CASES can't model.
+_NONEXISTENT_TRANSACTION_ID = "abcdef0123456789abcdef0123456789"
+
+
+@pytest.mark.vcr
+def test_v4finance_check_payment_unknown_transaction() -> None:
+    """v4finance check-payment replays a deterministic error_code=370.
+
+    Unlike the success cases, this command aborts (non-zero exit) when the
+    transaction is unknown — which is exactly the deterministic, side-effect
+    free response we want to lock into a cassette.
+    """
+    result = _invoke_read(
+        [
+            "v4finance",
+            "check-payment",
+            "--custom-transaction-id",
+            _NONEXISTENT_TRANSACTION_ID,
+        ]
+    )
+    assert result.exit_code != 0, (
+        f"expected non-zero exit for unknown transaction, got {result.exit_code}\n"
+        f"output: {result.output}"
+    )
+    assert (
+        "error_code=370" in result.output
+    ), f"expected error_code=370 in output, got: {result.output}"


### PR DESCRIPTION
## Что и зачем

Завершает offline-покрытие read-команд: 7 v4 Live read-команд теперь записаны в
VCR-кассеты и реплеятся в CI без токена и сети — так же, как 32 v5-кассеты из #455.

## Корень «зависания» (опровержение гипотезы #454)

Issue #454 предполагал, что **vcrpy не умеет перехватывать v4 Live HTTP-клиент**.
Это неверно:

1. vcrpy **уже записывал** v4 Live-кассеты в этом репо (коммит `547e837`) тем же
   `@pytest.mark.vcr`. Транспорт v4 = транспорт v5 (`requests`/`urllib3`).
2. Настоящая причина — **баг в `V4LiveClientAdapter.retry_request`**: ретрай ошибок
   request-limit (код 54/55) был **без ограничения числа попыток**
   (`time.sleep(10); return True` без проверки `repeat_number`) → бесконечный цикл.
3. Sandbox-аккаунт без v4-прав отдаёт код **54 «Not enough rights»** (v4 перегружает
   этот код и для rate-limit), из-за чего адаптер вис навсегда. Recording-аккаунт
   (профиль) v4-права имеет — на нём все 7 команд отвечают за пару секунд.

Подтверждено faulthandler-трейсом: до фикса `v4goals get-stat-goals` против аккаунта
без прав виснет на `adapter.py:180`; после фикса — 5 ограниченных ретраев и аккуратная
ошибка (exit 1). Это чинит и реальный production-зависон для любого вызывающего.

## Изменения

- **`direct_cli/_vendor/tapi_yandex_direct/v4/adapter.py`** — ограничил ветку 54/55 тем же
  бюджетом попыток, что и серверную. ⚠️ Это вендоренный файл: фикс нужно **также внести
  в форк `axisrow/tapi-yandex-direct`**, иначе он потеряется при следующем `update_vendor.sh`.
- **`tests/test_read_cassettes.py`** — +6 success-кейсов v4 в `READ_CASES`
  (`v4goals get-stat-goals`, `v4tags get-campaigns`, `v4forecast list`,
  `v4wordstat list-reports`, `v4events get-events-log`, `v4finance get-clients-units`)
  + отдельный тест `check-payment`, проверяющий детерминированную ошибку `error_code=370`
  (exit≠0). Docstring исправлен — убрано неверное утверждение про vcrpy×v4.
- **`tests/conftest.py`** — скраб логина и из **тела запроса** v4
  (`GetClientsUnits` шлёт логин аккаунта в `Logins`).
- **7 новых кассет** против `--sandbox`, все секреты/PII вычищены: токен в теле,
  логин в request-param и в response-поле `Login`, auth-заголовки.

## Проверка

- `pytest tests/test_read_cassettes.py` → **39 passed** (32 v5 + 7 v4) офлайн, без сети.
- `pytest -m "not integration"` → **1963 passed, 46 skipped** (вендор-фикс ничего не сломал).
- `ruff` / `black` → clean. `_vendor/` исключён из CI mypy.
- Секрет/PII-свип по всем кассетам (raw + `\uXXXX`-escaped) → **ALL CLEAN**.

## Follow-up
- Апстрим фикса retry-loop в форк `axisrow/tapi-yandex-direct` (чтобы пережил ре-вендоринг).

Closes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)