### PR TITLE
fix(output): Error 8300 hint for delete/moderate on Status=UNKNOWN ads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+**Fixes — explain Error 8300 on delete/moderate (#548):**
+
+- `raise_for_api_result_errors` now appends a hint when the API returns code
+  8300, mirroring the existing 8800 hint: the ad is likely not in `DRAFT`
+  status, and `Status=UNKNOWN` is an API fallback value (a status outside the
+  v5 enum), not a business status — such ads can only be archived/unarchived,
+  not deleted or sent to moderation. Covers `ads delete` / `ads moderate` and
+  any command routing through `format_output`. English-only, matching the 8800
+  hint (`output.py` does not import i18n).
+
 **Fixes — `ads update` can now clear AdImageHash (#552):**
 
 - Added `--clear-image-hash` to `ads update`. The flag sends

--- a/direct_cli/output.py
+++ b/direct_cli/output.py
@@ -78,6 +78,14 @@ def raise_for_api_result_errors(data: Any) -> None:
             "the selected auth profile for the target client."
         )
 
+    if any(_error_code(error) == 8300 for error in result_errors):
+        lines.append(
+            "Code 8300 on delete/moderate usually means the ad is not in DRAFT "
+            "status. Status=UNKNOWN is an API fallback value (a status outside "
+            "the v5 enum), not a business status — such ads can only be "
+            "archived/unarchived, not deleted or sent to moderation."
+        )
+
     raise DirectAPIResultError("\n".join(lines))
 
 

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -23219,3 +23219,37 @@ def test_bidmodifiers_get_rejects_empty_nested_field_names_csv(flag, wsdl_key):
 
     assert result.exit_code != 0
     assert f"Provide a non-empty comma-separated {wsdl_key} list." in result.output
+
+
+# --- Error 8300 hint (issue #548), mirror of the existing 8800 hint ---
+
+
+def test_raise_for_api_result_errors_adds_8300_hint():
+    from direct_cli.output import raise_for_api_result_errors, DirectAPIResultError
+
+    data = {"Errors": [{"Code": 8300, "Message": "Operation cannot be performed"}]}
+    with pytest.raises(DirectAPIResultError) as exc:
+        raise_for_api_result_errors(data)
+    msg = str(exc.value)
+    assert "Code 8300 on delete/moderate" in msg
+    assert "Status=UNKNOWN" in msg
+    assert "archived/unarchived" in msg
+
+
+def test_raise_for_api_result_errors_8300_hint_only_when_8300_present():
+    from direct_cli.output import raise_for_api_result_errors, DirectAPIResultError
+
+    data = {"Errors": [{"Code": 8000, "Message": "other"}]}
+    with pytest.raises(DirectAPIResultError) as exc:
+        raise_for_api_result_errors(data)
+    assert "Code 8300" not in str(exc.value)
+
+
+def test_raise_for_api_result_errors_8300_hint_has_no_url_literal():
+    # CLAUDE.md: no URL literals outside the registry. The hint must not embed one.
+    from direct_cli.output import raise_for_api_result_errors, DirectAPIResultError
+
+    data = {"Errors": [{"Code": 8300, "Message": "x"}]}
+    with pytest.raises(DirectAPIResultError) as exc:
+        raise_for_api_result_errors(data)
+    assert "https://" not in str(exc.value)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -771,5 +771,28 @@ class TestReadOnlyAuth(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, result.output)
 
 
+@pytest.mark.integration
+@skip_if_no_token
+class TestError8300Hint(unittest.TestCase):
+    """Issue #548: ``ads delete``/``moderate`` on a Status=UNKNOWN ad returns
+    API code 8300; the CLI must append the explanatory hint.
+
+    Opt-in only: requires an operator-provided ad whose Status is UNKNOWN via
+    ``YANDEX_DIRECT_UNKNOWN_AD_ID``. The API refuses to delete such an ad
+    (8300), so the call is effectively non-destructive, but we gate it behind
+    an explicit env var so a plain ``pytest -m integration`` never issues a
+    mutation against an arbitrary ad id.
+    """
+
+    def test_delete_unknown_status_ad_surfaces_8300_hint(self):
+        ad_id = os.environ.get("YANDEX_DIRECT_UNKNOWN_AD_ID")
+        if not ad_id:
+            self.skipTest("set YANDEX_DIRECT_UNKNOWN_AD_ID to a Status=UNKNOWN ad id")
+        result = invoke_get("ads", "delete", "--id", ad_id)
+        self.assertNotEqual(result.exit_code, 0, result.output)
+        self.assertIn("Code 8300 on delete/moderate", result.output)
+        self.assertIn("Status=UNKNOWN", result.output)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`ads delete` / `ads moderate` on an ad whose `Status=UNKNOWN` returns API **code 8300**, which the CLI printed raw — leaving operators to burn retries (`unarchive → moderate → delete`) on an operation that is impossible to begin with.

This adds a human-readable hint to `raise_for_api_result_errors`, mirroring the existing **8800** hint: `Status=UNKNOWN` is an API *fallback* value (a status outside the v5 enum), not a business status, so such ads can only be **archived/unarchived** — not deleted or sent to moderation.

## Implementation

- One `if any(_error_code(error) == 8300 ...)` block in `direct_cli/output.py`, right after the 8800 block.
- All lifecycle commands reach this via `format_output → raise_for_api_result_errors`, so **delete and moderate are covered with no per-command changes**.
- Kept as a **raw English literal** to mirror the 8800 hint (`output.py` does not import i18n).
- **No docs URL embedded** — CLAUDE.md forbids URL literals outside the registry; the actionable content (`Status=UNKNOWN` + archive/unarchive remedy) carries the hint without one.

## Tests (TDD)

- 3 unit tests on `raise_for_api_result_errors`: hint present on 8300, absent when 8300 not present, and no `https://` literal.
- Opt-in integration test (`TestError8300Hint`, gated by `YANDEX_DIRECT_UNKNOWN_AD_ID`) — never mutates an arbitrary ad on a plain `pytest -m integration`.

## Live API verification

```
$ direct ads delete --id <UNKNOWN_AD_ID>
✗ Yandex Direct API returned errors; operation was not applied.
Error 8300: Invalid object status. Details: Запрещено обновлять объявление в заархивированной кампании
Code 8300 on delete/moderate usually means the ad is not in DRAFT status. Status=UNKNOWN is an API fallback value (a status outside the v5 enum), not a business status — such ads can only be archived/unarchived, not deleted or sent to moderation.
```

The ad was **not** deleted (verified via a follow-up `ads get` — still present, Status=UNKNOWN). Operation refused by the API; this is non-destructive.

Closes #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)