### PR TITLE
refactor(commands): shared register_lifecycle_commands; drop 8 local wrappers (#589 #11)

### DIFF
--- a/direct_cli/commands/_lifecycle.py
+++ b/direct_cli/commands/_lifecycle.py
@@ -97,3 +97,18 @@ def make_lifecycle_command(
         format_output(result().extract(), "json", None)
 
     return _command
+
+
+def register_lifecycle_commands(group, id_param, id_help, create_client, specs):
+    """Register a batch of lifecycle commands sharing one id option.
+
+    Replaces the per-module ``_<resource>_lifecycle`` wrappers: each
+    ``(method, help_text)`` pair in *specs* is registered via
+    :func:`make_lifecycle_command` with the shared *id_param* / *id_help* /
+    *create_client*. The commands register themselves on *group* inside the
+    factory, so no return value is needed.
+    """
+    for method, help_text in specs:
+        make_lifecycle_command(
+            group, method, help_text, id_param, id_help, create_client
+        )

--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -9,7 +9,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
-from ._lifecycle import make_lifecycle_command
+from ._lifecycle import register_lifecycle_commands
 from . import _batch
 from ..utils import (
     add_criteria_csv,
@@ -3142,15 +3142,17 @@ def update(
     format_output(result().extract(), "json", None)
 
 
-def _ad_lifecycle(method, help_text):
-    return make_lifecycle_command(
-        ads, method, help_text, "ad_id", "Ad ID", create_client
-    )
-
-
-delete = _ad_lifecycle("delete", "Delete ad")
-archive = _ad_lifecycle("archive", "Archive ad")
-unarchive = _ad_lifecycle("unarchive", "Unarchive ad")
-suspend = _ad_lifecycle("suspend", "Suspend ad")
-resume = _ad_lifecycle("resume", "Resume ad")
-moderate = _ad_lifecycle("moderate", "Moderate ad")
+register_lifecycle_commands(
+    ads,
+    "ad_id",
+    "Ad ID",
+    create_client,
+    [
+        ("delete", "Delete ad"),
+        ("archive", "Archive ad"),
+        ("unarchive", "Unarchive ad"),
+        ("suspend", "Suspend ad"),
+        ("resume", "Resume ad"),
+        ("moderate", "Moderate ad"),
+    ],
+)

--- a/direct_cli/commands/audiencetargets.py
+++ b/direct_cli/commands/audiencetargets.py
@@ -9,7 +9,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
-from ._lifecycle import make_lifecycle_command
+from ._lifecycle import register_lifecycle_commands
 from ..utils import (
     MICRO_RUBLES,
     add_criteria_csv,
@@ -221,12 +221,14 @@ def set_bids(ctx, target_id, adgroup_id, campaign_id, context_bid, priority, dry
     format_output(result().extract(), "json", None)
 
 
-def _audiencetarget_lifecycle(method, help_text):
-    return make_lifecycle_command(
-        audiencetargets, method, help_text, "target_id", "Target ID", create_client
-    )
-
-
-delete = _audiencetarget_lifecycle("delete", "Delete audience target")
-suspend = _audiencetarget_lifecycle("suspend", "Suspend audience target")
-resume = _audiencetarget_lifecycle("resume", "Resume audience target")
+register_lifecycle_commands(
+    audiencetargets,
+    "target_id",
+    "Target ID",
+    create_client,
+    [
+        ("delete", "Delete audience target"),
+        ("suspend", "Suspend audience target"),
+        ("resume", "Resume audience target"),
+    ],
+)

--- a/direct_cli/commands/campaigns.py
+++ b/direct_cli/commands/campaigns.py
@@ -10,7 +10,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
-from ._lifecycle import make_lifecycle_command
+from ._lifecycle import register_lifecycle_commands
 from ..utils import (
     build_selection_criteria,
     build_common_params,
@@ -7207,14 +7207,16 @@ def update(
     format_output(result().extract(), "json", None)
 
 
-def _campaign_lifecycle(method, help_text):
-    return make_lifecycle_command(
-        campaigns, method, help_text, "campaign_id", "Campaign ID", create_client
-    )
-
-
-delete = _campaign_lifecycle("delete", "Delete campaign")
-archive = _campaign_lifecycle("archive", "Archive campaign")
-unarchive = _campaign_lifecycle("unarchive", "Unarchive campaign")
-suspend = _campaign_lifecycle("suspend", "Suspend campaign")
-resume = _campaign_lifecycle("resume", "Resume campaign")
+register_lifecycle_commands(
+    campaigns,
+    "campaign_id",
+    "Campaign ID",
+    create_client,
+    [
+        ("delete", "Delete campaign"),
+        ("archive", "Archive campaign"),
+        ("unarchive", "Unarchive campaign"),
+        ("suspend", "Suspend campaign"),
+        ("resume", "Resume campaign"),
+    ],
+)

--- a/direct_cli/commands/dynamicads.py
+++ b/direct_cli/commands/dynamicads.py
@@ -7,7 +7,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
-from ._lifecycle import make_lifecycle_command
+from ._lifecycle import register_lifecycle_commands
 from ..utils import (
     MICRO_RUBLES,
     build_common_params,
@@ -143,15 +143,17 @@ def add(ctx, adgroup_id, name, conditions, bid, context_bid, priority, dry_run):
     format_output(result().extract(), "json", None)
 
 
-def _dynamicad_lifecycle(method, help_text):
-    return make_lifecycle_command(
-        dynamicads, method, help_text, "target_id", "Target ID", create_client
-    )
-
-
-delete = _dynamicad_lifecycle("delete", "Delete dynamic ad target")
-suspend = _dynamicad_lifecycle("suspend", "Suspend dynamic ad target")
-resume = _dynamicad_lifecycle("resume", "Resume dynamic ad target")
+register_lifecycle_commands(
+    dynamicads,
+    "target_id",
+    "Target ID",
+    create_client,
+    [
+        ("delete", "Delete dynamic ad target"),
+        ("suspend", "Suspend dynamic ad target"),
+        ("resume", "Resume dynamic ad target"),
+    ],
+)
 
 
 @dynamicads.command(name="set-bids")

--- a/direct_cli/commands/dynamicfeedadtargets.py
+++ b/direct_cli/commands/dynamicfeedadtargets.py
@@ -9,7 +9,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
-from ._lifecycle import make_lifecycle_command
+from ._lifecycle import register_lifecycle_commands
 from ..utils import (
     MICRO_RUBLES,
     build_common_params,
@@ -155,15 +155,17 @@ def add(
     format_output(result().extract(), "json", None)
 
 
-def _dynamicfeedadtarget_lifecycle(method, help_text):
-    return make_lifecycle_command(
-        dynamicfeedadtargets, method, help_text, "target_id", "Target ID", create_client
-    )
-
-
-delete = _dynamicfeedadtarget_lifecycle("delete", "Delete dynamic feed ad target")
-suspend = _dynamicfeedadtarget_lifecycle("suspend", "Suspend dynamic feed ad target")
-resume = _dynamicfeedadtarget_lifecycle("resume", "Resume dynamic feed ad target")
+register_lifecycle_commands(
+    dynamicfeedadtargets,
+    "target_id",
+    "Target ID",
+    create_client,
+    [
+        ("delete", "Delete dynamic feed ad target"),
+        ("suspend", "Suspend dynamic feed ad target"),
+        ("resume", "Resume dynamic feed ad target"),
+    ],
+)
 
 
 @dynamicfeedadtargets.command(name="set-bids")

--- a/direct_cli/commands/keywords.py
+++ b/direct_cli/commands/keywords.py
@@ -30,7 +30,7 @@ from .._autotargeting import (
     parse_autotargeting_categories,
     reject_legacy_autotargeting_mix,
 )
-from ._lifecycle import make_lifecycle_command
+from ._lifecycle import register_lifecycle_commands
 from . import _batch
 
 # Yandex Direct keywords.get caps SelectionCriteria arrays at runtime
@@ -827,12 +827,14 @@ def update(
     format_output(result().extract(), "json", None)
 
 
-def _keyword_lifecycle(method, help_text):
-    return make_lifecycle_command(
-        keywords, method, help_text, "keyword_id", "Keyword ID", create_client
-    )
-
-
-delete = _keyword_lifecycle("delete", "Delete keyword")
-suspend = _keyword_lifecycle("suspend", "Suspend keyword")
-resume = _keyword_lifecycle("resume", "Resume keyword")
+register_lifecycle_commands(
+    keywords,
+    "keyword_id",
+    "Keyword ID",
+    create_client,
+    [
+        ("delete", "Delete keyword"),
+        ("suspend", "Suspend keyword"),
+        ("resume", "Resume keyword"),
+    ],
+)

--- a/direct_cli/commands/smartadtargets.py
+++ b/direct_cli/commands/smartadtargets.py
@@ -7,7 +7,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
-from ._lifecycle import make_lifecycle_command
+from ._lifecycle import register_lifecycle_commands
 from ..utils import (
     MICRO_RUBLES,
     build_common_params,
@@ -225,15 +225,17 @@ def update(
     format_output(result().extract(), "json", None)
 
 
-def _smartadtarget_lifecycle(method, help_text):
-    return make_lifecycle_command(
-        smartadtargets, method, help_text, "target_id", "Target ID", create_client
-    )
-
-
-delete = _smartadtarget_lifecycle("delete", "Delete smart ad target")
-suspend = _smartadtarget_lifecycle("suspend", "Suspend smart ad target")
-resume = _smartadtarget_lifecycle("resume", "Resume smart ad target")
+register_lifecycle_commands(
+    smartadtargets,
+    "target_id",
+    "Target ID",
+    create_client,
+    [
+        ("delete", "Delete smart ad target"),
+        ("suspend", "Suspend smart ad target"),
+        ("resume", "Resume smart ad target"),
+    ],
+)
 
 
 @smartadtargets.command(name="set-bids")

--- a/direct_cli/commands/strategies.py
+++ b/direct_cli/commands/strategies.py
@@ -7,7 +7,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
-from ._lifecycle import make_lifecycle_command
+from ._lifecycle import register_lifecycle_commands
 from ..utils import (
     MICRO_RUBLES,
     add_criteria_csv,
@@ -983,11 +983,13 @@ def update(
     format_output(result().extract(), "json", None)
 
 
-def _strategy_lifecycle(method, help_text):
-    return make_lifecycle_command(
-        strategies, method, help_text, "strategy_id", "Strategy ID", create_client
-    )
-
-
-archive = _strategy_lifecycle("archive", "Archive a strategy")
-unarchive = _strategy_lifecycle("unarchive", "Unarchive a strategy")
+register_lifecycle_commands(
+    strategies,
+    "strategy_id",
+    "Strategy ID",
+    create_client,
+    [
+        ("archive", "Archive a strategy"),
+        ("unarchive", "Unarchive a strategy"),
+    ],
+)


### PR DESCRIPTION
Part of #589 (finding #11) / follow-up of #582 / эпик #584.

## Что сделано

Восемь модулей (dynamicads, audiencetargets, smartadtargets, dynamicfeedadtargets, ads, campaigns, keywords, strategies) определяли почти идентичную локальную обёртку `_<resource>_lifecycle(method, help_text)` — только чтобы повторить `make_lifecycle_command(group, ..., id_param, id_help, create_client)` для delete/suspend/resume (+ archive/unarchive/moderate у ads/campaigns/strategies).

Восемь обёрток сведены в один общий `register_lifecycle_commands(group, id_param, id_help, create_client, specs)` в `_lifecycle.py`; каждый модуль передаёт свой список `(method, help_text)`.

## Байт-идентичность

- Все lifecycle-команды по-прежнему регистрируются через `@group.command` внутри фабрики; удалённые module-level биндинги (`delete=`/`suspend=`/…) нигде не импортировались (проверено grep).
- Примеры `--help` (ads delete, campaigns archive, strategies unarchive, dynamicads suspend) — на месте.
- Полный офлайн-прогон: **2536 passed**; ruff чисто.
- `/simplify`: 3 ревьюера; по сходящейся рекомендации убран преждевременный `**kwargs` из сигнатуры хелпера (немигрированные модули с non-default id-путями имеют по одной команде — batch им не нужен; вернуть тривиально при появлении реального кейса). Остальное — без изменений (module-level биндинги не используются, имя/import-time/spec-валидация — приемлемо).

Diff: +115 / −84 (структурный дедуп: 8 функций-обёрток → 1 общий хелпер; multi-line спеки от black дают нетто +31).

## Остаётся в #589
- #12 — `make_set_bids_command` (4 модуля).
- #13 — `execute_add` (~17 add-команд).

🤖 Generated with [Claude Code](https://claude.com/claude-code)