### PR TITLE
feat: @handle_api_errors decorator (dedup #491 A2, infra)

### DIFF
--- a/direct_cli/output.py
+++ b/direct_cli/output.py
@@ -3,10 +3,13 @@ Output formatting module for Direct CLI
 """
 
 import csv
+import functools
 import json
 import sys
 from io import StringIO
 from typing import Any, Iterator, List, Optional
+
+import click
 
 try:
     from tabulate import tabulate
@@ -211,3 +214,26 @@ def print_warning(message: str) -> None:
 def print_info(message: str) -> None:
     """Print info message"""
     print(f"ℹ {message}")
+
+
+def handle_api_errors(func):
+    """Convert uncaught exceptions into a printed error + ``click.Abort``.
+
+    ``click.ClickException`` (including ``click.UsageError``) is re-raised
+    unchanged so Click renders it normally (usage text, exit code 2). Any other
+    exception is printed via :func:`print_error` and converted to
+    ``click.Abort`` (exit code 1), matching the canonical command
+    error-handling block this decorator replaces.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except click.ClickException:
+            raise
+        except Exception as e:
+            print_error(str(e))
+            raise click.Abort()
+
+    return wrapper

--- a/tests/test_handle_api_errors.py
+++ b/tests/test_handle_api_errors.py
@@ -1,0 +1,101 @@
+"""Unit tests for the @handle_api_errors decorator (dedup #491 A2, issue #493).
+
+The decorator replaces the canonical command error-handling block:
+
+    except Exception as e:
+        print_error(str(e))
+        raise click.Abort()
+
+It must re-raise click.ClickException (incl. click.UsageError) unchanged so
+Click renders usage text / its own exit codes, and convert any other exception
+into a printed error + click.Abort.
+"""
+
+import click
+import pytest
+
+from direct_cli.output import handle_api_errors
+
+
+def test_passes_through_return_value():
+    @handle_api_errors
+    def ok():
+        return 42
+
+    assert ok() == 42
+
+
+def test_forwards_args_and_kwargs():
+    @handle_api_errors
+    def echo(a, b, c=0):
+        return (a, b, c)
+
+    assert echo(1, 2, c=3) == (1, 2, 3)
+
+
+def test_reraises_usage_error_unchanged():
+    @handle_api_errors
+    def boom():
+        raise click.UsageError("bad flag")
+
+    with pytest.raises(click.UsageError) as excinfo:
+        boom()
+    assert "bad flag" in str(excinfo.value)
+
+
+def test_reraises_click_exception_unchanged():
+    @handle_api_errors
+    def boom():
+        raise click.ClickException("click problem")
+
+    with pytest.raises(click.ClickException) as excinfo:
+        boom()
+    assert "click problem" in str(excinfo.value)
+
+
+def test_wraps_generic_exception_into_abort(capsys):
+    @handle_api_errors
+    def boom():
+        raise RuntimeError("api exploded")
+
+    with pytest.raises(click.Abort):
+        boom()
+    captured = capsys.readouterr()
+    # print_error writes the message to stderr with the ✗ marker.
+    assert "api exploded" in captured.err
+    assert "✗" in captured.err
+
+
+def test_value_error_is_wrapped_into_abort(capsys):
+    @handle_api_errors
+    def boom():
+        raise ValueError("value problem")
+
+    with pytest.raises(click.Abort):
+        boom()
+    assert "value problem" in capsys.readouterr().err
+
+
+def test_abort_raised_inside_is_treated_as_generic_exception():
+    """click.Abort is a RuntimeError, not a ClickException, so it falls into the
+    generic ``except Exception`` branch and re-raises as a (new) Abort — exactly
+    as the canonical block this decorator replaces would have behaved. In
+    practice commands never raise Abort inside the body; they raise UsageError or
+    let API exceptions propagate."""
+
+    @handle_api_errors
+    def boom():
+        raise click.Abort()
+
+    with pytest.raises(click.Abort):
+        boom()
+
+
+def test_preserves_function_metadata():
+    @handle_api_errors
+    def documented(ctx, value):
+        """Original docstring."""
+        return value
+
+    assert documented.__name__ == "documented"
+    assert documented.__doc__ == "Original docstring."


### PR DESCRIPTION
Часть эпика #491 (аудит дублирования), серия **A2** — инфраструктурный PR-1.

## Что сделано

В `direct_cli/output.py` добавлен декоратор `@handle_api_errors`, централизующий канонический «кожух» обработки ошибок команд:

```python
@functools.wraps(func)
def wrapper(*args, **kwargs):
    try:
        return func(*args, **kwargs)
    except click.ClickException:
        raise
    except Exception as e:
        print_error(str(e))
        raise click.Abort()
```

- `click.ClickException` (включая `UsageError`) пробрасывается без изменений → Click рендерит usage/exit-коды как раньше.
- Прочие исключения печатаются через `print_error` и превращаются в `click.Abort`.
- `functools.wraps` сохраняет `__name__`/`__doc__` — Click корректно берёт метаданные команды.

## Семантическая эквивалентность

`UsageError ⊂ ClickException ⊂ Exception`, а `click.Abort ⊂ RuntimeError` (не ClickException). Поэтому декоратор идентичен всем трём существующим формам блока (ALONE / pre-`except UsageError: raise` / pre-`except ClickException: raise`).

## Scope

Это **только инфраструктура** — команды пока не конвертируются. Снятие ручных `try/except` блоков (127 функций) и дедент тел произойдёт в следующих PR-ах серии A2 (codemod на стдлиб-`ast`), чтобы держать каждый PR ≤1000 строк.

## Тесты

8 unit-тестов: passthrough возвращаемого значения и args/kwargs, проброс `ClickException`/`UsageError`, оборачивание `RuntimeError`/`ValueError` в `Abort` с печатью `✗`, сохранение метаданных.

## Верификация

- `pytest tests/test_handle_api_errors.py` — 8 passed.
- Полный прогон: **2087 passed, 47 skipped** (было 2079 + 8 новых).
- `black --check` чисто; flake8 чисто; `import direct_cli.cli` OK (нет цикл. импорта от нового `import click`).

Part of #493 (закрывающий PR серии будет содержать `Closes #493`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)