### PR TITLE
refactor: campaigns lifecycle-command factory (#491 C1)

### DIFF
--- a/direct_cli/commands/campaigns.py
+++ b/direct_cli/commands/campaigns.py
@@ -7261,111 +7261,42 @@ def update(
     format_output(result().extract(), "json", None)
 
 
-@campaigns.command()
-@click.option("--id", "campaign_id", required=True, type=int, help="Campaign ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def delete(ctx, campaign_id, dry_run):
-    """Delete campaign"""
-    body = {
-        "method": "delete",
-        "params": {"SelectionCriteria": {"Ids": [campaign_id]}},
-    }
+def _make_lifecycle_command(method: str, help_text: str):
+    """Build a campaign lifecycle command (delete/archive/.../resume).
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
+    These commands are identical except for the ``method`` sent in the request
+    body and the help text shown in ``--help``. ``name=method`` pins the Click
+    command name (otherwise every command would register as ``_command``);
+    ``help=help_text`` pins the short help so ``--help`` is unchanged (setting
+    ``__doc__`` after decoration is too late — Click reads it at decoration
+    time).
+    """
 
-    client = client_from_ctx(ctx, create_client)
+    @campaigns.command(name=method, help=help_text)
+    @click.option("--id", "campaign_id", required=True, type=int, help="Campaign ID")
+    @click.option("--dry-run", is_flag=True, help="Show request without sending")
+    @click.pass_context
+    @handle_api_errors
+    def _command(ctx, campaign_id, dry_run):
+        body = {
+            "method": method,
+            "params": {"SelectionCriteria": {"Ids": [campaign_id]}},
+        }
 
-    result = client.campaigns().post(data=body)
-    format_output(result().extract(), "json", None)
+        if dry_run:
+            format_output(body, "json", None)
+            return
 
+        client = client_from_ctx(ctx, create_client)
 
-@campaigns.command()
-@click.option("--id", "campaign_id", required=True, type=int, help="Campaign ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def archive(ctx, campaign_id, dry_run):
-    """Archive campaign"""
-    body = {
-        "method": "archive",
-        "params": {"SelectionCriteria": {"Ids": [campaign_id]}},
-    }
+        result = client.campaigns().post(data=body)
+        format_output(result().extract(), "json", None)
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.campaigns().post(data=body)
-    format_output(result().extract(), "json", None)
+    return _command
 
 
-@campaigns.command()
-@click.option("--id", "campaign_id", required=True, type=int, help="Campaign ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def unarchive(ctx, campaign_id, dry_run):
-    """Unarchive campaign"""
-    body = {
-        "method": "unarchive",
-        "params": {"SelectionCriteria": {"Ids": [campaign_id]}},
-    }
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.campaigns().post(data=body)
-    format_output(result().extract(), "json", None)
-
-
-@campaigns.command()
-@click.option("--id", "campaign_id", required=True, type=int, help="Campaign ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def suspend(ctx, campaign_id, dry_run):
-    """Suspend campaign"""
-    body = {
-        "method": "suspend",
-        "params": {"SelectionCriteria": {"Ids": [campaign_id]}},
-    }
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.campaigns().post(data=body)
-    format_output(result().extract(), "json", None)
-
-
-@campaigns.command()
-@click.option("--id", "campaign_id", required=True, type=int, help="Campaign ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def resume(ctx, campaign_id, dry_run):
-    """Resume campaign"""
-    body = {
-        "method": "resume",
-        "params": {"SelectionCriteria": {"Ids": [campaign_id]}},
-    }
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.campaigns().post(data=body)
-    format_output(result().extract(), "json", None)
+delete = _make_lifecycle_command("delete", "Delete campaign")
+archive = _make_lifecycle_command("archive", "Archive campaign")
+unarchive = _make_lifecycle_command("unarchive", "Unarchive campaign")
+suspend = _make_lifecycle_command("suspend", "Suspend campaign")
+resume = _make_lifecycle_command("resume", "Resume campaign")

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -17746,6 +17746,38 @@ def test_campaigns_delete_dry_run_payload():
     }
 
 
+def test_campaigns_archive_dry_run_payload():
+    body = _dry_run("campaigns", "archive", "--id", "42")
+    assert body == {
+        "method": "archive",
+        "params": {"SelectionCriteria": {"Ids": [42]}},
+    }
+
+
+def test_campaigns_unarchive_dry_run_payload():
+    body = _dry_run("campaigns", "unarchive", "--id", "42")
+    assert body == {
+        "method": "unarchive",
+        "params": {"SelectionCriteria": {"Ids": [42]}},
+    }
+
+
+def test_campaigns_suspend_dry_run_payload():
+    body = _dry_run("campaigns", "suspend", "--id", "42")
+    assert body == {
+        "method": "suspend",
+        "params": {"SelectionCriteria": {"Ids": [42]}},
+    }
+
+
+def test_campaigns_resume_dry_run_payload():
+    body = _dry_run("campaigns", "resume", "--id", "42")
+    assert body == {
+        "method": "resume",
+        "params": {"SelectionCriteria": {"Ids": [42]}},
+    }
+
+
 def test_ads_moderate_dry_run_payload():
     body = _dry_run("ads", "moderate", "--id", "99")
     assert body == {


### PR DESCRIPTION
Часть #501 (Фаза C эпика #491, аудит дублирования). Первый слайс — самый узкий и низкорисковый.

## Что и зачем

Пять lifecycle-команд кампаний (`delete`/`archive`/`unarchive`/`suspend`/`resume`) были **байт-идентичны** кроме строки `method` в теле запроса и docstring. Заменил их одной локальной фабрикой `_make_lifecycle_command(method, help_text)`.

## Behavior-preserving (проверено)

- `@campaigns.command(name=method)` фиксирует имя Click-команды — без него все пять зарегистрировались бы под `__name__` фабричного колбэка (`_command`), сломав регистрацию и записи `smoke_matrix.py`, которые ключуются по `campaigns.<name>`.
- `help=help_text` передаётся в декоратор команды (а **не** через `__doc__` после декорирования — Click читает help в момент декорирования, поздний `__doc__` отбрасывается). **`--help` байт-идентичен main** в EN и в дефолтной RU-локали (i18n-каталог ключуется по английской исходной строке → локализация резолвится без изменений).
- Тело запроса `{"method": m, "params": {"SelectionCriteria": {"Ids": [id]}}}` строится механически из `method`; dry-run доказывает байт-идентичность всех пяти payload.

## Тесты

Добавил 4 недостающих dry-run теста (`archive`/`unarchive`/`suspend`/`resume`) — раньше покрыт был только `delete` — фиксируют вывод фабрики и закрывают пробел покрытия.

Полный прогон: **2151 passed / 47 skipped** (2147 + 4 новых); parity-gate и полный dry-run набор зелёные без правок; black/flake8 чисто (0 net-new). Diff: `65 insertions / 102 deletions` (production-код сокращается).

Closes #520

🤖 Generated with [Claude Code](https://claude.com/claude-code)