### PR TITLE
refactor: dedup behavior-identical .split(",") via parse_csv_strings (#491 B2a)

### DIFF
--- a/direct_cli/commands/adgroups.py
+++ b/direct_cli/commands/adgroups.py
@@ -611,7 +611,7 @@ def get(
 
     client = client_from_ctx(ctx, create_client)
 
-    field_names = fields.split(",") if fields else get_default_fields("adgroups")
+    field_names = parse_csv_strings(fields) or get_default_fields("adgroups")
 
     raw_nested = (
         (

--- a/direct_cli/commands/adimages.py
+++ b/direct_cli/commands/adimages.py
@@ -12,6 +12,7 @@ from ..utils import (
     get_default_fields,
     get_options,
     load_base64_file,
+    parse_csv_strings,
     parse_ids,
 )
 
@@ -43,7 +44,7 @@ def get(
     """Get ad images"""
     client = client_from_ctx(ctx, create_client)
 
-    field_names = fields.split(",") if fields else get_default_fields("adimages")
+    field_names = parse_csv_strings(fields) or get_default_fields("adimages")
 
     criteria = {}
     if ids:

--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -967,9 +967,7 @@ def get(
     if status and statuses:
         raise click.UsageError(t("--status and --statuses are mutually exclusive"))
 
-    field_names = (
-        fields.split(",") if fields else get_default_fields("ads", "FieldNames")
-    )
+    field_names = parse_csv_strings(fields) or get_default_fields("ads", "FieldNames")
 
     raw_nested = (
         (

--- a/direct_cli/commands/advideos.py
+++ b/direct_cli/commands/advideos.py
@@ -7,7 +7,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
-from ..utils import get_default_fields, get_options, load_base64_file
+from ..utils import get_default_fields, get_options, load_base64_file, parse_csv_strings
 
 
 @click.group()
@@ -24,9 +24,9 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
     """Get ad videos"""
     client = client_from_ctx(ctx, create_client)
 
-    field_names = fields.split(",") if fields else get_default_fields("advideos")
+    field_names = parse_csv_strings(fields) or get_default_fields("advideos")
 
-    criteria = {"Ids": [x.strip() for x in ids.split(",") if x.strip()]}
+    criteria = {"Ids": parse_csv_strings(ids) or []}
 
     params = {
         "SelectionCriteria": criteria,

--- a/direct_cli/commands/agencyclients.py
+++ b/direct_cli/commands/agencyclients.py
@@ -137,7 +137,7 @@ def get(
     """Get agency clients"""
     client = client_from_ctx(ctx, create_client)
 
-    field_names = fields.split(",") if fields else get_default_fields("agencyclients")
+    field_names = parse_csv_strings(fields) or get_default_fields("agencyclients")
 
     raw_nested = (
         ("ContractFieldNames", contract_field_names),

--- a/direct_cli/commands/audiencetargets.py
+++ b/direct_cli/commands/audiencetargets.py
@@ -12,6 +12,7 @@ from ..utils import (
     add_criteria_csv,
     get_default_fields,
     get_options,
+    parse_csv_strings,
     parse_ids,
 )
 
@@ -62,7 +63,7 @@ def get(
     add_criteria_csv(criteria, "InterestIds", interest_ids, integers=True)
     add_criteria_csv(criteria, "States", states, upper=True)
 
-    field_names = fields.split(",") if fields else get_default_fields("audiencetargets")
+    field_names = parse_csv_strings(fields) or get_default_fields("audiencetargets")
     params = {
         "SelectionCriteria": criteria,
         "FieldNames": field_names,

--- a/direct_cli/commands/bidmodifiers.py
+++ b/direct_cli/commands/bidmodifiers.py
@@ -7,7 +7,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
-from ..utils import get_default_fields, parse_csv_strings, parse_ids
+from ..utils import get_default_fields, parse_csv_strings, parse_csv_upper, parse_ids
 
 
 @click.group()
@@ -212,11 +212,9 @@ def get(
     if adgroup_ids:
         criteria["AdGroupIds"] = parse_ids(adgroup_ids)
     if types:
-        criteria["Types"] = [
-            item.strip().upper() for item in types.split(",") if item.strip()
-        ]
+        criteria["Types"] = parse_csv_upper(types) or []
 
-    field_names = fields.split(",") if fields else get_default_fields("bidmodifiers")
+    field_names = parse_csv_strings(fields) or get_default_fields("bidmodifiers")
     params = {
         "SelectionCriteria": criteria,
         "FieldNames": field_names,

--- a/direct_cli/commands/bids.py
+++ b/direct_cli/commands/bids.py
@@ -13,6 +13,7 @@ from ..utils import (
     add_single_id_selector,
     get_default_fields,
     get_options,
+    parse_csv_strings,
     parse_ids,
 )
 
@@ -64,7 +65,7 @@ def get(
             )
         )
 
-    field_names = fields.split(",") if fields else get_default_fields("bids")
+    field_names = parse_csv_strings(fields) or get_default_fields("bids")
     params = {
         "SelectionCriteria": criteria,
         "FieldNames": field_names,

--- a/direct_cli/commands/businesses.py
+++ b/direct_cli/commands/businesses.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..output import format_output, handle_api_errors
-from ..utils import get_default_fields, get_options, parse_ids
+from ..utils import get_default_fields, get_options, parse_csv_strings, parse_ids
 
 
 @click.group()
@@ -23,7 +23,7 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
     """Get businesses"""
     client = client_from_ctx(ctx, create_client)
 
-    field_names = fields.split(",") if fields else get_default_fields("businesses")
+    field_names = parse_csv_strings(fields) or get_default_fields("businesses")
 
     criteria = {}
     if ids:

--- a/direct_cli/commands/changes.py
+++ b/direct_cli/commands/changes.py
@@ -7,7 +7,12 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
-from ..utils import get_default_fields, parse_changes_datetime, parse_ids
+from ..utils import (
+    get_default_fields,
+    parse_changes_datetime,
+    parse_csv_strings,
+    parse_ids,
+)
 
 
 @click.group()
@@ -77,7 +82,7 @@ def check(
         )
 
     if fields:
-        field_names = [f.strip() for f in fields.split(",") if f.strip()]
+        field_names = parse_csv_strings(fields)
         if not field_names:
             raise click.UsageError(
                 t(

--- a/direct_cli/commands/clients.py
+++ b/direct_cli/commands/clients.py
@@ -103,7 +103,7 @@ def get(
     """Get clients"""
     client = client_from_ctx(ctx, create_client)
 
-    field_names = fields.split(",") if fields else get_default_fields("clients")
+    field_names = parse_csv_strings(fields) or get_default_fields("clients")
 
     raw_nested = (
         ("ContractFieldNames", contract_field_names),

--- a/direct_cli/commands/creatives.py
+++ b/direct_cli/commands/creatives.py
@@ -7,7 +7,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
-from ..utils import get_default_fields, parse_csv_strings, parse_ids
+from ..utils import get_default_fields, parse_csv_strings, parse_csv_upper, parse_ids
 
 
 @click.group()
@@ -77,7 +77,7 @@ def get(
     """Get creatives"""
     client = client_from_ctx(ctx, create_client)
 
-    field_names = fields.split(",") if fields else get_default_fields("creatives")
+    field_names = parse_csv_strings(fields) or get_default_fields("creatives")
 
     nested_field_name_options = (
         ("CpcVideoCreativeFieldNames", cpc_video_creative_field_names),
@@ -104,9 +104,7 @@ def get(
     if ids:
         criteria["Ids"] = parse_ids(ids)
     if types:
-        criteria["Types"] = [
-            item.strip().upper() for item in types.split(",") if item.strip()
-        ]
+        criteria["Types"] = parse_csv_upper(types) or []
 
     params = {"SelectionCriteria": criteria, "FieldNames": field_names}
     params.update(parsed_nested_field_names)

--- a/direct_cli/commands/dynamicads.py
+++ b/direct_cli/commands/dynamicads.py
@@ -12,6 +12,8 @@ from ..utils import (
     get_default_fields,
     get_options,
     parse_condition_specs,
+    parse_csv_strings,
+    parse_csv_upper,
     parse_ids,
 )
 
@@ -45,7 +47,7 @@ def get(
     """Get dynamic ad targets"""
     client = client_from_ctx(ctx, create_client)
 
-    field_names = fields.split(",") if fields else get_default_fields("dynamicads")
+    field_names = parse_csv_strings(fields) or get_default_fields("dynamicads")
 
     criteria = {}
     if ids:
@@ -55,9 +57,7 @@ def get(
     if campaign_ids:
         criteria["CampaignIds"] = parse_ids(campaign_ids)
     if states:
-        criteria["States"] = [
-            item.strip().upper() for item in states.split(",") if item.strip()
-        ]
+        criteria["States"] = parse_csv_upper(states) or []
 
     params = {"SelectionCriteria": criteria, "FieldNames": field_names}
 

--- a/direct_cli/commands/dynamicfeedadtargets.py
+++ b/direct_cli/commands/dynamicfeedadtargets.py
@@ -12,6 +12,8 @@ from ..utils import (
     get_default_fields,
     get_options,
     parse_condition_specs,
+    parse_csv_strings,
+    parse_csv_upper,
     parse_ids,
 )
 
@@ -45,8 +47,8 @@ def get(
     """Get dynamic feed ad targets"""
     client = client_from_ctx(ctx, create_client)
 
-    field_names = (
-        fields.split(",") if fields else get_default_fields("dynamicfeedadtargets")
+    field_names = parse_csv_strings(fields) or get_default_fields(
+        "dynamicfeedadtargets"
     )
 
     criteria = {}
@@ -57,9 +59,7 @@ def get(
     if campaign_ids:
         criteria["CampaignIds"] = parse_ids(campaign_ids)
     if states:
-        criteria["States"] = [
-            item.strip().upper() for item in states.split(",") if item.strip()
-        ]
+        criteria["States"] = parse_csv_upper(states) or []
 
     if not criteria:
         raise click.UsageError(t("Provide at least one typed filter"))

--- a/direct_cli/commands/feeds.py
+++ b/direct_cli/commands/feeds.py
@@ -156,7 +156,7 @@ def get(
     """Get feeds"""
     client = client_from_ctx(ctx, create_client)
 
-    field_names = fields.split(",") if fields else get_default_fields("feeds")
+    field_names = parse_csv_strings(fields) or get_default_fields("feeds")
 
     parsed_file_feed_field_names = parse_csv_strings(file_feed_field_names)
     if file_feed_field_names is not None and not parsed_file_feed_field_names:

--- a/direct_cli/commands/keywords.py
+++ b/direct_cli/commands/keywords.py
@@ -462,7 +462,7 @@ def get(
 
     client = client_from_ctx(ctx, create_client)
 
-    field_names = fields.split(",") if fields else get_default_fields("keywords")
+    field_names = parse_csv_strings(fields) or get_default_fields("keywords")
 
     parsed_brand_options = parse_csv_strings(
         autotargeting_settings_brand_options_field_names

--- a/direct_cli/commands/leads.py
+++ b/direct_cli/commands/leads.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..output import format_output, handle_api_errors
-from ..utils import get_default_fields, parse_ids
+from ..utils import get_default_fields, parse_csv_strings, parse_ids
 
 
 @click.group()
@@ -45,7 +45,7 @@ def get(
     """Get leads"""
     client = client_from_ctx(ctx, create_client)
 
-    field_names = fields.split(",") if fields else get_default_fields("leads")
+    field_names = parse_csv_strings(fields) or get_default_fields("leads")
 
     criteria = {"TurboPageIds": parse_ids(turbo_page_ids)}
     if datetime_from:

--- a/direct_cli/commands/negativekeywordsharedsets.py
+++ b/direct_cli/commands/negativekeywordsharedsets.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..output import format_output, handle_api_errors
-from ..utils import get_default_fields, get_options, parse_ids
+from ..utils import get_default_fields, get_options, parse_csv_strings, parse_ids
 
 
 @click.group()
@@ -23,8 +23,8 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
     """Get negative keyword shared sets"""
     client = client_from_ctx(ctx, create_client)
 
-    field_names = (
-        fields.split(",") if fields else get_default_fields("negativekeywordsharedsets")
+    field_names = parse_csv_strings(fields) or get_default_fields(
+        "negativekeywordsharedsets"
     )
 
     criteria = {}

--- a/direct_cli/commands/reports.py
+++ b/direct_cli/commands/reports.py
@@ -119,7 +119,7 @@ def _parse_filter(filter_str):
     field, operator, values_raw = parts
     field = field.strip()
     operator = operator.strip().upper()
-    values = [v.strip() for v in values_raw.split(",") if v.strip()]
+    values = parse_csv_strings(values_raw)
     if field in {"Goals", "AttributionModels"}:
         raise ValueError(f"{field} is a ReportDefinition field, not a filter field")
     _validate_report_field_usage(field, "Filter.Field")
@@ -218,7 +218,7 @@ def build_report_request(
     Returns:
         Reports API request body with CLI-normalized filters and field names.
     """
-    field_names = [field.strip() for field in fields.split(",") if field.strip()]
+    field_names = parse_csv_strings(fields)
     if not field_names:
         # Live API error 8000: "FieldNames must contain no less than 1
         # elements". Click ``required=True`` only checks presence, not content,

--- a/direct_cli/commands/retargeting.py
+++ b/direct_cli/commands/retargeting.py
@@ -9,7 +9,12 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
-from ..utils import get_default_fields, parse_ids, parse_retargeting_rule_specs
+from ..utils import (
+    get_default_fields,
+    parse_csv_strings,
+    parse_ids,
+    parse_retargeting_rule_specs,
+)
 
 
 @click.group()
@@ -31,9 +36,7 @@ def get(ctx, ids, types, limit, fetch_all, output_format, output, fields):
     """Get retargeting lists"""
     client = client_from_ctx(ctx, create_client)
 
-    field_names = (
-        fields.split(",") if fields else get_default_fields("retargetinglists")
-    )
+    field_names = parse_csv_strings(fields) or get_default_fields("retargetinglists")
 
     criteria = {}
     if ids:

--- a/direct_cli/commands/smartadtargets.py
+++ b/direct_cli/commands/smartadtargets.py
@@ -12,6 +12,8 @@ from ..utils import (
     get_default_fields,
     get_options,
     parse_condition_specs,
+    parse_csv_strings,
+    parse_csv_upper,
     parse_ids,
 )
 
@@ -45,7 +47,7 @@ def get(
     """Get smart ad targets"""
     client = client_from_ctx(ctx, create_client)
 
-    field_names = fields.split(",") if fields else get_default_fields("smartadtargets")
+    field_names = parse_csv_strings(fields) or get_default_fields("smartadtargets")
 
     criteria = {}
     if ids:
@@ -55,9 +57,7 @@ def get(
     if campaign_ids:
         criteria["CampaignIds"] = parse_ids(campaign_ids)
     if states:
-        criteria["States"] = [
-            item.strip().upper() for item in states.split(",") if item.strip()
-        ]
+        criteria["States"] = parse_csv_upper(states) or []
 
     params = {"SelectionCriteria": criteria, "FieldNames": field_names}
 

--- a/direct_cli/commands/strategies.py
+++ b/direct_cli/commands/strategies.py
@@ -612,7 +612,7 @@ def get(
     dry_run,
 ):
     """Get strategies"""
-    field_names = fields.split(",") if fields else get_default_fields("strategies")
+    field_names = parse_csv_strings(fields) or get_default_fields("strategies")
 
     raw_nested = (
         ("StrategyAverageCpaFieldNames", strategy_average_cpa_field_names),

--- a/direct_cli/commands/turbopages.py
+++ b/direct_cli/commands/turbopages.py
@@ -11,7 +11,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..output import format_output, handle_api_errors
-from ..utils import get_default_fields, get_options, parse_ids
+from ..utils import get_default_fields, get_options, parse_csv_strings, parse_ids
 
 
 @click.group()
@@ -31,15 +31,13 @@ def get(
     """Get Turbo Pages"""
     client = client_from_ctx(ctx, create_client)
 
-    field_names = fields.split(",") if fields else get_default_fields("turbopages")
+    field_names = parse_csv_strings(fields) or get_default_fields("turbopages")
 
     criteria = {}
     if ids:
         criteria["Ids"] = parse_ids(ids)
     if bound_with_hrefs:
-        criteria["BoundWithHrefs"] = [
-            item.strip() for item in bound_with_hrefs.split(",") if item.strip()
-        ]
+        criteria["BoundWithHrefs"] = parse_csv_strings(bound_with_hrefs) or []
 
     params = {"FieldNames": field_names}
     if criteria:

--- a/direct_cli/commands/vcards.py
+++ b/direct_cli/commands/vcards.py
@@ -9,7 +9,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
-from ..utils import get_default_fields, get_options, parse_ids
+from ..utils import get_default_fields, get_options, parse_csv_strings, parse_ids
 
 
 @click.group()
@@ -77,7 +77,7 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
     """Get vCards"""
     client = client_from_ctx(ctx, create_client)
 
-    field_names = fields.split(",") if fields else get_default_fields("vcards")
+    field_names = parse_csv_strings(fields) or get_default_fields("vcards")
 
     criteria = {}
     if ids:

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -301,6 +301,29 @@ def test_get_selection_criteria_new_typed_flags_payloads():
             assert criteria[key] == value
 
 
+def test_fields_whitespace_is_trimmed_after_csv_dedup():
+    """B2a (#497): --fields with surrounding spaces now trims via parse_csv_strings.
+
+    Before the dedup these field names were sent untrimmed (e.g. ``[" Name"]``);
+    parse_csv_strings strips whitespace and drops empty items.
+    """
+    body = _read_dry_run("adimages", "get", "--fields", "Id, Name ")
+    assert body["params"]["FieldNames"] == ["Id", "Name"]
+
+    body = _read_dry_run(
+        "bids", "get", "--campaign-ids", "1", "--fields", " Bid , CampaignId "
+    )
+    assert body["params"]["FieldNames"] == ["Bid", "CampaignId"]
+
+
+def test_states_whitespace_is_trimmed_and_uppercased_after_csv_dedup():
+    """B2a (#497): --states trims + uppercases via parse_csv_upper."""
+    body = _read_dry_run(
+        "dynamicads", "get", "--adgroup-ids", "1", "--states", " active , suspended "
+    )
+    assert body["params"]["SelectionCriteria"]["States"] == ["ACTIVE", "SUSPENDED"]
+
+
 def test_get_status_and_statuses_are_mutually_exclusive():
     """Legacy --status must not be silently overwritten by --statuses."""
     for command in ("adgroups", "ads", "campaigns", "keywords"):
@@ -460,7 +483,9 @@ def test_campaigns_get_rejects_empty_campaign_specific_fields_csv():
     )
 
     assert result.exit_code != 0
-    assert "--text-campaign-field-names must contain at least one value" in result.output
+    assert (
+        "--text-campaign-field-names must contain at least one value" in result.output
+    )
 
 
 def _reports_get_result(*extra_args: str) -> Result:
@@ -8343,7 +8368,9 @@ def test_campaigns_add_unified_priority_goals_with_mixed_strategy_sides_payload(
         "1234567:80000000",
     )
     unified = body["params"]["Campaigns"][0]["UnifiedCampaign"]
-    assert unified["PriorityGoals"] == {"Items": [{"GoalId": 1234567, "Value": 80000000}]}
+    assert unified["PriorityGoals"] == {
+        "Items": [{"GoalId": 1234567, "Value": 80000000}]
+    }
     bidding = unified["BiddingStrategy"]
     assert bidding["Search"]["BiddingStrategyType"] == "AVERAGE_CPC"
     assert bidding["Network"]["BiddingStrategyType"] == "MAX_PROFIT"
@@ -22181,8 +22208,7 @@ def test_sitelinks_get_rejects_empty_sitelink_field_names():
 
     assert result.exit_code != 0
     assert (
-        "Provide a non-empty comma-separated SitelinkFieldNames list."
-        in result.output
+        "Provide a non-empty comma-separated SitelinkFieldNames list." in result.output
     )
 
 
@@ -22261,10 +22287,7 @@ def test_keywordbids_get_rejects_empty_search_field_names():
     )
 
     assert result.exit_code != 0
-    assert (
-        "Provide a non-empty comma-separated SearchFieldNames list."
-        in result.output
-    )
+    assert "Provide a non-empty comma-separated SearchFieldNames list." in result.output
 
 
 def test_keywordbids_get_rejects_empty_network_field_names():
@@ -22276,8 +22299,7 @@ def test_keywordbids_get_rejects_empty_network_field_names():
 
     assert result.exit_code != 0
     assert (
-        "Provide a non-empty comma-separated NetworkFieldNames list."
-        in result.output
+        "Provide a non-empty comma-separated NetworkFieldNames list." in result.output
     )
 
 
@@ -22340,8 +22362,7 @@ def test_feeds_get_rejects_empty_file_feed_field_names_csv():
 
     assert result.exit_code != 0
     assert (
-        "Provide a non-empty comma-separated FileFeedFieldNames list."
-        in result.output
+        "Provide a non-empty comma-separated FileFeedFieldNames list." in result.output
     )
 
 
@@ -22354,8 +22375,7 @@ def test_feeds_get_rejects_empty_url_feed_field_names_csv():
 
     assert result.exit_code != 0
     assert (
-        "Provide a non-empty comma-separated UrlFeedFieldNames list."
-        in result.output
+        "Provide a non-empty comma-separated UrlFeedFieldNames list." in result.output
     )
 
 
@@ -22426,8 +22446,7 @@ def test_keywords_get_rejects_empty_brand_options_field_names_csv():
     assert result.exit_code != 0
     assert (
         "Provide a non-empty comma-separated "
-        "AutotargetingSettingsBrandOptionsFieldNames list."
-        in result.output
+        "AutotargetingSettingsBrandOptionsFieldNames list." in result.output
     )
 
 
@@ -22447,8 +22466,7 @@ def test_keywords_get_rejects_empty_categories_field_names_csv():
     assert result.exit_code != 0
     assert (
         "Provide a non-empty comma-separated "
-        "AutotargetingSettingsCategoriesFieldNames list."
-        in result.output
+        "AutotargetingSettingsCategoriesFieldNames list." in result.output
     )
 
 


### PR DESCRIPTION
Part of epic #491 (code-duplication audit). This is **B2a** of issue #497 — the issue stays **open** until the follow-up B2b PR; this one does not close it.

## Problem

~46 inline `.split(",")` calls in `direct_cli/commands/` duplicate the existing `utils.parse_csv_strings` (trims whitespace, drops empties, returns `None` on empty) and `utils.parse_csv_upper`. Issue #497 requires replacing **only** where a dry-run/payload test proves zero request drift. So we split:

- **B2a (this PR)** — 33 sites that are **byte-identical in payload** for clean input and strictly safer for whitespace/empty input.
- **B2b (later)** — 11 CARE sites (no-trim `Types`; keep-empties `Logins`/`NegativeKeywords`/`Keywords`/`names`) where the payload genuinely changes on "dirty" input; each needs a per-site payload proof + edge-case unit. Plus 2 int-cast sites (`strategies.py`) which are out of scope (helper returns strings).

## Change — three groups (all 1:1 on clean input)

1. **23 read-path `--fields`**: `fields.split(",") if fields else get_default_fields(...)` → `parse_csv_strings(fields) or get_default_fields(...)`. `get_default_fields` always returns a non-empty list, so `or` resolves `None` correctly.
2. **5 `.upper()` states/types** → `parse_csv_upper(x) or []`. The `or []` is **required**: the originals always assigned a list (never None), so all-whitespace input must stay `[]`, not drift to `None`.
3. **5 already trim+filter** → `parse_csv_strings`. `reports`/`changes` keep no `or []` (a `if not …: raise` guard catches `None` identically); `turbopages`/`advideos` append `or []` (assigned unconditionally into the payload).

## Zero payload drift — proven

- `tests/test_dry_run.py` + `tests/test_wsdl_parity_gate.py` stay green: **1201 passed**. These assert exact request JSON, so any drift would fail them.
- Added regression tests: `--fields "Id, Name "` and `--states " active , suspended "` now trim/uppercase correctly (would have shipped untrimmed before).
- Full suite: **2104 passed, 47 skipped** (2102 baseline + 2 new).
- `black`/`flake8`: **0 net-new** issues vs `main` (verified per-file).

## Remaining `.split(",")` (intentionally untouched → B2b / out of scope)
`adextensions:65`, `adgroups:662`, `agencyclients:163`, `dictionaries:44,65`, `keywordsresearch:34,44,66`, `negativekeywordsharedsets:69,98`, `retargeting` Types, `strategies:678,816,971`.

Part of #497 (B2a). Issue closed after B2b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)