### PR TITLE
refactor: empty-SelectionCriteria guard for 9 get-commands (#498 B3c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## 0.4.2
 
+**BREAKING CHANGES - get requires SelectionCriteria (#498):**
+
+- `adgroups` / `ads` / `keywords` / `strategies` / `creatives` / `dynamicads` /
+  `smartadtargets` / `audiencetargets` `get` now refuse an empty
+  `SelectionCriteria` before the API call, raising a `UsageError` that asks for
+  at least one filter — instead of sending `{"SelectionCriteria": {}}` (which the
+  API rejects with the opaque error 4001 for ad-group/ad/keyword resources).
+  Extends the same guard already shipped for `bids` / `keywordbids` in 0.4.1
+  (#483). WSDL declares `GetRequest.SelectionCriteria` as `minOccurs=1` for all
+  eight resources.
+- `retargeting get` gains `--dry-run` and the shared read/pagination option
+  stack; its `SelectionCriteria` stays optional (WSDL `minOccurs=0`), so a
+  no-filter call is still valid and now omits the empty criteria from the
+  payload.
+- All eight commands and `retargeting get` build their request via the shared
+  `build_common_params` helper, completing the dedup epic #491 (B3c).
+
 **BREAKING CHANGES - auth precedence (#489):**
 
 - Base `YANDEX_DIRECT_TOKEN` / `YANDEX_DIRECT_LOGIN` credentials from the

--- a/direct_cli/commands/adgroups.py
+++ b/direct_cli/commands/adgroups.py
@@ -11,6 +11,7 @@ from ..i18n import t
 from ..output import format_output, handle_api_errors
 from ..utils import (
     add_criteria_csv,
+    build_common_params,
     get_default_fields,
     parse_csv_strings,
     parse_ids,
@@ -545,11 +546,13 @@ def get(
         integers=True,
     )
 
-    params = {"SelectionCriteria": criteria, "FieldNames": field_names}
-    params.update(parsed_nested)
+    if not criteria:
+        raise click.UsageError(t("Provide at least one typed filter"))
 
-    if limit:
-        params["Page"] = {"Limit": limit}
+    params = build_common_params(
+        criteria=criteria, field_names=field_names, limit=limit
+    )
+    params.update(parsed_nested)
 
     body = {"method": "get", "params": params}
 

--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -11,6 +11,7 @@ from ..i18n import t
 from ..output import format_output, handle_api_errors
 from ..utils import (
     add_criteria_csv,
+    build_common_params,
     get_default_fields,
     MICRO_RUBLES,
     parse_condition_specs,
@@ -1025,14 +1026,13 @@ def get(
     )
     add_criteria_csv(criteria, "AdExtensionIds", adextension_ids, integers=True)
 
-    params = {
-        "SelectionCriteria": criteria,
-        "FieldNames": field_names,
-    }
-    params.update(parsed_nested)
+    if not criteria:
+        raise click.UsageError(t("Provide at least one typed filter"))
 
-    if limit:
-        params["Page"] = {"Limit": limit}
+    params = build_common_params(
+        criteria=criteria, field_names=field_names, limit=limit
+    )
+    params.update(parsed_nested)
 
     body = {"method": "get", "params": params}
 

--- a/direct_cli/commands/audiencetargets.py
+++ b/direct_cli/commands/audiencetargets.py
@@ -10,6 +10,7 @@ from ..output import format_output, handle_api_errors
 from ..utils import (
     MICRO_RUBLES,
     add_criteria_csv,
+    build_common_params,
     get_default_fields,
     get_options,
     parse_csv_strings,
@@ -63,14 +64,13 @@ def get(
     add_criteria_csv(criteria, "InterestIds", interest_ids, integers=True)
     add_criteria_csv(criteria, "States", states, upper=True)
 
-    field_names = parse_csv_strings(fields) or get_default_fields("audiencetargets")
-    params = {
-        "SelectionCriteria": criteria,
-        "FieldNames": field_names,
-    }
+    if not criteria:
+        raise click.UsageError(t("Provide at least one typed filter"))
 
-    if limit:
-        params["Page"] = {"Limit": limit}
+    field_names = parse_csv_strings(fields) or get_default_fields("audiencetargets")
+    params = build_common_params(
+        criteria=criteria, field_names=field_names, limit=limit
+    )
 
     body = {"method": "get", "params": params}
 

--- a/direct_cli/commands/creatives.py
+++ b/direct_cli/commands/creatives.py
@@ -5,8 +5,10 @@ Creatives commands
 import click
 
 from ..api import client_from_ctx, create_client
+from ..i18n import t
 from ..output import format_output, handle_api_errors
 from ..utils import (
+    build_common_params,
     get_default_fields,
     parse_csv_strings,
     parse_csv_upper,
@@ -101,11 +103,13 @@ def get(
     if types:
         criteria["Types"] = parse_csv_upper(types) or []
 
-    params = {"SelectionCriteria": criteria, "FieldNames": field_names}
-    params.update(parsed_nested_field_names)
+    if not criteria:
+        raise click.UsageError(t("Provide at least one typed filter"))
 
-    if limit:
-        params["Page"] = {"Limit": limit}
+    params = build_common_params(
+        criteria=criteria, field_names=field_names, limit=limit
+    )
+    params.update(parsed_nested_field_names)
 
     body = {"method": "get", "params": params}
 

--- a/direct_cli/commands/dynamicads.py
+++ b/direct_cli/commands/dynamicads.py
@@ -9,6 +9,7 @@ from ..i18n import t
 from ..output import format_output, handle_api_errors
 from ..utils import (
     MICRO_RUBLES,
+    build_common_params,
     get_default_fields,
     get_options,
     parse_condition_specs,
@@ -59,10 +60,12 @@ def get(
     if states:
         criteria["States"] = parse_csv_upper(states) or []
 
-    params = {"SelectionCriteria": criteria, "FieldNames": field_names}
+    if not criteria:
+        raise click.UsageError(t("Provide at least one typed filter"))
 
-    if limit:
-        params["Page"] = {"Limit": limit}
+    params = build_common_params(
+        criteria=criteria, field_names=field_names, limit=limit
+    )
 
     body = {"method": "get", "params": params}
 

--- a/direct_cli/commands/keywords.py
+++ b/direct_cli/commands/keywords.py
@@ -20,6 +20,7 @@ from ..output import (
 from ..utils import (
     MICRO_RUBLES,
     add_criteria_csv,
+    build_common_params,
     get_default_fields,
     parse_csv_strings,
     parse_ids,
@@ -361,14 +362,16 @@ def get(
         criteria["ModifiedSince"] = modified_since
     add_criteria_csv(criteria, "ServingStatuses", serving_statuses, upper=True)
 
-    params = {"SelectionCriteria": criteria, "FieldNames": field_names}
+    if not criteria:
+        raise click.UsageError(t("Provide at least one typed filter"))
+
+    params = build_common_params(
+        criteria=criteria, field_names=field_names, limit=limit
+    )
     if parsed_brand_options:
         params["AutotargetingSettingsBrandOptionsFieldNames"] = parsed_brand_options
     if parsed_categories:
         params["AutotargetingSettingsCategoriesFieldNames"] = parsed_categories
-
-    if limit:
-        params["Page"] = {"Limit": limit}
 
     body = {"method": "get", "params": params}
 

--- a/direct_cli/commands/retargeting.py
+++ b/direct_cli/commands/retargeting.py
@@ -11,7 +11,9 @@ from ..i18n import t
 from ..output import format_output, handle_api_errors
 from ..utils import (
     add_criteria_csv,
+    build_common_params,
     get_default_fields,
+    get_options,
     parse_csv_strings,
     parse_ids,
     parse_retargeting_rule_specs,
@@ -26,14 +28,20 @@ def retargeting():
 @retargeting.command()
 @click.option("--ids", help="Comma-separated list IDs")
 @click.option("--types", help="Filter by types")
-@click.option("--limit", type=int, help="Limit number of results")
-@click.option("--fetch-all", is_flag=True, help="Fetch all pages")
-@click.option("--format", "output_format", default="json", help="Output format")
-@click.option("--output", help="Output file")
-@click.option("--fields", help="Comma-separated field names")
+@get_options
 @click.pass_context
 @handle_api_errors
-def get(ctx, ids, types, limit, fetch_all, output_format, output, fields):
+def get(
+    ctx,
+    ids,
+    types,
+    limit,
+    fetch_all,
+    output_format,
+    output,
+    fields,
+    dry_run,
+):
     """Get retargeting lists"""
     client = client_from_ctx(ctx, create_client)
 
@@ -44,12 +52,15 @@ def get(ctx, ids, types, limit, fetch_all, output_format, output, fields):
         criteria["Ids"] = parse_ids(ids)
     add_criteria_csv(criteria, "Types", types, upper=True)
 
-    params = {"SelectionCriteria": criteria, "FieldNames": field_names}
-
-    if limit:
-        params["Page"] = {"Limit": limit}
+    params = build_common_params(
+        criteria=criteria, field_names=field_names, limit=limit
+    )
 
     body = {"method": "get", "params": params}
+
+    if dry_run:
+        format_output(body, "json", None)
+        return
 
     result = client.retargeting().post(data=body)
 

--- a/direct_cli/commands/smartadtargets.py
+++ b/direct_cli/commands/smartadtargets.py
@@ -9,6 +9,7 @@ from ..i18n import t
 from ..output import format_output, handle_api_errors
 from ..utils import (
     MICRO_RUBLES,
+    build_common_params,
     get_default_fields,
     get_options,
     parse_condition_specs,
@@ -59,10 +60,12 @@ def get(
     if states:
         criteria["States"] = parse_csv_upper(states) or []
 
-    params = {"SelectionCriteria": criteria, "FieldNames": field_names}
+    if not criteria:
+        raise click.UsageError(t("Provide at least one typed filter"))
 
-    if limit:
-        params["Page"] = {"Limit": limit}
+    params = build_common_params(
+        criteria=criteria, field_names=field_names, limit=limit
+    )
 
     body = {"method": "get", "params": params}
 

--- a/direct_cli/commands/strategies.py
+++ b/direct_cli/commands/strategies.py
@@ -10,6 +10,7 @@ from ..output import format_output, handle_api_errors
 from ..utils import (
     MICRO_RUBLES,
     add_criteria_csv,
+    build_common_params,
     get_default_fields,
     parse_csv_strings,
     parse_ids,
@@ -660,10 +661,13 @@ def get(
     if is_archived:
         criteria["IsArchived"] = is_archived.upper()
 
-    params = {"SelectionCriteria": criteria, "FieldNames": field_names}
+    if not criteria:
+        raise click.UsageError(t("Provide at least one typed filter"))
+
+    params = build_common_params(
+        criteria=criteria, field_names=field_names, limit=limit
+    )
     params.update(parsed_nested)
-    if limit:
-        params["Page"] = {"Limit": limit}
 
     body = {"method": "get", "params": params}
     if dry_run:

--- a/scripts/build_api_coverage_report.py
+++ b/scripts/build_api_coverage_report.py
@@ -38,6 +38,17 @@ FIELD_OPERATION_CAPTURE_OPTION_FIXTURES = {
     # wire-payload capture builds a valid request.
     ("bids", "get"): ["--campaign-ids", "1"],
     ("keywordbids", "get"): ["--campaign-ids", "1"],
+    # WSDL GetRequest.SelectionCriteria is minOccurs=1 for these resources, so
+    # the CLI requires at least one filter (#498 B3c); supply --ids so the
+    # wire-payload capture builds a valid request.
+    ("adgroups", "get"): ["--ids", "1"],
+    ("ads", "get"): ["--ids", "1"],
+    ("keywords", "get"): ["--ids", "1"],
+    ("strategies", "get"): ["--ids", "1"],
+    ("creatives", "get"): ["--ids", "1"],
+    ("dynamicads", "get"): ["--ids", "1"],
+    ("smartadtargets", "get"): ["--ids", "1"],
+    ("audiencetargets", "get"): ["--ids", "1"],
     ("changes", "check"): [
         "--campaign-ids",
         "1",

--- a/tests/api_coverage_payloads.py
+++ b/tests/api_coverage_payloads.py
@@ -19,6 +19,7 @@ DRY_RUN_PAYLOAD_EXCLUSIONS = {
     "keywords.get": "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria tests.",
     "leads.get": "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria tests.",
     "negativekeywordsharedsets.get": "Read path omits optional SelectionCriteria when --ids is absent.",
+    "retargeting.get": "Read path omits optional SelectionCriteria when --ids is absent.",
     "sitelinks.get": "Read path omits optional SelectionCriteria when --ids is absent.",
     "smartadtargets.get": "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria tests.",
     "turbopages.get": "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria tests.",

--- a/tests/cassettes/test_read_cassettes/test_read_command[creatives_get].yaml
+++ b/tests/cassettes/test_read_cassettes/test_read_command[creatives_get].yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"method":"get","params":{"SelectionCriteria":{},"FieldNames":["Id","Name","Type"]}}'
+    body: '{"method":"get","params":{"SelectionCriteria":{"Ids":[1]},"FieldNames":["Id","Name","Type"]}}'
     headers:
       Accept:
       - '*/*'
@@ -9,7 +9,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '84'
+      - '93'
       Content-Type:
       - application/json
       User-Agent:

--- a/tests/cassettes/test_read_cassettes/test_read_command[retargeting_get].yaml
+++ b/tests/cassettes/test_read_cassettes/test_read_command[retargeting_get].yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"method":"get","params":{"SelectionCriteria":{},"FieldNames":["Id","Name","Type","Scope"]}}'
+    body: '{"method":"get","params":{"FieldNames":["Id","Name","Type","Scope"]}}'
     headers:
       Accept:
       - '*/*'
@@ -9,7 +9,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '92'
+      - '69'
       Content-Type:
       - application/json
       User-Agent:

--- a/tests/cassettes/test_read_cassettes/test_read_command[strategies_get].yaml
+++ b/tests/cassettes/test_read_cassettes/test_read_command[strategies_get].yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"method":"get","params":{"SelectionCriteria":{},"FieldNames":["Id","Name","Type","StatusArchived"]}}'
+    body: '{"method":"get","params":{"SelectionCriteria":{"Ids":[1]},"FieldNames":["Id","Name","Type","StatusArchived"]}}'
     headers:
       Accept:
       - '*/*'
@@ -9,7 +9,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '101'
+      - '110'
       Content-Type:
       - application/json
       User-Agent:

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -351,9 +351,18 @@ def test_optional_ids_criteria_get_omits_empty_selection_criteria():
         "negativekeywordsharedsets",
         "sitelinks",
         "vcards",
+        # retargeting GetRequest.SelectionCriteria is minOccurs=0 (optional), so
+        # a no-filter call is valid and now omits the empty criteria — it also
+        # gained --dry-run in #498 (B3c).
+        "retargeting",
     ):
         body = _read_dry_run(command, "get")
         assert "SelectionCriteria" not in body["params"]
+
+
+def test_retargeting_get_with_ids_builds_selection_criteria():
+    body = _read_dry_run("retargeting", "get", "--ids", "1,2")
+    assert body["params"]["SelectionCriteria"] == {"Ids": [1, 2]}
 
 
 def test_advideos_get_ids_required():
@@ -17570,6 +17579,46 @@ def test_keywordbids_get_requires_selection_criteria():
     assert "--keyword-ids" in result.output
 
 
+# WSDL GetRequest.SelectionCriteria is minOccurs=1 for these resources, so a
+# no-filter ``get`` would send ``{"SelectionCriteria": {}}`` — rejected by the
+# live API (error 4001 for ad-group/ad/keyword). The CLI now refuses it before
+# the request, extending the bids/keywordbids guard shipped in 0.4.1 (#483).
+# Issue #498 (B3c).
+_SELECTION_CRITERIA_REQUIRED_GET_COMMANDS = (
+    "adgroups",
+    "ads",
+    "keywords",
+    "strategies",
+    "creatives",
+    "dynamicads",
+    "smartadtargets",
+    "audiencetargets",
+)
+
+
+@pytest.mark.parametrize("command", _SELECTION_CRITERIA_REQUIRED_GET_COMMANDS)
+def test_get_requires_selection_criteria(command):
+    result = CliRunner().invoke(
+        cli,
+        [command, "get", "--dry-run"],
+        env={"YANDEX_DIRECT_TOKEN": "test-token", "YANDEX_DIRECT_LOGIN": ""},
+    )
+    assert result.exit_code != 0, (
+        f"direct {command} get --dry-run unexpectedly succeeded with no filter\n"
+        f"output: {result.output}"
+    )
+    # The guard is a Click UsageError (exit 2), not an API Abort (exit 1).
+    assert result.exit_code == 2
+
+
+@pytest.mark.parametrize("command", _SELECTION_CRITERIA_REQUIRED_GET_COMMANDS)
+def test_get_with_filter_keeps_selection_criteria(command):
+    # With a filter present the payload still carries SelectionCriteria — the
+    # guard only rejects the empty case, the populated payload is unchanged.
+    body = _read_dry_run(command, "get", "--ids", "1,2")
+    assert body["params"]["SelectionCriteria"] == {"Ids": [1, 2]}
+
+
 def test_campaigns_get_empty_fields_raises_usage_error_not_abort():
     # The UsageError from _parse_csv_option must keep exit code 2 (UsageError),
     # not be swallowed by ``except Exception`` and downgraded to Abort (1).
@@ -22428,6 +22477,8 @@ def test_keywords_get_nested_field_names_payload():
     body = _read_dry_run(
         "keywords",
         "get",
+        "--ids",
+        "1",
         "--autotargeting-settings-brand-options-field-names",
         "WithoutBrands,WithAdvertiserBrand,WithCompetitorsBrand",
         "--autotargeting-settings-categories-field-names",
@@ -22448,7 +22499,7 @@ def test_keywords_get_nested_field_names_payload():
 
 
 def test_keywords_get_omits_nested_field_names_by_default():
-    body = _read_dry_run("keywords", "get")
+    body = _read_dry_run("keywords", "get", "--ids", "1")
 
     assert "AutotargetingSettingsBrandOptionsFieldNames" not in body["params"]
     assert "AutotargetingSettingsCategoriesFieldNames" not in body["params"]
@@ -22519,6 +22570,8 @@ def test_creatives_get_nested_field_names_payload():
     body = _read_dry_run(
         "creatives",
         "get",
+        "--ids",
+        "1",
         "--cpc-video-creative-field-names",
         "Duration",
         "--cpm-video-creative-field-names",
@@ -22541,7 +22594,7 @@ def test_creatives_get_nested_field_names_payload():
 
 
 def test_creatives_get_omits_nested_field_names_by_default():
-    body = _read_dry_run("creatives", "get")
+    body = _read_dry_run("creatives", "get", "--ids", "1")
 
     for key in (
         "CpcVideoCreativeFieldNames",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -382,6 +382,8 @@ class TestReadOnlyCreatives(unittest.TestCase):
         result = invoke_get(
             "creatives",
             "get",
+            "--ids",
+            "1",
             "--fields",
             "Id,Name,Type",
             "--limit",
@@ -509,7 +511,9 @@ class TestReadOnlyReports(unittest.TestCase):
 @skip_if_no_token
 class TestReadOnlyStrategies(unittest.TestCase):
     def test_get_strategies(self):
-        result = invoke_get("strategies", "get", "--limit", "1", "--format", "json")
+        result = invoke_get(
+            "strategies", "get", "--ids", "1", "--limit", "1", "--format", "json"
+        )
         assert_success(result, "strategies get")
 
 

--- a/tests/test_read_cassettes.py
+++ b/tests/test_read_cassettes.py
@@ -83,9 +83,13 @@ READ_CASES: list[tuple[str, list[str]]] = [
     ("keywords_get", ["keywords", "get", "--campaign-ids", SANDBOX_CAMPAIGN_ID]),
     ("adextensions_get", ["adextensions", "get"]),
     ("adimages_get", ["adimages", "get"]),
-    ("creatives_get", ["creatives", "get"]),
+    # creatives/strategies GetRequest.SelectionCriteria is WSDL minOccurs=1, so
+    # the CLI now requires a filter (#498 B3c) — pass --ids to satisfy the guard.
+    ("creatives_get", ["creatives", "get", "--ids", "1"]),
+    # retargeting SelectionCriteria is minOccurs=0; a no-filter call stays valid
+    # and now omits the empty criteria from the payload.
     ("retargeting_get", ["retargeting", "get"]),
-    ("strategies_get", ["strategies", "get"]),
+    ("strategies_get", ["strategies", "get", "--ids", "1"]),
     ("dictionaries_get", ["dictionaries", "get", "--names", "Currencies,GeoRegions"]),
     (
         "dynamicfeedadtargets_get",


### PR DESCRIPTION
## What

Completes the **#491 dedup epic (B3c)** — the final 9 `get`-commands that still built their request payload by hand now route through the shared `build_common_params` helper.

B3a (#516) and B3b (#517) covered the 14 commands where `SelectionCriteria` was optional or guaranteed non-empty. The remaining 9 were held back because a naive switch to the helper changes the wire payload: when no filter is given they currently send `{"SelectionCriteria": {}}`, and `build_common_params` omits an empty criteria entirely. This PR resolves that behavioural question.

## BREAKING CHANGE

WSDL `GetRequest.SelectionCriteria` is `minOccurs=1` for **adgroups, ads, keywords, strategies, creatives, dynamicads, smartadtargets, audiencetargets**. For these eight, a no-filter `get` was a knowingly-invalid request (the live API rejects it with the opaque error 4001 for ad-group/ad/keyword resources). They now raise a `UsageError` asking for at least one filter **before** the request — extending the exact guard already shipped for `bids`/`keywordbids` in 0.4.1 (#483).

`retargeting get` is the one exception (`SelectionCriteria` `minOccurs=0`): a no-filter call stays valid and now simply omits the empty criteria. It also **gains `--dry-run`** and the shared read/pagination option stack, so its payload is now testable.

## Changes

- Guard + `build_common_params` in all nine `get`-commands.
- New parametrized guard tests for the 8 required-SC commands; retargeting omit-empty + with-ids tests.
- Wire-payload capture fixtures (`scripts/build_api_coverage_report.py`) and the three read-cassette cases supply `--ids`; the three cassette request bodies were realigned to the new request shape (responses unchanged, offline replay verified).
- `retargeting.get` accounted as an optional-SC read-path exclusion in `api_coverage_payloads.py`.
- `CHANGELOG.md` BREAKING CHANGES entry under 0.4.2 (patch — stays in the open milestone).

## Verification

- `pytest` — 2177 passed, 49 skipped, 0 failed.
- `pytest -m integration` (live sandbox) — 32 passed.
- `ruff check .` — clean.
- API coverage report — `strict_parity_ok` / `live_model_parity_ok` / `schema_parity_ok` all True.

Closes #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)