### PR TITLE
refactor: client_from_ctx() helper (dedup #491 A1)

### DIFF
--- a/direct_cli/api.py
+++ b/direct_cli/api.py
@@ -68,6 +68,29 @@ def create_client(
     )
 
 
+def client_from_ctx(ctx, create_client_fn) -> YandexDirect:
+    """Build a YandexDirect client from the standard CLI context.
+
+    ``create_client_fn`` is the calling module's own ``create_client`` symbol,
+    so test patches on ``direct_cli.commands.<module>.create_client`` keep
+    intercepting the call and existing
+    ``assert_called_once_with(token=..., login=..., sandbox=...)`` assertions
+    stay valid.
+
+    Args:
+        ctx: Click context whose ``obj`` carries ``token``/``login``/``sandbox``
+        create_client_fn: the caller's ``create_client`` (passed for patchability)
+
+    Returns:
+        YandexDirect client instance
+    """
+    return create_client_fn(
+        token=ctx.obj.get("token"),
+        login=ctx.obj.get("login"),
+        sandbox=ctx.obj.get("sandbox"),
+    )
+
+
 def create_v4_client(
     token: Optional[str] = None,
     login: Optional[str] = None,

--- a/direct_cli/commands/adextensions.py
+++ b/direct_cli/commands/adextensions.py
@@ -4,7 +4,7 @@ AdExtensions commands
 
 import click
 
-from ..api import create_client
+from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import add_criteria_csv, get_default_fields, parse_csv_strings, parse_ids
@@ -49,11 +49,7 @@ def get(
 ):
     """Get ad extensions"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         field_names = parse_csv_strings(fields) or get_default_fields("adextensions")
         parsed_callout_field_names = parse_csv_strings(callout_field_names)
@@ -118,11 +114,7 @@ def add(ctx, callout_text, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.adextensions().post(data=body)
         format_output(result().extract(), "json", None)
@@ -150,11 +142,7 @@ def delete(ctx, extension_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.adextensions().post(data=body)
         format_output(result().extract(), "json", None)

--- a/direct_cli/commands/adgroups.py
+++ b/direct_cli/commands/adgroups.py
@@ -6,7 +6,7 @@ from typing import Any, Optional
 
 import click
 
-from ..api import create_client
+from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import (
@@ -609,11 +609,7 @@ def get(
         raise click.UsageError(t("--status and --statuses are mutually exclusive"))
 
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         field_names = fields.split(",") if fields else get_default_fields("adgroups")
 
@@ -1036,11 +1032,7 @@ def add(
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = _post_adgroups(client, body)
         format_output(result().extract(), "json", None)
@@ -1348,11 +1340,7 @@ def update(
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = _post_adgroups(client, body)
         format_output(result().extract(), "json", None)
@@ -1378,11 +1366,7 @@ def delete(ctx, adgroup_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.adgroups().post(data=body)
         format_output(result().extract(), "json", None)

--- a/direct_cli/commands/adimages.py
+++ b/direct_cli/commands/adimages.py
@@ -4,7 +4,7 @@ AdImages commands
 
 import click
 
-from ..api import create_client
+from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import add_criteria_csv, get_default_fields, load_base64_file, parse_ids
@@ -40,11 +40,7 @@ def get(
 ):
     """Get ad images"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         field_names = fields.split(",") if fields else get_default_fields("adimages")
 
@@ -112,11 +108,7 @@ def add(ctx, name, image_data, image_file, image_type, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.adimages().post(data=body)
         format_output(result().extract(), "json", None)
@@ -144,11 +136,7 @@ def delete(ctx, image_hash, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.adimages().post(data=body)
         format_output(result().extract(), "json", None)

--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 import click
 
-from ..api import create_client
+from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import (
@@ -1059,11 +1059,7 @@ def get(
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.ads().post(data=body)
 
@@ -1731,11 +1727,7 @@ def add(
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.ads().post(data=body)
         format_output(result().extract(), "json", None)
@@ -2344,11 +2336,7 @@ def update(
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.ads().post(data=body)
         format_output(result().extract(), "json", None)
@@ -2373,11 +2361,7 @@ def delete(ctx, ad_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.ads().post(data=body)
         format_output(result().extract(), "json", None)
@@ -2402,11 +2386,7 @@ def archive(ctx, ad_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.ads().post(data=body)
         format_output(result().extract(), "json", None)
@@ -2434,11 +2414,7 @@ def unarchive(ctx, ad_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.ads().post(data=body)
         format_output(result().extract(), "json", None)
@@ -2463,11 +2439,7 @@ def suspend(ctx, ad_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.ads().post(data=body)
         format_output(result().extract(), "json", None)
@@ -2492,11 +2464,7 @@ def resume(ctx, ad_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.ads().post(data=body)
         format_output(result().extract(), "json", None)
@@ -2521,11 +2489,7 @@ def moderate(ctx, ad_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.ads().post(data=body)
         format_output(result().extract(), "json", None)

--- a/direct_cli/commands/advideos.py
+++ b/direct_cli/commands/advideos.py
@@ -4,7 +4,7 @@ AdVideos commands
 
 import click
 
-from ..api import create_client
+from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import get_default_fields, load_base64_file
@@ -27,11 +27,7 @@ def advideos():
 def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
     """Get ad videos"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         field_names = fields.split(",") if fields else get_default_fields("advideos")
 
@@ -103,11 +99,7 @@ def add(ctx, url, video_data, video_file, name, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.advideos().post(data=body)
         format_output(result().extract(), "json", None)

--- a/direct_cli/commands/agencyclients.py
+++ b/direct_cli/commands/agencyclients.py
@@ -4,7 +4,7 @@ AgencyClients commands
 
 import click
 
-from ..api import create_client
+from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import (
@@ -135,11 +135,7 @@ def get(
 ):
     """Get agency clients"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         field_names = (
             fields.split(",") if fields else get_default_fields("agencyclients")
@@ -253,11 +249,7 @@ def add(
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.agencyclients().post(data=body)
         format_output(result().extract(), "json", None)
@@ -315,11 +307,7 @@ def add_passport_organization(
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
         result = client.agencyclients().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -366,11 +354,7 @@ def add_passport_organization_member(
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
         result = client.agencyclients().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -455,11 +439,7 @@ def update(
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
         result = client.agencyclients().post(data=body)
         format_output(result().extract(), "json", None)
 

--- a/direct_cli/commands/audiencetargets.py
+++ b/direct_cli/commands/audiencetargets.py
@@ -4,7 +4,7 @@ AudienceTargets commands
 
 import click
 
-from ..api import create_client
+from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import add_criteria_csv, get_default_fields, parse_ids, MICRO_RUBLES
@@ -46,11 +46,7 @@ def get(
 ):
     """Get audience targets"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         criteria = {}
         if ids:
@@ -145,11 +141,7 @@ def add(
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
         result = client.audiencetargets().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -201,11 +193,7 @@ def set_bids(ctx, target_id, adgroup_id, campaign_id, context_bid, priority, dry
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
         result = client.audiencetargets().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -232,11 +220,7 @@ def delete(ctx, target_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.audiencetargets().post(data=body)
         format_output(result().extract(), "json", None)
@@ -262,11 +246,7 @@ def suspend(ctx, target_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.audiencetargets().post(data=body)
         format_output(result().extract(), "json", None)
@@ -292,11 +272,7 @@ def resume(ctx, target_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.audiencetargets().post(data=body)
         format_output(result().extract(), "json", None)

--- a/direct_cli/commands/bidmodifiers.py
+++ b/direct_cli/commands/bidmodifiers.py
@@ -4,7 +4,7 @@ BidModifiers commands
 
 import click
 
-from ..api import create_client
+from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import get_default_fields, parse_csv_strings, parse_ids
@@ -175,11 +175,7 @@ def get(
 ):
     """Get bid modifiers"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         raw_nested = (
             ("AdGroupAdjustmentFieldNames", ad_group_adjustment_field_names),
@@ -461,11 +457,7 @@ def add(
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.bidmodifiers().post(data=body)
         format_output(result().extract(), "json", None)
@@ -559,11 +551,7 @@ def set(ctx, modifier_id, value, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.bidmodifiers().post(data=body)
         format_output(result().extract(), "json", None)
@@ -591,11 +579,7 @@ def delete(ctx, modifier_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.bidmodifiers().post(data=body)
         format_output(result().extract(), "json", None)

--- a/direct_cli/commands/bids.py
+++ b/direct_cli/commands/bids.py
@@ -4,7 +4,7 @@ Bids commands
 
 import click
 
-from ..api import create_client
+from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import (
@@ -48,11 +48,7 @@ def get(
 ):
     """Get bids"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         criteria = {}
         if campaign_ids:
@@ -176,11 +172,7 @@ def set(
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
         result = client.bids().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -247,11 +239,7 @@ def set_auto(
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
         result = client.bids().post(data=body)
         format_output(result().extract(), "json", None)
 

--- a/direct_cli/commands/businesses.py
+++ b/direct_cli/commands/businesses.py
@@ -4,7 +4,7 @@ Businesses commands
 
 import click
 
-from ..api import create_client
+from ..api import client_from_ctx, create_client
 from ..output import format_output, print_error
 from ..utils import get_default_fields, parse_ids
 
@@ -26,11 +26,7 @@ def businesses():
 def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
     """Get businesses"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         field_names = fields.split(",") if fields else get_default_fields("businesses")
 

--- a/direct_cli/commands/campaigns.py
+++ b/direct_cli/commands/campaigns.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional, Sequence
 
 import click
 
-from ..api import create_client
+from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import (
@@ -697,11 +697,7 @@ def get(
         raise click.UsageError(t("--status and --statuses are mutually exclusive"))
 
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         # Parse field names
         field_names = (
@@ -4234,11 +4230,7 @@ def add(
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.campaigns().post(data=body)
         format_output(result().extract(), "json", None)
@@ -7444,11 +7436,7 @@ def update(
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.campaigns().post(data=body)
         format_output(result().extract(), "json", None)
@@ -7476,11 +7464,7 @@ def delete(ctx, campaign_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.campaigns().post(data=body)
         format_output(result().extract(), "json", None)
@@ -7506,11 +7490,7 @@ def archive(ctx, campaign_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.campaigns().post(data=body)
         format_output(result().extract(), "json", None)
@@ -7536,11 +7516,7 @@ def unarchive(ctx, campaign_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.campaigns().post(data=body)
         format_output(result().extract(), "json", None)
@@ -7566,11 +7542,7 @@ def suspend(ctx, campaign_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.campaigns().post(data=body)
         format_output(result().extract(), "json", None)
@@ -7596,11 +7568,7 @@ def resume(ctx, campaign_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.campaigns().post(data=body)
         format_output(result().extract(), "json", None)

--- a/direct_cli/commands/changes.py
+++ b/direct_cli/commands/changes.py
@@ -4,7 +4,7 @@ Changes commands
 
 import click
 
-from ..api import create_client
+from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import get_default_fields, parse_changes_datetime, parse_ids
@@ -109,11 +109,7 @@ def check(
         )
 
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         params = {
             id_field: id_value,
@@ -146,11 +142,7 @@ def check(
 def check_campaigns(ctx, timestamp, output_format, output):
     """Check campaigns changes"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         params = {"Timestamp": parse_changes_datetime(timestamp)}
 
@@ -171,11 +163,7 @@ def check_campaigns(ctx, timestamp, output_format, output):
 def check_dictionaries(ctx, output_format, output):
     """Check dictionaries changes"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         body = {"method": "checkDictionaries", "params": {}}
 

--- a/direct_cli/commands/clients.py
+++ b/direct_cli/commands/clients.py
@@ -4,7 +4,7 @@ Clients commands
 
 import click
 
-from ..api import create_client
+from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import (
@@ -101,11 +101,7 @@ def get(
 ):
     """Get clients"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         field_names = fields.split(",") if fields else get_default_fields("clients")
 
@@ -355,11 +351,7 @@ def update(
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.clients().post(data=body)
         format_output(result().extract(), "json", None)

--- a/direct_cli/commands/creatives.py
+++ b/direct_cli/commands/creatives.py
@@ -4,7 +4,7 @@ Creatives commands
 
 import click
 
-from ..api import create_client
+from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import get_default_fields, parse_csv_strings, parse_ids
@@ -75,11 +75,7 @@ def get(
 ):
     """Get creatives"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         field_names = fields.split(",") if fields else get_default_fields("creatives")
 
@@ -160,11 +156,7 @@ def add(ctx, video_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
         result = client.creatives().post(data=body)
         format_output(result().extract(), "json", None)
 

--- a/direct_cli/commands/dictionaries.py
+++ b/direct_cli/commands/dictionaries.py
@@ -4,7 +4,7 @@ Dictionaries commands
 
 import click
 
-from ..api import create_client
+from ..api import client_from_ctx, create_client
 from ..output import format_output, print_error
 from ..utils import parse_csv_strings, parse_ids
 
@@ -39,11 +39,7 @@ def dictionaries():
 def get(ctx, names, output_format, output):
     """Get dictionaries"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         dictionary_names = [n.strip() for n in names.split(",")]
 
@@ -68,11 +64,7 @@ def get(ctx, names, output_format, output):
 def get_geo_regions(ctx, name, region_ids, exact_names, fields, output_format, output):
     """Get GeoRegions dictionary entries"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         params = {"FieldNames": [name.strip() for name in fields.split(",")]}
         selection_criteria = {}

--- a/direct_cli/commands/dynamicads.py
+++ b/direct_cli/commands/dynamicads.py
@@ -4,7 +4,7 @@ DynamicAds (Webpages) commands
 
 import click
 
-from ..api import create_client
+from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import get_default_fields, parse_condition_specs, parse_ids, MICRO_RUBLES
@@ -42,11 +42,7 @@ def get(
 ):
     """Get dynamic ad targets"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         field_names = fields.split(",") if fields else get_default_fields("dynamicads")
 
@@ -127,11 +123,7 @@ def add(ctx, adgroup_id, name, conditions, bid, context_bid, priority, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
         result = client.dynamicads().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -158,11 +150,7 @@ def delete(ctx, target_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.dynamicads().post(data=body)
         format_output(result().extract(), "json", None)
@@ -188,11 +176,7 @@ def suspend(ctx, target_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
         result = client.dynamicads().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -217,11 +201,7 @@ def resume(ctx, target_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
         result = client.dynamicads().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -281,11 +261,7 @@ def set_bids(
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
         result = client.dynamicads().post(data=body)
         format_output(result().extract(), "json", None)
 

--- a/direct_cli/commands/dynamicfeedadtargets.py
+++ b/direct_cli/commands/dynamicfeedadtargets.py
@@ -4,7 +4,7 @@ DynamicFeedAdTargets commands
 
 import click
 
-from ..api import create_client
+from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import get_default_fields, parse_condition_specs, parse_ids, MICRO_RUBLES
@@ -42,11 +42,7 @@ def get(
 ):
     """Get dynamic feed ad targets"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         field_names = (
             fields.split(",") if fields else get_default_fields("dynamicfeedadtargets")
@@ -141,11 +137,7 @@ def add(
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
         result = client.dynamicfeedadtargets().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -172,11 +164,7 @@ def delete(ctx, target_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.dynamicfeedadtargets().post(data=body)
         format_output(result().extract(), "json", None)
@@ -202,11 +190,7 @@ def suspend(ctx, target_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
         result = client.dynamicfeedadtargets().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -231,11 +215,7 @@ def resume(ctx, target_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
         result = client.dynamicfeedadtargets().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -284,11 +264,7 @@ def set_bids(ctx, target_id, adgroup_id, campaign_id, bid, context_bid, dry_run)
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
         result = client.dynamicfeedadtargets().post(data=body)
         format_output(result().extract(), "json", None)
 

--- a/direct_cli/commands/feeds.py
+++ b/direct_cli/commands/feeds.py
@@ -8,7 +8,7 @@ from typing import Dict, Optional
 
 import click
 
-from ..api import create_client
+from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import get_default_fields, parse_csv_strings, parse_ids
@@ -154,11 +154,7 @@ def get(
 ):
     """Get feeds"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         field_names = fields.split(",") if fields else get_default_fields("feeds")
 
@@ -295,11 +291,7 @@ def add(
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.feeds().post(data=body)
         format_output(result().extract(), "json", None)
@@ -414,11 +406,7 @@ def update(
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.feeds().post(data=body)
         format_output(result().extract(), "json", None)
@@ -443,11 +431,7 @@ def delete(ctx, feed_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.feeds().post(data=body)
         format_output(result().extract(), "json", None)

--- a/direct_cli/commands/keywordbids.py
+++ b/direct_cli/commands/keywordbids.py
@@ -4,7 +4,7 @@ KeywordBids commands
 
 import click
 
-from ..api import create_client
+from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import (
@@ -77,11 +77,7 @@ def get(
 ):
     """Get keyword bids"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         parsed_fields = parse_csv_strings(fields)
         if fields is not None and not parsed_fields:
@@ -231,11 +227,7 @@ def set(
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
         result = client.keywordbids().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -316,11 +308,7 @@ def set_auto(
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
         result = client.keywordbids().post(data=body)
         format_output(result().extract(), "json", None)
 

--- a/direct_cli/commands/keywords.py
+++ b/direct_cli/commands/keywords.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Iterator, List, Optional
 
 import click
 
-from ..api import create_client
+from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import (
     format_json,
@@ -459,11 +459,7 @@ def get(
         raise click.UsageError(t("--status and --statuses are mutually exclusive"))
 
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         field_names = fields.split(",") if fields else get_default_fields("keywords")
 
@@ -782,11 +778,7 @@ def add(
             format_output(body, output_format, None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.keywords().post(data=body)
         format_output(result().extract(), output_format, None)
@@ -845,11 +837,7 @@ def _bulk_add(
 
     all_results: List[Any] = []
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         for index, chunk in enumerate(chunks, start=1):
             click.echo(
@@ -1054,11 +1042,7 @@ def update(
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.keywords().post(data=body)
         format_output(result().extract(), "json", None)
@@ -1084,11 +1068,7 @@ def delete(ctx, keyword_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.keywords().post(data=body)
         format_output(result().extract(), "json", None)
@@ -1114,11 +1094,7 @@ def suspend(ctx, keyword_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.keywords().post(data=body)
         format_output(result().extract(), "json", None)
@@ -1144,11 +1120,7 @@ def resume(ctx, keyword_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.keywords().post(data=body)
         format_output(result().extract(), "json", None)

--- a/direct_cli/commands/keywordsresearch.py
+++ b/direct_cli/commands/keywordsresearch.py
@@ -4,7 +4,7 @@ KeywordsResearch commands
 
 import click
 
-from ..api import create_client
+from ..api import client_from_ctx, create_client
 from ..output import format_output, print_error
 from ..utils import get_default_fields, parse_ids
 
@@ -28,11 +28,7 @@ def keywordsresearch():
 def has_search_volume(ctx, keywords, region_ids, fields, output_format, output):
     """Check if keywords have search volume"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         field_names = (
             [f.strip() for f in fields.split(",")]
@@ -67,11 +63,7 @@ def has_search_volume(ctx, keywords, region_ids, fields, output_format, output):
 def deduplicate(ctx, keywords, output_format, output):
     """Deduplicate keywords"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         body = {
             "method": "deduplicate",

--- a/direct_cli/commands/leads.py
+++ b/direct_cli/commands/leads.py
@@ -4,7 +4,7 @@ Leads commands
 
 import click
 
-from ..api import create_client
+from ..api import client_from_ctx, create_client
 from ..output import format_output, print_error
 from ..utils import get_default_fields, parse_ids
 
@@ -43,11 +43,7 @@ def get(
 ):
     """Get leads"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         field_names = fields.split(",") if fields else get_default_fields("leads")
 

--- a/direct_cli/commands/negativekeywordsharedsets.py
+++ b/direct_cli/commands/negativekeywordsharedsets.py
@@ -4,7 +4,7 @@ NegativeKeywordSharedSets commands
 
 import click
 
-from ..api import create_client
+from ..api import client_from_ctx, create_client
 from ..output import format_output, print_error
 from ..utils import get_default_fields, parse_ids
 
@@ -26,11 +26,7 @@ def negativekeywordsharedsets():
 def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
     """Get negative keyword shared sets"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         field_names = (
             fields.split(",")
@@ -92,11 +88,7 @@ def add(ctx, name, keywords, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.negativekeywordsharedsets().post(data=body)
         format_output(result().extract(), "json", None)
@@ -135,11 +127,7 @@ def update(ctx, set_id, name, keywords, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.negativekeywordsharedsets().post(data=body)
         format_output(result().extract(), "json", None)
@@ -164,11 +152,7 @@ def delete(ctx, set_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.negativekeywordsharedsets().post(data=body)
         format_output(result().extract(), "json", None)

--- a/direct_cli/commands/retargeting.py
+++ b/direct_cli/commands/retargeting.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 import click
 
-from ..api import create_client
+from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import get_default_fields, parse_ids, parse_retargeting_rule_specs
@@ -29,11 +29,7 @@ def retargeting():
 def get(ctx, ids, types, limit, fetch_all, output_format, output, fields):
     """Get retargeting lists"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         field_names = (
             fields.split(",") if fields else get_default_fields("retargetinglists")
@@ -139,11 +135,7 @@ def add(ctx, name, description, list_type, rules, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
         result = client.retargeting().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -200,11 +192,7 @@ def update(ctx, list_id, name, description, list_type, rules, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
         result = client.retargeting().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -228,11 +216,7 @@ def delete(ctx, list_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.retargeting().post(data=body)
         format_output(result().extract(), "json", None)

--- a/direct_cli/commands/sitelinks.py
+++ b/direct_cli/commands/sitelinks.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List
 
 import click
 
-from ..api import create_client
+from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import (
@@ -155,11 +155,7 @@ def get(
 ):
     """Get sitelinks"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         field_names = parse_csv_strings(fields) or get_default_fields("sitelinks")
         parsed_sitelink_field_names = parse_csv_strings(sitelink_field_names)
@@ -284,11 +280,7 @@ def add(ctx, sitelinks_specs, sitelinks_json, sitelinks_from_file, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.sitelinks().post(data=body)
         format_output(result().extract(), "json", None)
@@ -313,11 +305,7 @@ def delete(ctx, set_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.sitelinks().post(data=body)
         format_output(result().extract(), "json", None)

--- a/direct_cli/commands/smartadtargets.py
+++ b/direct_cli/commands/smartadtargets.py
@@ -4,7 +4,7 @@ SmartAdTargets commands
 
 import click
 
-from ..api import create_client
+from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import get_default_fields, parse_condition_specs, parse_ids, MICRO_RUBLES
@@ -42,11 +42,7 @@ def get(
 ):
     """Get smart ad targets"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         field_names = (
             fields.split(",") if fields else get_default_fields("smartadtargets")
@@ -149,11 +145,7 @@ def add(
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
         result = client.smartadtargets().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -224,11 +216,7 @@ def update(
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
         result = client.smartadtargets().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -255,11 +243,7 @@ def delete(ctx, target_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.smartadtargets().post(data=body)
         format_output(result().extract(), "json", None)
@@ -285,11 +269,7 @@ def suspend(ctx, target_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
         result = client.smartadtargets().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -314,11 +294,7 @@ def resume(ctx, target_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
         result = client.smartadtargets().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -382,11 +358,7 @@ def set_bids(
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
         result = client.smartadtargets().post(data=body)
         format_output(result().extract(), "json", None)
 

--- a/direct_cli/commands/strategies.py
+++ b/direct_cli/commands/strategies.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 import click
 
-from ..api import create_client
+from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import (
@@ -689,11 +689,7 @@ def get(
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
         result = client.strategies().post(data=body)
 
         if fetch_all:
@@ -838,11 +834,7 @@ def add(
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
         result = client.strategies().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -1010,11 +1002,7 @@ def update(
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
         result = client.strategies().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -1041,11 +1029,7 @@ def archive(ctx, strategy_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
         result = client.strategies().post(data=body)
         format_output(result().extract(), "json", None)
 
@@ -1072,11 +1056,7 @@ def unarchive(ctx, strategy_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
         result = client.strategies().post(data=body)
         format_output(result().extract(), "json", None)
 

--- a/direct_cli/commands/turbopages.py
+++ b/direct_cli/commands/turbopages.py
@@ -9,7 +9,7 @@ sitelinks).  No ``add``/``update``/``delete`` methods exist on this service.
 
 import click
 
-from ..api import create_client
+from ..api import client_from_ctx, create_client
 from ..output import format_output, print_error
 from ..utils import get_default_fields, parse_ids
 
@@ -34,11 +34,7 @@ def get(
 ):
     """Get Turbo Pages"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         field_names = fields.split(",") if fields else get_default_fields("turbopages")
 

--- a/direct_cli/commands/vcards.py
+++ b/direct_cli/commands/vcards.py
@@ -6,7 +6,7 @@ from typing import Dict, Optional
 
 import click
 
-from ..api import create_client
+from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, print_error
 from ..utils import get_default_fields, parse_ids
@@ -80,11 +80,7 @@ def _build_point_on_map(
 def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
     """Get vCards"""
     try:
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         field_names = fields.split(",") if fields else get_default_fields("vcards")
 
@@ -243,11 +239,7 @@ def add(
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.vcards().post(data=body)
         format_output(result().extract(), "json", None)
@@ -275,11 +267,7 @@ def delete(ctx, vcard_id, dry_run):
             format_output(body, "json", None)
             return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
+        client = client_from_ctx(ctx, create_client)
 
         result = client.vcards().post(data=body)
         format_output(result().extract(), "json", None)


### PR DESCRIPTION
Часть эпика #491 (аудит дублирования кода), фаза **A1** — off-gate, вне WSDL parity.

## Что сделано

**Находка 6:** 113 байт-в-байт идентичных блоков boilerplate в 29 командных модулях:

```python
client = create_client(
    token=ctx.obj.get("token"),
    login=ctx.obj.get("login"),
    sandbox=ctx.obj.get("sandbox"),
)
```

Заменены одним вызовом `client = client_from_ctx(ctx, create_client)`. Хелпер добавлен в `direct_cli/api.py` рядом с `create_client`.

## Дизайн (инъекция фабрики → 0 правок тестов)

Тесты патчат `create_client` **на уровне каждого командного модуля** (`@patch("direct_cli.commands.<module>.create_client")`, `patch.object`, параметризованный `{module_path}.create_client`) и ассертят `assert_called_once_with(token=..., login=..., sandbox=...)`.

Поэтому хелпер принимает `create_client` модуля **аргументом** — реальный вызов фабрики по-прежнему идёт через модульный символ, патчи продолжают перехватывать, kwargs неизменны. **Правок тестов не потребовалось.**

## Не тронуто

- `reports.py` — extended-вызов с report-специфичными kwargs (`processing_mode`, `return_money_in_micros`, `skip_report_*`, `language`) оставлен как есть.
- v4-модули (`create_v4_client`) — вне scope.

## Объём

- 30 файлов, **+165 / −594** (чистое сокращение ~429 строк).

## Верификация

- Структура: 0 остаточных блоков, 113 вызовов хелпера, 29 модулей, `reports.py` цел.
- Полный прогон: **2079 passed, 47 skipped** (skips — live/integration без токена).
- `black --check` на затронутых файлах — чисто; flake8 — 0 новых замечаний относительно `main`.

Closes #492

🤖 Generated with [Claude Code](https://claude.com/claude-code)