### PR TITLE
fix(vendor): recover from tapi_yandex_direct 2026.5.29 bump regressions

### DIFF
--- a/direct_cli/_vendor/tapi_yandex_direct/tapi_yandex_direct.py
+++ b/direct_cli/_vendor/tapi_yandex_direct/tapi_yandex_direct.py
@@ -449,7 +449,7 @@ class YandexDirectClientAdapter(JSONAdapterMixin, TapiAdapter):
         columns = [[] for _ in range(len(kwargs["store"]["columns"]))]
         for values in self.iter_values(**kwargs):
             for i, col in enumerate(columns):
-                col.append(values[i])
+                col.append(values[i] if i < len(values) else "")
 
         return columns
 

--- a/direct_cli/_vendor/tapi_yandex_direct/tapi_yandex_direct.pyi
+++ b/direct_cli/_vendor/tapi_yandex_direct/tapi_yandex_direct.pyi
@@ -36,22 +36,24 @@ class YandexDirectClientExecutor:
     def help(self) -> YandexDirectClientExecutor:
         """Print docs of resource."""
     def get(
-        self, *, params: dict = None, data: dict = None, headers: dict = None
+        self, *, params: dict = None, data: dict = None, headers: dict = None, timeout: float = None
     ) -> YandexDirectClientExecutorResponse:
         """
         Send HTTP 'GET' request.
 
         :param params: querystring arguments in the URL
         :param data: send data in the body of the request
+        :param timeout: forwarded to requests as the connect+read timeout
         """
     def post(
-        self, *, params: dict = None, data: dict = None, headers: dict = None
+        self, *, params: dict = None, data: dict = None, headers: dict = None, timeout: float = None
     ) -> YandexDirectClientExecutorResponse:
         """
         Send HTTP 'POST' request.
 
         :param params: querystring arguments in the URL
         :param data: send data in the body of the request
+        :param timeout: forwarded to requests as the connect+read timeout
         """
 
 class YandexDirectPageIteratorResponse(YandexDirectBaseMethodsClientResponse):

--- a/scripts/patch_vendor_imports.py
+++ b/scripts/patch_vendor_imports.py
@@ -35,7 +35,9 @@ _TIMEOUT_PARAM = "timeout: float = None"
 _TIMEOUT_DOC = (
     "        :param timeout: forwarded to requests as the connect+read timeout"
 )
-_STUB_CLASS = "class YandexDirectClientExecutor"
+# Boundary-aware so we match ``class YandexDirectClientExecutor:`` exactly and
+# never the prefix-sharing ``class YandexDirectClientExecutorResponse(...)``.
+_STUB_CLASS_RE = re.compile(r"^class YandexDirectClientExecutor[:\(]")
 
 # Upstream emits the param list on a single line; match it so we can append the
 # kwarg. The guard against an already-present ``timeout`` keeps this idempotent.
@@ -192,7 +194,7 @@ def _patch_stub_text(text: str) -> str:
         # Track which class body we are in. A new ``class`` statement always
         # appears at column 0, so this never trips on nested defs.
         if line.startswith("class "):
-            in_stub_class = line.startswith(_STUB_CLASS)
+            in_stub_class = bool(_STUB_CLASS_RE.match(line))
 
         if in_stub_class and "timeout" not in line:
             sig = _EXECUTOR_SIG_RE.match(line)

--- a/scripts/patch_vendor_imports.py
+++ b/scripts/patch_vendor_imports.py
@@ -18,6 +18,44 @@ FROM_SUBMODULE_RE = re.compile(
     r"^from tapi_yandex_direct\.([A-Za-z0-9_\.]+) import (.+)$"
 )
 
+# --- Local stub patch: the `timeout` kwarg that the upstream fork drops ---
+#
+# auth._resolve_client_login_via_api passes ``timeout=`` to ``clients().post()``
+# on the credential-resolution hot path. tapi2 forwards it straight to
+# ``requests`` at runtime, but the hand-maintained ``.pyi`` stub omits it, so
+# mypy (the CI "Quality" gate) rejects the call. ``update_vendor.sh`` rebuilds
+# the vendor dir with ``rm -rf`` + ``cp -R`` of the fork, which has no such
+# edit, so the fix is wiped on every bump (it last survived ~10 minutes — see
+# the #480 follow-up). Re-applying it here, after the copy, makes it
+# self-healing. Keep the fork carrying it too as belt-and-braces.
+#
+# Scope is the *client* executor only — the type auth.py calls. The report
+# executor and v4 adapter never receive ``timeout``, so they stay untouched.
+_TIMEOUT_PARAM = "timeout: float = None"
+_TIMEOUT_DOC = (
+    "        :param timeout: forwarded to requests as the connect+read timeout"
+)
+_STUB_CLASS = "class YandexDirectClientExecutor"
+
+# Upstream emits the param list on a single line; match it so we can append the
+# kwarg. The guard against an already-present ``timeout`` keeps this idempotent.
+_EXECUTOR_SIG_RE = re.compile(
+    r"^(?P<head>\s*self, \*, params: dict = None, data: dict = None, "
+    r"headers: dict = None)(?P<tail>\s*)$"
+)
+_PARAM_DATA_RE = re.compile(r"^\s*:param data:")
+
+# --- Local runtime patch: to_columns must tolerate short report rows ---
+#
+# A report data row can carry fewer tab-separated cells than the column header
+# (Yandex omits trailing empty fields). Upstream's ``to_columns`` indexes
+# ``values[i]`` unconditionally and raises IndexError on such rows; our fix
+# pads the missing cells with "". Like the timeout stub, the upstream fork
+# drops this, so ``update_vendor.sh`` wipes it on every bump — re-apply here.
+# Covered by tests/test_reports_parsing.py::...to_columns_handles_short_rows.
+_TO_COLUMNS_UPSTREAM = "                col.append(values[i])"
+_TO_COLUMNS_PATCHED = '                col.append(values[i] if i < len(values) else "")'
+
 
 def _validate_captured(captured: str, path: Path, line_number: int, line: str) -> None:
     """Raise ValueError if the captured import group is unsupported."""
@@ -113,9 +151,68 @@ def _compute_patch(path: Path, vendor_dir: Path) -> str | None:
     if has_trailing_newline:
         patched += "\n"
 
+    patched = _patch_runtime_text(patched)
+
     if patched == original:
         return None
 
+    return patched
+
+
+def _patch_runtime_text(text: str) -> str:
+    """Re-apply local runtime patches to a vendored ``*.py`` source.
+
+    Currently restores the short-row guard in ``to_columns`` (see the
+    ``_TO_COLUMNS_*`` constants). Idempotent: a line already carrying the
+    guard is left unchanged, so repeated runs are a no-op.
+    """
+    if _TO_COLUMNS_PATCHED in text:
+        return text
+    return text.replace(_TO_COLUMNS_UPSTREAM, _TO_COLUMNS_PATCHED)
+
+
+def _patch_stub_text(text: str) -> str:
+    """Re-add the ``timeout`` kwarg to ``YandexDirectClientExecutor.get/post``.
+
+    Idempotent and scope-safe:
+
+    * A signature line that already mentions ``timeout`` is left untouched.
+    * The ``:param timeout:`` docstring line is inserted after ``:param data:``
+      only when it is not already the following line.
+    * Only lines inside the ``YandexDirectClientExecutor`` class body are
+      considered, so the report executor and v4 adapter signatures (which look
+      alike but never receive ``timeout``) are never modified.
+
+    Returns the text unchanged when there is nothing to patch.
+    """
+    lines = text.splitlines()
+    out: list[str] = []
+    in_stub_class = False
+    for i, line in enumerate(lines):
+        # Track which class body we are in. A new ``class`` statement always
+        # appears at column 0, so this never trips on nested defs.
+        if line.startswith("class "):
+            in_stub_class = line.startswith(_STUB_CLASS)
+
+        if in_stub_class and "timeout" not in line:
+            sig = _EXECUTOR_SIG_RE.match(line)
+            if sig:
+                line = f"{sig.group('head')}, {_TIMEOUT_PARAM}{sig.group('tail')}"
+
+        out.append(line)
+
+        # Insert the docstring line right after ``:param data:`` — but only
+        # inside the stub class and only if it is not already there. Dedup
+        # against the next *source* line (lines[i + 1]) keeps repeated runs a
+        # no-op regardless of how many lines we have already appended.
+        if in_stub_class and _PARAM_DATA_RE.match(line):
+            next_source = lines[i + 1] if i + 1 < len(lines) else ""
+            if next_source.strip() != _TIMEOUT_DOC.strip():
+                out.append(_TIMEOUT_DOC)
+
+    patched = "\n".join(out)
+    if text.endswith("\n"):
+        patched += "\n"
     return patched
 
 
@@ -123,8 +220,10 @@ def patch_vendor_dir(vendor_dir: Path) -> int:
     """
     Patch all Python files under a vendored tapi_yandex_direct directory.
 
-    Computes all patches before writing any files so that a ValueError on
-    any file prevents partial (broken) writes.
+    Rewrites upstream absolute imports in ``*.py`` files to relative ones and
+    re-applies the local ``timeout`` stub patch to ``*.pyi`` files (see
+    :func:`_patch_stub_text`). Computes all patches before writing any file so
+    that a ValueError on any file prevents partial (broken) writes.
 
     Args:
         vendor_dir: Path to the vendored package directory.
@@ -143,6 +242,12 @@ def patch_vendor_dir(vendor_dir: Path) -> int:
     for path in sorted(vendor_dir.rglob("*.py")):
         patched = _compute_patch(path, vendor_dir)
         if patched is not None:
+            patches[path] = patched
+
+    for path in sorted(vendor_dir.rglob("*.pyi")):
+        original = path.read_text(encoding="utf-8")
+        patched = _patch_stub_text(original)
+        if patched != original:
             patches[path] = patched
 
     for path, content in patches.items():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -242,6 +242,38 @@ def _before_record_response(response):
     return response
 
 
+# The Yandex Direct API answers on both ``api.direct.yandex.ru`` and
+# ``api.direct.yandex.com`` (likewise ``api-sandbox.``); the vendored client's
+# TLD has changed between releases. Cassettes recorded against one TLD must keep
+# replaying after a vendor bump switches the other, so the ``host`` matcher
+# treats the two as equivalent for Direct hosts only — every other host stays
+# matched verbatim, preserving the strictness of the original ``host`` matcher.
+_DIRECT_HOST_RE = re.compile(r"^(api(?:-sandbox)?\.direct\.yandex)\.(?:ru|com)$")
+
+
+def _normalize_direct_host(host):
+    """Collapse the ``.ru``/``.com`` TLD of a Yandex Direct API host."""
+    match = _DIRECT_HOST_RE.match(host or "")
+    return match.group(1) if match else host
+
+
+def _host_tld_insensitive(r1, r2):
+    """VCR ``host`` matcher that treats Direct ``.ru`` and ``.com`` as equal."""
+    if _normalize_direct_host(r1.host) != _normalize_direct_host(r2.host):
+        raise AssertionError(f"{r1.host} != {r2.host}")
+
+
+def pytest_recording_configure(config, vcr):
+    """Override the built-in ``host`` matcher before any cassette is matched.
+
+    pytest-recording calls this hook with the freshly built ``VCR`` instance,
+    before ``use_cassette`` resolves ``match_on`` names to matcher callables —
+    so re-registering ``host`` here makes ``match_on=[..., "host", ...]`` pick
+    up our TLD-insensitive variant.
+    """
+    vcr.register_matcher("host", _host_tld_insensitive)
+
+
 @pytest.fixture(scope="module")
 def vcr_config():
     """VCR config shared by every ``@pytest.mark.vcr`` test in this suite."""
@@ -256,7 +288,10 @@ def vcr_config():
         "decode_compressed_response": True,
         # Match on HTTP verb, URL and request body.  Body matching is
         # important: multiple sandbox commands hit the same endpoint and
-        # can only be distinguished by payload.
+        # can only be distinguished by payload.  ``host`` is the
+        # TLD-insensitive matcher registered in ``pytest_recording_configure``
+        # so a ``.ru`` cassette still matches a ``.com`` request (and vice
+        # versa) after a vendor bump changes the Direct API TLD.
         "match_on": ["method", "scheme", "host", "port", "path", "query", "body"],
         # NOTE: intentionally no ``record_mode`` key.  pytest-recording's
         # default is ``"none"`` (replay-only) when the CLI option

--- a/tests/test_transport_contract.py
+++ b/tests/test_transport_contract.py
@@ -35,32 +35,42 @@ def test_tapi_transport_exposes_cli_resource_executors():
     assert missing == []
 
 
-def test_direct_api_root_helper_uses_ru_hosts():
-    assert get_direct_api_root({}) == DIRECT_API_PRODUCTION_ROOT
-    assert get_direct_api_root({"is_sandbox": False}) == DIRECT_API_PRODUCTION_ROOT
-    assert get_direct_api_root({"is_sandbox": True}) == DIRECT_API_SANDBOX_ROOT
+def test_direct_api_root_helper_templates_tld():
+    # The host constants are ``{tld}`` templates; the helper substitutes the
+    # TLD (default ``com`` for the v5 JSON API) and selects prod vs sandbox.
+    assert get_direct_api_root({}) == DIRECT_API_PRODUCTION_ROOT.format(tld="com")
+    assert get_direct_api_root({"is_sandbox": False}) == (
+        DIRECT_API_PRODUCTION_ROOT.format(tld="com")
+    )
+    assert get_direct_api_root({"is_sandbox": True}) == (
+        DIRECT_API_SANDBOX_ROOT.format(tld="com")
+    )
+    # An explicit TLD (the v4 Live API uses ``ru``) is honored.
+    assert get_direct_api_root({}, tld="ru") == (
+        DIRECT_API_PRODUCTION_ROOT.format(tld="ru")
+    )
 
 
-def test_v5_adapter_uses_centralized_ru_hosts():
+def test_v5_adapter_uses_com_hosts():
     adapter = YandexDirectClientAdapter()
 
     assert adapter.get_api_root({"is_sandbox": False}, "campaigns") == (
-        DIRECT_API_PRODUCTION_ROOT
+        DIRECT_API_PRODUCTION_ROOT.format(tld="com")
     )
     assert adapter.get_api_root({"is_sandbox": True}, "campaigns") == (
-        DIRECT_API_SANDBOX_ROOT
+        DIRECT_API_SANDBOX_ROOT.format(tld="com")
     )
     assert adapter.get_api_root({"is_sandbox": False}, "debugtoken") == (
         DIRECT_DEBUG_ROOT
     )
 
 
-def test_v4_adapter_uses_centralized_ru_hosts():
+def test_v4_adapter_uses_ru_hosts():
     adapter = V4LiveClientAdapter()
 
     assert adapter.get_api_root({"is_sandbox": False}, "live") == (
-        DIRECT_API_PRODUCTION_ROOT
+        DIRECT_API_PRODUCTION_ROOT.format(tld="ru")
     )
     assert adapter.get_api_root({"is_sandbox": True}, "live") == (
-        DIRECT_API_SANDBOX_ROOT
+        DIRECT_API_SANDBOX_ROOT.format(tld="ru")
     )

--- a/tests/test_vendor_imports.py
+++ b/tests/test_vendor_imports.py
@@ -1,3 +1,5 @@
+import ast
+import importlib.util
 import subprocess
 import sys
 from pathlib import Path
@@ -5,6 +7,14 @@ from pathlib import Path
 ROOT_DIR = Path(__file__).resolve().parent.parent
 PATCH_SCRIPT = ROOT_DIR / "scripts/patch_vendor_imports.py"
 VENDOR_DIR = ROOT_DIR / "direct_cli/_vendor/tapi_yandex_direct"
+
+
+def _load_patch_module():
+    """Import scripts/patch_vendor_imports.py by path (no import-time effects)."""
+    spec = importlib.util.spec_from_file_location("patch_vendor_imports", PATCH_SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_patch_vendor_imports_rewrites_absolute_imports(tmp_path):
@@ -170,3 +180,88 @@ def test_vendored_tapi_yandex_direct_uses_relative_imports():
                 offenders.append(f"{path.relative_to(ROOT_DIR)}:{line_number}: {line}")
 
     assert offenders == []
+
+
+def test_vendored_executor_stub_declares_timeout_kwarg():
+    """The checked-in stub must keep ``timeout`` on the client executor's
+    ``get``/``post``, or mypy rejects ``auth._resolve_client_login_via_api``
+    (it passes ``timeout=`` on the credential-resolution hot path). The
+    upstream fork drops this kwarg, so ``update_vendor.sh`` would wipe it on
+    every bump if ``patch_vendor_imports.py`` did not re-apply it — see the
+    #480 follow-up. An ``ast`` check (not a substring grep) stays robust to
+    black reflowing the one-line signature back to multi-line.
+    """
+    stub = (VENDOR_DIR / "tapi_yandex_direct.pyi").read_text(encoding="utf-8")
+    tree = ast.parse(stub)
+    cls = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef)
+        and node.name == "YandexDirectClientExecutor"
+    )
+    for method_name in ("get", "post"):
+        func = next(
+            node
+            for node in cls.body
+            if isinstance(node, ast.FunctionDef) and node.name == method_name
+        )
+        kwonly = {arg.arg for arg in func.args.kwonlyargs}
+        assert "timeout" in kwonly, (
+            f"{method_name} stub lost the timeout kwarg — vendor patch not "
+            "re-applied (see scripts/patch_vendor_imports.py)"
+        )
+
+
+def test_patch_stub_text_adds_timeout_idempotently():
+    """``_patch_stub_text`` adds ``timeout`` to the client executor exactly
+    once, leaves the report executor alone, and is a no-op on a second pass.
+    """
+    pvi = _load_patch_module()
+    upstream = (
+        "class YandexDirectClientExecutor:\n"
+        "    def get(\n"
+        "        self, *, params: dict = None, data: dict = None, "
+        "headers: dict = None\n"
+        "    ) -> X:\n"
+        '        """\n'
+        "        Send HTTP 'GET' request.\n"
+        "\n"
+        "        :param params: q\n"
+        "        :param data: d\n"
+        '        """\n'
+        "    def post(\n"
+        "        self, *, params: dict = None, data: dict = None, "
+        "headers: dict = None\n"
+        "    ) -> X:\n"
+        '        """\n'
+        "        Send HTTP 'POST' request.\n"
+        "\n"
+        "        :param params: q\n"
+        "        :param data: d\n"
+        '        """\n'
+        "\n"
+        "class YandexDirectClientReportExecutor:\n"
+        "    def post(\n"
+        "        self, *, params: dict = None, data: dict = None, "
+        "headers: dict = None\n"
+        "    ) -> Y:\n"
+        '        """\n'
+        "        Send HTTP 'POST' request.\n"
+        "\n"
+        "        :param params: q\n"
+        "        :param data: d\n"
+        '        """\n'
+    )
+
+    first = pvi._patch_stub_text(upstream)
+
+    # Both client-executor methods gain the kwarg and exactly one doc line each.
+    assert first.count("timeout: float = None") == 2
+    assert first.count(":param timeout:") == 2
+
+    # The report executor is out of scope and must stay untouched.
+    report_block = first.split("class YandexDirectClientReportExecutor", 1)[1]
+    assert "timeout" not in report_block
+
+    # Running again on the patched text is a byte-for-byte no-op.
+    assert pvi._patch_stub_text(first) == first

--- a/tests/test_vendor_imports.py
+++ b/tests/test_vendor_imports.py
@@ -265,3 +265,27 @@ def test_patch_stub_text_adds_timeout_idempotently():
 
     # Running again on the patched text is a byte-for-byte no-op.
     assert pvi._patch_stub_text(first) == first
+
+
+def test_patch_stub_text_ignores_prefix_sharing_class():
+    """``_patch_stub_text`` must scope to ``YandexDirectClientExecutor`` exactly
+    and never the prefix-sharing ``YandexDirectClientExecutorResponse``. The
+    decoy class below carries a method with the exact executor signature; a
+    plain ``startswith`` scope check would wrongly patch it.
+    """
+    pvi = _load_patch_module()
+    decoy = (
+        "class YandexDirectClientExecutorResponse(Base):\n"
+        "    def get(\n"
+        "        self, *, params: dict = None, data: dict = None, "
+        "headers: dict = None\n"
+        "    ) -> X:\n"
+        '        """\n'
+        "        Send HTTP 'GET' request.\n"
+        "\n"
+        "        :param params: q\n"
+        "        :param data: d\n"
+        '        """\n'
+    )
+
+    assert pvi._patch_stub_text(decoy) == decoy  # untouched


### PR DESCRIPTION
## Что и зачем

Vendor bump `1ee8c2a` (обновление `tapi-yandex-direct` до 2026.5.29 через `update_vendor.sh` = `rm -rf` + `cp -R` форка) затёр локальные правки и рассинхронизировал вендор с тестами. CI показал только первую регрессию — job **Quality** падает на mypy ещё до шага с тестами.

## Четыре регрессии и фиксы

| # | Регрессия | Фикс |
|---|-----------|------|
| 1 | `.pyi`-стаб потерял `timeout` у `get/post` → mypy `[call-arg]` на `auth.py:631` (runtime ОК — tapi2 форвардит `**kwargs` в `requests`) | восстановлен стаб + **self-heal** `_patch_stub_text` в `patch_vendor_imports.py` + 2 тест-гейта |
| 2 | `to_columns` `IndexError` на коротких строках отчёта (апстрим откатил guard) | восстановлен guard + **self-heal** `_patch_runtime_text` |
| 3 | transport-хосты стали шаблоном `{tld}` (v5→`.com`, v4→`.ru`) | `test_transport_contract.py` переписан под новый контракт |
| 4 | кассеты `.ru` ≠ запросы `.com` → 42 теста падали при `--record-mode=none` | TLD-insensitive VCR host-matcher в `conftest.py` (`pytest_recording_configure`) |

**Корень** — `update_vendor.sh` затирает локальные правки при каждом bump. Поэтому #1 и #2 не просто восстановлены, а **самовосстанавливаются** после `cp -R` (идемпотентно), чтобы будущий bump не уронил CI снова.

## Проверка

- `mypy .` (Python 3.11) → `Success: no issues found in 60 source files`
- `pytest -m "not integration"` → **2035 passed, 46 skipped, 0 failed**
- `ruff check .` → `All checks passed!`
- кассеточные тесты → 47 passed / 15 skipped (как до bump'а)
- self-heal на tmp-копии: откат обеих правок → восстановлены (2 файла) → повтор no-op → байт-в-байт совпадает с репо

## Остаётся опционально (вне репо)

Внести `timeout` в `.pyi` форка `axisrow/tapi-yandex-direct` как страховку от ребейза апстрима — но self-heal делает это необязательным.

Closes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)