### PR TITLE
refactor: extract shared v4 emit-helpers (dedup #491 A3)

### DIFF
--- a/direct_cli/commands/v4account.py
+++ b/direct_cli/commands/v4account.py
@@ -6,21 +6,16 @@ from typing import Any, Optional
 
 import click
 
-from ..api import create_v4_client
 from ..i18n import t
-from ..output import format_output, handle_api_errors
 from ..utils import parse_csv_strings, parse_ids
-from ..v4 import build_v4_body, call_v4
+from ..v4.emit import emit_or_call_v4, emit_or_call_v4_finance
 from ..v4.money import parse_v4_money_sum
 from ..v4_contracts import v4_method_contract
 
 # Cross-module helpers shared with v4finance commands. AccountManagement's
 # financial sub-actions (Deposit/Invoice/TransferMoney) need the same
 # finance_token / operation_num plumbing as v4finance methods.
-from .v4finance import (  # noqa: E402
-    _finance_credentials,
-    _masked_finance_body,
-)
+from .v4finance import _finance_credentials  # noqa: E402
 from .v4shells import V4_EPILOG
 
 YES_NO = ("Yes", "No")
@@ -114,58 +109,6 @@ def _require_dry_run_or_sandbox(dry_run: bool, sandbox: bool) -> None:
     """Reject shared-account mutations outside explicit dry-run or sandbox."""
     if not dry_run and not sandbox:
         raise click.UsageError(t("--dry-run is required unless --sandbox is set"))
-
-
-@handle_api_errors
-def _emit_or_call_v4(
-    ctx: click.Context,
-    method: str,
-    param: dict,
-    dry_run: bool,
-    output_format: str,
-    output: Optional[str],
-) -> None:
-    """Print a v4 request preview or execute it against the sandbox API."""
-    if dry_run:
-        format_output(build_v4_body(method, param), "json", None)
-        return
-
-    client = create_v4_client(
-        token=ctx.obj.get("token"),
-        login=ctx.obj.get("login"),
-        profile=ctx.obj.get("profile"),
-        sandbox=ctx.obj.get("sandbox"),
-    )
-    data = call_v4(client, method, param)
-    format_output(data, output_format, output)
-
-
-@handle_api_errors
-def _emit_or_call_v4_finance(
-    ctx: click.Context,
-    method: str,
-    param: dict,
-    finance_token: str,
-    operation_num: int,
-    dry_run: bool,
-    output_format: str,
-    output: Optional[str],
-) -> None:
-    """Preview a finance-backed v4 request or execute it; masks the token."""
-    if dry_run:
-        format_output(_masked_finance_body(method, param, operation_num), "json", None)
-        return
-
-    client = create_v4_client(
-        token=ctx.obj.get("token"),
-        login=ctx.obj.get("login"),
-        profile=ctx.obj.get("profile"),
-        sandbox=ctx.obj.get("sandbox"),
-        finance_token=finance_token,
-        operation_num=operation_num,
-    )
-    data = call_v4(client, method, param)
-    format_output(data, output_format, output)
 
 
 def _non_empty(value: str, option_name: str) -> str:
@@ -476,7 +419,7 @@ def enable_shared_account(ctx, client_login, dry_run, output_format, output):
     """Enable a shared account for a client in sandbox, or preview the request."""
     _require_dry_run_or_sandbox(dry_run, ctx.obj.get("sandbox"))
     param = {"Login": _non_empty(client_login, "--client-login")}
-    _emit_or_call_v4(
+    emit_or_call_v4(
         ctx,
         "EnableSharedAccount",
         param,
@@ -675,9 +618,7 @@ def account_management(
 
     if action == "Get":
         param = _account_get_param(logins, account_ids)
-        _emit_or_call_v4(
-            ctx, "AccountManagement", param, dry_run, output_format, output
-        )
+        emit_or_call_v4(ctx, "AccountManagement", param, dry_run, output_format, output)
         return
 
     _require_dry_run_or_sandbox(dry_run, ctx.obj.get("sandbox"))
@@ -697,9 +638,7 @@ def account_management(
             money_warning_value,
             paused_by_day_budget,
         )
-        _emit_or_call_v4(
-            ctx, "AccountManagement", param, dry_run, output_format, output
-        )
+        emit_or_call_v4(ctx, "AccountManagement", param, dry_run, output_format, output)
         return
 
     # Deposit / Invoice / TransferMoney — financial sub-actions.
@@ -732,7 +671,7 @@ def account_management(
             from_account_id, to_account_id, amount, currency
         )
 
-    _emit_or_call_v4_finance(
+    emit_or_call_v4_finance(
         ctx,
         "AccountManagement",
         param,

--- a/direct_cli/commands/v4adimage.py
+++ b/direct_cli/commands/v4adimage.py
@@ -10,11 +10,9 @@ from typing import Optional
 
 import click
 
-from ..api import create_v4_client
 from ..i18n import t
-from ..output import format_output, handle_api_errors
 from ..utils import parse_csv_strings, parse_ids
-from ..v4 import build_v4_body, call_v4
+from ..v4.emit import emit_or_call_v4
 from ..v4_contracts import v4_method_contract
 from .v4shells import V4_EPILOG
 
@@ -109,21 +107,6 @@ def _set_param(associations: tuple[str, ...]) -> dict:
     return {"Action": "Set", "AdImageAssociations": items}
 
 
-@handle_api_errors
-def _run(ctx, param: dict, output_format: str, output: Optional[str], dry_run: bool):
-    if dry_run:
-        format_output(build_v4_body("AdImageAssociation", param), "json", None)
-        return
-    client = create_v4_client(
-        token=ctx.obj.get("token"),
-        login=ctx.obj.get("login"),
-        profile=ctx.obj.get("profile"),
-        sandbox=ctx.obj.get("sandbox"),
-    )
-    data = call_v4(client, "AdImageAssociation", param)
-    format_output(data, output_format, output)
-
-
 @click.group(epilog=V4_EPILOG)
 def v4adimage():
     """Yandex Direct v4 Live ad-image association commands."""
@@ -176,7 +159,7 @@ def get(
         limit,
         offset,
     )
-    _run(ctx, param, output_format, output, dry_run)
+    emit_or_call_v4(ctx, "AdImageAssociation", param, dry_run, output_format, output)
 
 
 @v4_method_contract("AdImageAssociation")
@@ -201,4 +184,4 @@ def get(
 def set_(ctx, associations, output_format, output, dry_run):
     """Attach or detach ad images (max 10000 associations)."""
     param = _set_param(associations)
-    _run(ctx, param, output_format, output, dry_run)
+    emit_or_call_v4(ctx, "AdImageAssociation", param, dry_run, output_format, output)

--- a/direct_cli/commands/v4events.py
+++ b/direct_cli/commands/v4events.py
@@ -6,11 +6,10 @@ from typing import Optional
 
 import click
 
-from ..api import create_v4_client
 from ..i18n import t
-from ..output import format_output, handle_api_errors
+from ..output import handle_api_errors
 from ..utils import parse_csv_strings, parse_ids
-from ..v4 import build_v4_body, call_v4
+from ..v4.emit import emit_or_call_v4
 from ..v4_contracts import v4_method_contract
 from .v4shells import V4_EPILOG
 
@@ -221,15 +220,4 @@ def get_events_log(
         account_ids=filter_account_ids,
         event_type=filter_event_type,
     )
-    if dry_run:
-        format_output(build_v4_body("GetEventsLog", param), "json", None)
-        return
-
-    client = create_v4_client(
-        token=ctx.obj.get("token"),
-        login=ctx.obj.get("login"),
-        profile=ctx.obj.get("profile"),
-        sandbox=ctx.obj.get("sandbox"),
-    )
-    data = call_v4(client, "GetEventsLog", param)
-    format_output(data, output_format, output)
+    emit_or_call_v4(ctx, "GetEventsLog", param, dry_run, output_format, output)

--- a/direct_cli/commands/v4finance.py
+++ b/direct_cli/commands/v4finance.py
@@ -1,20 +1,22 @@
 """Yandex Direct v4 Live finance commands."""
 
 import re
-from typing import Any, Optional
+from typing import Optional
 
 import click
 
-from ..api import create_v4_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
 from ..utils import parse_csv_strings, parse_ids
-from ..v4 import build_v4_body, call_v4
+from ..v4.emit import (
+    _masked_finance_body,
+    emit_or_call_v4,
+    emit_or_call_v4_finance,
+)
 from ..v4.money import build_finance_token, parse_v4_money_sum, validate_operation_num
 from ..v4_contracts import v4_method_contract
 from .v4shells import V4_EPILOG
 
-FINANCE_TOKEN_MASK = "<redacted>"
 CUSTOM_TRANSACTION_ID_RE = re.compile(r"[A-Za-z0-9]{32}")
 V4_PAY_METHODS = ["Bank", "Overdraft"]
 # All v4 Live finance commands are exposed but have NOT been exercised
@@ -129,14 +131,6 @@ _FINANCE_CREDENTIALS_ERROR = (
 )
 
 
-def _masked_finance_body(method: str, param: Any, operation_num: int) -> dict:
-    """Build a dry-run body without exposing the financial token."""
-    body = build_v4_body(method, param)
-    body["finance_token"] = FINANCE_TOKEN_MASK
-    body["operation_num"] = operation_num
-    return body
-
-
 def _require_dry_run(dry_run: bool) -> None:
     """Reject v4 finance money mutations unless dry-run is explicit."""
     if not dry_run:
@@ -208,19 +202,7 @@ def get_clients_units(ctx, logins, output_format, output, dry_run):
     ⚠ Not tested against the live API.
     """
     login_list = _logins_param(logins)
-
-    if dry_run:
-        format_output(build_v4_body("GetClientsUnits", login_list), "json", None)
-        return
-
-    client = create_v4_client(
-        token=ctx.obj.get("token"),
-        login=ctx.obj.get("login"),
-        profile=ctx.obj.get("profile"),
-        sandbox=ctx.obj.get("sandbox"),
-    )
-    data = call_v4(client, "GetClientsUnits", login_list)
-    format_output(data, output_format, output)
+    emit_or_call_v4(ctx, "GetClientsUnits", login_list, dry_run, output_format, output)
 
 
 @v4_method_contract("GetCreditLimits")
@@ -280,24 +262,16 @@ def get_credit_limits(
         ctx.obj.get("login"),
     )
 
-    if dry_run:
-        format_output(
-            _masked_finance_body("GetCreditLimits", None, operation_num),
-            "json",
-            None,
-        )
-        return
-
-    client = create_v4_client(
-        token=ctx.obj.get("token"),
-        login=ctx.obj.get("login"),
-        profile=ctx.obj.get("profile"),
-        sandbox=ctx.obj.get("sandbox"),
-        finance_token=finance_token,
-        operation_num=operation_num,
+    emit_or_call_v4_finance(
+        ctx,
+        "GetCreditLimits",
+        None,
+        finance_token,
+        operation_num,
+        dry_run,
+        output_format,
+        output,
     )
-    data = call_v4(client, "GetCreditLimits", None)
-    format_output(data, output_format, output)
 
 
 @v4_method_contract("CheckPayment")
@@ -330,18 +304,7 @@ def check_payment(
     ⚠ Not tested against the live API.
     """
     param = _custom_transaction_id_param(custom_transaction_id)
-    if dry_run:
-        format_output(build_v4_body("CheckPayment", param), "json", None)
-        return
-
-    client = create_v4_client(
-        token=ctx.obj.get("token"),
-        login=ctx.obj.get("login"),
-        profile=ctx.obj.get("profile"),
-        sandbox=ctx.obj.get("sandbox"),
-    )
-    data = call_v4(client, "CheckPayment", param)
-    format_output(data, output_format, output)
+    emit_or_call_v4(ctx, "CheckPayment", param, dry_run, output_format, output)
 
 
 @v4_method_contract("CreateInvoice")
@@ -416,25 +379,16 @@ def create_invoice(
         ctx.obj.get("login"),
     )
     param = _invoice_payments_param(payments, currency)
-
-    if dry_run:
-        format_output(
-            _masked_finance_body("CreateInvoice", param, operation_num),
-            "json",
-            None,
-        )
-        return
-
-    client = create_v4_client(
-        token=ctx.obj.get("token"),
-        login=ctx.obj.get("login"),
-        profile=ctx.obj.get("profile"),
-        sandbox=ctx.obj.get("sandbox"),
-        finance_token=finance_token,
-        operation_num=operation_num,
+    emit_or_call_v4_finance(
+        ctx,
+        "CreateInvoice",
+        param,
+        finance_token,
+        operation_num,
+        dry_run,
+        output_format,
+        output,
     )
-    data = call_v4(client, "CreateInvoice", param)
-    format_output(data, output_format, output)
 
 
 @v4_method_contract("TransferMoney")

--- a/direct_cli/commands/v4forecast.py
+++ b/direct_cli/commands/v4forecast.py
@@ -4,11 +4,9 @@ from typing import Optional
 
 import click
 
-from ..api import create_v4_client
 from ..i18n import t
-from ..output import format_output, handle_api_errors
 from ..utils import parse_csv_strings, parse_ids
-from ..v4 import build_v4_body, call_v4
+from ..v4.emit import emit_or_call_v4
 from ..v4_contracts import v4_method_contract
 from .v4shells import V4_EPILOG
 
@@ -53,25 +51,6 @@ def _forecast_param(
         if minus_words:
             param["CommonMinusWords"] = minus_words
     return param
-
-
-@handle_api_errors
-def _call_forecast(
-    ctx,
-    method: str,
-    param,
-    output_format: str,
-    output: Optional[str],
-) -> None:
-    """Call one v4 Live budget forecast method and print formatted output."""
-    client = create_v4_client(
-        token=ctx.obj.get("token"),
-        login=ctx.obj.get("login"),
-        profile=ctx.obj.get("profile"),
-        sandbox=ctx.obj.get("sandbox"),
-    )
-    data = call_v4(client, method, param)
-    format_output(data, output_format, output)
 
 
 @click.group(epilog=V4_EPILOG)
@@ -133,11 +112,7 @@ def create(
         auction_bids=auction_bids,
         common_minus_words=common_minus_words,
     )
-    if dry_run:
-        format_output(build_v4_body("CreateNewForecast", param), "json", None)
-        return
-
-    _call_forecast(ctx, "CreateNewForecast", param, output_format, output)
+    emit_or_call_v4(ctx, "CreateNewForecast", param, dry_run, output_format, output)
 
 
 @v4_method_contract("GetForecastList")
@@ -154,11 +129,7 @@ def create(
 @click.pass_context
 def list_forecasts(ctx, output_format, output, dry_run):
     """List v4 Live budget forecasts."""
-    if dry_run:
-        format_output(build_v4_body("GetForecastList"), "json", None)
-        return
-
-    _call_forecast(ctx, "GetForecastList", None, output_format, output)
+    emit_or_call_v4(ctx, "GetForecastList", None, dry_run, output_format, output)
 
 
 @v4_method_contract("GetForecast")
@@ -181,11 +152,7 @@ def list_forecasts(ctx, output_format, output, dry_run):
 @click.pass_context
 def get(ctx, forecast_id, output_format, output, dry_run):
     """Get a ready v4 Live budget forecast."""
-    if dry_run:
-        format_output(build_v4_body("GetForecast", forecast_id), "json", None)
-        return
-
-    _call_forecast(ctx, "GetForecast", forecast_id, output_format, output)
+    emit_or_call_v4(ctx, "GetForecast", forecast_id, dry_run, output_format, output)
 
 
 @v4_method_contract("DeleteForecastReport")
@@ -208,8 +175,6 @@ def get(ctx, forecast_id, output_format, output, dry_run):
 @click.pass_context
 def delete(ctx, forecast_id, output_format, output, dry_run):
     """Delete a v4 Live budget forecast."""
-    if dry_run:
-        format_output(build_v4_body("DeleteForecastReport", forecast_id), "json", None)
-        return
-
-    _call_forecast(ctx, "DeleteForecastReport", forecast_id, output_format, output)
+    emit_or_call_v4(
+        ctx, "DeleteForecastReport", forecast_id, dry_run, output_format, output
+    )

--- a/direct_cli/commands/v4goals.py
+++ b/direct_cli/commands/v4goals.py
@@ -2,11 +2,9 @@
 
 import click
 
-from ..api import create_v4_client
 from ..i18n import t
-from ..output import format_output, handle_api_errors
 from ..utils import parse_ids
-from ..v4 import build_v4_body, call_v4
+from ..v4.emit import emit_or_call_v4
 from ..v4_contracts import v4_method_contract
 from .v4shells import V4_EPILOG
 
@@ -20,30 +18,6 @@ def _campaign_ids_param(campaign_ids: str) -> dict:
     if not ids:
         raise click.UsageError(t("--campaign-ids must not be empty"))
     return {"CampaignIDS": ids}
-
-
-@handle_api_errors
-def _run_goals_command(
-    ctx,
-    method: str,
-    campaign_ids: str,
-    output_format: str,
-    output: str,
-    dry_run: bool,
-) -> None:
-    param = _campaign_ids_param(campaign_ids)
-    if dry_run:
-        format_output(build_v4_body(method, param), "json", None)
-        return
-
-    client = create_v4_client(
-        token=ctx.obj.get("token"),
-        login=ctx.obj.get("login"),
-        profile=ctx.obj.get("profile"),
-        sandbox=ctx.obj.get("sandbox"),
-    )
-    data = call_v4(client, method, param)
-    format_output(data, output_format, output)
 
 
 @click.group(epilog=V4_EPILOG)
@@ -66,14 +40,8 @@ def v4goals():
 @click.pass_context
 def get_stat_goals(ctx, campaign_ids, output_format, output, dry_run):
     """Get Yandex Metrica goals available for campaigns."""
-    _run_goals_command(
-        ctx,
-        "GetStatGoals",
-        campaign_ids,
-        output_format,
-        output,
-        dry_run,
-    )
+    param = _campaign_ids_param(campaign_ids)
+    emit_or_call_v4(ctx, "GetStatGoals", param, dry_run, output_format, output)
 
 
 @v4_method_contract("GetRetargetingGoals")
@@ -91,11 +59,5 @@ def get_stat_goals(ctx, campaign_ids, output_format, output, dry_run):
 @click.pass_context
 def get_retargeting_goals(ctx, campaign_ids, output_format, output, dry_run):
     """Get retargeting goals for campaigns."""
-    _run_goals_command(
-        ctx,
-        "GetRetargetingGoals",
-        campaign_ids,
-        output_format,
-        output,
-        dry_run,
-    )
+    param = _campaign_ids_param(campaign_ids)
+    emit_or_call_v4(ctx, "GetRetargetingGoals", param, dry_run, output_format, output)

--- a/direct_cli/commands/v4keywords.py
+++ b/direct_cli/commands/v4keywords.py
@@ -4,10 +4,9 @@ from typing import Optional
 
 import click
 
-from ..api import create_v4_client
 from ..i18n import t
-from ..output import format_output, handle_api_errors
-from ..v4 import build_v4_body, call_v4
+from ..output import handle_api_errors
+from ..v4.emit import emit_or_call_v4
 from ..v4_contracts import v4_method_contract
 from .v4shells import V4_EPILOG
 
@@ -62,15 +61,4 @@ def get_suggestion(
     when insufficient).
     """
     param = _keywords_param(keywords)
-    if dry_run:
-        format_output(build_v4_body("GetKeywordsSuggestion", param), "json", None)
-        return
-
-    client = create_v4_client(
-        token=ctx.obj.get("token"),
-        login=ctx.obj.get("login"),
-        profile=ctx.obj.get("profile"),
-        sandbox=ctx.obj.get("sandbox"),
-    )
-    data = call_v4(client, "GetKeywordsSuggestion", param)
-    format_output(data, output_format, output)
+    emit_or_call_v4(ctx, "GetKeywordsSuggestion", param, dry_run, output_format, output)

--- a/direct_cli/commands/v4tags.py
+++ b/direct_cli/commands/v4tags.py
@@ -4,11 +4,9 @@ from typing import Optional
 
 import click
 
-from ..api import create_v4_client
 from ..i18n import t
-from ..output import format_output, handle_api_errors
 from ..utils import parse_ids
-from ..v4 import build_v4_body, call_v4
+from ..v4.emit import emit_or_call_v4
 from ..v4_contracts import v4_method_contract
 from .v4shells import V4_EPILOG
 
@@ -142,19 +140,6 @@ def _update_banners_tags_param(
     ]
 
 
-@handle_api_errors
-def _call_v4tags(ctx, method: str, param, output_format: str, output: str) -> None:
-    """Call one v4 Live tag method and print formatted output."""
-    client = create_v4_client(
-        token=ctx.obj.get("token"),
-        login=ctx.obj.get("login"),
-        profile=ctx.obj.get("profile"),
-        sandbox=ctx.obj.get("sandbox"),
-    )
-    data = call_v4(client, method, param)
-    format_output(data, output_format, output)
-
-
 @click.group(epilog=V4_EPILOG)
 def v4tags():
     """Yandex Direct v4 Live tag commands."""
@@ -176,11 +161,7 @@ def v4tags():
 def get_campaigns(ctx, campaign_ids, output_format, output, dry_run):
     """Get campaign tags."""
     param = _get_campaigns_tags_param(campaign_ids)
-    if dry_run:
-        format_output(build_v4_body("GetCampaignsTags", param), "json", None)
-        return
-
-    _call_v4tags(ctx, "GetCampaignsTags", param, output_format, output)
+    emit_or_call_v4(ctx, "GetCampaignsTags", param, dry_run, output_format, output)
 
 
 @v4_method_contract("GetBannersTags")
@@ -200,11 +181,7 @@ def get_campaigns(ctx, campaign_ids, output_format, output, dry_run):
 def get_banners(ctx, campaign_ids, banner_ids, output_format, output, dry_run):
     """Get banner tag IDs."""
     param = _get_banners_tags_param(campaign_ids, banner_ids)
-    if dry_run:
-        format_output(build_v4_body("GetBannersTags", param), "json", None)
-        return
-
-    _call_v4tags(ctx, "GetBannersTags", param, output_format, output)
+    emit_or_call_v4(ctx, "GetBannersTags", param, dry_run, output_format, output)
 
 
 @v4_method_contract("UpdateCampaignsTags")
@@ -237,11 +214,7 @@ def update_campaigns(
 ):
     """Replace the campaign tag list."""
     param = _update_campaigns_tags_param(campaign_id, tag_specs, clear_tags)
-    if dry_run:
-        format_output(build_v4_body("UpdateCampaignsTags", param), "json", None)
-        return
-
-    _call_v4tags(ctx, "UpdateCampaignsTags", param, output_format, output)
+    emit_or_call_v4(ctx, "UpdateCampaignsTags", param, dry_run, output_format, output)
 
 
 @v4_method_contract("UpdateBannersTags")
@@ -264,8 +237,4 @@ def update_banners(
 ):
     """Replace banner tag assignments."""
     param = _update_banners_tags_param(banner_ids, tag_ids, clear_tags)
-    if dry_run:
-        format_output(build_v4_body("UpdateBannersTags", param), "json", None)
-        return
-
-    _call_v4tags(ctx, "UpdateBannersTags", param, output_format, output)
+    emit_or_call_v4(ctx, "UpdateBannersTags", param, dry_run, output_format, output)

--- a/direct_cli/commands/v4wordstat.py
+++ b/direct_cli/commands/v4wordstat.py
@@ -4,11 +4,9 @@ from typing import Optional
 
 import click
 
-from ..api import create_v4_client
 from ..i18n import t
-from ..output import format_output, handle_api_errors
 from ..utils import parse_csv_strings, parse_ids
-from ..v4 import build_v4_body, call_v4
+from ..v4.emit import emit_or_call_v4
 from ..v4_contracts import v4_method_contract
 from .v4shells import V4_EPILOG
 
@@ -30,25 +28,6 @@ def _wordstat_report_param(phrases: str, geo_ids: Optional[str]) -> dict:
         if parsed_geo_ids:
             param["GeoID"] = parsed_geo_ids
     return param
-
-
-@handle_api_errors
-def _call_wordstat(
-    ctx,
-    method: str,
-    param,
-    output_format: str,
-    output: Optional[str],
-) -> None:
-    """Call one v4 Live Wordstat method and print formatted output."""
-    client = create_v4_client(
-        token=ctx.obj.get("token"),
-        login=ctx.obj.get("login"),
-        profile=ctx.obj.get("profile"),
-        sandbox=ctx.obj.get("sandbox"),
-    )
-    data = call_v4(client, method, param)
-    format_output(data, output_format, output)
 
 
 @click.group(epilog=V4_EPILOG)
@@ -73,11 +52,9 @@ def v4wordstat():
 def create_report(ctx, phrases, geo_ids, output_format, output, dry_run):
     """Create a v4 Live Wordstat report."""
     param = _wordstat_report_param(phrases, geo_ids)
-    if dry_run:
-        format_output(build_v4_body("CreateNewWordstatReport", param), "json", None)
-        return
-
-    _call_wordstat(ctx, "CreateNewWordstatReport", param, output_format, output)
+    emit_or_call_v4(
+        ctx, "CreateNewWordstatReport", param, dry_run, output_format, output
+    )
 
 
 @v4_method_contract("GetWordstatReportList")
@@ -94,11 +71,7 @@ def create_report(ctx, phrases, geo_ids, output_format, output, dry_run):
 @click.pass_context
 def list_reports(ctx, output_format, output, dry_run):
     """List v4 Live Wordstat reports."""
-    if dry_run:
-        format_output(build_v4_body("GetWordstatReportList"), "json", None)
-        return
-
-    _call_wordstat(ctx, "GetWordstatReportList", None, output_format, output)
+    emit_or_call_v4(ctx, "GetWordstatReportList", None, dry_run, output_format, output)
 
 
 @v4_method_contract("GetWordstatReport")
@@ -121,11 +94,7 @@ def list_reports(ctx, output_format, output, dry_run):
 @click.pass_context
 def get_report(ctx, report_id, output_format, output, dry_run):
     """Get a ready v4 Live Wordstat report."""
-    if dry_run:
-        format_output(build_v4_body("GetWordstatReport", report_id), "json", None)
-        return
-
-    _call_wordstat(ctx, "GetWordstatReport", report_id, output_format, output)
+    emit_or_call_v4(ctx, "GetWordstatReport", report_id, dry_run, output_format, output)
 
 
 @v4_method_contract("DeleteWordstatReport")
@@ -148,8 +117,6 @@ def get_report(ctx, report_id, output_format, output, dry_run):
 @click.pass_context
 def delete_report(ctx, report_id, output_format, output, dry_run):
     """Delete a v4 Live Wordstat report."""
-    if dry_run:
-        format_output(build_v4_body("DeleteWordstatReport", report_id), "json", None)
-        return
-
-    _call_wordstat(ctx, "DeleteWordstatReport", report_id, output_format, output)
+    emit_or_call_v4(
+        ctx, "DeleteWordstatReport", report_id, dry_run, output_format, output
+    )

--- a/direct_cli/v4/emit.py
+++ b/direct_cli/v4/emit.py
@@ -1,0 +1,79 @@
+"""Shared v4 Live request emit-helpers.
+
+Centralizes the ``create_v4_client → call_v4 → format_output`` boilerplate (plus
+the dry-run preview branch) that every v4 command otherwise duplicates. Two
+variants: the plain :func:`emit_or_call_v4` and the finance-backed
+:func:`emit_or_call_v4_finance`, which threads the finance token / operation
+number and masks the token in dry-run output.
+"""
+
+from typing import Any, Optional
+
+import click
+
+from ..api import create_v4_client
+from ..output import format_output, handle_api_errors
+from . import build_v4_body, call_v4
+
+# Placeholder shown instead of the real finance token in dry-run previews.
+FINANCE_TOKEN_MASK = "<redacted>"
+
+
+def _masked_finance_body(method: str, param: Any, operation_num: int) -> dict:
+    """Build a dry-run body without exposing the financial token."""
+    body = build_v4_body(method, param)
+    body["finance_token"] = FINANCE_TOKEN_MASK
+    body["operation_num"] = operation_num
+    return body
+
+
+@handle_api_errors
+def emit_or_call_v4(
+    ctx: click.Context,
+    method: str,
+    param: Any,
+    dry_run: bool,
+    output_format: str,
+    output: Optional[str],
+) -> None:
+    """Print a v4 request preview or execute it against the sandbox API."""
+    if dry_run:
+        format_output(build_v4_body(method, param), "json", None)
+        return
+
+    client = create_v4_client(
+        token=ctx.obj.get("token"),
+        login=ctx.obj.get("login"),
+        profile=ctx.obj.get("profile"),
+        sandbox=ctx.obj.get("sandbox"),
+    )
+    data = call_v4(client, method, param)
+    format_output(data, output_format, output)
+
+
+@handle_api_errors
+def emit_or_call_v4_finance(
+    ctx: click.Context,
+    method: str,
+    param: Any,
+    finance_token: str,
+    operation_num: int,
+    dry_run: bool,
+    output_format: str,
+    output: Optional[str],
+) -> None:
+    """Preview a finance-backed v4 request or execute it; masks the token."""
+    if dry_run:
+        format_output(_masked_finance_body(method, param, operation_num), "json", None)
+        return
+
+    client = create_v4_client(
+        token=ctx.obj.get("token"),
+        login=ctx.obj.get("login"),
+        profile=ctx.obj.get("profile"),
+        sandbox=ctx.obj.get("sandbox"),
+        finance_token=finance_token,
+        operation_num=operation_num,
+    )
+    data = call_v4(client, method, param)
+    format_output(data, output_format, output)

--- a/tests/test_v4_exit_codes.py
+++ b/tests/test_v4_exit_codes.py
@@ -14,12 +14,12 @@ from click.testing import CliRunner
 
 from direct_cli.cli import cli
 
-
 # (module short name, argv invoked through the top-level `cli` group).
-# Each argv hits a code path that calls `call_v4` inside the wrapped
-# `try` block of the v4 command module. We patch the module-local alias
-# of `call_v4` (the wrappers do `from ..v4 import call_v4` so the alias
-# is rebound on `direct_cli.commands.<module>.call_v4`).
+# Each argv hits a code path that calls `call_v4` inside the shared
+# `emit_or_call_v4`/`emit_or_call_v4_finance` helpers (direct_cli.v4.emit).
+# Since #494 every v4 command routes through those helpers, so the real
+# `call_v4` / `create_v4_client` are invoked there — we patch the aliases on
+# `direct_cli.v4.emit`, not per-command-module.
 V4_COMMAND_PROBES = [
     (
         "v4account",
@@ -85,11 +85,11 @@ def test_usage_error_from_call_v4_yields_exit_code_2(module_name, argv):
 
     with (
         patch(
-            f"direct_cli.commands.{module_name}.call_v4",
+            "direct_cli.v4.emit.call_v4",
             side_effect=click.UsageError(sentinel),
         ),
         patch(
-            f"direct_cli.commands.{module_name}.create_v4_client",
+            "direct_cli.v4.emit.create_v4_client",
             return_value=object(),
         ),
     ):
@@ -114,11 +114,11 @@ def test_runtime_error_from_call_v4_still_exits_with_abort(module_name, argv):
     """Non-Click exceptions must still go through print_error + Abort (exit 1)."""
     with (
         patch(
-            f"direct_cli.commands.{module_name}.call_v4",
+            "direct_cli.v4.emit.call_v4",
             side_effect=RuntimeError("boom"),
         ),
         patch(
-            f"direct_cli.commands.{module_name}.create_v4_client",
+            "direct_cli.v4.emit.create_v4_client",
             return_value=object(),
         ),
     ):

--- a/tests/test_v4account.py
+++ b/tests/test_v4account.py
@@ -118,7 +118,7 @@ def test_account_management_update_dry_run_uses_nested_shared_account_body():
     ],
 )
 def test_v4account_commands_require_dry_run_before_api_call(args):
-    with patch("direct_cli.commands.v4account.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         result = _invoke(*args)
 
     assert result.exit_code != 0
@@ -127,9 +127,9 @@ def test_v4account_commands_require_dry_run_before_api_call(args):
 
 
 def test_enable_shared_account_sandbox_calls_v4_api_without_dry_run():
-    with patch("direct_cli.commands.v4account.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         with patch(
-            "direct_cli.commands.v4account.call_v4",
+            "direct_cli.v4.emit.call_v4",
             return_value={"result": "ok"},
         ) as call:
             result = _invoke(
@@ -160,9 +160,9 @@ def test_enable_shared_account_sandbox_calls_v4_api_without_dry_run():
 
 
 def test_account_management_sandbox_calls_v4_api_without_dry_run():
-    with patch("direct_cli.commands.v4account.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         with patch(
-            "direct_cli.commands.v4account.call_v4",
+            "direct_cli.v4.emit.call_v4",
             return_value={"ActionsResult": [{"AccountID": 1327944}]},
         ) as call:
             result = _invoke(
@@ -205,9 +205,9 @@ def test_account_management_sandbox_calls_v4_api_without_dry_run():
 
 
 def test_account_management_sandbox_formats_mocked_response_as_table():
-    with patch("direct_cli.commands.v4account.create_v4_client"):
+    with patch("direct_cli.v4.emit.create_v4_client"):
         with patch(
-            "direct_cli.commands.v4account.call_v4",
+            "direct_cli.v4.emit.call_v4",
             return_value=[{"AccountID": 1327944, "Status": "Updated"}],
         ):
             result = _invoke(
@@ -330,7 +330,7 @@ def test_account_management_sandbox_formats_mocked_response_as_table():
     ],
 )
 def test_v4account_usage_errors_fail_before_body_build(args, message):
-    with patch("direct_cli.commands.v4account.build_v4_body") as build_body:
+    with patch("direct_cli.v4.emit.build_v4_body") as build_body:
         result = _invoke(*args)
 
     assert result.exit_code != 0
@@ -498,7 +498,7 @@ def test_account_management_get_dry_run_with_both_filters():
 
 
 def test_account_management_get_rejects_update_only_flag():
-    with patch("direct_cli.commands.v4account.build_v4_body") as build_body:
+    with patch("direct_cli.v4.emit.build_v4_body") as build_body:
         result = _invoke(
             "v4account",
             "account-management",
@@ -515,9 +515,9 @@ def test_account_management_get_rejects_update_only_flag():
 
 
 def test_account_management_get_does_not_require_dry_run_or_sandbox():
-    with patch("direct_cli.commands.v4account.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         with patch(
-            "direct_cli.commands.v4account.call_v4",
+            "direct_cli.v4.emit.call_v4",
             return_value={"Accounts": []},
         ):
             result = _invoke(
@@ -537,7 +537,7 @@ def test_account_management_get_does_not_require_dry_run_or_sandbox():
 
 def test_account_management_get_caps_logins_at_50():
     logins = ",".join(f"login-{i}" for i in range(51))
-    with patch("direct_cli.commands.v4account.build_v4_body") as build_body:
+    with patch("direct_cli.v4.emit.build_v4_body") as build_body:
         result = _invoke(
             "v4account",
             "account-management",
@@ -555,7 +555,7 @@ def test_account_management_get_caps_logins_at_50():
 
 def test_account_management_get_caps_account_ids_at_100():
     ids = ",".join(str(i) for i in range(1, 102))
-    with patch("direct_cli.commands.v4account.build_v4_body") as build_body:
+    with patch("direct_cli.v4.emit.build_v4_body") as build_body:
         result = _invoke(
             "v4account",
             "account-management",
@@ -575,7 +575,7 @@ def test_account_management_get_caps_account_ids_at_100():
 
 
 def test_account_management_update_rejects_get_flag():
-    with patch("direct_cli.commands.v4account.build_v4_body") as build_body:
+    with patch("direct_cli.v4.emit.build_v4_body") as build_body:
         result = _invoke(
             "v4account",
             "account-management",
@@ -660,7 +660,7 @@ def test_account_management_deposit_with_origin_and_contract():
 
 
 def test_account_management_deposit_requires_dry_run_or_sandbox():
-    with patch("direct_cli.commands.v4account.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         result = _invoke(
             "--token",
             "token",
@@ -684,7 +684,7 @@ def test_account_management_deposit_requires_dry_run_or_sandbox():
 
 
 def test_account_management_deposit_requires_finance_credentials():
-    with patch("direct_cli.commands.v4account.build_v4_body") as build_body:
+    with patch("direct_cli.v4.emit.build_v4_body") as build_body:
         result = _invoke(
             "v4account",
             "account-management",
@@ -703,7 +703,7 @@ def test_account_management_deposit_requires_finance_credentials():
 
 
 def test_account_management_deposit_requires_currency():
-    with patch("direct_cli.commands.v4account.build_v4_body") as build_body:
+    with patch("direct_cli.v4.emit.build_v4_body") as build_body:
         result = _invoke(
             "v4account",
             "account-management",
@@ -724,7 +724,7 @@ def test_account_management_deposit_requires_currency():
 
 
 def test_account_management_deposit_rejects_duplicate_account_ids():
-    with patch("direct_cli.commands.v4account.build_v4_body") as build_body:
+    with patch("direct_cli.v4.emit.build_v4_body") as build_body:
         result = _invoke(
             "v4account",
             "account-management",
@@ -779,7 +779,7 @@ def test_account_management_invoice_dry_run_uses_payments_without_origin():
 
 
 def test_account_management_invoice_rejects_origin_flag():
-    with patch("direct_cli.commands.v4account.build_v4_body") as build_body:
+    with patch("direct_cli.v4.emit.build_v4_body") as build_body:
         result = _invoke(
             "v4account",
             "account-management",
@@ -843,7 +843,7 @@ def test_account_management_transfer_dry_run_uses_single_transfer():
 
 
 def test_account_management_transfer_rejects_equal_from_to():
-    with patch("direct_cli.commands.v4account.build_v4_body") as build_body:
+    with patch("direct_cli.v4.emit.build_v4_body") as build_body:
         result = _invoke(
             "v4account",
             "account-management",
@@ -870,7 +870,7 @@ def test_account_management_transfer_rejects_equal_from_to():
 
 
 def test_account_management_transfer_requires_currency():
-    with patch("direct_cli.commands.v4account.build_v4_body") as build_body:
+    with patch("direct_cli.v4.emit.build_v4_body") as build_body:
         result = _invoke(
             "v4account",
             "account-management",
@@ -895,7 +895,7 @@ def test_account_management_transfer_requires_currency():
 
 
 def test_account_management_transfer_requires_all_three_flags():
-    with patch("direct_cli.commands.v4account.build_v4_body") as build_body:
+    with patch("direct_cli.v4.emit.build_v4_body") as build_body:
         result = _invoke(
             "v4account",
             "account-management",
@@ -942,9 +942,9 @@ def test_account_management_options_are_all_in_allow_list():
         covered |= allowed
 
     uncovered = option_param_names - covered
-    assert not uncovered, (
-        f"account-management options not in any allow-list: {sorted(uncovered)}"
-    )
+    assert (
+        not uncovered
+    ), f"account-management options not in any allow-list: {sorted(uncovered)}"
 
 
 # ─── Envvar-vs-CLI source distinction (regression for PR #234 review) ────
@@ -998,7 +998,7 @@ def test_account_management_update_ignores_finance_envvars():
 
 def test_account_management_deposit_misleading_amount_message_uses_payment_label():
     """A bad amount in --payment must point at --payment, not --amount."""
-    with patch("direct_cli.commands.v4account.build_v4_body") as build_body:
+    with patch("direct_cli.v4.emit.build_v4_body") as build_body:
         result = _invoke(
             "v4account",
             "account-management",

--- a/tests/test_v4adimage.py
+++ b/tests/test_v4adimage.py
@@ -135,9 +135,9 @@ def test_set_rejects_duplicate_ad_id():
 
 
 def test_get_formats_mocked_response():
-    with patch("direct_cli.commands.v4adimage.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         with patch(
-            "direct_cli.commands.v4adimage.call_v4",
+            "direct_cli.v4.emit.call_v4",
             return_value=[{"AdID": 1, "AdImageHash": "h"}],
         ) as call:
             result = _invoke(

--- a/tests/test_v4events.py
+++ b/tests/test_v4events.py
@@ -159,7 +159,7 @@ def test_get_events_log_rejects_unknown_event_type():
 
 
 def test_get_events_log_rejects_invalid_filter_id_before_api_call():
-    with patch("direct_cli.commands.v4events.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         result = _invoke(
             "v4events",
             "get-events-log",
@@ -200,7 +200,7 @@ def test_get_events_log_rejects_noncanonical_from_datetime(timestamp):
 
 
 def test_get_events_log_rejects_from_after_to_before_api_call():
-    with patch("direct_cli.commands.v4events.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         result = _invoke(
             "v4events",
             "get-events-log",
@@ -216,9 +216,9 @@ def test_get_events_log_rejects_from_after_to_before_api_call():
 
 
 def test_get_events_log_formats_mocked_response_as_json():
-    with patch("direct_cli.commands.v4events.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         with patch(
-            "direct_cli.commands.v4events.call_v4",
+            "direct_cli.v4.emit.call_v4",
             return_value=[{"Timestamp": "2026-04-14T00:01:00", "EventType": "ADD"}],
         ) as call:
             result = _invoke(

--- a/tests/test_v4finance_money.py
+++ b/tests/test_v4finance_money.py
@@ -327,7 +327,7 @@ def test_master_token_requires_finance_login_without_login_fallback():
 
 
 def test_v4finance_money_commands_require_dry_run_before_api_call():
-    with patch("direct_cli.commands.v4finance.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         result = _invoke(
             "--token",
             "token",
@@ -353,7 +353,7 @@ def test_v4finance_money_commands_require_dry_run_before_api_call():
 
 
 def test_v4finance_money_commands_require_finance_credentials_before_api_call():
-    with patch("direct_cli.commands.v4finance.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         result = _invoke(
             "--token",
             "token",
@@ -378,7 +378,7 @@ def test_v4finance_money_commands_require_finance_credentials_before_api_call():
 
 
 def test_v4finance_money_commands_validate_amount_before_api_call():
-    with patch("direct_cli.commands.v4finance.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         result = _invoke(
             "v4finance",
             "transfer-money",
@@ -416,7 +416,7 @@ def test_create_invoice_rejects_invalid_payment_specs_before_api_call(
     payment,
     expected,
 ):
-    with patch("direct_cli.commands.v4finance.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         result = _invoke(
             "v4finance",
             "create-invoice",
@@ -437,7 +437,7 @@ def test_create_invoice_rejects_invalid_payment_specs_before_api_call(
 
 
 def test_create_invoice_rejects_duplicate_campaign_ids_before_api_call():
-    with patch("direct_cli.commands.v4finance.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         result = _invoke(
             "v4finance",
             "create-invoice",
@@ -614,7 +614,7 @@ def test_check_payment_dry_run_uses_custom_transaction_id_object():
     ],
 )
 def test_check_payment_rejects_invalid_custom_transaction_id_before_api_call(value):
-    with patch("direct_cli.commands.v4finance.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         result = _invoke(
             "v4finance",
             "check-payment",
@@ -630,9 +630,9 @@ def test_check_payment_rejects_invalid_custom_transaction_id_before_api_call(val
 
 
 def test_check_payment_formats_mocked_response_as_json():
-    with patch("direct_cli.commands.v4finance.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         with patch(
-            "direct_cli.commands.v4finance.call_v4",
+            "direct_cli.v4.emit.call_v4",
             return_value={"Status": "Done"},
         ) as call:
             result = _invoke(
@@ -662,9 +662,9 @@ def test_check_payment_formats_mocked_response_as_json():
 
 
 def test_create_invoice_formats_mocked_response_as_json():
-    with patch("direct_cli.commands.v4finance.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         with patch(
-            "direct_cli.commands.v4finance.call_v4",
+            "direct_cli.v4.emit.call_v4",
             return_value={"URL": "https://example.test/invoice"},
         ) as call:
             result = _invoke(

--- a/tests/test_v4finance_read.py
+++ b/tests/test_v4finance_read.py
@@ -60,9 +60,9 @@ def test_get_clients_units_dry_run_uses_login_list():
 
 
 def test_get_clients_units_formats_mocked_response_as_json():
-    with patch("direct_cli.commands.v4finance.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         with patch(
-            "direct_cli.commands.v4finance.call_v4",
+            "direct_cli.v4.emit.call_v4",
             return_value=[{"Login": "client-login", "UnitsRest": 100}],
         ) as call:
             result = _invoke(
@@ -137,7 +137,7 @@ def test_get_credit_limits_can_compute_finance_token_from_master_token():
 
 
 def test_get_credit_limits_requires_finance_credentials_before_api_call():
-    with patch("direct_cli.commands.v4finance.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         result = _invoke(
             "--token",
             "token",
@@ -151,7 +151,7 @@ def test_get_credit_limits_requires_finance_credentials_before_api_call():
 
 
 def test_get_credit_limits_rejects_blank_finance_token_before_api_call():
-    with patch("direct_cli.commands.v4finance.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         result = _invoke(
             "--token",
             "token",
@@ -169,8 +169,8 @@ def test_get_credit_limits_rejects_blank_finance_token_before_api_call():
 
 
 def test_get_credit_limits_strips_finance_token_before_api_call():
-    with patch("direct_cli.commands.v4finance.create_v4_client") as create_client:
-        with patch("direct_cli.commands.v4finance.call_v4", return_value=[]) as call:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
+        with patch("direct_cli.v4.emit.call_v4", return_value=[]) as call:
             result = _invoke(
                 "--token",
                 "token",
@@ -194,7 +194,7 @@ def test_get_credit_limits_strips_finance_token_before_api_call():
 
 def test_get_credit_limits_rejects_unknown_logins_flag():
     """--logins is no longer accepted; docs define the body without param."""
-    with patch("direct_cli.commands.v4finance.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         result = _invoke(
             "--token",
             "token",
@@ -214,9 +214,9 @@ def test_get_credit_limits_rejects_unknown_logins_flag():
 
 
 def test_get_credit_limits_formats_mocked_response_as_json():
-    with patch("direct_cli.commands.v4finance.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         with patch(
-            "direct_cli.commands.v4finance.call_v4",
+            "direct_cli.v4.emit.call_v4",
             return_value=[{"Login": "client-login", "CreditLimit": 1000}],
         ) as call:
             result = _invoke(

--- a/tests/test_v4forecast.py
+++ b/tests/test_v4forecast.py
@@ -111,7 +111,7 @@ def test_create_rejects_invalid_auction_bids():
 
 
 def test_create_invalid_categories_fail_before_api_call():
-    with patch("direct_cli.commands.v4forecast.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         result = _invoke(
             "v4forecast",
             "create",
@@ -140,7 +140,7 @@ def test_create_parses_three_phrase_entries():
 
 
 def test_create_empty_phrases_fail_before_api_call():
-    with patch("direct_cli.commands.v4forecast.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         result = _invoke(
             "v4forecast",
             "create",
@@ -155,7 +155,7 @@ def test_create_empty_phrases_fail_before_api_call():
 
 def test_create_more_than_100_phrases_fail_before_api_call():
     phrases = ",".join(str(index) for index in range(101))
-    with patch("direct_cli.commands.v4forecast.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         result = _invoke(
             "v4forecast",
             "create",
@@ -169,7 +169,7 @@ def test_create_more_than_100_phrases_fail_before_api_call():
 
 
 def test_create_invalid_geo_ids_fail_before_api_call():
-    with patch("direct_cli.commands.v4forecast.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         result = _invoke(
             "v4forecast",
             "create",
@@ -225,9 +225,9 @@ def test_delete_dry_run_uses_scalar_forecast_id():
 
 def test_list_formats_mocked_response_as_json():
     response = [{"ForecastID": 123, "StatusForecast": "Done"}]
-    with patch("direct_cli.commands.v4forecast.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         with patch(
-            "direct_cli.commands.v4forecast.call_v4",
+            "direct_cli.v4.emit.call_v4",
             return_value=response,
         ) as call:
             result = _invoke(

--- a/tests/test_v4goals.py
+++ b/tests/test_v4goals.py
@@ -84,9 +84,9 @@ def test_get_retargeting_goals_empty_campaign_ids_fails_with_usage_error():
 
 
 def test_get_stat_goals_formats_mocked_response_as_json():
-    with patch("direct_cli.commands.v4goals.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         with patch(
-            "direct_cli.commands.v4goals.call_v4",
+            "direct_cli.v4.emit.call_v4",
             return_value=[{"CampaignID": 1, "GoalID": 10, "Name": "Lead"}],
         ) as call:
             result = _invoke(
@@ -110,9 +110,9 @@ def test_get_stat_goals_formats_mocked_response_as_json():
 
 
 def test_get_stat_goals_with_login_keeps_method_param_schema():
-    with patch("direct_cli.commands.v4goals.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         with patch(
-            "direct_cli.commands.v4goals.call_v4",
+            "direct_cli.v4.emit.call_v4",
             return_value=[{"CampaignID": 1, "GoalID": 10, "Name": "Lead"}],
         ) as call:
             result = _invoke(
@@ -141,9 +141,9 @@ def test_get_stat_goals_with_login_keeps_method_param_schema():
 
 
 def test_get_retargeting_goals_formats_mocked_response_as_table():
-    with patch("direct_cli.commands.v4goals.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         with patch(
-            "direct_cli.commands.v4goals.call_v4",
+            "direct_cli.v4.emit.call_v4",
             return_value=[{"CampaignID": 1, "GoalID": 10, "Name": "Lead"}],
         ) as call:
             result = _invoke(

--- a/tests/test_v4keywords.py
+++ b/tests/test_v4keywords.py
@@ -68,9 +68,9 @@ def test_get_suggestion_all_blank_keywords_fails():
 
 
 def test_get_suggestion_formats_mocked_response():
-    with patch("direct_cli.commands.v4keywords.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         with patch(
-            "direct_cli.commands.v4keywords.call_v4",
+            "direct_cli.v4.emit.call_v4",
             return_value=["холодильник купить", "холодильник цена"],
         ) as call:
             result = _invoke(

--- a/tests/test_v4tags.py
+++ b/tests/test_v4tags.py
@@ -222,9 +222,9 @@ def test_update_banners_tags_rejects_missing_or_empty_tag_ids():
 
 
 def test_v4tags_formats_mocked_response_as_json():
-    with patch("direct_cli.commands.v4tags.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         with patch(
-            "direct_cli.commands.v4tags.call_v4",
+            "direct_cli.v4.emit.call_v4",
             return_value=[{"CampaignID": 1, "Tags": [{"TagID": 10, "Tag": "Sale"}]}],
         ) as call:
             result = _invoke(
@@ -248,8 +248,8 @@ def test_v4tags_formats_mocked_response_as_json():
 
 
 def test_v4tags_with_login_keeps_method_param_schema():
-    with patch("direct_cli.commands.v4tags.create_v4_client") as create_client:
-        with patch("direct_cli.commands.v4tags.call_v4", return_value=1) as call:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
+        with patch("direct_cli.v4.emit.call_v4", return_value=1) as call:
             result = _invoke(
                 "--token",
                 "token",

--- a/tests/test_v4wordstat.py
+++ b/tests/test_v4wordstat.py
@@ -70,7 +70,7 @@ def test_create_report_parses_three_phrase_entries():
 
 
 def test_create_report_empty_phrases_fail_before_api_call():
-    with patch("direct_cli.commands.v4wordstat.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         result = _invoke(
             "v4wordstat",
             "create-report",
@@ -85,7 +85,7 @@ def test_create_report_empty_phrases_fail_before_api_call():
 
 def test_create_report_more_than_10_phrases_fail_before_api_call():
     phrases = ",".join(str(index) for index in range(11))
-    with patch("direct_cli.commands.v4wordstat.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         result = _invoke(
             "v4wordstat",
             "create-report",
@@ -99,7 +99,7 @@ def test_create_report_more_than_10_phrases_fail_before_api_call():
 
 
 def test_create_report_invalid_geo_ids_fail_before_api_call():
-    with patch("direct_cli.commands.v4wordstat.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         result = _invoke(
             "v4wordstat",
             "create-report",
@@ -155,9 +155,9 @@ def test_delete_report_dry_run_uses_scalar_report_id():
 
 def test_list_reports_formats_mocked_response_as_json():
     response = [{"ReportID": 123, "StatusReport": "Done"}]
-    with patch("direct_cli.commands.v4wordstat.create_v4_client") as create_client:
+    with patch("direct_cli.v4.emit.create_v4_client") as create_client:
         with patch(
-            "direct_cli.commands.v4wordstat.call_v4",
+            "direct_cli.v4.emit.call_v4",
             return_value=response,
         ) as call:
             result = _invoke(
@@ -185,9 +185,9 @@ def test_list_reports_formats_mocked_response_as_json():
 
 
 def test_get_report_formats_mocked_response_as_table():
-    with patch("direct_cli.commands.v4wordstat.create_v4_client"):
+    with patch("direct_cli.v4.emit.create_v4_client"):
         with patch(
-            "direct_cli.commands.v4wordstat.call_v4",
+            "direct_cli.v4.emit.call_v4",
             return_value=[{"Phrase": "buy laptop", "Shows": 42}],
         ):
             result = _invoke(


### PR DESCRIPTION
Часть эпика #491, **A3** — off-gate, низкий риск.

## Что сделано

**Находка 9:** паттерн `create_v4_client → call_v4 → format_output` (+ dry-run) дублировался во всех v4-командах. Вынес в новый модуль `direct_cli/v4/emit.py`:
- `emit_or_call_v4(ctx, method, param, dry_run, output_format, output)`
- `emit_or_call_v4_finance(...)` (+finance_token/operation_num, маскирование токена)
- `_masked_finance_body(...)` (+ `FINANCE_TOKEN_MASK`)

Раньше это были приватные `_emit_or_call_v4*` в v4account.py и `_masked_finance_body` в v4finance.py.

Мигрировано **9 v4-модулей**, убраны локальные клоны/инлайн: v4account, v4finance, v4forecast, v4adimage, v4events, v4goals, v4keywords, v4tags, v4wordstat. Поведение не меняется — хелперы перенесены дословно (с `@handle_api_errors`), dry-run и маскирование finance-токена идентичны.

## Не мигрировано

`v4finance` `transfer_money`/`pay_campaigns`/`pay_campaigns_by_card` — dry-run-only (без live-вызова), оставлены инлайн с `_masked_finance_body` (теперь импортируется из общего модуля).

## Тесты

v4-сьюты патчили `direct_cli.commands.<module>.{call_v4,create_v4_client,build_v4_body}`. Поскольку реальные вызовы теперь в `direct_cli.v4.emit`, **73 patch-таргета** перенаправлены на `direct_cli.v4.emit.*` (те же поведенческие проверки, корректное новое место). Это прямое следствие централизации, не изменение поведения.

## Объём

21 файл + новый `emit.py` (79 строк), **+228 / −433**.

## Верификация

- Полный прогон: **2087 passed, 47 skipped** (0 регрессий).
- Поведенческая проверка: `v4finance create-invoice --dry-run` → `"finance_token":"<redacted>"`, реального токена нет, exit 0.
- `black --check` чисто; flake8 — **0 новых** vs main; нет цикл. импорта.

Closes #494.

🤖 Generated with [Claude Code](https://claude.com/claude-code)