### PR TITLE
refactor(commands): make_get_command factory for the v5 get skeleton (#582)

### DIFF
--- a/direct_cli/api.py
+++ b/direct_cli/api.py
@@ -2,6 +2,7 @@
 API client wrapper for Direct CLI
 """
 
+import sys
 from typing import Optional, Dict, Any, List
 
 from direct_cli._vendor.tapi_yandex_direct import YandexDirect
@@ -89,6 +90,25 @@ def client_from_ctx(ctx, create_client_fn) -> YandexDirect:
         login=ctx.obj.get("login"),
         sandbox=ctx.obj.get("sandbox"),
     )
+
+
+def resolve_module_create_client(module_name: str, fallback):
+    """Return a command module's *current* ``create_client``, for patchability.
+
+    The command factories (:mod:`direct_cli.commands._get`, and eventually the
+    lifecycle factory) capture ``create_client`` as a closure value at import
+    time. That pins the original function and would bypass a later
+    ``patch.object("direct_cli.commands.<module>", "create_client", ...)`` — the
+    patchability contract that unit tests and the coverage wire-payload capture
+    (``scripts/build_api_coverage_report.py``) rely on. Re-reading the attribute
+    from the live module at call time restores it. *fallback* is returned if the
+    module is somehow absent or lacks the attribute (it never should for a
+    registered command).
+    """
+    module = sys.modules.get(module_name)
+    if module is None:
+        return fallback
+    return getattr(module, "create_client", fallback)
 
 
 def create_v4_client(

--- a/direct_cli/commands/_get.py
+++ b/direct_cli/commands/_get.py
@@ -1,0 +1,120 @@
+"""Shared factory for v5 read (``get``) commands.
+
+Across many resource modules the ``get`` subcommand body is the same skeleton:
+resolve the field names, build a ``SelectionCriteria`` dict, assemble the common
+params, then either print the request (``--dry-run``) or post it and format the
+extracted / iterated result. Only a few values vary per resource: the service
+name, the default-field key, the ``--ids`` help / required-ness, any extra
+criteria options, and how the criteria dict is built. This factory hoists the
+single body — modeled on :func:`direct_cli.commands._lifecycle.make_lifecycle_command`
+— so each module registers its ``get`` with one call.
+
+``create_client`` is passed in by the calling module (not imported here), the
+same contract as the lifecycle factory: the ``--dry-run`` path needs no client,
+and the live path runs the module's real ``create_client`` (the VCR cassette
+read-tests replay it at the ``requests`` transport, so they are unaffected).
+"""
+
+from __future__ import annotations
+
+import click
+
+from ..api import client_from_ctx, resolve_module_create_client
+from ..output import format_output, handle_api_errors
+from ..utils import (
+    build_common_params,
+    get_default_fields,
+    get_options,
+    parse_csv_strings,
+    parse_ids,
+)
+
+
+def _default_ids_criteria(ids):
+    """Standard SelectionCriteria: an optional integer ``Ids`` list."""
+    criteria = {}
+    if ids:
+        criteria["Ids"] = parse_ids(ids)
+    return criteria
+
+
+def make_get_command(
+    group,
+    create_client,
+    *,
+    default_fields_key,
+    help_text=None,
+    ids_help="Comma-separated IDs",
+    ids_required=False,
+    extra_options=(),
+    criteria_builder=None,
+):
+    """Build and register a v5 ``get`` command on *group*.
+
+    Args:
+        group: the module's Click group; the command registers as ``get`` and
+            the client service defaults to ``group.name``.
+        create_client: the calling module's ``create_client`` symbol, forwarded
+            to :func:`client_from_ctx` (lifecycle-factory patchability contract).
+        default_fields_key: key passed to :func:`get_default_fields` for the
+            default ``FieldNames``.
+        help_text: English short help (the i18n catalog key) — the former ``get``
+            docstring, localized at render time.
+        ids_help: help text for the ``--ids`` option.
+        ids_required: whether ``--ids`` is required.
+        extra_options: extra ``click.option`` decorators for resource criteria,
+            given in ``--help`` display order. They are applied between ``--ids``
+            and the shared :func:`get_options` stack so the option order is kept.
+        criteria_builder: callable mapping the parsed options to a
+            ``SelectionCriteria`` dict. It receives ``ids`` plus every extra
+            option as keyword args; defaults to an optional ``Ids`` list.
+
+    Returns:
+        The registered Click command.
+    """
+    svc = group.name
+    module_name = group.callback.__module__
+    build_criteria = criteria_builder or (lambda ids, **_: _default_ids_criteria(ids))
+
+    @click.pass_context
+    @handle_api_errors
+    def get(
+        ctx, ids, limit, fetch_all, output_format, output, fields, dry_run, **kwargs
+    ):
+        field_names = parse_csv_strings(fields) or get_default_fields(
+            default_fields_key
+        )
+        criteria = build_criteria(ids, **kwargs)
+        params = build_common_params(
+            criteria=criteria, field_names=field_names, limit=limit
+        )
+        body = {"method": "get", "params": params}
+
+        if dry_run:
+            format_output(body, "json", None)
+            return
+
+        # Resolve ``create_client`` from the live command module so a
+        # ``patch.object(<module>, "create_client", ...)`` intercepts the live
+        # path (the closure would otherwise pin the import-time function).
+        resolved_create_client = resolve_module_create_client(
+            module_name, create_client
+        )
+        client = client_from_ctx(ctx, resolved_create_client)
+        result = getattr(client, svc)().post(data=body)
+
+        if fetch_all:
+            items = []
+            for item in result().iter_items():
+                items.append(item)
+            format_output(items, output_format, output)
+        else:
+            format_output(result().extract(), output_format, output)
+
+    # Apply the option decorators in the original stack order so ``--help`` lists
+    # ``--ids``, then any resource options, then the six ``get_options`` entries.
+    get = get_options(get)
+    for option in reversed(extra_options):
+        get = option(get)
+    get = click.option("--ids", required=ids_required, help=ids_help)(get)
+    return group.command(name="get", help=help_text)(get)

--- a/direct_cli/commands/advideos.py
+++ b/direct_cli/commands/advideos.py
@@ -7,13 +7,8 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
-from ..utils import (
-    build_common_params,
-    get_default_fields,
-    get_options,
-    load_base64_file,
-    parse_csv_strings,
-)
+from ..utils import load_base64_file, parse_csv_strings
+from ._get import make_get_command
 
 
 @click.group()
@@ -21,39 +16,15 @@ def advideos():
     """Manage ad videos"""
 
 
-@advideos.command()
-@click.option("--ids", required=True, help="Comma-separated video IDs")
-@get_options
-@click.pass_context
-@handle_api_errors
-def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
-    """Get ad videos"""
-    client = client_from_ctx(ctx, create_client)
-
-    field_names = parse_csv_strings(fields) or get_default_fields("advideos")
-
-    criteria = {"Ids": parse_csv_strings(ids) or []}
-
-    params = build_common_params(
-        criteria=criteria, field_names=field_names, limit=limit
-    )
-
-    body = {"method": "get", "params": params}
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    result = client.advideos().post(data=body)
-
-    if fetch_all:
-        items = []
-        for item in result().iter_items():
-            items.append(item)
-        format_output(items, output_format, output)
-    else:
-        data = result().extract()
-        format_output(data, output_format, output)
+get = make_get_command(
+    advideos,
+    create_client,
+    default_fields_key="advideos",
+    help_text="Get ad videos",
+    ids_help="Comma-separated video IDs",
+    ids_required=True,
+    criteria_builder=lambda ids, **_: {"Ids": parse_csv_strings(ids) or []},
+)
 
 
 @advideos.command()

--- a/direct_cli/commands/businesses.py
+++ b/direct_cli/commands/businesses.py
@@ -4,15 +4,8 @@ Businesses commands
 
 import click
 
-from ..api import client_from_ctx, create_client
-from ..output import format_output, handle_api_errors
-from ..utils import (
-    build_common_params,
-    get_default_fields,
-    get_options,
-    parse_csv_strings,
-    parse_ids,
-)
+from ..api import create_client
+from ._get import make_get_command
 
 
 @click.group()
@@ -20,38 +13,10 @@ def businesses():
     """Manage businesses"""
 
 
-@businesses.command()
-@click.option("--ids", help="Comma-separated business IDs")
-@get_options
-@click.pass_context
-@handle_api_errors
-def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
-    """Get businesses"""
-    client = client_from_ctx(ctx, create_client)
-
-    field_names = parse_csv_strings(fields) or get_default_fields("businesses")
-
-    criteria = {}
-    if ids:
-        criteria["Ids"] = parse_ids(ids)
-
-    params = build_common_params(
-        criteria=criteria, field_names=field_names, limit=limit
-    )
-
-    body = {"method": "get", "params": params}
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    result = client.businesses().post(data=body)
-
-    if fetch_all:
-        items = []
-        for item in result().iter_items():
-            items.append(item)
-        format_output(items, output_format, output)
-    else:
-        data = result().extract()
-        format_output(data, output_format, output)
+get = make_get_command(
+    businesses,
+    create_client,
+    default_fields_key="businesses",
+    help_text="Get businesses",
+    ids_help="Comma-separated business IDs",
+)

--- a/direct_cli/commands/negativekeywordsharedsets.py
+++ b/direct_cli/commands/negativekeywordsharedsets.py
@@ -6,13 +6,8 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..output import format_output, handle_api_errors
-from ..utils import (
-    build_common_params,
-    get_default_fields,
-    get_options,
-    parse_csv_strings,
-    parse_ids,
-)
+from ..utils import parse_csv_strings
+from ._get import make_get_command
 from ._lifecycle import make_lifecycle_command
 
 
@@ -21,43 +16,13 @@ def negativekeywordsharedsets():
     """Manage negative keyword shared sets"""
 
 
-@negativekeywordsharedsets.command()
-@click.option("--ids", help="Comma-separated set IDs")
-@get_options
-@click.pass_context
-@handle_api_errors
-def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
-    """Get negative keyword shared sets"""
-    client = client_from_ctx(ctx, create_client)
-
-    field_names = parse_csv_strings(fields) or get_default_fields(
-        "negativekeywordsharedsets"
-    )
-
-    criteria = {}
-    if ids:
-        criteria["Ids"] = parse_ids(ids)
-
-    params = build_common_params(
-        criteria=criteria, field_names=field_names, limit=limit
-    )
-
-    body = {"method": "get", "params": params}
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    result = client.negativekeywordsharedsets().post(data=body)
-
-    if fetch_all:
-        items = []
-        for item in result().iter_items():
-            items.append(item)
-        format_output(items, output_format, output)
-    else:
-        data = result().extract()
-        format_output(data, output_format, output)
+get = make_get_command(
+    negativekeywordsharedsets,
+    create_client,
+    default_fields_key="negativekeywordsharedsets",
+    help_text="Get negative keyword shared sets",
+    ids_help="Comma-separated set IDs",
+)
 
 
 @negativekeywordsharedsets.command()

--- a/direct_cli/commands/turbopages.py
+++ b/direct_cli/commands/turbopages.py
@@ -9,15 +9,9 @@ sitelinks).  No ``add``/``update``/``delete`` methods exist on this service.
 
 import click
 
-from ..api import client_from_ctx, create_client
-from ..output import format_output, handle_api_errors
-from ..utils import (
-    build_common_params,
-    get_default_fields,
-    get_options,
-    parse_csv_strings,
-    parse_ids,
-)
+from ..api import create_client
+from ..utils import parse_csv_strings, parse_ids
+from ._get import make_get_command
 
 
 @click.group()
@@ -25,43 +19,26 @@ def turbopages():
     """Manage Turbo Pages"""
 
 
-@turbopages.command()
-@click.option("--ids", help="Comma-separated Turbo Page IDs")
-@click.option("--bound-with-hrefs", help="Comma-separated hrefs bound with Turbo Pages")
-@get_options
-@click.pass_context
-@handle_api_errors
-def get(
-    ctx, ids, bound_with_hrefs, limit, fetch_all, output_format, output, fields, dry_run
-):
-    """Get Turbo Pages"""
-    client = client_from_ctx(ctx, create_client)
-
-    field_names = parse_csv_strings(fields) or get_default_fields("turbopages")
-
+def _turbopages_criteria(ids, bound_with_hrefs=None):
     criteria = {}
     if ids:
         criteria["Ids"] = parse_ids(ids)
     if bound_with_hrefs:
         criteria["BoundWithHrefs"] = parse_csv_strings(bound_with_hrefs) or []
+    return criteria
 
-    params = build_common_params(
-        criteria=criteria, field_names=field_names, limit=limit
-    )
 
-    body = {"method": "get", "params": params}
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    result = client.turbopages().post(data=body)
-
-    if fetch_all:
-        items = []
-        for item in result().iter_items():
-            items.append(item)
-        format_output(items, output_format, output)
-    else:
-        data = result().extract()
-        format_output(data, output_format, output)
+get = make_get_command(
+    turbopages,
+    create_client,
+    default_fields_key="turbopages",
+    help_text="Get Turbo Pages",
+    ids_help="Comma-separated Turbo Page IDs",
+    extra_options=[
+        click.option(
+            "--bound-with-hrefs",
+            help="Comma-separated hrefs bound with Turbo Pages",
+        )
+    ],
+    criteria_builder=_turbopages_criteria,
+)

--- a/direct_cli/commands/vcards.py
+++ b/direct_cli/commands/vcards.py
@@ -9,14 +9,8 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
+from ._get import make_get_command
 from ._lifecycle import make_lifecycle_command
-from ..utils import (
-    build_common_params,
-    get_default_fields,
-    get_options,
-    parse_csv_strings,
-    parse_ids,
-)
 
 
 @click.group()
@@ -75,41 +69,13 @@ def _build_point_on_map(
     return {name: value for name, value in values.items() if value is not None}
 
 
-@vcards.command()
-@click.option("--ids", help="Comma-separated vCard IDs")
-@get_options
-@click.pass_context
-@handle_api_errors
-def get(ctx, ids, limit, fetch_all, output_format, output, fields, dry_run):
-    """Get vCards"""
-    client = client_from_ctx(ctx, create_client)
-
-    field_names = parse_csv_strings(fields) or get_default_fields("vcards")
-
-    criteria = {}
-    if ids:
-        criteria["Ids"] = parse_ids(ids)
-
-    params = build_common_params(
-        criteria=criteria, field_names=field_names, limit=limit
-    )
-
-    body = {"method": "get", "params": params}
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    result = client.vcards().post(data=body)
-
-    if fetch_all:
-        items = []
-        for item in result().iter_items():
-            items.append(item)
-        format_output(items, output_format, output)
-    else:
-        data = result().extract()
-        format_output(data, output_format, output)
+get = make_get_command(
+    vcards,
+    create_client,
+    default_fields_key="vcards",
+    help_text="Get vCards",
+    ids_help="Comma-separated vCard IDs",
+)
 
 
 @vcards.command()

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -96,6 +96,24 @@ def _rejected(*args: str) -> Result:
     return result
 
 
+def test_make_get_command_dry_run_needs_no_credentials():
+    """``make_get_command`` builds the client *after* the ``--dry-run`` guard
+    (same as the lifecycle factory and CLAUDE.md's "print request JSON without
+    calling the API"), so a migrated ``get --dry-run`` prints its payload with
+    no credentials configured. ``_dry_run`` invokes with an empty env and
+    asserts exit code 0, so it fails if credential resolution creeps back in.
+    """
+    for argv in (
+        ["advideos", "get", "--ids", "1"],
+        ["businesses", "get"],
+        ["vcards", "get"],
+        ["negativekeywordsharedsets", "get"],
+        ["turbopages", "get"],
+    ):
+        body = _dry_run(*argv)
+        assert body["method"] == "get", argv
+
+
 def test_get_selection_criteria_new_typed_flags_payloads():
     """Focused payload coverage for WSDL SelectionCriteria flags added for #146."""
     cases = [


### PR DESCRIPTION
Closes #582. Part of epic #584 (аудит дублирования кода).

## Что сделано

Введена фабрика `direct_cli/commands/_get.py::make_get_command` — общий скелет тела v5 `get`-команды (разрешить поля → собрать `SelectionCriteria` → общие params → dry-run печать или post + format), по образцу `make_lifecycle_command`. На неё переведены **5 самых простых** get-команд: `advideos`, `businesses`, `negativekeywordsharedsets`, `vcards`, `turbopages`.

Вариативность ресурсов фабрика покрывает небольшими «ручками»: `default_fields_key`, `ids_help`/`ids_required`, `extra_options` (`--bound-with-hrefs` у turbopages) и опциональный `criteria_builder` (строковые `Ids` у advideos, `BoundWithHrefs` у turbopages).

## Patchability — строго лучше lifecycle-фабрики

Lifecycle-фабрика захватывает `create_client` в замыкании при загрузке модуля, из-за чего `patch.object(module, "create_client")` **не перехватывает** live-путь (латентный дефект; lifecycle-команды покрыты только через `--dry-run`). Здесь это исправлено: новый `api.resolve_module_create_client` перечитывает `create_client` из живого модуля команды **в момент вызова**, поэтому `patch.object(<module>, "create_client", ...)` — используемый юнит-тестами **и** coverage wire-payload capture (`scripts/build_api_coverage_report.py`) — перехватывает live-путь. Именно это держит зелёным schema-parity coverage-гейт.

## Байт-идентичность (проверено)

- `--help` (порядок опций, i18n-ключи) и `--dry-run` payload **байт-идентичны** для всех 5 команд (сверка с эталоном до рефакторинга, включая строковые vs целочисленные `Ids` и `BoundWithHrefs`).
- VCR-cassette read-тесты (`test_read_cassettes.py`) для этих 5 команд проходят — live-путь не изменился.
- Полный офлайн-прогон: **2535 passed, 23 skipped**; ruff чисто.
- `/simplify`: 4 ревьюера; применён вынос `resolve_module_create_client` в `api.py`, приватизация `_default_ids_criteria`, удаление неиспользуемого `service`; декларативный criteria-механизм отложен в follow-up под реальные требования групп 2-3 (YAGNI).

## Follow-up (под эпиком #584)

Остальная миграция вынесена отдельными issue (расширяют фабрику под свои паттерны с собственной верификацией байт-идентичности):
- Группа 2 (вложенные `*FieldNames` + `add_criteria_csv`): adextensions, adimages, leads, retargeting, sitelinks, feeds, clients, agencyclients.
- Группа 3 (`enforce_criteria_array_limits`): dynamicads, smartadtargets, dynamicfeedadtargets, bids, bidmodifiers, reports, keywordbids.
- Группа 4 (сложные: конфликты флагов, обязательные фильтры): keywords, campaigns, ads, adgroups, strategies, creatives, audiencetargets.
- Хелперы #11 (lifecycle-обёртки), #12 (`make_set_bids_command`), #13 (`execute_add`).

Diff: +198 / −214 (нетто −16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)