### PR TITLE
fix(docs): point removed-doc services at live WSDL (closes #463)

### DIFF
--- a/direct_cli/_vendor/tapi_yandex_direct/resource_mapping.py
+++ b/direct_cli/_vendor/tapi_yandex_direct/resource_mapping.py
@@ -76,14 +76,20 @@ RESOURCE_MAPPING_V5 = {
         "docs": "https://yandex.ru/dev/direct/doc/ru/dictionaries/dictionaries",
         "methods": ["get"],
     },
+    # Yandex removed the human-readable doc pages for DynamicTextAdTargets,
+    # DynamicFeedAdTargets, SmartAdTargets and VCards in September 2025 (the
+    # /ru/ and /en/ pages now 404, and the services are gone from the docs
+    # navigation). The services themselves remain live, so `docs` points at the
+    # WSDL endpoint — the only authoritative source still served for them. See
+    # issue #463.
     "dynamicads": {
         "resource": "json/v5/dynamictextadtargets",
-        "docs": "https://yandex.ru/dev/direct/doc/ru/dynamictextadtargets",
+        "docs": "https://api.direct.yandex.com/v5/dynamictextadtargets?wsdl",
         "methods": ["get", "add", "delete", "suspend", "resume", "setBids"],
     },
     "dynamicfeedadtargets": {
         "resource": "json/v5/dynamicfeedadtargets",
-        "docs": "https://yandex.ru/dev/direct/doc/ru/dynamicfeedadtargets",
+        "docs": "https://api.direct.yandex.com/v5/dynamicfeedadtargets?wsdl",
         "methods": ["get", "add", "delete", "suspend", "resume", "setBids"],
     },
     "keywordbids": {
@@ -118,7 +124,8 @@ RESOURCE_MAPPING_V5 = {
     },
     "vcards": {
         "resource": "json/v5/vcards",
-        "docs": "https://yandex.ru/dev/direct/doc/ru/vcards",
+        # Doc page removed Sep 2025 (see comment above); WSDL still live.
+        "docs": "https://api.direct.yandex.com/v5/vcards?wsdl",
         "methods": ["get", "add", "delete"],
     },
     "turbopages": {
@@ -154,7 +161,8 @@ RESOURCE_MAPPING_V5 = {
     },
     "smartadtargets": {
         "resource": "json/v5/smartadtargets",
-        "docs": "https://yandex.ru/dev/direct/doc/ru/smartadtargets",
+        # Doc page removed Sep 2025 (see comment above); WSDL still live.
+        "docs": "https://api.direct.yandex.com/v5/smartadtargets?wsdl",
         "methods": ["get", "add", "update", "delete", "suspend", "resume", "setBids"],
     },
     "strategies": {

--- a/scripts/audit_wire_shape.py
+++ b/scripts/audit_wire_shape.py
@@ -581,17 +581,27 @@ def audit_v5(retries: int, pause: float) -> list[Finding]:
 
         seen_urls: set[str] = set()
         targets: list[tuple[str, str]] = []
-        for op in methods:
-            # docs_pages override > derived URL from docs base
-            url = (docs_pages or {}).get(op)
-            if not url and docs_base:
-                url = _v5_per_method_url(docs_base, op)
-            if not url or url in seen_urls:
-                continue
-            seen_urls.add(url)
-            targets.append((op, url))
-        if not targets and docs_base:
+        # Services whose human-readable doc pages Yandex removed (#463) carry a
+        # WSDL endpoint as `docs`. Per-method URL derivation assumes a
+        # `…/ru/<svc>` page shape and would emit garbage like `…?wsdl/get`, so
+        # treat a WSDL base as a single group-level target instead.
+        wsdl_base = docs_base.rstrip("/").endswith("?wsdl") or docs_base.endswith(
+            ".wsdl"
+        )
+        if wsdl_base:
             targets.append(("__group__", docs_base))
+        else:
+            for op in methods:
+                # docs_pages override > derived URL from docs base
+                url = (docs_pages or {}).get(op)
+                if not url and docs_base:
+                    url = _v5_per_method_url(docs_base, op)
+                if not url or url in seen_urls:
+                    continue
+                seen_urls.add(url)
+                targets.append((op, url))
+            if not targets and docs_base:
+                targets.append(("__group__", docs_base))
 
         for op_name, url in targets:
             fetched = fetch_doc(url, retries=retries, pause=pause)

--- a/scripts/check_all_docs_urls.py
+++ b/scripts/check_all_docs_urls.py
@@ -26,6 +26,9 @@ from direct_cli.reports_coverage import REPORTS_SPEC_URLS
 USER_AGENT = "Mozilla/5.0 (direct-cli docs-drift checker)"
 CAPTCHA_MARKERS = ("showcaptcha", "smartcaptcha", "<title>captcha")
 MIN_BODY_BYTES = 30_000
+# WSDL payloads are XML, much smaller than HTML doc pages. Match the <3 KB
+# floor used by wsdl_coverage.fetch_wsdl (CLAUDE.md "Docs/cache freshness guard").
+MIN_WSDL_BYTES = 3_072
 INTER_REQUEST_DELAY = 1.5  # Yandex rate-limits aggressive UA-less scrapers
 CAPTCHA_RETRY_DELAY = 30   # captcha lockouts clear after ~30s
 
@@ -110,11 +113,14 @@ def _probe(url: str) -> tuple[str, str] | None:
 
     # WSDL endpoints (used as the docs source for services whose human-readable
     # doc pages Yandex removed — see RESOURCE_MAPPING_V5 / issue #463) are XML,
-    # not 30 KB HTML pages. Validate them as real WSDL instead.
+    # not 30 KB HTML pages. Validate them as real WSDL instead, with the same
+    # <3 KB floor the repo's freshness guard uses (wsdl_coverage.fetch_wsdl,
+    # per CLAUDE.md) so a truncated body can't pass on marker presence alone.
     if url.rstrip("/").endswith("?wsdl") or url.endswith(".wsdl"):
-        if "wsdl:definitions" in lower or "<definitions" in lower:
+        has_markers = "wsdl:definitions" in lower or "<definitions" in lower
+        if has_markers and len(body) >= MIN_WSDL_BYTES:
             return ("OK", f"GET {resp.status_code}, valid WSDL, {len(body)} bytes")
-        return ("SMALL", f"WSDL markers absent ({len(body)} bytes)")
+        return ("SMALL", f"WSDL markers/size insufficient ({len(body)} bytes)")
 
     if len(body) < MIN_BODY_BYTES:
         return ("SMALL", f"{len(body)} bytes < {MIN_BODY_BYTES}")

--- a/scripts/check_all_docs_urls.py
+++ b/scripts/check_all_docs_urls.py
@@ -107,6 +107,15 @@ def _probe(url: str) -> tuple[str, str] | None:
     for marker in CAPTCHA_MARKERS:
         if marker in lower:
             return None  # rate-limited
+
+    # WSDL endpoints (used as the docs source for services whose human-readable
+    # doc pages Yandex removed — see RESOURCE_MAPPING_V5 / issue #463) are XML,
+    # not 30 KB HTML pages. Validate them as real WSDL instead.
+    if url.rstrip("/").endswith("?wsdl") or url.endswith(".wsdl"):
+        if "wsdl:definitions" in lower or "<definitions" in lower:
+            return ("OK", f"GET {resp.status_code}, valid WSDL, {len(body)} bytes")
+        return ("SMALL", f"WSDL markers absent ({len(body)} bytes)")
+
     if len(body) < MIN_BODY_BYTES:
         return ("SMALL", f"{len(body)} bytes < {MIN_BODY_BYTES}")
     return ("OK", f"GET {resp.status_code}, {len(body)} bytes")

--- a/tests/test_audit_wire_shape.py
+++ b/tests/test_audit_wire_shape.py
@@ -156,3 +156,36 @@ def test_looks_like_captcha_recognises_markers():
 )
 def test_v5_per_method_url_chops_duplicate_tail(docs, method, expected):
     assert audit._v5_per_method_url(docs, method) == expected
+
+
+def test_audit_v5_treats_wsdl_base_as_single_group_target(monkeypatch):
+    # A service whose `docs` is a WSDL endpoint (#463) must NOT have per-method
+    # URLs derived from it — that would produce garbage like `…?wsdl/get`.
+    # It is audited as one group-level target instead.
+    fetched_urls: list[str] = []
+
+    def fake_fetch_doc(url, retries, pause):
+        fetched_urls.append(url)
+        return audit.FetchResult(
+            url=url, status="ok", html="<html></html>", attempts=1
+        )
+
+    monkeypatch.setattr(audit, "fetch_doc", fake_fetch_doc)
+    monkeypatch.setattr(
+        audit,
+        "RESOURCE_MAPPING_V5",
+        {
+            "vcards": {
+                "resource": "json/v5/vcards",
+                "docs": "https://api.direct.yandex.com/v5/vcards?wsdl",
+                "methods": ["get", "add", "delete"],
+            }
+        },
+    )
+    monkeypatch.setattr(audit, "CLI_TO_API_SERVICE", {"vcards": "vcards"})
+
+    audit.audit_v5(retries=1, pause=0)
+
+    wsdl = "https://api.direct.yandex.com/v5/vcards?wsdl"
+    assert fetched_urls == [wsdl]
+    assert not any("?wsdl/" in u for u in fetched_urls)


### PR DESCRIPTION
## Summary

Fixes the 4 stale `RESOURCE_MAPPING_V5` docs URLs that hard-failed the release preflight (`dynamicads`, `dynamicfeedadtargets`, `smartadtargets`, `vcards`).

**Root cause (confirmed via browser):** Yandex **removed the human-readable doc pages** for these services around September 2025. Both the `/ru/` and `/en/` pages now 404, and the services are gone from the docs navigation ("Основные объекты" menu no longer lists them; `ref-v5/<svc>/<svc>.html` redirects to a 404/default). This is a deletion, not a slug move — which is why no canonical replacement page exists.

The **services themselves remain live** — their WSDL endpoints return HTTP 200:
```
api.direct.yandex.com/v5/{dynamictextadtargets,dynamicfeedadtargets,smartadtargets,vcards}?wsdl  → 200
```

## Change

- **`RESOURCE_MAPPING_V5`**: repoint the 4 `docs` URLs at their WSDL endpoints — the only authoritative source Yandex still serves for them — with a comment explaining the Sep-2025 removal.
- **`check_all_docs_urls.py`**: validate `?wsdl`/`.wsdl` URLs as real WSDL (XML + `wsdl:definitions`) rather than the 30 KB HTML-page threshold (WSDL payloads are 14–21 KB).
- **`audit_wire_shape.py`**: treat a WSDL `docs` base as a single `__group__` target instead of deriving per-method URLs (which would produce malformed `…?wsdl/get`). Regression test added.

## Functional impact (corrected)

The `docs` field **is** read at runtime: `_register_command` (`cli.py:316`) calls `get_docs_url(...)` and appends `Documentation: <url>` to each group's `--help` epilog. So after this change, `direct dynamicads|dynamicfeedadtargets|smartadtargets|vcards --help` print a WSDL link instead of the old (now-dead 404) doc URL. This is a strict improvement — a live WSDL link beats a broken page — but it is a real user-facing help-text change, not "zero impact" as an earlier draft of this description claimed.

## Why WSDL and not a doc page
Investigated thoroughly: the doc pages are gone on every language/host; the WSDL is the only live, authoritative description still served. WSDL does not contain links to doc pages, so there is nothing else to point at.

## Note
Preflight now depends on `api.direct.yandex.com/v5/<svc>?wsdl` being publicly fetchable without a token (holds today; flagged for awareness — if Yandex ever gates WSDL behind auth, preflight would need adjusting).

## Testing
- `python scripts/check_all_docs_urls.py` → **all URLs canonical** (the 4 now report `valid WSDL`).
- Full suite green: **2036 passed, 47 skipped**; `ruff check .` clean.

Closes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)