### PR TITLE
fix(mutations): reject non-positive IDs before the request (#558)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+**Fixes — reject non-positive IDs before the request (#558):**
+
+- Mutating commands and lifecycle ops took `--id` / `--adgroup-id` /
+  `--campaign-id` as a bare `int`, which accepted `0` and negatives and
+  forwarded them to the API (opaque rejection). They now use
+  `click.IntRange(min=1)` and reject a non-positive id with a clear
+  `UsageError` (exit 2) before any request. Covers every `delete` / `suspend` /
+  `resume` / `archive` / `unarchive` / `moderate` lifecycle command (via the
+  shared `_lifecycle.py` factory) plus `ads add` / `ads update`,
+  `adgroups add` / `adgroups update`, and `keywords update`. The ad-image
+  lifecycle (`--hash`, a string) is unchanged.
+- Batch-size caps (the docs allow up to 1000 objects per add/update and 10000
+  ids per delete) are intentionally **not** added: the CLI builds a
+  single-item payload for every mutation, so there is no caller-controllable
+  array to overflow. Multi-item batch mode (`--from-file`) for ads/adgroups is
+  tracked as follow-up work.
+- De-staled the `KEYWORDS_ADD_MAX_BATCH` comment: it claimed the API caps a
+  `keywords.add` request at 10 (citing an outdated doc page that states no such
+  number). The real documented per-call limit is 1000; the value `10` is a
+  conservative chunk size for batch add, not the API ceiling — comment fixed,
+  value unchanged.
+
 **Fixes — explain Error 8300 on delete/moderate (#548):**
 
 - `raise_for_api_result_errors` now appends a hint when the API returns code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,30 @@
 
 **Fixes — reject non-positive IDs before the request (#558):**
 
-- Mutating commands and lifecycle ops took `--id` / `--adgroup-id` /
-  `--campaign-id` as a bare `int`, which accepted `0` and negatives and
-  forwarded them to the API (opaque rejection). They now use
-  `click.IntRange(min=1)` and reject a non-positive id with a clear
-  `UsageError` (exit 2) before any request. Covers every `delete` / `suspend` /
-  `resume` / `archive` / `unarchive` / `moderate` lifecycle command (via the
-  shared `_lifecycle.py` factory) plus `ads add` / `ads update`,
-  `adgroups add` / `adgroups update`, and `keywords update`. The ad-image
-  lifecycle (`--hash`, a string) is unchanged.
+- Mutating commands and lifecycle ops took their object-ID selector
+  (`--id` / `--adgroup-id` / `--campaign-id` / `--keyword-id` / `--client-id`)
+  as a bare `int`, which accepted `0` and negatives and forwarded them to the
+  API (opaque rejection). Every such selector now uses `click.IntRange(min=1)`
+  and rejects a non-positive id with a clear `UsageError` (exit 2) before any
+  request. Coverage is the full mutation surface, not a subset:
+  - every `delete` / `suspend` / `resume` / `archive` / `unarchive` /
+    `moderate` lifecycle command (via the shared `_lifecycle.py` factory);
+  - `ads add` / `ads update`, `adgroups add` / `adgroups update`,
+    `keywords add` / `keywords update`;
+  - `campaigns update`, `feeds update`, `strategies update`,
+    `retargeting update`, `negativekeywordsharedsets update`, `vcards add`;
+  - `smartadtargets add` / `update` / `set-bids`,
+    `audiencetargets add` / `set-bids`, `dynamicads add` / `set-bids`,
+    `dynamicfeedadtargets add` / `set-bids`;
+  - the bid setters `bids set` / `set-auto`, `keywordbids set` / `set-auto`
+    (the `campaign-id` / `adgroup-id` / `keyword-id` "exactly one of" trios),
+    `bidmodifiers add` / `set`;
+  - `agencyclients update --client-id`.
+
+  The ad-image lifecycle (`--hash`, a string) is unchanged. Secondary
+  reference-ID flags that point at *other* objects inside a write payload
+  (e.g. `--feed-id`, `--counter-id`, `--vcard-id`, `--region-id`,
+  `--retargeting-list-id`) are left as-is for now and tracked as follow-up.
 - Batch-size caps (the docs allow up to 1000 objects per add/update and 10000
   ids per delete) are intentionally **not** added: the CLI builds a
   single-item payload for every mutation, so there is no caller-controllable

--- a/direct_cli/commands/_lifecycle.py
+++ b/direct_cli/commands/_lifecycle.py
@@ -68,8 +68,15 @@ def make_lifecycle_command(
         ``@group.command`` registration sticks).
     """
 
+    # A lifecycle id is always a positive object id; type=int used to accept 0
+    # and negatives and forward them to the API (opaque rejection). For the
+    # integer path, validate min=1 before the request (issue #558). The
+    # ad-image path keeps id_type=str (a hash is not an integer) and is
+    # untouched.
+    option_type = click.IntRange(min=1) if id_type is int else id_type
+
     @group.command(name=method, help=help_text)
-    @click.option(id_option, id_param, required=True, type=id_type, help=id_help)
+    @click.option(id_option, id_param, required=True, type=option_type, help=id_help)
     @click.option("--dry-run", is_flag=True, help="Show request without sending")
     @click.pass_context
     @handle_api_errors

--- a/direct_cli/commands/adgroups.py
+++ b/direct_cli/commands/adgroups.py
@@ -575,7 +575,9 @@ def get(
 
 @adgroups.command()
 @click.option("--name", required=True, help="Ad group name")
-@click.option("--campaign-id", required=True, type=int, help="Campaign ID")
+@click.option(
+    "--campaign-id", required=True, type=click.IntRange(min=1), help="Campaign ID"
+)
 @click.option(
     "--type",
     "group_type",
@@ -909,7 +911,9 @@ def add(
 
 
 @adgroups.command()
-@click.option("--id", "adgroup_id", required=True, type=int, help="Ad group ID")
+@click.option(
+    "--id", "adgroup_id", required=True, type=click.IntRange(min=1), help="Ad group ID"
+)
 @click.option("--name", help="New ad group name")
 @click.option("--status", help="New status")
 @click.option("--region-ids", help="Comma-separated region IDs")

--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -1070,7 +1070,9 @@ def get(
 
 
 @ads.command()
-@click.option("--adgroup-id", required=True, type=int, help="Ad group ID")
+@click.option(
+    "--adgroup-id", required=True, type=click.IntRange(min=1), help="Ad group ID"
+)
 @click.option(
     "--type",
     "ad_type",
@@ -1722,7 +1724,7 @@ def add(
 
 
 @ads.command()
-@click.option("--id", "ad_id", required=True, type=int, help="Ad ID")
+@click.option("--id", "ad_id", required=True, type=click.IntRange(min=1), help="Ad ID")
 @click.option(
     "--type",
     "ad_type",

--- a/direct_cli/commands/agencyclients.py
+++ b/direct_cli/commands/agencyclients.py
@@ -333,7 +333,9 @@ def add_passport_organization_member(
 
 
 @agencyclients.command()
-@click.option("--client-id", required=True, type=int, help="Client ID")
+@click.option(
+    "--client-id", required=True, type=click.IntRange(min=1), help="Client ID"
+)
 @click.option("--client-info", help="Client information")
 @click.option("--phone", help="Client phone")
 @click.option("--notification-email", help="Notification email")

--- a/direct_cli/commands/agencyclients.py
+++ b/direct_cli/commands/agencyclients.py
@@ -412,7 +412,9 @@ def update(
 
 
 @agencyclients.command()
-@click.option("--id", "client_id", required=True, type=int, help="Client ID")
+@click.option(
+    "--id", "client_id", required=True, type=click.IntRange(min=1), help="Client ID"
+)
 @click.pass_context
 def delete(ctx, client_id):
     """Delete agency client (not supported by API)"""

--- a/direct_cli/commands/audiencetargets.py
+++ b/direct_cli/commands/audiencetargets.py
@@ -102,7 +102,9 @@ def get(
 
 
 @audiencetargets.command()
-@click.option("--adgroup-id", required=True, type=int, help="Ad group ID")
+@click.option(
+    "--adgroup-id", required=True, type=click.IntRange(min=1), help="Ad group ID"
+)
 @click.option("--retargeting-list-id", type=int, help="Retargeting list ID")
 @click.option("--interest-id", type=int, help="Interest ID")
 @click.option("--bid", type=MICRO_RUBLES, help="ContextBid value in micro-rubles")
@@ -154,9 +156,9 @@ def add(
 
 
 @audiencetargets.command(name="set-bids")
-@click.option("--id", "target_id", type=int, help="Target ID")
-@click.option("--adgroup-id", type=int, help="Ad group ID")
-@click.option("--campaign-id", type=int, help="Campaign ID")
+@click.option("--id", "target_id", type=click.IntRange(min=1), help="Target ID")
+@click.option("--adgroup-id", type=click.IntRange(min=1), help="Ad group ID")
+@click.option("--campaign-id", type=click.IntRange(min=1), help="Campaign ID")
 @click.option("--context-bid", type=MICRO_RUBLES, help="Context bid in micro-rubles")
 @click.option("--priority", help="Strategy priority")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")

--- a/direct_cli/commands/bidmodifiers.py
+++ b/direct_cli/commands/bidmodifiers.py
@@ -283,12 +283,12 @@ _BIDMODIFIER_ALLOWED_EXTRA_FLAGS = {
 @bidmodifiers.command()
 @click.option(
     "--campaign-id",
-    type=int,
+    type=click.IntRange(min=1),
     help="Campaign ID (mutually exclusive with --adgroup-id)",
 )
 @click.option(
     "--adgroup-id",
-    type=int,
+    type=click.IntRange(min=1),
     help="Ad group ID (mutually exclusive with --campaign-id)",
 )
 @click.option(
@@ -453,7 +453,7 @@ def _deprecated_legacy_option(ctx, param, value):
 @click.option(
     "--id",
     "modifier_id",
-    type=int,
+    type=click.IntRange(min=1),
     help=(
         "Existing BidModifier ID to update. This is the shape Yandex "
         "Direct's ``bidmodifiers/set`` method actually supports — pass "

--- a/direct_cli/commands/bids.py
+++ b/direct_cli/commands/bids.py
@@ -90,9 +90,9 @@ def get(
 
 
 @bids.command()
-@click.option("--campaign-id", type=int, help="Campaign ID selector")
-@click.option("--adgroup-id", type=int, help="Ad group ID selector")
-@click.option("--keyword-id", type=int, help="Keyword ID selector")
+@click.option("--campaign-id", type=click.IntRange(min=1), help="Campaign ID selector")
+@click.option("--adgroup-id", type=click.IntRange(min=1), help="Ad group ID selector")
+@click.option("--keyword-id", type=click.IntRange(min=1), help="Keyword ID selector")
 @click.option("--bid", type=MICRO_RUBLES, help="Bid in micro-rubles")
 @click.option("--context-bid", type=MICRO_RUBLES, help="ContextBid in micro-rubles")
 @click.option(
@@ -166,9 +166,9 @@ def set(
 
 
 @bids.command(name="set-auto")
-@click.option("--campaign-id", type=int, help="Campaign ID")
-@click.option("--adgroup-id", type=int, help="Ad group ID")
-@click.option("--keyword-id", type=int, help="Keyword ID")
+@click.option("--campaign-id", type=click.IntRange(min=1), help="Campaign ID")
+@click.option("--adgroup-id", type=click.IntRange(min=1), help="Ad group ID")
+@click.option("--keyword-id", type=click.IntRange(min=1), help="Keyword ID")
 @click.option("--max-bid", type=MICRO_RUBLES, help="Maximum bid in micro-rubles")
 @click.option("--position", help="Desired position")
 @click.option("--increase-percent", type=int, help="Increase percent")

--- a/direct_cli/commands/campaigns.py
+++ b/direct_cli/commands/campaigns.py
@@ -4232,7 +4232,9 @@ def add(
 
 
 @campaigns.command()
-@click.option("--id", "campaign_id", required=True, type=int, help="Campaign ID")
+@click.option(
+    "--id", "campaign_id", required=True, type=click.IntRange(min=1), help="Campaign ID"
+)
 @click.option("--name", help="New campaign name")
 @click.option("--status", help="New status")
 @click.option("--budget", type=MICRO_RUBLES, help="New daily budget in micro-rubles")

--- a/direct_cli/commands/dynamicads.py
+++ b/direct_cli/commands/dynamicads.py
@@ -99,7 +99,9 @@ def get(
 
 
 @dynamicads.command()
-@click.option("--adgroup-id", required=True, type=int, help="Ad group ID")
+@click.option(
+    "--adgroup-id", required=True, type=click.IntRange(min=1), help="Ad group ID"
+)
 @click.option("--name", required=True, help="Target name")
 @click.option(
     "--condition",
@@ -153,9 +155,9 @@ resume = _dynamicad_lifecycle("resume", "Resume dynamic ad target")
 
 
 @dynamicads.command(name="set-bids")
-@click.option("--id", "target_id", type=int, help="Target ID")
-@click.option("--adgroup-id", type=int, help="Ad group ID")
-@click.option("--campaign-id", type=int, help="Campaign ID")
+@click.option("--id", "target_id", type=click.IntRange(min=1), help="Target ID")
+@click.option("--adgroup-id", type=click.IntRange(min=1), help="Ad group ID")
+@click.option("--campaign-id", type=click.IntRange(min=1), help="Campaign ID")
 @click.option("--bid", type=MICRO_RUBLES, help="Search bid in micro-rubles")
 @click.option("--context-bid", type=MICRO_RUBLES, help="Context bid in micro-rubles")
 @click.option("--priority", help="Strategy priority")

--- a/direct_cli/commands/dynamicfeedadtargets.py
+++ b/direct_cli/commands/dynamicfeedadtargets.py
@@ -89,7 +89,9 @@ def get(
 
 
 @dynamicfeedadtargets.command()
-@click.option("--adgroup-id", required=True, type=int, help="Ad group ID")
+@click.option(
+    "--adgroup-id", required=True, type=click.IntRange(min=1), help="Ad group ID"
+)
 @click.option("--name", required=True, help="Target name")
 @click.option(
     "--condition",
@@ -148,9 +150,9 @@ resume = _dynamicfeedadtarget_lifecycle("resume", "Resume dynamic feed ad target
 
 
 @dynamicfeedadtargets.command(name="set-bids")
-@click.option("--id", "target_id", type=int, help="Target ID")
-@click.option("--adgroup-id", type=int, help="Ad group ID")
-@click.option("--campaign-id", type=int, help="Campaign ID")
+@click.option("--id", "target_id", type=click.IntRange(min=1), help="Target ID")
+@click.option("--adgroup-id", type=click.IntRange(min=1), help="Ad group ID")
+@click.option("--campaign-id", type=click.IntRange(min=1), help="Campaign ID")
 @click.option("--bid", type=MICRO_RUBLES, help="Search bid in micro-rubles")
 @click.option("--context-bid", type=MICRO_RUBLES, help="Context bid in micro-rubles")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")

--- a/direct_cli/commands/feeds.py
+++ b/direct_cli/commands/feeds.py
@@ -291,7 +291,9 @@ def add(
 
 
 @feeds.command()
-@click.option("--id", "feed_id", required=True, type=int, help="Feed ID")
+@click.option(
+    "--id", "feed_id", required=True, type=click.IntRange(min=1), help="Feed ID"
+)
 @click.option("--name", help="Feed name")
 @click.option(
     "--url",

--- a/direct_cli/commands/keywordbids.py
+++ b/direct_cli/commands/keywordbids.py
@@ -167,9 +167,9 @@ def get(
 
 
 @keywordbids.command()
-@click.option("--campaign-id", type=int, help="Campaign ID selector")
-@click.option("--adgroup-id", type=int, help="Ad group ID selector")
-@click.option("--keyword-id", type=int, help="Keyword ID selector")
+@click.option("--campaign-id", type=click.IntRange(min=1), help="Campaign ID selector")
+@click.option("--adgroup-id", type=click.IntRange(min=1), help="Ad group ID selector")
+@click.option("--keyword-id", type=click.IntRange(min=1), help="Keyword ID selector")
 @click.option("--search-bid", type=MICRO_RUBLES, help="Search bid in micro-rubles")
 @click.option("--network-bid", type=MICRO_RUBLES, help="Network bid in micro-rubles")
 @click.option(
@@ -244,9 +244,9 @@ def set(
 
 
 @keywordbids.command(name="set-auto")
-@click.option("--campaign-id", type=int, help="Campaign ID")
-@click.option("--adgroup-id", type=int, help="Ad group ID")
-@click.option("--keyword-id", type=int, help="Keyword ID")
+@click.option("--campaign-id", type=click.IntRange(min=1), help="Campaign ID")
+@click.option("--adgroup-id", type=click.IntRange(min=1), help="Ad group ID")
+@click.option("--keyword-id", type=click.IntRange(min=1), help="Keyword ID")
 @click.option(
     "--target-traffic-volume",
     type=int,

--- a/direct_cli/commands/keywords.py
+++ b/direct_cli/commands/keywords.py
@@ -396,7 +396,11 @@ def get(
 
 
 @keywords.command()
-@click.option("--adgroup-id", type=int, help="Ad group ID (default in batch mode)")
+@click.option(
+    "--adgroup-id",
+    type=click.IntRange(min=1),
+    help="Ad group ID (default in batch mode)",
+)
 @click.option("--keyword", help="Keyword text (single-item mode)")
 @click.option("--bid", type=MICRO_RUBLES, help="Search bid in micro-rubles")
 @click.option("--context-bid", type=MICRO_RUBLES, help="Context bid in micro-rubles")

--- a/direct_cli/commands/keywords.py
+++ b/direct_cli/commands/keywords.py
@@ -35,10 +35,13 @@ from .._autotargeting import (
 )
 from ._lifecycle import make_lifecycle_command
 
-# Yandex Direct API "keywords.add" caps a single AddItems request at 10
-# items; the WSDL declares maxOccurs="unbounded", so this limit comes from
-# the documentation rather than the contract:
-# https://yandex.ru/dev/direct/doc/dg/objects/keyword.html
+# Chunk size for batch `keywords add`: items from --from-file / --keywords-json
+# are split into chunks of this size and sent in a loop. This is a conservative
+# CHUNK SIZE, not the API ceiling — the documented per-call limit is 1000
+# (Yandex docs, keywords/add page). Keeping each request small means a partial
+# failure rolls back at most this many items, not 1000. The WSDL declares the
+# Keywords array maxOccurs="unbounded"; the real cap is runtime policy, not the
+# contract.
 KEYWORDS_ADD_MAX_BATCH = 10
 
 # Yandex Direct caps the number of keywords per ad group at 200 (same docs).
@@ -733,7 +736,9 @@ def _deprecated_bid_option(ctx, param, value):
 
 
 @keywords.command()
-@click.option("--id", "keyword_id", required=True, type=int, help="Keyword ID")
+@click.option(
+    "--id", "keyword_id", required=True, type=click.IntRange(min=1), help="Keyword ID"
+)
 @click.option("--keyword", help="New keyword text")
 @click.option("--user-param-1", help="User parameter 1")
 @click.option("--user-param-2", help="User parameter 2")

--- a/direct_cli/commands/negativekeywordsharedsets.py
+++ b/direct_cli/commands/negativekeywordsharedsets.py
@@ -86,7 +86,9 @@ def add(ctx, name, keywords, dry_run):
 
 
 @negativekeywordsharedsets.command()
-@click.option("--id", "set_id", required=True, type=int, help="Set ID")
+@click.option(
+    "--id", "set_id", required=True, type=click.IntRange(min=1), help="Set ID"
+)
 @click.option("--name", help="Set name")
 @click.option("--keywords", help="Comma-separated negative keywords")
 @click.option("--dry-run", is_flag=True, help="Show request without sending")

--- a/direct_cli/commands/retargeting.py
+++ b/direct_cli/commands/retargeting.py
@@ -150,7 +150,13 @@ def add(ctx, name, description, list_type, rules, dry_run):
 
 
 @retargeting.command()
-@click.option("--id", "list_id", required=True, type=int, help="Retargeting list ID")
+@click.option(
+    "--id",
+    "list_id",
+    required=True,
+    type=click.IntRange(min=1),
+    help="Retargeting list ID",
+)
 @click.option("--name", help="List name")
 @click.option(
     "--description",

--- a/direct_cli/commands/smartadtargets.py
+++ b/direct_cli/commands/smartadtargets.py
@@ -98,7 +98,9 @@ def get(
 
 
 @smartadtargets.command()
-@click.option("--adgroup-id", required=True, type=int, help="Ad group ID")
+@click.option(
+    "--adgroup-id", required=True, type=click.IntRange(min=1), help="Ad group ID"
+)
 @click.option("--name", required=True, help="Target name")
 @click.option("--audience", required=True, help="Audience value")
 @click.option(
@@ -159,7 +161,9 @@ def add(
 
 
 @smartadtargets.command()
-@click.option("--id", "target_id", required=True, type=int, help="Target ID")
+@click.option(
+    "--id", "target_id", required=True, type=click.IntRange(min=1), help="Target ID"
+)
 @click.option("--name", help="Target name")
 @click.option("--audience", help="Audience value")
 @click.option(
@@ -233,9 +237,9 @@ resume = _smartadtarget_lifecycle("resume", "Resume smart ad target")
 
 
 @smartadtargets.command(name="set-bids")
-@click.option("--id", "target_id", type=int, help="Target ID")
-@click.option("--adgroup-id", type=int, help="Ad group ID")
-@click.option("--campaign-id", type=int, help="Campaign ID")
+@click.option("--id", "target_id", type=click.IntRange(min=1), help="Target ID")
+@click.option("--adgroup-id", type=click.IntRange(min=1), help="Ad group ID")
+@click.option("--campaign-id", type=click.IntRange(min=1), help="Campaign ID")
 @click.option("--average-cpc", type=MICRO_RUBLES, help="Average CPC in micro-rubles")
 @click.option("--average-cpa", type=MICRO_RUBLES, help="Average CPA in micro-rubles")
 @click.option("--priority", help="Strategy priority")

--- a/direct_cli/commands/strategies.py
+++ b/direct_cli/commands/strategies.py
@@ -820,7 +820,9 @@ def add(
 
 
 @strategies.command()
-@click.option("--id", "strategy_id", required=True, type=int, help="Strategy ID")
+@click.option(
+    "--id", "strategy_id", required=True, type=click.IntRange(min=1), help="Strategy ID"
+)
 @click.option("--name", help="New strategy name")
 @click.option(
     "--type",

--- a/direct_cli/commands/vcards.py
+++ b/direct_cli/commands/vcards.py
@@ -113,7 +113,9 @@ def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
 
 
 @vcards.command()
-@click.option("--campaign-id", required=True, type=int, help="Campaign ID")
+@click.option(
+    "--campaign-id", required=True, type=click.IntRange(min=1), help="Campaign ID"
+)
 @click.option("--country", required=True, help="Country")
 @click.option("--city", required=True, help="City")
 @click.option("--company-name", required=True, help="Company name")

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -23441,3 +23441,99 @@ def test_adimages_delete_still_accepts_hash_string():
     # be retyped to IntRange — a hash is not a positive integer.
     body = _dry_run("adimages", "delete", "--hash", "abc123hash")
     assert body["params"]["SelectionCriteria"]["AdImageHashes"] == ["abc123hash"]
+
+
+# --- Positive-ID preflight, full mutation sweep (issue #558) ---
+# The first pass only retyped 5 flags + the lifecycle factory; every OTHER
+# mutating object-ID selector kept type=int and forwarded Id=0 / negatives to
+# the API. IntRange(min=1) is rejected at parse time (exit 2) before any
+# request is built, so these only need the offending flag, not all required
+# options — Click validates the value before the missing-option check.
+
+# (resource, verb, flag) for every mutating object-ID selector now guarded.
+_POSITIVE_ID_MUTATION_SELECTORS = [
+    ("campaigns", "update", "--id"),
+    ("feeds", "update", "--id"),
+    ("strategies", "update", "--id"),
+    ("retargeting", "update", "--id"),
+    ("smartadtargets", "update", "--id"),
+    ("smartadtargets", "add", "--adgroup-id"),
+    ("negativekeywordsharedsets", "update", "--id"),
+    ("audiencetargets", "add", "--adgroup-id"),
+    ("dynamicads", "add", "--adgroup-id"),
+    ("dynamicfeedadtargets", "add", "--adgroup-id"),
+    ("vcards", "add", "--campaign-id"),
+    ("keywords", "add", "--adgroup-id"),
+    ("bidmodifiers", "set", "--id"),
+    ("agencyclients", "update", "--client-id"),
+]
+
+# Selector trios validated by add_single_id_selector ("exactly one of"):
+# IntRange must reject a non-positive value per option without breaking the
+# one-of logic (the one-of check runs on `is not None`, after the type check).
+_POSITIVE_ID_BID_SELECTORS = [
+    ("bids", "set", "--campaign-id"),
+    ("bids", "set", "--adgroup-id"),
+    ("bids", "set", "--keyword-id"),
+    ("bids", "set-auto", "--campaign-id"),
+    ("bids", "set-auto", "--adgroup-id"),
+    ("bids", "set-auto", "--keyword-id"),
+    ("keywordbids", "set", "--campaign-id"),
+    ("keywordbids", "set", "--adgroup-id"),
+    ("keywordbids", "set", "--keyword-id"),
+    ("keywordbids", "set-auto", "--campaign-id"),
+    ("keywordbids", "set-auto", "--adgroup-id"),
+    ("keywordbids", "set-auto", "--keyword-id"),
+    ("smartadtargets", "set-bids", "--id"),
+    ("smartadtargets", "set-bids", "--adgroup-id"),
+    ("smartadtargets", "set-bids", "--campaign-id"),
+    ("audiencetargets", "set-bids", "--id"),
+    ("audiencetargets", "set-bids", "--adgroup-id"),
+    ("audiencetargets", "set-bids", "--campaign-id"),
+    ("dynamicads", "set-bids", "--id"),
+    ("dynamicads", "set-bids", "--adgroup-id"),
+    ("dynamicads", "set-bids", "--campaign-id"),
+    ("dynamicfeedadtargets", "set-bids", "--id"),
+    ("dynamicfeedadtargets", "set-bids", "--adgroup-id"),
+    ("dynamicfeedadtargets", "set-bids", "--campaign-id"),
+    ("bidmodifiers", "add", "--campaign-id"),
+    ("bidmodifiers", "add", "--adgroup-id"),
+]
+
+
+@pytest.mark.parametrize("bad", ["0", "-1"])
+@pytest.mark.parametrize(
+    "resource,verb,flag",
+    _POSITIVE_ID_MUTATION_SELECTORS + _POSITIVE_ID_BID_SELECTORS,
+    ids=lambda v: v if isinstance(v, str) else None,
+)
+def test_mutation_object_id_selector_rejects_non_positive(resource, verb, flag, bad):
+    result = _rejected(resource, verb, flag, bad)
+    assert result.exit_code == 2, result.output
+    assert "is not in the range" in result.output
+
+
+def test_campaigns_update_allows_positive_id():
+    body = _dry_run("campaigns", "update", "--id", "9", "--name", "X")
+    assert body["params"]["Campaigns"][0]["Id"] == 9
+
+
+def test_bids_set_positive_campaign_id_selector_still_builds_payload():
+    # Guard the exactly-one-of selector: a positive id must pass the IntRange
+    # check AND the one-of logic and land in the payload.
+    body = _dry_run("bids", "set", "--campaign-id", "77", "--bid", "100000000")
+    assert body["params"]["Bids"][0]["CampaignId"] == 77
+
+
+def test_keywordbids_set_positive_adgroup_id_selector_still_builds_payload():
+    body = _dry_run(
+        "keywordbids", "set", "--adgroup-id", "42", "--search-bid", "100000000"
+    )
+    assert body["params"]["KeywordBids"][0]["AdGroupId"] == 42
+
+
+def test_agencyclients_update_rejects_non_positive_client_id():
+    # agencyclients update is a DANGEROUS command — this guard is parse-time
+    # validation only (no live mutation is exercised).
+    result = _rejected("agencyclients", "update", "--client-id", "0", "--phone", "1")
+    assert result.exit_code == 2, result.output

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -23355,3 +23355,89 @@ def test_raise_for_api_result_errors_8300_hint_has_no_url_literal():
     with pytest.raises(DirectAPIResultError) as exc:
         raise_for_api_result_errors(data)
     assert "https://" not in str(exc.value)
+
+
+# --- Positive-ID preflight (issue #558) ---
+# Mutating commands and lifecycle ops take a single int id; type=int accepted
+# 0 and negatives. IntRange(min=1) rejects them with exit 2 before any request.
+
+
+@pytest.mark.parametrize("bad", ["0", "-5"])
+def test_ads_delete_rejects_non_positive_id(bad):
+    result = _rejected("ads", "delete", "--id", bad)
+    assert result.exit_code == 2, result.output
+
+
+def test_ads_delete_allows_positive_id():
+    body = _dry_run("ads", "delete", "--id", "5")
+    assert body["params"]["SelectionCriteria"]["Ids"] == [5]
+
+
+@pytest.mark.parametrize("bad", ["0", "-1"])
+def test_adgroups_delete_rejects_non_positive_id(bad):
+    result = _rejected("adgroups", "delete", "--id", bad)
+    assert result.exit_code == 2, result.output
+
+
+def test_adgroups_delete_allows_positive_id():
+    body = _dry_run("adgroups", "delete", "--id", "7")
+    assert body["params"]["SelectionCriteria"]["Ids"] == [7]
+
+
+def test_keywords_delete_rejects_zero_id():
+    result = _rejected("keywords", "delete", "--id", "0")
+    assert result.exit_code == 2, result.output
+
+
+def test_campaigns_delete_rejects_zero_id():
+    result = _rejected("campaigns", "delete", "--id", "0")
+    assert result.exit_code == 2, result.output
+
+
+def test_ads_add_rejects_zero_adgroup_id():
+    result = _rejected(
+        "ads",
+        "add",
+        "--adgroup-id",
+        "0",
+        "--type",
+        "TEXT_AD",
+        "--title",
+        "T",
+        "--text",
+        "X",
+        "--href",
+        "http://a.b",
+    )
+    assert result.exit_code == 2, result.output
+
+
+def test_ads_update_rejects_zero_id():
+    result = _rejected(
+        "ads", "update", "--id", "0", "--type", "TEXT_AD", "--title", "N"
+    )
+    assert result.exit_code == 2, result.output
+
+
+def test_adgroups_add_rejects_zero_campaign_id():
+    result = _rejected(
+        "adgroups", "add", "--campaign-id", "0", "--name", "G", "--region-ids", "225"
+    )
+    assert result.exit_code == 2, result.output
+
+
+def test_adgroups_update_rejects_zero_id():
+    result = _rejected("adgroups", "update", "--id", "0", "--name", "N")
+    assert result.exit_code == 2, result.output
+
+
+def test_keywords_update_rejects_zero_id():
+    result = _rejected("keywords", "update", "--id", "0", "--keyword", "foo")
+    assert result.exit_code == 2, result.output
+
+
+def test_adimages_delete_still_accepts_hash_string():
+    # Regression guard: the ad-image lifecycle uses --hash (str), which must NOT
+    # be retyped to IntRange — a hash is not a positive integer.
+    body = _dry_run("adimages", "delete", "--hash", "abc123hash")
+    assert body["params"]["SelectionCriteria"]["AdImageHashes"] == ["abc123hash"]

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -23537,3 +23537,14 @@ def test_agencyclients_update_rejects_non_positive_client_id():
     # validation only (no live mutation is exercised).
     result = _rejected("agencyclients", "update", "--client-id", "0", "--phone", "1")
     assert result.exit_code == 2, result.output
+
+
+@pytest.mark.parametrize("bad", ["0", "-1"])
+def test_agencyclients_delete_rejects_non_positive_id(bad):
+    # delete is a runtime-deprecated stub that always Aborts and never builds a
+    # payload (no --dry-run support), but its --id selector is guarded for
+    # surface consistency. Invoke directly (no --dry-run) and confirm IntRange
+    # rejects at parse time, before the Abort.
+    result = CliRunner().invoke(cli, ["agencyclients", "delete", "--id", bad])
+    assert result.exit_code == 2, result.output
+    assert "is not in the range" in result.output


### PR DESCRIPTION
## Summary

#558 asked for preflight batch-size limits on mutations. Investigation found that **every mutating CLI command builds a single-item payload** — `ads add/update`, `adgroups add/update`, `keywords update` send one object; lifecycle `delete/suspend/resume/archive/unarchive/moderate` send one `--id`; `keywords add` (the only batch command) already chunks. So the documented per-call caps (≤1000 add/update, ≤10000 delete ids) **have no caller-controllable array to overflow** — that half of #558 is a justified won't-fix.

The genuine gap: ID flags were `type=int`, which accepted `0` and negatives and forwarded them to the API for an opaque rejection. This PR closes that.

## Changes

- **`_lifecycle.py`**: the shared factory now applies `click.IntRange(min=1)` on the integer id path — covering every lifecycle command across ~16 modules in one place. The ad-image lifecycle (`--hash`, a string) is explicitly untouched.
- **Single-item mutations retyped** to `IntRange(min=1)`: `ads add --adgroup-id`, `ads update --id`, `adgroups add --campaign-id`, `adgroups update --id`, `keywords update --id`.
- **De-staled the `KEYWORDS_ADD_MAX_BATCH` comment**: it claimed the API caps `keywords.add` at 10 (citing an outdated doc page that states no such number). The real documented per-call limit is **1000**; `10` is a conservative *chunk size* for batch add, not the ceiling. Comment fixed, **value unchanged** (raising it would only change chunk atomicity, no correctness gain).

## Scope (triage)

| Command | Sends | Action |
|---|---|---|
| lifecycle delete/suspend/resume/archive/unarchive/moderate | one int `--id` | IntRange(min=1) via factory |
| ads add / ads update | one object | IntRange(min=1) on adgroup-id / id |
| adgroups add / adgroups update | one object | IntRange(min=1) on campaign-id / id |
| keywords update | one object | IntRange(min=1) on id |
| keywords add (batch) | already chunks | no-op |
| ad-image lifecycle (`--hash`, str) | one hash | untouched |
| batch caps 1000 / 10000 | — | **won't-fix** (single-item payloads) |

## Tests (TDD, dry-run only)

Per CLAUDE.md (never auto-test production mutations), verification is **dry-run only** — no live mutation probe was run. Tests assert: non-positive id → exit 2 *before* any API call; valid id builds the correct payload; ad-image `--hash` still accepts a string.

```
$ direct ads delete --id 0
Error: Invalid value for '--id': 0 is not in the range x>=1.   # exit 2, no API call
$ direct ads delete --id 5 --dry-run                            # builds {"Ids":[5]}
```

## Follow-up

Multi-item `--from-file` batch mode for ads/adgroups (the real speed win — 1000 objects/request instead of 1) is tracked as separate follow-up issues, with the batch engine centralized from `keywords add` into a shared `_batch.py`.

Closes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)