### PR TITLE
refactor: @get_options composite decorator for get commands (dedup #491 A4)

### DIFF
--- a/direct_cli/commands/adimages.py
+++ b/direct_cli/commands/adimages.py
@@ -7,7 +7,13 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
-from ..utils import add_criteria_csv, get_default_fields, load_base64_file, parse_ids
+from ..utils import (
+    add_criteria_csv,
+    get_default_fields,
+    get_options,
+    load_base64_file,
+    parse_ids,
+)
 
 
 @click.group()
@@ -19,12 +25,7 @@ def adimages():
 @click.option("--ids", help="Comma-separated image IDs")
 @click.option("--image-hashes", help="Comma-separated ad image hashes")
 @click.option("--associated", type=click.Choice(["YES", "NO"], case_sensitive=False))
-@click.option("--limit", type=int, help="Limit number of results")
-@click.option("--fetch-all", is_flag=True, help="Fetch all pages")
-@click.option("--format", "output_format", default="json", help="Output format")
-@click.option("--output", help="Output file")
-@click.option("--fields", help="Comma-separated field names")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@get_options
 @click.pass_context
 @handle_api_errors
 def get(

--- a/direct_cli/commands/advideos.py
+++ b/direct_cli/commands/advideos.py
@@ -7,7 +7,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
-from ..utils import get_default_fields, load_base64_file
+from ..utils import get_default_fields, get_options, load_base64_file
 
 
 @click.group()
@@ -17,12 +17,7 @@ def advideos():
 
 @advideos.command()
 @click.option("--ids", required=True, help="Comma-separated video IDs")
-@click.option("--limit", type=int, help="Limit number of results")
-@click.option("--fetch-all", is_flag=True, help="Fetch all pages")
-@click.option("--format", "output_format", default="json", help="Output format")
-@click.option("--output", help="Output file")
-@click.option("--fields", help="Comma-separated field names")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@get_options
 @click.pass_context
 @handle_api_errors
 def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):

--- a/direct_cli/commands/audiencetargets.py
+++ b/direct_cli/commands/audiencetargets.py
@@ -7,7 +7,13 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
-from ..utils import add_criteria_csv, get_default_fields, parse_ids, MICRO_RUBLES
+from ..utils import (
+    MICRO_RUBLES,
+    add_criteria_csv,
+    get_default_fields,
+    get_options,
+    parse_ids,
+)
 
 
 @click.group()
@@ -22,12 +28,7 @@ def audiencetargets():
 @click.option("--retargeting-list-ids", help="Comma-separated retargeting list IDs")
 @click.option("--interest-ids", help="Comma-separated interest IDs")
 @click.option("--states", help="Comma-separated states")
-@click.option("--limit", type=int, help="Limit number of results")
-@click.option("--fetch-all", is_flag=True, help="Fetch all pages")
-@click.option("--format", "output_format", default="json", help="Output format")
-@click.option("--output", help="Output file")
-@click.option("--fields", help="Comma-separated field names")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@get_options
 @click.pass_context
 @handle_api_errors
 def get(

--- a/direct_cli/commands/bids.py
+++ b/direct_cli/commands/bids.py
@@ -8,11 +8,12 @@ from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
 from ..utils import (
+    MICRO_RUBLES,
     add_criteria_csv,
     add_single_id_selector,
     get_default_fields,
+    get_options,
     parse_ids,
-    MICRO_RUBLES,
 )
 
 
@@ -26,12 +27,7 @@ def bids():
 @click.option("--adgroup-ids", help="Comma-separated ad group IDs")
 @click.option("--keyword-ids", help="Comma-separated keyword IDs")
 @click.option("--serving-statuses", help="Comma-separated serving statuses")
-@click.option("--limit", type=int, help="Limit number of results")
-@click.option("--fetch-all", is_flag=True, help="Fetch all pages")
-@click.option("--format", "output_format", default="json", help="Output format")
-@click.option("--output", help="Output file")
-@click.option("--fields", help="Comma-separated field names")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@get_options
 @click.pass_context
 @handle_api_errors
 def get(

--- a/direct_cli/commands/businesses.py
+++ b/direct_cli/commands/businesses.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..output import format_output, handle_api_errors
-from ..utils import get_default_fields, parse_ids
+from ..utils import get_default_fields, get_options, parse_ids
 
 
 @click.group()
@@ -16,12 +16,7 @@ def businesses():
 
 @businesses.command()
 @click.option("--ids", help="Comma-separated business IDs")
-@click.option("--limit", type=int, help="Limit number of results")
-@click.option("--fetch-all", is_flag=True, help="Fetch all pages")
-@click.option("--format", "output_format", default="json", help="Output format")
-@click.option("--output", help="Output file")
-@click.option("--fields", help="Comma-separated field names")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@get_options
 @click.pass_context
 @handle_api_errors
 def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):

--- a/direct_cli/commands/dynamicads.py
+++ b/direct_cli/commands/dynamicads.py
@@ -7,7 +7,13 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
-from ..utils import get_default_fields, parse_condition_specs, parse_ids, MICRO_RUBLES
+from ..utils import (
+    MICRO_RUBLES,
+    get_default_fields,
+    get_options,
+    parse_condition_specs,
+    parse_ids,
+)
 
 
 @click.group()
@@ -20,12 +26,7 @@ def dynamicads():
 @click.option("--adgroup-ids", help="Comma-separated ad group IDs")
 @click.option("--campaign-ids", help="Comma-separated campaign IDs")
 @click.option("--states", help="Comma-separated states")
-@click.option("--limit", type=int, help="Limit number of results")
-@click.option("--fetch-all", is_flag=True, help="Fetch all pages")
-@click.option("--format", "output_format", default="json", help="Output format")
-@click.option("--output", help="Output file")
-@click.option("--fields", help="Comma-separated field names")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@get_options
 @click.pass_context
 @handle_api_errors
 def get(

--- a/direct_cli/commands/dynamicfeedadtargets.py
+++ b/direct_cli/commands/dynamicfeedadtargets.py
@@ -7,7 +7,13 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
-from ..utils import get_default_fields, parse_condition_specs, parse_ids, MICRO_RUBLES
+from ..utils import (
+    MICRO_RUBLES,
+    get_default_fields,
+    get_options,
+    parse_condition_specs,
+    parse_ids,
+)
 
 
 @click.group()
@@ -20,12 +26,7 @@ def dynamicfeedadtargets():
 @click.option("--adgroup-ids", help="Comma-separated ad group IDs")
 @click.option("--campaign-ids", help="Comma-separated campaign IDs")
 @click.option("--states", help="Comma-separated states")
-@click.option("--limit", type=int, help="Limit number of results")
-@click.option("--fetch-all", is_flag=True, help="Fetch all pages")
-@click.option("--format", "output_format", default="json", help="Output format")
-@click.option("--output", help="Output file")
-@click.option("--fields", help="Comma-separated field names")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@get_options
 @click.pass_context
 @handle_api_errors
 def get(

--- a/direct_cli/commands/negativekeywordsharedsets.py
+++ b/direct_cli/commands/negativekeywordsharedsets.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..output import format_output, handle_api_errors
-from ..utils import get_default_fields, parse_ids
+from ..utils import get_default_fields, get_options, parse_ids
 
 
 @click.group()
@@ -16,12 +16,7 @@ def negativekeywordsharedsets():
 
 @negativekeywordsharedsets.command()
 @click.option("--ids", help="Comma-separated set IDs")
-@click.option("--limit", type=int, help="Limit number of results")
-@click.option("--fetch-all", is_flag=True, help="Fetch all pages")
-@click.option("--format", "output_format", default="json", help="Output format")
-@click.option("--output", help="Output file")
-@click.option("--fields", help="Comma-separated field names")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@get_options
 @click.pass_context
 @handle_api_errors
 def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):

--- a/direct_cli/commands/smartadtargets.py
+++ b/direct_cli/commands/smartadtargets.py
@@ -7,7 +7,13 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
-from ..utils import get_default_fields, parse_condition_specs, parse_ids, MICRO_RUBLES
+from ..utils import (
+    MICRO_RUBLES,
+    get_default_fields,
+    get_options,
+    parse_condition_specs,
+    parse_ids,
+)
 
 
 @click.group()
@@ -20,12 +26,7 @@ def smartadtargets():
 @click.option("--adgroup-ids", help="Comma-separated ad group IDs")
 @click.option("--campaign-ids", help="Comma-separated campaign IDs")
 @click.option("--states", help="Comma-separated states")
-@click.option("--limit", type=int, help="Limit number of results")
-@click.option("--fetch-all", is_flag=True, help="Fetch all pages")
-@click.option("--format", "output_format", default="json", help="Output format")
-@click.option("--output", help="Output file")
-@click.option("--fields", help="Comma-separated field names")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@get_options
 @click.pass_context
 @handle_api_errors
 def get(

--- a/direct_cli/commands/turbopages.py
+++ b/direct_cli/commands/turbopages.py
@@ -11,7 +11,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..output import format_output, handle_api_errors
-from ..utils import get_default_fields, parse_ids
+from ..utils import get_default_fields, get_options, parse_ids
 
 
 @click.group()
@@ -22,12 +22,7 @@ def turbopages():
 @turbopages.command()
 @click.option("--ids", help="Comma-separated Turbo Page IDs")
 @click.option("--bound-with-hrefs", help="Comma-separated hrefs bound with Turbo Pages")
-@click.option("--limit", type=int, help="Limit number of results")
-@click.option("--fetch-all", is_flag=True, help="Fetch all pages")
-@click.option("--format", "output_format", default="json", help="Output format")
-@click.option("--output", help="Output file")
-@click.option("--fields", help="Comma-separated field names")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@get_options
 @click.pass_context
 @handle_api_errors
 def get(

--- a/direct_cli/commands/vcards.py
+++ b/direct_cli/commands/vcards.py
@@ -9,7 +9,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
-from ..utils import get_default_fields, parse_ids
+from ..utils import get_default_fields, get_options, parse_ids
 
 
 @click.group()
@@ -70,12 +70,7 @@ def _build_point_on_map(
 
 @vcards.command()
 @click.option("--ids", help="Comma-separated vCard IDs")
-@click.option("--limit", type=int, help="Limit number of results")
-@click.option("--fetch-all", is_flag=True, help="Fetch all pages")
-@click.option("--format", "output_format", default="json", help="Output format")
-@click.option("--output", help="Output file")
-@click.option("--fields", help="Comma-separated field names")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
+@get_options
 @click.pass_context
 @handle_api_errors
 def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):

--- a/direct_cli/utils.py
+++ b/direct_cli/utils.py
@@ -250,8 +250,7 @@ def validate_priority_goal_value(value_int: int, error_prefix: str) -> None:
     """
     if value_int < 0:
         raise click.UsageError(
-            f"{error_prefix} "
-            f"Value must be non-negative, got {value_int}"
+            f"{error_prefix} " f"Value must be non-negative, got {value_int}"
         )
     if 0 < value_int < MICRO_RUBLE_MIN:
         raise click.UsageError(
@@ -898,3 +897,34 @@ def get_docs_pages(service: str) -> Dict[str, str]:
     entry = RESOURCE_MAPPING_V5.get(service)
     docs_pages = entry.get("docs_pages") if entry else None
     return dict(docs_pages) if docs_pages else {}
+
+
+def get_options(func):
+    """Apply the shared read/pagination option stack of a ``get`` command.
+
+    Equivalent to writing, in this exact top-to-bottom order::
+
+        @click.option("--limit", type=int, help="Limit number of results")
+        @click.option("--fetch-all", is_flag=True, help="Fetch all pages")
+        @click.option("--format", "output_format", default="json", help="Output format")
+        @click.option("--output", help="Output file")
+        @click.option("--fields", help="Comma-separated field names")
+        @click.option("--dry-run", is_flag=True, help="Show request without sending")
+
+    Click applies decorators bottom-up, so the options are added here in
+    reverse to keep ``--help`` listing them in the order above. Only commands
+    whose six shared options are contiguous and use exactly these definitions
+    use this decorator; commands with a divergent ``--fields`` help string,
+    interleaved resource options, or a different option subset keep their
+    explicit stack so the CLI surface stays byte-identical.
+    """
+    func = click.option("--dry-run", is_flag=True, help="Show request without sending")(
+        func
+    )
+    func = click.option("--fields", help="Comma-separated field names")(func)
+    func = click.option("--output", help="Output file")(func)
+    func = click.option(
+        "--format", "output_format", default="json", help="Output format"
+    )(func)
+    func = click.option("--fetch-all", is_flag=True, help="Fetch all pages")(func)
+    return click.option("--limit", type=int, help="Limit number of results")(func)


### PR DESCRIPTION
Часть эпика #491, **A4** — off-gate; затрагивает CLI-поверхность, поэтому с жёсткой проверкой `--help`.

## Что сделано

Добавлен `utils.get_options` — композитный декоратор стека из 6 опций (`--limit` / `--fetch-all` / `--format` / `--output` / `--fields` / `--dry-run`). Применён к **11 get-командам**, где эти опции идут **подряд** и используют точные канонические определения: adimages, advideos, audiencetargets, bids, businesses, dynamicads, dynamicfeedadtargets, negativekeywordsharedsets, smartadtargets, turbopages, vcards.

Декоратор добавляет опции в обратном порядке (Click применяет декораторы снизу вверх), чтобы `--help` показывал их в исходном порядке.

## Гарантия CLI-поверхности

**`--help` для всех 11 команд byte-identical** относительно main (0 diff — проверено программно перед/после).

## Намеренно НЕ мигрировано (чтобы не менять `--help`)

- команды, где 6 опций **разорваны** resource-специфичными опциями (adextensions, ads, adgroups, campaigns, clients, creatives, feeds, keywords, leads, sitelinks, strategies, agencyclients, bidmodifiers) — единый декоратор переставил бы порядок;
- команды с resource-специфичным help у `--fields` (ads, sitelinks);
- команды с другим набором опций (keywordbids без `--fields`, retargeting без `--dry-run`, campaigns без `--format`/`--fields`, reports/v4*).

Это сознательное решение (обсуждено): покрываем только безопасный CONTIG-набор, частичный дедуп при нулевом риске для поверхности.

## Объём

12 файлов, **+85 / −79**.

## Верификация

- Полный прогон: **2087 passed, 47 skipped**.
- `--help` byte-identical для всех 11 мигрированных команд.
- `black --check` чисто; flake8 — **0 новых** vs main; import OK.

Closes #495.

🤖 Generated with [Claude Code](https://claude.com/claude-code)