### PR TITLE
feat(i18n): localize static UsageError/BadParameter messages to Russian (#477)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 Russian-default CLI localization across all command modules (epic #466).
 
+**Localized — static error messages (#477):**
+
+- Wrapped all 179 static `click.UsageError` / `click.BadParameter` string
+  literals (and the `auth` OAuth-code `click.prompt`) across 33 command
+  modules in `t(...)`, with Russian translations added to the per-module
+  `translations/*.json` catalogs; seven messages shared across modules
+  (e.g. `Provide at least one field to update`,
+  `--status and --statuses are mutually exclusive`) live in `common.json`.
+  Validation errors now render in Russian by default and in English under
+  `--locale en`. Flag names, enum values, and WSDL field names are unchanged.
+- Extended `tests/test_i18n.py::test_localized_groups_wrap_runtime_messages`
+  to also scan `UsageError` / `BadParameter` / `prompt` / `confirm` (bare or
+  `click.<Name>`); a bare string literal first argument is rejected. Only
+  static `ast.Constant` literals are enforced for now — interpolated
+  (f-string / concat) messages are stage B (#478).
+- Test suite defaults the CLI locale to English (`tests/conftest.py` autouse
+  fixture) so the existing English error-contract assertions stay valid; the
+  Russian default remains covered by `tests/test_i18n.py`.
+
 **Added — scalable i18n mechanism (#467):**
 
 - Source-string-keyed translation catalog: the English `help=` / docstring /

--- a/direct_cli/commands/adextensions.py
+++ b/direct_cli/commands/adextensions.py
@@ -5,6 +5,7 @@ AdExtensions commands
 import click
 
 from ..api import create_client
+from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import add_criteria_csv, get_default_fields, parse_csv_strings, parse_ids
 
@@ -58,7 +59,7 @@ def get(
         parsed_callout_field_names = parse_csv_strings(callout_field_names)
         if callout_field_names is not None and not parsed_callout_field_names:
             raise click.UsageError(
-                "Provide a non-empty comma-separated CalloutFieldNames list."
+                t("Provide a non-empty comma-separated CalloutFieldNames list.")
             )
 
         criteria = {}

--- a/direct_cli/commands/adgroups.py
+++ b/direct_cli/commands/adgroups.py
@@ -7,6 +7,7 @@ from typing import Any, Optional
 import click
 
 from ..api import create_client
+from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import (
     add_criteria_csv,
@@ -221,8 +222,10 @@ def _parse_autotargeting_categories(
         category_raw, separator, value_raw = raw_value.strip().partition("=")
         if not separator:
             raise click.UsageError(
-                "--autotargeting-category expects CATEGORY=YES|NO "
-                "(for example EXACT=YES)"
+                t(
+                    "--autotargeting-category expects CATEGORY=YES|NO "
+                    "(for example EXACT=YES)"
+                )
             )
 
         category = _normalize_enum_token(category_raw)
@@ -290,8 +293,10 @@ def _reject_legacy_autotargeting_mix(
     """Reject ambiguous legacy AutotargetingCategories + Settings payloads."""
     if settings is not None and categories:
         raise click.UsageError(
-            "AutotargetingSettings flags cannot be combined with legacy "
-            "--autotargeting-category flags."
+            t(
+                "AutotargetingSettings flags cannot be combined with legacy "
+                "--autotargeting-category flags."
+            )
         )
 
 
@@ -328,7 +333,7 @@ def _build_dynamic_text_adgroup(
 
     has_dynamic_fields = bool(domain_url or parsed_categories or autotargeting_settings)
     if (force_domain_url or has_dynamic_fields) and not domain_url:
-        raise click.UsageError("--domain-url is required for DYNAMIC_TEXT_AD_GROUP")
+        raise click.UsageError(t("--domain-url is required for DYNAMIC_TEXT_AD_GROUP"))
 
     dynamic_text_adgroup: dict[str, object] = {}
     if domain_url:
@@ -351,7 +356,9 @@ def _build_dynamic_text_feed_adgroup(
     parsed_categories = _parse_autotargeting_categories(autotargeting_categories)
 
     if require_feed_id and feed_id is None:
-        raise click.UsageError("--feed-id is required for DYNAMIC_TEXT_FEED_AD_GROUP")
+        raise click.UsageError(
+            t("--feed-id is required for DYNAMIC_TEXT_FEED_AD_GROUP")
+        )
 
     dynamic_text_feed_adgroup: dict[str, object] = {}
     if feed_id is not None:
@@ -374,7 +381,9 @@ def _build_text_adgroup_feed_params(
     )
 
     if feed_id is None and parsed_feed_category_ids:
-        raise click.UsageError("--feed-id is required when --feed-category-ids is used")
+        raise click.UsageError(
+            t("--feed-id is required when --feed-category-ids is used")
+        )
     if feed_id is None:
         return None
 
@@ -575,7 +584,7 @@ def get(
 ):
     """Get ad groups"""
     if status and statuses:
-        raise click.UsageError("--status and --statuses are mutually exclusive")
+        raise click.UsageError(t("--status and --statuses are mutually exclusive"))
 
     try:
         client = create_client(
@@ -968,7 +977,7 @@ def add(
             adgroup_data["CpmVideoAdGroup"] = {}
         elif group_type_norm == "SMART_AD_GROUP":
             if feed_id is None:
-                raise click.UsageError("--feed-id is required for SMART_AD_GROUP")
+                raise click.UsageError(t("--feed-id is required for SMART_AD_GROUP"))
             smart_ad_group = {"FeedId": feed_id}
             if ad_title_source:
                 smart_ad_group["AdTitleSource"] = ad_title_source
@@ -978,7 +987,7 @@ def add(
         elif group_type_norm == "UNIFIED_AD_GROUP":
             if offer_retargeting is None:
                 raise click.UsageError(
-                    "--offer-retargeting is required for UNIFIED_AD_GROUP"
+                    t("--offer-retargeting is required for UNIFIED_AD_GROUP")
                 )
             adgroup_data["UnifiedAdGroup"] = {
                 "OfferRetargeting": offer_retargeting.upper()
@@ -1238,7 +1247,9 @@ def update(
         adgroup_data["TrackingParams"] = tracking_params
     if dynamic_feed:
         if not autotargeting_categories:
-            raise click.UsageError("--dynamic-feed requires --autotargeting-category")
+            raise click.UsageError(
+                t("--dynamic-feed requires --autotargeting-category")
+            )
         dynamic_text_feed_adgroup = _build_dynamic_text_feed_adgroup(
             autotargeting_categories=autotargeting_categories,
         )
@@ -1291,14 +1302,16 @@ def update(
     # Reject empty-payload no-op (issue #198 H5).
     if len(adgroup_data) == 1:
         raise click.UsageError(
-            "adgroups update requires at least one updatable field "
-            "(--name, --status, --region-ids, --negative-keywords, "
-            "--negative-keyword-shared-set-ids, --tracking-params, "
-            "--domain-url, --dynamic-feed, --autotargeting-category, "
-            "--autotargeting-settings-* flags, --target-device-types, "
-            "--target-carrier, --target-operating-system-version, "
-            "--feed-id, --feed-category-ids, --ad-title-source, "
-            "--ad-body-source, or --offer-retargeting)."
+            t(
+                "adgroups update requires at least one updatable field "
+                "(--name, --status, --region-ids, --negative-keywords, "
+                "--negative-keyword-shared-set-ids, --tracking-params, "
+                "--domain-url, --dynamic-feed, --autotargeting-category, "
+                "--autotargeting-settings-* flags, --target-device-types, "
+                "--target-carrier, --target-operating-system-version, "
+                "--feed-id, --feed-category-ids, --ad-title-source, "
+                "--ad-body-source, or --offer-retargeting)."
+            )
         )
 
     try:

--- a/direct_cli/commands/adimages.py
+++ b/direct_cli/commands/adimages.py
@@ -5,6 +5,7 @@ AdImages commands
 import click
 
 from ..api import create_client
+from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import add_criteria_csv, get_default_fields, load_base64_file, parse_ids
 
@@ -95,7 +96,7 @@ def add(ctx, name, image_data, image_file, image_type, dry_run):
     try:
         if bool(image_data) == bool(image_file):
             raise click.UsageError(
-                "Provide exactly one of --image-data or --image-file"
+                t("Provide exactly one of --image-data or --image-file")
             )
 
         payload = {

--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -7,6 +7,7 @@ from typing import Optional
 import click
 
 from ..api import create_client
+from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import (
     add_criteria_csv,
@@ -231,10 +232,12 @@ def _build_callout_setting(callouts_add, callouts_remove, callouts_set):
     """
     if callouts_set and (callouts_add or callouts_remove):
         raise click.UsageError(
-            "--callouts-set is mutually exclusive with "
-            "--callouts-add / --callouts-remove. "
-            "Use --callouts-set to replace the full callout list, "
-            "or --callouts-add / --callouts-remove for incremental edits."
+            t(
+                "--callouts-set is mutually exclusive with "
+                "--callouts-add / --callouts-remove. "
+                "Use --callouts-set to replace the full callout list, "
+                "or --callouts-add / --callouts-remove for incremental edits."
+            )
         )
     items = []
     for csv_value, op in (
@@ -376,7 +379,10 @@ def _parse_mobile_app_features(
         feature_raw, separator, enabled_raw = raw_value.strip().partition("=")
         if not separator:
             raise click.UsageError(
-                "--mobile-app-feature expects FEATURE=YES|NO (for example PRICE=YES)."
+                t(
+                    "--mobile-app-feature expects FEATURE=YES|NO "
+                    "(for example PRICE=YES)."
+                )
             )
 
         feature = feature_raw.strip().upper()
@@ -511,7 +517,7 @@ def _build_feed_based_ad_add(
 
     default_text = default_texts.strip() if default_texts else ""
     if not default_text:
-        raise click.UsageError("--default-texts must contain a value.")
+        raise click.UsageError(t("--default-texts must contain a value."))
 
     ad_payload: dict[str, object] = {
         "FeedId": feed_id,
@@ -556,7 +562,7 @@ def _build_dynamic_text_ad_add(
 ) -> dict[str, object]:
     """Build DynamicTextAdAdd payload from typed flags."""
     if not text:
-        raise click.UsageError("DYNAMIC_TEXT_AD requires --text")
+        raise click.UsageError(t("DYNAMIC_TEXT_AD requires --text"))
 
     dynamic_text_ad: dict[str, object] = {"Text": text}
     if image_hash:
@@ -586,7 +592,9 @@ def _build_ad_builder_update(
     ad_payload: dict[str, object] = {}
 
     if creative_erir_ad_description and creative_id is None:
-        raise click.UsageError("--creative-erir-ad-description requires --creative-id.")
+        raise click.UsageError(
+            t("--creative-erir-ad-description requires --creative-id.")
+        )
     if creative_id is not None:
         creative: dict[str, object] = {"CreativeId": creative_id}
         if creative_erir_ad_description:
@@ -683,7 +691,7 @@ def _build_mobile_app_image_ad_add(
 ) -> dict[str, object]:
     """Build MobileAppImageAdAdd payload from typed flags."""
     if not image_hash:
-        raise click.UsageError("MOBILE_APP_IMAGE_AD requires --image-hash")
+        raise click.UsageError(t("MOBILE_APP_IMAGE_AD requires --image-hash"))
 
     mobile_app_image_ad: dict[str, object] = {"AdImageHash": image_hash}
     if erir_ad_description:
@@ -921,7 +929,7 @@ def get(
 ):
     """Get ads"""
     if status and statuses:
-        raise click.UsageError("--status and --statuses are mutually exclusive")
+        raise click.UsageError(t("--status and --statuses are mutually exclusive"))
 
     try:
         field_names = (
@@ -1520,15 +1528,17 @@ def add(
         elif ad_type_norm == "TEXT_IMAGE_AD":
             if title or text:
                 raise click.UsageError(
-                    "--title/--text are only valid for TEXT_AD. "
-                    "For TEXT_IMAGE_AD, use --image-hash and "
-                    "--href / --turbo-page-id."
+                    t(
+                        "--title/--text are only valid for TEXT_AD. "
+                        "For TEXT_IMAGE_AD, use --image-hash and "
+                        "--href / --turbo-page-id."
+                    )
                 )
             if not image_hash:
-                raise click.UsageError("TEXT_IMAGE_AD requires --image-hash")
+                raise click.UsageError(t("TEXT_IMAGE_AD requires --image-hash"))
             if not href and turbo_page_id is None:
                 raise click.UsageError(
-                    "TEXT_IMAGE_AD requires either --href or --turbo-page-id."
+                    t("TEXT_IMAGE_AD requires either --href or --turbo-page-id.")
                 )
             text_image_ad = {"AdImageHash": image_hash}
             if erir_ad_description:
@@ -1555,7 +1565,7 @@ def add(
                 )
             if not href and business_id is None:
                 raise click.UsageError(
-                    "RESPONSIVE_AD requires either --href or --business-id."
+                    t("RESPONSIVE_AD requires either --href or --business-id.")
                 )
 
             parsed_texts = _parse_required_csv_strings(texts, "--texts")
@@ -1627,8 +1637,10 @@ def add(
         elif ad_type_norm == "MOBILE_APP_AD":
             if href:
                 raise click.UsageError(
-                    "--href does not apply to MOBILE_APP_AD. "
-                    "Use --tracking-url instead."
+                    t(
+                        "--href does not apply to MOBILE_APP_AD. "
+                        "Use --tracking-url instead."
+                    )
                 )
             missing_fields = [
                 option_name
@@ -1961,8 +1973,10 @@ def update(
     """Update ad"""
     if status:
         raise click.UsageError(
-            "Use 'direct ads suspend/resume/archive/unarchive' to change status. "
-            "The --status flag is not supported by WSDL AdUpdateItem."
+            t(
+                "Use 'direct ads suspend/resume/archive/unarchive' to change status. "
+                "The --status flag is not supported by WSDL AdUpdateItem."
+            )
         )
 
     ad_type_norm = ad_type.upper().replace("-", "_")

--- a/direct_cli/commands/advideos.py
+++ b/direct_cli/commands/advideos.py
@@ -5,6 +5,7 @@ AdVideos commands
 import click
 
 from ..api import create_client
+from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import get_default_fields, load_base64_file
 
@@ -81,7 +82,7 @@ def add(ctx, url, video_data, video_file, name, dry_run):
         sources = [s for s in (url, video_data, video_file) if s]
         if len(sources) != 1:
             raise click.UsageError(
-                "Provide exactly one of --url, --video-data, or --video-file."
+                t("Provide exactly one of --url, --video-data, or --video-file.")
             )
 
         item = {}

--- a/direct_cli/commands/agencyclients.py
+++ b/direct_cli/commands/agencyclients.py
@@ -342,7 +342,7 @@ def add_passport_organization_member(
     try:
         if not invite_email and not invite_phone:
             raise click.UsageError(
-                "Provide at least one of --invite-email or --invite-phone"
+                t("Provide at least one of --invite-email or --invite-phone")
             )
 
         send_invite_to = {}
@@ -421,7 +421,9 @@ def update(
     """Update agency client"""
     try:
         if grants and clear_grants:
-            raise click.UsageError("--grant and --clear-grants are mutually exclusive")
+            raise click.UsageError(
+                t("--grant and --clear-grants are mutually exclusive")
+            )
 
         notification = build_notification_update(
             notification_email,
@@ -443,7 +445,7 @@ def update(
         if clear_grants:
             client_data["Grants"] = []
         if len(client_data) == 1:
-            raise click.UsageError("Provide at least one field to update")
+            raise click.UsageError(t("Provide at least one field to update"))
 
         body = {"method": "update", "params": {"Clients": [client_data]}}
 

--- a/direct_cli/commands/audiencetargets.py
+++ b/direct_cli/commands/audiencetargets.py
@@ -5,6 +5,7 @@ AudienceTargets commands
 import click
 
 from ..api import create_client
+from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import add_criteria_csv, get_default_fields, parse_ids, MICRO_RUBLES
 
@@ -122,7 +123,7 @@ def add(
     try:
         if retargeting_list_id is None and interest_id is None:
             raise click.UsageError(
-                "Provide at least one of --retargeting-list-id or --interest-id"
+                t("Provide at least one of --retargeting-list-id or --interest-id")
             )
 
         target_data = {
@@ -187,11 +188,11 @@ def set_bids(ctx, target_id, adgroup_id, campaign_id, context_bid, priority, dry
         }
         if not selector_fields:
             raise click.UsageError(
-                "Provide a target selector (--id, --adgroup-id, or --campaign-id)"
+                t("Provide a target selector (--id, --adgroup-id, or --campaign-id)")
             )
         if not bid_fields:
             raise click.UsageError(
-                "Provide at least one bid field (--context-bid or --priority)"
+                t("Provide at least one bid field (--context-bid or --priority)")
             )
 
         body = {"method": "setBids", "params": {"Bids": [bid_data]}}

--- a/direct_cli/commands/auth.py
+++ b/direct_cli/commands/auth.py
@@ -143,7 +143,7 @@ def login(
         )
         print_info(t("Open this URL and grant access:"))
         click.echo(auth_url)
-        auth_code = click.prompt("Enter OAuth code", type=str).strip()
+        auth_code = click.prompt(t("Enter OAuth code"), type=str).strip()
     elif not client_secret:
         pending_pkce = get_pending_pkce(profile)
         if pending_pkce:

--- a/direct_cli/commands/balance.py
+++ b/direct_cli/commands/balance.py
@@ -3,6 +3,7 @@
 import click
 
 from ..api import create_v4_client
+from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import parse_csv_strings
 from ..v4 import build_v4_body, call_v4
@@ -35,7 +36,7 @@ def balance(ctx, logins, output_format, output, dry_run):
     if login_list:
         param["SelectionCriteria"] = {"Logins": login_list}
     elif ctx.obj.get("sandbox"):
-        raise click.UsageError("Provide --logins or configure YANDEX_DIRECT_LOGIN")
+        raise click.UsageError(t("Provide --logins or configure YANDEX_DIRECT_LOGIN"))
 
     if dry_run:
         format_output(build_v4_body("AccountManagement", param), "json", None)

--- a/direct_cli/commands/bidmodifiers.py
+++ b/direct_cli/commands/bidmodifiers.py
@@ -5,6 +5,7 @@ BidModifiers commands
 import click
 
 from ..api import create_client
+from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import get_default_fields, parse_csv_strings, parse_ids
 
@@ -385,7 +386,7 @@ def add(
     try:
         if (campaign_id is None) == (adgroup_id is None):
             raise click.UsageError(
-                "Exactly one of --campaign-id or --adgroup-id is required"
+                t("Exactly one of --campaign-id or --adgroup-id is required")
             )
 
         modifier_type_upper = modifier_type.upper()
@@ -416,26 +417,28 @@ def add(
                 nested["Age"] = age
             if "Gender" not in nested and "Age" not in nested:
                 raise click.UsageError(
-                    "DEMOGRAPHICS_ADJUSTMENT requires --gender and/or --age"
+                    t("DEMOGRAPHICS_ADJUSTMENT requires --gender and/or --age")
                 )
         elif modifier_type_upper == "RETARGETING_ADJUSTMENT":
             if retargeting_condition_id is None:
                 raise click.UsageError(
-                    "RETARGETING_ADJUSTMENT requires --retargeting-condition-id"
+                    t("RETARGETING_ADJUSTMENT requires --retargeting-condition-id")
                 )
             nested["RetargetingConditionId"] = retargeting_condition_id
         elif modifier_type_upper == "REGIONAL_ADJUSTMENT":
             if region_id is None:
-                raise click.UsageError("REGIONAL_ADJUSTMENT requires --region-id")
+                raise click.UsageError(t("REGIONAL_ADJUSTMENT requires --region-id"))
             nested["RegionId"] = region_id
         elif modifier_type_upper == "SERP_LAYOUT_ADJUSTMENT":
             if not serp_layout:
-                raise click.UsageError("SERP_LAYOUT_ADJUSTMENT requires --serp-layout")
+                raise click.UsageError(
+                    t("SERP_LAYOUT_ADJUSTMENT requires --serp-layout")
+                )
             nested["SerpLayout"] = serp_layout
         elif modifier_type_upper == "INCOME_GRADE_ADJUSTMENT":
             if not income_grade:
                 raise click.UsageError(
-                    "INCOME_GRADE_ADJUSTMENT requires --income-grade"
+                    t("INCOME_GRADE_ADJUSTMENT requires --income-grade")
                 )
             nested["Grade"] = income_grade
 
@@ -536,10 +539,12 @@ def set(ctx, modifier_id, value, dry_run):
     try:
         if modifier_id is None:
             raise click.UsageError(
-                "Provide --id with --value for bidmodifiers set. "
-                "The legacy --campaign-id/--type shape is not supported by "
-                "WSDL BidModifierSetItem; use bidmodifiers add to create a "
-                "new modifier."
+                t(
+                    "Provide --id with --value for bidmodifiers set. "
+                    "The legacy --campaign-id/--type shape is not supported by "
+                    "WSDL BidModifierSetItem; use bidmodifiers add to create a "
+                    "new modifier."
+                )
             )
 
         # Correct API shape: Id + BidModifier. Nothing else.

--- a/direct_cli/commands/bids.py
+++ b/direct_cli/commands/bids.py
@@ -5,6 +5,7 @@ Bids commands
 import click
 
 from ..api import create_client
+from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import (
     add_criteria_csv,
@@ -131,9 +132,11 @@ def set(
         and priority is None
     ):
         raise click.UsageError(
-            "bids set requires at least one bid field "
-            "(--bid, --context-bid, --priority, "
-            "or --autotargeting-search-bid-is-auto)."
+            t(
+                "bids set requires at least one bid field "
+                "(--bid, --context-bid, --priority, "
+                "or --autotargeting-search-bid-is-auto)."
+            )
         )
 
     try:
@@ -224,7 +227,7 @@ def set_auto(
         if scope:
             bid_data["Scope"] = list(scope)
         if "Scope" not in bid_data:
-            raise click.UsageError("Provide at least one --scope")
+            raise click.UsageError(t("Provide at least one --scope"))
 
         body = {"method": "setAuto", "params": {"Bids": [bid_data]}}
 

--- a/direct_cli/commands/campaigns.py
+++ b/direct_cli/commands/campaigns.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Optional, Sequence
 import click
 
 from ..api import create_client
+from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import (
     build_selection_criteria,
@@ -136,7 +137,7 @@ def _time_targeting_schedule_option(values: Sequence[str]) -> Optional[dict]:
     items = [value.strip() for value in values if value.strip()]
     if len(items) != len(values):
         raise click.UsageError(
-            "--time-targeting-schedule must contain at least one value"
+            t("--time-targeting-schedule must contain at least one value")
         )
     if len(items) > TIME_TARGETING_SCHEDULE_MAX_ITEMS:
         raise click.UsageError(
@@ -253,8 +254,10 @@ def _build_time_targeting(
         return None
     if consider_working_weekends is None:
         raise click.UsageError(
-            "TimeTargeting requires --consider-working-weekends when any "
-            "time-targeting flag is provided."
+            t(
+                "TimeTargeting requires --consider-working-weekends when any "
+                "time-targeting flag is provided."
+            )
         )
 
     time_targeting: dict = {
@@ -266,9 +269,11 @@ def _build_time_targeting(
     if has_holidays:
         if holidays_suspend_on_holidays is None:
             raise click.UsageError(
-                "TimeTargeting.HolidaysSchedule requires "
-                "--holidays-suspend-on-holidays when any --holidays-* flag "
-                "is provided."
+                t(
+                    "TimeTargeting.HolidaysSchedule requires "
+                    "--holidays-suspend-on-holidays when any --holidays-* flag "
+                    "is provided."
+                )
             )
         suspend_on_holidays = holidays_suspend_on_holidays.upper()
         if suspend_on_holidays == "YES" and any(
@@ -280,12 +285,14 @@ def _build_time_targeting(
             )
         ):
             raise click.UsageError(
-                "--holidays-bid-percent, --holidays-start-hour, and "
-                "--holidays-end-hour can be provided only when "
-                "--holidays-suspend-on-holidays is NO."
+                t(
+                    "--holidays-bid-percent, --holidays-start-hour, and "
+                    "--holidays-end-hour can be provided only when "
+                    "--holidays-suspend-on-holidays is NO."
+                )
             )
         if holidays_bid_percent is not None and holidays_bid_percent % 10 != 0:
-            raise click.UsageError("--holidays-bid-percent must be a multiple of 10")
+            raise click.UsageError(t("--holidays-bid-percent must be a multiple of 10"))
         holidays: dict = {"SuspendOnHolidays": suspend_on_holidays}
         if holidays_bid_percent is not None:
             holidays["BidPercent"] = holidays_bid_percent
@@ -310,8 +317,10 @@ def _build_relevant_keywords(
         return None
     if require_budget_percent and budget_percent is None:
         raise click.UsageError(
-            "--relevant-keywords-budget-percent is required when adding "
-            "TextCampaign.RelevantKeywords"
+            t(
+                "--relevant-keywords-budget-percent is required when adding "
+                "TextCampaign.RelevantKeywords"
+            )
         )
     relevant_keywords: dict = {}
     if budget_percent is not None:
@@ -351,18 +360,24 @@ def _build_frequency_cap(
         return None
     if period_days is not None and period_all:
         raise click.UsageError(
-            "--frequency-cap-period-days and --frequency-cap-period-all "
-            "are mutually exclusive"
+            t(
+                "--frequency-cap-period-days and --frequency-cap-period-all "
+                "are mutually exclusive"
+            )
         )
     if impressions is None:
         raise click.UsageError(
-            "--frequency-cap-impressions is required with "
-            "--frequency-cap-period-days or --frequency-cap-period-all"
+            t(
+                "--frequency-cap-impressions is required with "
+                "--frequency-cap-period-days or --frequency-cap-period-all"
+            )
         )
     if period_days is None and not period_all:
         raise click.UsageError(
-            "--frequency-cap-impressions requires --frequency-cap-period-days "
-            "or --frequency-cap-period-all"
+            t(
+                "--frequency-cap-impressions requires --frequency-cap-period-days "
+                "or --frequency-cap-period-all"
+            )
         )
     return {
         "Impressions": impressions,
@@ -460,8 +475,10 @@ def _build_smart_package_bidding_strategy(
         search is None or network is None
     ):
         raise click.UsageError(
-            "SmartCampaign.PackageBiddingStrategy requires "
-            "--package-platform-search and --package-platform-network"
+            t(
+                "SmartCampaign.PackageBiddingStrategy requires "
+                "--package-platform-search and --package-platform-network"
+            )
         )
 
     package_strategy: dict = {}
@@ -648,7 +665,7 @@ def get(
 ):
     """Get campaigns"""
     if status and statuses:
-        raise click.UsageError("--status and --statuses are mutually exclusive")
+        raise click.UsageError(t("--status and --statuses are mutually exclusive"))
 
     try:
         client = create_client(
@@ -3863,8 +3880,10 @@ def add(
             # (issue #198 H6).
             if counter_id is None:
                 raise click.UsageError(
-                    "--counter-id is required for SMART_CAMPAIGN "
-                    "(WSDL SmartCampaignAddItem.CounterId minOccurs=1)"
+                    t(
+                        "--counter-id is required for SMART_CAMPAIGN "
+                        "(WSDL SmartCampaignAddItem.CounterId minOccurs=1)"
+                    )
                 )
             smart_campaign: Dict[str, object] = {"CounterId": counter_id}
             if smart_package_bidding_strategy_obj is not None:
@@ -3953,9 +3972,11 @@ def add(
                 ]
                 if filter_average_cpc is not None and smart_network_typed_provided:
                     raise click.UsageError(
-                        "--filter-average-cpc cannot be combined with typed "
-                        "--smart-network-* flags; use "
-                        "--smart-network-filter-average-cpc instead"
+                        t(
+                            "--filter-average-cpc cannot be combined with typed "
+                            "--smart-network-* flags; use "
+                            "--smart-network-filter-average-cpc instead"
+                        )
                     )
                 # Bridge the legacy --filter-average-cpc flag onto the new
                 # typed Network builder. Only valid when network strategy is
@@ -3967,9 +3988,11 @@ def add(
                     ).upper()
                     if legacy_strategy != "AVERAGE_CPC_PER_FILTER":
                         raise click.UsageError(
-                            "--filter-average-cpc is only valid for "
-                            "SMART_CAMPAIGN with AVERAGE_CPC_PER_FILTER "
-                            "network strategy"
+                            t(
+                                "--filter-average-cpc is only valid for "
+                                "SMART_CAMPAIGN with AVERAGE_CPC_PER_FILTER "
+                                "network strategy"
+                            )
                         )
                     effective_filter_average_cpc = filter_average_cpc
                 effective_network_strategy = network_strategy
@@ -7373,7 +7396,7 @@ def update(
             campaign_data[subtype_container] = sub_block
 
         if len(campaign_data) == 1:
-            raise click.UsageError("Provide at least one field to update")
+            raise click.UsageError(t("Provide at least one field to update"))
 
         body = {"method": "update", "params": {"Campaigns": [campaign_data]}}
 

--- a/direct_cli/commands/changes.py
+++ b/direct_cli/commands/changes.py
@@ -5,6 +5,7 @@ Changes commands
 import click
 
 from ..api import create_client
+from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import get_default_fields, parse_changes_datetime, parse_ids
 
@@ -64,12 +65,14 @@ def check(
     )
     if sources_used == 0:
         raise click.UsageError(
-            "Provide exactly one of: --campaign-ids, --ad-group-ids, --ad-ids."
+            t("Provide exactly one of: --campaign-ids, --ad-group-ids, --ad-ids.")
         )
     if sources_used > 1:
         raise click.UsageError(
-            "--campaign-ids, --ad-group-ids, and --ad-ids are mutually "
-            "exclusive — provide exactly one."
+            t(
+                "--campaign-ids, --ad-group-ids, and --ad-ids are mutually "
+                "exclusive — provide exactly one."
+            )
         )
 
     if fields:

--- a/direct_cli/commands/clients.py
+++ b/direct_cli/commands/clients.py
@@ -5,6 +5,7 @@ Clients commands
 import click
 
 from ..api import create_client
+from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import (
     build_client_update_item,
@@ -344,7 +345,7 @@ def update(
             ),
         )
         if not client_data:
-            raise click.UsageError("Provide at least one field to update")
+            raise click.UsageError(t("Provide at least one field to update"))
 
         body = {"method": "update", "params": {"Clients": [client_data]}}
 

--- a/direct_cli/commands/dynamicads.py
+++ b/direct_cli/commands/dynamicads.py
@@ -5,6 +5,7 @@ DynamicAds (Webpages) commands
 import click
 
 from ..api import create_client
+from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import get_default_fields, parse_condition_specs, parse_ids, MICRO_RUBLES
 
@@ -264,11 +265,14 @@ def set_bids(
         }
         if not selector_fields:
             raise click.UsageError(
-                "Provide a target selector (--id, --adgroup-id, or --campaign-id)"
+                t("Provide a target selector (--id, --adgroup-id, or --campaign-id)")
             )
         if not bid_fields:
             raise click.UsageError(
-                "Provide at least one bid field (--bid, --context-bid, or --priority)"
+                t(
+                    "Provide at least one bid field "
+                    "(--bid, --context-bid, or --priority)"
+                )
             )
 
         body = {"method": "setBids", "params": {"Bids": [bid_data]}}

--- a/direct_cli/commands/dynamicfeedadtargets.py
+++ b/direct_cli/commands/dynamicfeedadtargets.py
@@ -5,6 +5,7 @@ DynamicFeedAdTargets commands
 import click
 
 from ..api import create_client
+from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import get_default_fields, parse_condition_specs, parse_ids, MICRO_RUBLES
 
@@ -64,7 +65,7 @@ def get(
             ]
 
         if not criteria:
-            raise click.UsageError("Provide at least one typed filter")
+            raise click.UsageError(t("Provide at least one typed filter"))
 
         params = {"SelectionCriteria": criteria, "FieldNames": field_names}
 
@@ -270,10 +271,12 @@ def set_bids(ctx, target_id, adgroup_id, campaign_id, bid, context_bid, dry_run)
         has_bid = any(k in bid_data for k in ("Bid", "ContextBid"))
         if not has_selector:
             raise click.UsageError(
-                "Provide a target selector (--id, --adgroup-id, or --campaign-id)"
+                t("Provide a target selector (--id, --adgroup-id, or --campaign-id)")
             )
         if not has_bid:
-            raise click.UsageError("Provide at least one bid (--bid or --context-bid)")
+            raise click.UsageError(
+                t("Provide at least one bid (--bid or --context-bid)")
+            )
 
         body = {"method": "setBids", "params": {"Bids": [bid_data]}}
 

--- a/direct_cli/commands/feeds.py
+++ b/direct_cli/commands/feeds.py
@@ -9,6 +9,7 @@ from typing import Dict, Optional
 import click
 
 from ..api import create_client
+from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import get_default_fields, parse_csv_strings, parse_ids
 
@@ -52,7 +53,7 @@ def _file_feed_payload(
     path = Path(file_feed_path)
     filename = file_feed_filename or path.name
     if not filename:
-        raise click.UsageError("FileFeed.Filename cannot be empty.")
+        raise click.UsageError(t("FileFeed.Filename cannot be empty."))
     if len(filename) > _FILE_FEED_MAX_FILENAME_LENGTH:
         raise click.UsageError(
             "FileFeed.Filename must be at most "
@@ -68,7 +69,7 @@ def _file_feed_payload(
 
     if file_size > _FILE_FEED_MAX_BYTES:
         raise click.UsageError(
-            "FileFeed.Data must be at most 50 MiB before base64 encoding."
+            t("FileFeed.Data must be at most 50 MiB before base64 encoding.")
         )
 
     try:
@@ -159,13 +160,13 @@ def get(
         parsed_file_feed_field_names = parse_csv_strings(file_feed_field_names)
         if file_feed_field_names is not None and not parsed_file_feed_field_names:
             raise click.UsageError(
-                "Provide a non-empty comma-separated FileFeedFieldNames list."
+                t("Provide a non-empty comma-separated FileFeedFieldNames list.")
             )
 
         parsed_url_feed_field_names = parse_csv_strings(url_feed_field_names)
         if url_feed_field_names is not None and not parsed_url_feed_field_names:
             raise click.UsageError(
-                "Provide a non-empty comma-separated UrlFeedFieldNames list."
+                t("Provide a non-empty comma-separated UrlFeedFieldNames list.")
             )
 
         criteria = {}
@@ -252,17 +253,21 @@ def add(
     """Add feed"""
     try:
         if file_feed_filename and not file_feed_path:
-            raise click.UsageError("--file-feed-filename requires --file-feed-path.")
+            raise click.UsageError(t("--file-feed-filename requires --file-feed-path."))
         if url and file_feed_path:
-            raise click.UsageError("Use either --url or --file-feed-path, not both.")
+            raise click.UsageError(t("Use either --url or --file-feed-path, not both."))
         if not url and not file_feed_path:
-            raise click.UsageError("Provide exactly one of --url or --file-feed-path.")
+            raise click.UsageError(
+                t("Provide exactly one of --url or --file-feed-path.")
+            )
         if file_feed_path and _has_url_feed_options(
             None, remove_utm_tags, feed_login, feed_password
         ):
             raise click.UsageError(
-                "--remove-utm-tags, --feed-login, and --feed-password are "
-                "only valid with --url feeds."
+                t(
+                    "--remove-utm-tags, --feed-login, and --feed-password are "
+                    "only valid with --url feeds."
+                )
             )
 
         feed_data = {
@@ -351,14 +356,14 @@ def update(
     try:
         if feed_login is not None and clear_feed_login:
             raise click.UsageError(
-                "Use either --feed-login or --clear-feed-login, not both"
+                t("Use either --feed-login or --clear-feed-login, not both")
             )
         if feed_password is not None and clear_feed_password:
             raise click.UsageError(
-                "Use either --feed-password or --clear-feed-password, not both"
+                t("Use either --feed-password or --clear-feed-password, not both")
             )
         if file_feed_filename and not file_feed_path:
-            raise click.UsageError("--file-feed-filename requires --file-feed-path.")
+            raise click.UsageError(t("--file-feed-filename requires --file-feed-path."))
         if file_feed_path and _has_url_feed_options(
             url,
             remove_utm_tags,
@@ -368,7 +373,7 @@ def update(
             clear_feed_password,
         ):
             raise click.UsageError(
-                "FileFeed options cannot be combined with UrlFeed options."
+                t("FileFeed options cannot be combined with UrlFeed options.")
             )
 
         feed_data = {"Id": feed_id}
@@ -391,9 +396,11 @@ def update(
             )
         if len(feed_data) == 1:
             raise click.UsageError(
-                "Provide at least one of --name, --url, --file-feed-path, "
-                "--remove-utm-tags, --feed-login, --feed-password, "
-                "--clear-feed-login, or --clear-feed-password"
+                t(
+                    "Provide at least one of --name, --url, --file-feed-path, "
+                    "--remove-utm-tags, --feed-login, --feed-password, "
+                    "--clear-feed-login, or --clear-feed-password"
+                )
             )
 
         body = {"method": "update", "params": {"Feeds": [feed_data]}}

--- a/direct_cli/commands/keywordbids.py
+++ b/direct_cli/commands/keywordbids.py
@@ -5,6 +5,7 @@ KeywordBids commands
 import click
 
 from ..api import create_client
+from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import (
     add_criteria_csv,
@@ -85,17 +86,17 @@ def get(
         parsed_fields = parse_csv_strings(fields)
         if fields is not None and not parsed_fields:
             raise click.UsageError(
-                "Provide a non-empty comma-separated FieldNames list."
+                t("Provide a non-empty comma-separated FieldNames list.")
             )
         parsed_search_field_names = parse_csv_strings(search_field_names)
         if search_field_names is not None and not parsed_search_field_names:
             raise click.UsageError(
-                "Provide a non-empty comma-separated SearchFieldNames list."
+                t("Provide a non-empty comma-separated SearchFieldNames list.")
             )
         parsed_network_field_names = parse_csv_strings(network_field_names)
         if network_field_names is not None and not parsed_network_field_names:
             raise click.UsageError(
-                "Provide a non-empty comma-separated NetworkFieldNames list."
+                t("Provide a non-empty comma-separated NetworkFieldNames list.")
             )
 
         criteria = {}
@@ -110,8 +111,7 @@ def get(
         params = {
             "SelectionCriteria": criteria,
             "FieldNames": (
-                parsed_fields
-                or get_default_fields("keywordbids", "FieldNames")
+                parsed_fields or get_default_fields("keywordbids", "FieldNames")
             ),
             "SearchFieldNames": (
                 parsed_search_field_names
@@ -188,9 +188,11 @@ def set(
         and priority is None
     ):
         raise click.UsageError(
-            "keywordbids set requires at least one bid field "
-            "(--search-bid, --network-bid, --priority, "
-            "or --autotargeting-search-bid-is-auto)."
+            t(
+                "keywordbids set requires at least one bid field "
+                "(--search-bid, --network-bid, --priority, "
+                "or --autotargeting-search-bid-is-auto)."
+            )
         )
 
     try:
@@ -270,7 +272,7 @@ def set_auto(
     try:
         if (target_traffic_volume is None) == (target_coverage is None):
             raise click.UsageError(
-                "Provide exactly one of --target-traffic-volume or --target-coverage"
+                t("Provide exactly one of --target-traffic-volume or --target-coverage")
             )
 
         bidding_rule = {}
@@ -279,9 +281,9 @@ def set_auto(
                 "TargetTrafficVolume": target_traffic_volume
             }
             if increase_percent is not None:
-                bidding_rule["SearchByTrafficVolume"]["IncreasePercent"] = (
-                    increase_percent
-                )
+                bidding_rule["SearchByTrafficVolume"][
+                    "IncreasePercent"
+                ] = increase_percent
             if bid_ceiling is not None:
                 bidding_rule["SearchByTrafficVolume"]["BidCeiling"] = bid_ceiling
         if target_coverage is not None:

--- a/direct_cli/commands/keywords.py
+++ b/direct_cli/commands/keywords.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Iterator, List, Optional
 import click
 
 from ..api import create_client
+from ..i18n import t
 from ..output import (
     format_json,
     format_output,
@@ -179,7 +180,7 @@ def _load_keyword_rows_from_inline(json_str: str) -> List[Any]:
         raise click.UsageError(f"--keywords-json: invalid JSON: {exc.msg}")
     if not isinstance(decoded, list):
         raise click.UsageError(
-            "--keywords-json must be a JSON array of keyword objects"
+            t("--keywords-json must be a JSON array of keyword objects")
         )
     return decoded
 
@@ -238,8 +239,10 @@ def _parse_autotargeting_categories(
         category_raw, separator, value_raw = raw_value.strip().partition("=")
         if not separator:
             raise click.UsageError(
-                "--autotargeting-category expects CATEGORY=YES|NO "
-                "(for example EXACT=YES)"
+                t(
+                    "--autotargeting-category expects CATEGORY=YES|NO "
+                    "(for example EXACT=YES)"
+                )
             )
 
         category = category_raw.strip().upper()
@@ -272,8 +275,10 @@ def _parse_autotargeting_brand_options(
         option_raw, separator, value_raw = raw_value.strip().partition("=")
         if not separator:
             raise click.UsageError(
-                "--autotargeting-brand-option expects OPTION=YES|NO "
-                "(for example WITHOUT_BRANDS=YES)"
+                t(
+                    "--autotargeting-brand-option expects OPTION=YES|NO "
+                    "(for example WITHOUT_BRANDS=YES)"
+                )
             )
 
         option = option_raw.strip().upper()
@@ -415,7 +420,7 @@ def get(
 ):
     """Get keywords"""
     if status and statuses:
-        raise click.UsageError("--status and --statuses are mutually exclusive")
+        raise click.UsageError(t("--status and --statuses are mutually exclusive"))
 
     try:
         client = create_client(
@@ -434,8 +439,10 @@ def get(
             and not parsed_brand_options
         ):
             raise click.UsageError(
-                "Provide a non-empty comma-separated "
-                "AutotargetingSettingsBrandOptionsFieldNames list."
+                t(
+                    "Provide a non-empty comma-separated "
+                    "AutotargetingSettingsBrandOptionsFieldNames list."
+                )
             )
 
         parsed_categories = parse_csv_strings(
@@ -446,8 +453,10 @@ def get(
             and not parsed_categories
         ):
             raise click.UsageError(
-                "Provide a non-empty comma-separated "
-                "AutotargetingSettingsCategoriesFieldNames list."
+                t(
+                    "Provide a non-empty comma-separated "
+                    "AutotargetingSettingsCategoriesFieldNames list."
+                )
             )
 
         criteria = {}
@@ -467,9 +476,7 @@ def get(
 
         params = {"SelectionCriteria": criteria, "FieldNames": field_names}
         if parsed_brand_options:
-            params["AutotargetingSettingsBrandOptionsFieldNames"] = (
-                parsed_brand_options
-            )
+            params["AutotargetingSettingsBrandOptionsFieldNames"] = parsed_brand_options
         if parsed_categories:
             params["AutotargetingSettingsCategoriesFieldNames"] = parsed_categories
 
@@ -619,13 +626,17 @@ def add(
     )
     if modes_used == 0:
         raise click.UsageError(
-            "Provide exactly one of: --keyword (single), --from-file (JSONL), "
-            "or --keywords-json (inline JSON array)."
+            t(
+                "Provide exactly one of: --keyword (single), --from-file (JSONL), "
+                "or --keywords-json (inline JSON array)."
+            )
         )
     if modes_used > 1:
         raise click.UsageError(
-            "Provide exactly one of: --keyword, --from-file, or "
-            "--keywords-json — they are mutually exclusive."
+            t(
+                "Provide exactly one of: --keyword, --from-file, or "
+                "--keywords-json — they are mutually exclusive."
+            )
         )
 
     batch_mode = from_file is not None or keywords_json is not None
@@ -676,7 +687,7 @@ def add(
         return
 
     if adgroup_id is None:
-        raise click.UsageError("Missing option '--adgroup-id'.")
+        raise click.UsageError(t("Missing option '--adgroup-id'."))
 
     parsed_autotargeting_categories = _parse_autotargeting_categories(
         autotargeting_categories
@@ -759,8 +770,10 @@ def _bulk_add(
 ) -> None:
     if output_format != "json":
         raise click.UsageError(
-            "--format other than 'json' is not supported in batch mode "
-            "(item-level results may include per-row Errors)."
+            t(
+                "--format other than 'json' is not supported in batch mode "
+                "(item-level results may include per-row Errors)."
+            )
         )
 
     if from_file is not None:
@@ -769,7 +782,7 @@ def _bulk_add(
         raw_rows = _load_keyword_rows_from_inline(keywords_json or "")
 
     if not raw_rows:
-        raise click.UsageError("Input contains no keyword rows.")
+        raise click.UsageError(t("Input contains no keyword rows."))
 
     items: List[Dict[str, Any]] = [
         _normalize_keyword_row(row, idx, adgroup_id)
@@ -989,10 +1002,12 @@ def update(
     # Reject empty-payload no-op (issue #198 H10).
     if len(keyword_data) == 1:
         raise click.UsageError(
-            "keywords update requires at least one updatable field "
-            "(--keyword, --user-param-1, --user-param-2, "
-            "--autotargeting-category, --autotargeting-brand-option, "
-            "or --autotargeting-settings-* flags)."
+            t(
+                "keywords update requires at least one updatable field "
+                "(--keyword, --user-param-1, --user-param-2, "
+                "--autotargeting-category, --autotargeting-brand-option, "
+                "or --autotargeting-settings-* flags)."
+            )
         )
 
     try:

--- a/direct_cli/commands/retargeting.py
+++ b/direct_cli/commands/retargeting.py
@@ -7,6 +7,7 @@ from typing import Optional
 import click
 
 from ..api import create_client
+from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import get_default_fields, parse_ids, parse_retargeting_rule_specs
 
@@ -118,7 +119,7 @@ def add(ctx, name, description, list_type, rules, dry_run):
     try:
         _validate_description(description)
         if not rules:
-            raise click.UsageError("Provide at least one --rule")
+            raise click.UsageError(t("Provide at least one --rule"))
         list_data = {
             "Name": name,
             "Type": list_type,
@@ -186,7 +187,7 @@ def update(ctx, list_id, name, description, list_type, rules, dry_run):
         if rules:
             list_data["Rules"] = parse_retargeting_rule_specs(list(rules))
         if len(list_data) == 1:
-            raise click.UsageError("Provide at least one field to update")
+            raise click.UsageError(t("Provide at least one field to update"))
 
         body = {"method": "update", "params": {"RetargetingLists": [list_data]}}
 

--- a/direct_cli/commands/sitelinks.py
+++ b/direct_cli/commands/sitelinks.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List
 import click
 
 from ..api import create_client
+from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import (
     get_default_fields,
@@ -72,7 +73,7 @@ def _load_sitelinks_from_inline(json_str: str) -> List[Any]:
         raise click.UsageError(f"--sitelink-json: invalid JSON: {exc.msg}")
     if not isinstance(decoded, list):
         raise click.UsageError(
-            "--sitelink-json must be a JSON array of sitelink objects"
+            t("--sitelink-json must be a JSON array of sitelink objects")
         )
     return decoded
 
@@ -144,7 +145,7 @@ def get(
         parsed_sitelink_field_names = parse_csv_strings(sitelink_field_names)
         if sitelink_field_names is not None and not parsed_sitelink_field_names:
             raise click.UsageError(
-                "Provide a non-empty comma-separated SitelinkFieldNames list."
+                t("Provide a non-empty comma-separated SitelinkFieldNames list.")
             )
 
         criteria = {}
@@ -221,13 +222,17 @@ def add(ctx, sitelinks_specs, sitelinks_json, sitelinks_from_file, dry_run):
     )
     if sources_used == 0:
         raise click.UsageError(
-            "Provide exactly one of: --sitelink (repeatable), "
-            "--sitelink-json (inline JSON array), or --sitelinks-from-file (JSONL)."
+            t(
+                "Provide exactly one of: --sitelink (repeatable), "
+                "--sitelink-json (inline JSON array), or --sitelinks-from-file (JSONL)."
+            )
         )
     if sources_used > 1:
         raise click.UsageError(
-            "--sitelink, --sitelink-json, and --sitelinks-from-file are "
-            "mutually exclusive — provide exactly one."
+            t(
+                "--sitelink, --sitelink-json, and --sitelinks-from-file are "
+                "mutually exclusive — provide exactly one."
+            )
         )
 
     try:
@@ -243,7 +248,7 @@ def add(ctx, sitelinks_specs, sitelinks_json, sitelinks_from_file, dry_run):
                 raw_rows = _load_sitelinks_from_file(sitelinks_from_file)
 
             if not raw_rows:
-                raise click.UsageError("Input contains no sitelink rows.")
+                raise click.UsageError(t("Input contains no sitelink rows."))
 
             sitelinks_payload = [
                 _normalize_sitelink_row(row, idx)

--- a/direct_cli/commands/smartadtargets.py
+++ b/direct_cli/commands/smartadtargets.py
@@ -5,6 +5,7 @@ SmartAdTargets commands
 import click
 
 from ..api import create_client
+from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import get_default_fields, parse_condition_specs, parse_ids, MICRO_RUBLES
 
@@ -215,7 +216,7 @@ def update(
         if available_items_only:
             target_data["AvailableItemsOnly"] = available_items_only.upper()
         if len(target_data) == 1:
-            raise click.UsageError("Provide at least one field to update")
+            raise click.UsageError(t("Provide at least one field to update"))
 
         body = {"method": "update", "params": {"SmartAdTargets": [target_data]}}
 
@@ -365,12 +366,14 @@ def set_bids(
         }
         if not bid_data:
             raise click.UsageError(
-                "Provide target selection and bid fields for set-bids"
+                t("Provide target selection and bid fields for set-bids")
             )
         if not bid_fields:
             raise click.UsageError(
-                "Provide at least one bid field"
-                " (--average-cpc, --average-cpa, or --priority)"
+                t(
+                    "Provide at least one bid field"
+                    " (--average-cpc, --average-cpa, or --priority)"
+                )
             )
 
         body = {"method": "setBids", "params": {"Bids": [bid_data]}}

--- a/direct_cli/commands/strategies.py
+++ b/direct_cli/commands/strategies.py
@@ -7,6 +7,7 @@ from typing import Optional
 import click
 
 from ..api import create_client
+from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import (
     MICRO_RUBLES,
@@ -215,7 +216,7 @@ def _build_custom_period_budget(
         return None
     if weekly_spend_limit is not None:
         raise click.UsageError(
-            "--weekly-spend-limit cannot be combined with --custom-period-* flags."
+            t("--weekly-spend-limit cannot be combined with --custom-period-* flags.")
         )
 
     missing = [
@@ -251,8 +252,10 @@ def _build_exploration_budget(
         and minimum_exploration_budget > weekly_spend_limit
     ):
         raise click.UsageError(
-            "--minimum-exploration-budget must be less than or equal to "
-            "--weekly-spend-limit when both flags are provided."
+            t(
+                "--minimum-exploration-budget must be less than or equal to "
+                "--weekly-spend-limit when both flags are provided."
+            )
         )
     return {
         "MinimumExplorationBudget": minimum_exploration_budget,
@@ -270,23 +273,23 @@ def _parse_priority_goal(spec: str) -> dict:
         or (len(parts) == 3 and not parts[2])
     ):
         raise click.UsageError(
-            "Invalid --priority-goal. Expected GOAL_ID:VALUE[:YES|NO], "
-            "for example 123:1000000:YES"
+            t(
+                "Invalid --priority-goal. Expected GOAL_ID:VALUE[:YES|NO], "
+                "for example 123:1000000:YES"
+            )
         )
     try:
         item = {"GoalId": int(parts[0]), "Value": int(parts[1])}
     except ValueError:
         raise click.UsageError(
-            "Invalid --priority-goal. GOAL_ID and VALUE must be integers"
+            t("Invalid --priority-goal. GOAL_ID and VALUE must be integers")
         )
-    validate_priority_goal_value(
-        item["Value"], f"Invalid --priority-goal '{spec}'."
-    )
+    validate_priority_goal_value(item["Value"], f"Invalid --priority-goal '{spec}'.")
     if len(parts) == 3:
         is_metrika_source = parts[2].upper()
         if is_metrika_source not in {"YES", "NO"}:
             raise click.UsageError(
-                "Invalid --priority-goal. IsMetrikaSourceOfValue must be YES or NO"
+                t("Invalid --priority-goal. IsMetrikaSourceOfValue must be YES or NO")
             )
         item["IsMetrikaSourceOfValue"] = is_metrika_source
     return item
@@ -332,7 +335,7 @@ def _build_strategy_fields(
             )
         ):
             raise click.UsageError(
-                "Provide --type when setting strategy-specific fields"
+                t("Provide --type when setting strategy-specific fields")
             )
         return {}
 
@@ -342,8 +345,10 @@ def _build_strategy_fields(
         and any(value is not None for value in custom_period_values)
     ):
         raise click.UsageError(
-            "--custom-period-* flags are not valid for --type AverageCpa "
-            "on strategies update."
+            t(
+                "--custom-period-* flags are not valid for --type AverageCpa "
+                "on strategies update."
+            )
         )
 
     field_options = STRATEGY_UPDATE_FIELD_OPTIONS if update else STRATEGY_FIELD_OPTIONS
@@ -800,7 +805,7 @@ def add(
             ),
         }
         if strategy_type in GOAL_ID_STRATEGY_TYPES and goal_id is None:
-            raise click.UsageError("Provide --goal-id for this strategy type")
+            raise click.UsageError(t("Provide --goal-id for this strategy type"))
         if counter_ids:
             strategy_data["CounterIds"] = {
                 "Items": [int(x.strip()) for x in counter_ids.split(",")]
@@ -945,7 +950,7 @@ def update(
         )
         if strategy_fields and not strategy_type:
             raise click.UsageError(
-                "Provide --type when setting strategy-specific fields"
+                t("Provide --type when setting strategy-specific fields")
             )
         if strategy_type and not strategy_fields:
             # Reject empty-subtype no-op (issue #198 sibling of H1/H5/H10):
@@ -980,7 +985,7 @@ def update(
             # Only `Id` populated — reject the no-op payload (sibling of
             # the H1/H5/H10 empty-payload guards on other resources).
             raise click.UsageError(
-                "strategies update requires at least one updatable field."
+                t("strategies update requires at least one updatable field.")
             )
 
         body = {"method": "update", "params": {"Strategies": [strategy_data]}}

--- a/direct_cli/commands/v4account.py
+++ b/direct_cli/commands/v4account.py
@@ -7,6 +7,7 @@ from typing import Any, Optional
 import click
 
 from ..api import create_v4_client
+from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import parse_csv_strings, parse_ids
 from ..v4 import build_v4_body, call_v4
@@ -112,7 +113,7 @@ def v4account():
 def _require_dry_run_or_sandbox(dry_run: bool, sandbox: bool) -> None:
     """Reject shared-account mutations outside explicit dry-run or sandbox."""
     if not dry_run and not sandbox:
-        raise click.UsageError("--dry-run is required unless --sandbox is set")
+        raise click.UsageError(t("--dry-run is required unless --sandbox is set"))
 
 
 def _emit_or_call_v4(
@@ -192,9 +193,9 @@ def _parse_day_budget(value: Optional[str]) -> Optional[float]:
     try:
         amount = Decimal(value)
     except InvalidOperation as exc:
-        raise click.UsageError("--day-budget must be a non-negative amount") from exc
+        raise click.UsageError(t("--day-budget must be a non-negative amount")) from exc
     if not amount.is_finite() or amount < 0 or (amount == 0 and amount.is_signed()):
-        raise click.UsageError("--day-budget must be a non-negative amount")
+        raise click.UsageError(t("--day-budget must be a non-negative amount"))
     return float(amount)
 
 
@@ -262,7 +263,7 @@ def _account_selection_criteria(
     """Build the Get SelectionCriteria object; None when no filter is provided."""
     parsed_logins = parse_csv_strings(logins)
     if logins is not None and not parsed_logins:
-        raise click.UsageError("--logins must not be empty when provided")
+        raise click.UsageError(t("--logins must not be empty when provided"))
 
     if account_ids is not None:
         try:
@@ -270,16 +271,18 @@ def _account_selection_criteria(
         except ValueError as exc:
             raise click.UsageError(str(exc)) from exc
         if not parsed_ids:
-            raise click.UsageError("--account-ids must not be empty when provided")
+            raise click.UsageError(t("--account-ids must not be empty when provided"))
         if any(account_id <= 0 for account_id in parsed_ids):
-            raise click.UsageError("--account-ids must contain only positive integers")
+            raise click.UsageError(
+                t("--account-ids must contain only positive integers")
+            )
     else:
         parsed_ids = None
 
     if parsed_logins and len(parsed_logins) > 50:
-        raise click.UsageError("--logins accepts at most 50 entries")
+        raise click.UsageError(t("--logins accepts at most 50 entries"))
     if parsed_ids and len(parsed_ids) > 100:
-        raise click.UsageError("--account-ids accepts at most 100 entries")
+        raise click.UsageError(t("--account-ids accepts at most 100 entries"))
 
     criteria: dict = {}
     if parsed_logins:
@@ -314,14 +317,14 @@ def _account_update_param(
 ) -> dict:
     """Build the AccountManagement Update parameter object."""
     if account_id is None:
-        raise click.UsageError("--account-id is required for --action Update")
+        raise click.UsageError(t("--account-id is required for --action Update"))
     account: dict = {"AccountID": account_id}
 
     parsed_day_budget = _parse_day_budget(day_budget)
     if parsed_day_budget is not None or spend_mode is not None:
         if parsed_day_budget is None or spend_mode is None:
             raise click.UsageError(
-                "--day-budget and --spend-mode must be provided together"
+                t("--day-budget and --spend-mode must be provided together")
             )
         account["AccountDayBudget"] = {
             "Amount": parsed_day_budget,
@@ -337,7 +340,7 @@ def _account_update_param(
         sms_notification["PausedByDayBudgetSms"] = paused_by_day_budget_sms
     if (sms_time_from is None) != (sms_time_to is None):
         raise click.UsageError(
-            "--sms-time-from and --sms-time-to must be provided together"
+            t("--sms-time-from and --sms-time-to must be provided together")
         )
     if sms_time_from is not None:
         sms_notification["SmsTimeFrom"] = _parse_hh_mm(sms_time_from, "--sms-time-from")
@@ -357,7 +360,7 @@ def _account_update_param(
         account["EmailNotification"] = email_notification
 
     if len(account) == 1:
-        raise click.UsageError("Provide at least one update field")
+        raise click.UsageError(t("Provide at least one update field"))
 
     return {"Action": action, "Accounts": [account]}
 
@@ -365,9 +368,9 @@ def _account_update_param(
 def _parse_account_payments(payments: tuple[str, ...], currency: str) -> list[dict]:
     """Parse repeated --payment ACCOUNT_ID=AMOUNT into PayCampElement-shaped items."""
     if not payments:
-        raise click.UsageError("--payment is required")
+        raise click.UsageError(t("--payment is required"))
     if len(payments) > 50:
-        raise click.UsageError("--payment accepts at most 50 entries per call")
+        raise click.UsageError(t("--payment accepts at most 50 entries per call"))
 
     normalized_currency = currency.upper()
     parsed_items: list[dict] = []
@@ -375,7 +378,7 @@ def _parse_account_payments(payments: tuple[str, ...], currency: str) -> list[di
     for entry in payments:
         spec = (entry or "").strip()
         if "=" not in spec:
-            raise click.UsageError("--payment must use ACCOUNT_ID=AMOUNT")
+            raise click.UsageError(t("--payment must use ACCOUNT_ID=AMOUNT"))
         account_id_text, amount_text = spec.split("=", 1)
         account_id_text = account_id_text.strip()
         amount_text = amount_text.strip()
@@ -383,12 +386,12 @@ def _parse_account_payments(payments: tuple[str, ...], currency: str) -> list[di
             account_id = int(account_id_text)
         except ValueError as exc:
             raise click.UsageError(
-                "--payment account ID must be a positive integer"
+                t("--payment account ID must be a positive integer")
             ) from exc
         if account_id <= 0:
-            raise click.UsageError("--payment account ID must be a positive integer")
+            raise click.UsageError(t("--payment account ID must be a positive integer"))
         if account_id in seen_account_ids:
-            raise click.UsageError("--payment account IDs must be unique")
+            raise click.UsageError(t("--payment account IDs must be unique"))
         seen_account_ids.add(account_id)
         parsed_items.append(
             {
@@ -435,7 +438,7 @@ def _account_transfer_param(
 ) -> dict:
     """Build the TransferMoney param object (single transfer per call)."""
     if from_account_id == to_account_id:
-        raise click.UsageError("--from-account-id and --to-account-id must differ")
+        raise click.UsageError(t("--from-account-id and --to-account-id must differ"))
     return {
         "Action": "TransferMoney",
         "Transfers": [
@@ -719,8 +722,10 @@ def account_management(
     else:  # TransferMoney
         if from_account_id is None or to_account_id is None or amount is None:
             raise click.UsageError(
-                "--from-account-id, --to-account-id, and --amount are required "
-                "for --action TransferMoney"
+                t(
+                    "--from-account-id, --to-account-id, and --amount are required "
+                    "for --action TransferMoney"
+                )
             )
         param = _account_transfer_param(
             from_account_id, to_account_id, amount, currency

--- a/direct_cli/commands/v4adimage.py
+++ b/direct_cli/commands/v4adimage.py
@@ -11,6 +11,7 @@ from typing import Optional
 import click
 
 from ..api import create_v4_client
+from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import parse_csv_strings, parse_ids
 from ..v4 import build_v4_body, call_v4
@@ -75,13 +76,13 @@ def _set_param(associations: tuple[str, ...]) -> dict:
     AdImageHash detaches the current image.
     """
     if not associations:
-        raise click.UsageError("--association is required for set")
+        raise click.UsageError(t("--association is required for set"))
     items = []
     seen_ad_ids = set()
     for spec in associations:
         spec = (spec or "").strip()
         if not spec:
-            raise click.UsageError("--association must not be empty")
+            raise click.UsageError(t("--association must not be empty"))
         if "=" in spec:
             ad_id_text, ad_image_hash = spec.split("=", 1)
             ad_image_hash = ad_image_hash.strip()
@@ -92,19 +93,19 @@ def _set_param(associations: tuple[str, ...]) -> dict:
             ad_id = int(ad_id_text)
         except ValueError as exc:
             raise click.UsageError(
-                "--association must be AD_ID or AD_ID=HASH with an integer AD_ID"
+                t("--association must be AD_ID or AD_ID=HASH with an integer AD_ID")
             ) from exc
         if ad_id <= 0:
-            raise click.UsageError("--association AD_ID must be a positive integer")
+            raise click.UsageError(t("--association AD_ID must be a positive integer"))
         if ad_id in seen_ad_ids:
-            raise click.UsageError("--association AD_ID values must be unique")
+            raise click.UsageError(t("--association AD_ID values must be unique"))
         seen_ad_ids.add(ad_id)
         item: dict = {"AdID": ad_id}
         if ad_image_hash:
             item["AdImageHash"] = ad_image_hash
         items.append(item)
     if len(items) > 10000:
-        raise click.UsageError("--association accepts at most 10000 entries")
+        raise click.UsageError(t("--association accepts at most 10000 entries"))
     return {"Action": "Set", "AdImageAssociations": items}
 
 

--- a/direct_cli/commands/v4events.py
+++ b/direct_cli/commands/v4events.py
@@ -7,6 +7,7 @@ from typing import Optional
 import click
 
 from ..api import create_v4_client
+from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import parse_csv_strings, parse_ids
 from ..v4 import build_v4_body, call_v4
@@ -99,7 +100,7 @@ def _events_log_param(
     from_dt = _parse_v4_datetime(timestamp_from, "--from")
     to_dt = _parse_v4_datetime(timestamp_to, "--to")
     if from_dt > to_dt:
-        raise click.UsageError("--from must be earlier than or equal to --to")
+        raise click.UsageError(t("--from must be earlier than or equal to --to"))
 
     param = {
         "TimestampFrom": timestamp_from,

--- a/direct_cli/commands/v4finance.py
+++ b/direct_cli/commands/v4finance.py
@@ -6,6 +6,7 @@ from typing import Any, Optional
 import click
 
 from ..api import create_v4_client
+from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import parse_csv_strings, parse_ids
 from ..v4 import build_v4_body, call_v4
@@ -43,14 +44,14 @@ def _logins_param(logins: str) -> list[str]:
     """Build the v4 Live login list parameter."""
     login_list = parse_csv_strings(logins)
     if not login_list:
-        raise click.UsageError("--logins must not be empty")
+        raise click.UsageError(t("--logins must not be empty"))
     return login_list
 
 
 def _invoice_payments_param(payments: tuple[str, ...], currency: str) -> dict:
     """Build the v4 Live CreateInvoice payment object parameter."""
     if not payments:
-        raise click.UsageError("--payment is required")
+        raise click.UsageError(t("--payment is required"))
 
     normalized_currency = currency.upper()
     parsed_payments = []
@@ -58,7 +59,7 @@ def _invoice_payments_param(payments: tuple[str, ...], currency: str) -> dict:
     for payment in payments:
         spec = (payment or "").strip()
         if "=" not in spec:
-            raise click.UsageError("--payment must use CAMPAIGN_ID=AMOUNT")
+            raise click.UsageError(t("--payment must use CAMPAIGN_ID=AMOUNT"))
         campaign_id_text, amount_text = spec.split("=", 1)
         campaign_id_text = campaign_id_text.strip()
         amount_text = amount_text.strip()
@@ -66,12 +67,14 @@ def _invoice_payments_param(payments: tuple[str, ...], currency: str) -> dict:
             campaign_id = int(campaign_id_text)
         except ValueError as exc:
             raise click.UsageError(
-                "--payment campaign ID must be a positive integer"
+                t("--payment campaign ID must be a positive integer")
             ) from exc
         if campaign_id <= 0:
-            raise click.UsageError("--payment campaign ID must be a positive integer")
+            raise click.UsageError(
+                t("--payment campaign ID must be a positive integer")
+            )
         if campaign_id in seen_campaign_ids:
-            raise click.UsageError("--payment campaign IDs must be unique")
+            raise click.UsageError(t("--payment campaign IDs must be unique"))
         seen_campaign_ids.add(campaign_id)
         parsed_payments.append(
             {
@@ -96,7 +99,9 @@ def _finance_credentials(
     normalized_token = (finance_token or "").strip()
     normalized_master_token = (master_token or "").strip()
     if normalized_token and normalized_master_token:
-        raise click.UsageError("Use either --finance-token or --master-token, not both")
+        raise click.UsageError(
+            t("Use either --finance-token or --master-token, not both")
+        )
     if operation_num is None:
         raise click.UsageError(_FINANCE_CREDENTIALS_ERROR)
     operation_num = validate_operation_num(operation_num)
@@ -106,8 +111,10 @@ def _finance_credentials(
         login = (finance_login or fallback_login or "").strip()
         if not login:
             raise click.UsageError(
-                "Provide --finance-login or set YANDEX_DIRECT_FINANCE_LOGIN "
-                "when using --master-token"
+                t(
+                    "Provide --finance-login or set YANDEX_DIRECT_FINANCE_LOGIN "
+                    "when using --master-token"
+                )
             )
         return (
             build_finance_token(normalized_master_token, operation_num, method, login),
@@ -133,7 +140,7 @@ def _masked_finance_body(method: str, param: Any, operation_num: int) -> dict:
 def _require_dry_run(dry_run: bool) -> None:
     """Reject v4 finance money mutations unless dry-run is explicit."""
     if not dry_run:
-        raise click.UsageError("--dry-run is required for v4finance money commands")
+        raise click.UsageError(t("--dry-run is required for v4finance money commands"))
 
 
 def _non_empty_option(value: str, option_name: str) -> str:
@@ -151,9 +158,9 @@ def _campaign_ids_param(campaign_ids: str) -> list[int]:
     except ValueError as exc:
         raise click.UsageError(str(exc)) from exc
     if not parsed:
-        raise click.UsageError("--campaign-ids must not be empty")
+        raise click.UsageError(t("--campaign-ids must not be empty"))
     if any(campaign_id <= 0 for campaign_id in parsed):
-        raise click.UsageError("--campaign-ids must contain only positive integers")
+        raise click.UsageError(t("--campaign-ids must contain only positive integers"))
     return parsed
 
 
@@ -162,7 +169,7 @@ def _custom_transaction_id_param(custom_transaction_id: str) -> dict:
     normalized = (custom_transaction_id or "").strip()
     if not CUSTOM_TRANSACTION_ID_RE.fullmatch(normalized):
         raise click.UsageError(
-            "--custom-transaction-id must be exactly 32 latin letters or digits"
+            t("--custom-transaction-id must be exactly 32 latin letters or digits")
         )
     return {"CustomTransactionID": normalized}
 
@@ -627,7 +634,7 @@ def pay_campaigns(
     normalized_currency = currency.upper()
     contract_id = (contract_id or "").strip()
     if pay_method == "Bank" and not contract_id:
-        raise click.UsageError("--contract-id is required when --pay-method Bank")
+        raise click.UsageError(t("--contract-id is required when --pay-method Bank"))
     param = {
         "Payments": [
             {

--- a/direct_cli/commands/v4forecast.py
+++ b/direct_cli/commands/v4forecast.py
@@ -5,6 +5,7 @@ from typing import Optional
 import click
 
 from ..api import create_v4_client
+from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import parse_csv_strings, parse_ids
 from ..v4 import build_v4_body, call_v4
@@ -23,9 +24,9 @@ def _forecast_param(
     """Build the v4 Live CreateNewForecast parameter."""
     phrase_list = parse_csv_strings(phrases)
     if not phrase_list:
-        raise click.UsageError("--phrases must not be empty")
+        raise click.UsageError(t("--phrases must not be empty"))
     if len(phrase_list) > 100:
-        raise click.UsageError("--phrases accepts at most 100 phrases")
+        raise click.UsageError(t("--phrases accepts at most 100 phrases"))
 
     param: dict[str, object] = {
         "Phrases": phrase_list,

--- a/direct_cli/commands/v4goals.py
+++ b/direct_cli/commands/v4goals.py
@@ -3,6 +3,7 @@
 import click
 
 from ..api import create_v4_client
+from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import parse_ids
 from ..v4 import build_v4_body, call_v4
@@ -17,7 +18,7 @@ def _campaign_ids_param(campaign_ids: str) -> dict:
     except ValueError as exc:
         raise click.UsageError(str(exc))
     if not ids:
-        raise click.UsageError("--campaign-ids must not be empty")
+        raise click.UsageError(t("--campaign-ids must not be empty"))
     return {"CampaignIDS": ids}
 
 

--- a/direct_cli/commands/v4keywords.py
+++ b/direct_cli/commands/v4keywords.py
@@ -5,6 +5,7 @@ from typing import Optional
 import click
 
 from ..api import create_v4_client
+from ..i18n import t
 from ..output import format_output, print_error
 from ..v4 import build_v4_body, call_v4
 from ..v4_contracts import v4_method_contract
@@ -19,7 +20,7 @@ def _keywords_param(keywords: tuple[str, ...]) -> dict:
     """
     seeds = [kw.strip() for kw in keywords if kw and kw.strip()]
     if not seeds:
-        raise click.UsageError("--keyword must not be empty")
+        raise click.UsageError(t("--keyword must not be empty"))
     return {"Keywords": seeds}
 
 

--- a/direct_cli/commands/v4tags.py
+++ b/direct_cli/commands/v4tags.py
@@ -5,6 +5,7 @@ from typing import Optional
 import click
 
 from ..api import create_v4_client
+from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import parse_ids
 from ..v4 import build_v4_body, call_v4
@@ -29,7 +30,7 @@ def _tag_ids_param(tag_ids: str) -> list[int]:
     """Parse v4 banner tag IDs."""
     parsed = _positive_ids_param(tag_ids, "--tag-ids")
     if len(parsed) > 30:
-        raise click.UsageError("--tag-ids accepts at most 30 tag IDs")
+        raise click.UsageError(t("--tag-ids accepts at most 30 tag IDs"))
     return parsed
 
 
@@ -43,16 +44,16 @@ def _get_banners_tags_param(
 ) -> dict:
     """Build the v4 Live GetBannersTags parameter."""
     if (campaign_ids is not None) == (banner_ids is not None):
-        raise click.UsageError("Use exactly one of --campaign-ids or --banner-ids")
+        raise click.UsageError(t("Use exactly one of --campaign-ids or --banner-ids"))
     if campaign_ids is not None:
         ids = _positive_ids_param(campaign_ids, "--campaign-ids")
         if len(ids) > 10:
-            raise click.UsageError("--campaign-ids accepts at most 10 campaign IDs")
+            raise click.UsageError(t("--campaign-ids accepts at most 10 campaign IDs"))
         return {"CampaignIDS": ids}
 
     ids = _positive_ids_param(banner_ids or "", "--banner-ids")
     if len(ids) > 2000:
-        raise click.UsageError("--banner-ids accepts at most 2000 banner IDs")
+        raise click.UsageError(t("--banner-ids accepts at most 2000 banner IDs"))
     return {"BannerIDS": ids}
 
 
@@ -60,10 +61,10 @@ def _campaign_tag_param(tag_specs: tuple[str, ...], clear_tags: bool) -> list[di
     """Build campaign TagInfo objects from repeated TAG_ID=TEXT specs."""
     if clear_tags:
         if tag_specs:
-            raise click.UsageError("Use either --tag or --clear-tags, not both")
+            raise click.UsageError(t("Use either --tag or --clear-tags, not both"))
         return []
     if not tag_specs:
-        raise click.UsageError("--tag is required unless --clear-tags is used")
+        raise click.UsageError(t("--tag is required unless --clear-tags is used"))
 
     tags = []
     seen_texts = set()
@@ -72,31 +73,33 @@ def _campaign_tag_param(tag_specs: tuple[str, ...], clear_tags: bool) -> list[di
         text = (spec or "").strip()
         tag_id_text, separator, tag_text = text.partition("=")
         if not separator:
-            raise click.UsageError("--tag must use TAG_ID=TEXT")
+            raise click.UsageError(t("--tag must use TAG_ID=TEXT"))
         tag_id_text = tag_id_text.strip()
         tag_text = tag_text.strip()
         try:
             tag_id = int(tag_id_text)
         except ValueError as exc:
-            raise click.UsageError("--tag ID must be a non-negative integer") from exc
+            raise click.UsageError(
+                t("--tag ID must be a non-negative integer")
+            ) from exc
         if tag_id < 0:
-            raise click.UsageError("--tag ID must be a non-negative integer")
+            raise click.UsageError(t("--tag ID must be a non-negative integer"))
         if tag_id > 0:
             if tag_id in seen_existing_ids:
-                raise click.UsageError("--tag IDs must be unique")
+                raise click.UsageError(t("--tag IDs must be unique"))
             seen_existing_ids.add(tag_id)
         if not tag_text:
-            raise click.UsageError("--tag text must not be empty")
+            raise click.UsageError(t("--tag text must not be empty"))
         if len(tag_text) > 25:
-            raise click.UsageError("--tag text must be 25 characters or fewer")
+            raise click.UsageError(t("--tag text must be 25 characters or fewer"))
         normalized_text = tag_text.casefold()
         if normalized_text in seen_texts:
-            raise click.UsageError("--tag texts must be unique ignoring case")
+            raise click.UsageError(t("--tag texts must be unique ignoring case"))
         seen_texts.add(normalized_text)
         tags.append({"TagID": tag_id, "Tag": tag_text})
 
     if len(tags) > 200:
-        raise click.UsageError("--tag accepts at most 200 campaign tags")
+        raise click.UsageError(t("--tag accepts at most 200 campaign tags"))
     return tags
 
 
@@ -119,11 +122,13 @@ def _update_banners_tags_param(
     parsed_banner_ids = _positive_ids_param(banner_ids, "--banner-ids")
     if clear_tags:
         if tag_ids is not None:
-            raise click.UsageError("Use either --tag-ids or --clear-tags, not both")
+            raise click.UsageError(t("Use either --tag-ids or --clear-tags, not both"))
         parsed_tag_ids: list[int] = []
     else:
         if tag_ids is None:
-            raise click.UsageError("--tag-ids is required unless --clear-tags is used")
+            raise click.UsageError(
+                t("--tag-ids is required unless --clear-tags is used")
+            )
         parsed_tag_ids = _tag_ids_param(tag_ids)
     return [
         {"BannerID": banner_id, "TagIDS": parsed_tag_ids}

--- a/direct_cli/commands/v4wordstat.py
+++ b/direct_cli/commands/v4wordstat.py
@@ -5,6 +5,7 @@ from typing import Optional
 import click
 
 from ..api import create_v4_client
+from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import parse_csv_strings, parse_ids
 from ..v4 import build_v4_body, call_v4
@@ -16,9 +17,9 @@ def _wordstat_report_param(phrases: str, geo_ids: Optional[str]) -> dict:
     """Build the v4 Live CreateNewWordstatReport parameter."""
     phrase_list = parse_csv_strings(phrases)
     if not phrase_list:
-        raise click.UsageError("--phrases must not be empty")
+        raise click.UsageError(t("--phrases must not be empty"))
     if len(phrase_list) > 10:
-        raise click.UsageError("--phrases accepts at most 10 phrases")
+        raise click.UsageError(t("--phrases accepts at most 10 phrases"))
 
     param = {"Phrases": phrase_list}
     if geo_ids:

--- a/direct_cli/commands/vcards.py
+++ b/direct_cli/commands/vcards.py
@@ -7,6 +7,7 @@ from typing import Dict, Optional
 import click
 
 from ..api import create_client
+from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import get_default_fields, parse_ids
 
@@ -24,8 +25,10 @@ def _build_instant_messenger(
         return None
     if not messenger_client or not messenger_login:
         raise click.UsageError(
-            "--instant-messenger-client and --instant-messenger-login must be "
-            "provided together"
+            t(
+                "--instant-messenger-client and --instant-messenger-login must be "
+                "provided together"
+            )
         )
     return {
         "MessengerClient": messenger_client,

--- a/direct_cli/translations/adextensions.json
+++ b/direct_cli/translations/adextensions.json
@@ -6,5 +6,6 @@
   "Delete ad extension": "Удалить расширение объявления",
   "Extension ID": "ID расширения",
   "Get ad extensions": "Получить расширения объявлений",
-  "Manage ad extensions": "Управление расширениями объявлений"
+  "Manage ad extensions": "Управление расширениями объявлений",
+  "Provide a non-empty comma-separated CalloutFieldNames list.": "Укажите непустой список CalloutFieldNames через запятую."
 }

--- a/direct_cli/translations/adgroups.json
+++ b/direct_cli/translations/adgroups.json
@@ -55,5 +55,13 @@
   "Tracking params query-string for AdGroupUpdateItem.TrackingParams (max 1024 chars)": "Строка query параметров отслеживания для AdGroupUpdateItem.TrackingParams (не более 1024 символов)",
   "UnifiedAdGroup.OfferRetargeting update value: YES or NO": "Значение обновления UnifiedAdGroup.OfferRetargeting: YES или NO",
   "UnifiedAdGroup.OfferRetargeting value: YES or NO": "Значение UnifiedAdGroup.OfferRetargeting: YES или NO",
-  "Update ad group": "Обновить группу объявлений"
+  "Update ad group": "Обновить группу объявлений",
+  "AutotargetingSettings flags cannot be combined with legacy --autotargeting-category flags.": "Флаги AutotargetingSettings нельзя сочетать с устаревшими флагами --autotargeting-category.",
+  "--domain-url is required for DYNAMIC_TEXT_AD_GROUP": "--domain-url обязателен для DYNAMIC_TEXT_AD_GROUP",
+  "--feed-id is required for DYNAMIC_TEXT_FEED_AD_GROUP": "--feed-id обязателен для DYNAMIC_TEXT_FEED_AD_GROUP",
+  "--feed-id is required when --feed-category-ids is used": "--feed-id обязателен при использовании --feed-category-ids",
+  "adgroups update requires at least one updatable field (--name, --status, --region-ids, --negative-keywords, --negative-keyword-shared-set-ids, --tracking-params, --domain-url, --dynamic-feed, --autotargeting-category, --autotargeting-settings-* flags, --target-device-types, --target-carrier, --target-operating-system-version, --feed-id, --feed-category-ids, --ad-title-source, --ad-body-source, or --offer-retargeting).": "adgroups update требует хотя бы одно изменяемое поле (--name, --status, --region-ids, --negative-keywords, --negative-keyword-shared-set-ids, --tracking-params, --domain-url, --dynamic-feed, --autotargeting-category, флаги --autotargeting-settings-*, --target-device-types, --target-carrier, --target-operating-system-version, --feed-id, --feed-category-ids, --ad-title-source, --ad-body-source или --offer-retargeting).",
+  "--dynamic-feed requires --autotargeting-category": "--dynamic-feed требует --autotargeting-category",
+  "--feed-id is required for SMART_AD_GROUP": "--feed-id обязателен для SMART_AD_GROUP",
+  "--offer-retargeting is required for UNIFIED_AD_GROUP": "--offer-retargeting обязателен для UNIFIED_AD_GROUP"
 }

--- a/direct_cli/translations/adimages.json
+++ b/direct_cli/translations/adimages.json
@@ -8,5 +8,6 @@
   "Get ad images": "Получить изображения объявлений",
   "Image name": "Имя изображения",
   "Manage ad images": "Управление изображениями объявлений",
-  "Path to an image file to base64-encode": "Путь к файлу изображения для кодирования в base64"
+  "Path to an image file to base64-encode": "Путь к файлу изображения для кодирования в base64",
+  "Provide exactly one of --image-data or --image-file": "Укажите ровно один из --image-data или --image-file"
 }

--- a/direct_cli/translations/ads.json
+++ b/direct_cli/translations/ads.json
@@ -98,5 +98,17 @@
   "Unarchive ad": "Разархивировать объявление",
   "Update ad": "Обновить объявление",
   "VCard ID (TEXT_AD / DYNAMIC_TEXT_AD)": "ID визитки (TEXT_AD / DYNAMIC_TEXT_AD)",
-  "Video extension CreativeId for TextAd/MobileAppAd.VideoExtension. TEXT_AD / MOBILE_APP_AD only.": "CreativeId видеорасширения для TextAd/MobileAppAd.VideoExtension. Только TEXT_AD / MOBILE_APP_AD."
+  "Video extension CreativeId for TextAd/MobileAppAd.VideoExtension. TEXT_AD / MOBILE_APP_AD only.": "CreativeId видеорасширения для TextAd/MobileAppAd.VideoExtension. Только TEXT_AD / MOBILE_APP_AD.",
+  "--callouts-set is mutually exclusive with --callouts-add / --callouts-remove. Use --callouts-set to replace the full callout list, or --callouts-add / --callouts-remove for incremental edits.": "--callouts-set взаимоисключающ с --callouts-add / --callouts-remove. Используйте --callouts-set для замены всего списка уточнений или --callouts-add / --callouts-remove для точечных изменений.",
+  "--default-texts must contain a value.": "--default-texts должен содержать значение.",
+  "DYNAMIC_TEXT_AD requires --text": "DYNAMIC_TEXT_AD требует --text",
+  "--creative-erir-ad-description requires --creative-id.": "--creative-erir-ad-description требует --creative-id.",
+  "MOBILE_APP_IMAGE_AD requires --image-hash": "MOBILE_APP_IMAGE_AD требует --image-hash",
+  "Use 'direct ads suspend/resume/archive/unarchive' to change status. The --status flag is not supported by WSDL AdUpdateItem.": "Используйте 'direct ads suspend/resume/archive/unarchive' для смены статуса. Флаг --status не поддерживается WSDL AdUpdateItem.",
+  "--mobile-app-feature expects FEATURE=YES|NO (for example PRICE=YES).": "--mobile-app-feature ожидает FEATURE=YES|NO (например, PRICE=YES).",
+  "--title/--text are only valid for TEXT_AD. For TEXT_IMAGE_AD, use --image-hash and --href / --turbo-page-id.": "--title/--text допустимы только для TEXT_AD. Для TEXT_IMAGE_AD используйте --image-hash и --href / --turbo-page-id.",
+  "TEXT_IMAGE_AD requires --image-hash": "TEXT_IMAGE_AD требует --image-hash",
+  "TEXT_IMAGE_AD requires either --href or --turbo-page-id.": "TEXT_IMAGE_AD требует либо --href, либо --turbo-page-id.",
+  "RESPONSIVE_AD requires either --href or --business-id.": "RESPONSIVE_AD требует либо --href, либо --business-id.",
+  "--href does not apply to MOBILE_APP_AD. Use --tracking-url instead.": "--href неприменим к MOBILE_APP_AD. Используйте --tracking-url."
 }

--- a/direct_cli/translations/advideos.json
+++ b/direct_cli/translations/advideos.json
@@ -6,5 +6,6 @@
   "Manage ad videos": "Управление видео для объявлений",
   "Path to a video file to base64-encode": "Путь к видеофайлу для кодирования в base64",
   "Video URL (mutually exclusive with --video-data/--video-file)": "URL видео (взаимоисключимо с --video-data/--video-file)",
-  "Video name": "Имя видео"
+  "Video name": "Имя видео",
+  "Provide exactly one of --url, --video-data, or --video-file.": "Укажите ровно один из --url, --video-data или --video-file."
 }

--- a/direct_cli/translations/agencyclients.json
+++ b/direct_cli/translations/agencyclients.json
@@ -26,5 +26,7 @@
   "Grant as PRIVILEGE=YES|NO": "Право доступа в формате PRIVILEGE=YES|NO",
   "Clear all grants": "Снять все права доступа",
   "Delete agency client (not supported by API)": "Удалить клиента агентства (не поддерживается API)",
-  "Agency clients cannot be deleted via the Yandex Direct API. The API only supports add, update, and get operations.": "Клиентов агентства нельзя удалить через API Yandex Direct. API поддерживает только операции add, update и get."
+  "Agency clients cannot be deleted via the Yandex Direct API. The API only supports add, update, and get operations.": "Клиентов агентства нельзя удалить через API Yandex Direct. API поддерживает только операции add, update и get.",
+  "Provide at least one of --invite-email or --invite-phone": "Укажите хотя бы один из --invite-email или --invite-phone",
+  "--grant and --clear-grants are mutually exclusive": "--grant и --clear-grants взаимоисключающи"
 }

--- a/direct_cli/translations/audiencetargets.json
+++ b/direct_cli/translations/audiencetargets.json
@@ -11,5 +11,7 @@
   "Retargeting list ID": "ID списка ретаргетинга",
   "Set audience target bids": "Установить ставки условий нацеливания на аудитории",
   "StrategyPriority value for automatic strategies": "Значение StrategyPriority для автоматических стратегий",
-  "Suspend audience target": "Приостановить условие нацеливания на аудиторию"
+  "Suspend audience target": "Приостановить условие нацеливания на аудиторию",
+  "Provide at least one of --retargeting-list-id or --interest-id": "Укажите хотя бы один из --retargeting-list-id или --interest-id",
+  "Provide at least one bid field (--context-bid or --priority)": "Укажите хотя бы одно поле ставки (--context-bid или --priority)"
 }

--- a/direct_cli/translations/auth.json
+++ b/direct_cli/translations/auth.json
@@ -16,5 +16,6 @@
   "Profile name (defaults to active profile)": "Имя профиля (по умолчанию — активный профиль)",
   "Open this URL and grant access:": "Откройте этот URL и предоставьте доступ:",
   "No profiles configured.": "Профили не настроены.",
-  "No active profile.": "Нет активного профиля."
+  "No active profile.": "Нет активного профиля.",
+  "Enter OAuth code": "Введите код OAuth"
 }

--- a/direct_cli/translations/balance.json
+++ b/direct_cli/translations/balance.json
@@ -1,3 +1,4 @@
 {
-  "Check account money balance.": "Проверить денежный баланс аккаунта."
+  "Check account money balance.": "Проверить денежный баланс аккаунта.",
+  "Provide --logins or configure YANDEX_DIRECT_LOGIN": "Укажите --logins или настройте YANDEX_DIRECT_LOGIN"
 }

--- a/direct_cli/translations/bidmodifiers.json
+++ b/direct_cli/translations/bidmodifiers.json
@@ -34,5 +34,12 @@
   "Removed: legacy --campaign-id/--type shape not supported by bidmodifiers set": "Удалено: устаревшая форма --campaign-id/--type не поддерживается bidmodifiers set",
   "Retargeting condition ID": "ID условия ретаргетинга",
   "SERP layout adjustment value": "Значение корректировки по вёрстке выдачи (SERP)",
-  "Set (update) an existing bid modifier\n\n    The Yandex Direct API's ``bidmodifiers/set`` method updates existing\n    modifiers by ``Id``. To create a new modifier, use ``bidmodifiers add``\n    instead.\n    ": "Обновить существующую корректировку ставки\n\nМетод ``bidmodifiers/set`` API Яндекс Директа обновляет существующие\nкорректировки по ``Id``. Чтобы создать новую корректировку,\nиспользуйте ``bidmodifiers add``."
+  "Set (update) an existing bid modifier\n\n    The Yandex Direct API's ``bidmodifiers/set`` method updates existing\n    modifiers by ``Id``. To create a new modifier, use ``bidmodifiers add``\n    instead.\n    ": "Обновить существующую корректировку ставки\n\nМетод ``bidmodifiers/set`` API Яндекс Директа обновляет существующие\nкорректировки по ``Id``. Чтобы создать новую корректировку,\nиспользуйте ``bidmodifiers add``.",
+  "Exactly one of --campaign-id or --adgroup-id is required": "Требуется ровно один из --campaign-id или --adgroup-id",
+  "Provide --id with --value for bidmodifiers set. The legacy --campaign-id/--type shape is not supported by WSDL BidModifierSetItem; use bidmodifiers add to create a new modifier.": "Укажите --id с --value для bidmodifiers set. Устаревшая форма --campaign-id/--type не поддерживается WSDL BidModifierSetItem; используйте bidmodifiers add для создания новой корректировки.",
+  "DEMOGRAPHICS_ADJUSTMENT requires --gender and/or --age": "DEMOGRAPHICS_ADJUSTMENT требует --gender и/или --age",
+  "RETARGETING_ADJUSTMENT requires --retargeting-condition-id": "RETARGETING_ADJUSTMENT требует --retargeting-condition-id",
+  "REGIONAL_ADJUSTMENT requires --region-id": "REGIONAL_ADJUSTMENT требует --region-id",
+  "SERP_LAYOUT_ADJUSTMENT requires --serp-layout": "SERP_LAYOUT_ADJUSTMENT требует --serp-layout",
+  "INCOME_GRADE_ADJUSTMENT requires --income-grade": "INCOME_GRADE_ADJUSTMENT требует --income-grade"
 }

--- a/direct_cli/translations/bids.json
+++ b/direct_cli/translations/bids.json
@@ -25,5 +25,7 @@
   "Maximum bid in micro-rubles": "Максимальная ставка в микрорублях",
   "One or more scope values": "Одно или несколько значений Scope",
   "Set bids": "Установить ставки",
-  "StrategyPriority value: LOW, NORMAL, or HIGH": "Значение StrategyPriority: LOW, NORMAL или HIGH"
+  "StrategyPriority value: LOW, NORMAL, or HIGH": "Значение StrategyPriority: LOW, NORMAL или HIGH",
+  "bids set requires at least one bid field (--bid, --context-bid, --priority, or --autotargeting-search-bid-is-auto).": "bids set требует хотя бы одно поле ставки (--bid, --context-bid, --priority или --autotargeting-search-bid-is-auto).",
+  "Provide at least one --scope": "Укажите хотя бы один --scope"
 }

--- a/direct_cli/translations/campaigns.json
+++ b/direct_cli/translations/campaigns.json
@@ -278,5 +278,18 @@
   "UnifiedCampaign Search strategy WeeklySpendLimit in micro-rubles (#363)": "UnifiedCampaign Search: стратегия WeeklySpendLimit в микрорублях (#363)",
   "UnifiedCampaign.PackageBiddingStrategy.Platforms.Maps": "UnifiedCampaign.PackageBiddingStrategy.Platforms.Maps",
   "UnifiedCampaign.PackageBiddingStrategy.Platforms.SearchOrganizationList": "UnifiedCampaign.PackageBiddingStrategy.Platforms.SearchOrganizationList",
-  "Update campaign": "Обновить кампанию"
+  "Update campaign": "Обновить кампанию",
+  "--time-targeting-schedule must contain at least one value": "--time-targeting-schedule должен содержать хотя бы одно значение",
+  "TimeTargeting requires --consider-working-weekends when any time-targeting flag is provided.": "TimeTargeting требует --consider-working-weekends, если задан любой флаг временного таргетинга.",
+  "--relevant-keywords-budget-percent is required when adding TextCampaign.RelevantKeywords": "--relevant-keywords-budget-percent обязателен при добавлении TextCampaign.RelevantKeywords",
+  "--frequency-cap-period-days and --frequency-cap-period-all are mutually exclusive": "--frequency-cap-period-days и --frequency-cap-period-all взаимоисключающи",
+  "--frequency-cap-impressions is required with --frequency-cap-period-days or --frequency-cap-period-all": "--frequency-cap-impressions обязателен вместе с --frequency-cap-period-days или --frequency-cap-period-all",
+  "--frequency-cap-impressions requires --frequency-cap-period-days or --frequency-cap-period-all": "--frequency-cap-impressions требует --frequency-cap-period-days или --frequency-cap-period-all",
+  "SmartCampaign.PackageBiddingStrategy requires --package-platform-search and --package-platform-network": "SmartCampaign.PackageBiddingStrategy требует --package-platform-search и --package-platform-network",
+  "TimeTargeting.HolidaysSchedule requires --holidays-suspend-on-holidays when any --holidays-* flag is provided.": "TimeTargeting.HolidaysSchedule требует --holidays-suspend-on-holidays, если задан любой флаг --holidays-*.",
+  "--holidays-bid-percent, --holidays-start-hour, and --holidays-end-hour can be provided only when --holidays-suspend-on-holidays is NO.": "--holidays-bid-percent, --holidays-start-hour и --holidays-end-hour можно указывать только при --holidays-suspend-on-holidays равном NO.",
+  "--holidays-bid-percent must be a multiple of 10": "--holidays-bid-percent должен быть кратен 10",
+  "--counter-id is required for SMART_CAMPAIGN (WSDL SmartCampaignAddItem.CounterId minOccurs=1)": "--counter-id обязателен для SMART_CAMPAIGN (WSDL SmartCampaignAddItem.CounterId minOccurs=1)",
+  "--filter-average-cpc cannot be combined with typed --smart-network-* flags; use --smart-network-filter-average-cpc instead": "--filter-average-cpc нельзя сочетать с типизированными флагами --smart-network-*; используйте --smart-network-filter-average-cpc",
+  "--filter-average-cpc is only valid for SMART_CAMPAIGN with AVERAGE_CPC_PER_FILTER network strategy": "--filter-average-cpc допустим только для SMART_CAMPAIGN со стратегией сети AVERAGE_CPC_PER_FILTER"
 }

--- a/direct_cli/translations/changes.json
+++ b/direct_cli/translations/changes.json
@@ -8,5 +8,7 @@
   "Comma-separated FieldNames; allowed values: CampaignIds, AdGroupIds, AdIds, CampaignsStat. Defaults to all four when omitted.": "Значения FieldNames через запятую; допустимые значения: CampaignIds, AdGroupIds, AdIds, CampaignsStat. По умолчанию — все четыре.",
   "Check campaigns changes": "Проверить изменения по кампаниям",
   "Timestamp for Changes.checkCampaigns (YYYY-MM-DDTHH:MM:SSZ or YYYY-MM-DDTHH:MM:SS+03:00)": "Метка времени для Changes.checkCampaigns (YYYY-MM-DDTHH:MM:SSZ или YYYY-MM-DDTHH:MM:SS+03:00)",
-  "Check dictionaries changes": "Проверить изменения в справочниках"
+  "Check dictionaries changes": "Проверить изменения в справочниках",
+  "Provide exactly one of: --campaign-ids, --ad-group-ids, --ad-ids.": "Укажите ровно один из: --campaign-ids, --ad-group-ids, --ad-ids.",
+  "--campaign-ids, --ad-group-ids, and --ad-ids are mutually exclusive — provide exactly one.": "--campaign-ids, --ad-group-ids и --ad-ids взаимоисключающи — укажите ровно один."
 }

--- a/direct_cli/translations/common.json
+++ b/direct_cli/translations/common.json
@@ -3,5 +3,12 @@
   "Language for help and messages (ru or en; default: ru)": "Язык справки и сообщений (ru или en; по умолчанию: ru)",
   "Output file": "Файл для вывода",
   "Output format": "Формат вывода",
-  "Show request without sending": "Показать запрос без отправки"
+  "Show request without sending": "Показать запрос без отправки",
+  "Provide at least one field to update": "Укажите хотя бы одно поле для обновления",
+  "--status and --statuses are mutually exclusive": "--status и --statuses взаимоисключающи",
+  "Provide a target selector (--id, --adgroup-id, or --campaign-id)": "Укажите селектор цели (--id, --adgroup-id или --campaign-id)",
+  "--autotargeting-category expects CATEGORY=YES|NO (for example EXACT=YES)": "--autotargeting-category ожидает CATEGORY=YES|NO (например, EXACT=YES)",
+  "--payment is required": "--payment обязателен",
+  "--campaign-ids must not be empty": "--campaign-ids не должен быть пустым",
+  "--phrases must not be empty": "--phrases не должен быть пустым"
 }

--- a/direct_cli/translations/dynamicads.json
+++ b/direct_cli/translations/dynamicads.json
@@ -5,5 +5,6 @@
   "Manage dynamic ad targets": "Управление условиями нацеливания динамических объявлений",
   "Resume dynamic ad target": "Возобновить условие нацеливания динамического объявления",
   "Set dynamic ad target bids": "Установить ставки условий нацеливания динамических объявлений",
-  "Suspend dynamic ad target": "Приостановить условие нацеливания динамического объявления"
+  "Suspend dynamic ad target": "Приостановить условие нацеливания динамического объявления",
+  "Provide at least one bid field (--bid, --context-bid, or --priority)": "Укажите хотя бы одно поле ставки (--bid, --context-bid или --priority)"
 }

--- a/direct_cli/translations/dynamicfeedadtargets.json
+++ b/direct_cli/translations/dynamicfeedadtargets.json
@@ -6,5 +6,7 @@
   "Restrict to currently available feed items": "Ограничить текущими доступными элементами фида",
   "Resume dynamic feed ad target": "Возобновить условие нацеливания динамического объявления по фиду",
   "Set dynamic feed ad target bids": "Установить ставки условий нацеливания динамических объявлений по фиду",
-  "Suspend dynamic feed ad target": "Приостановить условие нацеливания динамического объявления по фиду"
+  "Suspend dynamic feed ad target": "Приостановить условие нацеливания динамического объявления по фиду",
+  "Provide at least one typed filter": "Укажите хотя бы один типизированный фильтр",
+  "Provide at least one bid (--bid or --context-bid)": "Укажите хотя бы одну ставку (--bid или --context-bid)"
 }

--- a/direct_cli/translations/feeds.json
+++ b/direct_cli/translations/feeds.json
@@ -19,5 +19,17 @@
   "Update feed": "Обновить фид",
   "UrlFeed.Login for protected feed URL": "UrlFeed.Login для защищённого URL фида",
   "UrlFeed.Password for protected feed URL": "UrlFeed.Password для защищённого URL фида",
-  "UrlFeed.RemoveUtmTags: delete UTM tags from feed links, YES or NO.": "UrlFeed.RemoveUtmTags: удалять UTM-метки из ссылок фида, YES или NO."
+  "UrlFeed.RemoveUtmTags: delete UTM tags from feed links, YES or NO.": "UrlFeed.RemoveUtmTags: удалять UTM-метки из ссылок фида, YES или NO.",
+  "FileFeed.Filename cannot be empty.": "FileFeed.Filename не может быть пустым.",
+  "FileFeed.Data must be at most 50 MiB before base64 encoding.": "FileFeed.Data должен быть не более 50 МиБ до кодирования base64.",
+  "Provide a non-empty comma-separated FileFeedFieldNames list.": "Укажите непустой список FileFeedFieldNames через запятую.",
+  "Provide a non-empty comma-separated UrlFeedFieldNames list.": "Укажите непустой список UrlFeedFieldNames через запятую.",
+  "--file-feed-filename requires --file-feed-path.": "--file-feed-filename требует --file-feed-path.",
+  "Use either --url or --file-feed-path, not both.": "Используйте либо --url, либо --file-feed-path, но не оба.",
+  "Provide exactly one of --url or --file-feed-path.": "Укажите ровно один из --url или --file-feed-path.",
+  "--remove-utm-tags, --feed-login, and --feed-password are only valid with --url feeds.": "--remove-utm-tags, --feed-login и --feed-password допустимы только для фидов с --url.",
+  "Use either --feed-login or --clear-feed-login, not both": "Используйте либо --feed-login, либо --clear-feed-login, но не оба",
+  "Use either --feed-password or --clear-feed-password, not both": "Используйте либо --feed-password, либо --clear-feed-password, но не оба",
+  "FileFeed options cannot be combined with UrlFeed options.": "Опции FileFeed нельзя сочетать с опциями UrlFeed.",
+  "Provide at least one of --name, --url, --file-feed-path, --remove-utm-tags, --feed-login, --feed-password, --clear-feed-login, or --clear-feed-password": "Укажите хотя бы один из --name, --url, --file-feed-path, --remove-utm-tags, --feed-login, --feed-password, --clear-feed-login или --clear-feed-password"
 }

--- a/direct_cli/translations/keywordbids.json
+++ b/direct_cli/translations/keywordbids.json
@@ -11,5 +11,10 @@
   "NetworkByCoverage.TargetCoverage value": "Значение NetworkByCoverage.TargetCoverage",
   "Search bid in micro-rubles": "Ставка на поиске в микрорублях",
   "SearchByTrafficVolume.TargetTrafficVolume value": "Значение SearchByTrafficVolume.TargetTrafficVolume",
-  "Set keyword bids": "Установить ставки по ключевым фразам"
+  "Set keyword bids": "Установить ставки по ключевым фразам",
+  "keywordbids set requires at least one bid field (--search-bid, --network-bid, --priority, or --autotargeting-search-bid-is-auto).": "keywordbids set требует хотя бы одно поле ставки (--search-bid, --network-bid, --priority или --autotargeting-search-bid-is-auto).",
+  "Provide a non-empty comma-separated FieldNames list.": "Укажите непустой список FieldNames через запятую.",
+  "Provide a non-empty comma-separated SearchFieldNames list.": "Укажите непустой список SearchFieldNames через запятую.",
+  "Provide a non-empty comma-separated NetworkFieldNames list.": "Укажите непустой список NetworkFieldNames через запятую.",
+  "Provide exactly one of --target-traffic-volume or --target-coverage": "Укажите ровно один из --target-traffic-volume или --target-coverage"
 }

--- a/direct_cli/translations/keywords.json
+++ b/direct_cli/translations/keywords.json
@@ -31,5 +31,15 @@
   "Suspend keyword": "Приостановить ключевую фразу",
   "Update keyword text, user params, or autotargeting options.": "Обновить текст ключевой фразы, пользовательские параметры или опции автотаргетинга.",
   "User parameter 1": "Пользовательский параметр 1",
-  "User parameter 2": "Пользовательский параметр 2"
+  "User parameter 2": "Пользовательский параметр 2",
+  "--keywords-json must be a JSON array of keyword objects": "--keywords-json должен быть JSON-массивом объектов ключевых фраз",
+  "Provide exactly one of: --keyword (single), --from-file (JSONL), or --keywords-json (inline JSON array).": "Укажите ровно один из: --keyword (одна фраза), --from-file (JSONL) или --keywords-json (встроенный JSON-массив).",
+  "Provide exactly one of: --keyword, --from-file, or --keywords-json — they are mutually exclusive.": "Укажите ровно один из: --keyword, --from-file или --keywords-json — они взаимоисключающи.",
+  "Missing option '--adgroup-id'.": "Отсутствует опция '--adgroup-id'.",
+  "--format other than 'json' is not supported in batch mode (item-level results may include per-row Errors).": "--format, отличный от 'json', не поддерживается в пакетном режиме (результаты по элементам могут содержать построчные Errors).",
+  "Input contains no keyword rows.": "Во входных данных нет строк ключевых фраз.",
+  "keywords update requires at least one updatable field (--keyword, --user-param-1, --user-param-2, --autotargeting-category, --autotargeting-brand-option, or --autotargeting-settings-* flags).": "keywords update требует хотя бы одно изменяемое поле (--keyword, --user-param-1, --user-param-2, --autotargeting-category, --autotargeting-brand-option или флаги --autotargeting-settings-*).",
+  "--autotargeting-brand-option expects OPTION=YES|NO (for example WITHOUT_BRANDS=YES)": "--autotargeting-brand-option ожидает OPTION=YES|NO (например, WITHOUT_BRANDS=YES)",
+  "Provide a non-empty comma-separated AutotargetingSettingsBrandOptionsFieldNames list.": "Укажите непустой список AutotargetingSettingsBrandOptionsFieldNames через запятую.",
+  "Provide a non-empty comma-separated AutotargetingSettingsCategoriesFieldNames list.": "Укажите непустой список AutotargetingSettingsCategoriesFieldNames через запятую."
 }

--- a/direct_cli/translations/retargeting.json
+++ b/direct_cli/translations/retargeting.json
@@ -10,5 +10,6 @@
   "Retargeting list type": "Тип списка ретаргетинга",
   "Retargeting list type (case-insensitive). Yandex Direct accepts only RETARGETING (default — Metrica goals/segments + Audience segments, usable in text & image / mobile-app campaigns) or AUDIENCE (any goals/segments, usable in display campaigns). See axisrow/direct-cli#25.": "Тип списка ретаргетинга (регистр не важен). Яндекс Директ принимает только RETARGETING (по умолчанию — цели/сегменты Метрики + сегменты Аудиторий, для текстово-графических / мобильных кампаний) или AUDIENCE (любые цели/сегменты, для медийных кампаний). См. axisrow/direct-cli#25.",
   "Rule spec: OPERATOR:EXTERNAL_ID[:LIFESPAN][|EXTERNAL_ID[:LIFESPAN]]": "Спецификация правила: OPERATOR:EXTERNAL_ID[:LIFESPAN][|EXTERNAL_ID[:LIFESPAN]]",
-  "Update retargeting list": "Обновить список ретаргетинга"
+  "Update retargeting list": "Обновить список ретаргетинга",
+  "Provide at least one --rule": "Укажите хотя бы один --rule"
 }

--- a/direct_cli/translations/sitelinks.json
+++ b/direct_cli/translations/sitelinks.json
@@ -9,5 +9,10 @@
   "JSONL file with one sitelink object per line": "JSONL-файл с одним объектом быстрой ссылки в строке",
   "Manage sitelinks": "Управление быстрыми ссылками",
   "Sitelink spec: TITLE|HREF[|DESCRIPTION[|TURBO_PAGE_ID]]. Escape literal '|' as '\\|'.": "Спецификация быстрой ссылки: TITLE|HREF[|DESCRIPTION[|TURBO_PAGE_ID]]. Экранируйте литеральный '|' как '\\|'.",
-  "Sitelinks set ID": "ID набора быстрых ссылок"
+  "Sitelinks set ID": "ID набора быстрых ссылок",
+  "--sitelink-json must be a JSON array of sitelink objects": "--sitelink-json должен быть JSON-массивом объектов быстрых ссылок",
+  "Provide exactly one of: --sitelink (repeatable), --sitelink-json (inline JSON array), or --sitelinks-from-file (JSONL).": "Укажите ровно один из: --sitelink (повторяемый), --sitelink-json (встроенный JSON-массив) или --sitelinks-from-file (JSONL).",
+  "--sitelink, --sitelink-json, and --sitelinks-from-file are mutually exclusive — provide exactly one.": "--sitelink, --sitelink-json и --sitelinks-from-file взаимоисключающи — укажите ровно один.",
+  "Provide a non-empty comma-separated SitelinkFieldNames list.": "Укажите непустой список SitelinkFieldNames через запятую.",
+  "Input contains no sitelink rows.": "Во входных данных нет строк быстрых ссылок."
 }

--- a/direct_cli/translations/smartadtargets.json
+++ b/direct_cli/translations/smartadtargets.json
@@ -13,5 +13,7 @@
   "Target ID": "ID условия нацеливания",
   "Target name": "Имя условия нацеливания",
   "Update smart ad target": "Обновить условие нацеливания смарт-объявления",
-  "Whether only available items are targeted": "Нацеливаться только на доступные элементы"
+  "Whether only available items are targeted": "Нацеливаться только на доступные элементы",
+  "Provide target selection and bid fields for set-bids": "Укажите выбор цели и поля ставок для set-bids",
+  "Provide at least one bid field (--average-cpc, --average-cpa, or --priority)": "Укажите хотя бы одно поле ставки (--average-cpc, --average-cpa или --priority)"
 }

--- a/direct_cli/translations/strategies.json
+++ b/direct_cli/translations/strategies.json
@@ -43,5 +43,14 @@
   "Strategy type to update": "Тип стратегии для обновления",
   "Unarchive a strategy": "Разархивировать стратегию",
   "Update a strategy": "Обновить стратегию",
-  "Weekly spend limit in micro-rubles": "Недельный лимит расходов в микрорублях"
+  "Weekly spend limit in micro-rubles": "Недельный лимит расходов в микрорублях",
+  "--weekly-spend-limit cannot be combined with --custom-period-* flags.": "--weekly-spend-limit нельзя сочетать с флагами --custom-period-*.",
+  "--minimum-exploration-budget must be less than or equal to --weekly-spend-limit when both flags are provided.": "--minimum-exploration-budget должен быть меньше или равен --weekly-spend-limit, если заданы оба флага.",
+  "Invalid --priority-goal. Expected GOAL_ID:VALUE[:YES|NO], for example 123:1000000:YES": "Некорректный --priority-goal. Ожидается GOAL_ID:VALUE[:YES|NO], например 123:1000000:YES",
+  "--custom-period-* flags are not valid for --type AverageCpa on strategies update.": "Флаги --custom-period-* недопустимы для --type AverageCpa в strategies update.",
+  "Invalid --priority-goal. GOAL_ID and VALUE must be integers": "Некорректный --priority-goal. GOAL_ID и VALUE должны быть целыми числами",
+  "Invalid --priority-goal. IsMetrikaSourceOfValue must be YES or NO": "Некорректный --priority-goal. IsMetrikaSourceOfValue должен быть YES или NO",
+  "Provide --type when setting strategy-specific fields": "Укажите --type при задании полей конкретной стратегии",
+  "Provide --goal-id for this strategy type": "Укажите --goal-id для этого типа стратегии",
+  "strategies update requires at least one updatable field.": "strategies update требует хотя бы одно изменяемое поле."
 }

--- a/direct_cli/translations/v4account.json
+++ b/direct_cli/translations/v4account.json
@@ -27,5 +27,22 @@
   "Positive amount, e.g. 100.50 (TransferMoney only)": "Положительная сумма, например 100.50 (только TransferMoney)",
   "Precomputed financial token (Deposit / Invoice / TransferMoney)": "Заранее вычисленный финансовый токен (Deposit / Invoice / TransferMoney)",
   "Financial master token; computes the per-request token from operation_num + method + login (Deposit / Invoice / TransferMoney)": "Финансовый мастер-токен; вычисляет токен запроса из operation_num + method + login (Deposit / Invoice / TransferMoney)",
-  "Financial operation number (Deposit / Invoice / TransferMoney)": "Номер финансовой операции (Deposit / Invoice / TransferMoney)"
+  "Financial operation number (Deposit / Invoice / TransferMoney)": "Номер финансовой операции (Deposit / Invoice / TransferMoney)",
+  "--dry-run is required unless --sandbox is set": "--dry-run обязателен, если не задан --sandbox",
+  "--day-budget must be a non-negative amount": "--day-budget должен быть неотрицательной суммой",
+  "--logins must not be empty when provided": "--logins не должен быть пустым, если указан",
+  "--logins accepts at most 50 entries": "--logins принимает не более 50 записей",
+  "--account-ids accepts at most 100 entries": "--account-ids принимает не более 100 записей",
+  "--account-id is required for --action Update": "--account-id обязателен для --action Update",
+  "--sms-time-from and --sms-time-to must be provided together": "--sms-time-from и --sms-time-to должны указываться вместе",
+  "Provide at least one update field": "Укажите хотя бы одно поле обновления",
+  "--payment accepts at most 50 entries per call": "--payment принимает не более 50 записей за вызов",
+  "--from-account-id and --to-account-id must differ": "--from-account-id и --to-account-id должны различаться",
+  "--account-ids must not be empty when provided": "--account-ids не должен быть пустым, если указан",
+  "--account-ids must contain only positive integers": "--account-ids должен содержать только положительные целые числа",
+  "--day-budget and --spend-mode must be provided together": "--day-budget и --spend-mode должны указываться вместе",
+  "--payment must use ACCOUNT_ID=AMOUNT": "--payment должен использовать формат ACCOUNT_ID=AMOUNT",
+  "--payment account ID must be a positive integer": "ID счёта в --payment должен быть положительным целым числом",
+  "--payment account IDs must be unique": "ID счетов в --payment должны быть уникальными",
+  "--from-account-id, --to-account-id, and --amount are required for --action TransferMoney": "--from-account-id, --to-account-id и --amount обязательны для --action TransferMoney"
 }

--- a/direct_cli/translations/v4adimage.json
+++ b/direct_cli/translations/v4adimage.json
@@ -5,5 +5,11 @@
   "Page size": "Размер страницы",
   "Page offset": "Смещение страницы",
   "Attach or detach ad images (max 10000 associations).": "Привязать или отвязать изображения объявлений (до 10000 связей).",
-  "AD_ID to detach the image, or AD_ID=HASH to attach; repeat for multiple": "AD_ID для отвязки изображения или AD_ID=HASH для привязки; повторяйте для нескольких"
+  "AD_ID to detach the image, or AD_ID=HASH to attach; repeat for multiple": "AD_ID для отвязки изображения или AD_ID=HASH для привязки; повторяйте для нескольких",
+  "--association is required for set": "--association обязателен для set",
+  "--association accepts at most 10000 entries": "--association принимает не более 10000 записей",
+  "--association must not be empty": "--association не должен быть пустым",
+  "--association AD_ID must be a positive integer": "AD_ID в --association должен быть положительным целым числом",
+  "--association AD_ID values must be unique": "Значения AD_ID в --association должны быть уникальными",
+  "--association must be AD_ID or AD_ID=HASH with an integer AD_ID": "--association должен быть AD_ID или AD_ID=HASH с целочисленным AD_ID"
 }

--- a/direct_cli/translations/v4events.json
+++ b/direct_cli/translations/v4events.json
@@ -12,5 +12,6 @@
   "Filter: comma-separated account IDs": "Фильтр: ID счетов через запятую",
   "Filter: comma-separated event types (BannerModerated, CampaignFinished, LowCTR, MoneyOut, MoneyWarning, MoneyIn, PausedByDayBudget, WarnMinPrice, WarnPlace)": "Фильтр: типы событий через запятую (BannerModerated, CampaignFinished, LowCTR, MoneyOut, MoneyWarning, MoneyIn, PausedByDayBudget, WarnMinPrice, WarnPlace)",
   "Result limit": "Лимит результатов",
-  "Result offset": "Смещение результатов"
+  "Result offset": "Смещение результатов",
+  "--from must be earlier than or equal to --to": "--from должен быть раньше или равен --to"
 }

--- a/direct_cli/translations/v4finance.json
+++ b/direct_cli/translations/v4finance.json
@@ -23,5 +23,15 @@
   "Source campaign ID": "ID кампании-источника",
   "To issue a master token in the Yandex Direct UI, open Tools -> API -> Financial operations, enable the 'Allow financial operations' checkbox, click Save, then issue the master token on the same Financial operations page and confirm by SMS.": "Чтобы выпустить мастер-токен, в интерфейсе Яндекс Директа откройте Инструменты -> API -> Финансовые операции, включите чекбокс «Разрешить финансовые операции», нажмите «Сохранить», затем выпустите мастер-токен на этой же странице и подтвердите действие по SMS.",
   "Transfer currency (RUB/CHF/EUR/KZT/TRY/UAH/USD/BYN)": "Валюта перевода (RUB/CHF/EUR/KZT/TRY/UAH/USD/BYN)",
-  "Yandex Direct v4 Live finance commands.": "Финансовые команды Yandex Direct v4 Live."
+  "Yandex Direct v4 Live finance commands.": "Финансовые команды Yandex Direct v4 Live.",
+  "--logins must not be empty": "--logins не должен быть пустым",
+  "Use either --finance-token or --master-token, not both": "Используйте либо --finance-token, либо --master-token, но не оба",
+  "--dry-run is required for v4finance money commands": "--dry-run обязателен для денежных команд v4finance",
+  "--campaign-ids must contain only positive integers": "--campaign-ids должен содержать только положительные целые числа",
+  "--custom-transaction-id must be exactly 32 latin letters or digits": "--custom-transaction-id должен содержать ровно 32 латинские буквы или цифры",
+  "--contract-id is required when --pay-method Bank": "--contract-id обязателен при --pay-method Bank",
+  "--payment must use CAMPAIGN_ID=AMOUNT": "--payment должен использовать формат CAMPAIGN_ID=AMOUNT",
+  "--payment campaign ID must be a positive integer": "ID кампании в --payment должен быть положительным целым числом",
+  "--payment campaign IDs must be unique": "ID кампаний в --payment должны быть уникальными",
+  "Provide --finance-login or set YANDEX_DIRECT_FINANCE_LOGIN when using --master-token": "Укажите --finance-login или задайте YANDEX_DIRECT_FINANCE_LOGIN при использовании --master-token"
 }

--- a/direct_cli/translations/v4forecast.json
+++ b/direct_cli/translations/v4forecast.json
@@ -9,5 +9,6 @@
   "List v4 Live budget forecasts.": "Список прогнозов бюджета v4 Live.",
   "Get a ready v4 Live budget forecast.": "Получить готовый прогноз бюджета v4 Live.",
   "Forecast ID": "ID прогноза",
-  "Delete a v4 Live budget forecast.": "Удалить прогноз бюджета v4 Live."
+  "Delete a v4 Live budget forecast.": "Удалить прогноз бюджета v4 Live.",
+  "--phrases accepts at most 100 phrases": "--phrases принимает не более 100 фраз"
 }

--- a/direct_cli/translations/v4keywords.json
+++ b/direct_cli/translations/v4keywords.json
@@ -1,5 +1,6 @@
 {
   "Yandex Direct v4 Live keyword suggestion commands.": "Команды подсказок ключевых фраз Yandex Direct v4 Live.",
   "Suggest related keyword phrases for seed phrases.\n\n    Returns up to 20 suggestion phrases. Consumes API points (error_code=152\n    when insufficient).\n    ": "Подобрать связанные ключевые фразы для исходных фраз.\n\n    Возвращает до 20 фраз-подсказок. Расходует баллы API (error_code=152\n    при их нехватке).\n    ",
-  "Seed phrase; repeat for multiple phrases": "Исходная фраза; повторяйте для нескольких фраз"
+  "Seed phrase; repeat for multiple phrases": "Исходная фраза; повторяйте для нескольких фраз",
+  "--keyword must not be empty": "--keyword не должен быть пустым"
 }

--- a/direct_cli/translations/v4tags.json
+++ b/direct_cli/translations/v4tags.json
@@ -10,5 +10,20 @@
   "Replace banner tag assignments.": "Заменить назначения тегов баннеров.",
   "Comma-separated banner IDs": "ID баннеров через запятую",
   "Comma-separated campaign tag IDs, up to 30": "ID тегов кампании через запятую, до 30",
-  "Remove all banner tags": "Удалить все теги баннеров"
+  "Remove all banner tags": "Удалить все теги баннеров",
+  "--tag-ids accepts at most 30 tag IDs": "--tag-ids принимает не более 30 ID тегов",
+  "Use exactly one of --campaign-ids or --banner-ids": "Используйте ровно один из --campaign-ids или --banner-ids",
+  "--banner-ids accepts at most 2000 banner IDs": "--banner-ids принимает не более 2000 ID баннеров",
+  "--tag is required unless --clear-tags is used": "--tag обязателен, если не используется --clear-tags",
+  "--tag accepts at most 200 campaign tags": "--tag принимает не более 200 тегов кампании",
+  "--campaign-ids accepts at most 10 campaign IDs": "--campaign-ids принимает не более 10 ID кампаний",
+  "Use either --tag or --clear-tags, not both": "Используйте либо --tag, либо --clear-tags, но не оба",
+  "--tag must use TAG_ID=TEXT": "--tag должен использовать формат TAG_ID=TEXT",
+  "--tag ID must be a non-negative integer": "ID тега в --tag должен быть неотрицательным целым числом",
+  "--tag text must not be empty": "Текст тега в --tag не должен быть пустым",
+  "--tag text must be 25 characters or fewer": "Текст тега в --tag должен быть не длиннее 25 символов",
+  "--tag texts must be unique ignoring case": "Тексты тегов в --tag должны быть уникальными без учёта регистра",
+  "Use either --tag-ids or --clear-tags, not both": "Используйте либо --tag-ids, либо --clear-tags, но не оба",
+  "--tag-ids is required unless --clear-tags is used": "--tag-ids обязателен, если не используется --clear-tags",
+  "--tag IDs must be unique": "ID тегов в --tag должны быть уникальными"
 }

--- a/direct_cli/translations/v4wordstat.json
+++ b/direct_cli/translations/v4wordstat.json
@@ -5,5 +5,6 @@
   "List v4 Live Wordstat reports.": "Список отчётов Wordstat v4 Live.",
   "Get a ready v4 Live Wordstat report.": "Получить готовый отчёт Wordstat v4 Live.",
   "Wordstat report ID": "ID отчёта Wordstat",
-  "Delete a v4 Live Wordstat report.": "Удалить отчёт Wordstat v4 Live."
+  "Delete a v4 Live Wordstat report.": "Удалить отчёт Wordstat v4 Live.",
+  "--phrases accepts at most 10 phrases": "--phrases принимает не более 10 фраз"
 }

--- a/direct_cli/translations/vcards.json
+++ b/direct_cli/translations/vcards.json
@@ -28,5 +28,6 @@
   "PointOnMap.Y2 coordinate": "Координата PointOnMap.Y2",
   "Street": "Улица",
   "Work time string": "Строка времени работы",
-  "vCard ID": "ID визитки"
+  "vCard ID": "ID визитки",
+  "--instant-messenger-client and --instant-messenger-login must be provided together": "--instant-messenger-client и --instant-messenger-login должны указываться вместе"
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,23 @@ from direct_cli.cli import cli
 load_dotenv()
 
 
+@pytest.fixture(autouse=True)
+def _default_cli_locale_en(monkeypatch):
+    """Default the CLI UI locale to English across the suite.
+
+    Russian is the product default UI locale (epic #466). The overwhelming
+    majority of tests assert the stable *English* contract text of help and
+    error messages; the Russian-default behaviour is owned exclusively by
+    ``tests/test_i18n.py`` (and a handful of spots that pin Russian
+    explicitly). Pinning the env default to ``en`` here keeps those English
+    contract assertions valid without touching hundreds of call sites. Tests
+    that need another locale override via ``--locale`` or an explicit
+    ``YANDEX_DIRECT_CLI_LOCALE`` in the CliRunner env (an empty value resolves
+    back to the Russian default).
+    """
+    monkeypatch.setenv("YANDEX_DIRECT_CLI_LOCALE", "en")
+
+
 def _resolve_test_credentials():
     """Resolve API credentials for tests with env-vars taking priority.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -72,7 +72,10 @@ class TestCLI(unittest.TestCase):
 
     def test_cli_help_russian_by_default(self):
         """Root help and epilog default to Russian."""
-        result = self.runner.invoke(cli, ["--help"])
+        # Clear the suite-wide en pin so the genuine Russian default renders.
+        result = self.runner.invoke(
+            cli, ["--help"], env={"YANDEX_DIRECT_CLI_LOCALE": ""}
+        )
         self.assertEqual(result.exit_code, 0)
         self.assertIn("Контекст учётных данных", result.output)
         self.assertIn("Ошибка 8800", result.output)

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -83,11 +83,32 @@ LOCALIZED_GROUPS = (
     "v4meta",
 )
 
-_RUNTIME_MESSAGE_FUNCS = {"print_error", "print_info", "print_warning"}
+# Functions whose first argument is a human-readable message that must localize.
+# Beyond the print_* helpers, this also covers Click's user-facing error/prompt
+# surfaces (UsageError / BadParameter / prompt / confirm), matched by bare name
+# or as a ``click.<Name>`` attribute. Stage A (#477) wraps only *static* string
+# literals in ``t(...)``; interpolated forms (f-string / concat) are stage B
+# (#478), so the AST scan below flags only ``ast.Constant`` first arguments.
+_RUNTIME_MESSAGE_FUNCS = {
+    "print_error",
+    "print_info",
+    "print_warning",
+    "UsageError",
+    "BadParameter",
+    "prompt",
+    "confirm",
+}
 
 
 def _invoke(*args, env=None):
-    base_env = {"YANDEX_DIRECT_TOKEN": "", "YANDEX_DIRECT_LOGIN": ""}
+    # The suite-wide autouse fixture pins YANDEX_DIRECT_CLI_LOCALE=en; clear it
+    # here so these tests exercise the genuine Russian default (empty resolves
+    # back to ru). Individual tests still override via --locale or env.
+    base_env = {
+        "YANDEX_DIRECT_TOKEN": "",
+        "YANDEX_DIRECT_LOGIN": "",
+        "YANDEX_DIRECT_CLI_LOCALE": "",
+    }
     if env:
         base_env.update(env)
     with patch("direct_cli.cli.get_active_profile", return_value=None):
@@ -267,8 +288,12 @@ def test_localized_groups_have_complete_translations():
 
 
 def test_localized_groups_wrap_runtime_messages():
-    """print_error/info/warning in a localized module must not take a bare
-    string literal — the text has to pass through t(...) to localize."""
+    """User-facing message calls in a localized module must not take a bare
+    string literal. ``_RUNTIME_MESSAGE_FUNCS`` (print_* plus Click's
+    UsageError / BadParameter / prompt / confirm) must pass their first
+    argument through ``t(...)`` so it localizes. Only ``ast.Constant`` literals
+    are flagged here; interpolated messages (f-string / concat) are stage B
+    (#478) and intentionally not yet enforced."""
     offenders: dict[str, list[str]] = {}
     seen_files: set[str] = set()
     for name in LOCALIZED_GROUPS:

--- a/tests/test_v4finance_money.py
+++ b/tests/test_v4finance_money.py
@@ -768,7 +768,8 @@ def test_finance_commands_help_carries_not_tested_disclaimer():
         ("v4finance", "pay-campaigns-by-card", "--help"),
     ]:
         # Russian is the default locale; English is opt-in via --locale en.
-        result_ru = _invoke(*args)
+        # Clear the suite-wide en pin so the genuine Russian default renders.
+        result_ru = _invoke(*args, env={"YANDEX_DIRECT_CLI_LOCALE": ""})
         assert result_ru.exit_code == 0
         assert "Не проверено на боевом API" in result_ru.output
         result_en = _invoke("--locale", "en", *args)


### PR DESCRIPTION
## Что

Follow-up A эпика #466: локализация **статических** пользовательских сообщений об ошибках (`click.UsageError` / `click.BadParameter`) и интерактивного `click.prompt` в `auth`.

## Как

- Обёрнуты в `t(...)` все **179 статических** литералов `UsageError`/`BadParameter` (первый аргумент — `ast.Constant`) по 33 модулям + `auth` prompt («Enter OAuth code»). Позиционный codemod, без переформатирования прочего кода.
- Русские переводы добавлены в существующие `translations/<module>.json`; **7 межмодульных дублей** (напр. `Provide at least one field to update`, `--status and --statuses are mutually exclusive`) — в `common.json`.
- Имена флагов, enum-значения и WSDL-поля сохранены дословно; переводится только человекочитаемый текст.
- Расширен инвариант `test_localized_groups_wrap_runtime_messages`: теперь сканирует `UsageError`/`BadParameter`/`prompt`/`confirm` (bare и `click.<Name>`); голый строковый литерал первым аргументом запрещён. Флагуются пока только `ast.Constant` — интерполированные (f-string/concat) сообщения вынесены в этап B (#478).
- Добавлен autouse-fixture в `tests/conftest.py`, дефолтящий локаль тестов на английский, чтобы существующие английские контрактные ассерты (≈127 в 14 файлах) остались валидными. Русский дефолт по-прежнему покрыт `tests/test_i18n.py` (+ 3 точечных пина, очищающих локаль).

## Проверка

- Полный набор: 1998 passed, 8 skipped.
- `pytest tests/test_i18n.py` — 19 passed.
- `black --check` чисто; `flake8` — без новых нарушений (10 предсуществующих E501 не затронуты).
- Спот-проверка: `direct keywords add --keyword x --adgroup-id 1 --from-file f` → русское «Укажите ровно один из…»; `--locale en` → «Provide exactly one of…».

Часть #466.

🤖 Generated with [Claude Code](https://claude.com/claude-code)