### PR TITLE
fix(docs): re-pin 4 removed-doc services at live WSDL (re-fixes #463)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Unreleased
+
+**Fixes — docs-URL drift regression (re-fixes #463):**
+
+- Restored the four WSDL `docs` URLs for `dynamicads`,
+  `dynamicfeedadtargets`, `smartadtargets` and `vcards` that the
+  `tapi-yandex-direct` 2026.5.29 vendor update silently reverted back to the
+  removed `…/dev/direct/doc/ru/<service>` HTML pages (which 404 since Yandex
+  dropped those pages in September 2025). The fix from #464 was overwritten by
+  the `rm -rf` + `cp -R` vendor sync; preflight
+  (`scripts/check_all_docs_urls.py`) caught it. URLs now point back at the live
+  `https://api.direct.yandex.com/v5/<service>?wsdl` endpoints — the only
+  authoritative source still served.
+- Fixed the same URLs at the source in the `axisrow/tapi-yandex-direct` fork so
+  the next vendor update no longer re-introduces the dead pages.
+- Added an offline regression guard
+  (`tests/test_audit_wire_shape.py::test_removed_doc_services_pin_wsdl_url`):
+  the four doc-removed services must keep WSDL `docs` URLs, failing in CI before
+  the network preflight ever runs.
+
 ## 0.4.2
 
 **BREAKING CHANGES - get requires SelectionCriteria (#498):**

--- a/direct_cli/_vendor/tapi_yandex_direct/resource_mapping.py
+++ b/direct_cli/_vendor/tapi_yandex_direct/resource_mapping.py
@@ -76,14 +76,20 @@ RESOURCE_MAPPING_V5 = {
         "docs": "https://yandex.ru/dev/direct/doc/ru/dictionaries/dictionaries",
         "methods": ["get"],
     },
+    # Yandex removed the human-readable doc pages for DynamicTextAdTargets,
+    # DynamicFeedAdTargets, SmartAdTargets and VCards in September 2025 (the
+    # /ru/ and /en/ pages now 404, and the services are gone from the docs
+    # navigation). The services themselves remain live, so `docs` points at the
+    # WSDL endpoint — the only authoritative source still served for them. See
+    # issue #463.
     "dynamicads": {
         "resource": "json/v5/dynamictextadtargets",
-        "docs": "https://yandex.ru/dev/direct/doc/ru/dynamictextadtargets",
+        "docs": "https://api.direct.yandex.com/v5/dynamictextadtargets?wsdl",
         "methods": ["get", "add", "delete", "suspend", "resume", "setBids"],
     },
     "dynamicfeedadtargets": {
         "resource": "json/v5/dynamicfeedadtargets",
-        "docs": "https://yandex.ru/dev/direct/doc/ru/dynamicfeedadtargets",
+        "docs": "https://api.direct.yandex.com/v5/dynamicfeedadtargets?wsdl",
         "methods": ["get", "add", "delete", "suspend", "resume", "setBids"],
     },
     "keywordbids": {
@@ -118,7 +124,8 @@ RESOURCE_MAPPING_V5 = {
     },
     "vcards": {
         "resource": "json/v5/vcards",
-        "docs": "https://yandex.ru/dev/direct/doc/ru/vcards",
+        # Doc page removed Sep 2025 (see comment above); WSDL still live.
+        "docs": "https://api.direct.yandex.com/v5/vcards?wsdl",
         "methods": ["get", "add", "delete"],
     },
     "turbopages": {
@@ -154,7 +161,8 @@ RESOURCE_MAPPING_V5 = {
     },
     "smartadtargets": {
         "resource": "json/v5/smartadtargets",
-        "docs": "https://yandex.ru/dev/direct/doc/ru/smartadtargets",
+        # Doc page removed Sep 2025 (see comment above); WSDL still live.
+        "docs": "https://api.direct.yandex.com/v5/smartadtargets?wsdl",
         "methods": ["get", "add", "update", "delete", "suspend", "resume", "setBids"],
     },
     "strategies": {

--- a/tests/test_audit_wire_shape.py
+++ b/tests/test_audit_wire_shape.py
@@ -196,3 +196,40 @@ def test_audit_v5_treats_wsdl_base_as_single_group_target(monkeypatch):
     kinds = {f.kind for f in findings}
     assert "v5_wsdl_group_ok" in kinds
     assert "docs_unreachable" not in kinds
+
+
+# Services whose human-readable doc pages Yandex removed in September 2025.
+# Their `docs` URL must stay pinned to the live WSDL endpoint — never revert
+# to a `…/dev/direct/doc/…` HTML page, which now 404s. See issue #463 and the
+# regression it caused when a vendor update (tapi-yandex-direct 2026.5.29)
+# silently restored the dead HTML URLs.
+_WSDL_DOCS_SERVICES = (
+    "dynamicads",
+    "dynamicfeedadtargets",
+    "smartadtargets",
+    "vcards",
+)
+
+
+@pytest.mark.parametrize("service", _WSDL_DOCS_SERVICES)
+def test_removed_doc_services_pin_wsdl_url(service):
+    """Guard #463 regression: the 4 doc-removed services keep WSDL `docs` URLs.
+
+    Catches a vendor update (rm -rf + cp -R from the fork) re-introducing the
+    dead `…/dev/direct/doc/ru/<service>` HTML pages. Offline — fails in CI
+    before the network preflight (scripts/check_all_docs_urls.py) ever runs.
+    """
+    from direct_cli._vendor.tapi_yandex_direct.resource_mapping import (
+        RESOURCE_MAPPING_V5,
+    )
+
+    docs = RESOURCE_MAPPING_V5[service]["docs"]
+    base = docs.rstrip("/")
+    assert base.endswith("?wsdl") or base.endswith(".wsdl"), (
+        f"{service}.docs must point at the live WSDL endpoint (Yandex removed "
+        f"its HTML doc page in Sep 2025, see #463), got: {docs!r}"
+    )
+    assert "/dev/direct/doc/" not in docs, (
+        f"{service}.docs reverted to a removed HTML doc page (404), see #463: "
+        f"{docs!r}"
+    )


### PR DESCRIPTION
## Problem

The release preflight (`scripts/check_all_docs_urls.py`) failed with **4× HTTP 404**:

- `dynamicads.docs`, `dynamicfeedadtargets.docs`, `smartadtargets.docs`, `vcards.docs` → `…/dev/direct/doc/ru/<service>`

These are **not stale-script false positives** — Yandex removed those human-readable doc pages in **September 2025**. #464 already fixed this by repointing the 4 `docs` URLs at their live WSDL endpoints.

## Root cause — a vendor-update regression

The `tapi-yandex-direct` **2026.5.29** vendor update (`1ee8c2a`) silently reverted #464. The vendor sync is `rm -rf` + `cp -R` from the fork, and the fork never carried the #464 fix — so it overwrote the WSDL URLs in `direct_cli/_vendor/.../resource_mapping.py` back to the dead HTML pages.

## Fix (3 parts)

1. **Restore the vendored URLs** — `resource_mapping.py` 4 `docs` URLs back to `https://api.direct.yandex.com/v5/<service>?wsdl` (byte-identical to `b15498e`). Verified live: all 4 return HTTP 200 valid WSDL (13–21 KB).
2. **Offline regression guard** — `tests/test_audit_wire_shape.py::test_removed_doc_services_pin_wsdl_url` asserts these 4 services keep a WSDL `docs` URL and never a `/dev/direct/doc/` HTML page. Fails in **CI before the network preflight** if a future vendor sync reverts them again.
3. **Source fix in the fork** — axisrow/tapi-yandex-direct#26 applies the same fix upstream, so the next vendor update no longer re-introduces the dead URLs. The vendored copy is now byte-identical to the fixed fork file.

## Verification

- `python scripts/check_all_docs_urls.py` → `OK — all URLs canonical.` (4 previously-404 URLs now valid WSDL)
- New guard: 4 parametrized cases pass; negative-tested to confirm it fails on a reverted URL.
- Full suite: **2181 passed, 49 skipped**.
- `direct_cli/_vendor/` is excluded from black/flake8; added comments are ≤80 chars.

`docs` is metadata/preflight-only (requests build from `resource`), so no functional/runtime impact.

Closes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)