### PR TITLE
refactor: @handle_api_errors on pre-try functions, closes A2 (dedup #491 A2c)

### DIFF
--- a/direct_cli/commands/adgroups.py
+++ b/direct_cli/commands/adgroups.py
@@ -8,7 +8,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..i18n import t
-from ..output import format_output, handle_api_errors, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import (
     add_criteria_csv,
     get_default_fields,
@@ -577,6 +577,7 @@ def _post_adgroups(client: Any, body: dict[str, Any]) -> Any:
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def get(
     ctx,
     ids,
@@ -608,97 +609,90 @@ def get(
     if status and statuses:
         raise click.UsageError(t("--status and --statuses are mutually exclusive"))
 
-    try:
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        field_names = fields.split(",") if fields else get_default_fields("adgroups")
+    field_names = fields.split(",") if fields else get_default_fields("adgroups")
 
-        raw_nested = (
-            (
-                "AutotargetingSettingsBrandOptionsFieldNames",
-                autotargeting_settings_brand_options_field_names,
-            ),
-            (
-                "AutotargetingSettingsCategoriesFieldNames",
-                autotargeting_settings_categories_field_names,
-            ),
-            (
-                "DynamicTextAdGroupFieldNames",
-                dynamic_text_ad_group_field_names,
-            ),
-            (
-                "DynamicTextFeedAdGroupFieldNames",
-                dynamic_text_feed_ad_group_field_names,
-            ),
-            ("MobileAppAdGroupFieldNames", mobile_app_ad_group_field_names),
-            ("SmartAdGroupFieldNames", smart_ad_group_field_names),
-            (
-                "TextAdGroupFeedParamsFieldNames",
-                text_ad_group_feed_params_field_names,
-            ),
-            ("UnifiedAdGroupFieldNames", unified_ad_group_field_names),
-        )
-        parsed_nested = {}
-        for wsdl_key, raw_value in raw_nested:
-            parsed = parse_csv_strings(raw_value)
-            if raw_value is not None and not parsed:
-                raise click.UsageError(
-                    t("Provide a non-empty comma-separated {wsdl_key} list.").format(
-                        wsdl_key=wsdl_key
-                    )
+    raw_nested = (
+        (
+            "AutotargetingSettingsBrandOptionsFieldNames",
+            autotargeting_settings_brand_options_field_names,
+        ),
+        (
+            "AutotargetingSettingsCategoriesFieldNames",
+            autotargeting_settings_categories_field_names,
+        ),
+        (
+            "DynamicTextAdGroupFieldNames",
+            dynamic_text_ad_group_field_names,
+        ),
+        (
+            "DynamicTextFeedAdGroupFieldNames",
+            dynamic_text_feed_ad_group_field_names,
+        ),
+        ("MobileAppAdGroupFieldNames", mobile_app_ad_group_field_names),
+        ("SmartAdGroupFieldNames", smart_ad_group_field_names),
+        (
+            "TextAdGroupFeedParamsFieldNames",
+            text_ad_group_feed_params_field_names,
+        ),
+        ("UnifiedAdGroupFieldNames", unified_ad_group_field_names),
+    )
+    parsed_nested = {}
+    for wsdl_key, raw_value in raw_nested:
+        parsed = parse_csv_strings(raw_value)
+        if raw_value is not None and not parsed:
+            raise click.UsageError(
+                t("Provide a non-empty comma-separated {wsdl_key} list.").format(
+                    wsdl_key=wsdl_key
                 )
-            if parsed:
-                parsed_nested[wsdl_key] = parsed
+            )
+        if parsed:
+            parsed_nested[wsdl_key] = parsed
 
-        criteria = {}
-        if ids:
-            criteria["Ids"] = parse_ids(ids)
-        if campaign_ids:
-            criteria["CampaignIds"] = parse_ids(campaign_ids)
-        if status:
-            criteria["Statuses"] = [status]
-        add_criteria_csv(criteria, "Statuses", statuses, upper=True)
-        if types:
-            criteria["Types"] = types.split(",")
-        add_criteria_csv(criteria, "TagIds", tag_ids, integers=True)
-        add_criteria_csv(criteria, "Tags", tags)
-        add_criteria_csv(criteria, "AppIconStatuses", app_icon_statuses, upper=True)
-        add_criteria_csv(criteria, "ServingStatuses", serving_statuses, upper=True)
-        add_criteria_csv(
-            criteria,
-            "NegativeKeywordSharedSetIds",
-            negative_keyword_shared_set_ids,
-            integers=True,
-        )
+    criteria = {}
+    if ids:
+        criteria["Ids"] = parse_ids(ids)
+    if campaign_ids:
+        criteria["CampaignIds"] = parse_ids(campaign_ids)
+    if status:
+        criteria["Statuses"] = [status]
+    add_criteria_csv(criteria, "Statuses", statuses, upper=True)
+    if types:
+        criteria["Types"] = types.split(",")
+    add_criteria_csv(criteria, "TagIds", tag_ids, integers=True)
+    add_criteria_csv(criteria, "Tags", tags)
+    add_criteria_csv(criteria, "AppIconStatuses", app_icon_statuses, upper=True)
+    add_criteria_csv(criteria, "ServingStatuses", serving_statuses, upper=True)
+    add_criteria_csv(
+        criteria,
+        "NegativeKeywordSharedSetIds",
+        negative_keyword_shared_set_ids,
+        integers=True,
+    )
 
-        params = {"SelectionCriteria": criteria, "FieldNames": field_names}
-        params.update(parsed_nested)
+    params = {"SelectionCriteria": criteria, "FieldNames": field_names}
+    params.update(parsed_nested)
 
-        if limit:
-            params["Page"] = {"Limit": limit}
+    if limit:
+        params["Page"] = {"Limit": limit}
 
-        body = {"method": "get", "params": params}
+    body = {"method": "get", "params": params}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        result = client.adgroups().post(data=body)
+    result = client.adgroups().post(data=body)
 
-        if fetch_all:
-            items = []
-            for item in result().iter_items():
-                items.append(item)
-            format_output(items, output_format, output)
-        else:
-            data = result().extract()
-            format_output(data, output_format, output)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    if fetch_all:
+        items = []
+        for item in result().iter_items():
+            items.append(item)
+        format_output(items, output_format, output)
+    else:
+        data = result().extract()
+        format_output(data, output_format, output)
 
 
 @adgroups.command()
@@ -1152,6 +1146,7 @@ def add(
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def update(
     ctx,
     adgroup_id,
@@ -1323,21 +1318,16 @@ def update(
             )
         )
 
-    try:
-        body = {"method": "update", "params": {"AdGroups": [adgroup_data]}}
+    body = {"method": "update", "params": {"AdGroups": [adgroup_data]}}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        result = _post_adgroups(client, body)
-        format_output(result().extract(), "json", None)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = _post_adgroups(client, body)
+    format_output(result().extract(), "json", None)
 
 
 @adgroups.command()

--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -8,7 +8,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..i18n import t
-from ..output import format_output, handle_api_errors, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import (
     add_criteria_csv,
     get_default_fields,
@@ -922,6 +922,7 @@ def _build_smart_ad_builder_ad_update(
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def get(
     ctx,
     ids,
@@ -966,117 +967,110 @@ def get(
     if status and statuses:
         raise click.UsageError(t("--status and --statuses are mutually exclusive"))
 
-    try:
-        field_names = (
-            fields.split(",") if fields else get_default_fields("ads", "FieldNames")
-        )
+    field_names = (
+        fields.split(",") if fields else get_default_fields("ads", "FieldNames")
+    )
 
-        raw_nested = (
-            (
-                "CpcVideoAdBuilderAdFieldNames",
-                cpc_video_ad_builder_ad_field_names,
-            ),
-            (
-                "CpmBannerAdBuilderAdFieldNames",
-                cpm_banner_ad_builder_ad_field_names,
-            ),
-            (
-                "CpmVideoAdBuilderAdFieldNames",
-                cpm_video_ad_builder_ad_field_names,
-            ),
-            ("DynamicTextAdFieldNames", dynamic_text_ad_field_names),
-            ("ListingAdFieldNames", listing_ad_field_names),
-            ("MobileAppAdBuilderAdFieldNames", mobile_app_ad_builder_ad_field_names),
-            ("MobileAppAdFieldNames", mobile_app_ad_field_names),
-            (
-                "MobileAppCpcVideoAdBuilderAdFieldNames",
-                mobile_app_cpc_video_ad_builder_ad_field_names,
-            ),
-            ("MobileAppImageAdFieldNames", mobile_app_image_ad_field_names),
-            ("ResponsiveAdFieldNames", responsive_ad_field_names),
-            ("ShoppingAdFieldNames", shopping_ad_field_names),
-            ("SmartAdBuilderAdFieldNames", smart_ad_builder_ad_field_names),
-            ("TextAdBuilderAdFieldNames", text_ad_builder_ad_field_names),
-            ("TextAdFieldNames", text_ad_field_names),
-            (
-                "TextAdPriceExtensionFieldNames",
-                text_ad_price_extension_field_names,
-            ),
-            ("TextImageAdFieldNames", text_image_ad_field_names),
-        )
-        parsed_nested = {}
-        for wsdl_key, raw_value in raw_nested:
-            parsed = _parse_field_names_option(wsdl_key, raw_value)
-            if parsed:
-                parsed_nested[wsdl_key] = parsed
-        parsed_nested.setdefault(
-            "TextAdFieldNames", get_default_fields("ads", "TextAdFieldNames")
-        )
+    raw_nested = (
+        (
+            "CpcVideoAdBuilderAdFieldNames",
+            cpc_video_ad_builder_ad_field_names,
+        ),
+        (
+            "CpmBannerAdBuilderAdFieldNames",
+            cpm_banner_ad_builder_ad_field_names,
+        ),
+        (
+            "CpmVideoAdBuilderAdFieldNames",
+            cpm_video_ad_builder_ad_field_names,
+        ),
+        ("DynamicTextAdFieldNames", dynamic_text_ad_field_names),
+        ("ListingAdFieldNames", listing_ad_field_names),
+        ("MobileAppAdBuilderAdFieldNames", mobile_app_ad_builder_ad_field_names),
+        ("MobileAppAdFieldNames", mobile_app_ad_field_names),
+        (
+            "MobileAppCpcVideoAdBuilderAdFieldNames",
+            mobile_app_cpc_video_ad_builder_ad_field_names,
+        ),
+        ("MobileAppImageAdFieldNames", mobile_app_image_ad_field_names),
+        ("ResponsiveAdFieldNames", responsive_ad_field_names),
+        ("ShoppingAdFieldNames", shopping_ad_field_names),
+        ("SmartAdBuilderAdFieldNames", smart_ad_builder_ad_field_names),
+        ("TextAdBuilderAdFieldNames", text_ad_builder_ad_field_names),
+        ("TextAdFieldNames", text_ad_field_names),
+        (
+            "TextAdPriceExtensionFieldNames",
+            text_ad_price_extension_field_names,
+        ),
+        ("TextImageAdFieldNames", text_image_ad_field_names),
+    )
+    parsed_nested = {}
+    for wsdl_key, raw_value in raw_nested:
+        parsed = _parse_field_names_option(wsdl_key, raw_value)
+        if parsed:
+            parsed_nested[wsdl_key] = parsed
+    parsed_nested.setdefault(
+        "TextAdFieldNames", get_default_fields("ads", "TextAdFieldNames")
+    )
 
-        criteria = {}
-        if ids:
-            criteria["Ids"] = parse_ids(ids)
-        if campaign_ids:
-            criteria["CampaignIds"] = parse_ids(campaign_ids)
-        if adgroup_ids:
-            criteria["AdGroupIds"] = parse_ids(adgroup_ids)
-        if status:
-            criteria["Statuses"] = [status]
-        add_criteria_csv(criteria, "Statuses", statuses, upper=True)
-        add_criteria_csv(criteria, "States", states, upper=True)
-        add_criteria_csv(criteria, "Types", types, upper=True)
-        if mobile:
-            criteria["Mobile"] = mobile.upper()
-        add_criteria_csv(criteria, "VCardIds", vcard_ids, integers=True)
-        add_criteria_csv(criteria, "SitelinkSetIds", sitelink_set_ids, integers=True)
-        add_criteria_csv(criteria, "AdImageHashes", image_hashes)
-        add_criteria_csv(
-            criteria, "VCardModerationStatuses", vcard_moderation_statuses, upper=True
-        )
-        add_criteria_csv(
-            criteria,
-            "SitelinksModerationStatuses",
-            sitelinks_moderation_statuses,
-            upper=True,
-        )
-        add_criteria_csv(
-            criteria, "AdImageModerationStatuses", image_moderation_statuses, upper=True
-        )
-        add_criteria_csv(criteria, "AdExtensionIds", adextension_ids, integers=True)
+    criteria = {}
+    if ids:
+        criteria["Ids"] = parse_ids(ids)
+    if campaign_ids:
+        criteria["CampaignIds"] = parse_ids(campaign_ids)
+    if adgroup_ids:
+        criteria["AdGroupIds"] = parse_ids(adgroup_ids)
+    if status:
+        criteria["Statuses"] = [status]
+    add_criteria_csv(criteria, "Statuses", statuses, upper=True)
+    add_criteria_csv(criteria, "States", states, upper=True)
+    add_criteria_csv(criteria, "Types", types, upper=True)
+    if mobile:
+        criteria["Mobile"] = mobile.upper()
+    add_criteria_csv(criteria, "VCardIds", vcard_ids, integers=True)
+    add_criteria_csv(criteria, "SitelinkSetIds", sitelink_set_ids, integers=True)
+    add_criteria_csv(criteria, "AdImageHashes", image_hashes)
+    add_criteria_csv(
+        criteria, "VCardModerationStatuses", vcard_moderation_statuses, upper=True
+    )
+    add_criteria_csv(
+        criteria,
+        "SitelinksModerationStatuses",
+        sitelinks_moderation_statuses,
+        upper=True,
+    )
+    add_criteria_csv(
+        criteria, "AdImageModerationStatuses", image_moderation_statuses, upper=True
+    )
+    add_criteria_csv(criteria, "AdExtensionIds", adextension_ids, integers=True)
 
-        params = {
-            "SelectionCriteria": criteria,
-            "FieldNames": field_names,
-        }
-        params.update(parsed_nested)
+    params = {
+        "SelectionCriteria": criteria,
+        "FieldNames": field_names,
+    }
+    params.update(parsed_nested)
 
-        if limit:
-            params["Page"] = {"Limit": limit}
+    if limit:
+        params["Page"] = {"Limit": limit}
 
-        body = {"method": "get", "params": params}
+    body = {"method": "get", "params": params}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        result = client.ads().post(data=body)
+    result = client.ads().post(data=body)
 
-        if fetch_all:
-            items = []
-            for item in result().iter_items():
-                items.append(item)
-            format_output(items, output_format, output)
-        else:
-            data = result().extract()
-            format_output(data, output_format, output)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    if fetch_all:
+        items = []
+        for item in result().iter_items():
+            items.append(item)
+        format_output(items, output_format, output)
+    else:
+        data = result().extract()
+        format_output(data, output_format, output)
 
 
 @ads.command()
@@ -1948,6 +1942,7 @@ def add(
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def update(
     ctx,
     ad_id,
@@ -2321,23 +2316,16 @@ def update(
             ).format(ad_type_norm=ad_type_norm)
         )
 
-    try:
-        body = {"method": "update", "params": {"Ads": [ad_data]}}
+    body = {"method": "update", "params": {"Ads": [ad_data]}}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        result = client.ads().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.ads().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @ads.command()

--- a/direct_cli/commands/balance.py
+++ b/direct_cli/commands/balance.py
@@ -4,7 +4,7 @@ import click
 
 from ..api import create_v4_client
 from ..i18n import t
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import parse_csv_strings
 from ..v4 import build_v4_body, call_v4
 from ..v4_contracts import v4_method_contract
@@ -23,6 +23,7 @@ from ..v4_contracts import v4_method_contract
 @click.option("--output", help="Output file")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def balance(ctx, logins, output_format, output, dry_run):
     """Check account money balance."""
     login_list = parse_csv_strings(logins)
@@ -42,17 +43,11 @@ def balance(ctx, logins, output_format, output, dry_run):
         format_output(build_v4_body("AccountManagement", param), "json", None)
         return
 
-    try:
-        client = create_v4_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            profile=ctx.obj.get("profile"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
-        data = call_v4(client, "AccountManagement", param)
-        format_output(data, output_format, output)
-    except click.ClickException:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = create_v4_client(
+        token=ctx.obj.get("token"),
+        login=ctx.obj.get("login"),
+        profile=ctx.obj.get("profile"),
+        sandbox=ctx.obj.get("sandbox"),
+    )
+    data = call_v4(client, "AccountManagement", param)
+    format_output(data, output_format, output)

--- a/direct_cli/commands/bids.py
+++ b/direct_cli/commands/bids.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..i18n import t
-from ..output import format_output, handle_api_errors, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import (
     add_criteria_csv,
     add_single_id_selector,
@@ -113,6 +113,7 @@ def get(
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def set(
     ctx,
     campaign_id,
@@ -140,41 +141,34 @@ def set(
             )
         )
 
-    try:
-        bid_data = {}
-        add_single_id_selector(
-            bid_data,
-            campaign_id=campaign_id,
-            adgroup_id=adgroup_id,
-            keyword_id=keyword_id,
-            command_name="bids set",
+    bid_data = {}
+    add_single_id_selector(
+        bid_data,
+        campaign_id=campaign_id,
+        adgroup_id=adgroup_id,
+        keyword_id=keyword_id,
+        command_name="bids set",
+    )
+    if bid is not None:
+        bid_data["Bid"] = bid
+    if context_bid is not None:
+        bid_data["ContextBid"] = context_bid
+    if autotargeting_search_bid_is_auto is not None:
+        bid_data["AutotargetingSearchBidIsAuto"] = (
+            autotargeting_search_bid_is_auto.upper()
         )
-        if bid is not None:
-            bid_data["Bid"] = bid
-        if context_bid is not None:
-            bid_data["ContextBid"] = context_bid
-        if autotargeting_search_bid_is_auto is not None:
-            bid_data["AutotargetingSearchBidIsAuto"] = (
-                autotargeting_search_bid_is_auto.upper()
-            )
-        if priority is not None:
-            bid_data["StrategyPriority"] = priority.upper()
+    if priority is not None:
+        bid_data["StrategyPriority"] = priority.upper()
 
-        body = {"method": "set", "params": {"Bids": [bid_data]}}
+    body = {"method": "set", "params": {"Bids": [bid_data]}}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
-        result = client.bids().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = client_from_ctx(ctx, create_client)
+    result = client.bids().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @bids.command(name="set-auto")

--- a/direct_cli/commands/campaigns.py
+++ b/direct_cli/commands/campaigns.py
@@ -9,7 +9,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..i18n import t
-from ..output import format_output, handle_api_errors, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import (
     build_selection_criteria,
     build_common_params,
@@ -667,6 +667,7 @@ def _reject_incompatible_flags(
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def get(
     ctx,
     ids,
@@ -696,100 +697,91 @@ def get(
     if status and statuses:
         raise click.UsageError(t("--status and --statuses are mutually exclusive"))
 
-    try:
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        # Parse field names
-        field_names = (
-            _parse_csv_option("--fields", fields)
-            if fields is not None
-            else get_default_fields("campaigns")
-        )
+    # Parse field names
+    field_names = (
+        _parse_csv_option("--fields", fields)
+        if fields is not None
+        else get_default_fields("campaigns")
+    )
 
-        # Build selection criteria
-        criteria = build_selection_criteria(
-            ids=parse_ids(ids), status=status, types=types
-        )
-        if criteria is None:
-            criteria = {}
-        add_criteria_csv(criteria, "Statuses", statuses, upper=True)
-        add_criteria_csv(criteria, "States", states, upper=True)
-        add_criteria_csv(criteria, "StatusesPayment", payment_statuses, upper=True)
+    # Build selection criteria
+    criteria = build_selection_criteria(ids=parse_ids(ids), status=status, types=types)
+    if criteria is None:
+        criteria = {}
+    add_criteria_csv(criteria, "Statuses", statuses, upper=True)
+    add_criteria_csv(criteria, "States", states, upper=True)
+    add_criteria_csv(criteria, "StatusesPayment", payment_statuses, upper=True)
 
-        # Build params
-        params = build_common_params(
-            criteria=criteria, field_names=field_names, limit=limit
-        )
-        selector_options = {
-            "TextCampaignFieldNames": (
-                "--text-campaign-field-names",
-                text_campaign_field_names,
-            ),
-            "TextCampaignSearchStrategyPlacementTypesFieldNames": (
-                "--text-campaign-search-strategy-placement-types-field-names",
-                text_campaign_search_strategy_placement_types_field_names,
-            ),
-            "MobileAppCampaignFieldNames": (
-                "--mobile-app-campaign-field-names",
-                mobile_app_campaign_field_names,
-            ),
-            "DynamicTextCampaignFieldNames": (
-                "--dynamic-text-campaign-field-names",
-                dynamic_text_campaign_field_names,
-            ),
-            "DynamicTextCampaignSearchStrategyPlacementTypesFieldNames": (
-                "--dynamic-text-campaign-search-strategy-placement-types-field-names",
-                dynamic_text_campaign_search_strategy_placement_types_field_names,
-            ),
-            "CpmBannerCampaignFieldNames": (
-                "--cpm-banner-campaign-field-names",
-                cpm_banner_campaign_field_names,
-            ),
-            "SmartCampaignFieldNames": (
-                "--smart-campaign-field-names",
-                smart_campaign_field_names,
-            ),
-            "UnifiedCampaignFieldNames": (
-                "--unified-campaign-field-names",
-                unified_campaign_field_names,
-            ),
-            "UnifiedCampaignSearchStrategyPlacementTypesFieldNames": (
-                "--unified-campaign-search-strategy-placement-types-field-names",
-                unified_campaign_search_strategy_placement_types_field_names,
-            ),
-            "UnifiedCampaignPackageBiddingStrategyPlatformsFieldNames": (
-                "--unified-campaign-package-bidding-strategy-platforms-field-names",
-                unified_campaign_package_bidding_strategy_platforms_field_names,
-            ),
-        }
-        for request_key, (option_name, value) in selector_options.items():
-            parsed = _parse_csv_option(option_name, value)
-            if parsed:
-                params[request_key] = parsed
+    # Build params
+    params = build_common_params(
+        criteria=criteria, field_names=field_names, limit=limit
+    )
+    selector_options = {
+        "TextCampaignFieldNames": (
+            "--text-campaign-field-names",
+            text_campaign_field_names,
+        ),
+        "TextCampaignSearchStrategyPlacementTypesFieldNames": (
+            "--text-campaign-search-strategy-placement-types-field-names",
+            text_campaign_search_strategy_placement_types_field_names,
+        ),
+        "MobileAppCampaignFieldNames": (
+            "--mobile-app-campaign-field-names",
+            mobile_app_campaign_field_names,
+        ),
+        "DynamicTextCampaignFieldNames": (
+            "--dynamic-text-campaign-field-names",
+            dynamic_text_campaign_field_names,
+        ),
+        "DynamicTextCampaignSearchStrategyPlacementTypesFieldNames": (
+            "--dynamic-text-campaign-search-strategy-placement-types-field-names",
+            dynamic_text_campaign_search_strategy_placement_types_field_names,
+        ),
+        "CpmBannerCampaignFieldNames": (
+            "--cpm-banner-campaign-field-names",
+            cpm_banner_campaign_field_names,
+        ),
+        "SmartCampaignFieldNames": (
+            "--smart-campaign-field-names",
+            smart_campaign_field_names,
+        ),
+        "UnifiedCampaignFieldNames": (
+            "--unified-campaign-field-names",
+            unified_campaign_field_names,
+        ),
+        "UnifiedCampaignSearchStrategyPlacementTypesFieldNames": (
+            "--unified-campaign-search-strategy-placement-types-field-names",
+            unified_campaign_search_strategy_placement_types_field_names,
+        ),
+        "UnifiedCampaignPackageBiddingStrategyPlatformsFieldNames": (
+            "--unified-campaign-package-bidding-strategy-platforms-field-names",
+            unified_campaign_package_bidding_strategy_platforms_field_names,
+        ),
+    }
+    for request_key, (option_name, value) in selector_options.items():
+        parsed = _parse_csv_option(option_name, value)
+        if parsed:
+            params[request_key] = parsed
 
-        body = {"method": "get", "params": params}
+    body = {"method": "get", "params": params}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        result = client.campaigns().post(data=body)
+    result = client.campaigns().post(data=body)
 
-        if fetch_all:
-            # Get all pages
-            items = []
-            for item in result().iter_items():
-                items.append(item)
-            format_output(items, output_format, output)
-        else:
-            data = result().extract()
-            format_output(data, output_format, output)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    if fetch_all:
+        # Get all pages
+        items = []
+        for item in result().iter_items():
+            items.append(item)
+        format_output(items, output_format, output)
+    else:
+        data = result().extract()
+        format_output(data, output_format, output)
 
 
 @campaigns.command()

--- a/direct_cli/commands/changes.py
+++ b/direct_cli/commands/changes.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..i18n import t
-from ..output import format_output, handle_api_errors, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import get_default_fields, parse_changes_datetime, parse_ids
 
 
@@ -51,6 +51,7 @@ _CHECK_FIELD_NAMES = frozenset({"CampaignIds", "AdGroupIds", "AdIds", "Campaigns
 @click.option("--format", "output_format", default="json", help="Output format")
 @click.option("--output", help="Output file")
 @click.pass_context
+@handle_api_errors
 def check(
     ctx, campaign_ids, ad_group_ids, ad_ids, timestamp, fields, output_format, output
 ):
@@ -108,23 +109,18 @@ def check(
             t("{id_flag} produced no valid IDs.").format(id_flag=id_flag)
         )
 
-    try:
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        params = {
-            id_field: id_value,
-            "Timestamp": parse_changes_datetime(timestamp),
-            "FieldNames": field_names,
-        }
+    params = {
+        id_field: id_value,
+        "Timestamp": parse_changes_datetime(timestamp),
+        "FieldNames": field_names,
+    }
 
-        body = {"method": "check", "params": params}
+    body = {"method": "check", "params": params}
 
-        result = client.changes().post(data=body)
-        format_output(result.data, output_format, output)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.changes().post(data=body)
+    format_output(result.data, output_format, output)
 
 
 @changes.command()

--- a/direct_cli/commands/keywordbids.py
+++ b/direct_cli/commands/keywordbids.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..i18n import t
-from ..output import format_output, handle_api_errors, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import (
     add_criteria_csv,
     add_single_id_selector,
@@ -167,6 +167,7 @@ def get(
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def set(
     ctx,
     campaign_id,
@@ -194,42 +195,35 @@ def set(
             )
         )
 
-    try:
-        bid_data = {}
-        add_single_id_selector(
-            bid_data,
-            campaign_id=campaign_id,
-            adgroup_id=adgroup_id,
-            keyword_id=keyword_id,
-            command_name="keywordbids set",
+    bid_data = {}
+    add_single_id_selector(
+        bid_data,
+        campaign_id=campaign_id,
+        adgroup_id=adgroup_id,
+        keyword_id=keyword_id,
+        command_name="keywordbids set",
+    )
+
+    if search_bid is not None:
+        bid_data["SearchBid"] = search_bid
+    if network_bid is not None:
+        bid_data["NetworkBid"] = network_bid
+    if autotargeting_search_bid_is_auto is not None:
+        bid_data["AutotargetingSearchBidIsAuto"] = (
+            autotargeting_search_bid_is_auto.upper()
         )
+    if priority is not None:
+        bid_data["StrategyPriority"] = priority.upper()
 
-        if search_bid is not None:
-            bid_data["SearchBid"] = search_bid
-        if network_bid is not None:
-            bid_data["NetworkBid"] = network_bid
-        if autotargeting_search_bid_is_auto is not None:
-            bid_data["AutotargetingSearchBidIsAuto"] = (
-                autotargeting_search_bid_is_auto.upper()
-            )
-        if priority is not None:
-            bid_data["StrategyPriority"] = priority.upper()
+    body = {"method": "set", "params": {"KeywordBids": [bid_data]}}
 
-        body = {"method": "set", "params": {"KeywordBids": [bid_data]}}
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
-
-        client = client_from_ctx(ctx, create_client)
-        result = client.keywordbids().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = client_from_ctx(ctx, create_client)
+    result = client.keywordbids().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @keywordbids.command(name="set-auto")

--- a/direct_cli/commands/keywords.py
+++ b/direct_cli/commands/keywords.py
@@ -436,6 +436,7 @@ def keywords():
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def get(
     ctx,
     ids,
@@ -459,85 +460,76 @@ def get(
     if status and statuses:
         raise click.UsageError(t("--status and --statuses are mutually exclusive"))
 
-    try:
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        field_names = fields.split(",") if fields else get_default_fields("keywords")
+    field_names = fields.split(",") if fields else get_default_fields("keywords")
 
-        parsed_brand_options = parse_csv_strings(
-            autotargeting_settings_brand_options_field_names
-        )
-        if (
-            autotargeting_settings_brand_options_field_names is not None
-            and not parsed_brand_options
-        ):
-            raise click.UsageError(
-                t(
-                    "Provide a non-empty comma-separated "
-                    "AutotargetingSettingsBrandOptionsFieldNames list."
-                )
+    parsed_brand_options = parse_csv_strings(
+        autotargeting_settings_brand_options_field_names
+    )
+    if (
+        autotargeting_settings_brand_options_field_names is not None
+        and not parsed_brand_options
+    ):
+        raise click.UsageError(
+            t(
+                "Provide a non-empty comma-separated "
+                "AutotargetingSettingsBrandOptionsFieldNames list."
             )
-
-        parsed_categories = parse_csv_strings(
-            autotargeting_settings_categories_field_names
         )
-        if (
-            autotargeting_settings_categories_field_names is not None
-            and not parsed_categories
-        ):
-            raise click.UsageError(
-                t(
-                    "Provide a non-empty comma-separated "
-                    "AutotargetingSettingsCategoriesFieldNames list."
-                )
+
+    parsed_categories = parse_csv_strings(autotargeting_settings_categories_field_names)
+    if (
+        autotargeting_settings_categories_field_names is not None
+        and not parsed_categories
+    ):
+        raise click.UsageError(
+            t(
+                "Provide a non-empty comma-separated "
+                "AutotargetingSettingsCategoriesFieldNames list."
             )
+        )
 
-        criteria = {}
-        if ids:
-            criteria["Ids"] = parse_ids(ids)
-        if adgroup_ids:
-            criteria["AdGroupIds"] = parse_ids(adgroup_ids)
-        if campaign_ids:
-            criteria["CampaignIds"] = parse_ids(campaign_ids)
-        if status:
-            criteria["Statuses"] = [status]
-        add_criteria_csv(criteria, "Statuses", statuses, upper=True)
-        add_criteria_csv(criteria, "States", states, upper=True)
-        if modified_since:
-            criteria["ModifiedSince"] = modified_since
-        add_criteria_csv(criteria, "ServingStatuses", serving_statuses, upper=True)
+    criteria = {}
+    if ids:
+        criteria["Ids"] = parse_ids(ids)
+    if adgroup_ids:
+        criteria["AdGroupIds"] = parse_ids(adgroup_ids)
+    if campaign_ids:
+        criteria["CampaignIds"] = parse_ids(campaign_ids)
+    if status:
+        criteria["Statuses"] = [status]
+    add_criteria_csv(criteria, "Statuses", statuses, upper=True)
+    add_criteria_csv(criteria, "States", states, upper=True)
+    if modified_since:
+        criteria["ModifiedSince"] = modified_since
+    add_criteria_csv(criteria, "ServingStatuses", serving_statuses, upper=True)
 
-        params = {"SelectionCriteria": criteria, "FieldNames": field_names}
-        if parsed_brand_options:
-            params["AutotargetingSettingsBrandOptionsFieldNames"] = parsed_brand_options
-        if parsed_categories:
-            params["AutotargetingSettingsCategoriesFieldNames"] = parsed_categories
+    params = {"SelectionCriteria": criteria, "FieldNames": field_names}
+    if parsed_brand_options:
+        params["AutotargetingSettingsBrandOptionsFieldNames"] = parsed_brand_options
+    if parsed_categories:
+        params["AutotargetingSettingsCategoriesFieldNames"] = parsed_categories
 
-        if limit:
-            params["Page"] = {"Limit": limit}
+    if limit:
+        params["Page"] = {"Limit": limit}
 
-        body = {"method": "get", "params": params}
+    body = {"method": "get", "params": params}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        result = client.keywords().post(data=body)
+    result = client.keywords().post(data=body)
 
-        if fetch_all:
-            items = []
-            for item in result().iter_items():
-                items.append(item)
-            format_output(items, output_format, output)
-        else:
-            data = result().extract()
-            format_output(data, output_format, output)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    if fetch_all:
+        items = []
+        for item in result().iter_items():
+            items.append(item)
+        format_output(items, output_format, output)
+    else:
+        data = result().extract()
+        format_output(data, output_format, output)
 
 
 @keywords.command()
@@ -628,6 +620,7 @@ def get(
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def add(
     ctx,
     adgroup_id,
@@ -745,48 +738,41 @@ def add(
         brand_options=autotargeting_brand_options,
     )
 
-    try:
-        keyword_data: Dict[str, Any] = {
-            "AdGroupId": adgroup_id,
-            "Keyword": keyword,
-        }
-        if bid is not None:
-            keyword_data["Bid"] = bid
-        if context_bid is not None:
-            keyword_data["ContextBid"] = context_bid
-        if autotargeting_search_bid_is_auto is not None:
-            keyword_data["AutotargetingSearchBidIsAuto"] = (
-                autotargeting_search_bid_is_auto.upper()
-            )
-        if priority is not None:
-            keyword_data["StrategyPriority"] = priority.upper()
-        if parsed_autotargeting_categories is not None:
-            keyword_data["AutotargetingCategories"] = parsed_autotargeting_categories
-        if parsed_autotargeting_brand_options is not None:
-            keyword_data["AutotargetingBrandOptions"] = (
-                parsed_autotargeting_brand_options
-            )
-        if autotargeting_settings is not None:
-            keyword_data["AutotargetingSettings"] = autotargeting_settings
-        if user_param_1:
-            keyword_data["UserParam1"] = user_param_1
-        if user_param_2:
-            keyword_data["UserParam2"] = user_param_2
+    keyword_data: Dict[str, Any] = {
+        "AdGroupId": adgroup_id,
+        "Keyword": keyword,
+    }
+    if bid is not None:
+        keyword_data["Bid"] = bid
+    if context_bid is not None:
+        keyword_data["ContextBid"] = context_bid
+    if autotargeting_search_bid_is_auto is not None:
+        keyword_data["AutotargetingSearchBidIsAuto"] = (
+            autotargeting_search_bid_is_auto.upper()
+        )
+    if priority is not None:
+        keyword_data["StrategyPriority"] = priority.upper()
+    if parsed_autotargeting_categories is not None:
+        keyword_data["AutotargetingCategories"] = parsed_autotargeting_categories
+    if parsed_autotargeting_brand_options is not None:
+        keyword_data["AutotargetingBrandOptions"] = parsed_autotargeting_brand_options
+    if autotargeting_settings is not None:
+        keyword_data["AutotargetingSettings"] = autotargeting_settings
+    if user_param_1:
+        keyword_data["UserParam1"] = user_param_1
+    if user_param_2:
+        keyword_data["UserParam2"] = user_param_2
 
-        body = {"method": "add", "params": {"Keywords": [keyword_data]}}
+    body = {"method": "add", "params": {"Keywords": [keyword_data]}}
 
-        if dry_run:
-            format_output(body, output_format, None)
-            return
+    if dry_run:
+        format_output(body, output_format, None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        result = client.keywords().post(data=body)
-        format_output(result().extract(), output_format, None)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.keywords().post(data=body)
+    format_output(result().extract(), output_format, None)
 
 
 def _bulk_add(
@@ -970,6 +956,7 @@ def _deprecated_bid_option(ctx, param, value):
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def update(
     ctx,
     keyword_id,
@@ -1036,21 +1023,16 @@ def update(
             )
         )
 
-    try:
-        body = {"method": "update", "params": {"Keywords": [keyword_data]}}
+    body = {"method": "update", "params": {"Keywords": [keyword_data]}}
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        result = client.keywords().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.keywords().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @keywords.command()

--- a/direct_cli/commands/sitelinks.py
+++ b/direct_cli/commands/sitelinks.py
@@ -10,7 +10,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..i18n import t
-from ..output import format_output, handle_api_errors, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import (
     get_default_fields,
     parse_csv_strings,
@@ -219,6 +219,7 @@ def get(
 )
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def add(ctx, sitelinks_specs, sitelinks_json, sitelinks_from_file, dry_run):
     """Add sitelinks set.
 
@@ -245,45 +246,38 @@ def add(ctx, sitelinks_specs, sitelinks_json, sitelinks_from_file, dry_run):
             )
         )
 
-    try:
-        if sitelinks_specs:
-            try:
-                sitelinks_payload = parse_sitelink_specs(list(sitelinks_specs))
-            except ValueError as exc:
-                raise click.UsageError(str(exc))
+    if sitelinks_specs:
+        try:
+            sitelinks_payload = parse_sitelink_specs(list(sitelinks_specs))
+        except ValueError as exc:
+            raise click.UsageError(str(exc))
+    else:
+        if sitelinks_json is not None:
+            raw_rows = _load_sitelinks_from_inline(sitelinks_json)
         else:
-            if sitelinks_json is not None:
-                raw_rows = _load_sitelinks_from_inline(sitelinks_json)
-            else:
-                raw_rows = _load_sitelinks_from_file(sitelinks_from_file)
+            raw_rows = _load_sitelinks_from_file(sitelinks_from_file)
 
-            if not raw_rows:
-                raise click.UsageError(t("Input contains no sitelink rows."))
+        if not raw_rows:
+            raise click.UsageError(t("Input contains no sitelink rows."))
 
-            sitelinks_payload = [
-                _normalize_sitelink_row(row, idx)
-                for idx, row in enumerate(raw_rows, start=1)
-            ]
+        sitelinks_payload = [
+            _normalize_sitelink_row(row, idx)
+            for idx, row in enumerate(raw_rows, start=1)
+        ]
 
-        body = {
-            "method": "add",
-            "params": {"SitelinksSets": [{"Sitelinks": sitelinks_payload}]},
-        }
+    body = {
+        "method": "add",
+        "params": {"SitelinksSets": [{"Sitelinks": sitelinks_payload}]},
+    }
 
-        if dry_run:
-            format_output(body, "json", None)
-            return
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
-        client = client_from_ctx(ctx, create_client)
+    client = client_from_ctx(ctx, create_client)
 
-        result = client.sitelinks().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    except click.UsageError:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    result = client.sitelinks().post(data=body)
+    format_output(result().extract(), "json", None)
 
 
 @sitelinks.command()

--- a/direct_cli/commands/v4account.py
+++ b/direct_cli/commands/v4account.py
@@ -8,7 +8,7 @@ import click
 
 from ..api import create_v4_client
 from ..i18n import t
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import parse_csv_strings, parse_ids
 from ..v4 import build_v4_body, call_v4
 from ..v4.money import parse_v4_money_sum
@@ -116,6 +116,7 @@ def _require_dry_run_or_sandbox(dry_run: bool, sandbox: bool) -> None:
         raise click.UsageError(t("--dry-run is required unless --sandbox is set"))
 
 
+@handle_api_errors
 def _emit_or_call_v4(
     ctx: click.Context,
     method: str,
@@ -129,22 +130,17 @@ def _emit_or_call_v4(
         format_output(build_v4_body(method, param), "json", None)
         return
 
-    try:
-        client = create_v4_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            profile=ctx.obj.get("profile"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
-        data = call_v4(client, method, param)
-        format_output(data, output_format, output)
-    except click.ClickException:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = create_v4_client(
+        token=ctx.obj.get("token"),
+        login=ctx.obj.get("login"),
+        profile=ctx.obj.get("profile"),
+        sandbox=ctx.obj.get("sandbox"),
+    )
+    data = call_v4(client, method, param)
+    format_output(data, output_format, output)
 
 
+@handle_api_errors
 def _emit_or_call_v4_finance(
     ctx: click.Context,
     method: str,
@@ -160,22 +156,16 @@ def _emit_or_call_v4_finance(
         format_output(_masked_finance_body(method, param, operation_num), "json", None)
         return
 
-    try:
-        client = create_v4_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            profile=ctx.obj.get("profile"),
-            sandbox=ctx.obj.get("sandbox"),
-            finance_token=finance_token,
-            operation_num=operation_num,
-        )
-        data = call_v4(client, method, param)
-        format_output(data, output_format, output)
-    except click.ClickException:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = create_v4_client(
+        token=ctx.obj.get("token"),
+        login=ctx.obj.get("login"),
+        profile=ctx.obj.get("profile"),
+        sandbox=ctx.obj.get("sandbox"),
+        finance_token=finance_token,
+        operation_num=operation_num,
+    )
+    data = call_v4(client, method, param)
+    format_output(data, output_format, output)
 
 
 def _non_empty(value: str, option_name: str) -> str:

--- a/direct_cli/commands/v4adimage.py
+++ b/direct_cli/commands/v4adimage.py
@@ -12,7 +12,7 @@ import click
 
 from ..api import create_v4_client
 from ..i18n import t
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import parse_csv_strings, parse_ids
 from ..v4 import build_v4_body, call_v4
 from ..v4_contracts import v4_method_contract
@@ -109,24 +109,19 @@ def _set_param(associations: tuple[str, ...]) -> dict:
     return {"Action": "Set", "AdImageAssociations": items}
 
 
+@handle_api_errors
 def _run(ctx, param: dict, output_format: str, output: Optional[str], dry_run: bool):
     if dry_run:
         format_output(build_v4_body("AdImageAssociation", param), "json", None)
         return
-    try:
-        client = create_v4_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            profile=ctx.obj.get("profile"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
-        data = call_v4(client, "AdImageAssociation", param)
-        format_output(data, output_format, output)
-    except click.ClickException:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = create_v4_client(
+        token=ctx.obj.get("token"),
+        login=ctx.obj.get("login"),
+        profile=ctx.obj.get("profile"),
+        sandbox=ctx.obj.get("sandbox"),
+    )
+    data = call_v4(client, "AdImageAssociation", param)
+    format_output(data, output_format, output)
 
 
 @click.group(epilog=V4_EPILOG)

--- a/direct_cli/commands/v4events.py
+++ b/direct_cli/commands/v4events.py
@@ -8,7 +8,7 @@ import click
 
 from ..api import create_v4_client
 from ..i18n import t
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import parse_csv_strings, parse_ids
 from ..v4 import build_v4_body, call_v4
 from ..v4_contracts import v4_method_contract
@@ -185,6 +185,7 @@ def v4events():
 @click.option("--output", help="Output file")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def get_events_log(
     ctx,
     timestamp_from,
@@ -224,17 +225,11 @@ def get_events_log(
         format_output(build_v4_body("GetEventsLog", param), "json", None)
         return
 
-    try:
-        client = create_v4_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            profile=ctx.obj.get("profile"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
-        data = call_v4(client, "GetEventsLog", param)
-        format_output(data, output_format, output)
-    except click.ClickException:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = create_v4_client(
+        token=ctx.obj.get("token"),
+        login=ctx.obj.get("login"),
+        profile=ctx.obj.get("profile"),
+        sandbox=ctx.obj.get("sandbox"),
+    )
+    data = call_v4(client, "GetEventsLog", param)
+    format_output(data, output_format, output)

--- a/direct_cli/commands/v4finance.py
+++ b/direct_cli/commands/v4finance.py
@@ -7,7 +7,7 @@ import click
 
 from ..api import create_v4_client
 from ..i18n import t
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import parse_csv_strings, parse_ids
 from ..v4 import build_v4_body, call_v4
 from ..v4.money import build_finance_token, parse_v4_money_sum, validate_operation_num
@@ -201,6 +201,7 @@ v4finance.i18n_epilog_suffix = V4_EPILOG
 @click.option("--output", help="Output file")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def get_clients_units(ctx, logins, output_format, output, dry_run):
     """Get available API units for clients.
 
@@ -212,20 +213,14 @@ def get_clients_units(ctx, logins, output_format, output, dry_run):
         format_output(build_v4_body("GetClientsUnits", login_list), "json", None)
         return
 
-    try:
-        client = create_v4_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            profile=ctx.obj.get("profile"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
-        data = call_v4(client, "GetClientsUnits", login_list)
-        format_output(data, output_format, output)
-    except click.ClickException:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = create_v4_client(
+        token=ctx.obj.get("token"),
+        login=ctx.obj.get("login"),
+        profile=ctx.obj.get("profile"),
+        sandbox=ctx.obj.get("sandbox"),
+    )
+    data = call_v4(client, "GetClientsUnits", login_list)
+    format_output(data, output_format, output)
 
 
 @v4_method_contract("GetCreditLimits")
@@ -261,6 +256,7 @@ def get_clients_units(ctx, logins, output_format, output, dry_run):
 @click.option("--output", help="Output file")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def get_credit_limits(
     ctx,
     finance_token,
@@ -292,22 +288,16 @@ def get_credit_limits(
         )
         return
 
-    try:
-        client = create_v4_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            profile=ctx.obj.get("profile"),
-            sandbox=ctx.obj.get("sandbox"),
-            finance_token=finance_token,
-            operation_num=operation_num,
-        )
-        data = call_v4(client, "GetCreditLimits", None)
-        format_output(data, output_format, output)
-    except click.ClickException:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = create_v4_client(
+        token=ctx.obj.get("token"),
+        login=ctx.obj.get("login"),
+        profile=ctx.obj.get("profile"),
+        sandbox=ctx.obj.get("sandbox"),
+        finance_token=finance_token,
+        operation_num=operation_num,
+    )
+    data = call_v4(client, "GetCreditLimits", None)
+    format_output(data, output_format, output)
 
 
 @v4_method_contract("CheckPayment")
@@ -327,6 +317,7 @@ def get_credit_limits(
 @click.option("--output", help="Output file")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def check_payment(
     ctx,
     custom_transaction_id,
@@ -343,20 +334,14 @@ def check_payment(
         format_output(build_v4_body("CheckPayment", param), "json", None)
         return
 
-    try:
-        client = create_v4_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            profile=ctx.obj.get("profile"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
-        data = call_v4(client, "CheckPayment", param)
-        format_output(data, output_format, output)
-    except click.ClickException:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = create_v4_client(
+        token=ctx.obj.get("token"),
+        login=ctx.obj.get("login"),
+        profile=ctx.obj.get("profile"),
+        sandbox=ctx.obj.get("sandbox"),
+    )
+    data = call_v4(client, "CheckPayment", param)
+    format_output(data, output_format, output)
 
 
 @v4_method_contract("CreateInvoice")
@@ -405,6 +390,7 @@ def check_payment(
 @click.option("--output", help="Output file")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def create_invoice(
     ctx,
     payments,
@@ -439,22 +425,16 @@ def create_invoice(
         )
         return
 
-    try:
-        client = create_v4_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            profile=ctx.obj.get("profile"),
-            sandbox=ctx.obj.get("sandbox"),
-            finance_token=finance_token,
-            operation_num=operation_num,
-        )
-        data = call_v4(client, "CreateInvoice", param)
-        format_output(data, output_format, output)
-    except click.ClickException:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = create_v4_client(
+        token=ctx.obj.get("token"),
+        login=ctx.obj.get("login"),
+        profile=ctx.obj.get("profile"),
+        sandbox=ctx.obj.get("sandbox"),
+        finance_token=finance_token,
+        operation_num=operation_num,
+    )
+    data = call_v4(client, "CreateInvoice", param)
+    format_output(data, output_format, output)
 
 
 @v4_method_contract("TransferMoney")

--- a/direct_cli/commands/v4goals.py
+++ b/direct_cli/commands/v4goals.py
@@ -4,7 +4,7 @@ import click
 
 from ..api import create_v4_client
 from ..i18n import t
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors
 from ..utils import parse_ids
 from ..v4 import build_v4_body, call_v4
 from ..v4_contracts import v4_method_contract
@@ -22,6 +22,7 @@ def _campaign_ids_param(campaign_ids: str) -> dict:
     return {"CampaignIDS": ids}
 
 
+@handle_api_errors
 def _run_goals_command(
     ctx,
     method: str,
@@ -35,20 +36,14 @@ def _run_goals_command(
         format_output(build_v4_body(method, param), "json", None)
         return
 
-    try:
-        client = create_v4_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            profile=ctx.obj.get("profile"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
-        data = call_v4(client, method, param)
-        format_output(data, output_format, output)
-    except click.ClickException:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = create_v4_client(
+        token=ctx.obj.get("token"),
+        login=ctx.obj.get("login"),
+        profile=ctx.obj.get("profile"),
+        sandbox=ctx.obj.get("sandbox"),
+    )
+    data = call_v4(client, method, param)
+    format_output(data, output_format, output)
 
 
 @click.group(epilog=V4_EPILOG)

--- a/direct_cli/commands/v4keywords.py
+++ b/direct_cli/commands/v4keywords.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import create_v4_client
 from ..i18n import t
-from ..output import format_output, print_error
+from ..output import format_output, handle_api_errors
 from ..v4 import build_v4_body, call_v4
 from ..v4_contracts import v4_method_contract
 from .v4shells import V4_EPILOG
@@ -48,6 +48,7 @@ def v4keywords():
 @click.option("--output", help="Output file")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")
 @click.pass_context
+@handle_api_errors
 def get_suggestion(
     ctx,
     keywords: tuple[str, ...],
@@ -65,17 +66,11 @@ def get_suggestion(
         format_output(build_v4_body("GetKeywordsSuggestion", param), "json", None)
         return
 
-    try:
-        client = create_v4_client(
-            token=ctx.obj.get("token"),
-            login=ctx.obj.get("login"),
-            profile=ctx.obj.get("profile"),
-            sandbox=ctx.obj.get("sandbox"),
-        )
-        data = call_v4(client, "GetKeywordsSuggestion", param)
-        format_output(data, output_format, output)
-    except click.ClickException:
-        raise
-    except Exception as e:
-        print_error(str(e))
-        raise click.Abort()
+    client = create_v4_client(
+        token=ctx.obj.get("token"),
+        login=ctx.obj.get("login"),
+        profile=ctx.obj.get("profile"),
+        sandbox=ctx.obj.get("sandbox"),
+    )
+    data = call_v4(client, "GetKeywordsSuggestion", param)
+    format_output(data, output_format, output)


### PR DESCRIPTION
Часть эпика #491, серия **A2** — **закрывающий PR**. Зависит от #503.

## Что сделано

Последние **23 функции** с кодом валидации ДО `try` переведены на `@handle_api_errors`. Декоратор теперь обнимает всё тело (включая pre-try валидацию) — поведение сохранено, т.к. весь pre-try код кидает только `click.UsageError`/`ClickException`, который декоратор пробрасывает без изменений.

Функции: adgroups(get,update), ads(get,update), balance, bids(set), campaigns(get), changes(check), keywordbids(set), sitelinks(add), keywords(get,add,update), v4account(_emit_or_call_v4,_emit_or_call_v4_finance), v4adimage(_run), v4events(get_events_log), v4finance(get_clients_units,get_credit_limits,check_payment,create_invoice), v4goals(_run_goals_command), v4keywords(get_suggestion).

## Оставлено вручную

`keywords._bulk_add` — его except печатает partial-success диагностику с локальным аккумулятором перед print_error/Abort, что декоратор-обёртка не воспроизведёт. Поэтому функция не декорируется, а `print_error` сохранён в импорте keywords.py.

## Метод

Тот же ast-codemod (string-aware дедент + гейт ast-эквивалентности), расширенный для pre-try случая: pre-try стейтменты разрешены, когда `Try` — последний стейтмент функции (после него ничего нет). `print_error` убран из импортов, где больше не используется.

## Объём

15 файлов, **+584 / −709**.

## Верификация

- Полный прогон: **2087 passed, 47 skipped** (0 регрессий, включая v4 dry-run пути).
- Поведенческие spot-check: `bids set` без полей → **exit 2** (UsageError рендерит usage); `v4keywords get-suggestion --dry-run` → печатает body, **exit 0**.
- `black --check` чисто; flake8 — **0 новых** vs main; import OK.

Завершает находку 7: все 127 канонических блоков заменены декоратором (104 чистых + 23 pre-try); `_bulk_add` намеренно оставлен.

Closes #493.

🤖 Generated with [Claude Code](https://claude.com/claude-code)