### PR TITLE
refactor(v4,coverage): shared v4 option helpers + single captcha registry (#583)

### DIFF
--- a/direct_cli/_captcha.py
+++ b/direct_cli/_captcha.py
@@ -1,0 +1,32 @@
+"""Single source of truth for Yandex SmartCaptcha gateway detection.
+
+Yandex rate-limits the docs and WSDL hosts with a SmartCaptcha interstitial. A
+captcha page must never be cached as if it were real content — that is how the
+docs cache was poisoned in #426. Per CLAUDE.md ("No URL literals outside the
+registry"), the marker set is declared here ONCE and shared by
+:mod:`direct_cli.reports_coverage`, :mod:`direct_cli.wsdl_coverage`, and their
+cache-freshness tests, rather than duplicated as literals in each.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+# Substrings that appear only in a SmartCaptcha interstitial, never in a real
+# Yandex docs HTML page or WSDL/XSD XML. Matched case-insensitively. The
+# ``<title>Captcha`` marker is HTML-only, so applying the full set to WSDL/XSD
+# fetches only tightens detection — real XML can never contain it.
+CAPTCHA_MARKERS = ("showcaptcha", "smartcaptcha", "<title>Captcha")
+
+
+def find_captcha_marker(content: str) -> Optional[str]:
+    """Return the first captcha marker present in *content*, or ``None``.
+
+    Comparison is case-insensitive; the returned value is the canonical
+    registry spelling, suitable for the caller's error message.
+    """
+    lower = content.lower()
+    for marker in CAPTCHA_MARKERS:
+        if marker.lower() in lower:
+            return marker
+    return None

--- a/direct_cli/commands/v4account.py
+++ b/direct_cli/commands/v4account.py
@@ -10,6 +10,7 @@ from ..i18n import t
 from ..utils import parse_csv_strings, parse_ids
 from ..v4.emit import emit_or_call_v4, emit_or_call_v4_finance
 from ..v4.money import parse_v4_money_sum
+from ..v4.parse import non_empty, parse_id_value_specs
 from ..v4_contracts import v4_method_contract
 
 # Cross-module helpers shared with v4finance commands. AccountManagement's
@@ -109,16 +110,6 @@ def _require_dry_run_or_sandbox(dry_run: bool, sandbox: bool) -> None:
     """Reject shared-account mutations outside explicit dry-run or sandbox."""
     if not dry_run and not sandbox:
         raise click.UsageError(t("--dry-run is required unless --sandbox is set"))
-
-
-def _non_empty(value: str, option_name: str) -> str:
-    """Normalize a required string option."""
-    normalized = (value or "").strip()
-    if not normalized:
-        raise click.UsageError(
-            t("{option_name} must not be empty").format(option_name=option_name)
-        )
-    return normalized
 
 
 def _parse_day_budget(value: Optional[str]) -> Optional[float]:
@@ -293,7 +284,7 @@ def _account_update_param(
 
     email_notification: dict = {}
     if email is not None:
-        email_notification["Email"] = _non_empty(email, "--email")
+        email_notification["Email"] = non_empty(email, "--email")
     if money_warning_value is not None:
         email_notification["MoneyWarningValue"] = money_warning_value
     if paused_by_day_budget is not None:
@@ -309,41 +300,23 @@ def _account_update_param(
 
 def _parse_account_payments(payments: tuple[str, ...], currency: str) -> list[dict]:
     """Parse repeated --payment ACCOUNT_ID=AMOUNT into PayCampElement-shaped items."""
-    if not payments:
-        raise click.UsageError(t("--payment is required"))
-    if len(payments) > 50:
-        raise click.UsageError(t("--payment accepts at most 50 entries per call"))
-
     normalized_currency = currency.upper()
-    parsed_items: list[dict] = []
-    seen_account_ids: set[int] = set()
-    for entry in payments:
-        spec = (entry or "").strip()
-        if "=" not in spec:
-            raise click.UsageError(t("--payment must use ACCOUNT_ID=AMOUNT"))
-        account_id_text, amount_text = spec.split("=", 1)
-        account_id_text = account_id_text.strip()
-        amount_text = amount_text.strip()
-        try:
-            account_id = int(account_id_text)
-        except ValueError as exc:
-            raise click.UsageError(
-                t("--payment account ID must be a positive integer")
-            ) from exc
-        if account_id <= 0:
-            raise click.UsageError(t("--payment account ID must be a positive integer"))
-        if account_id in seen_account_ids:
-            raise click.UsageError(t("--payment account IDs must be unique"))
-        seen_account_ids.add(account_id)
-        parsed_items.append(
-            {
-                "AccountID": account_id,
-                "Amount": parse_v4_money_sum(amount_text, option_name="--payment"),
-                "Currency": normalized_currency,
-            }
-        )
-
-    return parsed_items
+    positive_int_msg = t("--payment account ID must be a positive integer")
+    pairs = parse_id_value_specs(
+        payments,
+        required_msg=t("--payment is required"),
+        malformed_msg=t("--payment must use ACCOUNT_ID=AMOUNT"),
+        not_integer_msg=positive_int_msg,
+        non_positive_msg=positive_int_msg,
+        duplicate_msg=t("--payment account IDs must be unique"),
+        value_parser=lambda amt: parse_v4_money_sum(amt, option_name="--payment"),
+        max_entries=50,
+        max_entries_msg=t("--payment accepts at most 50 entries per call"),
+    )
+    return [
+        {"AccountID": account_id, "Amount": amount, "Currency": normalized_currency}
+        for account_id, amount in pairs
+    ]
 
 
 def _account_deposit_param(
@@ -418,7 +391,7 @@ def _account_transfer_param(
 def enable_shared_account(ctx, client_login, dry_run, output_format, output):
     """Enable a shared account for a client in sandbox, or preview the request."""
     _require_dry_run_or_sandbox(dry_run, ctx.obj.get("sandbox"))
-    param = {"Login": _non_empty(client_login, "--client-login")}
+    param = {"Login": non_empty(client_login, "--client-login")}
     emit_or_call_v4(
         ctx,
         "EnableSharedAccount",

--- a/direct_cli/commands/v4adimage.py
+++ b/direct_cli/commands/v4adimage.py
@@ -13,6 +13,7 @@ import click
 from ..i18n import t
 from ..utils import parse_csv_strings, parse_ids, v4_output_options
 from ..v4.emit import emit_or_call_v4
+from ..v4.parse import parse_id_value_specs
 from ..v4_contracts import v4_method_contract
 from .v4shells import V4_EPILOG
 
@@ -73,37 +74,26 @@ def _set_param(associations: tuple[str, ...]) -> dict:
     (attach the image). Per the docs, AdID is required and omitting
     AdImageHash detaches the current image.
     """
-    if not associations:
-        raise click.UsageError(t("--association is required for set"))
-    items = []
-    seen_ad_ids = set()
-    for spec in associations:
-        spec = (spec or "").strip()
-        if not spec:
-            raise click.UsageError(t("--association must not be empty"))
-        if "=" in spec:
-            ad_id_text, ad_image_hash = spec.split("=", 1)
-            ad_image_hash = ad_image_hash.strip()
-        else:
-            ad_id_text, ad_image_hash = spec, ""
-        ad_id_text = ad_id_text.strip()
-        try:
-            ad_id = int(ad_id_text)
-        except ValueError as exc:
-            raise click.UsageError(
-                t("--association must be AD_ID or AD_ID=HASH with an integer AD_ID")
-            ) from exc
-        if ad_id <= 0:
-            raise click.UsageError(t("--association AD_ID must be a positive integer"))
-        if ad_id in seen_ad_ids:
-            raise click.UsageError(t("--association AD_ID values must be unique"))
-        seen_ad_ids.add(ad_id)
+    pairs = parse_id_value_specs(
+        associations,
+        required_msg=t("--association is required for set"),
+        empty_spec_msg=t("--association must not be empty"),
+        allow_bare_id=True,
+        not_integer_msg=t(
+            "--association must be AD_ID or AD_ID=HASH with an integer AD_ID"
+        ),
+        non_positive_msg=t("--association AD_ID must be a positive integer"),
+        duplicate_msg=t("--association AD_ID values must be unique"),
+        max_entries=10000,
+        max_entries_msg=t("--association accepts at most 10000 entries"),
+        max_check="after",
+    )
+    items: list = []
+    for ad_id, ad_image_hash in pairs:
         item: dict = {"AdID": ad_id}
         if ad_image_hash:
             item["AdImageHash"] = ad_image_hash
         items.append(item)
-    if len(items) > 10000:
-        raise click.UsageError(t("--association accepts at most 10000 entries"))
     return {"Action": "Set", "AdImageAssociations": items}
 
 

--- a/direct_cli/commands/v4finance.py
+++ b/direct_cli/commands/v4finance.py
@@ -7,13 +7,14 @@ import click
 
 from ..i18n import t
 from ..output import format_output, handle_api_errors
-from ..utils import parse_csv_strings, parse_ids, v4_output_options
+from ..utils import parse_csv_strings, v4_output_options
 from ..v4.emit import (
     _masked_finance_body,
     emit_or_call_v4,
     emit_or_call_v4_finance,
 )
 from ..v4.money import build_finance_token, parse_v4_money_sum, validate_operation_num
+from ..v4.parse import non_empty, parse_id_value_specs, parse_positive_ids
 from ..v4_contracts import v4_method_contract
 from .v4shells import V4_EPILOG
 
@@ -52,41 +53,23 @@ def _logins_param(logins: str) -> list[str]:
 
 def _invoice_payments_param(payments: tuple[str, ...], currency: str) -> dict:
     """Build the v4 Live CreateInvoice payment object parameter."""
-    if not payments:
-        raise click.UsageError(t("--payment is required"))
-
     normalized_currency = currency.upper()
-    parsed_payments = []
-    seen_campaign_ids = set()
-    for payment in payments:
-        spec = (payment or "").strip()
-        if "=" not in spec:
-            raise click.UsageError(t("--payment must use CAMPAIGN_ID=AMOUNT"))
-        campaign_id_text, amount_text = spec.split("=", 1)
-        campaign_id_text = campaign_id_text.strip()
-        amount_text = amount_text.strip()
-        try:
-            campaign_id = int(campaign_id_text)
-        except ValueError as exc:
-            raise click.UsageError(
-                t("--payment campaign ID must be a positive integer")
-            ) from exc
-        if campaign_id <= 0:
-            raise click.UsageError(
-                t("--payment campaign ID must be a positive integer")
-            )
-        if campaign_id in seen_campaign_ids:
-            raise click.UsageError(t("--payment campaign IDs must be unique"))
-        seen_campaign_ids.add(campaign_id)
-        parsed_payments.append(
-            {
-                "CampaignID": campaign_id,
-                "Sum": parse_v4_money_sum(amount_text),
-                "Currency": normalized_currency,
-            }
-        )
-
-    return {"Payments": parsed_payments}
+    positive_int_msg = t("--payment campaign ID must be a positive integer")
+    pairs = parse_id_value_specs(
+        payments,
+        required_msg=t("--payment is required"),
+        malformed_msg=t("--payment must use CAMPAIGN_ID=AMOUNT"),
+        not_integer_msg=positive_int_msg,
+        non_positive_msg=positive_int_msg,
+        duplicate_msg=t("--payment campaign IDs must be unique"),
+        value_parser=parse_v4_money_sum,
+    )
+    return {
+        "Payments": [
+            {"CampaignID": campaign_id, "Sum": amount, "Currency": normalized_currency}
+            for campaign_id, amount in pairs
+        ]
+    }
 
 
 def _finance_credentials(
@@ -137,27 +120,9 @@ def _require_dry_run(dry_run: bool) -> None:
         raise click.UsageError(t("--dry-run is required for v4finance money commands"))
 
 
-def _non_empty_option(value: str, option_name: str) -> str:
-    """Normalize a required string option."""
-    normalized = (value or "").strip()
-    if not normalized:
-        raise click.UsageError(
-            t("{option_name} must not be empty").format(option_name=option_name)
-        )
-    return normalized
-
-
 def _campaign_ids_param(campaign_ids: str) -> list[int]:
     """Parse one or more campaign IDs."""
-    try:
-        parsed = parse_ids(campaign_ids)
-    except ValueError as exc:
-        raise click.UsageError(str(exc)) from exc
-    if not parsed:
-        raise click.UsageError(t("--campaign-ids must not be empty"))
-    if any(campaign_id <= 0 for campaign_id in parsed):
-        raise click.UsageError(t("--campaign-ids must contain only positive integers"))
-    return parsed
+    return parse_positive_ids(campaign_ids, "--campaign-ids")
 
 
 def _custom_transaction_id_param(custom_transaction_id: str) -> dict:
@@ -534,7 +499,7 @@ def pay_campaigns(
     )
     parsed_amount = parse_v4_money_sum(amount)
     parsed_campaign_ids = _campaign_ids_param(campaign_ids)
-    pay_method = _non_empty_option(pay_method, "--pay-method")
+    pay_method = non_empty(pay_method, "--pay-method")
     normalized_currency = currency.upper()
     contract_id = (contract_id or "").strip()
     if pay_method == "Bank" and not contract_id:

--- a/direct_cli/commands/v4goals.py
+++ b/direct_cli/commands/v4goals.py
@@ -2,22 +2,20 @@
 
 import click
 
-from ..i18n import t
-from ..utils import parse_ids, v4_output_options
+from ..utils import v4_output_options
 from ..v4.emit import emit_or_call_v4
+from ..v4.parse import parse_positive_ids
 from ..v4_contracts import v4_method_contract
 from .v4shells import V4_EPILOG
 
 
 def _campaign_ids_param(campaign_ids: str) -> dict:
     """Build the v4 Live CampaignIDInfo parameter."""
-    try:
-        ids = parse_ids(campaign_ids)
-    except ValueError as exc:
-        raise click.UsageError(str(exc))
-    if not ids:
-        raise click.UsageError(t("--campaign-ids must not be empty"))
-    return {"CampaignIDS": ids}
+    return {
+        "CampaignIDS": parse_positive_ids(
+            campaign_ids, "--campaign-ids", require_positive=False
+        )
+    }
 
 
 @click.group(epilog=V4_EPILOG)

--- a/direct_cli/commands/v4tags.py
+++ b/direct_cli/commands/v4tags.py
@@ -5,34 +5,16 @@ from typing import Optional
 import click
 
 from ..i18n import t
-from ..utils import parse_ids, v4_output_options
+from ..utils import v4_output_options
 from ..v4.emit import emit_or_call_v4
+from ..v4.parse import parse_positive_ids
 from ..v4_contracts import v4_method_contract
 from .v4shells import V4_EPILOG
 
 
-def _positive_ids_param(value: str, option_name: str) -> list[int]:
-    """Parse a required comma-separated positive integer list."""
-    try:
-        ids = parse_ids(value)
-    except ValueError as exc:
-        raise click.UsageError(str(exc)) from exc
-    if not ids:
-        raise click.UsageError(
-            t("{option_name} must not be empty").format(option_name=option_name)
-        )
-    if any(item <= 0 for item in ids):
-        raise click.UsageError(
-            t("{option_name} must contain only positive integers").format(
-                option_name=option_name
-            )
-        )
-    return ids
-
-
 def _tag_ids_param(tag_ids: str) -> list[int]:
     """Parse v4 banner tag IDs."""
-    parsed = _positive_ids_param(tag_ids, "--tag-ids")
+    parsed = parse_positive_ids(tag_ids, "--tag-ids")
     if len(parsed) > 30:
         raise click.UsageError(t("--tag-ids accepts at most 30 tag IDs"))
     return parsed
@@ -40,7 +22,7 @@ def _tag_ids_param(tag_ids: str) -> list[int]:
 
 def _get_campaigns_tags_param(campaign_ids: str) -> dict:
     """Build the v4 Live GetCampaignsTags parameter."""
-    return {"CampaignIDS": _positive_ids_param(campaign_ids, "--campaign-ids")}
+    return {"CampaignIDS": parse_positive_ids(campaign_ids, "--campaign-ids")}
 
 
 def _get_banners_tags_param(
@@ -50,12 +32,12 @@ def _get_banners_tags_param(
     if (campaign_ids is not None) == (banner_ids is not None):
         raise click.UsageError(t("Use exactly one of --campaign-ids or --banner-ids"))
     if campaign_ids is not None:
-        ids = _positive_ids_param(campaign_ids, "--campaign-ids")
+        ids = parse_positive_ids(campaign_ids, "--campaign-ids")
         if len(ids) > 10:
             raise click.UsageError(t("--campaign-ids accepts at most 10 campaign IDs"))
         return {"CampaignIDS": ids}
 
-    ids = _positive_ids_param(banner_ids or "", "--banner-ids")
+    ids = parse_positive_ids(banner_ids or "", "--banner-ids")
     if len(ids) > 2000:
         raise click.UsageError(t("--banner-ids accepts at most 2000 banner IDs"))
     return {"BannerIDS": ids}
@@ -123,7 +105,7 @@ def _update_banners_tags_param(
     banner_ids: str, tag_ids: Optional[str], clear_tags: bool
 ) -> list[dict]:
     """Build the v4 Live UpdateBannersTags parameter."""
-    parsed_banner_ids = _positive_ids_param(banner_ids, "--banner-ids")
+    parsed_banner_ids = parse_positive_ids(banner_ids, "--banner-ids")
     if clear_tags:
         if tag_ids is not None:
             raise click.UsageError(t("Use either --tag-ids or --clear-tags, not both"))

--- a/direct_cli/reports_coverage.py
+++ b/direct_cli/reports_coverage.py
@@ -11,6 +11,7 @@ import json
 import re
 from pathlib import Path
 
+from ._captcha import find_captcha_marker
 from .utils import get_docs_pages
 
 _REPORTS_DOCS_PAGES = get_docs_pages("reports")
@@ -31,20 +32,18 @@ REPORTS_SPEC_URLS: dict[str, str] = {
 
 REPORTS_CACHE_DIR = Path(__file__).resolve().parent.parent / "tests" / "reports_cache"
 
-_CAPTCHA_MARKERS = ("showcaptcha", "smartcaptcha", "<title>Captcha")
 _MIN_HTML_SIZE = 30_000
 
 
 def _assert_real_doc_page(url: str, html: str) -> None:
     """Reject captcha gateways or empty pages — they would silently poison the cache."""
-    lower = html.lower()
-    for marker in _CAPTCHA_MARKERS:
-        if marker.lower() in lower:
-            raise RuntimeError(
-                f"Yandex returned a captcha page for {url!r} (marker {marker!r}). "
-                "Likely the doc URL has moved — verify and update "
-                "RESOURCE_MAPPING_V5['reports']['docs_pages'] / REPORTS_SPEC_URLS."
-            )
+    marker = find_captcha_marker(html)
+    if marker is not None:
+        raise RuntimeError(
+            f"Yandex returned a captcha page for {url!r} (marker {marker!r}). "
+            "Likely the doc URL has moved — verify and update "
+            "RESOURCE_MAPPING_V5['reports']['docs_pages'] / REPORTS_SPEC_URLS."
+        )
     if len(html) < _MIN_HTML_SIZE:
         raise RuntimeError(
             f"Response for {url!r} is suspiciously small ({len(html)} bytes < "

--- a/direct_cli/translations/common.json
+++ b/direct_cli/translations/common.json
@@ -9,7 +9,6 @@
   "Provide a target selector (--id, --adgroup-id, or --campaign-id)": "Укажите селектор цели (--id, --adgroup-id или --campaign-id)",
   "--autotargeting-category expects CATEGORY=YES|NO (for example EXACT=YES)": "--autotargeting-category ожидает CATEGORY=YES|NO (например, EXACT=YES)",
   "--payment is required": "--payment обязателен",
-  "--campaign-ids must not be empty": "--campaign-ids не должен быть пустым",
   "--phrases must not be empty": "--phrases не должен быть пустым",
   "Provide a non-empty comma-separated {wsdl_key} list.": "Укажите непустой список {wsdl_key} через запятую.",
   "{option_name} must not be empty": "{option_name} не должен быть пустым",

--- a/direct_cli/translations/v4finance.json
+++ b/direct_cli/translations/v4finance.json
@@ -27,7 +27,6 @@
   "--logins must not be empty": "--logins не должен быть пустым",
   "Use either --finance-token or --master-token, not both": "Используйте либо --finance-token, либо --master-token, но не оба",
   "--dry-run is required for v4finance money commands": "--dry-run обязателен для денежных команд v4finance",
-  "--campaign-ids must contain only positive integers": "--campaign-ids должен содержать только положительные целые числа",
   "--custom-transaction-id must be exactly 32 latin letters or digits": "--custom-transaction-id должен содержать ровно 32 латинские буквы или цифры",
   "--contract-id is required when --pay-method Bank": "--contract-id обязателен при --pay-method Bank",
   "--payment must use CAMPAIGN_ID=AMOUNT": "--payment должен использовать формат CAMPAIGN_ID=AMOUNT",

--- a/direct_cli/v4/parse.py
+++ b/direct_cli/v4/parse.py
@@ -1,0 +1,135 @@
+"""Shared option parsing/validation helpers for v4 Live commands.
+
+Several v4 command modules grew byte-identical (or near-identical) option
+validators. They are hoisted here so the logic — and the i18n keys behind each
+error message — lives in one place. Every user-facing message is either reused
+verbatim (``non_empty``/``parse_positive_ids`` use the templated
+``{option_name}`` keys) or passed in by the caller (``parse_id_value_specs``),
+so the rendered CLI surface stays byte-identical.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, List, Optional, Tuple
+
+import click
+
+from ..i18n import t
+from ..utils import parse_ids
+
+
+def non_empty(value: Optional[str], option_name: str) -> str:
+    """Normalize a required string option, rejecting blank/whitespace input."""
+    normalized = (value or "").strip()
+    if not normalized:
+        raise click.UsageError(
+            t("{option_name} must not be empty").format(option_name=option_name)
+        )
+    return normalized
+
+
+def parse_positive_ids(
+    value: Optional[str],
+    option_name: str,
+    *,
+    require_positive: bool = True,
+) -> List[int]:
+    """Parse a required comma-separated integer ID list.
+
+    The list must be non-empty; when *require_positive* is true (the default)
+    every ID must be > 0. Callers wrap the returned ``list[int]`` in whatever
+    request shape they need.
+    """
+    try:
+        ids = parse_ids(value)
+    except ValueError as exc:
+        raise click.UsageError(str(exc)) from exc
+    if not ids:
+        raise click.UsageError(
+            t("{option_name} must not be empty").format(option_name=option_name)
+        )
+    if require_positive and any(item <= 0 for item in ids):
+        raise click.UsageError(
+            t("{option_name} must contain only positive integers").format(
+                option_name=option_name
+            )
+        )
+    return ids
+
+
+def parse_id_value_specs(
+    specs: Tuple[str, ...],
+    *,
+    required_msg: str,
+    not_integer_msg: str,
+    non_positive_msg: str,
+    duplicate_msg: str,
+    malformed_msg: Optional[str] = None,
+    allow_bare_id: bool = False,
+    empty_spec_msg: Optional[str] = None,
+    value_parser: Optional[Callable[[Optional[str]], object]] = None,
+    max_entries: Optional[int] = None,
+    max_entries_msg: Optional[str] = None,
+    max_check: str = "before",
+) -> List[Tuple[int, object]]:
+    """Validate repeated ``ID=VALUE`` specs into ``(id_int, value)`` pairs.
+
+    Shared skeleton for the v4 payment/association parsers: split on ``=``,
+    strip, integer + positivity validation, and duplicate-ID rejection in spec
+    order. Each caller supplies its exact error strings (preserving its i18n
+    keys) and maps the returned pairs to its own WSDL field names.
+
+    Args:
+        specs: the raw ``--option`` tuple from Click.
+        required_msg: raised when *specs* is empty.
+        not_integer_msg: raised when an ID is not an integer.
+        non_positive_msg: raised when an ID is <= 0 (same string as
+            *not_integer_msg* for callers that share one message).
+        duplicate_msg: raised on a repeated ID.
+        malformed_msg: raised when a spec lacks ``=`` and *allow_bare_id* is
+            false.
+        allow_bare_id: when true, a spec without ``=`` yields ``value=None``
+            (a bare ID rather than a malformed entry).
+        empty_spec_msg: when set, a blank entry raises this instead of being
+            treated as malformed.
+        value_parser: optional callable applied to the stripped value text
+            (after the ID passes all checks), so value parsing keeps the
+            original per-entry ordering. Defaults to returning the text as-is.
+        max_entries / max_entries_msg: optional cap and its message.
+        max_check: ``"before"`` checks the cap up front (on the raw count),
+            ``"after"`` checks it once all entries are validated.
+    """
+    if not specs:
+        raise click.UsageError(required_msg)
+    if max_entries is not None and max_check == "before" and len(specs) > max_entries:
+        raise click.UsageError(max_entries_msg)
+
+    seen: set = set()
+    pairs: List[Tuple[int, object]] = []
+    for entry in specs:
+        spec = (entry or "").strip()
+        if not spec and empty_spec_msg is not None:
+            raise click.UsageError(empty_spec_msg)
+        if "=" in spec:
+            id_text, value_text = spec.split("=", 1)
+            value_text = value_text.strip()
+        elif allow_bare_id:
+            id_text, value_text = spec, None
+        else:
+            raise click.UsageError(malformed_msg)
+        id_text = id_text.strip()
+        try:
+            id_int = int(id_text)
+        except ValueError as exc:
+            raise click.UsageError(not_integer_msg) from exc
+        if id_int <= 0:
+            raise click.UsageError(non_positive_msg)
+        if id_int in seen:
+            raise click.UsageError(duplicate_msg)
+        seen.add(id_int)
+        value = value_parser(value_text) if value_parser is not None else value_text
+        pairs.append((id_int, value))
+
+    if max_entries is not None and max_check == "after" and len(pairs) > max_entries:
+        raise click.UsageError(max_entries_msg)
+    return pairs

--- a/direct_cli/wsdl_coverage.py
+++ b/direct_cli/wsdl_coverage.py
@@ -12,6 +12,8 @@ from functools import lru_cache
 from io import StringIO
 from pathlib import Path
 
+from ._captcha import find_captcha_marker
+
 WSDL_BASE_URL = "https://api.direct.yandex.com/v5/{service}?wsdl"
 # Imported XSD schemas are served from a different host than the WSDL
 # endpoints. If Yandex changes either domain, refresh_all_caches() and
@@ -167,8 +169,7 @@ _WSDL_REQUIRED_MARKERS = ("<?xml", "wsdl:definitions")
 
 def _assert_real_wsdl(url: str, xml_text: str) -> None:
     """Reject captcha gateways, HTML error pages, or empty XML responses."""
-    lower = xml_text.lower()
-    if "showcaptcha" in lower or "smartcaptcha" in lower:
+    if find_captcha_marker(xml_text) is not None:
         raise RuntimeError(
             f"Yandex returned a captcha page for WSDL endpoint {url!r}. "
             "Verify that WSDL_BASE_URL is still canonical."
@@ -237,8 +238,7 @@ _XSD_MIN_SIZE = 1_000
 def _assert_real_xsd(url: str, xml_text: str) -> None:
     """Same shape as _assert_real_wsdl, but for imported XSD schemas
     (smaller, no wsdl:definitions, only xsd:schema)."""
-    lower = xml_text.lower()
-    if "showcaptcha" in lower or "smartcaptcha" in lower:
+    if find_captcha_marker(xml_text) is not None:
         raise RuntimeError(
             f"Yandex returned a captcha page for XSD {url!r}. "
             "Verify that XSD_BASE_URL is still canonical."

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -2282,6 +2282,7 @@ class TestReportsCoverage:
     def test_reports_cache_files_are_real_content(self):
         """Guard against silent cache poisoning: every raw HTML must be a real
         Yandex docs page, not a captcha gateway or empty redirect."""
+        from direct_cli._captcha import find_captcha_marker
         from direct_cli.reports_coverage import REPORTS_CACHE_DIR, REPORTS_SPEC_URLS
 
         raw_dir = REPORTS_CACHE_DIR / "raw"
@@ -2293,12 +2294,12 @@ class TestReportsCoverage:
                 f"raw/{key}.html is suspiciously small ({len(html)} bytes < 30 KB). "
                 "Likely captcha or redirect — refresh and verify the URL."
             )
+            marker = find_captcha_marker(html)
+            assert marker is None, (
+                f"raw/{key}.html contains captcha marker {marker!r}. "
+                f"URL {REPORTS_SPEC_URLS[key]!r} likely retired by Yandex."
+            )
             lower = html.lower()
-            for marker in ("showcaptcha", "smartcaptcha", "<title>captcha"):
-                assert marker not in lower, (
-                    f"raw/{key}.html contains captcha marker {marker!r}. "
-                    f"URL {REPORTS_SPEC_URLS[key]!r} likely retired by Yandex."
-                )
             assert "direct/doc" in lower or "<h1" in lower, (
                 f"raw/{key}.html does not look like a Yandex docs page "
                 "(no /direct/doc/ link and no <h1>)."
@@ -2311,38 +2312,40 @@ class TestWsdlCacheFreshness:
     def test_wsdl_cache_files_are_real_content(self):
         from pathlib import Path
 
+        from direct_cli._captcha import find_captcha_marker
+
         cache = Path(__file__).resolve().parent / "wsdl_cache"
         xml_files = sorted(cache.glob("*.xml"))
         assert xml_files, "tests/wsdl_cache/*.xml is empty"
         for path in xml_files:
             text = path.read_text(encoding="utf-8")
-            assert len(text) >= 3_000, (
-                f"{path.name} is suspiciously small ({len(text)} bytes < 3 KB)"
-            )
-            lower = text.lower()
-            assert "showcaptcha" not in lower and "smartcaptcha" not in lower, (
-                f"{path.name} contains a captcha marker — refresh the cache"
-            )
+            assert (
+                len(text) >= 3_000
+            ), f"{path.name} is suspiciously small ({len(text)} bytes < 3 KB)"
+            assert (
+                find_captcha_marker(text) is None
+            ), f"{path.name} contains a captcha marker — refresh the cache"
             assert "<?xml" in text, f"{path.name} missing XML declaration"
-            assert "wsdl:definitions" in text or "xsd:schema" in text, (
-                f"{path.name} missing wsdl:definitions/xsd:schema — likely HTML"
-            )
+            assert (
+                "wsdl:definitions" in text or "xsd:schema" in text
+            ), f"{path.name} missing wsdl:definitions/xsd:schema — likely HTML"
 
     def test_imported_xsd_cache_files_are_real_content(self):
         from pathlib import Path
+
+        from direct_cli._captcha import find_captcha_marker
 
         imports = Path(__file__).resolve().parent / "wsdl_cache" / "imports"
         xsd_files = sorted(imports.glob("*.xsd"))
         assert xsd_files, "tests/wsdl_cache/imports/*.xsd is empty"
         for path in xsd_files:
             text = path.read_text(encoding="utf-8")
-            assert len(text) >= 1_000, (
-                f"{path.name} is suspiciously small ({len(text)} bytes < 1 KB)"
-            )
-            lower = text.lower()
-            assert "showcaptcha" not in lower and "smartcaptcha" not in lower, (
-                f"{path.name} contains a captcha marker — refresh the cache"
-            )
+            assert (
+                len(text) >= 1_000
+            ), f"{path.name} is suspiciously small ({len(text)} bytes < 1 KB)"
+            assert (
+                find_captcha_marker(text) is None
+            ), f"{path.name} contains a captcha marker — refresh the cache"
             assert "<?xml" in text, f"{path.name} missing XML declaration"
             assert "schema" in text, f"{path.name} missing schema element"
 


### PR DESCRIPTION
Closes #583. Part of epic #584 (аудит дублирования кода).

## Что сделано

Убраны три пласта дублирования из issue #583, **CLI-поверхность 1:1** (имена флагов, тексты ошибок, i18n-ключи, `--dry-run` payload — байт-идентичны).

### v4-хелперы — `direct_cli/v4/parse.py` (новый)
- `non_empty` — заменяет байт-идентичные `_non_empty` (v4account) и `_non_empty_option` (v4finance).
- `parse_id_value_specs` — общий скелет парсинга `ID=VALUE` для трёх парсеров: `_parse_account_payments` (v4account), `_invoice_payments_param` (v4finance), `_set_param` (v4adimage). Каждый caller передаёт свои точные тексты ошибок и маппит пары на свои WSDL-поля; порядок проверок (включая позицию max-check before/after) и парсинг суммы сохранены пер-entry.
- `parse_positive_ids` — заменяет три обёртки над `parse_ids()` (v4tags, v4finance, v4goals). v4goals сохраняет прежнее поведение (без проверки положительности) через `require_positive=False`.

Шаблонные i18n-ключи `{option_name}` дают байт-идентичный RU-вывод там, где раньше были литеральные ключи (проверено).

### Единая captcha-детекция — `direct_cli/_captcha.py` (новый)
- Единый реестр `CAPTCHA_MARKERS` + `find_captcha_marker` вместо маркеров, заинлайненных в `wsdl_coverage` и продублированных в `reports_coverage` и тестах-гейтах (CLAUDE.md: «No URL literals outside the registry» — то же правило для маркеров).
- Пороги размеров (HTML 30KB / WSDL 10KB / XSD 1KB) и тексты ошибок per-module — без изменений.
- WSDL/XSD теперь тоже учитывают HTML-only маркер `<title>Captcha` — безопасное ужесточение (реальный XML его не содержит).
- Тесты `test_*_cache_files_are_real_content` импортируют общий хелпер вместо хардкода.

## Проверка
- Полный офлайн-прогон: **2535 passed, 23 skipped**.
- `ruff check .` — чисто; mypy-категории (`arg-type` и др.) отключены конфигом.
- Dry-run payload и сообщения об ошибках вручную сверены на байт-идентичность (bare AD_ID, AD_ID=HASH, отрицательный campaign-id в v4goals, и т.д.).
- `/simplify`: 4 ревьюера, применён откат формат-шума + поясняющий docstring; остальные находки обоснованно отклонены (сохранение байт-идентичности).

Diff: +274 / −197 (нетто +77).

🤖 Generated with [Claude Code](https://claude.com/claude-code)