### PR TITLE
refactor: dedup money parsers via max_decimals (#491 B1)

### DIFF
--- a/direct_cli/utils.py
+++ b/direct_cli/utils.py
@@ -354,6 +354,21 @@ TIN_TYPES = {
 YES_NO_VALUES = {"YES", "NO"}
 
 DECIMAL_RE = re.compile(r"^(?:0|[1-9]\d*)(?:\.\d+)?$")
+# Compiled decimal patterns keyed by the maximum allowed fractional digits,
+# so callers that cap precision (e.g. v4 money, max 2 dp) don't recompile.
+_DECIMAL_RE_CACHE: Dict[int, "re.Pattern[str]"] = {}
+
+
+def _decimal_re(max_decimals: Optional[int]) -> "re.Pattern[str]":
+    """Return the decimal validator, optionally capping fractional digits."""
+    if max_decimals is None:
+        return DECIMAL_RE
+    cached = _DECIMAL_RE_CACHE.get(max_decimals)
+    if cached is None:
+        cached = re.compile(r"^(?:0|[1-9]\d*)(?:\.\d{1," + str(max_decimals) + "})?$")
+        _DECIMAL_RE_CACHE[max_decimals] = cached
+    return cached
+
 
 CONTRACT_TYPES = {
     "CONTRACT",
@@ -555,10 +570,17 @@ def build_erir_contragent(
     return contragent or None
 
 
-def parse_positive_decimal_amount(value: str, option_name: str) -> float:
-    """Parse a positive finite decimal CLI amount."""
+def parse_positive_decimal_amount(
+    value: str, option_name: str, *, max_decimals: Optional[int] = None
+) -> float:
+    """Parse a positive finite decimal CLI amount.
+
+    ``max_decimals`` caps the number of fractional digits accepted (``None``
+    means unlimited). v4 ``Sum`` fields pass ``max_decimals=2`` via
+    :func:`direct_cli.v4.money.parse_v4_money_sum`.
+    """
     normalized = (value or "").strip()
-    if not DECIMAL_RE.fullmatch(normalized):
+    if not _decimal_re(max_decimals).fullmatch(normalized):
         raise click.UsageError(
             f"{option_name} must be a positive decimal amount, for example 100.50"
         )

--- a/direct_cli/v4/money.py
+++ b/direct_cli/v4/money.py
@@ -2,44 +2,25 @@
 
 from __future__ import annotations
 
-from decimal import Decimal, InvalidOperation
 import hashlib
-import math
-import re
 
 import click
 
-_MONEY_RE = re.compile(r"^(?:0|[1-9]\d*)(?:\.\d{1,2})?$")
+from ..utils import parse_positive_decimal_amount
+
 MAX_OPERATION_NUM = 9223372036854775807
 
 
 def parse_v4_money_sum(value: str, option_name: str = "--amount") -> float:
     """Parse a positive API-native decimal amount for v4 ``Sum`` fields.
 
-    ``option_name`` controls the CLI flag label that appears in error messages
-    so callers (e.g. ``--payment ACCOUNT_ID=AMOUNT`` parsers) get a diagnostic
-    that names the flag the user actually typed.
+    v4 ``Sum`` fields allow at most two fractional digits, so this delegates to
+    the shared :func:`direct_cli.utils.parse_positive_decimal_amount` with
+    ``max_decimals=2``. ``option_name`` controls the CLI flag label that appears
+    in error messages so callers (e.g. ``--payment ACCOUNT_ID=AMOUNT`` parsers)
+    get a diagnostic that names the flag the user actually typed.
     """
-    normalized = (value or "").strip()
-    if not _MONEY_RE.fullmatch(normalized):
-        raise click.UsageError(
-            f"{option_name} must be a positive decimal amount, for example 100.50"
-        )
-
-    try:
-        amount = Decimal(normalized)
-    except InvalidOperation as exc:
-        raise click.UsageError(
-            f"{option_name} must be a positive decimal amount, for example 100.50"
-        ) from exc
-
-    if amount <= 0:
-        raise click.UsageError(f"{option_name} must be greater than zero")
-
-    result = float(amount)
-    if not math.isfinite(result):
-        raise click.UsageError(f"{option_name} must be a finite decimal amount")
-    return result
+    return parse_positive_decimal_amount(value, option_name, max_decimals=2)
 
 
 def normalize_finance_login(login: str) -> str:

--- a/tests/test_v4finance_money.py
+++ b/tests/test_v4finance_money.py
@@ -7,6 +7,7 @@ from click import UsageError
 from click.testing import CliRunner
 
 from direct_cli.cli import cli
+from direct_cli.utils import parse_positive_decimal_amount
 from direct_cli.v4_contracts import get_v4_contract
 from direct_cli.v4.money import (
     build_finance_token,
@@ -48,6 +49,37 @@ def test_parse_v4_money_sum_accepts_positive_decimal_amounts(value, expected):
 def test_parse_v4_money_sum_rejects_invalid_amounts(value):
     with pytest.raises(UsageError):
         parse_v4_money_sum(value)
+
+
+def test_parse_positive_decimal_amount_unlimited_accepts_many_decimals():
+    # v5 callers pass no max_decimals: unlimited fractional precision.
+    assert parse_positive_decimal_amount("1.23456", "--x") == 1.23456
+
+
+def test_parse_positive_decimal_amount_max_decimals_caps_precision():
+    # v4 money delegates with max_decimals=2 and must reject 3+ dp.
+    assert parse_positive_decimal_amount("1.23", "--x", max_decimals=2) == 1.23
+    with pytest.raises(UsageError):
+        parse_positive_decimal_amount("1.234", "--x", max_decimals=2)
+
+
+@pytest.mark.parametrize("value", ["", "0", "-1", "abc", "NaN", "inf"])
+@pytest.mark.parametrize("max_decimals", [None, 2])
+def test_parse_positive_decimal_amount_rejects_invalid_both_modes(value, max_decimals):
+    with pytest.raises(UsageError):
+        parse_positive_decimal_amount(value, "--x", max_decimals=max_decimals)
+
+
+def test_parse_positive_decimal_amount_error_message_identical_across_modes():
+    # The diagnostic text must not change between unlimited and capped modes.
+    def _msg(max_decimals):
+        try:
+            parse_positive_decimal_amount("abc", "--x", max_decimals=max_decimals)
+        except UsageError as exc:
+            return str(exc)
+        raise AssertionError("expected UsageError")
+
+    assert _msg(None) == _msg(2)
 
 
 def test_build_finance_token_uses_docs_formula_and_normalized_login():


### PR DESCRIPTION
Part of epic #491 (code-duplication audit), phase B1.

## Problem

`direct_cli/utils.py::parse_positive_decimal_amount` and
`direct_cli/v4/money.py::parse_v4_money_sum` had **line-for-line identical**
bodies (normalize → regex check → `Decimal` → `<= 0` → `float` → `isfinite`),
differing only in:

- the regex decimal cap: `DECIMAL_RE` (unlimited) vs `_MONEY_RE` (`\.\d{1,2}`, v4);
- docstring;
- default `option_name` (`parse_v4_money_sum` has `="--amount"`).

## Change

- Generalize `utils.parse_positive_decimal_amount` with a keyword-only
  `max_decimals` (`None` = unlimited → **v5 behavior unchanged**), backed by a
  tiny `_DECIMAL_RE_CACHE` so capped patterns aren't recompiled per call.
- `parse_v4_money_sum` now delegates with `max_decimals=2`, keeping its default
  `option_name="--amount"` and v4 `Sum` semantics. Removed the now-dead
  `_MONEY_RE` and the `Decimal`/`InvalidOperation`/`math`/`re` imports from
  `v4/money.py`.

## Behavior is 1:1

- Error text (`... must be a positive decimal amount, for example 100.50`) is
  byte-identical across modes.
- The existing v4 reject test (`"1.234"` etc.) stays green **untouched**.
- No import cycle: `utils.py` imports nothing from `v4`.

## Tests

- Existing `test_v4finance_money.py` v4 accept/reject cases unchanged.
- New direct units on `parse_positive_decimal_amount`: unlimited mode accepts
  `1.23456`; `max_decimals=2` rejects `1.234`; shared invalid cases
  (`<=0`/`NaN`/`inf`/empty) for both modes; identical diagnostics across modes.
- Full suite: **2102 passed, 47 skipped** (baseline 2087 + 15 new params).
- `black`/`flake8` clean on changed files.

Closes #496

🤖 Generated with [Claude Code](https://claude.com/claude-code)