### PR TITLE
refactor: reuse build_common_params in guaranteed-criteria get-commands (#491 B3b)

### DIFF
--- a/direct_cli/commands/advideos.py
+++ b/direct_cli/commands/advideos.py
@@ -7,7 +7,13 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
-from ..utils import get_default_fields, get_options, load_base64_file, parse_csv_strings
+from ..utils import (
+    build_common_params,
+    get_default_fields,
+    get_options,
+    load_base64_file,
+    parse_csv_strings,
+)
 
 
 @click.group()
@@ -28,13 +34,9 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
 
     criteria = {"Ids": parse_csv_strings(ids) or []}
 
-    params = {
-        "SelectionCriteria": criteria,
-        "FieldNames": field_names,
-    }
-
-    if limit:
-        params["Page"] = {"Limit": limit}
+    params = build_common_params(
+        criteria=criteria, field_names=field_names, limit=limit
+    )
 
     body = {"method": "get", "params": params}
 

--- a/direct_cli/commands/agencyclients.py
+++ b/direct_cli/commands/agencyclients.py
@@ -10,6 +10,7 @@ from ..output import format_output, handle_api_errors, print_error
 from ..utils import (
     assert_not_runtime_deprecated,
     build_client_update_item,
+    build_common_params,
     build_notification_update,
     get_default_fields,
     parse_client_setting_specs,
@@ -162,11 +163,10 @@ def get(
     if logins:
         criteria["Logins"] = parse_csv_strings(logins)
 
-    params = {"SelectionCriteria": criteria, "FieldNames": field_names}
+    params = build_common_params(
+        criteria=criteria, field_names=field_names, limit=limit
+    )
     params.update(parsed_nested)
-
-    if limit:
-        params["Page"] = {"Limit": limit}
 
     body = {"method": "get", "params": params}
 

--- a/direct_cli/commands/bidmodifiers.py
+++ b/direct_cli/commands/bidmodifiers.py
@@ -7,7 +7,13 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
-from ..utils import get_default_fields, parse_csv_strings, parse_csv_upper, parse_ids
+from ..utils import (
+    build_common_params,
+    get_default_fields,
+    parse_csv_strings,
+    parse_csv_upper,
+    parse_ids,
+)
 
 
 @click.group()
@@ -215,14 +221,10 @@ def get(
         criteria["Types"] = parse_csv_upper(types) or []
 
     field_names = parse_csv_strings(fields) or get_default_fields("bidmodifiers")
-    params = {
-        "SelectionCriteria": criteria,
-        "FieldNames": field_names,
-    }
+    params = build_common_params(
+        criteria=criteria, field_names=field_names, limit=limit
+    )
     params.update(parsed_nested)
-
-    if limit:
-        params["Page"] = {"Limit": limit}
 
     body = {"method": "get", "params": params}
 

--- a/direct_cli/commands/bids.py
+++ b/direct_cli/commands/bids.py
@@ -11,6 +11,7 @@ from ..utils import (
     MICRO_RUBLES,
     add_criteria_csv,
     add_single_id_selector,
+    build_common_params,
     get_default_fields,
     get_options,
     parse_csv_strings,
@@ -66,13 +67,9 @@ def get(
         )
 
     field_names = parse_csv_strings(fields) or get_default_fields("bids")
-    params = {
-        "SelectionCriteria": criteria,
-        "FieldNames": field_names,
-    }
-
-    if limit:
-        params["Page"] = {"Limit": limit}
+    params = build_common_params(
+        criteria=criteria, field_names=field_names, limit=limit
+    )
 
     body = {"method": "get", "params": params}
 

--- a/direct_cli/commands/clients.py
+++ b/direct_cli/commands/clients.py
@@ -9,6 +9,7 @@ from ..i18n import t
 from ..output import format_output, handle_api_errors
 from ..utils import (
     build_client_update_item,
+    build_common_params,
     build_erir_attributes,
     build_erir_contragent,
     build_erir_contract,
@@ -128,15 +129,10 @@ def get(
     if ids:
         criteria["ClientIds"] = parse_ids(ids)
 
-    params = {"FieldNames": field_names}
-
-    if criteria:
-        params["SelectionCriteria"] = criteria
-
+    params = build_common_params(
+        criteria=criteria, field_names=field_names, limit=limit
+    )
     params.update(parsed_nested)
-
-    if limit:
-        params["Page"] = {"Limit": limit}
 
     body = {"method": "get", "params": params}
 

--- a/direct_cli/commands/dynamicfeedadtargets.py
+++ b/direct_cli/commands/dynamicfeedadtargets.py
@@ -9,6 +9,7 @@ from ..i18n import t
 from ..output import format_output, handle_api_errors
 from ..utils import (
     MICRO_RUBLES,
+    build_common_params,
     get_default_fields,
     get_options,
     parse_condition_specs,
@@ -64,10 +65,9 @@ def get(
     if not criteria:
         raise click.UsageError(t("Provide at least one typed filter"))
 
-    params = {"SelectionCriteria": criteria, "FieldNames": field_names}
-
-    if limit:
-        params["Page"] = {"Limit": limit}
+    params = build_common_params(
+        criteria=criteria, field_names=field_names, limit=limit
+    )
 
     body = {"method": "get", "params": params}
 

--- a/direct_cli/commands/leads.py
+++ b/direct_cli/commands/leads.py
@@ -6,7 +6,12 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..output import format_output, handle_api_errors
-from ..utils import get_default_fields, parse_csv_strings, parse_ids
+from ..utils import (
+    build_common_params,
+    get_default_fields,
+    parse_csv_strings,
+    parse_ids,
+)
 
 
 @click.group()
@@ -53,10 +58,9 @@ def get(
     if datetime_to:
         criteria["DateTimeTo"] = datetime_to
 
-    params = {"SelectionCriteria": criteria, "FieldNames": field_names}
-
-    if limit:
-        params["Page"] = {"Limit": limit}
+    params = build_common_params(
+        criteria=criteria, field_names=field_names, limit=limit
+    )
 
     body = {"method": "get", "params": params}
 


### PR DESCRIPTION
Part of epic #491. This is **B3b** of issue #498 — the issue stays **open** until B3c.

## Change — 7 modules with guaranteed non-empty criteria

`build_common_params` omits an **empty** SelectionCriteria. B3b converts only the modules where `criteria` is guaranteed non-empty at runtime, so the helper is a **byte-identical 1:1 swap**:

- **bids, dynamicfeedadtargets** — explicit `if not criteria: raise UsageError` guard.
- **advideos** (`--ids` required), **leads** (`--turbo-page-ids` required) — criteria always carries its key → truthy dict.
- **agencyclients** (`Archived` always set), **bidmodifiers** (`Levels` always set) — criteria never empty.
- **clients** — already used `if criteria: params["SelectionCriteria"] = criteria` → directly compatible.

`agencyclients`/`bidmodifiers`/`clients` keep their multi-FieldNames `params.update(parsed_nested)` after the helper. Payload-identical: dry-run tests assert the **parsed dict** (`body["params"][...]`), so key order is irrelevant.

## Out of scope (deferred to B3c)

The 9 modules that currently emit `{"SelectionCriteria": {}}` when run with **no filters** (confirmed via dry-run): adgroups, ads, keywords, strategies, creatives, dynamicads, smartadtargets, audiencetargets, retargeting. Switching them would **drop** the empty SelectionCriteria — a payload change, not a pure dedup. They need a dedicated decision (Yandex returns 4001 on empty SC for Ids-required resources, so omitting is arguably a fix — but it's behavioral and warrants WSDL/live-API checking). **keywordbids** stays manual (always builds `Search`/`NetworkFieldNames` with defaults).

## Verification

- Full suite: **2111 passed, 47 skipped** — unchanged vs baseline (pure refactor; existing payload tests for the 7 modules stayed green = zero drift).
- `black`/`flake8`: **0 net-new**.
- Behavioral spot-check: SC always present, `Page` on `--limit`, guards still fire.

Part of #498 (B3b). Issue closed after B3c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)