### PR TITLE
refactor: @handle_api_errors on 12 mid command modules (dedup #491 A2a-2)

### DIFF
--- a/direct_cli/commands/adimages.py
+++ b/direct_cli/commands/adimages.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..i18n import t
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import add_criteria_csv, get_default_fields, load_base64_file, parse_ids
 
 
@@ -26,6 +26,7 @@ def adimages():
 @click.option("--fields", help="Comma-separated field names")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def get(
     ctx,
     ids,
@@ -39,45 +40,40 @@ def get(
     dry_run,
 ):
     """Get ad images"""
-    try:
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        field_names = fields.split(",") if fields else get_default_fields("adimages")
+    field_names = fields.split(",") if fields else get_default_fields("adimages")
 
-        criteria = {}
-        if ids:
-            criteria["Ids"] = parse_ids(ids)
-        add_criteria_csv(criteria, "AdImageHashes", image_hashes)
-        if associated:
-            criteria["Associated"] = associated.upper()
+    criteria = {}
+    if ids:
+        criteria["Ids"] = parse_ids(ids)
+    add_criteria_csv(criteria, "AdImageHashes", image_hashes)
+    if associated:
+        criteria["Associated"] = associated.upper()
 
-        params = {"FieldNames": field_names}
-        if criteria:
-            params["SelectionCriteria"] = criteria
+    params = {"FieldNames": field_names}
+    if criteria:
+        params["SelectionCriteria"] = criteria
 
-        if limit:
-            params["Page"] = {"Limit": limit}
+    if limit:
+        params["Page"] = {"Limit": limit}
 
-        body = {"method": "get", "params": params}
+    body = {"method": "get", "params": params}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        result = client.adimages().post(data=body)
+    result = client.adimages().post(data=body)
 
-        if fetch_all:
-            items = []
-            for item in result().iter_items():
-                items.append(item)
-            format_output(items, output_format, output)
-        else:
-            data = result().extract()
-            format_output(data, output_format, output)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    if fetch_all:
+        items = []
+        for item in result().iter_items():
+            items.append(item)
+        format_output(items, output_format, output)
+    else:
+        data = result().extract()
+        format_output(data, output_format, output)
 
 
 @adimages.command()
@@ -87,60 +83,48 @@ def get(
 @click.option("--type", "image_type", help="Ad image type")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def add(ctx, name, image_data, image_file, image_type, dry_run):
     """Add ad image"""
-    try:
-        if bool(image_data) == bool(image_file):
-            raise click.UsageError(
-                t("Provide exactly one of --image-data or --image-file")
-            )
+    if bool(image_data) == bool(image_file):
+        raise click.UsageError(t("Provide exactly one of --image-data or --image-file"))
 
-        payload = {
-            "Name": name,
-            "ImageData": image_data if image_data else load_base64_file(image_file),
-        }
-        if image_type:
-            payload["Type"] = image_type
+    payload = {
+        "Name": name,
+        "ImageData": image_data if image_data else load_base64_file(image_file),
+    }
+    if image_type:
+        payload["Type"] = image_type
 
-        body = {"method": "add", "params": {"AdImages": [payload]}}
+    body = {"method": "add", "params": {"AdImages": [payload]}}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        result = client.adimages().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.adimages().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @adimages.command()
 @click.option("--hash", "image_hash", required=True, help="Ad image hash")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def delete(ctx, image_hash, dry_run):
     """Delete ad image"""
-    try:
-        body = {
-            "method": "delete",
-            "params": {"SelectionCriteria": {"AdImageHashes": [image_hash]}},
-        }
+    body = {
+        "method": "delete",
+        "params": {"SelectionCriteria": {"AdImageHashes": [image_hash]}},
+    }
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        result = client.adimages().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.adimages().post(data=body)
+    format_output(result().extract(), "json", None)

--- a/direct_cli/commands/advideos.py
+++ b/direct_cli/commands/advideos.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..i18n import t
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import get_default_fields, load_base64_file
 
 
@@ -24,45 +24,39 @@ def advideos():
 @click.option("--fields", help="Comma-separated field names")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
     """Get ad videos"""
-    try:
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        field_names = fields.split(",") if fields else get_default_fields("advideos")
+    field_names = fields.split(",") if fields else get_default_fields("advideos")
 
-        criteria = {"Ids": [x.strip() for x in ids.split(",") if x.strip()]}
+    criteria = {"Ids": [x.strip() for x in ids.split(",") if x.strip()]}
 
-        params = {
-            "SelectionCriteria": criteria,
-            "FieldNames": field_names,
-        }
+    params = {
+        "SelectionCriteria": criteria,
+        "FieldNames": field_names,
+    }
 
-        if limit:
-            params["Page"] = {"Limit": limit}
+    if limit:
+        params["Page"] = {"Limit": limit}
 
-        body = {"method": "get", "params": params}
+    body = {"method": "get", "params": params}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        result = client.advideos().post(data=body)
+    result = client.advideos().post(data=body)
 
-        if fetch_all:
-            items = []
-            for item in result().iter_items():
-                items.append(item)
-            format_output(items, output_format, output)
-        else:
-            data = result().extract()
-            format_output(data, output_format, output)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    if fetch_all:
+        items = []
+        for item in result().iter_items():
+            items.append(item)
+        format_output(items, output_format, output)
+    else:
+        data = result().extract()
+        format_output(data, output_format, output)
 
 
 @advideos.command()
@@ -74,38 +68,32 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
 @click.option("--name", help="Video name")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def add(ctx, url, video_data, video_file, name, dry_run):
     """Add a new ad video (by URL or binary data)"""
-    try:
-        sources = [s for s in (url, video_data, video_file) if s]
-        if len(sources) != 1:
-            raise click.UsageError(
-                t("Provide exactly one of --url, --video-data, or --video-file.")
-            )
+    sources = [s for s in (url, video_data, video_file) if s]
+    if len(sources) != 1:
+        raise click.UsageError(
+            t("Provide exactly one of --url, --video-data, or --video-file.")
+        )
 
-        item = {}
-        if url:
-            item["Url"] = url
-        elif video_data:
-            item["VideoData"] = video_data
-        else:
-            item["VideoData"] = load_base64_file(video_file)
-        if name:
-            item["Name"] = name
+    item = {}
+    if url:
+        item["Url"] = url
+    elif video_data:
+        item["VideoData"] = video_data
+    else:
+        item["VideoData"] = load_base64_file(video_file)
+    if name:
+        item["Name"] = name
 
-        body = {"method": "add", "params": {"AdVideos": [item]}}
+    body = {"method": "add", "params": {"AdVideos": [item]}}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        result = client.advideos().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.advideos().post(data=body)
+    format_output(result().extract(), "json", None)

--- a/direct_cli/commands/businesses.py
+++ b/direct_cli/commands/businesses.py
@@ -5,7 +5,7 @@ Businesses commands
 import click
 
 from ..api import client_from_ctx, create_client
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import get_default_fields, parse_ids
 
 
@@ -23,41 +23,37 @@ def businesses():
 @click.option("--fields", help="Comma-separated field names")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
     """Get businesses"""
-    try:
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        field_names = fields.split(",") if fields else get_default_fields("businesses")
+    field_names = fields.split(",") if fields else get_default_fields("businesses")
 
-        criteria = {}
-        if ids:
-            criteria["Ids"] = parse_ids(ids)
+    criteria = {}
+    if ids:
+        criteria["Ids"] = parse_ids(ids)
 
-        params = {"FieldNames": field_names}
-        if criteria:
-            params["SelectionCriteria"] = criteria
+    params = {"FieldNames": field_names}
+    if criteria:
+        params["SelectionCriteria"] = criteria
 
-        if limit:
-            params["Page"] = {"Limit": limit}
+    if limit:
+        params["Page"] = {"Limit": limit}
 
-        body = {"method": "get", "params": params}
+    body = {"method": "get", "params": params}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        result = client.businesses().post(data=body)
+    result = client.businesses().post(data=body)
 
-        if fetch_all:
-            items = []
-            for item in result().iter_items():
-                items.append(item)
-            format_output(items, output_format, output)
-        else:
-            data = result().extract()
-            format_output(data, output_format, output)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    if fetch_all:
+        items = []
+        for item in result().iter_items():
+            items.append(item)
+        format_output(items, output_format, output)
+    else:
+        data = result().extract()
+        format_output(data, output_format, output)

--- a/direct_cli/commands/changes.py
+++ b/direct_cli/commands/changes.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..i18n import t
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors, print_error
 from ..utils import get_default_fields, parse_changes_datetime, parse_ids
 
 
@@ -139,37 +139,29 @@ def check(
 @click.option("--format", "output_format", default="json", help="Output format")
 @click.option("--output", help="Output file")
 @click.pass_context
+@handle_api_errors
 def check_campaigns(ctx, timestamp, output_format, output):
     """Check campaigns changes"""
-    try:
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        params = {"Timestamp": parse_changes_datetime(timestamp)}
+    params = {"Timestamp": parse_changes_datetime(timestamp)}
 
-        body = {"method": "checkCampaigns", "params": params}
+    body = {"method": "checkCampaigns", "params": params}
 
-        result = client.changes().post(data=body)
-        format_output(result.data, output_format, output)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.changes().post(data=body)
+    format_output(result.data, output_format, output)
 
 
 @changes.command()
 @click.option("--format", "output_format", default="json", help="Output format")
 @click.option("--output", help="Output file")
 @click.pass_context
+@handle_api_errors
 def check_dictionaries(ctx, output_format, output):
     """Check dictionaries changes"""
-    try:
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        body = {"method": "checkDictionaries", "params": {}}
+    body = {"method": "checkDictionaries", "params": {}}
 
-        result = client.changes().post(data=body)
-        format_output(result.data, output_format, output)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.changes().post(data=body)
+    format_output(result.data, output_format, output)

--- a/direct_cli/commands/dictionaries.py
+++ b/direct_cli/commands/dictionaries.py
@@ -5,7 +5,7 @@ Dictionaries commands
 import click
 
 from ..api import client_from_ctx, create_client
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import parse_csv_strings, parse_ids
 
 DICTIONARY_NAMES = [
@@ -36,21 +36,17 @@ def dictionaries():
 @click.option("--format", "output_format", default="json", help="Output format")
 @click.option("--output", help="Output file")
 @click.pass_context
+@handle_api_errors
 def get(ctx, names, output_format, output):
     """Get dictionaries"""
-    try:
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        dictionary_names = [n.strip() for n in names.split(",")]
+    dictionary_names = [n.strip() for n in names.split(",")]
 
-        body = {"method": "get", "params": {"DictionaryNames": dictionary_names}}
+    body = {"method": "get", "params": {"DictionaryNames": dictionary_names}}
 
-        result = client.dictionaries().post(data=body)
-        format_output(result.data, output_format, output)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.dictionaries().post(data=body)
+    format_output(result.data, output_format, output)
 
 
 @dictionaries.command(name="get-geo-regions")
@@ -61,30 +57,26 @@ def get(ctx, names, output_format, output):
 @click.option("--format", "output_format", default="json", help="Output format")
 @click.option("--output", help="Output file")
 @click.pass_context
+@handle_api_errors
 def get_geo_regions(ctx, name, region_ids, exact_names, fields, output_format, output):
     """Get GeoRegions dictionary entries"""
-    try:
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        params = {"FieldNames": [name.strip() for name in fields.split(",")]}
-        selection_criteria = {}
-        if name:
-            selection_criteria["Name"] = name
-        if region_ids:
-            selection_criteria["RegionIds"] = parse_ids(region_ids)
-        if exact_names:
-            selection_criteria["ExactNames"] = parse_csv_strings(exact_names)
-        if selection_criteria:
-            params["SelectionCriteria"] = selection_criteria
+    params = {"FieldNames": [name.strip() for name in fields.split(",")]}
+    selection_criteria = {}
+    if name:
+        selection_criteria["Name"] = name
+    if region_ids:
+        selection_criteria["RegionIds"] = parse_ids(region_ids)
+    if exact_names:
+        selection_criteria["ExactNames"] = parse_csv_strings(exact_names)
+    if selection_criteria:
+        params["SelectionCriteria"] = selection_criteria
 
-        body = {"method": "getGeoRegions", "params": params}
+    body = {"method": "getGeoRegions", "params": params}
 
-        result = client.dictionaries().post(data=body)
-        format_output(result.data, output_format, output)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.dictionaries().post(data=body)
+    format_output(result.data, output_format, output)
 
 
 @dictionaries.command()

--- a/direct_cli/commands/leads.py
+++ b/direct_cli/commands/leads.py
@@ -5,7 +5,7 @@ Leads commands
 import click
 
 from ..api import client_from_ctx, create_client
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import get_default_fields, parse_ids
 
 
@@ -29,6 +29,7 @@ def leads():
 @click.option("--fields", help="Comma-separated field names")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def get(
     ctx,
     turbo_page_ids,
@@ -42,39 +43,34 @@ def get(
     dry_run,
 ):
     """Get leads"""
-    try:
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        field_names = fields.split(",") if fields else get_default_fields("leads")
+    field_names = fields.split(",") if fields else get_default_fields("leads")
 
-        criteria = {"TurboPageIds": parse_ids(turbo_page_ids)}
-        if datetime_from:
-            criteria["DateTimeFrom"] = datetime_from
-        if datetime_to:
-            criteria["DateTimeTo"] = datetime_to
+    criteria = {"TurboPageIds": parse_ids(turbo_page_ids)}
+    if datetime_from:
+        criteria["DateTimeFrom"] = datetime_from
+    if datetime_to:
+        criteria["DateTimeTo"] = datetime_to
 
-        params = {"SelectionCriteria": criteria, "FieldNames": field_names}
+    params = {"SelectionCriteria": criteria, "FieldNames": field_names}
 
-        if limit:
-            params["Page"] = {"Limit": limit}
+    if limit:
+        params["Page"] = {"Limit": limit}
 
-        body = {"method": "get", "params": params}
+    body = {"method": "get", "params": params}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        result = client.leads().post(data=body)
+    result = client.leads().post(data=body)
 
-        if fetch_all:
-            items = []
-            for item in result().iter_items():
-                items.append(item)
-            format_output(items, output_format, output)
-        else:
-            data = result().extract()
-            format_output(data, output_format, output)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    if fetch_all:
+        items = []
+        for item in result().iter_items():
+            items.append(item)
+        format_output(items, output_format, output)
+    else:
+        data = result().extract()
+        format_output(data, output_format, output)

--- a/direct_cli/commands/reports.py
+++ b/direct_cli/commands/reports.py
@@ -9,7 +9,7 @@ import json
 import click
 
 from ..api import create_client
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import parse_csv_strings
 
 ATTRIBUTION_MODELS = {"FC", "LC", "LSC", "LYDC", "FCCD", "LSCCD", "LYDCCD", "AUTO"}
@@ -390,6 +390,7 @@ def reports():
     help="Print request headers and body without calling the API",
 )
 @click.pass_context
+@handle_api_errors
 def get(
     ctx,
     report_type,
@@ -419,71 +420,66 @@ def get(
     dry_run,
 ):
     """Get report"""
-    try:
-        body = build_report_request(
-            report_type=report_type.upper(),
-            date_from=date_from,
-            date_to=date_to,
-            name=name,
-            fields=fields,
-            campaign_ids=campaign_ids,
-            adgroup_ids=adgroup_ids,
-            date_range_type=date_range_type.upper(),
-            include_vat=include_vat,
-            include_discount=include_discount,
-            page_limit=page_limit,
-            page_offset=page_offset,
-            filters=filters,
-            order_by=order_by,
-            goals=goals,
-            attribution_models=attribution_models,
-        )
+    body = build_report_request(
+        report_type=report_type.upper(),
+        date_from=date_from,
+        date_to=date_to,
+        name=name,
+        fields=fields,
+        campaign_ids=campaign_ids,
+        adgroup_ids=adgroup_ids,
+        date_range_type=date_range_type.upper(),
+        include_vat=include_vat,
+        include_discount=include_discount,
+        page_limit=page_limit,
+        page_offset=page_offset,
+        filters=filters,
+        order_by=order_by,
+        goals=goals,
+        attribution_models=attribution_models,
+    )
 
-        request_headers = {}
-        if processing_mode:
-            request_headers["processingMode"] = processing_mode
-        if skip_report_header:
-            request_headers["skipReportHeader"] = "true"
-        if skip_column_header:
-            request_headers["skipColumnHeader"] = "true"
-        if skip_report_summary:
-            request_headers["skipReportSummary"] = "true"
-        if return_money_in_micros:
-            request_headers["returnMoneyInMicros"] = "true"
-        if language:
-            request_headers["Accept-Language"] = language
+    request_headers = {}
+    if processing_mode:
+        request_headers["processingMode"] = processing_mode
+    if skip_report_header:
+        request_headers["skipReportHeader"] = "true"
+    if skip_column_header:
+        request_headers["skipColumnHeader"] = "true"
+    if skip_report_summary:
+        request_headers["skipReportSummary"] = "true"
+    if return_money_in_micros:
+        request_headers["returnMoneyInMicros"] = "true"
+    if language:
+        request_headers["Accept-Language"] = language
 
-        if dry_run:
-            output_data = {"headers": request_headers, "body": body}
-            click.echo(json.dumps(output_data, indent=2, ensure_ascii=False))
-            return
+    if dry_run:
+        output_data = {"headers": request_headers, "body": body}
+        click.echo(json.dumps(output_data, indent=2, ensure_ascii=False))
+        return
 
-        client = create_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            sandbox=ctx.obj.get("sandbox"),
-            processing_mode=processing_mode or "auto",
-            return_money_in_micros=return_money_in_micros,
-            skip_report_header=skip_report_header,
-            skip_column_header=skip_column_header,
-            skip_report_summary=skip_report_summary,
-            language=language,
-        )
+    client = create_client(
+        token=ctx.obj.get("token"),
+        login=ctx.obj.get("login"),
+        sandbox=ctx.obj.get("sandbox"),
+        processing_mode=processing_mode or "auto",
+        return_money_in_micros=return_money_in_micros,
+        skip_report_header=skip_report_header,
+        skip_column_header=skip_column_header,
+        skip_report_summary=skip_report_summary,
+        language=language,
+    )
 
-        result = client.reports().post(data=body)
+    result = client.reports().post(data=body)
 
-        if output_format == "json":
-            format_output(result().to_dicts(), "json", output)
-        elif output_format == "table":
-            format_output(result().to_dicts(), "table", output)
-        elif output_format == "csv":
-            format_output(result().to_values(), "csv", output, headers=result.columns)
-        elif output_format == "tsv":
-            format_output(result().to_values(), "tsv", output, headers=result.columns)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    if output_format == "json":
+        format_output(result().to_dicts(), "json", output)
+    elif output_format == "table":
+        format_output(result().to_dicts(), "table", output)
+    elif output_format == "csv":
+        format_output(result().to_values(), "csv", output, headers=result.columns)
+    elif output_format == "tsv":
+        format_output(result().to_values(), "tsv", output, headers=result.columns)
 
 
 @reports.command()

--- a/direct_cli/commands/sitelinks.py
+++ b/direct_cli/commands/sitelinks.py
@@ -10,7 +10,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..i18n import t
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors, print_error
 from ..utils import (
     get_default_fields,
     parse_csv_strings,
@@ -142,6 +142,7 @@ def sitelinks():
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def get(
     ctx,
     ids,
@@ -154,51 +155,44 @@ def get(
     dry_run,
 ):
     """Get sitelinks"""
-    try:
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        field_names = parse_csv_strings(fields) or get_default_fields("sitelinks")
-        parsed_sitelink_field_names = parse_csv_strings(sitelink_field_names)
-        if sitelink_field_names is not None and not parsed_sitelink_field_names:
-            raise click.UsageError(
-                t("Provide a non-empty comma-separated SitelinkFieldNames list.")
-            )
+    field_names = parse_csv_strings(fields) or get_default_fields("sitelinks")
+    parsed_sitelink_field_names = parse_csv_strings(sitelink_field_names)
+    if sitelink_field_names is not None and not parsed_sitelink_field_names:
+        raise click.UsageError(
+            t("Provide a non-empty comma-separated SitelinkFieldNames list.")
+        )
 
-        criteria = {}
-        if ids:
-            criteria["Ids"] = parse_ids(ids)
+    criteria = {}
+    if ids:
+        criteria["Ids"] = parse_ids(ids)
 
-        params = {"FieldNames": field_names}
-        if criteria:
-            params["SelectionCriteria"] = criteria
-        if parsed_sitelink_field_names:
-            params["SitelinkFieldNames"] = parsed_sitelink_field_names
+    params = {"FieldNames": field_names}
+    if criteria:
+        params["SelectionCriteria"] = criteria
+    if parsed_sitelink_field_names:
+        params["SitelinkFieldNames"] = parsed_sitelink_field_names
 
-        if limit:
-            params["Page"] = {"Limit": limit}
+    if limit:
+        params["Page"] = {"Limit": limit}
 
-        body = {"method": "get", "params": params}
+    body = {"method": "get", "params": params}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        result = client.sitelinks().post(data=body)
+    result = client.sitelinks().post(data=body)
 
-        if fetch_all:
-            items = []
-            for item in result().iter_items():
-                items.append(item)
-            format_output(items, output_format, output)
-        else:
-            data = result().extract()
-            format_output(data, output_format, output)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    if fetch_all:
+        items = []
+        for item in result().iter_items():
+            items.append(item)
+        format_output(items, output_format, output)
+    else:
+        data = result().extract()
+        format_output(data, output_format, output)
 
 
 @sitelinks.command()
@@ -296,20 +290,16 @@ def add(ctx, sitelinks_specs, sitelinks_json, sitelinks_from_file, dry_run):
 @click.option("--id", "set_id", required=True, type=int, help="Sitelinks set ID")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def delete(ctx, set_id, dry_run):
     """Delete sitelinks set"""
-    try:
-        body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [set_id]}}}
+    body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [set_id]}}}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        result = client.sitelinks().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.sitelinks().post(data=body)
+    format_output(result().extract(), "json", None)

--- a/direct_cli/commands/turbopages.py
+++ b/direct_cli/commands/turbopages.py
@@ -10,7 +10,7 @@ sitelinks).  No ``add``/``update``/``delete`` methods exist on this service.
 import click
 
 from ..api import client_from_ctx, create_client
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import get_default_fields, parse_ids
 
 
@@ -29,47 +29,43 @@ def turbopages():
 @click.option("--fields", help="Comma-separated field names")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def get(
     ctx, ids, bound_with_hrefs, limit, fetch_all, output_format, output, fields, dry_run
 ):
     """Get Turbo Pages"""
-    try:
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        field_names = fields.split(",") if fields else get_default_fields("turbopages")
+    field_names = fields.split(",") if fields else get_default_fields("turbopages")
 
-        criteria = {}
-        if ids:
-            criteria["Ids"] = parse_ids(ids)
-        if bound_with_hrefs:
-            criteria["BoundWithHrefs"] = [
-                item.strip() for item in bound_with_hrefs.split(",") if item.strip()
-            ]
+    criteria = {}
+    if ids:
+        criteria["Ids"] = parse_ids(ids)
+    if bound_with_hrefs:
+        criteria["BoundWithHrefs"] = [
+            item.strip() for item in bound_with_hrefs.split(",") if item.strip()
+        ]
 
-        params = {"FieldNames": field_names}
-        if criteria:
-            params["SelectionCriteria"] = criteria
+    params = {"FieldNames": field_names}
+    if criteria:
+        params["SelectionCriteria"] = criteria
 
-        if limit:
-            params["Page"] = {"Limit": limit}
+    if limit:
+        params["Page"] = {"Limit": limit}
 
-        body = {"method": "get", "params": params}
+    body = {"method": "get", "params": params}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        result = client.turbopages().post(data=body)
+    result = client.turbopages().post(data=body)
 
-        if fetch_all:
-            items = []
-            for item in result().iter_items():
-                items.append(item)
-            format_output(items, output_format, output)
-        else:
-            data = result().extract()
-            format_output(data, output_format, output)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    if fetch_all:
+        items = []
+        for item in result().iter_items():
+            items.append(item)
+        format_output(items, output_format, output)
+    else:
+        data = result().extract()
+        format_output(data, output_format, output)

--- a/direct_cli/commands/v4forecast.py
+++ b/direct_cli/commands/v4forecast.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import create_v4_client
 from ..i18n import t
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import parse_csv_strings, parse_ids
 from ..v4 import build_v4_body, call_v4
 from ..v4_contracts import v4_method_contract
@@ -55,6 +55,7 @@ def _forecast_param(
     return param
 
 
+@handle_api_errors
 def _call_forecast(
     ctx,
     method: str,
@@ -63,20 +64,14 @@ def _call_forecast(
     output: Optional[str],
 ) -> None:
     """Call one v4 Live budget forecast method and print formatted output."""
-    try:
-        client = create_v4_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            profile=ctx.obj.get("profile"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
-        data = call_v4(client, method, param)
-        format_output(data, output_format, output)
-    except click.ClickException:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = create_v4_client(
+        token=ctx.obj.get("token"),
+        login=ctx.obj.get("login"),
+        profile=ctx.obj.get("profile"),
+        sandbox=ctx.obj.get("sandbox"),
+    )
+    data = call_v4(client, method, param)
+    format_output(data, output_format, output)
 
 
 @click.group(epilog=V4_EPILOG)

--- a/direct_cli/commands/v4tags.py
+++ b/direct_cli/commands/v4tags.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import create_v4_client
 from ..i18n import t
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import parse_ids
 from ..v4 import build_v4_body, call_v4
 from ..v4_contracts import v4_method_contract
@@ -142,22 +142,17 @@ def _update_banners_tags_param(
     ]
 
 
+@handle_api_errors
 def _call_v4tags(ctx, method: str, param, output_format: str, output: str) -> None:
     """Call one v4 Live tag method and print formatted output."""
-    try:
-        client = create_v4_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            profile=ctx.obj.get("profile"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
-        data = call_v4(client, method, param)
-        format_output(data, output_format, output)
-    except click.ClickException:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = create_v4_client(
+        token=ctx.obj.get("token"),
+        login=ctx.obj.get("login"),
+        profile=ctx.obj.get("profile"),
+        sandbox=ctx.obj.get("sandbox"),
+    )
+    data = call_v4(client, method, param)
+    format_output(data, output_format, output)
 
 
 @click.group(epilog=V4_EPILOG)

--- a/direct_cli/commands/v4wordstat.py
+++ b/direct_cli/commands/v4wordstat.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import create_v4_client
 from ..i18n import t
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import parse_csv_strings, parse_ids
 from ..v4 import build_v4_body, call_v4
 from ..v4_contracts import v4_method_contract
@@ -32,6 +32,7 @@ def _wordstat_report_param(phrases: str, geo_ids: Optional[str]) -> dict:
     return param
 
 
+@handle_api_errors
 def _call_wordstat(
     ctx,
     method: str,
@@ -40,20 +41,14 @@ def _call_wordstat(
     output: Optional[str],
 ) -> None:
     """Call one v4 Live Wordstat method and print formatted output."""
-    try:
-        client = create_v4_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            profile=ctx.obj.get("profile"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
-        data = call_v4(client, method, param)
-        format_output(data, output_format, output)
-    except click.ClickException:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = create_v4_client(
+        token=ctx.obj.get("token"),
+        login=ctx.obj.get("login"),
+        profile=ctx.obj.get("profile"),
+        sandbox=ctx.obj.get("sandbox"),
+    )
+    data = call_v4(client, method, param)
+    format_output(data, output_format, output)
 
 
 @click.group(epilog=V4_EPILOG)


### PR DESCRIPTION
Часть эпика #491, серия **A2** — PR конверсии №2. Зависит от #503 (декоратор в `main`).

## Что сделано

`@handle_api_errors` применён в **12 модулях**: adimages, advideos, businesses, changes, dictionaries, leads, reports, sitelinks, turbopages, v4forecast, v4tags, v4wordstat.

Тот же ast-codemod + гейт ast-эквивалентности, что и в #504. В `reports.py` конвертирован только `get`; хелперы `_load_*` сохраняют своё `except Exception: return default` (не каноничная форма print_error/Abort — codemod их корректно пропустил).

## Объём

12 файлов, **+353 / −438**.

## Верификация

- Полный прогон: **2087 passed, 47 skipped** (0 регрессий).
- `black --check` чисто; flake8 — **0 новых** замечаний vs main (6 пред-существующих PIE786/E501 в reports.py).
- `import direct_cli.cli` OK.

Part of #493.

🤖 Generated with [Claude Code](https://claude.com/claude-code)