### PR TITLE
refactor(commands): shared execute_request for single-item mutation tails (#589 #13)

### DIFF
--- a/direct_cli/commands/_execute.py
+++ b/direct_cli/commands/_execute.py
@@ -1,0 +1,30 @@
+"""Shared runtime tail for single-item v5 mutation commands.
+
+Across many resource modules the single-item ``add`` and ``update`` subcommands
+end with the same four-step tail: print the request body under ``--dry-run``,
+otherwise build the client, post the body, and format the extracted result as
+JSON. Only the service name varies (the RPC method lives in ``body`` already).
+This helper hoists that tail; the per-command ``body`` construction stays in
+each command.
+
+``create_client`` is passed in by the calling command — its own module global,
+resolved at call time — so ``patch.object("direct_cli.commands.<module>",
+"create_client", ...)`` keeps intercepting the live path (unlike the command
+factories, a normal command body re-reads the global on every call).
+"""
+
+from __future__ import annotations
+
+from ..api import client_from_ctx
+from ..output import format_output
+
+
+def execute_request(ctx, service, body, dry_run, create_client):
+    """Print *body* under ``--dry-run`` or post it and format the result."""
+    if dry_run:
+        format_output(body, "json", None)
+        return
+
+    client = client_from_ctx(ctx, create_client)
+    result = getattr(client, service)().post(data=body)
+    format_output(result().extract(), "json", None)

--- a/direct_cli/commands/adextensions.py
+++ b/direct_cli/commands/adextensions.py
@@ -7,6 +7,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
+from ._execute import execute_request
 from ._lifecycle import make_lifecycle_command
 from ..utils import add_criteria_csv, get_default_fields, parse_csv_strings, parse_ids
 
@@ -104,14 +105,7 @@ def add(ctx, callout_text, dry_run):
 
     body = {"method": "add", "params": {"AdExtensions": [ext_data]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.adextensions().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "adextensions", body, dry_run, create_client)
 
 
 delete = make_lifecycle_command(

--- a/direct_cli/commands/adimages.py
+++ b/direct_cli/commands/adimages.py
@@ -7,6 +7,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
+from ._execute import execute_request
 from ._lifecycle import make_lifecycle_command
 from ..utils import (
     add_criteria_csv,
@@ -99,14 +100,7 @@ def add(ctx, name, image_data, image_file, image_type, dry_run):
 
     body = {"method": "add", "params": {"AdImages": [payload]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.adimages().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "adimages", body, dry_run, create_client)
 
 
 delete = make_lifecycle_command(

--- a/direct_cli/commands/ads.py
+++ b/direct_cli/commands/ads.py
@@ -9,6 +9,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
+from ._execute import execute_request
 from ._lifecycle import register_lifecycle_commands
 from . import _batch
 from ..utils import (
@@ -2712,14 +2713,7 @@ def add(
 
     body = {"method": "add", "params": {"Ads": [ad_data]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.ads().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "ads", body, dry_run, create_client)
 
 
 @ads.command()
@@ -3132,14 +3126,7 @@ def update(
 
     body = {"method": "update", "params": {"Ads": [ad_data]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.ads().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "ads", body, dry_run, create_client)
 
 
 register_lifecycle_commands(

--- a/direct_cli/commands/advideos.py
+++ b/direct_cli/commands/advideos.py
@@ -4,10 +4,11 @@ AdVideos commands
 
 import click
 
-from ..api import client_from_ctx, create_client
+from ..api import create_client
 from ..i18n import t
-from ..output import format_output, handle_api_errors
+from ..output import handle_api_errors
 from ..utils import load_base64_file, parse_csv_strings
+from ._execute import execute_request
 from ._get import make_get_command
 
 
@@ -57,11 +58,4 @@ def add(ctx, url, video_data, video_file, name, dry_run):
 
     body = {"method": "add", "params": {"AdVideos": [item]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.advideos().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "advideos", body, dry_run, create_client)

--- a/direct_cli/commands/agencyclients.py
+++ b/direct_cli/commands/agencyclients.py
@@ -5,6 +5,7 @@ AgencyClients commands
 import click
 
 from ..api import client_from_ctx, create_client
+from ._execute import execute_request
 from ..i18n import t
 from ..output import format_output, handle_api_errors, print_error
 from ..utils import (
@@ -228,14 +229,7 @@ def add(
         },
     }
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.agencyclients().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "agencyclients", body, dry_run, create_client)
 
 
 @agencyclients.command(name="add-passport-organization")
@@ -280,13 +274,7 @@ def add_passport_organization(
 
     body = {"method": "addPassportOrganization", "params": params}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-    result = client.agencyclients().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "agencyclients", body, dry_run, create_client)
 
 
 @agencyclients.command(name="add-passport-organization-member")
@@ -323,13 +311,7 @@ def add_passport_organization_member(
         },
     }
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-    result = client.agencyclients().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "agencyclients", body, dry_run, create_client)
 
 
 @agencyclients.command()
@@ -402,13 +384,7 @@ def update(
 
     body = {"method": "update", "params": {"Clients": [client_data]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-    result = client.agencyclients().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "agencyclients", body, dry_run, create_client)
 
 
 @agencyclients.command()

--- a/direct_cli/commands/audiencetargets.py
+++ b/direct_cli/commands/audiencetargets.py
@@ -9,6 +9,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
+from ._execute import execute_request
 from ._lifecycle import register_lifecycle_commands
 from ..utils import (
     MICRO_RUBLES,
@@ -168,13 +169,7 @@ def add(
 
     body = {"method": "add", "params": {"AudienceTargets": [target_data]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-    result = client.audiencetargets().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "audiencetargets", body, dry_run, create_client)
 
 
 @audiencetargets.command(name="set-bids")
@@ -212,13 +207,7 @@ def set_bids(ctx, target_id, adgroup_id, campaign_id, context_bid, priority, dry
 
     body = {"method": "setBids", "params": {"Bids": [bid_data]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-    result = client.audiencetargets().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "audiencetargets", body, dry_run, create_client)
 
 
 register_lifecycle_commands(

--- a/direct_cli/commands/bidmodifiers.py
+++ b/direct_cli/commands/bidmodifiers.py
@@ -9,6 +9,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
+from ._execute import execute_request
 from ._lifecycle import make_lifecycle_command
 from ..utils import (
     build_common_params,
@@ -432,14 +433,7 @@ def add(
 
     body = {"method": "add", "params": {"BidModifiers": [modifier_data]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.bidmodifiers().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "bidmodifiers", body, dry_run, create_client)
 
 
 _DEPRECATED_BIDMODIFIERS_SET_OPTIONS = {
@@ -520,14 +514,7 @@ def set(ctx, modifier_id, value, dry_run):
 
     body = {"method": "set", "params": {"BidModifiers": [modifier_data]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.bidmodifiers().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "bidmodifiers", body, dry_run, create_client)
 
 
 delete = make_lifecycle_command(

--- a/direct_cli/commands/bids.py
+++ b/direct_cli/commands/bids.py
@@ -7,6 +7,7 @@ from typing import Any
 import click
 
 from ..api import client_from_ctx, create_client
+from ._execute import execute_request
 from ..i18n import t
 from ..output import format_output, handle_api_errors
 from ..utils import (
@@ -170,13 +171,7 @@ def set(
 
     body = {"method": "set", "params": {"Bids": [bid_data]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-    result = client.bids().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "bids", body, dry_run, create_client)
 
 
 @bids.command(name="set-auto")
@@ -231,10 +226,4 @@ def set_auto(
 
     body = {"method": "setAuto", "params": {"Bids": [bid_data]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-    result = client.bids().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "bids", body, dry_run, create_client)

--- a/direct_cli/commands/campaigns.py
+++ b/direct_cli/commands/campaigns.py
@@ -10,6 +10,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
+from ._execute import execute_request
 from ._lifecycle import register_lifecycle_commands
 from ..utils import (
     build_selection_criteria,
@@ -4234,14 +4235,7 @@ def add(
 
     body = {"method": "add", "params": {"Campaigns": [campaign_data]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.campaigns().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "campaigns", body, dry_run, create_client)
 
 
 @campaigns.command()
@@ -7197,14 +7191,7 @@ def update(
 
     body = {"method": "update", "params": {"Campaigns": [campaign_data]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.campaigns().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "campaigns", body, dry_run, create_client)
 
 
 register_lifecycle_commands(

--- a/direct_cli/commands/clients.py
+++ b/direct_cli/commands/clients.py
@@ -5,6 +5,7 @@ Clients commands
 import click
 
 from ..api import client_from_ctx, create_client
+from ._execute import execute_request
 from ..i18n import t
 from ..output import format_output, handle_api_errors
 from ..utils import (
@@ -328,11 +329,4 @@ def update(
 
     body = {"method": "update", "params": {"Clients": [client_data]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.clients().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "clients", body, dry_run, create_client)

--- a/direct_cli/commands/creatives.py
+++ b/direct_cli/commands/creatives.py
@@ -5,6 +5,7 @@ Creatives commands
 import click
 
 from ..api import client_from_ctx, create_client
+from ._execute import execute_request
 from ..i18n import t
 from ..output import format_output, handle_api_errors
 from ..utils import (
@@ -141,10 +142,4 @@ def add(ctx, video_id, dry_run):
         "params": {"Creatives": [{"VideoExtensionCreative": {"VideoId": video_id}}]},
     }
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-    result = client.creatives().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "creatives", body, dry_run, create_client)

--- a/direct_cli/commands/dynamicads.py
+++ b/direct_cli/commands/dynamicads.py
@@ -7,6 +7,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
+from ._execute import execute_request
 from ._lifecycle import register_lifecycle_commands
 from ..utils import (
     MICRO_RUBLES,
@@ -134,13 +135,7 @@ def add(ctx, adgroup_id, name, conditions, bid, context_bid, priority, dry_run):
 
     body = {"method": "add", "params": {"Webpages": [target_data]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-    result = client.dynamicads().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "dynamicads", body, dry_run, create_client)
 
 
 register_lifecycle_commands(
@@ -196,10 +191,4 @@ def set_bids(
 
     body = {"method": "setBids", "params": {"Bids": [bid_data]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-    result = client.dynamicads().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "dynamicads", body, dry_run, create_client)

--- a/direct_cli/commands/dynamicfeedadtargets.py
+++ b/direct_cli/commands/dynamicfeedadtargets.py
@@ -9,6 +9,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
+from ._execute import execute_request
 from ._lifecycle import register_lifecycle_commands
 from ..utils import (
     MICRO_RUBLES,
@@ -146,13 +147,7 @@ def add(
 
     body = {"method": "add", "params": {"DynamicFeedAdTargets": [target_data]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-    result = client.dynamicfeedadtargets().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "dynamicfeedadtargets", body, dry_run, create_client)
 
 
 register_lifecycle_commands(
@@ -202,10 +197,4 @@ def set_bids(ctx, target_id, adgroup_id, campaign_id, bid, context_bid, dry_run)
 
     body = {"method": "setBids", "params": {"Bids": [bid_data]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-    result = client.dynamicfeedadtargets().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "dynamicfeedadtargets", body, dry_run, create_client)

--- a/direct_cli/commands/feeds.py
+++ b/direct_cli/commands/feeds.py
@@ -11,6 +11,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
+from ._execute import execute_request
 from ._lifecycle import make_lifecycle_command
 from ..utils import (
     build_common_params,
@@ -280,14 +281,7 @@ def add(
 
     body = {"method": "add", "params": {"Feeds": [feed_data]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.feeds().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "feeds", body, dry_run, create_client)
 
 
 @feeds.command()
@@ -389,14 +383,7 @@ def update(
 
     body = {"method": "update", "params": {"Feeds": [feed_data]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.feeds().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "feeds", body, dry_run, create_client)
 
 
 delete = make_lifecycle_command(

--- a/direct_cli/commands/keywordbids.py
+++ b/direct_cli/commands/keywordbids.py
@@ -5,6 +5,7 @@ KeywordBids commands
 import click
 
 from ..api import client_from_ctx, create_client
+from ._execute import execute_request
 from ..i18n import t
 from ..output import format_output, handle_api_errors
 from ..utils import (
@@ -234,13 +235,7 @@ def set(
 
     body = {"method": "set", "params": {"KeywordBids": [bid_data]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-    result = client.keywordbids().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "keywordbids", body, dry_run, create_client)
 
 
 @keywordbids.command(name="set-auto")
@@ -307,10 +302,4 @@ def set_auto(
 
     body = {"method": "setAuto", "params": {"KeywordBids": [bid_data]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-    result = client.keywordbids().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "keywordbids", body, dry_run, create_client)

--- a/direct_cli/commands/keywords.py
+++ b/direct_cli/commands/keywords.py
@@ -30,6 +30,7 @@ from .._autotargeting import (
     parse_autotargeting_categories,
     reject_legacy_autotargeting_mix,
 )
+from ._execute import execute_request
 from ._lifecycle import register_lifecycle_commands
 from . import _batch
 
@@ -817,14 +818,7 @@ def update(
 
     body = {"method": "update", "params": {"Keywords": [keyword_data]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.keywords().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "keywords", body, dry_run, create_client)
 
 
 register_lifecycle_commands(

--- a/direct_cli/commands/negativekeywordsharedsets.py
+++ b/direct_cli/commands/negativekeywordsharedsets.py
@@ -4,9 +4,10 @@ NegativeKeywordSharedSets commands
 
 import click
 
-from ..api import client_from_ctx, create_client
-from ..output import format_output, handle_api_errors
+from ..api import create_client
+from ..output import handle_api_errors
 from ..utils import parse_csv_strings
+from ._execute import execute_request
 from ._get import make_get_command
 from ._lifecycle import make_lifecycle_command
 
@@ -40,14 +41,7 @@ def add(ctx, name, keywords, dry_run):
 
     body = {"method": "add", "params": {"NegativeKeywordSharedSets": [set_data]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.negativekeywordsharedsets().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "negativekeywordsharedsets", body, dry_run, create_client)
 
 
 @negativekeywordsharedsets.command()
@@ -75,14 +69,7 @@ def update(ctx, set_id, name, keywords, dry_run):
         "params": {"NegativeKeywordSharedSets": [set_data]},
     }
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.negativekeywordsharedsets().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "negativekeywordsharedsets", body, dry_run, create_client)
 
 
 delete = make_lifecycle_command(

--- a/direct_cli/commands/retargeting.py
+++ b/direct_cli/commands/retargeting.py
@@ -9,6 +9,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
+from ._execute import execute_request
 from ._lifecycle import make_lifecycle_command
 from ..utils import (
     add_criteria_csv,
@@ -140,13 +141,7 @@ def add(ctx, name, description, list_type, rules, dry_run):
 
     body = {"method": "add", "params": {"RetargetingLists": [list_data]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-    result = client.retargeting().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "retargeting", body, dry_run, create_client)
 
 
 @retargeting.command()
@@ -197,13 +192,7 @@ def update(ctx, list_id, name, description, list_type, rules, dry_run):
 
     body = {"method": "update", "params": {"RetargetingLists": [list_data]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-    result = client.retargeting().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "retargeting", body, dry_run, create_client)
 
 
 delete = make_lifecycle_command(

--- a/direct_cli/commands/sitelinks.py
+++ b/direct_cli/commands/sitelinks.py
@@ -11,6 +11,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
+from ._execute import execute_request
 from ._lifecycle import make_lifecycle_command
 from ..utils import (
     build_common_params,
@@ -269,14 +270,7 @@ def add(ctx, sitelinks_specs, sitelinks_json, sitelinks_from_file, dry_run):
         "params": {"SitelinksSets": [{"Sitelinks": sitelinks_payload}]},
     }
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.sitelinks().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "sitelinks", body, dry_run, create_client)
 
 
 delete = make_lifecycle_command(

--- a/direct_cli/commands/smartadtargets.py
+++ b/direct_cli/commands/smartadtargets.py
@@ -7,6 +7,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
+from ._execute import execute_request
 from ._lifecycle import register_lifecycle_commands
 from ..utils import (
     MICRO_RUBLES,
@@ -151,13 +152,7 @@ def add(
 
     body = {"method": "add", "params": {"SmartAdTargets": [target_data]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-    result = client.smartadtargets().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "smartadtargets", body, dry_run, create_client)
 
 
 @smartadtargets.command()
@@ -216,13 +211,7 @@ def update(
 
     body = {"method": "update", "params": {"SmartAdTargets": [target_data]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-    result = client.smartadtargets().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "smartadtargets", body, dry_run, create_client)
 
 
 register_lifecycle_commands(
@@ -289,10 +278,4 @@ def set_bids(
 
     body = {"method": "setBids", "params": {"Bids": [bid_data]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-    result = client.smartadtargets().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "smartadtargets", body, dry_run, create_client)

--- a/direct_cli/commands/strategies.py
+++ b/direct_cli/commands/strategies.py
@@ -7,6 +7,7 @@ import click
 from ..api import client_from_ctx, create_client
 from ..i18n import t
 from ..output import format_output, handle_api_errors
+from ._execute import execute_request
 from ._lifecycle import register_lifecycle_commands
 from ..utils import (
     MICRO_RUBLES,
@@ -810,13 +811,7 @@ def add(
 
     body = {"method": "add", "params": {"Strategies": [strategy_data]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-    result = client.strategies().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "strategies", body, dry_run, create_client)
 
 
 @strategies.command()
@@ -974,13 +969,7 @@ def update(
 
     body = {"method": "update", "params": {"Strategies": [strategy_data]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-    result = client.strategies().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "strategies", body, dry_run, create_client)
 
 
 register_lifecycle_commands(

--- a/direct_cli/commands/vcards.py
+++ b/direct_cli/commands/vcards.py
@@ -6,9 +6,10 @@ from typing import Dict, Optional
 
 import click
 
-from ..api import client_from_ctx, create_client
+from ..api import create_client
 from ..i18n import t
-from ..output import format_output, handle_api_errors
+from ..output import handle_api_errors
+from ._execute import execute_request
 from ._get import make_get_command
 from ._lifecycle import make_lifecycle_command
 
@@ -198,14 +199,7 @@ def add(
 
     body = {"method": "add", "params": {"VCards": [vcard]}}
 
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    client = client_from_ctx(ctx, create_client)
-
-    result = client.vcards().post(data=body)
-    format_output(result().extract(), "json", None)
+    execute_request(ctx, "vcards", body, dry_run, create_client)
 
 
 delete = make_lifecycle_command(


### PR DESCRIPTION
Part of #589 (finding #13) / follow-up of #582 / эпик #584.

## Что сделано

В ~22 модулях одиночные `add`/`update`/`set`-команды заканчивались одинаковым хвостом из 4 шагов — печать `body` под `--dry-run`, иначе построить клиент, отправить и отформатировать `result().extract()` как JSON; различался только сервис (RPC-метод уже лежит в `body`). Этот хвост вынесён в один `execute_request(ctx, service, body, dry_run, create_client)` в `direct_cli/commands/_execute.py`; построение `body` (сборка item) остаётся в каждой команде.

Хелпер назван **метод-агностично** (по итогам `/simplify`-ревью): покрывает add, update и set-bids одинаково.

## Байт-идентичность

- `create_client` передаётся из module global вызывающей команды (резолвится в момент вызова), поэтому `patch.object(<module>, "create_client")` продолжает перехватывать live-путь (в отличие от фабрик; обычное тело команды перечитывает глобал каждый вызов). Покрыто `test_cli` (патч ads/campaigns create_client + invoke mutation).
- get-команды **не затронуты** (у них `format_output(..., output_format, output)`, не hardcoded JSON — regex не совпадает).
- Полный офлайн-прогон: **2536 passed** (PAYLOAD_CASES для add/update dry-run + cassettes для post-пути); ruff чисто.
- `/simplify`: 2 ревьюера. Applied: метод-агностичное имя + покрытие update (altitude). Отклонено: слияние с `_batch.send_batch` (разные задачи — chunking/partial-success vs простой single-item хвост); «patchability-риск» — намеренный корректный дизайн, доказан suite.

Diff: +97 / −297 (нетто −200), 23 файла.

## Остаётся в #589
- #12 — `make_set_bids_command` (дедуп **тела** set-bids: сборка `Bids[]` + валидация селектор/bid-полей в 4 модулях).

🤖 Generated with [Claude Code](https://claude.com/claude-code)