### PR TITLE
docs(audiencetargets): explain required filter; recommend campaigns-get sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+**Docs — audiencetargets get requires a filter (#554):**
+
+- Clarified that `audiencetargets get` cannot page the whole account: unlike
+  `retargeting get --fetch-all`, the live API hard-rejects an empty
+  `SelectionCriteria` (error 8000 with no criteria, 4001 with `{}`). The
+  required-filter guard now explains this and recommends the `campaigns get` →
+  batched `campaign_ids` sweep instead. No API behavior change; message only.
+
 **Fixes — `ads update` can now clear AdImageHash (#552):**
 
 - Added `--clear-image-hash` to `ads update`. The flag sends

--- a/README.md
+++ b/README.md
@@ -669,6 +669,9 @@ direct bidmodifiers set --id 99 --value 130 --dry-run
 
 # Canonical multiword groups
 direct negativekeywordsharedsets update --id 123 --keywords "foo,bar"
+# audiencetargets get always needs a filter — the API rejects an empty
+# SelectionCriteria, so there is no whole-account paging. To sweep the account,
+# run `campaigns get` first, then page audiencetargets get in batches of campaign ids.
 direct audiencetargets get --campaign-ids 123 --fields Id,AdGroupId,RetargetingListId,State,ContextBid
 direct audiencetargets add --adgroup-id 100 --retargeting-list-id 200 --bid 12000000 --priority HIGH --dry-run
 direct audiencetargets set-bids --id 101 --context-bid 7000000 --priority LOW --dry-run
@@ -1503,6 +1506,9 @@ direct bidmodifiers set --id 99 --value 130 --dry-run
 
 # Канонические многословные группы
 direct negativekeywordsharedsets update --id 123 --keywords "foo,bar"
+# audiencetargets get всегда требует фильтр — API отклоняет пустой
+# SelectionCriteria, поэтому обхода всего аккаунта нет. Чтобы собрать аккаунт,
+# сначала выполните `campaigns get`, затем запрашивайте audiencetargets get батчами campaign id.
 direct audiencetargets get --campaign-ids 123 --fields Id,AdGroupId,RetargetingListId,State,ContextBid
 direct audiencetargets add --adgroup-id 100 --retargeting-list-id 200 --bid 12000000 --priority HIGH --dry-run
 direct audiencetargets set-bids --id 101 --context-bid 7000000 --priority LOW --dry-run

--- a/direct_cli/commands/audiencetargets.py
+++ b/direct_cli/commands/audiencetargets.py
@@ -66,7 +66,17 @@ def get(
     add_criteria_csv(criteria, "States", states, upper=True)
 
     if not criteria:
-        raise click.UsageError(t("Provide at least one typed filter"))
+        raise click.UsageError(
+            t(
+                "audiencetargets get requires at least one filter "
+                "(--ids, --adgroup-ids, --campaign-ids, --retargeting-list-ids, "
+                "--interest-ids, or --states). The Yandex Direct API rejects an "
+                "empty SelectionCriteria (error 8000/4001), so whole-account "
+                "paging is not available. To sweep the account, first run "
+                "`campaigns get`, then page `audiencetargets get` in batches of "
+                "campaign ids."
+            )
+        )
 
     field_names = parse_csv_strings(fields) or get_default_fields("audiencetargets")
     params = build_common_params(

--- a/direct_cli/translations/audiencetargets.json
+++ b/direct_cli/translations/audiencetargets.json
@@ -13,5 +13,6 @@
   "StrategyPriority value for automatic strategies": "Значение StrategyPriority для автоматических стратегий",
   "Suspend audience target": "Приостановить условие нацеливания на аудиторию",
   "Provide at least one of --retargeting-list-id or --interest-id": "Укажите хотя бы один из --retargeting-list-id или --interest-id",
-  "Provide at least one bid field (--context-bid or --priority)": "Укажите хотя бы одно поле ставки (--context-bid или --priority)"
+  "Provide at least one bid field (--context-bid or --priority)": "Укажите хотя бы одно поле ставки (--context-bid или --priority)",
+  "audiencetargets get requires at least one filter (--ids, --adgroup-ids, --campaign-ids, --retargeting-list-ids, --interest-ids, or --states). The Yandex Direct API rejects an empty SelectionCriteria (error 8000/4001), so whole-account paging is not available. To sweep the account, first run `campaigns get`, then page `audiencetargets get` in batches of campaign ids.": "audiencetargets get требует хотя бы один фильтр (--ids, --adgroup-ids, --campaign-ids, --retargeting-list-ids, --interest-ids или --states). API Яндекс Директа отклоняет пустой SelectionCriteria (ошибка 8000/4001), поэтому постраничный обход всего аккаунта недоступен. Чтобы собрать весь аккаунт, сначала выполните `campaigns get`, затем запрашивайте `audiencetargets get` батчами campaign id."
 }

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -17726,6 +17726,21 @@ def test_get_with_filter_keeps_selection_criteria(command):
     assert body["params"]["SelectionCriteria"] == {"Ids": [1, 2]}
 
 
+def test_audiencetargets_get_requires_filter_message_names_workaround():
+    # Issue #554: the live API hard-rejects an empty SelectionCriteria for
+    # audiencetargets (8000 with no criteria, 4001 with {}), so whole-account
+    # paging is impossible. The guard message must say so and point at the
+    # campaigns-get → batched campaign-ids workaround.
+    result = CliRunner().invoke(
+        cli,
+        ["audiencetargets", "get", "--dry-run"],
+        env={"YANDEX_DIRECT_TOKEN": "test-token", "YANDEX_DIRECT_LOGIN": ""},
+    )
+    assert result.exit_code == 2, result.output
+    assert "whole-account paging is not available" in result.output
+    assert "campaigns get" in result.output
+
+
 def test_campaigns_get_empty_fields_raises_usage_error_not_abort():
     # The UsageError from _parse_csv_option must keep exit code 2 (UsageError),
     # not be swallowed by ``except Exception`` and downgraded to Abort (1).

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -771,5 +771,27 @@ class TestReadOnlyAuth(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, result.output)
 
 
+@pytest.mark.integration
+@skip_if_no_token
+class TestAudienceTargetsRequiredFilter(unittest.TestCase):
+    """Issue #554: the live API hard-requires a SelectionCriteria filter for
+    audiencetargets.get, so the CLI guard is correct and whole-account paging
+    is impossible. These tests document both halves: the guard rejects the
+    no-filter call locally, and the recommended `--campaign-ids` pattern works.
+    """
+
+    def test_get_with_no_filter_is_rejected_locally(self):
+        result = invoke_get("audiencetargets", "get")
+        self.assertEqual(result.exit_code, 2, result.output)
+        self.assertIn("whole-account paging is not available", result.output)
+
+    def test_get_with_campaign_filter_succeeds(self):
+        cid = get_first_campaign_id()
+        if cid is None:
+            self.skipTest("no campaigns in account")
+        result = invoke_get("audiencetargets", "get", "--campaign-ids", str(cid))
+        assert_success(result, "audiencetargets get --campaign-ids")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`audiencetargets get` requires at least one `SelectionCriteria` filter and rejects a no-filter call. The issue asked to allow whole-account paging via `--fetch-all` (parity with `retargeting get --fetch-all`).

**That is impossible** — verified live against the v5 API (2026-06-16): `audiencetargets.get` with **no** `SelectionCriteria` → error **8000** ("Omitted required parameter SelectionCriteria"), and with an **empty `{}`** → error **4001** ("Required parameter omitted in the SelectionCriteria structure"). Unlike `retargeting` (whose `SelectionCriteria` is `minOccurs=0`), the API hard-requires a filter here. So the existing guard is **correct** and must stay.

This PR implements the **documented fallback** the issue itself specifies ("задокументировать обязательность фильтра и рекомендуемый паттерн").

## Changes

- **Expanded the guard's `UsageError`**: names every accepted filter, states that whole-account paging is unavailable (and why — API 8000/4001), and recommends the `campaigns get` → batched `campaign_ids` sweep. The generic `"Provide at least one typed filter"` key is untouched (still used by dynamicads/smartadtargets).
- **i18n**: EN source + RU translation in `audiencetargets.json`.
- **README**: one-line notes (EN + RU) in the `audiencetargets get` example blocks.
- **Tests (TDD)**: unit test asserting the new message names the workaround; integration class `TestAudienceTargetsRequiredFilter` documenting both halves.

## Live API verification

```
$ direct audiencetargets get --fetch-all
Error: audiencetargets get requires at least one filter (…). The Yandex Direct API
rejects an empty SelectionCriteria (error 8000/4001), so whole-account paging is
not available. To sweep the account, first run `campaigns get`, then page
`audiencetargets get` in batches of campaign ids.            # exit 2

$ direct audiencetargets get --campaign-ids 3016555
[]                                                           # valid response, exit 0
```

No API behavior change; message + docs only.

Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)