### PR TITLE
refactor: reuse build_common_params in clean get-commands (#491 B3a)

### DIFF
--- a/direct_cli/commands/adimages.py
+++ b/direct_cli/commands/adimages.py
@@ -9,6 +9,7 @@ from ..i18n import t
 from ..output import format_output, handle_api_errors
 from ..utils import (
     add_criteria_csv,
+    build_common_params,
     get_default_fields,
     get_options,
     load_base64_file,
@@ -53,12 +54,9 @@ def get(
     if associated:
         criteria["Associated"] = associated.upper()
 
-    params = {"FieldNames": field_names}
-    if criteria:
-        params["SelectionCriteria"] = criteria
-
-    if limit:
-        params["Page"] = {"Limit": limit}
+    params = build_common_params(
+        criteria=criteria, field_names=field_names, limit=limit
+    )
 
     body = {"method": "get", "params": params}
 

--- a/direct_cli/commands/businesses.py
+++ b/direct_cli/commands/businesses.py
@@ -6,7 +6,13 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..output import format_output, handle_api_errors
-from ..utils import get_default_fields, get_options, parse_csv_strings, parse_ids
+from ..utils import (
+    build_common_params,
+    get_default_fields,
+    get_options,
+    parse_csv_strings,
+    parse_ids,
+)
 
 
 @click.group()
@@ -29,12 +35,9 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
     if ids:
         criteria["Ids"] = parse_ids(ids)
 
-    params = {"FieldNames": field_names}
-    if criteria:
-        params["SelectionCriteria"] = criteria
-
-    if limit:
-        params["Page"] = {"Limit": limit}
+    params = build_common_params(
+        criteria=criteria, field_names=field_names, limit=limit
+    )
 
     body = {"method": "get", "params": params}
 

--- a/direct_cli/commands/feeds.py
+++ b/direct_cli/commands/feeds.py
@@ -11,7 +11,12 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
-from ..utils import get_default_fields, parse_csv_strings, parse_ids
+from ..utils import (
+    build_common_params,
+    get_default_fields,
+    parse_csv_strings,
+    parse_ids,
+)
 
 _YES_NO = ["YES", "NO"]
 # Yandex Direct docs cap FileFeed.Data by total request size. This
@@ -174,16 +179,13 @@ def get(
     if ids:
         criteria["Ids"] = parse_ids(ids)
 
-    params = {"FieldNames": field_names}
-    if criteria:
-        params["SelectionCriteria"] = criteria
+    params = build_common_params(
+        criteria=criteria, field_names=field_names, limit=limit
+    )
     if parsed_file_feed_field_names:
         params["FileFeedFieldNames"] = parsed_file_feed_field_names
     if parsed_url_feed_field_names:
         params["UrlFeedFieldNames"] = parsed_url_feed_field_names
-
-    if limit:
-        params["Page"] = {"Limit": limit}
 
     body = {"method": "get", "params": params}
 

--- a/direct_cli/commands/negativekeywordsharedsets.py
+++ b/direct_cli/commands/negativekeywordsharedsets.py
@@ -6,7 +6,13 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..output import format_output, handle_api_errors
-from ..utils import get_default_fields, get_options, parse_csv_strings, parse_ids
+from ..utils import (
+    build_common_params,
+    get_default_fields,
+    get_options,
+    parse_csv_strings,
+    parse_ids,
+)
 
 
 @click.group()
@@ -31,12 +37,9 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
     if ids:
         criteria["Ids"] = parse_ids(ids)
 
-    params = {"FieldNames": field_names}
-    if criteria:
-        params["SelectionCriteria"] = criteria
-
-    if limit:
-        params["Page"] = {"Limit": limit}
+    params = build_common_params(
+        criteria=criteria, field_names=field_names, limit=limit
+    )
 
     body = {"method": "get", "params": params}
 

--- a/direct_cli/commands/sitelinks.py
+++ b/direct_cli/commands/sitelinks.py
@@ -12,6 +12,7 @@ from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
 from ..utils import (
+    build_common_params,
     get_default_fields,
     parse_csv_strings,
     parse_ids,
@@ -168,14 +169,11 @@ def get(
     if ids:
         criteria["Ids"] = parse_ids(ids)
 
-    params = {"FieldNames": field_names}
-    if criteria:
-        params["SelectionCriteria"] = criteria
+    params = build_common_params(
+        criteria=criteria, field_names=field_names, limit=limit
+    )
     if parsed_sitelink_field_names:
         params["SitelinkFieldNames"] = parsed_sitelink_field_names
-
-    if limit:
-        params["Page"] = {"Limit": limit}
 
     body = {"method": "get", "params": params}
 

--- a/direct_cli/commands/turbopages.py
+++ b/direct_cli/commands/turbopages.py
@@ -11,7 +11,13 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..output import format_output, handle_api_errors
-from ..utils import get_default_fields, get_options, parse_csv_strings, parse_ids
+from ..utils import (
+    build_common_params,
+    get_default_fields,
+    get_options,
+    parse_csv_strings,
+    parse_ids,
+)
 
 
 @click.group()
@@ -39,12 +45,9 @@ def get(
     if bound_with_hrefs:
         criteria["BoundWithHrefs"] = parse_csv_strings(bound_with_hrefs) or []
 
-    params = {"FieldNames": field_names}
-    if criteria:
-        params["SelectionCriteria"] = criteria
-
-    if limit:
-        params["Page"] = {"Limit": limit}
+    params = build_common_params(
+        criteria=criteria, field_names=field_names, limit=limit
+    )
 
     body = {"method": "get", "params": params}
 

--- a/direct_cli/commands/vcards.py
+++ b/direct_cli/commands/vcards.py
@@ -9,7 +9,13 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
-from ..utils import get_default_fields, get_options, parse_csv_strings, parse_ids
+from ..utils import (
+    build_common_params,
+    get_default_fields,
+    get_options,
+    parse_csv_strings,
+    parse_ids,
+)
 
 
 @click.group()
@@ -83,12 +89,9 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
     if ids:
         criteria["Ids"] = parse_ids(ids)
 
-    params = {"FieldNames": field_names}
-    if criteria:
-        params["SelectionCriteria"] = criteria
-
-    if limit:
-        params["Page"] = {"Limit": limit}
+    params = build_common_params(
+        criteria=criteria, field_names=field_names, limit=limit
+    )
 
     body = {"method": "get", "params": params}
 


### PR DESCRIPTION
Part of epic #491. This is **B3a** of issue #498 — the issue stays **open** until the follow-up B3b PR.

## Problem

`build_selection_criteria` / `build_common_params` (`direct_cli/utils.py`) were called **only from `campaigns.py`**; ~25 get-commands assemble `params`/`Page` by hand.

## Change — 7 clean modules

B3a converts the 7 modules where the manual assembly is a **byte-identical 1:1 match** for `build_common_params(criteria, field_names, limit)`: **businesses, vcards, adimages, turbopages, negativekeywordsharedsets, feeds, sitelinks**.

All seven already used the exact shape:
```python
params = {"FieldNames": field_names}
if criteria: params["SelectionCriteria"] = criteria
if limit:    params["Page"] = {"Limit": limit}
```
→ `params = build_common_params(criteria=criteria, field_names=field_names, limit=limit)`.

- Empty `SelectionCriteria` is omitted identically (proven by the existing `test_optional_ids_criteria_get_omits_empty_selection_criteria`).
- **feeds / sitelinks** keep their extra `*FieldNames` selectors, now appended **after** the helper. Payload-identical: dry-run tests assert the **parsed dict** (`body["params"][...]`), not a string, so key order is irrelevant.

## Scope notes

- The `parse_csv_upper` part of #498 was **already done** in B2a/B2b (bidmodifiers, dynamicads, dynamicfeedadtargets, creatives, smartadtargets). The remaining `.strip().upper()` sites are single-value parsers, not CSV lists.
- The ~18 remaining modules either **always** set `SelectionCriteria` (so the helper's empty-omission could change the payload) or have **multi-FieldNames** top-level selectors → deferred to **B3b**, each with a dry-run drift proof.

## Verification

- Full suite: **2111 passed, 47 skipped** — unchanged vs baseline (pure refactor).
- `black`/`flake8`: **0 net-new**.
- Behavioral dry-run spot-check: all 7 omit empty `SelectionCriteria`; `--ids`+`--limit` produce `SelectionCriteria`+`Page`; feeds extras coexist with `Page`.

Part of #498 (B3a). Issue closed after B3b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)