### PR TITLE
feat(output): human-readable text default for reference commands (#578)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+**Features — human-readable `text` output for reference commands (#578):**
+
+- Local reference commands now default to a human-readable `text` format instead
+  of raw JSON: `trackingparams` (dynamic tracking-parameter reference) and
+  `dictionaries list-names` (previously hardcoded JSON with no `--format`). Both
+  expose `--format {text,json,table,csv,tsv}` / `--output` via the new shared
+  `reference_output_options` decorator (sibling of `v4_output_options`, default
+  `text`). API-data commands keep their `json` default.
+- Global `output.py` fix: `--format table/csv/tsv` now render a list of scalar
+  values (e.g. dictionary names) as a single `Value` column instead of a Python
+  `repr` (`['Currencies', …]`) / empty output. Affects any caller that passes a
+  scalar list, not just the reference commands.
+
 **Features — preflight `SelectionCriteria` array caps on remaining read-get commands (#571):**
 
 - `ads`, `adgroups`, `bids`, `bidmodifiers`, `campaigns`, `keywords`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,9 @@ Click group-of-groups. Each Yandex Direct API resource = one file in `direct_cli
 
 **Shared utilities** (`utils.py`): `parse_ids`, `parse_json`, `build_selection_criteria`, `build_common_params`, `get_default_fields`, `COMMON_FIELDS` dict. All command modules import from here — don't duplicate.
 
-**Output** (`output.py`): `format_output()` supports json (default), table, csv, tsv. Colored helpers: `print_success`, `print_error`, `print_warning`, `print_info`.
+**Output** (`output.py`): `format_output()` supports json (default), table, csv, tsv, and `text` (human-readable plain blocks via `format_text`). Colored helpers: `print_success`, `print_error`, `print_warning`, `print_info`.
+
+**Reference commands** (local value lists / templates, e.g. `trackingparams`, `dictionaries list-names`) default to the human-readable `text` format and expose `--format {text,json,table,csv,tsv}` / `--output` via the shared `reference_output_options` decorator (`utils.py`, sibling of `v4_output_options`). API-data commands keep `json` default. New reference commands should use this decorator.
 
 ## Key Conventions
 

--- a/direct_cli/commands/dictionaries.py
+++ b/direct_cli/commands/dictionaries.py
@@ -6,7 +6,7 @@ import click
 
 from ..api import client_from_ctx, create_client
 from ..output import format_output, handle_api_errors
-from ..utils import parse_csv_strings, parse_ids
+from ..utils import parse_csv_strings, parse_ids, reference_output_options
 
 DICTIONARY_NAMES = [
     "Currencies",
@@ -80,6 +80,7 @@ def get_geo_regions(ctx, name, region_ids, exact_names, fields, output_format, o
 
 
 @dictionaries.command()
-def list_names():
+@reference_output_options
+def list_names(output_format, output):
     """List available dictionary names"""
-    format_output(DICTIONARY_NAMES, "json", None)
+    format_output(DICTIONARY_NAMES, output_format, output)

--- a/direct_cli/commands/trackingparams.py
+++ b/direct_cli/commands/trackingparams.py
@@ -6,14 +6,14 @@ import click
 
 from ..output import format_output
 from ..tracking_params import TRACKING_PARAMS, TRACKING_PARAMS_DOCS_URL
+from ..utils import reference_output_options
 
 
 @click.command(
     name="trackingparams",
     epilog=f"\b\nDocumentation: {TRACKING_PARAMS_DOCS_URL}",
 )
-@click.option("--format", "output_format", default="json", help="Output format")
-@click.option("--output", help="Output file")
+@reference_output_options
 def tracking_params(output_format, output):
     """Dynamic tracking parameters reference (UTM template placeholders).
 

--- a/direct_cli/output.py
+++ b/direct_cli/output.py
@@ -32,7 +32,7 @@ def format_output(
 
     Args:
         data: Data to format
-        format_type: Output format ('json', 'table', 'csv', 'tsv')
+        format_type: Output format ('text', 'json', 'table', 'csv', 'tsv')
         output_file: Output file path (if None, print to stdout)
         headers: Column headers for table/csv/tsv format
 
@@ -43,6 +43,8 @@ def format_output(
 
     if format_type == "json":
         output = format_json(data)
+    elif format_type == "text":
+        output = format_text(data)
     elif format_type == "table":
         output = format_table(data, headers)
     elif format_type == "csv":
@@ -157,6 +159,30 @@ def format_json(data: Any, indent: int = 2) -> str:
     return json.dumps(data, ensure_ascii=False, indent=indent, default=str)
 
 
+def format_text(data: Any) -> str:
+    """Format data as a human-readable plain-text block.
+
+    The default for reference commands — the same kind of flat plain-text the
+    ``auth status`` / ``auth list`` commands print by hand (stylistic mirror, not
+    shared code): a list of records prints each record as ``key: value`` lines
+    separated by a blank line; a list of scalars prints one per line; a mapping
+    prints ``key: value`` lines; anything else falls back to ``str``.
+    """
+    if isinstance(data, list):
+        if not data:
+            return ""
+        if isinstance(data[0], dict):
+            blocks = [
+                "\n".join(f"{key}: {value}" for key, value in item.items())
+                for item in data
+            ]
+            return "\n\n".join(blocks)
+        return "\n".join(str(item) for item in data)
+    if isinstance(data, dict):
+        return "\n".join(f"{key}: {value}" for key, value in data.items())
+    return str(data)
+
+
 def format_table(data: Any, headers: Optional[List[str]] = None) -> str:
     """Format data as table"""
     if not tabulate:
@@ -167,6 +193,10 @@ def format_table(data: Any, headers: Optional[List[str]] = None) -> str:
             return tabulate(data, headers="keys", tablefmt="grid")
         elif isinstance(data[0], list):
             return tabulate(data, headers=headers or [], tablefmt="grid")
+        else:
+            # list of scalars -> a single "Value" column
+            rows = [[item] for item in data]
+            return tabulate(rows, headers=headers or ["Value"], tablefmt="grid")
     elif isinstance(data, dict):
         # Convert dict to list of lists for table display
         rows = [[k, v] for k, v in data.items()]
@@ -175,52 +205,43 @@ def format_table(data: Any, headers: Optional[List[str]] = None) -> str:
     return str(data)
 
 
-def format_csv(data: Any, headers: Optional[List[str]] = None) -> str:
-    """Format data as CSV"""
+def _format_delimited(data: Any, headers: Optional[List[str]], delimiter: str) -> str:
+    """Shared CSV/TSV writer — only the delimiter differs between the two."""
     output = StringIO()
 
     if isinstance(data, list) and len(data) > 0:
         if isinstance(data[0], dict):
             fieldnames = headers or list(data[0].keys())
-            writer = csv.DictWriter(output, fieldnames=fieldnames)
+            writer = csv.DictWriter(output, fieldnames=fieldnames, delimiter=delimiter)
             writer.writeheader()
             writer.writerows(data)
         elif isinstance(data[0], list):
-            writer = csv.writer(output)
+            writer = csv.writer(output, delimiter=delimiter)
             if headers:
                 writer.writerow(headers)
             writer.writerows(data)
+        else:
+            writer = csv.writer(output, delimiter=delimiter)
+            writer.writerow(headers or ["Value"])
+            for item in data:
+                writer.writerow([item])
     elif isinstance(data, dict):
-        writer = csv.writer(output)
+        writer = csv.writer(output, delimiter=delimiter)
         writer.writerow(["Key", "Value"])
         for k, v in data.items():
             writer.writerow([k, v])
 
     return output.getvalue()
+
+
+def format_csv(data: Any, headers: Optional[List[str]] = None) -> str:
+    """Format data as CSV"""
+    return _format_delimited(data, headers, delimiter=",")
 
 
 def format_tsv(data: Any, headers: Optional[List[str]] = None) -> str:
     """Format data as TSV"""
-    output = StringIO()
-
-    if isinstance(data, list) and len(data) > 0:
-        if isinstance(data[0], dict):
-            fieldnames = headers or list(data[0].keys())
-            writer = csv.DictWriter(output, fieldnames=fieldnames, delimiter="\t")
-            writer.writeheader()
-            writer.writerows(data)
-        elif isinstance(data[0], list):
-            writer = csv.writer(output, delimiter="\t")
-            if headers:
-                writer.writerow(headers)
-            writer.writerows(data)
-    elif isinstance(data, dict):
-        writer = csv.writer(output, delimiter="\t")
-        writer.writerow(["Key", "Value"])
-        for k, v in data.items():
-            writer.writerow([k, v])
-
-    return output.getvalue()
+    return _format_delimited(data, headers, delimiter="\t")
 
 
 def print_success(message: str) -> None:

--- a/direct_cli/utils.py
+++ b/direct_cli/utils.py
@@ -1083,3 +1083,31 @@ def v4_output_options(func):
         type=click.Choice(["json", "table", "csv", "tsv"]),
         help="Output format",
     )(func)
+
+
+def reference_output_options(func):
+    """Apply the output-option stack of a local reference command.
+
+    Equivalent to, top-to-bottom::
+
+        @click.option(
+            "--format", "output_format", default="text",
+            type=click.Choice(["text", "json", "table", "csv", "tsv"]),
+            help="Output format",
+        )
+        @click.option("--output", help="Output file")
+
+    Like :func:`v4_output_options`, but the default is the human-readable
+    ``text`` (reference commands list values for a person, not a pipeline) and
+    there is no ``--dry-run`` (no API call). The shared convention for local
+    reference commands (``trackingparams``, ``dictionaries list-names``, …);
+    ``text`` is rendered by :func:`direct_cli.output.format_text`.
+    """
+    func = click.option("--output", help="Output file")(func)
+    return click.option(
+        "--format",
+        "output_format",
+        default="text",
+        type=click.Choice(["text", "json", "table", "csv", "tsv"]),
+        help="Output format",
+    )(func)

--- a/tests/test_reference_output.py
+++ b/tests/test_reference_output.py
@@ -1,0 +1,104 @@
+"""Human-readable default output for local reference commands (issue #578).
+
+Reference commands (``trackingparams``, ``dictionaries list-names``) list values
+for a person, so they default to the human-readable ``text`` format and keep the
+machine formats (json/table/csv/tsv) as ``--format`` options via
+``reference_output_options``. ``YANDEX_DIRECT_CLI_LOCALE=en`` is pinned by the
+conftest autouse fixture (irrelevant here — the reference data is language-neutral
+or Russian by source).
+"""
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from direct_cli.cli import cli
+from direct_cli.output import format_csv, format_table, format_text, format_tsv
+
+
+def _run(*args):
+    return CliRunner().invoke(cli, list(args))
+
+
+# ── format_text unit ──────────────────────────────────────────────────────
+
+
+def test_format_text_list_of_dicts_blocks():
+    out = format_text([{"A": "1", "B": "x"}, {"A": "2", "B": "y"}])
+    assert out == "A: 1\nB: x\n\nA: 2\nB: y"
+
+
+def test_format_text_list_of_scalars_one_per_line():
+    assert format_text(["Currencies", "GeoRegions"]) == "Currencies\nGeoRegions"
+
+
+def test_format_text_dict_is_key_value():
+    assert format_text({"profile": "p", "source": "env"}) == "profile: p\nsource: env"
+
+
+def test_format_text_empty_list_and_scalar():
+    assert format_text([]) == ""
+    assert format_text(42) == "42"
+
+
+# ── scalar-list rendering in table/csv/tsv (previously a Python repr) ─────
+
+
+def test_format_table_scalar_list_single_column():
+    out = format_table(["Currencies", "GeoRegions"])
+    assert "Value" in out and "Currencies" in out
+    assert "['Currencies'" not in out  # not the old str(data) repr
+
+
+def test_format_csv_tsv_scalar_list_single_column():
+    assert format_csv(["a", "b"]).splitlines() == ["Value", "a", "b"]
+    assert format_tsv(["a", "b"]).splitlines() == ["Value", "a", "b"]
+
+
+# ── trackingparams ────────────────────────────────────────────────────────
+
+
+def test_trackingparams_default_is_text_not_json():
+    result = _run("trackingparams")
+    assert result.exit_code == 0
+    assert "{campaign_id}" in result.output
+    assert not result.output.lstrip().startswith("[")
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(result.output)
+
+
+def test_trackingparams_format_json():
+    result = _run("trackingparams", "--format", "json")
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert any(row["Parameter"] == "{campaign_id}" for row in data)
+
+
+def test_trackingparams_rejects_unknown_format():
+    result = _run("trackingparams", "--format", "xml")
+    assert result.exit_code == 2
+    assert "Invalid value for '--format'" in result.output
+
+
+# ── dictionaries list-names ───────────────────────────────────────────────
+
+
+def test_list_names_default_is_text():
+    result = _run("dictionaries", "list-names")
+    assert result.exit_code == 0
+    assert "Currencies" in result.output.split("\n")
+    assert not result.output.lstrip().startswith("[")
+
+
+def test_list_names_format_json():
+    result = _run("dictionaries", "list-names", "--format", "json")
+    assert result.exit_code == 0
+    assert "Currencies" in json.loads(result.output)
+
+
+@pytest.mark.parametrize("fmt", ["text", "json", "table", "csv", "tsv"])
+def test_list_names_all_formats_succeed(fmt):
+    result = _run("dictionaries", "list-names", "--format", fmt)
+    assert result.exit_code == 0, result.output
+    assert "Currencies" in result.output


### PR DESCRIPTION
Closes #578.

## Что сделано

Справочные команды показывают человеку список значений, а не данные API — JSON по умолчанию читался плохо. Теперь:

- **`text`-формат в `format_output`** (`output.py`, `format_text`): список записей → блоки `key: value` с пустой строкой между; список скаляров → по строке; mapping → `key: value`. Доступен всем командам, но дефолт — только у справочных.
- **Декоратор `reference_output_options`** (`utils.py`, зеркало `v4_output_options`): `--format {text,json,table,csv,tsv}` (default `text`) + `--output`, без `--dry-run`. Конвенция для справочных команд.
- **Применён к двум локальным справочным командам:**
  - `trackingparams` — был `--format` json-default → теперь `text` по умолчанию.
  - `dictionaries list-names` — был хардкод JSON без `--format` → теперь полный стек `--format`/`--output`, дефолт `text`.

## Попутно (по итогам /simplify)

- Починен пред­существующий пробел: список скаляров под `--format table/csv/tsv` рендерился Python-repr (`['Currencies', ...]`) → теперь один столбец «Value».
- `format_csv`/`format_tsv` (почти идентичные) сведены в один `_format_delimited(delimiter=…)`.
- `format_text` унифицирован на `:` (records и dict), docstring уточнён (стилистическое зеркало `auth status`, не code-reuse).

## Границы / проверка

- API-команды (`dictionaries get`/`get-geo-regions`) — json-default не тронут.
- Решение целиком на устоявшихся паттернах: `auth status` (`--format text` default), `v4_output_options` (декоратор), `format_output` (переиспользование).
- Тесты: новый `tests/test_reference_output.py` (16) — дефолт `text`, все `--format`, скаляр-список, отказ неверного формата. Полный офлайн-прогон: **2552 passed**; ruff чисто.

Diff: 6 файлов, нетто +156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)