### PR TITLE
fix(auth): stop --help and tests hanging on client-login network call

### DIFF
--- a/direct_cli/_vendor/tapi_yandex_direct/tapi_yandex_direct.pyi
+++ b/direct_cli/_vendor/tapi_yandex_direct/tapi_yandex_direct.pyi
@@ -36,22 +36,34 @@ class YandexDirectClientExecutor:
     def help(self) -> YandexDirectClientExecutor:
         """Print docs of resource."""
     def get(
-        self, *, params: dict = None, data: dict = None, headers: dict = None
+        self,
+        *,
+        params: dict = None,
+        data: dict = None,
+        headers: dict = None,
+        timeout: float = None,
     ) -> YandexDirectClientExecutorResponse:
         """
         Send HTTP 'GET' request.
 
         :param params: querystring arguments in the URL
         :param data: send data in the body of the request
+        :param timeout: forwarded to requests as the connect+read timeout
         """
     def post(
-        self, *, params: dict = None, data: dict = None, headers: dict = None
+        self,
+        *,
+        params: dict = None,
+        data: dict = None,
+        headers: dict = None,
+        timeout: float = None,
     ) -> YandexDirectClientExecutorResponse:
         """
         Send HTTP 'POST' request.
 
         :param params: querystring arguments in the URL
         :param data: send data in the body of the request
+        :param timeout: forwarded to requests as the connect+read timeout
         """
 
 class YandexDirectPageIteratorResponse(YandexDirectBaseMethodsClientResponse):

--- a/direct_cli/auth.py
+++ b/direct_cli/auth.py
@@ -33,6 +33,9 @@ DEFAULT_OAUTH_CLIENT_ID = "dcf15d9625f6471d94d6d054d52017ba"
 AUTH_STORE_PATH = Path.home() / ".direct-cli" / "auth.json"
 OAUTH_REFRESH_SKEW_SECONDS = 60
 PENDING_PKCE_TTL_SECONDS = 600
+# Hard ceiling for the best-effort client-login resolution network call so it
+# can never hang the credential-resolution path (see #480 follow-up).
+LOGIN_RESOLVE_TIMEOUT_SECONDS = 8
 
 
 def op_read(ref: str) -> str:
@@ -616,13 +619,18 @@ def _resolve_client_login_via_api(token: str) -> Optional[str]:
         # auth, so a function-local import is safe.
         from ._vendor.tapi_yandex_direct import YandexDirect
 
+        # Best-effort, on the credential-resolution hot path: cap the wait so a
+        # slow network or a Yandex SmartCaptcha gateway can never hang the CLI
+        # indefinitely (requests defaults to no timeout). Retries are disabled
+        # so the ceiling stays a single connect+read window.
         client = YandexDirect(
             access_token=token,
-            retry_if_exceeded_limit=True,
-            retries_if_server_error=2,
+            retry_if_exceeded_limit=False,
+            retries_if_server_error=0,
         )
         result = client.clients().post(
-            data={"method": "get", "params": {"FieldNames": ["Login"]}}
+            data={"method": "get", "params": {"FieldNames": ["Login"]}},
+            timeout=LOGIN_RESOLVE_TIMEOUT_SECONDS,
         )
         data = result().extract()
         clients = data.get("Clients") if isinstance(data, dict) else None
@@ -657,6 +665,7 @@ def get_credentials(
     bw_token_ref: Optional[str] = None,
     bw_login_ref: Optional[str] = None,
     profile: Optional[str] = None,
+    allow_login_resolve: bool = True,
 ) -> Tuple[str, Optional[str]]:
     """
     Get credentials with priority:
@@ -704,7 +713,8 @@ def get_credentials(
                 final_login = oauth_profile["login"]
             stored_login = oauth_profile.get("login")
             if (
-                not login
+                allow_login_resolve
+                and not login
                 and oauth_profile.get("source") == "oauth"
                 and isinstance(stored_login, str)
                 and "@" in stored_login

--- a/direct_cli/cli.py
+++ b/direct_cli/cli.py
@@ -3,6 +3,8 @@
 Direct CLI - Command-line interface for Yandex Direct API
 """
 
+import sys
+
 import click
 from click.core import ParameterSource
 
@@ -368,6 +370,13 @@ def cli(
         or bw_token_ref
         or bw_login_ref
     )
+    # When the user is only asking for help/version, no command will run, so
+    # skip the best-effort network client-login resolution (#480 migration).
+    # Otherwise ``<group> --help`` would block on a network round-trip — and on
+    # a slow link or a SmartCaptcha gateway it could hang the CLI. ``ctx`` can't
+    # tell a help pass from a real subcommand in the group callback, so detect
+    # the eager flags in argv directly.
+    help_or_version = any(arg in ("--help", "-h", "--version") for arg in sys.argv[1:])
     if has_refs:
         try:
             resolved_token, resolved_login = get_credentials(
@@ -378,6 +387,7 @@ def cli(
                 op_login_ref=explicit_op_login_ref,
                 bw_token_ref=explicit_bw_token_ref,
                 bw_login_ref=explicit_bw_login_ref,
+                allow_login_resolve=not help_or_version,
             )
             ctx.obj["token"] = resolved_token
             ctx.obj["login"] = resolved_login

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,24 @@ load_dotenv()
 
 
 @pytest.fixture(autouse=True)
+def _block_login_resolve_network(monkeypatch):
+    """Stop unit tests from ever hitting the network to resolve a client login.
+
+    A developer machine with an active ``direct auth`` profile whose stored
+    login is an email triggers a one-time network ``clients.get`` inside
+    ``get_credentials`` (issue #480 migration). Under ``CliRunner`` that call
+    can fire per invocation and — if the network is slow or Yandex serves a
+    SmartCaptcha gateway — hang the whole suite (it had no timeout). Tests must
+    never depend on that round-trip, so neutralize the resolver here. Tests
+    that specifically exercise the resolver patch it themselves.
+    """
+    monkeypatch.setattr(
+        "direct_cli.auth._resolve_client_login_via_api",
+        lambda *_args, **_kwargs: None,
+    )
+
+
+@pytest.fixture(autouse=True)
 def _default_cli_locale_en(monkeypatch):
     """Default the CLI UI locale to English across the suite.
 
@@ -62,12 +80,20 @@ def _resolve_test_credentials():
     if env_token:
         return env_token, env_login
 
-    from direct_cli.auth import get_credentials
+    import direct_cli.auth as auth
 
+    # This runs at import time (before the autouse fixture can patch anything).
+    # Falling back to the active profile must not trigger the network
+    # client-login resolution (#480) — that call could hang collection on a
+    # slow network / SmartCaptcha gateway. Neutralize it for this one call.
+    original_resolver = auth._resolve_client_login_via_api
+    auth._resolve_client_login_via_api = lambda *_a, **_k: None
     try:
-        return get_credentials()
+        return auth.get_credentials()
     except (RuntimeError, ValueError):
         return None, None
+    finally:
+        auth._resolve_client_login_via_api = original_resolver
 
 
 _REAL_TOKEN, _REAL_LOGIN = _resolve_test_credentials()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ Tests for Direct CLI
 import io
 import json
 import os
+import sys
 import unittest
 from contextlib import redirect_stderr
 from importlib import import_module
@@ -126,6 +127,74 @@ class TestCLI(unittest.TestCase):
                     f"Documentation: {get_docs_url(group)}",
                     result.output,
                 )
+
+    def test_group_help_does_not_resolve_client_login_over_network(self):
+        """``<group> --help`` must never make the #480 client-login API call.
+
+        Regression: a cold OAuth profile with an email login + no
+        ``login_migration_checked`` flag made every CLI invocation — including
+        ``--help`` — fire a network ``clients.get`` with no timeout, which
+        could hang the CLI (and the whole test suite). Help/version passes run
+        no command, so they must skip the resolver entirely.
+        """
+        import direct_cli.auth as auth_module
+
+        cold_profile = {
+            "source": "oauth",
+            "token": "cold-token",
+            "refresh_token": "cold-refresh",
+            "login": "someone@yandex.ru",
+            "expires_at": float(2**31),
+        }
+        calls = {"n": 0}
+
+        def _counting_resolver(*_args, **_kwargs):
+            calls["n"] += 1
+            return None
+
+        with (
+            patch.object(auth_module, "get_active_profile", return_value="default"),
+            patch.object(auth_module, "get_oauth_profile", return_value=cold_profile),
+            patch.object(
+                auth_module, "_resolve_client_login_via_api", _counting_resolver
+            ),
+            patch.object(sys, "argv", ["direct", "bids", "--help"]),
+        ):
+            result = self.runner.invoke(cli, ["bids", "--help"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(
+            calls["n"], 0, "client-login resolver must not run on a --help pass"
+        )
+
+    def test_get_credentials_skips_login_resolve_when_disallowed(self):
+        """``allow_login_resolve=False`` suppresses the #480 network migration."""
+        import direct_cli.auth as auth_module
+
+        cold_profile = {
+            "source": "oauth",
+            "token": "cold-token",
+            "refresh_token": "cold-refresh",
+            "login": "someone@yandex.ru",
+            "expires_at": float(2**31),
+        }
+        calls = {"n": 0}
+
+        def _counting_resolver(*_args, **_kwargs):
+            calls["n"] += 1
+            return None
+
+        with (
+            patch.object(auth_module, "get_active_profile", return_value="default"),
+            patch.object(auth_module, "get_oauth_profile", return_value=cold_profile),
+            patch.object(
+                auth_module, "_resolve_client_login_via_api", _counting_resolver
+            ),
+        ):
+            token, login = auth_module.get_credentials(allow_login_resolve=False)
+
+        self.assertEqual(token, "cold-token")
+        self.assertEqual(calls["n"], 0)
 
     def test_adgroups_v501_resource_mapping_exists_for_unified_groups(self):
         """Unified ad groups must be sent to the documented v501 endpoint."""


### PR DESCRIPTION
## Проблема

Регрессия из #480: `get_credentials()` при активном OAuth-профиле с email-логином (и невыставленным `login_migration_checked`) делал сетевой `clients.get` для резолва bare Client-Login **на каждый вызов CLI — включая `<group> --help`**. У этого запроса **не было таймаута** (ни в vendored-клиенте, ни в `tapi2`), поэтому медленная сеть или Yandex SmartCaptcha-гейт могли подвесить CLI бесконечно.

Под `CliRunner` это вешало и весь unit-набор: прогон вставал на `test_registered_mapped_groups_show_docs_url` (~30 вызовов `--help`).

## Что сделано (3 независимых барьера)

1. **`auth.py`** — потолок `LOGIN_RESOLVE_TIMEOUT_SECONDS = 8` на best-effort резолвер + отключены ретраи. Никогда не висит.
2. **`cli.py`** — `--help`/`--version`/`-h` пропускают резолвер (`allow_login_resolve=False`): команда не исполняется → логин не нужен.
3. **`tests/conftest.py`** — autouse-фикстура нейтрализует сетевой резолвер для всего unit-набора; модульный сбор test-creds его больше не триггерит.

## Тесты

- `test_group_help_does_not_resolve_client_login_over_network` — `--help`-проход делает 0 вызовов резолвера.
- `test_get_credentials_skips_login_resolve_when_disallowed` — `allow_login_resolve=False` подавляет миграцию.
- Ранее зависавший `test_registered_mapped_groups_show_docs_url` теперь идёт **0.02с** (был ~30с / бесконечно).
- Полный unit-набор: 2064 passed, 47 skipped за 82с.

🤖 Generated with [Claude Code](https://claude.com/claude-code)