### PR TITLE
refactor: reuse _route_cpa_flag in update CPA routing (#491 C11/4a)

### DIFF
--- a/direct_cli/commands/campaigns.py
+++ b/direct_cli/commands/campaigns.py
@@ -6488,24 +6488,20 @@ def update(
                 )
 
                 def _u_route_update(
-                    value,
-                    search_support: set,
-                    network_support: set,
-                    default: str,
+                    value, search_support: set, network_support: set, default: str
                 ):
-                    if value is None:
-                        return (None, None)
-                    s_ok = _u_search_subtype_for_routing_up in search_support
-                    n_ok = _u_network_subtype_for_routing_up in network_support
-                    if s_ok and n_ok:
-                        return (value, value)
-                    if s_ok:
-                        return (value, None)
-                    if n_ok:
-                        return (None, value)
-                    if default == "network":
-                        return (None, value)
-                    return (value, None)
+                    """Route a shared CPA flag for UnifiedCampaign update (thin
+                    wrapper over the module-level ``_route_cpa_flag``, binding
+                    this block's Search/Network routing subtypes). Mirrors the
+                    add path (#544 C11)."""
+                    return _route_cpa_flag(
+                        value,
+                        _u_search_subtype_for_routing_up,
+                        _u_network_subtype_for_routing_up,
+                        search_support,
+                        network_support,
+                        default,
+                    )
 
                 _u_default_side_up = (
                     "network"
@@ -6775,24 +6771,20 @@ def update(
                 )
 
                 def _route_update(
-                    value,
-                    search_support: set,
-                    network_support: set,
-                    default: str,
+                    value, search_support: set, network_support: set, default: str
                 ):
-                    if value is None:
-                        return (None, None)
-                    s_ok = _search_subtype_for_routing in search_support
-                    n_ok = _network_subtype_for_routing in network_support
-                    if s_ok and n_ok:
-                        return (value, value)
-                    if s_ok:
-                        return (value, None)
-                    if n_ok:
-                        return (None, value)
-                    if default == "network":
-                        return (None, value)
-                    return (value, None)
+                    """Route a shared CPA flag for TextCampaign update (thin
+                    wrapper over the module-level ``_route_cpa_flag``, binding
+                    this block's Search/Network routing subtypes). Mirrors the
+                    add path (#544 C11)."""
+                    return _route_cpa_flag(
+                        value,
+                        _search_subtype_for_routing,
+                        _network_subtype_for_routing,
+                        search_support,
+                        network_support,
+                        default,
+                    )
 
                 _search_goal_id, _network_goal_id = _route_update(
                     goal_id,


### PR DESCRIPTION
Под-issue эпика дедупа кода **#491**, Phase C (зонтик **#501**), Находка 4a.

## Что сделано

TextCampaign и UnifiedCampaign update-пути каждый инлайнили 19-строчное CPA-routing замыкание (`_route_update` / `_u_route_update`), чьё тело **байт-идентично** — включая guard `if value is None: return (None, None)` — модуль-левел хелперу `_route_cpa_flag`, в который add-путь уже делегирует через тонкие враппер-замыкания (`_route` / `_u_route` на строках 3357/3561).

Оба инлайн-замыкания заменены на тот же враппер-паттерн: связываем захваченные Search/Network subtype-переменные блока и делегируем в `_route_cpa_flag`. **Имена замыканий и все их call-site'ы сохранены** — меняются только тела `def`.

## Почему payload-нейтрально

Враппер передаёт те же захваченные subtype-переменные → `(search_value, network_value)` идентичен для любого входа. Проверено:
- dry-run payload **байт-в-байт** (TEXT + UNIFIED, routing с обеих сторон);
- `tests/test_wsdl_parity_gate.py` + `tests/test_dry_run.py` зелёные (1222 passed);
- полный `pytest` — 2177 passed, 49 skipped;
- `ruff check .` чист.

Нетто **−8 строк**.

## Объём C11: почему Находка 2 и 4b НЕ делаются

Замер на актуальном main показал, что заявленные «~250 строк» завышены — большая часть payload-несущая (урок C10: поверхностное сходство ≠ безопасный дедуп):

- **Находка 2 (per-side fallback)** — add использует безусловные дефолты (`(search_strategy or "HIGHEST_POSITION").upper()`), update — `{...} if value is not None else None` («не трогать поле»). Семантически разный payload, не дубль.
- **4b (builder-call kwargs)** — 3 различающихся kwarg'а (`budget_type`/`include_default`/`is_update`) payload-несущие и системно различают add/update. Dispatch-таблица спрятала бы именно те различия, что ловит parity-gate.

Только **4a** — настоящий, безопасный дубль.

Closes #544

🤖 Generated with [Claude Code](https://claude.com/claude-code)