### PR TITLE
feat(cli): add `trackingparams` reference command + offline-by-default pytest

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -30,4 +30,6 @@ jobs:
         run: mypy .
 
       - name: Run offline tests
-        run: pytest -m "not integration"
+        # Offline default comes from pyproject addopts (skips the live-network
+        # markers). integration_write stays in — it replays VCR cassettes offline.
+        run: pytest

--- a/direct_cli/cli.py
+++ b/direct_cli/cli.py
@@ -37,6 +37,7 @@ from .commands.leads import leads
 from .commands.clients import clients
 from .commands.agencyclients import agencyclients
 from .commands.dictionaries import dictionaries
+from .commands.trackingparams import tracking_params
 from .commands.changes import changes
 from .commands.reports import reports
 from .commands.turbopages import turbopages
@@ -446,6 +447,7 @@ for command in (
     clients,
     agencyclients,
     dictionaries,
+    tracking_params,
     changes,
     reports,
     turbopages,

--- a/direct_cli/commands/trackingparams.py
+++ b/direct_cli/commands/trackingparams.py
@@ -1,0 +1,24 @@
+"""
+Tracking parameters reference command (local, no API call).
+"""
+
+import click
+
+from ..output import format_output
+from ..tracking_params import TRACKING_PARAMS, TRACKING_PARAMS_DOCS_URL
+
+
+@click.command(
+    name="trackingparams",
+    epilog=f"\b\nDocumentation: {TRACKING_PARAMS_DOCS_URL}",
+)
+@click.option("--format", "output_format", default="json", help="Output format")
+@click.option("--output", help="Output file")
+def tracking_params(output_format, output):
+    """Dynamic tracking parameters reference (UTM template placeholders).
+
+    Подстановочные переменные Яндекс Директа для ссылок/UTM-меток:
+    {campaign_id}, {keyword}, {source_type} и т.п. Подставляются в URL
+    объявления (включая UTM-метки) в момент клика.
+    """
+    format_output(TRACKING_PARAMS, output_format, output)

--- a/direct_cli/smoke_matrix.py
+++ b/direct_cli/smoke_matrix.py
@@ -20,6 +20,7 @@ DANGEROUS = "DANGEROUS"
 SMOKE_MATRIX = {
     SAFE: [
         "balance",
+        "trackingparams",
         "adextensions.get",
         "adgroups.get",
         "adimages.get",

--- a/direct_cli/tracking_params.py
+++ b/direct_cli/tracking_params.py
@@ -1,0 +1,122 @@
+"""
+Dynamic tracking parameters reference for Yandex Direct.
+
+Yandex calls these "динамические параметры" (dynamic parameters) — placeholder
+variables like ``{campaign_id}`` or ``{keyword}`` that Yandex substitutes into an
+ad's URL (including UTM tags) at click time. Used in ``--tracking-params`` for
+``campaigns``/``adgroups`` and in ``--sitelink`` hrefs.
+
+The docs URL is declared here once (the registry point for the url-tags page),
+mirroring how ``reports_coverage.py`` declares the ``spec`` URL outside the
+vendored resource mapping. ``scripts/check_all_docs_urls.py`` imports it so the
+release preflight health-checks this URL too. Keep it as the single literal —
+see CLAUDE.md "No URL literals outside the registry".
+"""
+
+# Yandex help page for tracking parameters — single literal (url-tags registry point).
+TRACKING_PARAMS_DOCS_URL = "https://yandex.ru/support/direct/statistics/url-tags.html"
+
+# Each entry: placeholder name, human description, possible values.
+TRACKING_PARAMS = [
+    {
+        "Parameter": "{campaign_id}",
+        "Description": "Идентификатор кампании",
+        "Values": "число",
+    },
+    {
+        "Parameter": "{campaign_name}",
+        "Description": "Название кампании",
+        "Values": "текст",
+    },
+    {
+        "Parameter": "{campaign_name_lat}",
+        "Description": "Название кампании в транслите",
+        "Values": "текст",
+    },
+    {
+        "Parameter": "{campaign_type}",
+        "Description": "Тип кампании",
+        "Values": "type1..type6",
+    },
+    {
+        "Parameter": "{ad_id} / {banner_id}",
+        "Description": "Идентификатор объявления",
+        "Values": "число",
+    },
+    {
+        "Parameter": "{creative_id}",
+        "Description": "Идентификатор креатива из конструктора",
+        "Values": "число",
+    },
+    {
+        "Parameter": "{device_type}",
+        "Description": "Тип устройства",
+        "Values": "desktop, mobile, tablet",
+    },
+    {
+        "Parameter": "{gbid}",
+        "Description": "Идентификатор группы объявлений",
+        "Values": "число",
+    },
+    {
+        "Parameter": "{keyword}",
+        "Description": "Ключевая фраза, по которой показано объявление",
+        "Values": "текст",
+    },
+    {
+        "Parameter": "{phrase_id}",
+        "Description": "Идентификатор ключевой фразы",
+        "Values": "число",
+    },
+    {
+        "Parameter": "{matched_keyword}",
+        "Description": "Подобранная (фактическая) фраза",
+        "Values": "текст",
+    },
+    {
+        "Parameter": "{match_type}",
+        "Description": "Тип соответствия фразы",
+        "Values": "rm, syn",
+    },
+    {
+        "Parameter": "{retargeting_id}",
+        "Description": "Идентификатор условия нацеливания на аудиторию",
+        "Values": "число",
+    },
+    {
+        "Parameter": "{adtarget_id}",
+        "Description": "Идентификатор условия нацеливания (динам./смарт)",
+        "Values": "число",
+    },
+    {
+        "Parameter": "{position}",
+        "Description": "Точная позиция объявления в блоке",
+        "Values": "число; 0 — сети",
+    },
+    {
+        "Parameter": "{position_type}",
+        "Description": "Тип блока размещения",
+        "Values": "premium, dynamic_places, other, none",
+    },
+    {
+        "Parameter": "{source}",
+        "Description": "Место показа (домен площадки в сетях)",
+        "Values": "текст/домен",
+    },
+    {
+        "Parameter": "{source_type}",
+        "Description": "Тип площадки",
+        "Values": "search, context",
+    },
+    {"Parameter": "{region_name}", "Description": "Регион показа", "Values": "текст"},
+    {
+        "Parameter": "{region_id}",
+        "Description": "Идентификатор региона",
+        "Values": "число",
+    },
+    {
+        "Parameter": "{yclid}",
+        "Description": "Идентификатор клика (связка с Метрикой)",
+        "Values": "число",
+    },
+]

--- a/direct_cli/tracking_params.py
+++ b/direct_cli/tracking_params.py
@@ -36,7 +36,8 @@ TRACKING_PARAMS = [
     {
         "Parameter": "{campaign_type}",
         "Description": "Тип кампании",
-        "Values": "type1..type6",
+        "Values": "type1 (перформанс), type2 (приложения), type3 (динамические), "
+        "type4 (смарт-баннеры), type6 (баннер на поиске)",
     },
     {
         "Parameter": "{ad_id} / {banner_id}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,14 @@ testpaths = ["tests"]
 python_files = "test_*.py"
 python_classes = "Test*"
 python_functions = "test_*"
+# Default run is offline: skip the live-network markers so a plain `pytest` never
+# hits the Yandex API (those tests took ~76s and ran whenever a token was present
+# in .env). integration_write is intentionally NOT excluded — it replays VCR
+# cassettes offline (<1s). Run the network tiers explicitly, e.g.
+#   pytest -m integration            (real read-only API)
+#   pytest -m v4_live_read           (v4 Live read contracts)
+#   pytest -m "integration or v4_live_read or integration_live_write"
+addopts = "-m 'not integration and not v4_live_read and not integration_live_write'"
 markers = [
     "integration: marks tests as integration tests requiring a real API token (deselect with '-m \"not integration\"')",
     "integration_write: sandbox integration tests for write commands (replays VCR cassettes offline; --record-mode=rewrite needs YANDEX_DIRECT_TOKEN)",

--- a/scripts/check_all_docs_urls.py
+++ b/scripts/check_all_docs_urls.py
@@ -26,6 +26,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from direct_cli._vendor.tapi_yandex_direct.resource_mapping import RESOURCE_MAPPING_V5
 from direct_cli.reports_coverage import REPORTS_SPEC_URLS
+from direct_cli.tracking_params import TRACKING_PARAMS_DOCS_URL  # noqa: E402
 
 USER_AGENT = "Mozilla/5.0 (direct-cli docs-drift checker)"
 CAPTCHA_MARKERS = ("showcaptcha", "smartcaptcha", "<title>captcha")
@@ -47,6 +48,7 @@ def collect_urls() -> dict[str, str]:
             urls[f"{svc}.{k}"] = v
     for k, v in REPORTS_SPEC_URLS.items():
         urls.setdefault(f"reports.{k}", v)
+    urls.setdefault("trackingparams.docs", TRACKING_PARAMS_DOCS_URL)
     return urls
 
 

--- a/tests/test_comprehensive.py
+++ b/tests/test_comprehensive.py
@@ -40,6 +40,7 @@ class TestCommandsRegistered(unittest.TestCase):
         "clients",
         "agencyclients",
         "dictionaries",
+        "trackingparams",
         "changes",
         "reports",
         "turbopages",


### PR DESCRIPTION
## Что и зачем

Пользователь спросил, какие параметры можно передавать в UTM-метках Яндекс Директа. У Яндекса это называется **«динамические параметры»** — подстановочные переменные (`{campaign_id}`, `{keyword}`, `{source_type}` …), которые подставляются в URL объявления (включая UTM-метки) в момент клика. Этот PR добавляет справочную команду по ним, а заодно убирает сетевые тесты из дефолтного прогона.

## Команда `direct trackingparams`

- Печатает 21 динамический параметр (`Parameter` / `Description` / `Values`) **без обращения к API**, форматы json (по умолчанию) / table / csv / tsv.
- В `--help` — ссылка на справку Яндекса (`statistics/url-tags`).
- Имя слитное (`trackingparams`, не `tracking-params`) — по конвенции проекта команды верхнего уровня одним словом (`keywordbids`, `smartadtargets`); проверяется `test_registered_cli_names_are_canonical`.
- URL объявлен один раз в `direct_cli/tracking_params.py` (вне vendor, чтобы не затёрло `update_vendor.sh`; прецедент — `reports_coverage.py`) и **подключён к `scripts/check_all_docs_urls.py`**, так что release-preflight теперь проверяет и его доступность.
- Зарегистрирована в `cli.py`, `smoke_matrix.py` (SAFE) и `test_comprehensive.py` (`EXPECTED_COMMANDS`).

## Оффлайн pytest по умолчанию

- `pyproject.toml` → `addopts` дескилектит живые-сетевые маркеры (`integration`, `v4_live_read`, `integration_live_write`). Теперь `pytest` **не ходит в Яндекс-API даже при наличии токена в `.env`**.
- Дефолтный прогон: **~93с → ~20с**.
- `integration_write` оставлен в дефолте — он играет VCR-кассеты оффлайн (<1с).
- `quality.yml`: шаг «Run offline tests» упрощён до `pytest` (наследует оффлайн-дефолт; прежний `-m "not integration"` не отсекал `v4_live_read`).
- Сетевые слои запускаются явно: `pytest -m integration`, `pytest -m v4_live_read`.

Частично адресует #579 (пункт «разделить unit/сеть»); xdist-параллелизм и дедуп fixture там остаются на потом.

## Проверка

- `direct trackingparams --help` / `--format table|csv` — работают.
- `collect_urls()` теперь возвращает 38 URL, включая `trackingparams.docs`.
- `black --check`, `flake8` — чисто.
- Полный `pytest` (с сетью): 2596 passed, 50 skipped. Дефолтный (оффлайн): 2558, ~20с.

🤖 Generated with [Claude Code](https://claude.com/claude-code)