### PR TITLE
refactor: @handle_api_errors on targets/clients modules (dedup #491 A2b)

### DIFF
--- a/direct_cli/commands/agencyclients.py
+++ b/direct_cli/commands/agencyclients.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..i18n import t
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors, print_error
 from ..utils import (
     assert_not_runtime_deprecated,
     build_client_update_item,
@@ -117,6 +117,7 @@ def agencyclients():
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def get(
     ctx,
     logins,
@@ -134,64 +135,55 @@ def get(
     dry_run,
 ):
     """Get agency clients"""
-    try:
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        field_names = (
-            fields.split(",") if fields else get_default_fields("agencyclients")
-        )
+    field_names = fields.split(",") if fields else get_default_fields("agencyclients")
 
-        raw_nested = (
-            ("ContractFieldNames", contract_field_names),
-            ("ContragentFieldNames", contragent_field_names),
-            ("ContragentTinInfoFieldNames", contragent_tin_info_field_names),
-            ("OrganizationFieldNames", organization_field_names),
-            ("TinInfoFieldNames", tin_info_field_names),
-        )
-        parsed_nested = {}
-        for wsdl_key, raw_value in raw_nested:
-            parsed = parse_csv_strings(raw_value)
-            if raw_value is not None and not parsed:
-                raise click.UsageError(
-                    t("Provide a non-empty comma-separated {wsdl_key} list.").format(
-                        wsdl_key=wsdl_key
-                    )
+    raw_nested = (
+        ("ContractFieldNames", contract_field_names),
+        ("ContragentFieldNames", contragent_field_names),
+        ("ContragentTinInfoFieldNames", contragent_tin_info_field_names),
+        ("OrganizationFieldNames", organization_field_names),
+        ("TinInfoFieldNames", tin_info_field_names),
+    )
+    parsed_nested = {}
+    for wsdl_key, raw_value in raw_nested:
+        parsed = parse_csv_strings(raw_value)
+        if raw_value is not None and not parsed:
+            raise click.UsageError(
+                t("Provide a non-empty comma-separated {wsdl_key} list.").format(
+                    wsdl_key=wsdl_key
                 )
-            if parsed:
-                parsed_nested[wsdl_key] = parsed
+            )
+        if parsed:
+            parsed_nested[wsdl_key] = parsed
 
-        criteria = {"Archived": archived}
-        if logins:
-            criteria["Logins"] = [login.strip() for login in logins.split(",")]
+    criteria = {"Archived": archived}
+    if logins:
+        criteria["Logins"] = [login.strip() for login in logins.split(",")]
 
-        params = {"SelectionCriteria": criteria, "FieldNames": field_names}
-        params.update(parsed_nested)
+    params = {"SelectionCriteria": criteria, "FieldNames": field_names}
+    params.update(parsed_nested)
 
-        if limit:
-            params["Page"] = {"Limit": limit}
+    if limit:
+        params["Page"] = {"Limit": limit}
 
-        body = {"method": "get", "params": params}
+    body = {"method": "get", "params": params}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        result = client.agencyclients().post(data=body)
+    result = client.agencyclients().post(data=body)
 
-        if fetch_all:
-            items = []
-            for item in result().iter_items():
-                items.append(item)
-            format_output(items, output_format, output)
-        else:
-            data = result().extract()
-            format_output(data, output_format, output)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    if fetch_all:
+        items = []
+        for item in result().iter_items():
+            items.append(item)
+        format_output(items, output_format, output)
+    else:
+        data = result().extract()
+        format_output(data, output_format, output)
 
 
 @agencyclients.command()
@@ -213,6 +205,7 @@ def get(
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def add(
     ctx,
     login,
@@ -226,39 +219,32 @@ def add(
     dry_run,
 ):
     """Add agency client"""
-    try:
-        assert_not_runtime_deprecated("agencyclients", "add")
+    assert_not_runtime_deprecated("agencyclients", "add")
 
-        body = {
-            "method": "add",
-            "params": {
-                "Login": login,
-                "FirstName": first_name,
-                "LastName": last_name,
-                "Currency": currency,
-                "Notification": _build_notification(
-                    notification_email,
-                    notification_lang,
-                    send_account_news,
-                    send_warnings,
-                ),
-            },
-        }
+    body = {
+        "method": "add",
+        "params": {
+            "Login": login,
+            "FirstName": first_name,
+            "LastName": last_name,
+            "Currency": currency,
+            "Notification": _build_notification(
+                notification_email,
+                notification_lang,
+                send_account_news,
+                send_warnings,
+            ),
+        },
+    }
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        result = client.agencyclients().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.agencyclients().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @agencyclients.command(name="add-passport-organization")
@@ -278,6 +264,7 @@ def add(
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def add_passport_organization(
     ctx,
     name,
@@ -289,31 +276,26 @@ def add_passport_organization(
     dry_run,
 ):
     """Add passport organization agency client"""
-    try:
-        params = {
-            "Name": name,
-            "Currency": currency,
-            "Notification": _build_notification(
-                notification_email,
-                notification_lang,
-                send_account_news,
-                send_warnings,
-            ),
-        }
+    params = {
+        "Name": name,
+        "Currency": currency,
+        "Notification": _build_notification(
+            notification_email,
+            notification_lang,
+            send_account_news,
+            send_warnings,
+        ),
+    }
 
-        body = {"method": "addPassportOrganization", "params": params}
+    body = {"method": "addPassportOrganization", "params": params}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
-        result = client.agencyclients().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = client_from_ctx(ctx, create_client)
+    result = client.agencyclients().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @agencyclients.command(name="add-passport-organization-member")
@@ -325,44 +307,38 @@ def add_passport_organization(
 @click.option("--invite-phone", help="Invitation phone")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def add_passport_organization_member(
     ctx, passport_organization_login, role, invite_email, invite_phone, dry_run
 ):
     """Invite user to passport organization"""
-    try:
-        if not invite_email and not invite_phone:
-            raise click.UsageError(
-                t("Provide at least one of --invite-email or --invite-phone")
-            )
+    if not invite_email and not invite_phone:
+        raise click.UsageError(
+            t("Provide at least one of --invite-email or --invite-phone")
+        )
 
-        send_invite_to = {}
-        if invite_email:
-            send_invite_to["Email"] = invite_email
-        if invite_phone:
-            send_invite_to["Phone"] = invite_phone
+    send_invite_to = {}
+    if invite_email:
+        send_invite_to["Email"] = invite_email
+    if invite_phone:
+        send_invite_to["Phone"] = invite_phone
 
-        body = {
-            "method": "addPassportOrganizationMember",
-            "params": {
-                "PassportOrganizationLogin": passport_organization_login,
-                "Role": role,
-                "SendInviteTo": send_invite_to,
-            },
-        }
+    body = {
+        "method": "addPassportOrganizationMember",
+        "params": {
+            "PassportOrganizationLogin": passport_organization_login,
+            "Role": role,
+            "SendInviteTo": send_invite_to,
+        },
+    }
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
-        result = client.agencyclients().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = client_from_ctx(ctx, create_client)
+    result = client.agencyclients().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @agencyclients.command()
@@ -389,6 +365,7 @@ def add_passport_organization_member(
 @click.option("--clear-grants", is_flag=True, help="Clear all grants")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def update(
     ctx,
     client_id,
@@ -405,49 +382,40 @@ def update(
     dry_run,
 ):
     """Update agency client"""
-    try:
-        if grants and clear_grants:
-            raise click.UsageError(
-                t("--grant and --clear-grants are mutually exclusive")
-            )
+    if grants and clear_grants:
+        raise click.UsageError(t("--grant and --clear-grants are mutually exclusive"))
 
-        notification = build_notification_update(
-            notification_email,
-            notification_lang,
-            parse_email_subscription_specs(list(email_subscriptions)),
-        )
-        client_data = {
-            "ClientId": client_id,
-            **build_client_update_item(
-                client_info,
-                phone,
-                notification,
-                parse_client_setting_specs(list(settings)),
-                parse_tin_info(tin_type, tin),
-            ),
-        }
-        if grants:
-            client_data["Grants"] = parse_grant_specs(list(grants))
-        if clear_grants:
-            client_data["Grants"] = []
-        if len(client_data) == 1:
-            raise click.UsageError(t("Provide at least one field to update"))
+    notification = build_notification_update(
+        notification_email,
+        notification_lang,
+        parse_email_subscription_specs(list(email_subscriptions)),
+    )
+    client_data = {
+        "ClientId": client_id,
+        **build_client_update_item(
+            client_info,
+            phone,
+            notification,
+            parse_client_setting_specs(list(settings)),
+            parse_tin_info(tin_type, tin),
+        ),
+    }
+    if grants:
+        client_data["Grants"] = parse_grant_specs(list(grants))
+    if clear_grants:
+        client_data["Grants"] = []
+    if len(client_data) == 1:
+        raise click.UsageError(t("Provide at least one field to update"))
 
-        body = {"method": "update", "params": {"Clients": [client_data]}}
+    body = {"method": "update", "params": {"Clients": [client_data]}}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
-        result = client.agencyclients().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = client_from_ctx(ctx, create_client)
+    result = client.agencyclients().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @agencyclients.command()

--- a/direct_cli/commands/audiencetargets.py
+++ b/direct_cli/commands/audiencetargets.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..i18n import t
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import add_criteria_csv, get_default_fields, parse_ids, MICRO_RUBLES
 
 
@@ -29,6 +29,7 @@ def audiencetargets():
 @click.option("--fields", help="Comma-separated field names")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def get(
     ctx,
     ids,
@@ -45,53 +46,46 @@ def get(
     dry_run,
 ):
     """Get audience targets"""
-    try:
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        criteria = {}
-        if ids:
-            criteria["Ids"] = parse_ids(ids)
-        if adgroup_ids:
-            criteria["AdGroupIds"] = parse_ids(adgroup_ids)
-        if campaign_ids:
-            criteria["CampaignIds"] = parse_ids(campaign_ids)
-        add_criteria_csv(
-            criteria, "RetargetingListIds", retargeting_list_ids, integers=True
-        )
-        add_criteria_csv(criteria, "InterestIds", interest_ids, integers=True)
-        add_criteria_csv(criteria, "States", states, upper=True)
+    criteria = {}
+    if ids:
+        criteria["Ids"] = parse_ids(ids)
+    if adgroup_ids:
+        criteria["AdGroupIds"] = parse_ids(adgroup_ids)
+    if campaign_ids:
+        criteria["CampaignIds"] = parse_ids(campaign_ids)
+    add_criteria_csv(
+        criteria, "RetargetingListIds", retargeting_list_ids, integers=True
+    )
+    add_criteria_csv(criteria, "InterestIds", interest_ids, integers=True)
+    add_criteria_csv(criteria, "States", states, upper=True)
 
-        field_names = (
-            fields.split(",") if fields else get_default_fields("audiencetargets")
-        )
-        params = {
-            "SelectionCriteria": criteria,
-            "FieldNames": field_names,
-        }
+    field_names = fields.split(",") if fields else get_default_fields("audiencetargets")
+    params = {
+        "SelectionCriteria": criteria,
+        "FieldNames": field_names,
+    }
 
-        if limit:
-            params["Page"] = {"Limit": limit}
+    if limit:
+        params["Page"] = {"Limit": limit}
 
-        body = {"method": "get", "params": params}
+    body = {"method": "get", "params": params}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        result = client.audiencetargets().post(data=body)
+    result = client.audiencetargets().post(data=body)
 
-        if fetch_all:
-            items = []
-            for item in result().iter_items():
-                items.append(item)
-            format_output(items, output_format, output)
-        else:
-            data = result().extract()
-            format_output(data, output_format, output)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    if fetch_all:
+        items = []
+        for item in result().iter_items():
+            items.append(item)
+        format_output(items, output_format, output)
+    else:
+        data = result().extract()
+        format_output(data, output_format, output)
 
 
 @audiencetargets.command()
@@ -106,6 +100,7 @@ def get(
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def add(
     ctx,
     adgroup_id,
@@ -116,40 +111,33 @@ def add(
     dry_run,
 ):
     """Add audience target"""
-    try:
-        if retargeting_list_id is None and interest_id is None:
-            raise click.UsageError(
-                t("Provide at least one of --retargeting-list-id or --interest-id")
-            )
+    if retargeting_list_id is None and interest_id is None:
+        raise click.UsageError(
+            t("Provide at least one of --retargeting-list-id or --interest-id")
+        )
 
-        target_data = {
-            "AdGroupId": adgroup_id,
-        }
-        if retargeting_list_id is not None:
-            target_data["RetargetingListId"] = retargeting_list_id
-        if interest_id is not None:
-            target_data["InterestId"] = interest_id
+    target_data = {
+        "AdGroupId": adgroup_id,
+    }
+    if retargeting_list_id is not None:
+        target_data["RetargetingListId"] = retargeting_list_id
+    if interest_id is not None:
+        target_data["InterestId"] = interest_id
 
-        if bid is not None:
-            target_data["ContextBid"] = bid
-        if priority:
-            target_data["StrategyPriority"] = priority.upper()
+    if bid is not None:
+        target_data["ContextBid"] = bid
+    if priority:
+        target_data["StrategyPriority"] = priority.upper()
 
-        body = {"method": "add", "params": {"AudienceTargets": [target_data]}}
+    body = {"method": "add", "params": {"AudienceTargets": [target_data]}}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
-        result = client.audiencetargets().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = client_from_ctx(ctx, create_client)
+    result = client.audiencetargets().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @audiencetargets.command(name="set-bids")
@@ -160,123 +148,103 @@ def add(
 @click.option("--priority", help="Strategy priority")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def set_bids(ctx, target_id, adgroup_id, campaign_id, context_bid, priority, dry_run):
     """Set audience target bids"""
-    try:
-        bid_data = {}
-        if target_id is not None:
-            bid_data["Id"] = target_id
-        if adgroup_id is not None:
-            bid_data["AdGroupId"] = adgroup_id
-        if campaign_id is not None:
-            bid_data["CampaignId"] = campaign_id
-        if context_bid is not None:
-            bid_data["ContextBid"] = context_bid
-        if priority:
-            bid_data["StrategyPriority"] = priority
-        bid_fields = {k for k in ("ContextBid", "StrategyPriority") if k in bid_data}
-        selector_fields = {
-            k for k in ("Id", "AdGroupId", "CampaignId") if k in bid_data
-        }
-        if not selector_fields:
-            raise click.UsageError(
-                t("Provide a target selector (--id, --adgroup-id, or --campaign-id)")
-            )
-        if not bid_fields:
-            raise click.UsageError(
-                t("Provide at least one bid field (--context-bid or --priority)")
-            )
+    bid_data = {}
+    if target_id is not None:
+        bid_data["Id"] = target_id
+    if adgroup_id is not None:
+        bid_data["AdGroupId"] = adgroup_id
+    if campaign_id is not None:
+        bid_data["CampaignId"] = campaign_id
+    if context_bid is not None:
+        bid_data["ContextBid"] = context_bid
+    if priority:
+        bid_data["StrategyPriority"] = priority
+    bid_fields = {k for k in ("ContextBid", "StrategyPriority") if k in bid_data}
+    selector_fields = {k for k in ("Id", "AdGroupId", "CampaignId") if k in bid_data}
+    if not selector_fields:
+        raise click.UsageError(
+            t("Provide a target selector (--id, --adgroup-id, or --campaign-id)")
+        )
+    if not bid_fields:
+        raise click.UsageError(
+            t("Provide at least one bid field (--context-bid or --priority)")
+        )
 
-        body = {"method": "setBids", "params": {"Bids": [bid_data]}}
+    body = {"method": "setBids", "params": {"Bids": [bid_data]}}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
-        result = client.audiencetargets().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = client_from_ctx(ctx, create_client)
+    result = client.audiencetargets().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @audiencetargets.command()
 @click.option("--id", "target_id", required=True, type=int, help="Target ID")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def delete(ctx, target_id, dry_run):
     """Delete audience target"""
-    try:
-        body = {
-            "method": "delete",
-            "params": {"SelectionCriteria": {"Ids": [target_id]}},
-        }
+    body = {
+        "method": "delete",
+        "params": {"SelectionCriteria": {"Ids": [target_id]}},
+    }
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        result = client.audiencetargets().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.audiencetargets().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @audiencetargets.command()
 @click.option("--id", "target_id", required=True, type=int, help="Target ID")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def suspend(ctx, target_id, dry_run):
     """Suspend audience target"""
-    try:
-        body = {
-            "method": "suspend",
-            "params": {"SelectionCriteria": {"Ids": [target_id]}},
-        }
+    body = {
+        "method": "suspend",
+        "params": {"SelectionCriteria": {"Ids": [target_id]}},
+    }
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        result = client.audiencetargets().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.audiencetargets().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @audiencetargets.command()
 @click.option("--id", "target_id", required=True, type=int, help="Target ID")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def resume(ctx, target_id, dry_run):
     """Resume audience target"""
-    try:
-        body = {
-            "method": "resume",
-            "params": {"SelectionCriteria": {"Ids": [target_id]}},
-        }
+    body = {
+        "method": "resume",
+        "params": {"SelectionCriteria": {"Ids": [target_id]}},
+    }
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        result = client.audiencetargets().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.audiencetargets().post(data=body)
+    format_output(result().extract(), "json", None)

--- a/direct_cli/commands/dynamicads.py
+++ b/direct_cli/commands/dynamicads.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..i18n import t
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import get_default_fields, parse_condition_specs, parse_ids, MICRO_RUBLES
 
 
@@ -27,6 +27,7 @@ def dynamicads():
 @click.option("--fields", help="Comma-separated field names")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def get(
     ctx,
     ids,
@@ -41,48 +42,43 @@ def get(
     dry_run,
 ):
     """Get dynamic ad targets"""
-    try:
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        field_names = fields.split(",") if fields else get_default_fields("dynamicads")
+    field_names = fields.split(",") if fields else get_default_fields("dynamicads")
 
-        criteria = {}
-        if ids:
-            criteria["Ids"] = parse_ids(ids)
-        if adgroup_ids:
-            criteria["AdGroupIds"] = parse_ids(adgroup_ids)
-        if campaign_ids:
-            criteria["CampaignIds"] = parse_ids(campaign_ids)
-        if states:
-            criteria["States"] = [
-                item.strip().upper() for item in states.split(",") if item.strip()
-            ]
+    criteria = {}
+    if ids:
+        criteria["Ids"] = parse_ids(ids)
+    if adgroup_ids:
+        criteria["AdGroupIds"] = parse_ids(adgroup_ids)
+    if campaign_ids:
+        criteria["CampaignIds"] = parse_ids(campaign_ids)
+    if states:
+        criteria["States"] = [
+            item.strip().upper() for item in states.split(",") if item.strip()
+        ]
 
-        params = {"SelectionCriteria": criteria, "FieldNames": field_names}
+    params = {"SelectionCriteria": criteria, "FieldNames": field_names}
 
-        if limit:
-            params["Page"] = {"Limit": limit}
+    if limit:
+        params["Page"] = {"Limit": limit}
 
-        body = {"method": "get", "params": params}
+    body = {"method": "get", "params": params}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        result = client.dynamicads().post(data=body)
+    result = client.dynamicads().post(data=body)
 
-        if fetch_all:
-            items = []
-            for item in result().iter_items():
-                items.append(item)
-            format_output(items, output_format, output)
-        else:
-            data = result().extract()
-            format_output(data, output_format, output)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    if fetch_all:
+        items = []
+        for item in result().iter_items():
+            items.append(item)
+        format_output(items, output_format, output)
+    else:
+        data = result().extract()
+        format_output(data, output_format, output)
 
 
 @dynamicads.command()
@@ -99,115 +95,97 @@ def get(
 @click.option("--priority", help="Strategy priority")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def add(ctx, adgroup_id, name, conditions, bid, context_bid, priority, dry_run):
     """Add dynamic ad target"""
-    try:
-        # WSDL DynamicTextAdTargetAddItem.Conditions is minOccurs=0;
-        # the CLI used to require it (over-constraint, issue #198 H7).
-        target_data = {
-            "AdGroupId": adgroup_id,
-            "Name": name,
-        }
-        if conditions:
-            target_data["Conditions"] = parse_condition_specs(list(conditions))
-        if bid is not None:
-            target_data["Bid"] = bid
-        if context_bid is not None:
-            target_data["ContextBid"] = context_bid
-        if priority:
-            target_data["StrategyPriority"] = priority
+    # WSDL DynamicTextAdTargetAddItem.Conditions is minOccurs=0;
+    # the CLI used to require it (over-constraint, issue #198 H7).
+    target_data = {
+        "AdGroupId": adgroup_id,
+        "Name": name,
+    }
+    if conditions:
+        target_data["Conditions"] = parse_condition_specs(list(conditions))
+    if bid is not None:
+        target_data["Bid"] = bid
+    if context_bid is not None:
+        target_data["ContextBid"] = context_bid
+    if priority:
+        target_data["StrategyPriority"] = priority
 
-        body = {"method": "add", "params": {"Webpages": [target_data]}}
+    body = {"method": "add", "params": {"Webpages": [target_data]}}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
-        result = client.dynamicads().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = client_from_ctx(ctx, create_client)
+    result = client.dynamicads().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @dynamicads.command()
 @click.option("--id", "target_id", required=True, type=int, help="Target ID")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def delete(ctx, target_id, dry_run):
     """Delete dynamic ad target"""
-    try:
-        body = {
-            "method": "delete",
-            "params": {"SelectionCriteria": {"Ids": [target_id]}},
-        }
+    body = {
+        "method": "delete",
+        "params": {"SelectionCriteria": {"Ids": [target_id]}},
+    }
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        result = client.dynamicads().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.dynamicads().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @dynamicads.command()
 @click.option("--id", "target_id", required=True, type=int, help="Target ID")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def suspend(ctx, target_id, dry_run):
     """Suspend dynamic ad target"""
-    try:
-        body = {
-            "method": "suspend",
-            "params": {"SelectionCriteria": {"Ids": [target_id]}},
-        }
+    body = {
+        "method": "suspend",
+        "params": {"SelectionCriteria": {"Ids": [target_id]}},
+    }
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
-        result = client.dynamicads().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = client_from_ctx(ctx, create_client)
+    result = client.dynamicads().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @dynamicads.command()
 @click.option("--id", "target_id", required=True, type=int, help="Target ID")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def resume(ctx, target_id, dry_run):
     """Resume dynamic ad target"""
-    try:
-        body = {
-            "method": "resume",
-            "params": {"SelectionCriteria": {"Ids": [target_id]}},
-        }
+    body = {
+        "method": "resume",
+        "params": {"SelectionCriteria": {"Ids": [target_id]}},
+    }
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
-        result = client.dynamicads().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = client_from_ctx(ctx, create_client)
+    result = client.dynamicads().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @dynamicads.command(name="set-bids")
@@ -219,54 +197,41 @@ def resume(ctx, target_id, dry_run):
 @click.option("--priority", help="Strategy priority")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def set_bids(
     ctx, target_id, adgroup_id, campaign_id, bid, context_bid, priority, dry_run
 ):
     """Set dynamic ad target bids"""
-    try:
-        bid_data = {}
-        if target_id is not None:
-            bid_data["Id"] = target_id
-        if adgroup_id is not None:
-            bid_data["AdGroupId"] = adgroup_id
-        if campaign_id is not None:
-            bid_data["CampaignId"] = campaign_id
-        if bid is not None:
-            bid_data["Bid"] = bid
-        if context_bid is not None:
-            bid_data["ContextBid"] = context_bid
-        if priority:
-            bid_data["StrategyPriority"] = priority
-        bid_fields = {
-            k for k in ("Bid", "ContextBid", "StrategyPriority") if k in bid_data
-        }
-        selector_fields = {
-            k for k in ("Id", "AdGroupId", "CampaignId") if k in bid_data
-        }
-        if not selector_fields:
-            raise click.UsageError(
-                t("Provide a target selector (--id, --adgroup-id, or --campaign-id)")
-            )
-        if not bid_fields:
-            raise click.UsageError(
-                t(
-                    "Provide at least one bid field "
-                    "(--bid, --context-bid, or --priority)"
-                )
-            )
+    bid_data = {}
+    if target_id is not None:
+        bid_data["Id"] = target_id
+    if adgroup_id is not None:
+        bid_data["AdGroupId"] = adgroup_id
+    if campaign_id is not None:
+        bid_data["CampaignId"] = campaign_id
+    if bid is not None:
+        bid_data["Bid"] = bid
+    if context_bid is not None:
+        bid_data["ContextBid"] = context_bid
+    if priority:
+        bid_data["StrategyPriority"] = priority
+    bid_fields = {k for k in ("Bid", "ContextBid", "StrategyPriority") if k in bid_data}
+    selector_fields = {k for k in ("Id", "AdGroupId", "CampaignId") if k in bid_data}
+    if not selector_fields:
+        raise click.UsageError(
+            t("Provide a target selector (--id, --adgroup-id, or --campaign-id)")
+        )
+    if not bid_fields:
+        raise click.UsageError(
+            t("Provide at least one bid field " "(--bid, --context-bid, or --priority)")
+        )
 
-        body = {"method": "setBids", "params": {"Bids": [bid_data]}}
+    body = {"method": "setBids", "params": {"Bids": [bid_data]}}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
-        result = client.dynamicads().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = client_from_ctx(ctx, create_client)
+    result = client.dynamicads().post(data=body)
+    format_output(result().extract(), "json", None)

--- a/direct_cli/commands/dynamicfeedadtargets.py
+++ b/direct_cli/commands/dynamicfeedadtargets.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..i18n import t
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import get_default_fields, parse_condition_specs, parse_ids, MICRO_RUBLES
 
 
@@ -27,6 +27,7 @@ def dynamicfeedadtargets():
 @click.option("--fields", help="Comma-separated field names")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def get(
     ctx,
     ids,
@@ -41,55 +42,48 @@ def get(
     dry_run,
 ):
     """Get dynamic feed ad targets"""
-    try:
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        field_names = (
-            fields.split(",") if fields else get_default_fields("dynamicfeedadtargets")
-        )
+    field_names = (
+        fields.split(",") if fields else get_default_fields("dynamicfeedadtargets")
+    )
 
-        criteria = {}
-        if ids:
-            criteria["Ids"] = parse_ids(ids)
-        if adgroup_ids:
-            criteria["AdGroupIds"] = parse_ids(adgroup_ids)
-        if campaign_ids:
-            criteria["CampaignIds"] = parse_ids(campaign_ids)
-        if states:
-            criteria["States"] = [
-                item.strip().upper() for item in states.split(",") if item.strip()
-            ]
+    criteria = {}
+    if ids:
+        criteria["Ids"] = parse_ids(ids)
+    if adgroup_ids:
+        criteria["AdGroupIds"] = parse_ids(adgroup_ids)
+    if campaign_ids:
+        criteria["CampaignIds"] = parse_ids(campaign_ids)
+    if states:
+        criteria["States"] = [
+            item.strip().upper() for item in states.split(",") if item.strip()
+        ]
 
-        if not criteria:
-            raise click.UsageError(t("Provide at least one typed filter"))
+    if not criteria:
+        raise click.UsageError(t("Provide at least one typed filter"))
 
-        params = {"SelectionCriteria": criteria, "FieldNames": field_names}
+    params = {"SelectionCriteria": criteria, "FieldNames": field_names}
 
-        if limit:
-            params["Page"] = {"Limit": limit}
+    if limit:
+        params["Page"] = {"Limit": limit}
 
-        body = {"method": "get", "params": params}
+    body = {"method": "get", "params": params}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        result = client.dynamicfeedadtargets().post(data=body)
+    result = client.dynamicfeedadtargets().post(data=body)
 
-        if fetch_all:
-            items = []
-            for item in result().iter_items():
-                items.append(item)
-            format_output(items, output_format, output)
-        else:
-            data = result().extract()
-            format_output(data, output_format, output)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    if fetch_all:
+        items = []
+        for item in result().iter_items():
+            items.append(item)
+        format_output(items, output_format, output)
+    else:
+        data = result().extract()
+        format_output(data, output_format, output)
 
 
 @dynamicfeedadtargets.command()
@@ -110,118 +104,98 @@ def get(
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def add(
     ctx, adgroup_id, name, conditions, bid, context_bid, available_items_only, dry_run
 ):
     """Add dynamic feed ad target"""
-    try:
-        target_data = {
-            "AdGroupId": adgroup_id,
-            "Name": name,
-        }
-        parsed_conditions = (
-            parse_condition_specs(list(conditions)) if conditions else None
-        )
-        if parsed_conditions:
-            target_data["Conditions"] = {"Items": parsed_conditions}
-        if bid is not None:
-            target_data["Bid"] = bid
-        if context_bid is not None:
-            target_data["ContextBid"] = context_bid
-        if available_items_only:
-            target_data["AvailableItemsOnly"] = available_items_only.upper()
+    target_data = {
+        "AdGroupId": adgroup_id,
+        "Name": name,
+    }
+    parsed_conditions = parse_condition_specs(list(conditions)) if conditions else None
+    if parsed_conditions:
+        target_data["Conditions"] = {"Items": parsed_conditions}
+    if bid is not None:
+        target_data["Bid"] = bid
+    if context_bid is not None:
+        target_data["ContextBid"] = context_bid
+    if available_items_only:
+        target_data["AvailableItemsOnly"] = available_items_only.upper()
 
-        body = {"method": "add", "params": {"DynamicFeedAdTargets": [target_data]}}
+    body = {"method": "add", "params": {"DynamicFeedAdTargets": [target_data]}}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
-        result = client.dynamicfeedadtargets().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = client_from_ctx(ctx, create_client)
+    result = client.dynamicfeedadtargets().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @dynamicfeedadtargets.command()
 @click.option("--id", "target_id", required=True, type=int, help="Target ID")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def delete(ctx, target_id, dry_run):
     """Delete dynamic feed ad target"""
-    try:
-        body = {
-            "method": "delete",
-            "params": {"SelectionCriteria": {"Ids": [target_id]}},
-        }
+    body = {
+        "method": "delete",
+        "params": {"SelectionCriteria": {"Ids": [target_id]}},
+    }
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        result = client.dynamicfeedadtargets().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.dynamicfeedadtargets().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @dynamicfeedadtargets.command()
 @click.option("--id", "target_id", required=True, type=int, help="Target ID")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def suspend(ctx, target_id, dry_run):
     """Suspend dynamic feed ad target"""
-    try:
-        body = {
-            "method": "suspend",
-            "params": {"SelectionCriteria": {"Ids": [target_id]}},
-        }
+    body = {
+        "method": "suspend",
+        "params": {"SelectionCriteria": {"Ids": [target_id]}},
+    }
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
-        result = client.dynamicfeedadtargets().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = client_from_ctx(ctx, create_client)
+    result = client.dynamicfeedadtargets().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @dynamicfeedadtargets.command()
 @click.option("--id", "target_id", required=True, type=int, help="Target ID")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def resume(ctx, target_id, dry_run):
     """Resume dynamic feed ad target"""
-    try:
-        body = {
-            "method": "resume",
-            "params": {"SelectionCriteria": {"Ids": [target_id]}},
-        }
+    body = {
+        "method": "resume",
+        "params": {"SelectionCriteria": {"Ids": [target_id]}},
+    }
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
-        result = client.dynamicfeedadtargets().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = client_from_ctx(ctx, create_client)
+    result = client.dynamicfeedadtargets().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @dynamicfeedadtargets.command(name="set-bids")
@@ -232,44 +206,36 @@ def resume(ctx, target_id, dry_run):
 @click.option("--context-bid", type=MICRO_RUBLES, help="Context bid in micro-rubles")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def set_bids(ctx, target_id, adgroup_id, campaign_id, bid, context_bid, dry_run):
     """Set dynamic feed ad target bids"""
-    try:
-        bid_data = {}
-        if target_id is not None:
-            bid_data["Id"] = target_id
-        if adgroup_id is not None:
-            bid_data["AdGroupId"] = adgroup_id
-        if campaign_id is not None:
-            bid_data["CampaignId"] = campaign_id
-        if bid is not None:
-            bid_data["Bid"] = bid
-        if context_bid is not None:
-            bid_data["ContextBid"] = context_bid
+    bid_data = {}
+    if target_id is not None:
+        bid_data["Id"] = target_id
+    if adgroup_id is not None:
+        bid_data["AdGroupId"] = adgroup_id
+    if campaign_id is not None:
+        bid_data["CampaignId"] = campaign_id
+    if bid is not None:
+        bid_data["Bid"] = bid
+    if context_bid is not None:
+        bid_data["ContextBid"] = context_bid
 
-        has_selector = any(k in bid_data for k in ("Id", "AdGroupId", "CampaignId"))
-        has_bid = any(k in bid_data for k in ("Bid", "ContextBid"))
-        if not has_selector:
-            raise click.UsageError(
-                t("Provide a target selector (--id, --adgroup-id, or --campaign-id)")
-            )
-        if not has_bid:
-            raise click.UsageError(
-                t("Provide at least one bid (--bid or --context-bid)")
-            )
+    has_selector = any(k in bid_data for k in ("Id", "AdGroupId", "CampaignId"))
+    has_bid = any(k in bid_data for k in ("Bid", "ContextBid"))
+    if not has_selector:
+        raise click.UsageError(
+            t("Provide a target selector (--id, --adgroup-id, or --campaign-id)")
+        )
+    if not has_bid:
+        raise click.UsageError(t("Provide at least one bid (--bid or --context-bid)"))
 
-        body = {"method": "setBids", "params": {"Bids": [bid_data]}}
+    body = {"method": "setBids", "params": {"Bids": [bid_data]}}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
-        result = client.dynamicfeedadtargets().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = client_from_ctx(ctx, create_client)
+    result = client.dynamicfeedadtargets().post(data=body)
+    format_output(result().extract(), "json", None)

--- a/direct_cli/commands/smartadtargets.py
+++ b/direct_cli/commands/smartadtargets.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..i18n import t
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import get_default_fields, parse_condition_specs, parse_ids, MICRO_RUBLES
 
 
@@ -27,6 +27,7 @@ def smartadtargets():
 @click.option("--fields", help="Comma-separated field names")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def get(
     ctx,
     ids,
@@ -41,50 +42,43 @@ def get(
     dry_run,
 ):
     """Get smart ad targets"""
-    try:
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        field_names = (
-            fields.split(",") if fields else get_default_fields("smartadtargets")
-        )
+    field_names = fields.split(",") if fields else get_default_fields("smartadtargets")
 
-        criteria = {}
-        if ids:
-            criteria["Ids"] = parse_ids(ids)
-        if adgroup_ids:
-            criteria["AdGroupIds"] = parse_ids(adgroup_ids)
-        if campaign_ids:
-            criteria["CampaignIds"] = parse_ids(campaign_ids)
-        if states:
-            criteria["States"] = [
-                item.strip().upper() for item in states.split(",") if item.strip()
-            ]
+    criteria = {}
+    if ids:
+        criteria["Ids"] = parse_ids(ids)
+    if adgroup_ids:
+        criteria["AdGroupIds"] = parse_ids(adgroup_ids)
+    if campaign_ids:
+        criteria["CampaignIds"] = parse_ids(campaign_ids)
+    if states:
+        criteria["States"] = [
+            item.strip().upper() for item in states.split(",") if item.strip()
+        ]
 
-        params = {"SelectionCriteria": criteria, "FieldNames": field_names}
+    params = {"SelectionCriteria": criteria, "FieldNames": field_names}
 
-        if limit:
-            params["Page"] = {"Limit": limit}
+    if limit:
+        params["Page"] = {"Limit": limit}
 
-        body = {"method": "get", "params": params}
+    body = {"method": "get", "params": params}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        result = client.smartadtargets().post(data=body)
+    result = client.smartadtargets().post(data=body)
 
-        if fetch_all:
-            items = []
-            for item in result().iter_items():
-                items.append(item)
-            format_output(items, output_format, output)
-        else:
-            data = result().extract()
-            format_output(data, output_format, output)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    if fetch_all:
+        items = []
+        for item in result().iter_items():
+            items.append(item)
+        format_output(items, output_format, output)
+    else:
+        data = result().extract()
+        format_output(data, output_format, output)
 
 
 @smartadtargets.command()
@@ -107,6 +101,7 @@ def get(
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def add(
     ctx,
     adgroup_id,
@@ -120,40 +115,31 @@ def add(
     dry_run,
 ):
     """Add smart ad target"""
-    try:
-        target_data = {
-            "AdGroupId": adgroup_id,
-            "Name": name,
-            "Audience": audience,
-        }
-        if conditions:
-            target_data["Conditions"] = {
-                "Items": parse_condition_specs(list(conditions))
-            }
-        if average_cpc is not None:
-            target_data["AverageCpc"] = average_cpc
-        if average_cpa is not None:
-            target_data["AverageCpa"] = average_cpa
-        if priority:
-            target_data["StrategyPriority"] = priority
-        if available_items_only:
-            target_data["AvailableItemsOnly"] = available_items_only.upper()
+    target_data = {
+        "AdGroupId": adgroup_id,
+        "Name": name,
+        "Audience": audience,
+    }
+    if conditions:
+        target_data["Conditions"] = {"Items": parse_condition_specs(list(conditions))}
+    if average_cpc is not None:
+        target_data["AverageCpc"] = average_cpc
+    if average_cpa is not None:
+        target_data["AverageCpa"] = average_cpa
+    if priority:
+        target_data["StrategyPriority"] = priority
+    if available_items_only:
+        target_data["AvailableItemsOnly"] = available_items_only.upper()
 
-        body = {"method": "add", "params": {"SmartAdTargets": [target_data]}}
+    body = {"method": "add", "params": {"SmartAdTargets": [target_data]}}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
-        result = client.smartadtargets().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = client_from_ctx(ctx, create_client)
+    result = client.smartadtargets().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @smartadtargets.command()
@@ -176,6 +162,7 @@ def add(
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def update(
     ctx,
     target_id,
@@ -189,118 +176,97 @@ def update(
     dry_run,
 ):
     """Update smart ad target"""
-    try:
-        target_data = {"Id": target_id}
-        if name:
-            target_data["Name"] = name
-        if audience:
-            target_data["Audience"] = audience
-        if conditions:
-            target_data["Conditions"] = {
-                "Items": parse_condition_specs(list(conditions))
-            }
-        if average_cpc is not None:
-            target_data["AverageCpc"] = average_cpc
-        if average_cpa is not None:
-            target_data["AverageCpa"] = average_cpa
-        if priority:
-            target_data["StrategyPriority"] = priority
-        if available_items_only:
-            target_data["AvailableItemsOnly"] = available_items_only.upper()
-        if len(target_data) == 1:
-            raise click.UsageError(t("Provide at least one field to update"))
+    target_data = {"Id": target_id}
+    if name:
+        target_data["Name"] = name
+    if audience:
+        target_data["Audience"] = audience
+    if conditions:
+        target_data["Conditions"] = {"Items": parse_condition_specs(list(conditions))}
+    if average_cpc is not None:
+        target_data["AverageCpc"] = average_cpc
+    if average_cpa is not None:
+        target_data["AverageCpa"] = average_cpa
+    if priority:
+        target_data["StrategyPriority"] = priority
+    if available_items_only:
+        target_data["AvailableItemsOnly"] = available_items_only.upper()
+    if len(target_data) == 1:
+        raise click.UsageError(t("Provide at least one field to update"))
 
-        body = {"method": "update", "params": {"SmartAdTargets": [target_data]}}
+    body = {"method": "update", "params": {"SmartAdTargets": [target_data]}}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
-        result = client.smartadtargets().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = client_from_ctx(ctx, create_client)
+    result = client.smartadtargets().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @smartadtargets.command()
 @click.option("--id", "target_id", required=True, type=int, help="Target ID")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def delete(ctx, target_id, dry_run):
     """Delete smart ad target"""
-    try:
-        body = {
-            "method": "delete",
-            "params": {"SelectionCriteria": {"Ids": [target_id]}},
-        }
+    body = {
+        "method": "delete",
+        "params": {"SelectionCriteria": {"Ids": [target_id]}},
+    }
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        result = client.smartadtargets().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.smartadtargets().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @smartadtargets.command()
 @click.option("--id", "target_id", required=True, type=int, help="Target ID")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def suspend(ctx, target_id, dry_run):
     """Suspend smart ad target"""
-    try:
-        body = {
-            "method": "suspend",
-            "params": {"SelectionCriteria": {"Ids": [target_id]}},
-        }
+    body = {
+        "method": "suspend",
+        "params": {"SelectionCriteria": {"Ids": [target_id]}},
+    }
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
-        result = client.smartadtargets().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = client_from_ctx(ctx, create_client)
+    result = client.smartadtargets().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @smartadtargets.command()
 @click.option("--id", "target_id", required=True, type=int, help="Target ID")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def resume(ctx, target_id, dry_run):
     """Resume smart ad target"""
-    try:
-        body = {
-            "method": "resume",
-            "params": {"SelectionCriteria": {"Ids": [target_id]}},
-        }
+    body = {
+        "method": "resume",
+        "params": {"SelectionCriteria": {"Ids": [target_id]}},
+    }
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
-        result = client.smartadtargets().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = client_from_ctx(ctx, create_client)
+    result = client.smartadtargets().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @smartadtargets.command(name="set-bids")
@@ -312,6 +278,7 @@ def resume(ctx, target_id, dry_run):
 @click.option("--priority", help="Strategy priority")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def set_bids(
     ctx,
     target_id,
@@ -323,47 +290,40 @@ def set_bids(
     dry_run,
 ):
     """Set smart ad target bids"""
-    try:
-        bid_data = {}
-        if target_id is not None:
-            bid_data["Id"] = target_id
-        if adgroup_id is not None:
-            bid_data["AdGroupId"] = adgroup_id
-        if campaign_id is not None:
-            bid_data["CampaignId"] = campaign_id
-        if average_cpc is not None:
-            bid_data["AverageCpc"] = average_cpc
-        if average_cpa is not None:
-            bid_data["AverageCpa"] = average_cpa
-        if priority:
-            bid_data["StrategyPriority"] = priority
-        bid_fields = {
-            k for k in ("AverageCpc", "AverageCpa", "StrategyPriority") if k in bid_data
-        }
-        if not bid_data:
-            raise click.UsageError(
-                t("Provide target selection and bid fields for set-bids")
+    bid_data = {}
+    if target_id is not None:
+        bid_data["Id"] = target_id
+    if adgroup_id is not None:
+        bid_data["AdGroupId"] = adgroup_id
+    if campaign_id is not None:
+        bid_data["CampaignId"] = campaign_id
+    if average_cpc is not None:
+        bid_data["AverageCpc"] = average_cpc
+    if average_cpa is not None:
+        bid_data["AverageCpa"] = average_cpa
+    if priority:
+        bid_data["StrategyPriority"] = priority
+    bid_fields = {
+        k for k in ("AverageCpc", "AverageCpa", "StrategyPriority") if k in bid_data
+    }
+    if not bid_data:
+        raise click.UsageError(
+            t("Provide target selection and bid fields for set-bids")
+        )
+    if not bid_fields:
+        raise click.UsageError(
+            t(
+                "Provide at least one bid field"
+                " (--average-cpc, --average-cpa, or --priority)"
             )
-        if not bid_fields:
-            raise click.UsageError(
-                t(
-                    "Provide at least one bid field"
-                    " (--average-cpc, --average-cpa, or --priority)"
-                )
-            )
+        )
 
-        body = {"method": "setBids", "params": {"Bids": [bid_data]}}
+    body = {"method": "setBids", "params": {"Bids": [bid_data]}}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
-        result = client.smartadtargets().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = client_from_ctx(ctx, create_client)
+    result = client.smartadtargets().post(data=body)
+    format_output(result().extract(), "json", None)


### PR DESCRIPTION
Часть эпика #491, серия **A2** — конверсия targets/clients модулей. Зависит от #503.

## Что сделано

Чистые wrapper-команды → `@handle_api_errors`:
- `agencyclients.py`: get, add, add_passport_organization, add_passport_organization_member, update (5)
- `audiencetargets.py`: get, add, set_bids, delete, suspend, resume (6)
- `dynamicads.py`: get, add, delete, suspend, resume, set_bids (6)
- `dynamicfeedadtargets.py`: get, add, delete, suspend, resume, set_bids (6)
- `smartadtargets.py`: get, add, update, delete, suspend, resume, set_bids (7)

Тот же string-aware ast-codemod + гейт ast-эквивалентности.

## Объём

5 файлов, **+677 / −850**.

## Верификация

- Таргетные тесты: **74 passed, 10 skipped**.
- `black --check` чисто; flake8 — **0 новых** vs main (эти файлы вообще без замечаний); import OK.

Part of #493.

🤖 Generated with [Claude Code](https://claude.com/claude-code)