### PR TITLE
test: guard bidding-strategy subtype constants (#491 C2)

### DIFF
--- a/tests/test_bidding_strategy_constants.py
+++ b/tests/test_bidding_strategy_constants.py
@@ -1,0 +1,197 @@
+"""Guard tests for the bidding-strategy subtype constants (Finding 8, #491 C2).
+
+``direct_cli/_bidding_strategy.py`` exposes ~99 per-side ``_*_SUBTYPES`` /
+``_*_SUPPORTS_*`` constants; ``campaigns.py`` imports 25 of them by name to
+route typed strategy flags. Many share identical *values* across contexts
+(TEXT vs UNIFIED, search vs network), but the names are intentionally
+**separate**: each carries its own WSDL provenance, and aliasing across
+contexts would create false coupling (a future WSDL change to one context
+would silently drag the other). Finding 8's "dedupe via aliases" was therefore
+rejected as low-value/unsafe; this guard is the lasting deliverable.
+
+It pins three invariants so the later Phase-C refactors (C3-C8) cannot
+regress silently:
+
+1. **Import contract** — every name ``campaigns.py`` imports from
+   ``_bidding_strategy`` still resolves (catches a silently broken import).
+2. **Golden snapshot** — the 19 imported subtype *sets* keep their exact
+   values (catches an accidental value change).
+3. **Anti-merge** — the look-alike-but-different TEXT/UNIFIED pairs stay
+   distinct (the ``AverageRoi`` trap), so no "optimizer" merges them.
+"""
+
+import ast
+from pathlib import Path
+
+import direct_cli._bidding_strategy as bs
+from direct_cli._bidding_strategy import (
+    _TEXT_NETWORK_BID_CEILING_SUBTYPES,
+    _TEXT_NETWORK_GOAL_ID_SUBTYPES,
+    _UNIFIED_NETWORK_BID_CEILING_SUBTYPES,
+    _UNIFIED_NETWORK_GOAL_ID_SUBTYPES,
+)
+
+_CAMPAIGNS_PY = (
+    Path(__file__).resolve().parent.parent / "direct_cli" / "commands" / "campaigns.py"
+)
+
+# Golden snapshot of the 19 subtype *sets* imported by campaigns.py, captured
+# from the runtime values. A mismatch means a constant's value drifted.
+_GOLDEN_SETS = {
+    "_TEXT_NETWORK_AVERAGE_CPA_SUBTYPES": {"AverageCpa"},
+    "_TEXT_NETWORK_BID_CEILING_SUBTYPES": {
+        "AverageCpa",
+        "AverageCpaMultipleGoals",
+        "AverageRoi",
+        "WbMaximumClicks",
+        "WbMaximumConversionRate",
+        "WeeklyClickPackage",
+    },
+    "_TEXT_NETWORK_CRR_SUBTYPES": {"AverageCrr", "PayForConversionCrr"},
+    "_TEXT_NETWORK_GOAL_ID_SUBTYPES": {
+        "AverageCpa",
+        "AverageCrr",
+        "AverageRoi",
+        "PayForConversion",
+        "PayForConversionCrr",
+        "WbMaximumConversionRate",
+    },
+    "_TEXT_NETWORK_REQUIRES_PRIORITY_GOALS": {
+        "AverageCpaMultipleGoals",
+        "MaxProfit",
+        "PayForConversionMultipleGoals",
+    },
+    "_TEXT_SEARCH_SUPPORTS_AVERAGE_CPA": {"AverageCpa"},
+    "_TEXT_SEARCH_SUPPORTS_BID_CEILING": {
+        "AverageCpa",
+        "AverageCpaMultipleGoals",
+        "AverageRoi",
+        "WbMaximumClicks",
+        "WbMaximumConversionRate",
+        "WeeklyClickPackage",
+    },
+    "_TEXT_SEARCH_SUPPORTS_CRR": {"AverageCrr", "PayForConversionCrr"},
+    "_TEXT_SEARCH_SUPPORTS_GOAL_ID": {
+        "AverageCpa",
+        "AverageCrr",
+        "AverageRoi",
+        "PayForConversion",
+        "PayForConversionCrr",
+        "WbMaximumConversionRate",
+    },
+    "_UNIFIED_NETWORK_AVERAGE_CPA_SUBTYPES": {"AverageCpa"},
+    "_UNIFIED_NETWORK_BID_CEILING_SUBTYPES": {
+        "AverageCpa",
+        "AverageCpaMultipleGoals",
+        "WbMaximumClicks",
+        "WbMaximumConversionRate",
+    },
+    "_UNIFIED_NETWORK_CRR_SUBTYPES": {"AverageCrr", "PayForConversionCrr"},
+    "_UNIFIED_NETWORK_GOAL_ID_SUBTYPES": {
+        "AverageCpa",
+        "AverageCrr",
+        "PayForConversion",
+        "PayForConversionCrr",
+        "WbMaximumConversionRate",
+    },
+    "_UNIFIED_NETWORK_REQUIRES_PRIORITY_GOALS": {
+        "AverageCpaMultipleGoals",
+        "MaxProfit",
+        "PayForConversionMultipleGoals",
+    },
+    "_UNIFIED_SEARCH_REQUIRES_PRIORITY_GOALS": {
+        "AverageCpaMultipleGoals",
+        "MaxProfit",
+        "PayForConversionMultipleGoals",
+    },
+    "_UNIFIED_SEARCH_SUPPORTS_AVERAGE_CPA": {"AverageCpa"},
+    "_UNIFIED_SEARCH_SUPPORTS_BID_CEILING": {
+        "AverageCpa",
+        "AverageCpaMultipleGoals",
+        "WbMaximumClicks",
+        "WbMaximumConversionRate",
+    },
+    "_UNIFIED_SEARCH_SUPPORTS_CRR": {"AverageCrr", "PayForConversionCrr"},
+    "_UNIFIED_SEARCH_SUPPORTS_GOAL_ID": {
+        "AverageCpa",
+        "AverageCrr",
+        "PayForConversion",
+        "PayForConversionCrr",
+        "WbMaximumConversionRate",
+    },
+}
+
+# Non-set members imported by campaigns.py — pinned by existence + kind, not
+# by value (their contents are larger and more volatile than the subtype sets).
+_EXPECTED_LIST_NAMES = {"BUDGET_TYPES"}
+_EXPECTED_DICT_NAMES = {
+    "TEXT_CAMPAIGN_NETWORK_STRATEGY_TO_WSDL_SUBTYPE",
+    "UNIFIED_CAMPAIGN_NETWORK_STRATEGY_TO_WSDL_SUBTYPE",
+    "_TEXT_CAMPAIGN_SEARCH_STRATEGY_TO_WSDL_SUBTYPE",
+    "_UNIFIED_CAMPAIGN_SEARCH_STRATEGY_TO_WSDL_SUBTYPE",
+}
+_EXPECTED_CALLABLE_NAMES = {"get_bidding_strategy_builder"}
+
+
+def _imported_bidding_strategy_names():
+    """Names campaigns.py imports from .._bidding_strategy (parsed from source)."""
+    tree = ast.parse(_CAMPAIGNS_PY.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "_bidding_strategy":
+            return {alias.name for alias in node.names}
+    raise AssertionError("no `from .._bidding_strategy import (...)` in campaigns.py")
+
+
+def test_import_contract_every_imported_name_resolves():
+    # Every name campaigns.py imports must still exist on the module, or the
+    # import would break at load time (a silent regression for a later refactor).
+    imported = _imported_bidding_strategy_names()
+    missing = sorted(name for name in imported if not hasattr(bs, name))
+    assert (
+        not missing
+    ), f"campaigns.py imports names absent from _bidding_strategy: {missing}"
+
+
+def test_import_contract_matches_known_membership():
+    # Two-sided check: the import block equals the union of the names this guard
+    # knows about. Adding/removing an import without updating the snapshot fails
+    # here — forcing a deliberate update of the golden set.
+    imported = _imported_bidding_strategy_names()
+    known = (
+        set(_GOLDEN_SETS)
+        | _EXPECTED_LIST_NAMES
+        | _EXPECTED_DICT_NAMES
+        | _EXPECTED_CALLABLE_NAMES
+    )
+    assert imported == known, (
+        "import block drifted from the guard snapshot.\n"
+        f"  only in campaigns.py import: {sorted(imported - known)}\n"
+        f"  only in guard snapshot:      {sorted(known - imported)}"
+    )
+
+
+def test_golden_snapshot_subtype_sets_unchanged():
+    for name, expected in _GOLDEN_SETS.items():
+        actual = getattr(bs, name)
+        assert actual == expected, f"{name} value drifted: {sorted(actual)!r}"
+
+
+def test_non_set_members_have_expected_kind():
+    for name in _EXPECTED_LIST_NAMES:
+        assert isinstance(getattr(bs, name), list), name
+    for name in _EXPECTED_DICT_NAMES:
+        assert isinstance(getattr(bs, name), dict), name
+    for name in _EXPECTED_CALLABLE_NAMES:
+        assert callable(getattr(bs, name)), name
+
+
+def test_lookalike_text_vs_unified_sets_stay_distinct():
+    # The AverageRoi trap: UnifiedCampaign network does NOT support AverageRoi,
+    # so these TEXT/UNIFIED pairs are value-similar but MUST stay different.
+    # Pin the non-equality so no future dedup merges them.
+    assert _TEXT_NETWORK_BID_CEILING_SUBTYPES != _UNIFIED_NETWORK_BID_CEILING_SUBTYPES
+    assert _TEXT_NETWORK_GOAL_ID_SUBTYPES != _UNIFIED_NETWORK_GOAL_ID_SUBTYPES
+    assert "AverageRoi" in _TEXT_NETWORK_BID_CEILING_SUBTYPES
+    assert "AverageRoi" not in _UNIFIED_NETWORK_BID_CEILING_SUBTYPES
+    assert "AverageRoi" in _TEXT_NETWORK_GOAL_ID_SUBTYPES
+    assert "AverageRoi" not in _UNIFIED_NETWORK_GOAL_ID_SUBTYPES


### PR DESCRIPTION
Часть #501 (Фаза C эпика #491). Находка 8 (per-side константы `_*_SUBTYPES`).

## Алиасы отвергнуты (0 безопасных кластеров)

Находка 8 предлагала дедуп ~99 констант через алиасы. **Отвергнуто:** все совпадения значений — **кросс-контекстные** (TEXT↔UNIFIED, search↔network), поэтому алиас создал бы ложную связь (будущее WSDL-изменение одного контекста молча потащило бы другой), а экономия строк ≈0. Разведка нашла **0 семантически-безопасных** (один контекст, одна доменная сущность) кластеров → алиасы не добавляются.

## Вместо алиасов — guard-тест (главный deliverable)

Новый `tests/test_bidding_strategy_constants.py` фиксирует 3 инварианта, чтобы будущие builder/payload-рефакторы фазы C (C3–C8) не сломали эти константы молча:

- **Импорт-контракт:** каждое имя, которое `campaigns.py` импортирует из `_bidding_strategy` (парсится из исходника через AST), резолвится; блок импорта сверяется со снимком двусторонне (добавление/удаление импорта без обновления снимка → падение, заставляет осознанно обновить).
- **Золотой снимок:** 19 импортируемых subtype-множеств сохраняют точные значения (сняты с runtime); не-множества (`BUDGET_TYPES`, 4 strategy→subtype маппинга, `get_bidding_strategy_builder`) пинятся по типу.
- **Анти-слияние:** похожие-но-разные TEXT/UNIFIED пары остаются различны — UnifiedCampaign network НЕ поддерживает `AverageRoi`, поэтому `_TEXT_NETWORK_BID_CEILING_SUBTYPES`/`_GOAL_ID_SUBTYPES` никогда не равны UNIFIED-аналогам. Проверил, что guard реально падает на инжектированном дрейфе перед коммитом.

## Нулевой поведенческий радиус

0 правок исходников → parity-gate и полный dry-run набор зелёные **без изменений**. Полный прогон: **2156 passed / 47 skipped** (2151 + 5 новых). black/flake8 чисто.

Closes #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)