### PR TITLE
refactor: shared lifecycle-command factory across v5 modules (#491 C9)

### DIFF
--- a/direct_cli/commands/_lifecycle.py
+++ b/direct_cli/commands/_lifecycle.py
@@ -1,0 +1,92 @@
+"""Shared factory for v5 lifecycle commands (delete/suspend/resume/archive/...).
+
+Across ~18 resource modules the lifecycle subcommands
+(``delete``/``suspend``/``resume``/``archive``/``unarchive`` and ``ads moderate``)
+are byte-for-byte identical except for four values: the RPC ``method`` sent in
+the request body, the service name on the client, the id argument's name/option,
+and the help text. This module hoists the single command body — previously
+duplicated as ``campaigns._make_lifecycle_command`` (dedup epic #491, C1) — into
+one factory every module can reuse (#491 C9).
+
+The factory preserves the CLI surface exactly: the same command name, the same
+required id option (``--id``/``--hash``), the same ``--dry-run`` flag, and the
+same English help strings (the i18n catalog keys, localized at render time by
+``cli._LocalizedHelpMixin`` / ``LocalizedOption``). The request payload is
+unchanged: ``{"method": <method>, "params": {"SelectionCriteria": {<key>: [id]}}}``.
+
+``create_client`` is passed in by the calling module (not imported here) so that
+``@patch("direct_cli.commands.<module>.create_client")`` keeps intercepting, the
+same patchability contract as :func:`direct_cli.api.client_from_ctx`.
+"""
+
+from __future__ import annotations
+
+import click
+
+from ..api import client_from_ctx
+from ..output import format_output, handle_api_errors
+
+
+def make_lifecycle_command(
+    group,
+    method,
+    help_text,
+    id_param,
+    id_help,
+    create_client,
+    *,
+    service=None,
+    id_option="--id",
+    id_type=int,
+    criteria_key="Ids",
+):
+    """Build and register a v5 lifecycle command on *group*.
+
+    Args:
+        group: the module's Click group; the command registers via
+            ``@group.command(name=method, ...)`` and the service defaults to
+            ``group.name``.
+        method: RPC method sent in the body (``delete``/``suspend``/``resume``/
+            ``archive``/``unarchive``/``moderate``).
+        help_text: English short help — the i18n catalog key (== the former
+            command docstring) localized at render time.
+        id_param: the callback parameter name (``ad_id``/``keyword_id``/...),
+            kept identical so ``--help`` and tracebacks are unchanged.
+        id_help: English help for the id option — the i18n catalog key.
+        create_client: the calling module's ``create_client`` symbol, forwarded
+            to :func:`client_from_ctx` to preserve per-module patchability.
+        service: client service attribute; defaults to ``group.name``.
+        id_option: the id option flag (``--id`` by default, ``--hash`` for
+            ad images).
+        id_type: the id option Click type (``int`` by default, ``str`` for the
+            ad-image hash).
+        criteria_key: the ``SelectionCriteria`` key (``Ids`` by default,
+            ``AdImageHashes`` for ad images).
+
+    Returns:
+        The registered Click command (also assigned to a module global so the
+        ``@group.command`` registration sticks).
+    """
+
+    @group.command(name=method, help=help_text)
+    @click.option(id_option, id_param, required=True, type=id_type, help=id_help)
+    @click.option("--dry-run", is_flag=True, help="Show request without sending")
+    @click.pass_context
+    @handle_api_errors
+    def _command(ctx, dry_run, **kwargs):
+        identifier = kwargs[id_param]
+        body = {
+            "method": method,
+            "params": {"SelectionCriteria": {criteria_key: [identifier]}},
+        }
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        client = client_from_ctx(ctx, create_client)
+
+        result = getattr(client, service or group.name)().post(data=body)
+        format_output(result().extract(), "json", None)
+
+    return _command

--- a/direct_cli/commands/adextensions.py
+++ b/direct_cli/commands/adextensions.py
@@ -7,6 +7,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
+from ._lifecycle import make_lifecycle_command
 from ..utils import add_criteria_csv, get_default_fields, parse_csv_strings, parse_ids
 
 
@@ -113,23 +114,11 @@ def add(ctx, callout_text, dry_run):
     format_output(result().extract(), "json", None)
 
 
-@adextensions.command()
-@click.option("--id", "extension_id", required=True, type=int, help="Extension ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def delete(ctx, extension_id, dry_run):
-    """Delete ad extension"""
-    body = {
-        "method": "delete",
-        "params": {"SelectionCriteria": {"Ids": [extension_id]}},
-    }
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.adextensions().post(data=body)
-    format_output(result().extract(), "json", None)
+delete = make_lifecycle_command(
+    adextensions,
+    "delete",
+    "Delete ad extension",
+    "extension_id",
+    "Extension ID",
+    create_client,
+)

--- a/direct_cli/commands/adgroups.py
+++ b/direct_cli/commands/adgroups.py
@@ -9,6 +9,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
+from ._lifecycle import make_lifecycle_command
 from ..utils import (
     add_criteria_csv,
     build_common_params,
@@ -1209,23 +1210,6 @@ def update(
     format_output(result().extract(), "json", None)
 
 
-@adgroups.command()
-@click.option("--id", "adgroup_id", required=True, type=int, help="Ad group ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def delete(ctx, adgroup_id, dry_run):
-    """Delete ad group"""
-    body = {
-        "method": "delete",
-        "params": {"SelectionCriteria": {"Ids": [adgroup_id]}},
-    }
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.adgroups().post(data=body)
-    format_output(result().extract(), "json", None)
+delete = make_lifecycle_command(
+    adgroups, "delete", "Delete ad group", "adgroup_id", "Ad group ID", create_client
+)

--- a/direct_cli/commands/adimages.py
+++ b/direct_cli/commands/adimages.py
@@ -7,6 +7,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
+from ._lifecycle import make_lifecycle_command
 from ..utils import (
     add_criteria_csv,
     build_common_params,
@@ -108,23 +109,14 @@ def add(ctx, name, image_data, image_file, image_type, dry_run):
     format_output(result().extract(), "json", None)
 
 
-@adimages.command()
-@click.option("--hash", "image_hash", required=True, help="Ad image hash")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def delete(ctx, image_hash, dry_run):
-    """Delete ad image"""
-    body = {
-        "method": "delete",
-        "params": {"SelectionCriteria": {"AdImageHashes": [image_hash]}},
-    }
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.adimages().post(data=body)
-    format_output(result().extract(), "json", None)
+delete = make_lifecycle_command(
+    adimages,
+    "delete",
+    "Delete ad image",
+    "image_hash",
+    "Ad image hash",
+    create_client,
+    id_option="--hash",
+    id_type=str,
+    criteria_key="AdImageHashes",
+)

--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -9,6 +9,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
+from ._lifecycle import make_lifecycle_command
 from ..utils import (
     add_criteria_csv,
     build_common_params,
@@ -2309,118 +2310,13 @@ def update(
     format_output(result().extract(), "json", None)
 
 
-@ads.command()
-@click.option("--id", "ad_id", required=True, type=int, help="Ad ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def delete(ctx, ad_id, dry_run):
-    """Delete ad"""
-    body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [ad_id]}}}
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.ads().post(data=body)
-    format_output(result().extract(), "json", None)
+def _ad_lifecycle(method, help_text):
+    return make_lifecycle_command(ads, method, help_text, "ad_id", "Ad ID", create_client)
 
 
-@ads.command()
-@click.option("--id", "ad_id", required=True, type=int, help="Ad ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def archive(ctx, ad_id, dry_run):
-    """Archive ad"""
-    body = {"method": "archive", "params": {"SelectionCriteria": {"Ids": [ad_id]}}}
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.ads().post(data=body)
-    format_output(result().extract(), "json", None)
-
-
-@ads.command()
-@click.option("--id", "ad_id", required=True, type=int, help="Ad ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def unarchive(ctx, ad_id, dry_run):
-    """Unarchive ad"""
-    body = {
-        "method": "unarchive",
-        "params": {"SelectionCriteria": {"Ids": [ad_id]}},
-    }
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.ads().post(data=body)
-    format_output(result().extract(), "json", None)
-
-
-@ads.command()
-@click.option("--id", "ad_id", required=True, type=int, help="Ad ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def suspend(ctx, ad_id, dry_run):
-    """Suspend ad"""
-    body = {"method": "suspend", "params": {"SelectionCriteria": {"Ids": [ad_id]}}}
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.ads().post(data=body)
-    format_output(result().extract(), "json", None)
-
-
-@ads.command()
-@click.option("--id", "ad_id", required=True, type=int, help="Ad ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def resume(ctx, ad_id, dry_run):
-    """Resume ad"""
-    body = {"method": "resume", "params": {"SelectionCriteria": {"Ids": [ad_id]}}}
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.ads().post(data=body)
-    format_output(result().extract(), "json", None)
-
-
-@ads.command()
-@click.option("--id", "ad_id", required=True, type=int, help="Ad ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def moderate(ctx, ad_id, dry_run):
-    """Moderate ad"""
-    body = {"method": "moderate", "params": {"SelectionCriteria": {"Ids": [ad_id]}}}
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.ads().post(data=body)
-    format_output(result().extract(), "json", None)
+delete = _ad_lifecycle("delete", "Delete ad")
+archive = _ad_lifecycle("archive", "Archive ad")
+unarchive = _ad_lifecycle("unarchive", "Unarchive ad")
+suspend = _ad_lifecycle("suspend", "Suspend ad")
+resume = _ad_lifecycle("resume", "Resume ad")
+moderate = _ad_lifecycle("moderate", "Moderate ad")

--- a/direct_cli/commands/audiencetargets.py
+++ b/direct_cli/commands/audiencetargets.py
@@ -7,6 +7,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
+from ._lifecycle import make_lifecycle_command
 from ..utils import (
     MICRO_RUBLES,
     add_criteria_csv,
@@ -186,67 +187,12 @@ def set_bids(ctx, target_id, adgroup_id, campaign_id, context_bid, priority, dry
     format_output(result().extract(), "json", None)
 
 
-@audiencetargets.command()
-@click.option("--id", "target_id", required=True, type=int, help="Target ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def delete(ctx, target_id, dry_run):
-    """Delete audience target"""
-    body = {
-        "method": "delete",
-        "params": {"SelectionCriteria": {"Ids": [target_id]}},
-    }
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.audiencetargets().post(data=body)
-    format_output(result().extract(), "json", None)
+def _audiencetarget_lifecycle(method, help_text):
+    return make_lifecycle_command(
+        audiencetargets, method, help_text, "target_id", "Target ID", create_client
+    )
 
 
-@audiencetargets.command()
-@click.option("--id", "target_id", required=True, type=int, help="Target ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def suspend(ctx, target_id, dry_run):
-    """Suspend audience target"""
-    body = {
-        "method": "suspend",
-        "params": {"SelectionCriteria": {"Ids": [target_id]}},
-    }
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.audiencetargets().post(data=body)
-    format_output(result().extract(), "json", None)
-
-
-@audiencetargets.command()
-@click.option("--id", "target_id", required=True, type=int, help="Target ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def resume(ctx, target_id, dry_run):
-    """Resume audience target"""
-    body = {
-        "method": "resume",
-        "params": {"SelectionCriteria": {"Ids": [target_id]}},
-    }
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.audiencetargets().post(data=body)
-    format_output(result().extract(), "json", None)
+delete = _audiencetarget_lifecycle("delete", "Delete audience target")
+suspend = _audiencetarget_lifecycle("suspend", "Suspend audience target")
+resume = _audiencetarget_lifecycle("resume", "Resume audience target")

--- a/direct_cli/commands/bidmodifiers.py
+++ b/direct_cli/commands/bidmodifiers.py
@@ -7,6 +7,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
+from ._lifecycle import make_lifecycle_command
 from ..utils import (
     build_common_params,
     get_default_fields,
@@ -515,23 +516,11 @@ def set(ctx, modifier_id, value, dry_run):
     format_output(result().extract(), "json", None)
 
 
-@bidmodifiers.command()
-@click.option("--id", "modifier_id", required=True, type=int, help="Modifier ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def delete(ctx, modifier_id, dry_run):
-    """Delete bid modifier"""
-    body = {
-        "method": "delete",
-        "params": {"SelectionCriteria": {"Ids": [modifier_id]}},
-    }
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.bidmodifiers().post(data=body)
-    format_output(result().extract(), "json", None)
+delete = make_lifecycle_command(
+    bidmodifiers,
+    "delete",
+    "Delete bid modifier",
+    "modifier_id",
+    "Modifier ID",
+    create_client,
+)

--- a/direct_cli/commands/campaigns.py
+++ b/direct_cli/commands/campaigns.py
@@ -10,6 +10,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
+from ._lifecycle import make_lifecycle_command
 from ..utils import (
     build_selection_criteria,
     build_common_params,
@@ -7199,42 +7200,14 @@ def update(
     format_output(result().extract(), "json", None)
 
 
-def _make_lifecycle_command(method: str, help_text: str):
-    """Build a campaign lifecycle command (delete/archive/.../resume).
-
-    These commands are identical except for the ``method`` sent in the request
-    body and the help text shown in ``--help``. ``name=method`` pins the Click
-    command name (otherwise every command would register as ``_command``);
-    ``help=help_text`` pins the short help so ``--help`` is unchanged (setting
-    ``__doc__`` after decoration is too late — Click reads it at decoration
-    time).
-    """
-
-    @campaigns.command(name=method, help=help_text)
-    @click.option("--id", "campaign_id", required=True, type=int, help="Campaign ID")
-    @click.option("--dry-run", is_flag=True, help="Show request without sending")
-    @click.pass_context
-    @handle_api_errors
-    def _command(ctx, campaign_id, dry_run):
-        body = {
-            "method": method,
-            "params": {"SelectionCriteria": {"Ids": [campaign_id]}},
-        }
-
-        if dry_run:
-            format_output(body, "json", None)
-            return
-
-        client = client_from_ctx(ctx, create_client)
-
-        result = client.campaigns().post(data=body)
-        format_output(result().extract(), "json", None)
-
-    return _command
+def _campaign_lifecycle(method, help_text):
+    return make_lifecycle_command(
+        campaigns, method, help_text, "campaign_id", "Campaign ID", create_client
+    )
 
 
-delete = _make_lifecycle_command("delete", "Delete campaign")
-archive = _make_lifecycle_command("archive", "Archive campaign")
-unarchive = _make_lifecycle_command("unarchive", "Unarchive campaign")
-suspend = _make_lifecycle_command("suspend", "Suspend campaign")
-resume = _make_lifecycle_command("resume", "Resume campaign")
+delete = _campaign_lifecycle("delete", "Delete campaign")
+archive = _campaign_lifecycle("archive", "Archive campaign")
+unarchive = _campaign_lifecycle("unarchive", "Unarchive campaign")
+suspend = _campaign_lifecycle("suspend", "Suspend campaign")
+resume = _campaign_lifecycle("resume", "Resume campaign")

--- a/direct_cli/commands/dynamicads.py
+++ b/direct_cli/commands/dynamicads.py
@@ -7,6 +7,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
+from ._lifecycle import make_lifecycle_command
 from ..utils import (
     MICRO_RUBLES,
     build_common_params,
@@ -128,68 +129,15 @@ def add(ctx, adgroup_id, name, conditions, bid, context_bid, priority, dry_run):
     format_output(result().extract(), "json", None)
 
 
-@dynamicads.command()
-@click.option("--id", "target_id", required=True, type=int, help="Target ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def delete(ctx, target_id, dry_run):
-    """Delete dynamic ad target"""
-    body = {
-        "method": "delete",
-        "params": {"SelectionCriteria": {"Ids": [target_id]}},
-    }
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.dynamicads().post(data=body)
-    format_output(result().extract(), "json", None)
+def _dynamicad_lifecycle(method, help_text):
+    return make_lifecycle_command(
+        dynamicads, method, help_text, "target_id", "Target ID", create_client
+    )
 
 
-@dynamicads.command()
-@click.option("--id", "target_id", required=True, type=int, help="Target ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def suspend(ctx, target_id, dry_run):
-    """Suspend dynamic ad target"""
-    body = {
-        "method": "suspend",
-        "params": {"SelectionCriteria": {"Ids": [target_id]}},
-    }
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-    result = client.dynamicads().post(data=body)
-    format_output(result().extract(), "json", None)
-
-
-@dynamicads.command()
-@click.option("--id", "target_id", required=True, type=int, help="Target ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def resume(ctx, target_id, dry_run):
-    """Resume dynamic ad target"""
-    body = {
-        "method": "resume",
-        "params": {"SelectionCriteria": {"Ids": [target_id]}},
-    }
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-    result = client.dynamicads().post(data=body)
-    format_output(result().extract(), "json", None)
+delete = _dynamicad_lifecycle("delete", "Delete dynamic ad target")
+suspend = _dynamicad_lifecycle("suspend", "Suspend dynamic ad target")
+resume = _dynamicad_lifecycle("resume", "Resume dynamic ad target")
 
 
 @dynamicads.command(name="set-bids")

--- a/direct_cli/commands/dynamicfeedadtargets.py
+++ b/direct_cli/commands/dynamicfeedadtargets.py
@@ -7,6 +7,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
+from ._lifecycle import make_lifecycle_command
 from ..utils import (
     MICRO_RUBLES,
     build_common_params,
@@ -135,68 +136,15 @@ def add(
     format_output(result().extract(), "json", None)
 
 
-@dynamicfeedadtargets.command()
-@click.option("--id", "target_id", required=True, type=int, help="Target ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def delete(ctx, target_id, dry_run):
-    """Delete dynamic feed ad target"""
-    body = {
-        "method": "delete",
-        "params": {"SelectionCriteria": {"Ids": [target_id]}},
-    }
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.dynamicfeedadtargets().post(data=body)
-    format_output(result().extract(), "json", None)
+def _dynamicfeedadtarget_lifecycle(method, help_text):
+    return make_lifecycle_command(
+        dynamicfeedadtargets, method, help_text, "target_id", "Target ID", create_client
+    )
 
 
-@dynamicfeedadtargets.command()
-@click.option("--id", "target_id", required=True, type=int, help="Target ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def suspend(ctx, target_id, dry_run):
-    """Suspend dynamic feed ad target"""
-    body = {
-        "method": "suspend",
-        "params": {"SelectionCriteria": {"Ids": [target_id]}},
-    }
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-    result = client.dynamicfeedadtargets().post(data=body)
-    format_output(result().extract(), "json", None)
-
-
-@dynamicfeedadtargets.command()
-@click.option("--id", "target_id", required=True, type=int, help="Target ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def resume(ctx, target_id, dry_run):
-    """Resume dynamic feed ad target"""
-    body = {
-        "method": "resume",
-        "params": {"SelectionCriteria": {"Ids": [target_id]}},
-    }
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-    result = client.dynamicfeedadtargets().post(data=body)
-    format_output(result().extract(), "json", None)
+delete = _dynamicfeedadtarget_lifecycle("delete", "Delete dynamic feed ad target")
+suspend = _dynamicfeedadtarget_lifecycle("suspend", "Suspend dynamic feed ad target")
+resume = _dynamicfeedadtarget_lifecycle("resume", "Resume dynamic feed ad target")
 
 
 @dynamicfeedadtargets.command(name="set-bids")

--- a/direct_cli/commands/feeds.py
+++ b/direct_cli/commands/feeds.py
@@ -11,6 +11,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
+from ._lifecycle import make_lifecycle_command
 from ..utils import (
     build_common_params,
     get_default_fields,
@@ -396,20 +397,6 @@ def update(
     format_output(result().extract(), "json", None)
 
 
-@feeds.command()
-@click.option("--id", "feed_id", required=True, type=int, help="Feed ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def delete(ctx, feed_id, dry_run):
-    """Delete feed"""
-    body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [feed_id]}}}
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.feeds().post(data=body)
-    format_output(result().extract(), "json", None)
+delete = make_lifecycle_command(
+    feeds, "delete", "Delete feed", "feed_id", "Feed ID", create_client
+)

--- a/direct_cli/commands/keywords.py
+++ b/direct_cli/commands/keywords.py
@@ -33,6 +33,7 @@ from .._autotargeting import (
     parse_autotargeting_categories,
     reject_legacy_autotargeting_mix,
 )
+from ._lifecycle import make_lifecycle_command
 
 # Yandex Direct API "keywords.add" caps a single AddItems request at 10
 # items; the WSDL declares maxOccurs="unbounded", so this limit comes from
@@ -898,67 +899,12 @@ def update(
     format_output(result().extract(), "json", None)
 
 
-@keywords.command()
-@click.option("--id", "keyword_id", required=True, type=int, help="Keyword ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def delete(ctx, keyword_id, dry_run):
-    """Delete keyword"""
-    body = {
-        "method": "delete",
-        "params": {"SelectionCriteria": {"Ids": [keyword_id]}},
-    }
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.keywords().post(data=body)
-    format_output(result().extract(), "json", None)
+def _keyword_lifecycle(method, help_text):
+    return make_lifecycle_command(
+        keywords, method, help_text, "keyword_id", "Keyword ID", create_client
+    )
 
 
-@keywords.command()
-@click.option("--id", "keyword_id", required=True, type=int, help="Keyword ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def suspend(ctx, keyword_id, dry_run):
-    """Suspend keyword"""
-    body = {
-        "method": "suspend",
-        "params": {"SelectionCriteria": {"Ids": [keyword_id]}},
-    }
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.keywords().post(data=body)
-    format_output(result().extract(), "json", None)
-
-
-@keywords.command()
-@click.option("--id", "keyword_id", required=True, type=int, help="Keyword ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def resume(ctx, keyword_id, dry_run):
-    """Resume keyword"""
-    body = {
-        "method": "resume",
-        "params": {"SelectionCriteria": {"Ids": [keyword_id]}},
-    }
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.keywords().post(data=body)
-    format_output(result().extract(), "json", None)
+delete = _keyword_lifecycle("delete", "Delete keyword")
+suspend = _keyword_lifecycle("suspend", "Suspend keyword")
+resume = _keyword_lifecycle("resume", "Resume keyword")

--- a/direct_cli/commands/negativekeywordsharedsets.py
+++ b/direct_cli/commands/negativekeywordsharedsets.py
@@ -13,6 +13,7 @@ from ..utils import (
     parse_csv_strings,
     parse_ids,
 )
+from ._lifecycle import make_lifecycle_command
 
 
 @click.group()
@@ -117,20 +118,11 @@ def update(ctx, set_id, name, keywords, dry_run):
     format_output(result().extract(), "json", None)
 
 
-@negativekeywordsharedsets.command()
-@click.option("--id", "set_id", required=True, type=int, help="Set ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def delete(ctx, set_id, dry_run):
-    """Delete negative keyword shared set"""
-    body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [set_id]}}}
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.negativekeywordsharedsets().post(data=body)
-    format_output(result().extract(), "json", None)
+delete = make_lifecycle_command(
+    negativekeywordsharedsets,
+    "delete",
+    "Delete negative keyword shared set",
+    "set_id",
+    "Set ID",
+    create_client,
+)

--- a/direct_cli/commands/retargeting.py
+++ b/direct_cli/commands/retargeting.py
@@ -9,6 +9,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
+from ._lifecycle import make_lifecycle_command
 from ..utils import (
     add_criteria_csv,
     build_common_params,
@@ -199,20 +200,11 @@ def update(ctx, list_id, name, description, list_type, rules, dry_run):
     format_output(result().extract(), "json", None)
 
 
-@retargeting.command()
-@click.option("--id", "list_id", required=True, type=int, help="Retargeting list ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def delete(ctx, list_id, dry_run):
-    """Delete retargeting list"""
-    body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [list_id]}}}
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.retargeting().post(data=body)
-    format_output(result().extract(), "json", None)
+delete = make_lifecycle_command(
+    retargeting,
+    "delete",
+    "Delete retargeting list",
+    "list_id",
+    "Retargeting list ID",
+    create_client,
+)

--- a/direct_cli/commands/sitelinks.py
+++ b/direct_cli/commands/sitelinks.py
@@ -11,6 +11,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
+from ._lifecycle import make_lifecycle_command
 from ..utils import (
     build_common_params,
     get_default_fields,
@@ -278,20 +279,11 @@ def add(ctx, sitelinks_specs, sitelinks_json, sitelinks_from_file, dry_run):
     format_output(result().extract(), "json", None)
 
 
-@sitelinks.command()
-@click.option("--id", "set_id", required=True, type=int, help="Sitelinks set ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def delete(ctx, set_id, dry_run):
-    """Delete sitelinks set"""
-    body = {"method": "delete", "params": {"SelectionCriteria": {"Ids": [set_id]}}}
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.sitelinks().post(data=body)
-    format_output(result().extract(), "json", None)
+delete = make_lifecycle_command(
+    sitelinks,
+    "delete",
+    "Delete sitelinks set",
+    "set_id",
+    "Sitelinks set ID",
+    create_client,
+)

--- a/direct_cli/commands/smartadtargets.py
+++ b/direct_cli/commands/smartadtargets.py
@@ -7,6 +7,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
+from ._lifecycle import make_lifecycle_command
 from ..utils import (
     MICRO_RUBLES,
     build_common_params,
@@ -209,68 +210,15 @@ def update(
     format_output(result().extract(), "json", None)
 
 
-@smartadtargets.command()
-@click.option("--id", "target_id", required=True, type=int, help="Target ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def delete(ctx, target_id, dry_run):
-    """Delete smart ad target"""
-    body = {
-        "method": "delete",
-        "params": {"SelectionCriteria": {"Ids": [target_id]}},
-    }
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.smartadtargets().post(data=body)
-    format_output(result().extract(), "json", None)
+def _smartadtarget_lifecycle(method, help_text):
+    return make_lifecycle_command(
+        smartadtargets, method, help_text, "target_id", "Target ID", create_client
+    )
 
 
-@smartadtargets.command()
-@click.option("--id", "target_id", required=True, type=int, help="Target ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def suspend(ctx, target_id, dry_run):
-    """Suspend smart ad target"""
-    body = {
-        "method": "suspend",
-        "params": {"SelectionCriteria": {"Ids": [target_id]}},
-    }
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-    result = client.smartadtargets().post(data=body)
-    format_output(result().extract(), "json", None)
-
-
-@smartadtargets.command()
-@click.option("--id", "target_id", required=True, type=int, help="Target ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def resume(ctx, target_id, dry_run):
-    """Resume smart ad target"""
-    body = {
-        "method": "resume",
-        "params": {"SelectionCriteria": {"Ids": [target_id]}},
-    }
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-    result = client.smartadtargets().post(data=body)
-    format_output(result().extract(), "json", None)
+delete = _smartadtarget_lifecycle("delete", "Delete smart ad target")
+suspend = _smartadtarget_lifecycle("suspend", "Suspend smart ad target")
+resume = _smartadtarget_lifecycle("resume", "Resume smart ad target")
 
 
 @smartadtargets.command(name="set-bids")

--- a/direct_cli/commands/strategies.py
+++ b/direct_cli/commands/strategies.py
@@ -7,6 +7,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
+from ._lifecycle import make_lifecycle_command
 from ..utils import (
     MICRO_RUBLES,
     add_criteria_csv,
@@ -980,43 +981,11 @@ def update(
     format_output(result().extract(), "json", None)
 
 
-@strategies.command()
-@click.option("--id", "strategy_id", required=True, type=int, help="Strategy ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def archive(ctx, strategy_id, dry_run):
-    """Archive a strategy"""
-    body = {
-        "method": "archive",
-        "params": {"SelectionCriteria": {"Ids": [strategy_id]}},
-    }
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-    result = client.strategies().post(data=body)
-    format_output(result().extract(), "json", None)
+def _strategy_lifecycle(method, help_text):
+    return make_lifecycle_command(
+        strategies, method, help_text, "strategy_id", "Strategy ID", create_client
+    )
 
 
-@strategies.command()
-@click.option("--id", "strategy_id", required=True, type=int, help="Strategy ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def unarchive(ctx, strategy_id, dry_run):
-    """Unarchive a strategy"""
-    body = {
-        "method": "unarchive",
-        "params": {"SelectionCriteria": {"Ids": [strategy_id]}},
-    }
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-    result = client.strategies().post(data=body)
-    format_output(result().extract(), "json", None)
+archive = _strategy_lifecycle("archive", "Archive a strategy")
+unarchive = _strategy_lifecycle("unarchive", "Unarchive a strategy")

--- a/direct_cli/commands/vcards.py
+++ b/direct_cli/commands/vcards.py
@@ -9,6 +9,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
+from ._lifecycle import make_lifecycle_command
 from ..utils import (
     build_common_params,
     get_default_fields,
@@ -239,23 +240,6 @@ def add(
     format_output(result().extract(), "json", None)
 
 
-@vcards.command()
-@click.option("--id", "vcard_id", required=True, type=int, help="vCard ID")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def delete(ctx, vcard_id, dry_run):
-    """Delete vCard"""
-    body = {
-        "method": "delete",
-        "params": {"SelectionCriteria": {"Ids": [vcard_id]}},
-    }
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.vcards().post(data=body)
-    format_output(result().extract(), "json", None)
+delete = make_lifecycle_command(
+    vcards, "delete", "Delete vCard", "vcard_id", "vCard ID", create_client
+)


### PR DESCRIPTION
## Что

Выносит общую фабрику lifecycle-команд (`delete`/`suspend`/`resume`/`archive`/`unarchive` + `ads moderate`) в новый `direct_cli/commands/_lifecycle.py` и переводит на неё **17 модулей** (~35 команд). До этого тело было построчно склонировано в каждом модуле, а фабрика из C1 (#520) жила только в `campaigns.py`.

**Net −525 строк** (660 удалено, 135 добавлено) + новый `_lifecycle.py` (~110 строк).

## Поведенчески нейтрально

Каждая команда сохраняет CLI-поверхность байт-в-байт: имя, обязательную id-опцию (`--id`/`--hash`), `--dry-run`, английские help-строки (которые i18n-каталог локализует при рендере), и payload `{"method": M, "params": {"SelectionCriteria": {<key>: [id]}}}`.

Проверено:
- **`--help` байт-в-байт** для всех 37 команд (ru и en локали);
- **полный `pytest`** — 2177 passed, 49 skipped;
- `tests/test_dry_run.py` + `tests/test_api_coverage.py` — 1333 passed;
- `ruff check .` — clean; `black --check` на затронутых файлах — clean.

Реестры `PAYLOAD_CASES` / `smoke_matrix` / `comprehensive` правок не требуют — ни одно имя команды/argv не изменилось.

## Детали дизайна

- `make_lifecycle_command(group, method, help_text, id_param, id_help, create_client, *, service=None, id_option="--id", id_type=int, criteria_key="Ids")`.
- `create_client` передаётся **модулем-вызывателем** (не импортируется в фабрике), чтобы сохранить `@patch("...commands.<module>.create_client")` — тот же контракт patchability, что у `client_from_ctx`.
- Сервис по умолчанию = `group.name` (во всех модулях имя сервиса == имя Click-группы).
- Спецслучай: `adimages delete` через `id_option="--hash"`, `id_type=str`, `criteria_key="AdImageHashes"`.

## Исключено из фабрики (намеренно)

- `agencyclients delete` — блокирующий stub, не вызывает API (нет `--dry-run`/`@handle_api_errors`).
- `v4forecast delete` — v4 Live транспорт (`emit_or_call_v4`, другие опции).

## ⚠️ DANGEROUS

Lifecycle-команды мутирующие. Верификация только через `--dry-run`-снапшоты, никогда не live (CLAUDE.md «Dangerous Commands»). `scripts/test_dangerous_commands.sh` остаётся manual-only.

Closes #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)