### PR TITLE
test: live-write coverage for feeds/retargeting/strategies + cassette refresh

### DIFF
--- a/tests/MANUAL_COVERAGE.md
+++ b/tests/MANUAL_COVERAGE.md
@@ -75,6 +75,31 @@ Live tests skip gracefully when the API returns error 3500.
 - **creatives add** — depends on a valid `video_id` from `advideos add`,
   so it inherits the same limitation.
 
+## Sandbox-Unreachable, Covered Live (Phase 6)
+
+These mutating commands cannot run in the sandbox (it returns 8800/6000) but
+are exercised against the live draft API in `test_v5_live_write.py`. Notes
+captured while recording the cassettes — re-recording must honour them:
+
+- **feeds add/update/delete** — sandbox rejects `feeds update` (8800); live
+  records the full lifecycle. Standard URL feed, no external dependency, fully
+  reversible (delete removes the feed).
+- **retargeting add/update/delete** — a `RETARGETING` rule argument needs a
+  Metrica goal id **_and_ a MembershipLifeSpan** (`--rule ALL:<goal>:<days>`);
+  a bare `ALL:<goal>` is rejected with error 5000 ("Not specified time for goal
+  or segment"). The test uses a **synthetic placeholder goal** (`ALL:12345:30`,
+  the same convention as the audiencetargets smoke tests) — no real account goal
+  id is ever hardcoded — so the live API returns 8800 ("Object not found") and
+  the test skips. Records the request shape, not a passing lifecycle.
+- **strategies add/update/archive/unarchive** — a shared strategy must be made
+  public, which requires a shared-account wallet; accounts without one are
+  rejected with error 6000 and the test skips. **The Yandex Direct API has no
+  `Strategies.delete` operation** (the service exposes only add/update/get/
+  archive/unarchive), so a strategy created by the test cannot be removed via
+  the API — cleanup archives it (`StatusArchived=YES`, non-serving). On an
+  account with a wallet the test leaves one archived strategy behind; this is
+  an API limitation, not a test defect.
+
 ## Summary
 
 | Command | Reason | Risk |

--- a/tests/cassettes/test_v5_live_write/test_v5_live_draft_ads_add_update_delete.yaml
+++ b/tests/cassettes/test_v5_live_write/test_v5_live_draft_ads_add_update_delete.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"method":"add","params":{"Campaigns":[{"Name":"direct-cli-live-draft-test-cassette-nested-ads","StartDate":"2030-01-15","TextCampaign":{"BiddingStrategy":{"Search":{"BiddingStrategyType":"HIGHEST_POSITION"},"Network":{"BiddingStrategyType":"SERVING_OFF"}},"Settings":[]}}]}}'
+    body: '{"method":"add","params":{"Campaigns":[{"Name":"direct-cli-live-draft-test-cassette-nested-ads","StartDate":"2030-01-15","TextCampaign":{"Settings":[],"BiddingStrategy":{"Search":{"BiddingStrategyType":"HIGHEST_POSITION"},"Network":{"BiddingStrategyType":"SERVING_OFF"}}}}]}}'
     headers:
       Accept:
       - '*/*'
@@ -13,7 +13,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.34.2
       authorization:
       - REDACTED
       client-login:
@@ -29,25 +29,25 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.ru/json/v5/campaigns
+    uri: https://api.direct.yandex.com/json/v5/campaigns
   response:
     body:
-      string: '{"result":{"AddResults":[{"Id":100000014}]}}'
+      string: '{"result":{"AddResults":[{"Id":710422462,"Errors":[]}]}}'
     headers:
       Content-Length:
-      - '44'
+      - '56'
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Mon, 01 Jan 2024 00:00:00 GMT
+      - Wed, 03 Jun 2026 07:35:39 GMT
       RequestId:
-      - '0000000000000000000'
+      - '4232593486999321662'
       Set-Cookie:
       - REDACTED
       Units:
-      - 15/3299210/3310000
+      - 15/153620/168000
       Units-Used-Login:
       - REDACTED
       X-Accel-Info:
@@ -62,7 +62,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"method":"add","params":{"AdGroups":[{"Name":"draft-ads-group","CampaignId":100000014,"RegionIds":[1,225]}]}}'
+    body: '{"method":"add","params":{"AdGroups":[{"Name":"draft-ads-group","CampaignId":710422462,"RegionIds":[1,225]}]}}'
     headers:
       Accept:
       - '*/*'
@@ -75,7 +75,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.34.2
       authorization:
       - REDACTED
       client-login:
@@ -91,25 +91,25 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.ru/json/v5/adgroups
+    uri: https://api.direct.yandex.com/json/v5/adgroups
   response:
     body:
-      string: '{"result":{"AddResults":[{"Id":2000000002}]}}'
+      string: '{"result":{"AddResults":[{"Id":5757287178,"Errors":[]}]}}'
     headers:
       Content-Length:
-      - '45'
+      - '57'
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Mon, 01 Jan 2024 00:00:00 GMT
+      - Wed, 03 Jun 2026 07:35:42 GMT
       RequestId:
-      - '0000000000000000000'
+      - '2823753636632488468'
       Set-Cookie:
       - REDACTED
       Units:
-      - 40/3299170/3310000
+      - 40/153580/168000
       Units-Used-Login:
       - REDACTED
       X-Accel-Info:
@@ -124,7 +124,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"method":"add","params":{"Ads":[{"AdGroupId":2000000002,"TextAd":{"Mobile":"NO","Title":"Draft
+    body: '{"method":"add","params":{"Ads":[{"AdGroupId":5757287178,"TextAd":{"Mobile":"NO","Title":"Draft
       Test Ad","Text":"Test ad text","Href":"https://example.com"}}]}}'
     headers:
       Accept:
@@ -138,7 +138,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.34.2
       authorization:
       - REDACTED
       client-login:
@@ -154,26 +154,26 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.ru/json/v5/ads
+    uri: https://api.direct.yandex.com/json/v5/ads
   response:
     body:
-      string: '{"result":{"AddResults":[{"Id":30000000001,"Warnings":[{"Code":10165,"Message":"Parameter
-        will not be applied"}]}]}}'
+      string: '{"result":{"AddResults":[{"Id":17735868496,"Warnings":[{"Code":10165,"Message":"Parameter
+        will not be applied"}],"Errors":[]}]}}'
     headers:
       Content-Length:
-      - '116'
+      - '128'
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Mon, 01 Jan 2024 00:00:00 GMT
+      - Wed, 03 Jun 2026 07:35:44 GMT
       RequestId:
-      - '0000000000000000000'
+      - '2575238583776737676'
       Set-Cookie:
       - REDACTED
       Units:
-      - 40/3299130/3310000
+      - 40/153540/168000
       Units-Used-Login:
       - REDACTED
       X-Accel-Info:
@@ -188,7 +188,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"method":"update","params":{"Ads":[{"Id":30000000001,"TextAd":{"Title":"Updated
+    body: '{"method":"update","params":{"Ads":[{"Id":17735868496,"TextAd":{"Title":"Updated
       Draft Ad"}}]}}'
     headers:
       Accept:
@@ -202,7 +202,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.34.2
       authorization:
       - REDACTED
       client-login:
@@ -218,25 +218,25 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.ru/json/v5/ads
+    uri: https://api.direct.yandex.com/json/v5/ads
   response:
     body:
-      string: '{"result":{"UpdateResults":[{"Id":30000000001}]}}'
+      string: '{"result":{"UpdateResults":[{"Id":17735868496,"Errors":[]}]}}'
     headers:
       Content-Length:
-      - '49'
+      - '61'
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Mon, 01 Jan 2024 00:00:00 GMT
+      - Wed, 03 Jun 2026 07:35:46 GMT
       RequestId:
-      - '0000000000000000000'
+      - '3070910446522258668'
       Set-Cookie:
       - REDACTED
       Units:
-      - 40/3299090/3310000
+      - 40/153500/168000
       Units-Used-Login:
       - REDACTED
       X-Accel-Info:
@@ -251,7 +251,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"method":"get","params":{"SelectionCriteria":{"Ids":[30000000001]},"FieldNames":["Id","CampaignId","AdGroupId","Status","State","Type"],"TextAdFieldNames":["Title","Title2","Text","Href"]}}'
+    body: '{"method":"get","params":{"SelectionCriteria":{"Ids":[17735868496]},"FieldNames":["Id","CampaignId","AdGroupId","Status","State","Type"],"TextAdFieldNames":["Title","Title2","Text","Href"]}}'
     headers:
       Accept:
       - '*/*'
@@ -264,7 +264,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.34.2
       authorization:
       - REDACTED
       client-login:
@@ -280,10 +280,10 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.ru/json/v5/ads
+    uri: https://api.direct.yandex.com/json/v5/ads
   response:
     body:
-      string: '{"result":{"Ads":[{"Id":30000000001,"CampaignId":100000014,"AdGroupId":2000000002,"Status":"DRAFT","State":"OFF","Type":"TEXT_AD","TextAd":{"Text":"Test
+      string: '{"result":{"Ads":[{"Id":17735868496,"CampaignId":710422462,"AdGroupId":5757287178,"Status":"DRAFT","State":"OFF","Type":"TEXT_AD","TextAd":{"Text":"Test
         ad text","Title":"Updated Draft Ad","Title2":null,"Href":"https://example.com"}}]}}'
     headers:
       Content-Security-Policy:
@@ -291,15 +291,15 @@ interactions:
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Mon, 01 Jan 2024 00:00:00 GMT
+      - Wed, 03 Jun 2026 07:35:47 GMT
       RequestId:
-      - '0000000000000000000'
+      - '1131365963989191745'
       Set-Cookie:
       - REDACTED
       Transfer-Encoding:
       - chunked
       Units:
-      - 16/3299074/3310000
+      - 16/153484/168000
       Units-Used-Login:
       - REDACTED
       X-Accel-Info:
@@ -314,7 +314,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"method":"delete","params":{"SelectionCriteria":{"Ids":[30000000001]}}}'
+    body: '{"method":"delete","params":{"SelectionCriteria":{"Ids":[17735868496]}}}'
     headers:
       Accept:
       - '*/*'
@@ -327,7 +327,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.34.2
       authorization:
       - REDACTED
       client-login:
@@ -343,25 +343,25 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.ru/json/v5/ads
+    uri: https://api.direct.yandex.com/json/v5/ads
   response:
     body:
-      string: '{"result":{"DeleteResults":[{"Id":30000000001}]}}'
+      string: '{"result":{"DeleteResults":[{"Id":17735868496,"Errors":[]}]}}'
     headers:
       Content-Length:
-      - '49'
+      - '61'
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Mon, 01 Jan 2024 00:00:00 GMT
+      - Wed, 03 Jun 2026 07:35:49 GMT
       RequestId:
-      - '0000000000000000000'
+      - '8095981206608613097'
       Set-Cookie:
       - REDACTED
       Units:
-      - 10/3299064/3310000
+      - 10/153474/168000
       Units-Used-Login:
       - REDACTED
       X-Accel-Info:
@@ -376,7 +376,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"method":"delete","params":{"SelectionCriteria":{"Ids":[2000000002]}}}'
+    body: '{"method":"delete","params":{"SelectionCriteria":{"Ids":[5757287178]}}}'
     headers:
       Accept:
       - '*/*'
@@ -389,7 +389,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.34.2
       authorization:
       - REDACTED
       client-login:
@@ -405,25 +405,25 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.ru/json/v5/adgroups
+    uri: https://api.direct.yandex.com/json/v5/adgroups
   response:
     body:
-      string: '{"result":{"DeleteResults":[{"Id":2000000002}]}}'
+      string: '{"result":{"DeleteResults":[{"Id":5757287178,"Errors":[]}]}}'
     headers:
       Content-Length:
-      - '48'
+      - '60'
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Mon, 01 Jan 2024 00:00:00 GMT
+      - Wed, 03 Jun 2026 07:35:51 GMT
       RequestId:
-      - '593114932089351967'
+      - '306967585896578055'
       Set-Cookie:
       - REDACTED
       Units:
-      - 10/3299054/3310000
+      - 10/153464/168000
       Units-Used-Login:
       - REDACTED
       X-Accel-Info:
@@ -438,7 +438,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"method":"delete","params":{"SelectionCriteria":{"Ids":[100000014]}}}'
+    body: '{"method":"delete","params":{"SelectionCriteria":{"Ids":[710422462]}}}'
     headers:
       Accept:
       - '*/*'
@@ -451,7 +451,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.34.2
       authorization:
       - REDACTED
       client-login:
@@ -467,25 +467,25 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.ru/json/v5/campaigns
+    uri: https://api.direct.yandex.com/json/v5/campaigns
   response:
     body:
-      string: '{"result":{"DeleteResults":[{"Id":100000014}]}}'
+      string: '{"result":{"DeleteResults":[{"Id":710422462,"Errors":[]}]}}'
     headers:
       Content-Length:
-      - '47'
+      - '59'
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Mon, 01 Jan 2024 00:00:00 GMT
+      - Wed, 03 Jun 2026 07:35:52 GMT
       RequestId:
-      - '0000000000000000000'
+      - '8130205322790991263'
       Set-Cookie:
       - REDACTED
       Units:
-      - 12/3299042/3310000
+      - 12/153452/168000
       Units-Used-Login:
       - REDACTED
       X-Accel-Info:

--- a/tests/cassettes/test_v5_live_write/test_v5_live_draft_feeds_add_update_delete.yaml
+++ b/tests/cassettes/test_v5_live_write/test_v5_live_draft_feeds_add_update_delete.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"method":"add","params":{"Feeds":[{"Name":"draft-smart-feed","BusinessType":"RETAIL","SourceType":"URL","UrlFeed":{"Url":"https://example.com/feed.xml"}}]}}'
+    body: '{"method":"add","params":{"Feeds":[{"Name":"direct-cli-live-draft-test-feed","BusinessType":"RETAIL","SourceType":"URL","UrlFeed":{"Url":"https://example.com/feed.xml"}}]}}'
     headers:
       Accept:
       - '*/*'
@@ -9,7 +9,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '157'
+      - '172'
       Content-Type:
       - application/json
       User-Agent:
@@ -32,7 +32,7 @@ interactions:
     uri: https://api.direct.yandex.com/json/v5/feeds
   response:
     body:
-      string: '{"result":{"AddResults":[{"Id":3436618,"Errors":[]}]}}'
+      string: '{"result":{"AddResults":[{"Id":3436439,"Errors":[]}]}}'
     headers:
       Content-Length:
       - '54'
@@ -41,13 +41,13 @@ interactions:
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Wed, 03 Jun 2026 07:56:18 GMT
+      - Wed, 03 Jun 2026 07:13:43 GMT
       RequestId:
-      - '6981818689689122171'
+      - '4142323325907663908'
       Set-Cookie:
       - REDACTED
       Units:
-      - 40/152194/168000
+      - 40/154243/168000
       Units-Used-Login:
       - REDACTED
       X-Accel-Info:
@@ -62,7 +62,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"method":"add","params":{"Campaigns":[{"Name":"direct-cli-live-draft-test-cassette-smart","StartDate":"2030-01-15","SmartCampaign":{"CounterId":12345678,"BiddingStrategy":{"Search":{"BiddingStrategyType":"SERVING_OFF"},"Network":{"BiddingStrategyType":"AVERAGE_CPC_PER_FILTER","AverageCpcPerFilter":{"FilterAverageCpc":1000000}}}}}]}}'
+    body: '{"method":"update","params":{"Feeds":[{"Id":3436439,"Name":"direct-cli-live-draft-test-feed-renamed"}]}}'
     headers:
       Accept:
       - '*/*'
@@ -71,7 +71,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '335'
+      - '104'
       Content-Type:
       - application/json
       User-Agent:
@@ -91,32 +91,29 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.com/json/v5/campaigns
+    uri: https://api.direct.yandex.com/json/v5/feeds
   response:
     body:
-      string: "{\"result\":{\"AddResults\":[{\"Errors\":[{\"Code\":3500,\"Message\":\"Not
-        supported\",\"Details\":\"\u0421\u043E\u0437\u0434\u0430\u043D\u0438\u0435
-        \u043A\u0430\u043C\u043F\u0430\u043D\u0438\u0438 \u0437\u0430\u0434\u0430\u043D\u043D\u043E\u0433\u043E
-        \u0442\u0438\u043F\u0430 \u043D\u0435 \u043F\u043E\u0434\u0434\u0435\u0440\u0436\u0438\u0432\u0430\u0435\u0442\u0441\u044F\"}]}]}}"
+      string: '{"result":{"UpdateResults":[{"Id":3436439,"Errors":[]}]}}'
     headers:
       Content-Length:
-      - '188'
+      - '57'
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Wed, 03 Jun 2026 07:56:19 GMT
+      - Wed, 03 Jun 2026 07:13:44 GMT
       RequestId:
-      - '9087556804487818955'
+      - '1560614584176991383'
       Set-Cookie:
       - REDACTED
       Units:
-      - 30/152164/168000
+      - 40/154203/168000
       Units-Used-Login:
       - REDACTED
       X-Accel-Info:
-      - reqid:0000000000000000000,cmd:direct.api5/campaigns.add,appcode:0
+      - reqid:0000000000000000000,cmd:direct.api5/feeds.update,appcode:0
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -127,7 +124,69 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"method":"delete","params":{"SelectionCriteria":{"Ids":[3436618]}}}'
+    body: '{"method":"get","params":{"SelectionCriteria":{"Ids":[3436439]},"FieldNames":["Id","Name","BusinessType","SourceType","Status"]}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '129'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      authorization:
+      - REDACTED
+      client-login:
+      - REDACTED
+      processingMode:
+      - auto
+      returnMoneyInMicros:
+      - 'false'
+      skipColumnHeader:
+      - 'false'
+      skipReportHeader:
+      - 'true'
+      skipReportSummary:
+      - 'true'
+    method: POST
+    uri: https://api.direct.yandex.com/json/v5/feeds
+  response:
+    body:
+      string: '{"result":{"Feeds":[{"Id":3436439,"Name":"direct-cli-live-draft-test-feed-renamed","BusinessType":"OTHER","SourceType":"URL","Status":"NEW"}]}}'
+    headers:
+      Content-Length:
+      - '143'
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 03 Jun 2026 07:13:45 GMT
+      RequestId:
+      - '5343849081123897741'
+      Set-Cookie:
+      - REDACTED
+      Units:
+      - 16/154187/168000
+      Units-Used-Login:
+      - REDACTED
+      X-Accel-Info:
+      - reqid:0000000000000000000,cmd:direct.api5/feeds.get,appcode:0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"method":"delete","params":{"SelectionCriteria":{"Ids":[3436439]}}}'
     headers:
       Accept:
       - '*/*'
@@ -159,7 +218,7 @@ interactions:
     uri: https://api.direct.yandex.com/json/v5/feeds
   response:
     body:
-      string: '{"result":{"DeleteResults":[{"Id":3436618,"Errors":[]}]}}'
+      string: '{"result":{"DeleteResults":[{"Id":3436439,"Errors":[]}]}}'
     headers:
       Content-Length:
       - '57'
@@ -168,13 +227,13 @@ interactions:
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Wed, 03 Jun 2026 07:56:21 GMT
+      - Wed, 03 Jun 2026 07:13:47 GMT
       RequestId:
-      - '5522986236314096685'
+      - '2810921237595498537'
       Set-Cookie:
       - REDACTED
       Units:
-      - 10/152154/168000
+      - 10/154177/168000
       Units-Used-Login:
       - REDACTED
       X-Accel-Info:

--- a/tests/cassettes/test_v5_live_write/test_v5_live_draft_keywords_add_update_delete.yaml
+++ b/tests/cassettes/test_v5_live_write/test_v5_live_draft_keywords_add_update_delete.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"method":"add","params":{"Campaigns":[{"Name":"direct-cli-live-draft-test-cassette-nested-keywords","StartDate":"2030-01-15","TextCampaign":{"BiddingStrategy":{"Search":{"BiddingStrategyType":"HIGHEST_POSITION"},"Network":{"BiddingStrategyType":"SERVING_OFF"}},"Settings":[]}}]}}'
+    body: '{"method":"add","params":{"Campaigns":[{"Name":"direct-cli-live-draft-test-cassette-nested-keywords","StartDate":"2030-01-15","TextCampaign":{"Settings":[],"BiddingStrategy":{"Search":{"BiddingStrategyType":"HIGHEST_POSITION"},"Network":{"BiddingStrategyType":"SERVING_OFF"}}}}]}}'
     headers:
       Accept:
       - '*/*'
@@ -13,7 +13,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.34.2
       authorization:
       - REDACTED
       client-login:
@@ -29,25 +29,25 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.ru/json/v5/campaigns
+    uri: https://api.direct.yandex.com/json/v5/campaigns
   response:
     body:
-      string: '{"result":{"AddResults":[{"Id":100000019}]}}'
+      string: '{"result":{"AddResults":[{"Id":710422380,"Errors":[]}]}}'
     headers:
       Content-Length:
-      - '44'
+      - '56'
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Mon, 01 Jan 2024 00:00:00 GMT
+      - Wed, 03 Jun 2026 07:33:52 GMT
       RequestId:
-      - '0000000000000000000'
+      - '8488629144068086255'
       Set-Cookie:
       - REDACTED
       Units:
-      - 15/3297077/3310000
+      - 15/153894/168000
       Units-Used-Login:
       - REDACTED
       X-Accel-Info:
@@ -62,7 +62,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"method":"add","params":{"AdGroups":[{"Name":"draft-kw-group","CampaignId":100000019,"RegionIds":[1,225]}]}}'
+    body: '{"method":"add","params":{"AdGroups":[{"Name":"draft-kw-group","CampaignId":710422380,"RegionIds":[1,225]}]}}'
     headers:
       Accept:
       - '*/*'
@@ -75,7 +75,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.34.2
       authorization:
       - REDACTED
       client-login:
@@ -91,25 +91,25 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.ru/json/v5/adgroups
+    uri: https://api.direct.yandex.com/json/v5/adgroups
   response:
     body:
-      string: '{"result":{"AddResults":[{"Id":2000000007}]}}'
+      string: '{"result":{"AddResults":[{"Id":5757286613,"Errors":[]}]}}'
     headers:
       Content-Length:
-      - '45'
+      - '57'
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Mon, 01 Jan 2024 00:00:00 GMT
+      - Wed, 03 Jun 2026 07:33:55 GMT
       RequestId:
-      - '0000000000000000000'
+      - '1555830171960138949'
       Set-Cookie:
       - REDACTED
       Units:
-      - 40/3297037/3310000
+      - 40/153854/168000
       Units-Used-Login:
       - REDACTED
       X-Accel-Info:
@@ -124,7 +124,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"method":"add","params":{"Keywords":[{"AdGroupId":2000000007,"Keyword":"draft
+    body: '{"method":"add","params":{"Keywords":[{"AdGroupId":5757286613,"Keyword":"draft
       test keyword"}]}}'
     headers:
       Accept:
@@ -138,7 +138,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.34.2
       authorization:
       - REDACTED
       client-login:
@@ -154,25 +154,25 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.ru/json/v5/keywords
+    uri: https://api.direct.yandex.com/json/v5/keywords
   response:
     body:
-      string: '{"result":{"AddResults":[{"Id":40000000004}]}}'
+      string: '{"result":{"AddResults":[{"Id":57377680464,"Errors":[]}]}}'
     headers:
       Content-Length:
-      - '46'
+      - '58'
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Mon, 01 Jan 2024 00:00:00 GMT
+      - Wed, 03 Jun 2026 07:33:57 GMT
       RequestId:
-      - '0000000000000000000'
+      - '5410449393323071461'
       Set-Cookie:
       - REDACTED
       Units:
-      - 22/3297015/3310000
+      - 22/153832/168000
       Units-Used-Login:
       - REDACTED
       X-Accel-Info:
@@ -187,7 +187,8 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"method":"update","params":{"Keywords":[{"Id":40000000004,"Status":"SUSPENDED"}]}}'
+    body: '{"method":"update","params":{"Keywords":[{"Id":57377680464,"Keyword":"draft
+      test keyword updated"}]}}'
     headers:
       Accept:
       - '*/*'
@@ -196,11 +197,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '83'
+      - '101'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.34.2
       authorization:
       - REDACTED
       client-login:
@@ -216,31 +217,29 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.ru/json/v5/keywords
+    uri: https://api.direct.yandex.com/json/v5/keywords
   response:
     body:
-      string: '{"error":{"request_id":"930706505971356658","error_code":8000,"error_detail":"An
-        item in the Keywords array contains the unknown parameter Status","error_string":"Invalid
-        request"}}'
+      string: '{"result":{"UpdateResults":[{"Id":57377680464,"Errors":[]}]}}'
     headers:
       Content-Length:
-      - '181'
+      - '61'
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Mon, 01 Jan 2024 00:00:00 GMT
+      - Wed, 03 Jun 2026 07:33:59 GMT
       RequestId:
-      - '930706505971356658'
+      - '2656606203821940518'
       Set-Cookie:
       - REDACTED
       Units:
-      - 50/3296965/3310000
+      - 22/153810/168000
       Units-Used-Login:
       - REDACTED
       X-Accel-Info:
-      - reqid:0000000000000000000,cmd:direct.api5/keywords.update,appcode:8000
+      - reqid:0000000000000000000,cmd:direct.api5/keywords.update,appcode:0
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -251,7 +250,70 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"method":"delete","params":{"SelectionCriteria":{"Ids":[40000000004]}}}'
+    body: '{"method":"get","params":{"SelectionCriteria":{"CampaignIds":[710422380]},"FieldNames":["Id","Keyword","CampaignId","AdGroupId","Status","ServingStatus","Bid","ContextBid"]}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '174'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      authorization:
+      - REDACTED
+      client-login:
+      - REDACTED
+      processingMode:
+      - auto
+      returnMoneyInMicros:
+      - 'false'
+      skipColumnHeader:
+      - 'false'
+      skipReportHeader:
+      - 'true'
+      skipReportSummary:
+      - 'true'
+    method: POST
+    uri: https://api.direct.yandex.com/json/v5/keywords
+  response:
+    body:
+      string: '{"result":{"Keywords":[{"Id":57377680464,"Keyword":"draft test keyword
+        updated","AdGroupId":5757286613,"CampaignId":710422380,"Bid":300000,"ContextBid":300000,"Status":"ACCEPTED","ServingStatus":"ELIGIBLE"},{"Id":205757286613,"Keyword":"---autotargeting","AdGroupId":5757286613,"CampaignId":710422380,"Bid":300000,"ContextBid":30000000,"Status":"ACCEPTED","ServingStatus":"ELIGIBLE"}]}}'
+    headers:
+      Content-Length:
+      - '386'
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 03 Jun 2026 07:34:00 GMT
+      RequestId:
+      - '7483436399931084546'
+      Set-Cookie:
+      - REDACTED
+      Units:
+      - 15/153795/168000
+      Units-Used-Login:
+      - REDACTED
+      X-Accel-Info:
+      - reqid:0000000000000000000,cmd:direct.api5/keywords.get,appcode:0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"method":"delete","params":{"SelectionCriteria":{"Ids":[57377680464]}}}'
     headers:
       Accept:
       - '*/*'
@@ -264,7 +326,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.34.2
       authorization:
       - REDACTED
       client-login:
@@ -280,25 +342,25 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.ru/json/v5/keywords
+    uri: https://api.direct.yandex.com/json/v5/keywords
   response:
     body:
-      string: '{"result":{"DeleteResults":[{"Id":40000000004}]}}'
+      string: '{"result":{"DeleteResults":[{"Id":57377680464,"Errors":[]}]}}'
     headers:
       Content-Length:
-      - '49'
+      - '61'
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Mon, 01 Jan 2024 00:00:00 GMT
+      - Wed, 03 Jun 2026 07:34:02 GMT
       RequestId:
-      - '0000000000000000000'
+      - '6068384580019202479'
       Set-Cookie:
       - REDACTED
       Units:
-      - 11/3296954/3310000
+      - 11/153784/168000
       Units-Used-Login:
       - REDACTED
       X-Accel-Info:
@@ -313,7 +375,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"method":"delete","params":{"SelectionCriteria":{"Ids":[2000000007]}}}'
+    body: '{"method":"delete","params":{"SelectionCriteria":{"Ids":[5757286613]}}}'
     headers:
       Accept:
       - '*/*'
@@ -326,7 +388,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.34.2
       authorization:
       - REDACTED
       client-login:
@@ -342,25 +404,25 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.ru/json/v5/adgroups
+    uri: https://api.direct.yandex.com/json/v5/adgroups
   response:
     body:
-      string: '{"result":{"DeleteResults":[{"Id":2000000007}]}}'
+      string: '{"result":{"DeleteResults":[{"Id":5757286613,"Errors":[]}]}}'
     headers:
       Content-Length:
-      - '48'
+      - '60'
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Mon, 01 Jan 2024 00:00:00 GMT
+      - Wed, 03 Jun 2026 07:34:05 GMT
       RequestId:
-      - '0000000000000000000'
+      - '8310222769123470261'
       Set-Cookie:
       - REDACTED
       Units:
-      - 10/3296944/3310000
+      - 10/153774/168000
       Units-Used-Login:
       - REDACTED
       X-Accel-Info:
@@ -375,7 +437,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"method":"delete","params":{"SelectionCriteria":{"Ids":[100000019]}}}'
+    body: '{"method":"delete","params":{"SelectionCriteria":{"Ids":[710422380]}}}'
     headers:
       Accept:
       - '*/*'
@@ -388,7 +450,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.34.2
       authorization:
       - REDACTED
       client-login:
@@ -404,25 +466,25 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.ru/json/v5/campaigns
+    uri: https://api.direct.yandex.com/json/v5/campaigns
   response:
     body:
-      string: '{"result":{"DeleteResults":[{"Id":100000019}]}}'
+      string: '{"result":{"DeleteResults":[{"Id":710422380,"Errors":[]}]}}'
     headers:
       Content-Length:
-      - '47'
+      - '59'
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Mon, 01 Jan 2024 00:00:00 GMT
+      - Wed, 03 Jun 2026 07:34:07 GMT
       RequestId:
-      - '0000000000000000000'
+      - '5725161427448854230'
       Set-Cookie:
       - REDACTED
       Units:
-      - 12/3296932/3310000
+      - 12/153762/168000
       Units-Used-Login:
       - REDACTED
       X-Accel-Info:

--- a/tests/cassettes/test_v5_live_write/test_v5_live_draft_retargeting_add_update_delete.yaml
+++ b/tests/cassettes/test_v5_live_write/test_v5_live_draft_retargeting_add_update_delete.yaml
@@ -1,0 +1,65 @@
+interactions:
+- request:
+    body: '{"method":"add","params":{"RetargetingLists":[{"Name":"direct-cli-live-draft-test-rtg","Type":"RETARGETING","Rules":[{"Operator":"ALL","Arguments":[{"ExternalId":12345,"MembershipLifeSpan":30}]}]}]}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '199'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      authorization:
+      - REDACTED
+      client-login:
+      - REDACTED
+      processingMode:
+      - auto
+      returnMoneyInMicros:
+      - 'false'
+      skipColumnHeader:
+      - 'false'
+      skipReportHeader:
+      - 'true'
+      skipReportSummary:
+      - 'true'
+    method: POST
+    uri: https://api.direct.yandex.com/json/v5/retargetinglists
+  response:
+    body:
+      string: '{"result":{"AddResults":[{"Errors":[{"Code":8800,"Message":"Object
+        not found"}]}]}}'
+    headers:
+      Content-Length:
+      - '83'
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 03 Jun 2026 07:56:26 GMT
+      RequestId:
+      - '4939222587227294365'
+      Set-Cookie:
+      - REDACTED
+      Units:
+      - 30/152044/168000
+      Units-Used-Login:
+      - REDACTED
+      X-Accel-Info:
+      - reqid:0000000000000000000,cmd:direct.api5/retargetinglists.add,appcode:0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_v5_live_write/test_v5_live_draft_smartadtargets_suspend_resume.yaml
+++ b/tests/cassettes/test_v5_live_write/test_v5_live_draft_smartadtargets_suspend_resume.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"method":"add","params":{"Feeds":[{"Name":"draft-sr-smart-feed","SourceType":"URL","UrlFeed":{"Url":"https://example.com/feed.xml"}}]}}'
+    body: '{"method":"add","params":{"Feeds":[{"Name":"draft-sr-smart-feed","BusinessType":"RETAIL","SourceType":"URL","UrlFeed":{"Url":"https://example.com/feed.xml"}}]}}'
     headers:
       Accept:
       - '*/*'
@@ -9,11 +9,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '136'
+      - '160'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.34.2
       authorization:
       - REDACTED
       client-login:
@@ -29,25 +29,25 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.ru/json/v5/feeds
+    uri: https://api.direct.yandex.com/json/v5/feeds
   response:
     body:
-      string: '{"result":{"AddResults":[{"Id":1000002}]}}'
+      string: '{"result":{"AddResults":[{"Id":3436619,"Errors":[]}]}}'
     headers:
       Content-Length:
-      - '42'
+      - '54'
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Mon, 01 Jan 2024 00:00:00 GMT
+      - Wed, 03 Jun 2026 07:56:22 GMT
       RequestId:
-      - '0000000000000000000'
+      - '5783015196113203362'
       Set-Cookie:
       - REDACTED
       Units:
-      - 40/3296538/3310000
+      - 40/152114/168000
       Units-Used-Login:
       - REDACTED
       X-Accel-Info:
@@ -62,7 +62,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"method":"add","params":{"Campaigns":[{"Name":"direct-cli-live-draft-test-cassette-smart-sr","StartDate":"2030-01-15","SmartCampaign":{"BiddingStrategy":{"Search":{"BiddingStrategyType":"SERVING_OFF"},"Network":{"BiddingStrategyType":"AVERAGE_CPC_PER_FILTER","AverageCpcPerFilter":{"FilterAverageCpc":1000000}}}}}]}}'
+    body: '{"method":"add","params":{"Campaigns":[{"Name":"direct-cli-live-draft-test-cassette-smart-sr","StartDate":"2030-01-15","SmartCampaign":{"CounterId":12345678,"BiddingStrategy":{"Search":{"BiddingStrategyType":"SERVING_OFF"},"Network":{"BiddingStrategyType":"AVERAGE_CPC_PER_FILTER","AverageCpcPerFilter":{"FilterAverageCpc":1000000}}}}}]}}'
     headers:
       Accept:
       - '*/*'
@@ -71,11 +71,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '317'
+      - '338'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.34.2
       authorization:
       - REDACTED
       client-login:
@@ -91,7 +91,7 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.ru/json/v5/campaigns
+    uri: https://api.direct.yandex.com/json/v5/campaigns
   response:
     body:
       string: "{\"result\":{\"AddResults\":[{\"Errors\":[{\"Code\":3500,\"Message\":\"Not
@@ -106,13 +106,13 @@ interactions:
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Mon, 01 Jan 2024 00:00:00 GMT
+      - Wed, 03 Jun 2026 07:56:23 GMT
       RequestId:
-      - '0000000000000000000'
+      - '5994695497542019570'
       Set-Cookie:
       - REDACTED
       Units:
-      - 30/3296508/3310000
+      - 30/152084/168000
       Units-Used-Login:
       - REDACTED
       X-Accel-Info:
@@ -127,7 +127,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"method":"delete","params":{"SelectionCriteria":{"Ids":[1000002]}}}'
+    body: '{"method":"delete","params":{"SelectionCriteria":{"Ids":[3436619]}}}'
     headers:
       Accept:
       - '*/*'
@@ -140,7 +140,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.5
+      - python-requests/2.34.2
       authorization:
       - REDACTED
       client-login:
@@ -156,25 +156,25 @@ interactions:
       skipReportSummary:
       - 'true'
     method: POST
-    uri: https://api.direct.yandex.ru/json/v5/feeds
+    uri: https://api.direct.yandex.com/json/v5/feeds
   response:
     body:
-      string: '{"result":{"DeleteResults":[{"Id":1000002}]}}'
+      string: '{"result":{"DeleteResults":[{"Id":3436619,"Errors":[]}]}}'
     headers:
       Content-Length:
-      - '45'
+      - '57'
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Mon, 01 Jan 2024 00:00:00 GMT
+      - Wed, 03 Jun 2026 07:56:25 GMT
       RequestId:
-      - '0000000000000000000'
+      - '614386322285229638'
       Set-Cookie:
       - REDACTED
       Units:
-      - 10/3296498/3310000
+      - 10/152074/168000
       Units-Used-Login:
       - REDACTED
       X-Accel-Info:

--- a/tests/cassettes/test_v5_live_write/test_v5_live_draft_strategies_add_update_archive_unarchive.yaml
+++ b/tests/cassettes/test_v5_live_write/test_v5_live_draft_strategies_add_update_archive_unarchive.yaml
@@ -1,0 +1,312 @@
+interactions:
+- request:
+    body: '{"method":"add","params":{"Strategies":[{"Name":"direct-cli-live-draft-test-strategy","AverageCpc":{"AverageCpc":30000000,"WeeklySpendLimit":300000000}}]}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '155'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      authorization:
+      - REDACTED
+      client-login:
+      - REDACTED
+      processingMode:
+      - auto
+      returnMoneyInMicros:
+      - 'false'
+      skipColumnHeader:
+      - 'false'
+      skipReportHeader:
+      - 'true'
+      skipReportSummary:
+      - 'true'
+    method: POST
+    uri: https://api.direct.yandex.com/json/v5/strategies
+  response:
+    body:
+      string: '{"result":{"AddResults":[{"Id":708915404,"Errors":[]}]}}'
+    headers:
+      Content-Length:
+      - '56'
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 03 Jun 2026 07:14:22 GMT
+      RequestId:
+      - '3165779444944969127'
+      Set-Cookie:
+      - REDACTED
+      Units:
+      - 15/154132/168000
+      Units-Used-Login:
+      - REDACTED
+      X-Accel-Info:
+      - reqid:0000000000000000000,cmd:direct.api5/strategies.add,appcode:0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"method":"update","params":{"Strategies":[{"Id":708915404,"Name":"direct-cli-live-draft-test-strategy-renamed"}]}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '115'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      authorization:
+      - REDACTED
+      client-login:
+      - REDACTED
+      processingMode:
+      - auto
+      returnMoneyInMicros:
+      - 'false'
+      skipColumnHeader:
+      - 'false'
+      skipReportHeader:
+      - 'true'
+      skipReportSummary:
+      - 'true'
+    method: POST
+    uri: https://api.direct.yandex.com/json/v5/strategies
+  response:
+    body:
+      string: '{"result":{"UpdateResults":[{"Id":708915404,"Errors":[]}]}}'
+    headers:
+      Content-Length:
+      - '59'
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 03 Jun 2026 07:14:24 GMT
+      RequestId:
+      - '591443445115331982'
+      Set-Cookie:
+      - REDACTED
+      Units:
+      - 13/154119/168000
+      Units-Used-Login:
+      - REDACTED
+      X-Accel-Info:
+      - reqid:0000000000000000000,cmd:direct.api5/strategies.update,appcode:0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"method":"archive","params":{"SelectionCriteria":{"Ids":[708915404]}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      authorization:
+      - REDACTED
+      client-login:
+      - REDACTED
+      processingMode:
+      - auto
+      returnMoneyInMicros:
+      - 'false'
+      skipColumnHeader:
+      - 'false'
+      skipReportHeader:
+      - 'true'
+      skipReportSummary:
+      - 'true'
+    method: POST
+    uri: https://api.direct.yandex.com/json/v5/strategies
+  response:
+    body:
+      string: '{"result":{"ArchiveResults":[{"Id":708915404,"Errors":[]}]}}'
+    headers:
+      Content-Length:
+      - '60'
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 03 Jun 2026 07:14:25 GMT
+      RequestId:
+      - '8464317094764351129'
+      Set-Cookie:
+      - REDACTED
+      Units:
+      - 15/154104/168000
+      Units-Used-Login:
+      - REDACTED
+      X-Accel-Info:
+      - reqid:0000000000000000000,cmd:direct.api5/strategies.archive,appcode:0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"method":"unarchive","params":{"SelectionCriteria":{"Ids":[708915404]}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '73'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      authorization:
+      - REDACTED
+      client-login:
+      - REDACTED
+      processingMode:
+      - auto
+      returnMoneyInMicros:
+      - 'false'
+      skipColumnHeader:
+      - 'false'
+      skipReportHeader:
+      - 'true'
+      skipReportSummary:
+      - 'true'
+    method: POST
+    uri: https://api.direct.yandex.com/json/v5/strategies
+  response:
+    body:
+      string: '{"result":{"UnarchiveResults":[{"Id":708915404,"Errors":[]}]}}'
+    headers:
+      Content-Length:
+      - '62'
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 03 Jun 2026 07:14:27 GMT
+      RequestId:
+      - '4433565921262051173'
+      Set-Cookie:
+      - REDACTED
+      Units:
+      - 15/154089/168000
+      Units-Used-Login:
+      - REDACTED
+      X-Accel-Info:
+      - reqid:0000000000000000000,cmd:direct.api5/strategies.unarchive,appcode:0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"method":"archive","params":{"SelectionCriteria":{"Ids":[708915404]}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      authorization:
+      - REDACTED
+      client-login:
+      - REDACTED
+      processingMode:
+      - auto
+      returnMoneyInMicros:
+      - 'false'
+      skipColumnHeader:
+      - 'false'
+      skipReportHeader:
+      - 'true'
+      skipReportSummary:
+      - 'true'
+    method: POST
+    uri: https://api.direct.yandex.com/json/v5/strategies
+  response:
+    body:
+      string: '{"result":{"ArchiveResults":[{"Id":708915404,"Errors":[]}]}}'
+    headers:
+      Content-Length:
+      - '60'
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 03 Jun 2026 07:14:28 GMT
+      RequestId:
+      - '4648638098761024346'
+      Set-Cookie:
+      - REDACTED
+      Units:
+      - 15/154074/168000
+      Units-Used-Login:
+      - REDACTED
+      X-Accel-Info:
+      - reqid:0000000000000000000,cmd:direct.api5/strategies.archive,appcode:0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_v5_live_write.py
+++ b/tests/test_v5_live_write.py
@@ -32,6 +32,13 @@ Coverage status (issue #59):
     - keywords/audiencetargets/dynamicads/smartadtargets suspend/resume
     - ads suspend/resume/archive/unarchive
     (draft-state operations may be rejected — tests skip gracefully)
+
+  Phase 6 — standalone draft assets, full lifecycle (sandbox-unreachable):
+    - feeds add/update/delete (sandbox returns 8800 on update)
+    - retargeting add/update/delete (rule uses a synthetic goal placeholder
+      ALL:12345:30; skips on 8800 — the placeholder goal is in no account)
+    - strategies add/update/archive/unarchive (no delete method; skips on
+      6000 if the account has no shared wallet)
 """
 
 import json
@@ -50,6 +57,11 @@ from conftest import _resolve_test_credentials  # noqa: E402
 LIVE_WRITE_ENV = "YANDEX_DIRECT_LIVE_WRITE"
 TEST_CAMPAIGN_NAME = "direct-cli-live-draft-test-cassette"
 TEST_CAMPAIGN_START_DATE = "2030-01-15"
+# Synthetic Metrica counter placeholder. SmartCampaignAddItem.CounterId is
+# WSDL-required (minOccurs=1), so the flag must be present, but SMART_CAMPAIGN
+# creation itself is rejected on standard accounts (3500) — the test skips
+# before the counter is validated. Never hardcode a real account counter id.
+TEST_METRIKA_COUNTER_ID = "12345678"
 
 # 450x450 solid red PNG — meets Yandex Direct minimum image dimension
 # requirements.  Validated: decodes to 1487 bytes, correct PNG header,
@@ -558,7 +570,14 @@ def test_v5_live_draft_ads_add_update_delete() -> None:
         aid = _extract_first_id(r.output)
 
         r = _invoke_live(
-            "ads", "update", "--id", str(aid), "--title", "Updated Draft Ad"
+            "ads",
+            "update",
+            "--id",
+            str(aid),
+            "--type",
+            "TEXT_AD",
+            "--title",
+            "Updated Draft Ad",
         )
         _assert_success(r, "ads update")
 
@@ -888,6 +907,8 @@ def test_v5_live_draft_smartadtargets_add_update_delete() -> None:
         "draft-smart-feed",
         "--url",
         "https://example.com/feed.xml",
+        "--business-type",
+        "RETAIL",
     )
     _assert_success(r, "feeds add")
     fid = _extract_first_id(r.output)
@@ -909,6 +930,8 @@ def test_v5_live_draft_smartadtargets_add_update_delete() -> None:
             "AVERAGE_CPC_PER_FILTER",
             "--filter-average-cpc",
             "1000000",
+            "--counter-id",
+            TEST_METRIKA_COUNTER_ID,
         )
         # 3500 = campaign type not supported on this account (agency-only feature)
         # See API_COVERAGE.md Category B and MANUAL_COVERAGE.md.
@@ -1139,6 +1162,8 @@ def test_v5_live_draft_smartadtargets_suspend_resume() -> None:
         "draft-sr-smart-feed",
         "--url",
         "https://example.com/feed.xml",
+        "--business-type",
+        "RETAIL",
     )
     _assert_success(r, "feeds add")
     fid = _extract_first_id(r.output)
@@ -1160,6 +1185,8 @@ def test_v5_live_draft_smartadtargets_suspend_resume() -> None:
             "AVERAGE_CPC_PER_FILTER",
             "--filter-average-cpc",
             "1000000",
+            "--counter-id",
+            TEST_METRIKA_COUNTER_ID,
         )
         if "3500" in r.output:
             pytest.skip("SMART_CAMPAIGN not supported on this account (3500)")
@@ -1249,3 +1276,150 @@ def test_v5_live_draft_ads_suspend_resume_archive_unarchive() -> None:
             _invoke_live("ads", "delete", "--id", str(aid))
         _invoke_live("adgroups", "delete", "--id", str(gid))
         _safe_delete_campaign(cid)
+
+
+# ── Phase 6: standalone draft assets — full lifecycle ─────────────────────
+#
+# feeds/retargeting/strategies are top-level resources that the sandbox cannot
+# exercise (8800/6000), so their live-write coverage lives here.  feeds add and
+# delete are already touched as smartadtargets dependencies, but feeds *update*,
+# the retargeting lifecycle, and strategies were previously uncovered live.
+
+
+@pytest.mark.vcr
+def test_v5_live_draft_feeds_add_update_delete() -> None:
+    """Create a URL feed, rename it via update, then delete it."""
+    r = _invoke_live(
+        "feeds",
+        "add",
+        "--name",
+        "direct-cli-live-draft-test-feed",
+        "--url",
+        "https://example.com/feed.xml",
+        "--business-type",
+        "RETAIL",
+    )
+    _assert_success(r, "feeds add")
+    fid = _extract_first_id(r.output)
+
+    try:
+        r = _invoke_live(
+            "feeds",
+            "update",
+            "--id",
+            str(fid),
+            "--name",
+            "direct-cli-live-draft-test-feed-renamed",
+        )
+        _assert_success(r, "feeds update")
+
+        r = _invoke_live("feeds", "get", "--ids", str(fid), "--format", "json")
+        _assert_success(r, "feeds get after update")
+    finally:
+        r = _invoke_live("feeds", "delete", "--id", str(fid))
+        if r.exit_code != 0:
+            pytest.fail(
+                f"Failed to delete feed {fid}. "
+                f"Manual cleanup required.\noutput: {r.output}"
+            )
+
+
+@pytest.mark.vcr
+def test_v5_live_draft_retargeting_add_update_delete() -> None:
+    """Create a retargeting list, rename it via update, then delete it.
+
+    The rule uses a synthetic Metrica goal placeholder (``ALL:12345:30``) — the
+    same convention as the audiencetargets smoke tests.  A MembershipLifeSpan is
+    required (the API rejects a goal argument without one — error 5000); the
+    placeholder goal itself is not present in any account, so the live API
+    rejects the add with "Object not found" (8800) and the test skips.  Never
+    hardcode a real account goal id here (see tests/MANUAL_COVERAGE.md).
+    """
+    r = _invoke_live(
+        "retargeting",
+        "add",
+        "--name",
+        "direct-cli-live-draft-test-rtg",
+        "--type",
+        "RETARGETING",
+        "--rule",
+        "ALL:12345:30",
+    )
+    if r.exit_code != 0 and ("8800" in r.output or "not found" in r.output.lower()):
+        pytest.skip(
+            "retargeting add rejected (8800) — synthetic goal not found in "
+            f"account: {r.output[:200]}"
+        )
+    _assert_success(r, "retargeting add")
+    rid = _extract_first_id(r.output)
+
+    try:
+        r = _invoke_live(
+            "retargeting",
+            "update",
+            "--id",
+            str(rid),
+            "--name",
+            "direct-cli-live-draft-test-rtg-renamed",
+        )
+        _assert_success(r, "retargeting update")
+
+        r = _invoke_live("retargeting", "get", "--ids", str(rid), "--format", "json")
+        _assert_success(r, "retargeting get after update")
+    finally:
+        r = _invoke_live("retargeting", "delete", "--id", str(rid))
+        if r.exit_code != 0:
+            pytest.fail(
+                f"Failed to delete retargeting list {rid}. "
+                f"Manual cleanup required.\noutput: {r.output}"
+            )
+
+
+@pytest.mark.vcr
+def test_v5_live_draft_strategies_add_update_archive_unarchive() -> None:
+    """Create a shared strategy, update/archive/unarchive, then archive cleanup.
+
+    Strategies must be public, which Yandex Direct forbids without a shared
+    account wallet (error 6000).  Accounts without a wallet are a documented
+    restriction (see tests/MANUAL_COVERAGE.md); skip gracefully on 6000.
+    The strategies service has no delete method — cleanup is archive only.
+    """
+    r = _invoke_live(
+        "strategies",
+        "add",
+        "--name",
+        "direct-cli-live-draft-test-strategy",
+        "--type",
+        "AverageCpc",
+        "--average-cpc",
+        "30000000",
+        "--weekly-spend-limit",
+        "300000000",
+    )
+    if r.exit_code != 0 and "6000" in r.output:
+        pytest.skip(
+            "strategies add rejected — shared account wallet required (6000): "
+            f"{r.output[:200]}"
+        )
+    _assert_success(r, "strategies add")
+    sid = _extract_first_id(r.output)
+
+    try:
+        r = _invoke_live(
+            "strategies",
+            "update",
+            "--id",
+            str(sid),
+            "--name",
+            "direct-cli-live-draft-test-strategy-renamed",
+        )
+        _assert_success(r, "strategies update")
+
+        r = _invoke_live("strategies", "archive", "--id", str(sid))
+        _assert_draft_or_success(r, "strategies archive")
+
+        r = _invoke_live("strategies", "unarchive", "--id", str(sid))
+        _assert_draft_or_success(r, "strategies unarchive")
+    finally:
+        # No strategies delete method exists; leave the strategy archived.
+        _invoke_live("strategies", "archive", "--id", str(sid))

--- a/tests/test_v5_live_write.py
+++ b/tests/test_v5_live_write.py
@@ -1421,5 +1421,10 @@ def test_v5_live_draft_strategies_add_update_archive_unarchive() -> None:
         r = _invoke_live("strategies", "unarchive", "--id", str(sid))
         _assert_draft_or_success(r, "strategies unarchive")
     finally:
-        # No strategies delete method exists; leave the strategy archived.
-        _invoke_live("strategies", "archive", "--id", str(sid))
+        # No strategies delete method exists; archive is the only cleanup.
+        r = _invoke_live("strategies", "archive", "--id", str(sid))
+        if r.exit_code != 0:
+            pytest.fail(
+                f"Failed to archive strategy {sid}. "
+                f"Manual cleanup required.\noutput: {r.output}"
+            )


### PR DESCRIPTION
## Summary

- Add Phase 6 live-write lifecycle tests (`tests/test_v5_live_write.py`) for **feeds**, **retargeting** and **strategies** — mutating resources the sandbox cannot exercise (returns 8800/6000), so they were previously only covered via dry-run.
- **No real account ids anywhere.** retargeting uses the synthetic goal placeholder `ALL:12345:30` (same convention as the existing audiencetargets smoke tests); the live API returns 8800 and the test skips, recording the request shape rather than a passing lifecycle.
- Refresh four cassettes that drifted out of sync with the CLI after the #491 refactor (WSDL-parity gate made fields required): `ads update` now needs `--type`, `feeds add` needs `--business-type`, `campaigns add --type SMART_CAMPAIGN` needs `--counter-id` (synthetic `12345678`). smartadtargets skips on 3500 as documented.
- Document in `tests/MANUAL_COVERAGE.md` that the Yandex Direct API has **no `Strategies.delete`** operation (only add/update/get/archive/unarchive) — a created strategy can only be archived (`StatusArchived=YES`), not removed via the API.

## Test plan

- [x] Live-write replay (no network): `YANDEX_DIRECT_TOKEN=dummy YANDEX_DIRECT_LOGIN=dummy YANDEX_DIRECT_LIVE_WRITE=1 pytest -m integration_live_write` → 12 passed, 9 skipped, **0 failed**
- [x] Full suite: `pytest -q` → **2156 passed, 50 skipped, 0 failed**
- [x] Secret/real-id scan across cassettes, test file and docs → clean (0 tokens, 0 logins, 0 real account ids)
- [x] flake8 → no new violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)