### PR TITLE
refactor: @handle_api_errors on 10 small command modules (dedup #491 A2a-1)

### DIFF
--- a/direct_cli/commands/adextensions.py
+++ b/direct_cli/commands/adextensions.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..i18n import t
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import add_criteria_csv, get_default_fields, parse_csv_strings, parse_ids
 
 
@@ -32,6 +32,7 @@ def adextensions():
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def get(
     ctx,
     ids,
@@ -48,105 +49,88 @@ def get(
     dry_run,
 ):
     """Get ad extensions"""
-    try:
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        field_names = parse_csv_strings(fields) or get_default_fields("adextensions")
-        parsed_callout_field_names = parse_csv_strings(callout_field_names)
-        if callout_field_names is not None and not parsed_callout_field_names:
-            raise click.UsageError(
-                t("Provide a non-empty comma-separated CalloutFieldNames list.")
-            )
+    field_names = parse_csv_strings(fields) or get_default_fields("adextensions")
+    parsed_callout_field_names = parse_csv_strings(callout_field_names)
+    if callout_field_names is not None and not parsed_callout_field_names:
+        raise click.UsageError(
+            t("Provide a non-empty comma-separated CalloutFieldNames list.")
+        )
 
-        criteria = {}
-        if ids:
-            criteria["Ids"] = parse_ids(ids)
-        if types:
-            criteria["Types"] = types.split(",")
-        add_criteria_csv(criteria, "States", states, upper=True)
-        add_criteria_csv(criteria, "Statuses", statuses, upper=True)
-        if modified_since:
-            criteria["ModifiedSince"] = modified_since
+    criteria = {}
+    if ids:
+        criteria["Ids"] = parse_ids(ids)
+    if types:
+        criteria["Types"] = types.split(",")
+    add_criteria_csv(criteria, "States", states, upper=True)
+    add_criteria_csv(criteria, "Statuses", statuses, upper=True)
+    if modified_since:
+        criteria["ModifiedSince"] = modified_since
 
-        params = {"SelectionCriteria": criteria, "FieldNames": field_names}
-        if parsed_callout_field_names:
-            params["CalloutFieldNames"] = parsed_callout_field_names
+    params = {"SelectionCriteria": criteria, "FieldNames": field_names}
+    if parsed_callout_field_names:
+        params["CalloutFieldNames"] = parsed_callout_field_names
 
-        if limit:
-            params["Page"] = {"Limit": limit}
+    if limit:
+        params["Page"] = {"Limit": limit}
 
-        body = {"method": "get", "params": params}
+    body = {"method": "get", "params": params}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        result = client.adextensions().post(data=body)
+    result = client.adextensions().post(data=body)
 
-        if fetch_all:
-            items = []
-            for item in result().iter_items():
-                items.append(item)
-            format_output(items, output_format, output)
-        else:
-            data = result().extract()
-            format_output(data, output_format, output)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    if fetch_all:
+        items = []
+        for item in result().iter_items():
+            items.append(item)
+        format_output(items, output_format, output)
+    else:
+        data = result().extract()
+        format_output(data, output_format, output)
 
 
 @adextensions.command()
 @click.option("--callout-text", required=True, help="Callout text")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def add(ctx, callout_text, dry_run):
     """Add ad extension (callout)"""
-    try:
-        ext_data = {"Callout": {"CalloutText": callout_text}}
+    ext_data = {"Callout": {"CalloutText": callout_text}}
 
-        body = {"method": "add", "params": {"AdExtensions": [ext_data]}}
+    body = {"method": "add", "params": {"AdExtensions": [ext_data]}}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        result = client.adextensions().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.adextensions().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @adextensions.command()
 @click.option("--id", "extension_id", required=True, type=int, help="Extension ID")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def delete(ctx, extension_id, dry_run):
     """Delete ad extension"""
-    try:
-        body = {
-            "method": "delete",
-            "params": {"SelectionCriteria": {"Ids": [extension_id]}},
-        }
+    body = {
+        "method": "delete",
+        "params": {"SelectionCriteria": {"Ids": [extension_id]}},
+    }
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        result = client.adextensions().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.adextensions().post(data=body)
+    format_output(result().extract(), "json", None)

--- a/direct_cli/commands/bidmodifiers.py
+++ b/direct_cli/commands/bidmodifiers.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..i18n import t
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import get_default_fields, parse_csv_strings, parse_ids
 
 
@@ -146,6 +146,7 @@ def bidmodifiers():
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def get(
     ctx,
     ids,
@@ -174,82 +175,73 @@ def get(
     dry_run,
 ):
     """Get bid modifiers"""
-    try:
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        raw_nested = (
-            ("AdGroupAdjustmentFieldNames", ad_group_adjustment_field_names),
-            ("DemographicsAdjustmentFieldNames", demographics_adjustment_field_names),
-            ("DesktopAdjustmentFieldNames", desktop_adjustment_field_names),
-            ("DesktopOnlyAdjustmentFieldNames", desktop_only_adjustment_field_names),
-            ("IncomeGradeAdjustmentFieldNames", income_grade_adjustment_field_names),
-            ("MobileAdjustmentFieldNames", mobile_adjustment_field_names),
-            ("RegionalAdjustmentFieldNames", regional_adjustment_field_names),
-            ("RetargetingAdjustmentFieldNames", retargeting_adjustment_field_names),
-            ("SerpLayoutAdjustmentFieldNames", serp_layout_adjustment_field_names),
-            ("SmartAdAdjustmentFieldNames", smart_ad_adjustment_field_names),
-            ("SmartTvAdjustmentFieldNames", smart_tv_adjustment_field_names),
-            ("TabletAdjustmentFieldNames", tablet_adjustment_field_names),
-            ("VideoAdjustmentFieldNames", video_adjustment_field_names),
-        )
-        parsed_nested = {}
-        for wsdl_key, raw_value in raw_nested:
-            parsed = parse_csv_strings(raw_value)
-            if raw_value is not None and not parsed:
-                raise click.UsageError(
-                    t("Provide a non-empty comma-separated {wsdl_key} list.").format(
-                        wsdl_key=wsdl_key
-                    )
+    raw_nested = (
+        ("AdGroupAdjustmentFieldNames", ad_group_adjustment_field_names),
+        ("DemographicsAdjustmentFieldNames", demographics_adjustment_field_names),
+        ("DesktopAdjustmentFieldNames", desktop_adjustment_field_names),
+        ("DesktopOnlyAdjustmentFieldNames", desktop_only_adjustment_field_names),
+        ("IncomeGradeAdjustmentFieldNames", income_grade_adjustment_field_names),
+        ("MobileAdjustmentFieldNames", mobile_adjustment_field_names),
+        ("RegionalAdjustmentFieldNames", regional_adjustment_field_names),
+        ("RetargetingAdjustmentFieldNames", retargeting_adjustment_field_names),
+        ("SerpLayoutAdjustmentFieldNames", serp_layout_adjustment_field_names),
+        ("SmartAdAdjustmentFieldNames", smart_ad_adjustment_field_names),
+        ("SmartTvAdjustmentFieldNames", smart_tv_adjustment_field_names),
+        ("TabletAdjustmentFieldNames", tablet_adjustment_field_names),
+        ("VideoAdjustmentFieldNames", video_adjustment_field_names),
+    )
+    parsed_nested = {}
+    for wsdl_key, raw_value in raw_nested:
+        parsed = parse_csv_strings(raw_value)
+        if raw_value is not None and not parsed:
+            raise click.UsageError(
+                t("Provide a non-empty comma-separated {wsdl_key} list.").format(
+                    wsdl_key=wsdl_key
                 )
-            if parsed:
-                parsed_nested[wsdl_key] = parsed
+            )
+        if parsed:
+            parsed_nested[wsdl_key] = parsed
 
-        criteria = {"Levels": [lv.upper() for lv in levels]}
-        if ids:
-            criteria["Ids"] = parse_ids(ids)
-        if campaign_ids:
-            criteria["CampaignIds"] = parse_ids(campaign_ids)
-        if adgroup_ids:
-            criteria["AdGroupIds"] = parse_ids(adgroup_ids)
-        if types:
-            criteria["Types"] = [
-                item.strip().upper() for item in types.split(",") if item.strip()
-            ]
+    criteria = {"Levels": [lv.upper() for lv in levels]}
+    if ids:
+        criteria["Ids"] = parse_ids(ids)
+    if campaign_ids:
+        criteria["CampaignIds"] = parse_ids(campaign_ids)
+    if adgroup_ids:
+        criteria["AdGroupIds"] = parse_ids(adgroup_ids)
+    if types:
+        criteria["Types"] = [
+            item.strip().upper() for item in types.split(",") if item.strip()
+        ]
 
-        field_names = (
-            fields.split(",") if fields else get_default_fields("bidmodifiers")
-        )
-        params = {
-            "SelectionCriteria": criteria,
-            "FieldNames": field_names,
-        }
-        params.update(parsed_nested)
+    field_names = fields.split(",") if fields else get_default_fields("bidmodifiers")
+    params = {
+        "SelectionCriteria": criteria,
+        "FieldNames": field_names,
+    }
+    params.update(parsed_nested)
 
-        if limit:
-            params["Page"] = {"Limit": limit}
+    if limit:
+        params["Page"] = {"Limit": limit}
 
-        body = {"method": "get", "params": params}
+    body = {"method": "get", "params": params}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        result = client.bidmodifiers().post(data=body)
+    result = client.bidmodifiers().post(data=body)
 
-        if fetch_all:
-            items = []
-            for item in result().iter_items():
-                items.append(item)
-            format_output(items, output_format, output)
-        else:
-            data = result().extract()
-            format_output(data, output_format, output)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    if fetch_all:
+        items = []
+        for item in result().iter_items():
+            items.append(item)
+        format_output(items, output_format, output)
+    else:
+        data = result().extract()
+        format_output(data, output_format, output)
 
 
 # Map CLI --type values to the nested BidModifier object field name.
@@ -354,6 +346,7 @@ def _reject_incompatible_extra_flags(
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def add(
     ctx,
     campaign_id,
@@ -382,91 +375,80 @@ def add(
     For types with extra fields, use the corresponding typed flags
     (for example ``--gender`` / ``--age`` for demographics).
     """
-    try:
-        if (campaign_id is None) == (adgroup_id is None):
-            raise click.UsageError(
-                t("Exactly one of --campaign-id or --adgroup-id is required")
-            )
-
-        modifier_type_upper = modifier_type.upper()
-        _reject_incompatible_extra_flags(
-            modifier_type_upper,
-            {
-                "--gender": gender,
-                "--age": age,
-                "--retargeting-condition-id": retargeting_condition_id,
-                "--region-id": region_id,
-                "--serp-layout": serp_layout,
-                "--income-grade": income_grade,
-                "--operating-system-type": operating_system_type,
-            },
+    if (campaign_id is None) == (adgroup_id is None):
+        raise click.UsageError(
+            t("Exactly one of --campaign-id or --adgroup-id is required")
         )
 
-        nested_key = _BIDMODIFIER_TYPE_TO_NESTED[modifier_type_upper]
-        nested = {"BidModifier": value}
-        if (
-            modifier_type_upper in _OPERATING_SYSTEM_TYPE_MODIFIERS
-            and operating_system_type
-        ):
-            nested["OperatingSystemType"] = operating_system_type.upper()
-        if modifier_type_upper == "DEMOGRAPHICS_ADJUSTMENT":
-            if gender:
-                nested["Gender"] = gender
-            if age:
-                nested["Age"] = age
-            if "Gender" not in nested and "Age" not in nested:
-                raise click.UsageError(
-                    t("DEMOGRAPHICS_ADJUSTMENT requires --gender and/or --age")
-                )
-        elif modifier_type_upper == "RETARGETING_ADJUSTMENT":
-            if retargeting_condition_id is None:
-                raise click.UsageError(
-                    t("RETARGETING_ADJUSTMENT requires --retargeting-condition-id")
-                )
-            nested["RetargetingConditionId"] = retargeting_condition_id
-        elif modifier_type_upper == "REGIONAL_ADJUSTMENT":
-            if region_id is None:
-                raise click.UsageError(t("REGIONAL_ADJUSTMENT requires --region-id"))
-            nested["RegionId"] = region_id
-        elif modifier_type_upper == "SERP_LAYOUT_ADJUSTMENT":
-            if not serp_layout:
-                raise click.UsageError(
-                    t("SERP_LAYOUT_ADJUSTMENT requires --serp-layout")
-                )
-            nested["SerpLayout"] = serp_layout
-        elif modifier_type_upper == "INCOME_GRADE_ADJUSTMENT":
-            if not income_grade:
-                raise click.UsageError(
-                    t("INCOME_GRADE_ADJUSTMENT requires --income-grade")
-                )
-            nested["Grade"] = income_grade
+    modifier_type_upper = modifier_type.upper()
+    _reject_incompatible_extra_flags(
+        modifier_type_upper,
+        {
+            "--gender": gender,
+            "--age": age,
+            "--retargeting-condition-id": retargeting_condition_id,
+            "--region-id": region_id,
+            "--serp-layout": serp_layout,
+            "--income-grade": income_grade,
+            "--operating-system-type": operating_system_type,
+        },
+    )
 
-        # Plural fields expect a list per WSDL BidModifierAddItem
-        if nested_key in _PLURAL_NESTED_KEYS:
-            modifier_data = {nested_key: [nested]}
-        else:
-            modifier_data = {nested_key: nested}
-        if campaign_id is not None:
-            modifier_data["CampaignId"] = campaign_id
-        else:
-            modifier_data["AdGroupId"] = adgroup_id
+    nested_key = _BIDMODIFIER_TYPE_TO_NESTED[modifier_type_upper]
+    nested = {"BidModifier": value}
+    if (
+        modifier_type_upper in _OPERATING_SYSTEM_TYPE_MODIFIERS
+        and operating_system_type
+    ):
+        nested["OperatingSystemType"] = operating_system_type.upper()
+    if modifier_type_upper == "DEMOGRAPHICS_ADJUSTMENT":
+        if gender:
+            nested["Gender"] = gender
+        if age:
+            nested["Age"] = age
+        if "Gender" not in nested and "Age" not in nested:
+            raise click.UsageError(
+                t("DEMOGRAPHICS_ADJUSTMENT requires --gender and/or --age")
+            )
+    elif modifier_type_upper == "RETARGETING_ADJUSTMENT":
+        if retargeting_condition_id is None:
+            raise click.UsageError(
+                t("RETARGETING_ADJUSTMENT requires --retargeting-condition-id")
+            )
+        nested["RetargetingConditionId"] = retargeting_condition_id
+    elif modifier_type_upper == "REGIONAL_ADJUSTMENT":
+        if region_id is None:
+            raise click.UsageError(t("REGIONAL_ADJUSTMENT requires --region-id"))
+        nested["RegionId"] = region_id
+    elif modifier_type_upper == "SERP_LAYOUT_ADJUSTMENT":
+        if not serp_layout:
+            raise click.UsageError(t("SERP_LAYOUT_ADJUSTMENT requires --serp-layout"))
+        nested["SerpLayout"] = serp_layout
+    elif modifier_type_upper == "INCOME_GRADE_ADJUSTMENT":
+        if not income_grade:
+            raise click.UsageError(t("INCOME_GRADE_ADJUSTMENT requires --income-grade"))
+        nested["Grade"] = income_grade
 
-        body = {"method": "add", "params": {"BidModifiers": [modifier_data]}}
+    # Plural fields expect a list per WSDL BidModifierAddItem
+    if nested_key in _PLURAL_NESTED_KEYS:
+        modifier_data = {nested_key: [nested]}
+    else:
+        modifier_data = {nested_key: nested}
+    if campaign_id is not None:
+        modifier_data["CampaignId"] = campaign_id
+    else:
+        modifier_data["AdGroupId"] = adgroup_id
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    body = {"method": "add", "params": {"BidModifiers": [modifier_data]}}
 
-        client = client_from_ctx(ctx, create_client)
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        result = client.bidmodifiers().post(data=body)
-        format_output(result().extract(), "json", None)
+    client = client_from_ctx(ctx, create_client)
 
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.bidmodifiers().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 _DEPRECATED_BIDMODIFIERS_SET_OPTIONS = {
@@ -524,6 +506,7 @@ def _deprecated_legacy_option(ctx, param, value):
 @click.option("--value", type=int, required=True, help="Modifier value")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def set(ctx, modifier_id, value, dry_run):
     """Set (update) an existing bid modifier
 
@@ -531,59 +514,48 @@ def set(ctx, modifier_id, value, dry_run):
     modifiers by ``Id``. To create a new modifier, use ``bidmodifiers add``
     instead.
     """
-    try:
-        if modifier_id is None:
-            raise click.UsageError(
-                t(
-                    "Provide --id with --value for bidmodifiers set. "
-                    "The legacy --campaign-id/--type shape is not supported by "
-                    "WSDL BidModifierSetItem; use bidmodifiers add to create a "
-                    "new modifier."
-                )
+    if modifier_id is None:
+        raise click.UsageError(
+            t(
+                "Provide --id with --value for bidmodifiers set. "
+                "The legacy --campaign-id/--type shape is not supported by "
+                "WSDL BidModifierSetItem; use bidmodifiers add to create a "
+                "new modifier."
             )
+        )
 
-        # Correct API shape: Id + BidModifier. Nothing else.
-        modifier_data = {"Id": modifier_id, "BidModifier": value}
+    # Correct API shape: Id + BidModifier. Nothing else.
+    modifier_data = {"Id": modifier_id, "BidModifier": value}
 
-        body = {"method": "set", "params": {"BidModifiers": [modifier_data]}}
+    body = {"method": "set", "params": {"BidModifiers": [modifier_data]}}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        result = client.bidmodifiers().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.bidmodifiers().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @bidmodifiers.command()
 @click.option("--id", "modifier_id", required=True, type=int, help="Modifier ID")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def delete(ctx, modifier_id, dry_run):
     """Delete bid modifier"""
-    try:
-        body = {
-            "method": "delete",
-            "params": {"SelectionCriteria": {"Ids": [modifier_id]}},
-        }
+    body = {
+        "method": "delete",
+        "params": {"SelectionCriteria": {"Ids": [modifier_id]}},
+    }
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        result = client.bidmodifiers().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.bidmodifiers().post(data=body)
+    format_output(result().extract(), "json", None)

--- a/direct_cli/commands/bids.py
+++ b/direct_cli/commands/bids.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..i18n import t
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors, print_error
 from ..utils import (
     add_criteria_csv,
     add_single_id_selector,
@@ -33,6 +33,7 @@ def bids():
 @click.option("--fields", help="Comma-separated field names")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def get(
     ctx,
     campaign_ids,
@@ -47,58 +48,51 @@ def get(
     dry_run,
 ):
     """Get bids"""
-    try:
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        criteria = {}
-        if campaign_ids:
-            criteria["CampaignIds"] = parse_ids(campaign_ids)
-        if adgroup_ids:
-            criteria["AdGroupIds"] = parse_ids(adgroup_ids)
-        if keyword_ids:
-            criteria["KeywordIds"] = parse_ids(keyword_ids)
-        add_criteria_csv(criteria, "ServingStatuses", serving_statuses, upper=True)
+    criteria = {}
+    if campaign_ids:
+        criteria["CampaignIds"] = parse_ids(campaign_ids)
+    if adgroup_ids:
+        criteria["AdGroupIds"] = parse_ids(adgroup_ids)
+    if keyword_ids:
+        criteria["KeywordIds"] = parse_ids(keyword_ids)
+    add_criteria_csv(criteria, "ServingStatuses", serving_statuses, upper=True)
 
-        if not criteria:
-            raise click.UsageError(
-                t(
-                    "bids get requires at least one filter: "
-                    "--campaign-ids, --adgroup-ids, --keyword-ids, "
-                    "or --serving-statuses."
-                )
+    if not criteria:
+        raise click.UsageError(
+            t(
+                "bids get requires at least one filter: "
+                "--campaign-ids, --adgroup-ids, --keyword-ids, "
+                "or --serving-statuses."
             )
+        )
 
-        field_names = fields.split(",") if fields else get_default_fields("bids")
-        params = {
-            "SelectionCriteria": criteria,
-            "FieldNames": field_names,
-        }
+    field_names = fields.split(",") if fields else get_default_fields("bids")
+    params = {
+        "SelectionCriteria": criteria,
+        "FieldNames": field_names,
+    }
 
-        if limit:
-            params["Page"] = {"Limit": limit}
+    if limit:
+        params["Page"] = {"Limit": limit}
 
-        body = {"method": "get", "params": params}
+    body = {"method": "get", "params": params}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        result = client.bids().post(data=body)
+    result = client.bids().post(data=body)
 
-        if fetch_all:
-            items = []
-            for item in result().iter_items():
-                items.append(item)
-            format_output(items, output_format, output)
-        else:
-            data = result().extract()
-            format_output(data, output_format, output)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    if fetch_all:
+        items = []
+        for item in result().iter_items():
+            items.append(item)
+        format_output(items, output_format, output)
+    else:
+        data = result().extract()
+        format_output(data, output_format, output)
 
 
 @bids.command()
@@ -195,6 +189,7 @@ def set(
 @click.option("--scope", multiple=True, help="One or more scope values")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def set_auto(
     ctx,
     campaign_id,
@@ -209,42 +204,35 @@ def set_auto(
     dry_run,
 ):
     """Configure automatic bidding"""
-    try:
-        bid_data = {}
-        add_single_id_selector(
-            bid_data,
-            campaign_id=campaign_id,
-            adgroup_id=adgroup_id,
-            keyword_id=keyword_id,
-            command_name="bids set-auto",
-        )
-        if max_bid is not None:
-            bid_data["MaxBid"] = max_bid
-        if position:
-            bid_data["Position"] = position
-        if increase_percent is not None:
-            bid_data["IncreasePercent"] = increase_percent
-        if calculate_by:
-            bid_data["CalculateBy"] = calculate_by
-        if context_coverage is not None:
-            bid_data["ContextCoverage"] = context_coverage
-        if scope:
-            bid_data["Scope"] = list(scope)
-        if "Scope" not in bid_data:
-            raise click.UsageError(t("Provide at least one --scope"))
+    bid_data = {}
+    add_single_id_selector(
+        bid_data,
+        campaign_id=campaign_id,
+        adgroup_id=adgroup_id,
+        keyword_id=keyword_id,
+        command_name="bids set-auto",
+    )
+    if max_bid is not None:
+        bid_data["MaxBid"] = max_bid
+    if position:
+        bid_data["Position"] = position
+    if increase_percent is not None:
+        bid_data["IncreasePercent"] = increase_percent
+    if calculate_by:
+        bid_data["CalculateBy"] = calculate_by
+    if context_coverage is not None:
+        bid_data["ContextCoverage"] = context_coverage
+    if scope:
+        bid_data["Scope"] = list(scope)
+    if "Scope" not in bid_data:
+        raise click.UsageError(t("Provide at least one --scope"))
 
-        body = {"method": "setAuto", "params": {"Bids": [bid_data]}}
+    body = {"method": "setAuto", "params": {"Bids": [bid_data]}}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
-        result = client.bids().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = client_from_ctx(ctx, create_client)
+    result = client.bids().post(data=body)
+    format_output(result().extract(), "json", None)

--- a/direct_cli/commands/clients.py
+++ b/direct_cli/commands/clients.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..i18n import t
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import (
     build_client_update_item,
     build_erir_attributes,
@@ -84,6 +84,7 @@ def clients():
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def get(
     ctx,
     ids,
@@ -100,66 +101,59 @@ def get(
     dry_run,
 ):
     """Get clients"""
-    try:
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        field_names = fields.split(",") if fields else get_default_fields("clients")
+    field_names = fields.split(",") if fields else get_default_fields("clients")
 
-        raw_nested = (
-            ("ContractFieldNames", contract_field_names),
-            ("ContragentFieldNames", contragent_field_names),
-            ("ContragentTinInfoFieldNames", contragent_tin_info_field_names),
-            ("OrganizationFieldNames", organization_field_names),
-            ("TinInfoFieldNames", tin_info_field_names),
-        )
-        parsed_nested = {}
-        for wsdl_key, raw_value in raw_nested:
-            parsed = parse_csv_strings(raw_value)
-            if raw_value is not None and not parsed:
-                raise click.UsageError(
-                    t("Provide a non-empty comma-separated {wsdl_key} list.").format(
-                        wsdl_key=wsdl_key
-                    )
+    raw_nested = (
+        ("ContractFieldNames", contract_field_names),
+        ("ContragentFieldNames", contragent_field_names),
+        ("ContragentTinInfoFieldNames", contragent_tin_info_field_names),
+        ("OrganizationFieldNames", organization_field_names),
+        ("TinInfoFieldNames", tin_info_field_names),
+    )
+    parsed_nested = {}
+    for wsdl_key, raw_value in raw_nested:
+        parsed = parse_csv_strings(raw_value)
+        if raw_value is not None and not parsed:
+            raise click.UsageError(
+                t("Provide a non-empty comma-separated {wsdl_key} list.").format(
+                    wsdl_key=wsdl_key
                 )
-            if parsed:
-                parsed_nested[wsdl_key] = parsed
+            )
+        if parsed:
+            parsed_nested[wsdl_key] = parsed
 
-        criteria = {}
-        if ids:
-            criteria["ClientIds"] = parse_ids(ids)
+    criteria = {}
+    if ids:
+        criteria["ClientIds"] = parse_ids(ids)
 
-        params = {"FieldNames": field_names}
+    params = {"FieldNames": field_names}
 
-        if criteria:
-            params["SelectionCriteria"] = criteria
+    if criteria:
+        params["SelectionCriteria"] = criteria
 
-        params.update(parsed_nested)
+    params.update(parsed_nested)
 
-        if limit:
-            params["Page"] = {"Limit": limit}
+    if limit:
+        params["Page"] = {"Limit": limit}
 
-        body = {"method": "get", "params": params}
+    body = {"method": "get", "params": params}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        result = client.clients().post(data=body)
+    result = client.clients().post(data=body)
 
-        if fetch_all:
-            items = []
-            for item in result().iter_items():
-                items.append(item)
-            format_output(items, output_format, output)
-        else:
-            data = result().extract()
-            format_output(data, output_format, output)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    if fetch_all:
+        items = []
+        for item in result().iter_items():
+            items.append(item)
+        format_output(items, output_format, output)
+    else:
+        data = result().extract()
+        format_output(data, output_format, output)
 
 
 @clients.command()
@@ -255,6 +249,7 @@ def get(
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def update(
     ctx,
     client_info,
@@ -290,74 +285,67 @@ def update(
     dry_run,
 ):
     """Update client settings"""
-    try:
-        notification = build_notification_update(
-            notification_email,
-            notification_lang,
-            parse_email_subscription_specs(list(email_subscriptions)),
+    notification = build_notification_update(
+        notification_email,
+        notification_lang,
+        parse_email_subscription_specs(list(email_subscriptions)),
+    )
+    price_amount = None
+    if erir_contract_price_amount is not None:
+        price_amount = parse_positive_decimal_amount(
+            erir_contract_price_amount,
+            "--erir-contract-price-amount",
         )
-        price_amount = None
-        if erir_contract_price_amount is not None:
-            price_amount = parse_positive_decimal_amount(
-                erir_contract_price_amount,
-                "--erir-contract-price-amount",
-            )
-        client_data = build_client_update_item(
-            client_info,
-            phone,
-            notification,
-            parse_client_setting_specs(list(settings)),
-            parse_tin_info(tin_type, tin),
-            erir_attributes=build_erir_attributes(
-                organization=build_erir_organization(
-                    erir_organization_name,
-                    erir_organization_kpp,
-                    erir_organization_epay_number,
-                    erir_organization_reg_number,
-                    erir_organization_oksm_number,
-                    erir_organization_okved_code,
-                ),
-                contract=build_erir_contract(
-                    erir_contract_number,
-                    erir_contract_date,
-                    erir_contract_type,
-                    erir_contract_action_type,
-                    erir_contract_subject_type,
-                    erir_contract_is_agency_payment,
-                    price_amount,
-                    erir_contract_price_including_vat,
-                ),
-                contragent=build_erir_contragent(
-                    erir_contragent_name,
-                    erir_contragent_kpp,
-                    erir_contragent_phone,
-                    erir_contragent_epay_number,
-                    erir_contragent_reg_number,
-                    erir_contragent_oksm_number,
-                    parse_tin_info(
-                        erir_contragent_tin_type,
-                        erir_contragent_tin,
-                        "--erir-contragent-tin-type",
-                    ),
+    client_data = build_client_update_item(
+        client_info,
+        phone,
+        notification,
+        parse_client_setting_specs(list(settings)),
+        parse_tin_info(tin_type, tin),
+        erir_attributes=build_erir_attributes(
+            organization=build_erir_organization(
+                erir_organization_name,
+                erir_organization_kpp,
+                erir_organization_epay_number,
+                erir_organization_reg_number,
+                erir_organization_oksm_number,
+                erir_organization_okved_code,
+            ),
+            contract=build_erir_contract(
+                erir_contract_number,
+                erir_contract_date,
+                erir_contract_type,
+                erir_contract_action_type,
+                erir_contract_subject_type,
+                erir_contract_is_agency_payment,
+                price_amount,
+                erir_contract_price_including_vat,
+            ),
+            contragent=build_erir_contragent(
+                erir_contragent_name,
+                erir_contragent_kpp,
+                erir_contragent_phone,
+                erir_contragent_epay_number,
+                erir_contragent_reg_number,
+                erir_contragent_oksm_number,
+                parse_tin_info(
+                    erir_contragent_tin_type,
+                    erir_contragent_tin,
+                    "--erir-contragent-tin-type",
                 ),
             ),
-        )
-        if not client_data:
-            raise click.UsageError(t("Provide at least one field to update"))
+        ),
+    )
+    if not client_data:
+        raise click.UsageError(t("Provide at least one field to update"))
 
-        body = {"method": "update", "params": {"Clients": [client_data]}}
+    body = {"method": "update", "params": {"Clients": [client_data]}}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        result = client.clients().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.clients().post(data=body)
+    format_output(result().extract(), "json", None)

--- a/direct_cli/commands/creatives.py
+++ b/direct_cli/commands/creatives.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..i18n import t
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import get_default_fields, parse_csv_strings, parse_ids
 
 
@@ -58,6 +58,7 @@ def creatives():
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def get(
     ctx,
     ids,
@@ -74,92 +75,79 @@ def get(
     dry_run,
 ):
     """Get creatives"""
-    try:
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        field_names = fields.split(",") if fields else get_default_fields("creatives")
+    field_names = fields.split(",") if fields else get_default_fields("creatives")
 
-        nested_field_name_options = (
-            ("CpcVideoCreativeFieldNames", cpc_video_creative_field_names),
-            ("CpmVideoCreativeFieldNames", cpm_video_creative_field_names),
-            ("SmartCreativeFieldNames", smart_creative_field_names),
-            (
-                "VideoExtensionCreativeFieldNames",
-                video_extension_creative_field_names,
-            ),
-        )
-        parsed_nested_field_names = {}
-        for wsdl_key, raw_value in nested_field_name_options:
-            parsed = parse_csv_strings(raw_value)
-            if raw_value is not None and not parsed:
-                raise click.UsageError(
-                    t("Provide a non-empty comma-separated {wsdl_key} list.").format(
-                        wsdl_key=wsdl_key
-                    )
+    nested_field_name_options = (
+        ("CpcVideoCreativeFieldNames", cpc_video_creative_field_names),
+        ("CpmVideoCreativeFieldNames", cpm_video_creative_field_names),
+        ("SmartCreativeFieldNames", smart_creative_field_names),
+        (
+            "VideoExtensionCreativeFieldNames",
+            video_extension_creative_field_names,
+        ),
+    )
+    parsed_nested_field_names = {}
+    for wsdl_key, raw_value in nested_field_name_options:
+        parsed = parse_csv_strings(raw_value)
+        if raw_value is not None and not parsed:
+            raise click.UsageError(
+                t("Provide a non-empty comma-separated {wsdl_key} list.").format(
+                    wsdl_key=wsdl_key
                 )
-            if parsed:
-                parsed_nested_field_names[wsdl_key] = parsed
+            )
+        if parsed:
+            parsed_nested_field_names[wsdl_key] = parsed
 
-        criteria = {}
-        if ids:
-            criteria["Ids"] = parse_ids(ids)
-        if types:
-            criteria["Types"] = [
-                item.strip().upper() for item in types.split(",") if item.strip()
-            ]
+    criteria = {}
+    if ids:
+        criteria["Ids"] = parse_ids(ids)
+    if types:
+        criteria["Types"] = [
+            item.strip().upper() for item in types.split(",") if item.strip()
+        ]
 
-        params = {"SelectionCriteria": criteria, "FieldNames": field_names}
-        params.update(parsed_nested_field_names)
+    params = {"SelectionCriteria": criteria, "FieldNames": field_names}
+    params.update(parsed_nested_field_names)
 
-        if limit:
-            params["Page"] = {"Limit": limit}
+    if limit:
+        params["Page"] = {"Limit": limit}
 
-        body = {"method": "get", "params": params}
+    body = {"method": "get", "params": params}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        result = client.creatives().post(data=body)
+    result = client.creatives().post(data=body)
 
-        if fetch_all:
-            items = []
-            for item in result().iter_items():
-                items.append(item)
-            format_output(items, output_format, output)
-        else:
-            data = result().extract()
-            format_output(data, output_format, output)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    if fetch_all:
+        items = []
+        for item in result().iter_items():
+            items.append(item)
+        format_output(items, output_format, output)
+    else:
+        data = result().extract()
+        format_output(data, output_format, output)
 
 
 @creatives.command()
 @click.option("--video-id", required=True, help="Video extension creative video ID")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def add(ctx, video_id, dry_run):
     """Add creative"""
-    try:
-        body = {
-            "method": "add",
-            "params": {
-                "Creatives": [{"VideoExtensionCreative": {"VideoId": video_id}}]
-            },
-        }
+    body = {
+        "method": "add",
+        "params": {"Creatives": [{"VideoExtensionCreative": {"VideoId": video_id}}]},
+    }
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
-        result = client.creatives().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = client_from_ctx(ctx, create_client)
+    result = client.creatives().post(data=body)
+    format_output(result().extract(), "json", None)

--- a/direct_cli/commands/feeds.py
+++ b/direct_cli/commands/feeds.py
@@ -10,7 +10,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..i18n import t
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import get_default_fields, parse_csv_strings, parse_ids
 
 _YES_NO = ["YES", "NO"]
@@ -140,6 +140,7 @@ def feeds():
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def get(
     ctx,
     ids,
@@ -153,60 +154,53 @@ def get(
     dry_run,
 ):
     """Get feeds"""
-    try:
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        field_names = fields.split(",") if fields else get_default_fields("feeds")
+    field_names = fields.split(",") if fields else get_default_fields("feeds")
 
-        parsed_file_feed_field_names = parse_csv_strings(file_feed_field_names)
-        if file_feed_field_names is not None and not parsed_file_feed_field_names:
-            raise click.UsageError(
-                t("Provide a non-empty comma-separated FileFeedFieldNames list.")
-            )
+    parsed_file_feed_field_names = parse_csv_strings(file_feed_field_names)
+    if file_feed_field_names is not None and not parsed_file_feed_field_names:
+        raise click.UsageError(
+            t("Provide a non-empty comma-separated FileFeedFieldNames list.")
+        )
 
-        parsed_url_feed_field_names = parse_csv_strings(url_feed_field_names)
-        if url_feed_field_names is not None and not parsed_url_feed_field_names:
-            raise click.UsageError(
-                t("Provide a non-empty comma-separated UrlFeedFieldNames list.")
-            )
+    parsed_url_feed_field_names = parse_csv_strings(url_feed_field_names)
+    if url_feed_field_names is not None and not parsed_url_feed_field_names:
+        raise click.UsageError(
+            t("Provide a non-empty comma-separated UrlFeedFieldNames list.")
+        )
 
-        criteria = {}
-        if ids:
-            criteria["Ids"] = parse_ids(ids)
+    criteria = {}
+    if ids:
+        criteria["Ids"] = parse_ids(ids)
 
-        params = {"FieldNames": field_names}
-        if criteria:
-            params["SelectionCriteria"] = criteria
-        if parsed_file_feed_field_names:
-            params["FileFeedFieldNames"] = parsed_file_feed_field_names
-        if parsed_url_feed_field_names:
-            params["UrlFeedFieldNames"] = parsed_url_feed_field_names
+    params = {"FieldNames": field_names}
+    if criteria:
+        params["SelectionCriteria"] = criteria
+    if parsed_file_feed_field_names:
+        params["FileFeedFieldNames"] = parsed_file_feed_field_names
+    if parsed_url_feed_field_names:
+        params["UrlFeedFieldNames"] = parsed_url_feed_field_names
 
-        if limit:
-            params["Page"] = {"Limit": limit}
+    if limit:
+        params["Page"] = {"Limit": limit}
 
-        body = {"method": "get", "params": params}
+    body = {"method": "get", "params": params}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        result = client.feeds().post(data=body)
+    result = client.feeds().post(data=body)
 
-        if fetch_all:
-            items = []
-            for item in result().iter_items():
-                items.append(item)
-            format_output(items, output_format, output)
-        else:
-            data = result().extract()
-            format_output(data, output_format, output)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    if fetch_all:
+        items = []
+        for item in result().iter_items():
+            items.append(item)
+        format_output(items, output_format, output)
+    else:
+        data = result().extract()
+        format_output(data, output_format, output)
 
 
 @feeds.command()
@@ -239,6 +233,7 @@ def get(
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def add(
     ctx,
     name,
@@ -252,55 +247,44 @@ def add(
     dry_run,
 ):
     """Add feed"""
-    try:
-        if file_feed_filename and not file_feed_path:
-            raise click.UsageError(t("--file-feed-filename requires --file-feed-path."))
-        if url and file_feed_path:
-            raise click.UsageError(t("Use either --url or --file-feed-path, not both."))
-        if not url and not file_feed_path:
-            raise click.UsageError(
-                t("Provide exactly one of --url or --file-feed-path.")
+    if file_feed_filename and not file_feed_path:
+        raise click.UsageError(t("--file-feed-filename requires --file-feed-path."))
+    if url and file_feed_path:
+        raise click.UsageError(t("Use either --url or --file-feed-path, not both."))
+    if not url and not file_feed_path:
+        raise click.UsageError(t("Provide exactly one of --url or --file-feed-path."))
+    if file_feed_path and _has_url_feed_options(
+        None, remove_utm_tags, feed_login, feed_password
+    ):
+        raise click.UsageError(
+            t(
+                "--remove-utm-tags, --feed-login, and --feed-password are "
+                "only valid with --url feeds."
             )
-        if file_feed_path and _has_url_feed_options(
-            None, remove_utm_tags, feed_login, feed_password
-        ):
-            raise click.UsageError(
-                t(
-                    "--remove-utm-tags, --feed-login, and --feed-password are "
-                    "only valid with --url feeds."
-                )
-            )
+        )
 
-        feed_data = {
-            "Name": name,
-            "BusinessType": business_type.upper(),
-            "SourceType": "FILE" if file_feed_path else "URL",
-        }
-        if file_feed_path:
-            feed_data["FileFeed"] = _file_feed_payload(
-                file_feed_path, file_feed_filename
-            )
-        else:
-            feed_data["UrlFeed"] = _url_feed_payload(
-                url, remove_utm_tags, feed_login, feed_password
-            )
+    feed_data = {
+        "Name": name,
+        "BusinessType": business_type.upper(),
+        "SourceType": "FILE" if file_feed_path else "URL",
+    }
+    if file_feed_path:
+        feed_data["FileFeed"] = _file_feed_payload(file_feed_path, file_feed_filename)
+    else:
+        feed_data["UrlFeed"] = _url_feed_payload(
+            url, remove_utm_tags, feed_login, feed_password
+        )
 
-        body = {"method": "add", "params": {"Feeds": [feed_data]}}
+    body = {"method": "add", "params": {"Feeds": [feed_data]}}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        result = client.feeds().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.feeds().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @feeds.command()
@@ -335,6 +319,7 @@ def add(
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def update(
     ctx,
     feed_id,
@@ -350,92 +335,79 @@ def update(
     dry_run,
 ):
     """Update feed"""
-    try:
-        if feed_login is not None and clear_feed_login:
-            raise click.UsageError(
-                t("Use either --feed-login or --clear-feed-login, not both")
-            )
-        if feed_password is not None and clear_feed_password:
-            raise click.UsageError(
-                t("Use either --feed-password or --clear-feed-password, not both")
-            )
-        if file_feed_filename and not file_feed_path:
-            raise click.UsageError(t("--file-feed-filename requires --file-feed-path."))
-        if file_feed_path and _has_url_feed_options(
-            url,
-            remove_utm_tags,
-            feed_login,
-            feed_password,
-            clear_feed_login,
-            clear_feed_password,
-        ):
-            raise click.UsageError(
-                t("FileFeed options cannot be combined with UrlFeed options.")
-            )
-
-        feed_data = {"Id": feed_id}
-
-        if name:
-            feed_data["Name"] = name
-        url_feed = _url_feed_payload(
-            url,
-            remove_utm_tags,
-            feed_login,
-            feed_password,
-            clear_feed_login,
-            clear_feed_password,
+    if feed_login is not None and clear_feed_login:
+        raise click.UsageError(
+            t("Use either --feed-login or --clear-feed-login, not both")
         )
-        if url_feed:
-            feed_data["UrlFeed"] = url_feed
-        if file_feed_path:
-            feed_data["FileFeed"] = _file_feed_payload(
-                file_feed_path, file_feed_filename
+    if feed_password is not None and clear_feed_password:
+        raise click.UsageError(
+            t("Use either --feed-password or --clear-feed-password, not both")
+        )
+    if file_feed_filename and not file_feed_path:
+        raise click.UsageError(t("--file-feed-filename requires --file-feed-path."))
+    if file_feed_path and _has_url_feed_options(
+        url,
+        remove_utm_tags,
+        feed_login,
+        feed_password,
+        clear_feed_login,
+        clear_feed_password,
+    ):
+        raise click.UsageError(
+            t("FileFeed options cannot be combined with UrlFeed options.")
+        )
+
+    feed_data = {"Id": feed_id}
+
+    if name:
+        feed_data["Name"] = name
+    url_feed = _url_feed_payload(
+        url,
+        remove_utm_tags,
+        feed_login,
+        feed_password,
+        clear_feed_login,
+        clear_feed_password,
+    )
+    if url_feed:
+        feed_data["UrlFeed"] = url_feed
+    if file_feed_path:
+        feed_data["FileFeed"] = _file_feed_payload(file_feed_path, file_feed_filename)
+    if len(feed_data) == 1:
+        raise click.UsageError(
+            t(
+                "Provide at least one of --name, --url, --file-feed-path, "
+                "--remove-utm-tags, --feed-login, --feed-password, "
+                "--clear-feed-login, or --clear-feed-password"
             )
-        if len(feed_data) == 1:
-            raise click.UsageError(
-                t(
-                    "Provide at least one of --name, --url, --file-feed-path, "
-                    "--remove-utm-tags, --feed-login, --feed-password, "
-                    "--clear-feed-login, or --clear-feed-password"
-                )
-            )
+        )
 
-        body = {"method": "update", "params": {"Feeds": [feed_data]}}
+    body = {"method": "update", "params": {"Feeds": [feed_data]}}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        result = client.feeds().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.feeds().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @feeds.command()
 @click.option("--id", "feed_id", required=True, type=int, help="Feed ID")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def delete(ctx, feed_id, dry_run):
     """Delete feed"""
-    try:
-        body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [feed_id]}}}
+    body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [feed_id]}}}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        result = client.feeds().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.feeds().post(data=body)
+    format_output(result().extract(), "json", None)

--- a/direct_cli/commands/keywordbids.py
+++ b/direct_cli/commands/keywordbids.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..i18n import t
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors, print_error
 from ..utils import (
     add_criteria_csv,
     add_single_id_selector,
@@ -60,6 +60,7 @@ def keywordbids():
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def get(
     ctx,
     keyword_ids,
@@ -76,83 +77,76 @@ def get(
     dry_run,
 ):
     """Get keyword bids"""
-    try:
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        parsed_fields = parse_csv_strings(fields)
-        if fields is not None and not parsed_fields:
-            raise click.UsageError(
-                t("Provide a non-empty comma-separated FieldNames list.")
+    parsed_fields = parse_csv_strings(fields)
+    if fields is not None and not parsed_fields:
+        raise click.UsageError(
+            t("Provide a non-empty comma-separated FieldNames list.")
+        )
+    parsed_search_field_names = parse_csv_strings(search_field_names)
+    if search_field_names is not None and not parsed_search_field_names:
+        raise click.UsageError(
+            t("Provide a non-empty comma-separated SearchFieldNames list.")
+        )
+    parsed_network_field_names = parse_csv_strings(network_field_names)
+    if network_field_names is not None and not parsed_network_field_names:
+        raise click.UsageError(
+            t("Provide a non-empty comma-separated NetworkFieldNames list.")
+        )
+
+    criteria = {}
+    if keyword_ids:
+        criteria["KeywordIds"] = parse_ids(keyword_ids)
+    if adgroup_ids:
+        criteria["AdGroupIds"] = parse_ids(adgroup_ids)
+    if campaign_ids:
+        criteria["CampaignIds"] = parse_ids(campaign_ids)
+    add_criteria_csv(criteria, "ServingStatuses", serving_statuses, upper=True)
+
+    if not criteria:
+        raise click.UsageError(
+            t(
+                "keywordbids get requires at least one filter: "
+                "--keyword-ids, --adgroup-ids, --campaign-ids, "
+                "or --serving-statuses."
             )
-        parsed_search_field_names = parse_csv_strings(search_field_names)
-        if search_field_names is not None and not parsed_search_field_names:
-            raise click.UsageError(
-                t("Provide a non-empty comma-separated SearchFieldNames list.")
-            )
-        parsed_network_field_names = parse_csv_strings(network_field_names)
-        if network_field_names is not None and not parsed_network_field_names:
-            raise click.UsageError(
-                t("Provide a non-empty comma-separated NetworkFieldNames list.")
-            )
+        )
 
-        criteria = {}
-        if keyword_ids:
-            criteria["KeywordIds"] = parse_ids(keyword_ids)
-        if adgroup_ids:
-            criteria["AdGroupIds"] = parse_ids(adgroup_ids)
-        if campaign_ids:
-            criteria["CampaignIds"] = parse_ids(campaign_ids)
-        add_criteria_csv(criteria, "ServingStatuses", serving_statuses, upper=True)
+    params = {
+        "SelectionCriteria": criteria,
+        "FieldNames": (
+            parsed_fields or get_default_fields("keywordbids", "FieldNames")
+        ),
+        "SearchFieldNames": (
+            parsed_search_field_names
+            or get_default_fields("keywordbids", "SearchFieldNames")
+        ),
+        "NetworkFieldNames": (
+            parsed_network_field_names
+            or get_default_fields("keywordbids", "NetworkFieldNames")
+        ),
+    }
 
-        if not criteria:
-            raise click.UsageError(
-                t(
-                    "keywordbids get requires at least one filter: "
-                    "--keyword-ids, --adgroup-ids, --campaign-ids, "
-                    "or --serving-statuses."
-                )
-            )
+    if limit:
+        params["Page"] = {"Limit": limit}
 
-        params = {
-            "SelectionCriteria": criteria,
-            "FieldNames": (
-                parsed_fields or get_default_fields("keywordbids", "FieldNames")
-            ),
-            "SearchFieldNames": (
-                parsed_search_field_names
-                or get_default_fields("keywordbids", "SearchFieldNames")
-            ),
-            "NetworkFieldNames": (
-                parsed_network_field_names
-                or get_default_fields("keywordbids", "NetworkFieldNames")
-            ),
-        }
+    body = {"method": "get", "params": params}
 
-        if limit:
-            params["Page"] = {"Limit": limit}
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        body = {"method": "get", "params": params}
+    result = client.keywordbids().post(data=body)
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
-
-        result = client.keywordbids().post(data=body)
-
-        if fetch_all:
-            items = []
-            for item in result().iter_items():
-                items.append(item)
-            format_output(items, output_format, output)
-        else:
-            data = result().extract()
-            format_output(data, output_format, output)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    if fetch_all:
+        items = []
+        for item in result().iter_items():
+            items.append(item)
+        format_output(items, output_format, output)
+    else:
+        data = result().extract()
+        format_output(data, output_format, output)
 
 
 @keywordbids.command()
@@ -258,6 +252,7 @@ def set(
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def set_auto(
     ctx,
     campaign_id,
@@ -270,50 +265,41 @@ def set_auto(
     dry_run,
 ):
     """Configure automatic keyword bidding"""
-    try:
-        if (target_traffic_volume is None) == (target_coverage is None):
-            raise click.UsageError(
-                t("Provide exactly one of --target-traffic-volume or --target-coverage")
-            )
+    if (target_traffic_volume is None) == (target_coverage is None):
+        raise click.UsageError(
+            t("Provide exactly one of --target-traffic-volume or --target-coverage")
+        )
 
-        bidding_rule = {}
-        if target_traffic_volume is not None:
-            bidding_rule["SearchByTrafficVolume"] = {
-                "TargetTrafficVolume": target_traffic_volume
-            }
-            if increase_percent is not None:
-                bidding_rule["SearchByTrafficVolume"][
-                    "IncreasePercent"
-                ] = increase_percent
-            if bid_ceiling is not None:
-                bidding_rule["SearchByTrafficVolume"]["BidCeiling"] = bid_ceiling
-        if target_coverage is not None:
-            bidding_rule["NetworkByCoverage"] = {"TargetCoverage": target_coverage}
-            if increase_percent is not None:
-                bidding_rule["NetworkByCoverage"]["IncreasePercent"] = increase_percent
-            if bid_ceiling is not None:
-                bidding_rule["NetworkByCoverage"]["BidCeiling"] = bid_ceiling
+    bidding_rule = {}
+    if target_traffic_volume is not None:
+        bidding_rule["SearchByTrafficVolume"] = {
+            "TargetTrafficVolume": target_traffic_volume
+        }
+        if increase_percent is not None:
+            bidding_rule["SearchByTrafficVolume"]["IncreasePercent"] = increase_percent
+        if bid_ceiling is not None:
+            bidding_rule["SearchByTrafficVolume"]["BidCeiling"] = bid_ceiling
+    if target_coverage is not None:
+        bidding_rule["NetworkByCoverage"] = {"TargetCoverage": target_coverage}
+        if increase_percent is not None:
+            bidding_rule["NetworkByCoverage"]["IncreasePercent"] = increase_percent
+        if bid_ceiling is not None:
+            bidding_rule["NetworkByCoverage"]["BidCeiling"] = bid_ceiling
 
-        bid_data = {"BiddingRule": bidding_rule}
-        if campaign_id is not None:
-            bid_data["CampaignId"] = campaign_id
-        if adgroup_id is not None:
-            bid_data["AdGroupId"] = adgroup_id
-        if keyword_id is not None:
-            bid_data["KeywordId"] = keyword_id
+    bid_data = {"BiddingRule": bidding_rule}
+    if campaign_id is not None:
+        bid_data["CampaignId"] = campaign_id
+    if adgroup_id is not None:
+        bid_data["AdGroupId"] = adgroup_id
+    if keyword_id is not None:
+        bid_data["KeywordId"] = keyword_id
 
-        body = {"method": "setAuto", "params": {"KeywordBids": [bid_data]}}
+    body = {"method": "setAuto", "params": {"KeywordBids": [bid_data]}}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
-        result = client.keywordbids().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = client_from_ctx(ctx, create_client)
+    result = client.keywordbids().post(data=body)
+    format_output(result().extract(), "json", None)

--- a/direct_cli/commands/negativekeywordsharedsets.py
+++ b/direct_cli/commands/negativekeywordsharedsets.py
@@ -5,7 +5,7 @@ NegativeKeywordSharedSets commands
 import click
 
 from ..api import client_from_ctx, create_client
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import get_default_fields, parse_ids
 
 
@@ -23,50 +23,42 @@ def negativekeywordsharedsets():
 @click.option("--fields", help="Comma-separated field names")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
     """Get negative keyword shared sets"""
-    try:
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        field_names = (
-            fields.split(",")
-            if fields
-            else get_default_fields("negativekeywordsharedsets")
-        )
+    field_names = (
+        fields.split(",") if fields else get_default_fields("negativekeywordsharedsets")
+    )
 
-        criteria = {}
-        if ids:
-            criteria["Ids"] = parse_ids(ids)
+    criteria = {}
+    if ids:
+        criteria["Ids"] = parse_ids(ids)
 
-        params = {"FieldNames": field_names}
-        if criteria:
-            params["SelectionCriteria"] = criteria
+    params = {"FieldNames": field_names}
+    if criteria:
+        params["SelectionCriteria"] = criteria
 
-        if limit:
-            params["Page"] = {"Limit": limit}
+    if limit:
+        params["Page"] = {"Limit": limit}
 
-        body = {"method": "get", "params": params}
+    body = {"method": "get", "params": params}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        result = client.negativekeywordsharedsets().post(data=body)
+    result = client.negativekeywordsharedsets().post(data=body)
 
-        if fetch_all:
-            items = []
-            for item in result().iter_items():
-                items.append(item)
-            format_output(items, output_format, output)
-        else:
-            data = result().extract()
-            format_output(data, output_format, output)
-
-    except click.ClickException:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    if fetch_all:
+        items = []
+        for item in result().iter_items():
+            items.append(item)
+        format_output(items, output_format, output)
+    else:
+        data = result().extract()
+        format_output(data, output_format, output)
 
 
 @negativekeywordsharedsets.command()
@@ -74,30 +66,24 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
 @click.option("--keywords", required=True, help="Comma-separated negative keywords")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def add(ctx, name, keywords, dry_run):
     """Add negative keyword shared set"""
-    try:
-        set_data = {
-            "Name": name,
-            "NegativeKeywords": [k.strip() for k in keywords.split(",")],
-        }
+    set_data = {
+        "Name": name,
+        "NegativeKeywords": [k.strip() for k in keywords.split(",")],
+    }
 
-        body = {"method": "add", "params": {"NegativeKeywordSharedSets": [set_data]}}
+    body = {"method": "add", "params": {"NegativeKeywordSharedSets": [set_data]}}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        result = client.negativekeywordsharedsets().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.ClickException:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.negativekeywordsharedsets().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @negativekeywordsharedsets.command()
@@ -106,59 +92,47 @@ def add(ctx, name, keywords, dry_run):
 @click.option("--keywords", help="Comma-separated negative keywords")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def update(ctx, set_id, name, keywords, dry_run):
     """Update negative keyword shared set"""
-    try:
-        set_data = {"Id": set_id}
+    set_data = {"Id": set_id}
 
-        if name:
-            set_data["Name"] = name
-        if keywords:
-            set_data["NegativeKeywords"] = [k.strip() for k in keywords.split(",")]
-        if len(set_data) == 1:
-            raise click.ClickException("Provide at least one of --name or --keywords")
+    if name:
+        set_data["Name"] = name
+    if keywords:
+        set_data["NegativeKeywords"] = [k.strip() for k in keywords.split(",")]
+    if len(set_data) == 1:
+        raise click.ClickException("Provide at least one of --name or --keywords")
 
-        body = {
-            "method": "update",
-            "params": {"NegativeKeywordSharedSets": [set_data]},
-        }
+    body = {
+        "method": "update",
+        "params": {"NegativeKeywordSharedSets": [set_data]},
+    }
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        result = client.negativekeywordsharedsets().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.ClickException:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.negativekeywordsharedsets().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @negativekeywordsharedsets.command()
 @click.option("--id", "set_id", required=True, type=int, help="Set ID")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def delete(ctx, set_id, dry_run):
     """Delete negative keyword shared set"""
-    try:
-        body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [set_id]}}}
+    body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [set_id]}}}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        result = client.negativekeywordsharedsets().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.ClickException:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.negativekeywordsharedsets().post(data=body)
+    format_output(result().extract(), "json", None)

--- a/direct_cli/commands/retargeting.py
+++ b/direct_cli/commands/retargeting.py
@@ -8,7 +8,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..i18n import t
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import get_default_fields, parse_ids, parse_retargeting_rule_specs
 
 
@@ -26,44 +26,38 @@ def retargeting():
 @click.option("--output", help="Output file")
 @click.option("--fields", help="Comma-separated field names")
 @click.pass_context
+@handle_api_errors
 def get(ctx, ids, types, limit, fetch_all, output_format, output, fields):
     """Get retargeting lists"""
-    try:
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        field_names = (
-            fields.split(",") if fields else get_default_fields("retargetinglists")
-        )
+    field_names = (
+        fields.split(",") if fields else get_default_fields("retargetinglists")
+    )
 
-        criteria = {}
-        if ids:
-            criteria["Ids"] = parse_ids(ids)
-        if types:
-            criteria["Types"] = types.split(",")
+    criteria = {}
+    if ids:
+        criteria["Ids"] = parse_ids(ids)
+    if types:
+        criteria["Types"] = types.split(",")
 
-        params = {"SelectionCriteria": criteria, "FieldNames": field_names}
+    params = {"SelectionCriteria": criteria, "FieldNames": field_names}
 
-        if limit:
-            params["Page"] = {"Limit": limit}
+    if limit:
+        params["Page"] = {"Limit": limit}
 
-        body = {"method": "get", "params": params}
+    body = {"method": "get", "params": params}
 
-        result = client.retargeting().post(data=body)
+    result = client.retargeting().post(data=body)
 
-        if fetch_all:
-            items = []
-            for item in result().iter_items():
-                items.append(item)
-            format_output(items, output_format, output)
-        else:
-            data = result().extract()
-            format_output(data, output_format, output)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    if fetch_all:
+        items = []
+        for item in result().iter_items():
+            items.append(item)
+        format_output(items, output_format, output)
+    else:
+        data = result().extract()
+        format_output(data, output_format, output)
 
 
 _RETARGETING_LIST_TYPES = ["RETARGETING", "AUDIENCE"]
@@ -115,35 +109,29 @@ def _validate_description(description: Optional[str]) -> None:
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def add(ctx, name, description, list_type, rules, dry_run):
     """Add new retargeting list"""
-    try:
-        _validate_description(description)
-        if not rules:
-            raise click.UsageError(t("Provide at least one --rule"))
-        list_data = {
-            "Name": name,
-            "Type": list_type,
-            "Rules": parse_retargeting_rule_specs(list(rules)),
-        }
-        if description is not None:
-            list_data["Description"] = description
+    _validate_description(description)
+    if not rules:
+        raise click.UsageError(t("Provide at least one --rule"))
+    list_data = {
+        "Name": name,
+        "Type": list_type,
+        "Rules": parse_retargeting_rule_specs(list(rules)),
+    }
+    if description is not None:
+        list_data["Description"] = description
 
-        body = {"method": "add", "params": {"RetargetingLists": [list_data]}}
+    body = {"method": "add", "params": {"RetargetingLists": [list_data]}}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
-        result = client.retargeting().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = client_from_ctx(ctx, create_client)
+    result = client.retargeting().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @retargeting.command()
@@ -170,59 +158,47 @@ def add(ctx, name, description, list_type, rules, dry_run):
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def update(ctx, list_id, name, description, list_type, rules, dry_run):
     """Update retargeting list"""
-    try:
-        _validate_description(description)
-        list_data = {"Id": list_id}
-        if name:
-            list_data["Name"] = name
-        if description is not None:
-            list_data["Description"] = description
-        if list_type:
-            list_data["Type"] = list_type
-        if rules:
-            list_data["Rules"] = parse_retargeting_rule_specs(list(rules))
-        if len(list_data) == 1:
-            raise click.UsageError(t("Provide at least one field to update"))
+    _validate_description(description)
+    list_data = {"Id": list_id}
+    if name:
+        list_data["Name"] = name
+    if description is not None:
+        list_data["Description"] = description
+    if list_type:
+        list_data["Type"] = list_type
+    if rules:
+        list_data["Rules"] = parse_retargeting_rule_specs(list(rules))
+    if len(list_data) == 1:
+        raise click.UsageError(t("Provide at least one field to update"))
 
-        body = {"method": "update", "params": {"RetargetingLists": [list_data]}}
+    body = {"method": "update", "params": {"RetargetingLists": [list_data]}}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
-        result = client.retargeting().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = client_from_ctx(ctx, create_client)
+    result = client.retargeting().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @retargeting.command()
 @click.option("--id", "list_id", required=True, type=int, help="Retargeting list ID")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def delete(ctx, list_id, dry_run):
     """Delete retargeting list"""
-    try:
-        body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [list_id]}}}
+    body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [list_id]}}}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        result = client.retargeting().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.retargeting().post(data=body)
+    format_output(result().extract(), "json", None)

--- a/direct_cli/commands/vcards.py
+++ b/direct_cli/commands/vcards.py
@@ -8,7 +8,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..i18n import t
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import get_default_fields, parse_ids
 
 
@@ -77,44 +77,40 @@ def _build_point_on_map(
 @click.option("--fields", help="Comma-separated field names")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
     """Get vCards"""
-    try:
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        field_names = fields.split(",") if fields else get_default_fields("vcards")
+    field_names = fields.split(",") if fields else get_default_fields("vcards")
 
-        criteria = {}
-        if ids:
-            criteria["Ids"] = parse_ids(ids)
+    criteria = {}
+    if ids:
+        criteria["Ids"] = parse_ids(ids)
 
-        params = {"FieldNames": field_names}
-        if criteria:
-            params["SelectionCriteria"] = criteria
+    params = {"FieldNames": field_names}
+    if criteria:
+        params["SelectionCriteria"] = criteria
 
-        if limit:
-            params["Page"] = {"Limit": limit}
+    if limit:
+        params["Page"] = {"Limit": limit}
 
-        body = {"method": "get", "params": params}
+    body = {"method": "get", "params": params}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        result = client.vcards().post(data=body)
+    result = client.vcards().post(data=body)
 
-        if fetch_all:
-            items = []
-            for item in result().iter_items():
-                items.append(item)
-            format_output(items, output_format, output)
-        else:
-            data = result().extract()
-            format_output(data, output_format, output)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    if fetch_all:
+        items = []
+        for item in result().iter_items():
+            items.append(item)
+        format_output(items, output_format, output)
+    else:
+        data = result().extract()
+        format_output(data, output_format, output)
 
 
 @vcards.command()
@@ -152,6 +148,7 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
 @click.option("--point-on-map-y2", type=float, help="PointOnMap.Y2 coordinate")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def add(
     ctx,
     campaign_id,
@@ -183,95 +180,84 @@ def add(
     dry_run,
 ):
     """Add vCard"""
-    try:
-        instant_messenger = _build_instant_messenger(
-            instant_messenger_client,
-            instant_messenger_login,
-        )
-        point_on_map = _build_point_on_map(
-            point_on_map_x,
-            point_on_map_y,
-            point_on_map_x1,
-            point_on_map_y1,
-            point_on_map_x2,
-            point_on_map_y2,
-        )
-        vcard = {
-            "CampaignId": campaign_id,
-            "Country": country,
-            "City": city,
-            "CompanyName": company_name,
-            "WorkTime": work_time,
-            "Phone": {
-                "CountryCode": phone_country_code,
-                "CityCode": phone_city_code,
-                "PhoneNumber": phone_number,
-            },
-        }
-        if phone_extension:
-            vcard["Phone"]["Extension"] = phone_extension
-        if street:
-            vcard["Street"] = street
-        if house:
-            vcard["House"] = house
-        if building:
-            vcard["Building"] = building
-        if apartment:
-            vcard["Apartment"] = apartment
-        if contact_person:
-            vcard["ContactPerson"] = contact_person
-        if contact_email:
-            vcard["ContactEmail"] = contact_email
-        if extra_message:
-            vcard["ExtraMessage"] = extra_message
-        if ogrn:
-            vcard["Ogrn"] = ogrn
-        if metro_station_id is not None:
-            vcard["MetroStationId"] = metro_station_id
-        if instant_messenger:
-            vcard["InstantMessenger"] = instant_messenger
-        if point_on_map:
-            vcard["PointOnMap"] = point_on_map
+    instant_messenger = _build_instant_messenger(
+        instant_messenger_client,
+        instant_messenger_login,
+    )
+    point_on_map = _build_point_on_map(
+        point_on_map_x,
+        point_on_map_y,
+        point_on_map_x1,
+        point_on_map_y1,
+        point_on_map_x2,
+        point_on_map_y2,
+    )
+    vcard = {
+        "CampaignId": campaign_id,
+        "Country": country,
+        "City": city,
+        "CompanyName": company_name,
+        "WorkTime": work_time,
+        "Phone": {
+            "CountryCode": phone_country_code,
+            "CityCode": phone_city_code,
+            "PhoneNumber": phone_number,
+        },
+    }
+    if phone_extension:
+        vcard["Phone"]["Extension"] = phone_extension
+    if street:
+        vcard["Street"] = street
+    if house:
+        vcard["House"] = house
+    if building:
+        vcard["Building"] = building
+    if apartment:
+        vcard["Apartment"] = apartment
+    if contact_person:
+        vcard["ContactPerson"] = contact_person
+    if contact_email:
+        vcard["ContactEmail"] = contact_email
+    if extra_message:
+        vcard["ExtraMessage"] = extra_message
+    if ogrn:
+        vcard["Ogrn"] = ogrn
+    if metro_station_id is not None:
+        vcard["MetroStationId"] = metro_station_id
+    if instant_messenger:
+        vcard["InstantMessenger"] = instant_messenger
+    if point_on_map:
+        vcard["PointOnMap"] = point_on_map
 
-        body = {"method": "add", "params": {"VCards": [vcard]}}
+    body = {"method": "add", "params": {"VCards": [vcard]}}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        result = client.vcards().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.vcards().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @vcards.command()
 @click.option("--id", "vcard_id", required=True, type=int, help="vCard ID")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def delete(ctx, vcard_id, dry_run):
     """Delete vCard"""
-    try:
-        body = {
-            "method": "delete",
-            "params": {"SelectionCriteria": {"Ids": [vcard_id]}},
-        }
+    body = {
+        "method": "delete",
+        "params": {"SelectionCriteria": {"Ids": [vcard_id]}},
+    }
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        result = client.vcards().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.vcards().post(data=body)
+    format_output(result().extract(), "json", None)


### PR DESCRIPTION
Часть эпика #491 (аудит дублирования), серия **A2** — PR конверсии №1.

Зависит от #503 (декоратор `@handle_api_errors` уже в `main`).

## Что сделано

Канонический «кожух» `try / except click.UsageError: raise / except Exception: print_error; Abort` заменён декоратором `@handle_api_errors` в **10 командных модулях**:
adextensions, bidmodifiers, bids, clients, creatives, feeds, keywordbids, negativekeywordsharedsets, retargeting, vcards.

## Как (механически, через ast-codemod)

1. `ast` находит каноничный `Try` (handler `except Exception as e: print_error(str(e)); raise click.Abort()`, опц. с пред-`except click.UsageError/ClickException: raise`).
2. Добавляет `@handle_api_errors` как **innermost** декоратор (ниже `@click.pass_context`).
3. Удаляет `try:` + handlers, дедентит тело на 4 пробела.
4. **Гейт ast-эквивалентности:** тело после правки байт-в-байт совпадает со старым телом `try` (отличие только в отступе и убранном кожухе). `black` нормализует пустые строки.

Конвертированы только чистые wrapper-функции. Функции с кодом до `try` (pre-validation) и `keywords._bulk_add` (доп. логика в except) — в следующих PR-ах серии.

## Импорт

`print_error` убран из `from ..output import ...` там, где больше не вызывается напрямую (заменён на `handle_api_errors`); сохранён рядом, где pre-validation пути всё ещё его зовут.

## Объём

10 файлов, **+944 / −1130** (insertions <1000, держим лимит эпика). Большой diff — из-за дедента: каждая строка тела показана как перемещённая.

## Верификация

- Полный прогон: **2087 passed, 47 skipped** (идентично baseline — 0 регрессий).
- `black --check` чисто; flake8 — **0 новых** замечаний vs main (2 пред-существующих E501 в feeds/retargeting).
- `import direct_cli.cli` OK.

Part of #493 (закрывающий PR серии будет содержать `Closes #493`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)