### PR TITLE
refactor: migrate criteria-limit ad-target get to make_get_command (part of #587)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+**Internal — `make_get_command` covers the criteria-limit ad-target `get`s (part of #587):**
+
+- `dynamicads get`, `smartadtargets get` and `dynamicfeedadtargets get` — three
+  byte-for-byte identical command bodies — now register through the shared
+  `make_get_command` factory (`direct_cli/commands/_get.py`) instead of hand-rolled
+  copies (net −131 lines). The factory gained two optional, generic parameters:
+  `criteria_limits` (forwarded to `enforce_criteria_array_limits`, command name
+  derived as `"<group> get"`) and `require_criteria_message` (the "provide at
+  least one filter" guard), plus a shared `ids_adgroup_campaign_states_criteria`
+  builder for the `Ids`/`AdGroupIds`/`CampaignIds`/`States` selection shape.
+- No CLI surface change: `--help`, `--dry-run` payloads, the over-limit and
+  empty-criteria errors, and module patchability are byte-identical (verified
+  against pre-migration baselines). Group 2 (nested `*FieldNames`) and the
+  no-`--ids` commands (`bids`, `keywordbids`, `bidmodifiers`) follow in a
+  separate PR.
+
 **Features — human-readable `text` output for reference commands (#578):**
 
 - Local reference commands now default to a human-readable `text` format instead

--- a/direct_cli/commands/_get.py
+++ b/direct_cli/commands/_get.py
@@ -20,12 +20,15 @@ from __future__ import annotations
 import click
 
 from ..api import client_from_ctx, resolve_module_create_client
+from ..i18n import t
 from ..output import format_output, handle_api_errors
 from ..utils import (
     build_common_params,
+    enforce_criteria_array_limits,
     get_default_fields,
     get_options,
     parse_csv_strings,
+    parse_csv_upper,
     parse_ids,
 )
 
@@ -35,6 +38,26 @@ def _default_ids_criteria(ids):
     criteria = {}
     if ids:
         criteria["Ids"] = parse_ids(ids)
+    return criteria
+
+
+def ids_adgroup_campaign_states_criteria(
+    ids, adgroup_ids=None, campaign_ids=None, states=None, **_
+):
+    """SelectionCriteria for the dynamic/smart ad-target ``get`` commands.
+
+    Optional integer ``Ids`` / ``AdGroupIds`` / ``CampaignIds`` lists plus an
+    upper-cased ``States`` list (an empty ``--states`` CSV maps to ``[]``), in
+    that key order — the shared shape of ``dynamicads``, ``smartadtargets`` and
+    ``dynamicfeedadtargets``.
+    """
+    criteria = _default_ids_criteria(ids)
+    if adgroup_ids:
+        criteria["AdGroupIds"] = parse_ids(adgroup_ids)
+    if campaign_ids:
+        criteria["CampaignIds"] = parse_ids(campaign_ids)
+    if states:
+        criteria["States"] = parse_csv_upper(states) or []
     return criteria
 
 
@@ -48,6 +71,8 @@ def make_get_command(
     ids_required=False,
     extra_options=(),
     criteria_builder=None,
+    criteria_limits=None,
+    require_criteria_message=None,
 ):
     """Build and register a v5 ``get`` command on *group*.
 
@@ -68,6 +93,12 @@ def make_get_command(
         criteria_builder: callable mapping the parsed options to a
             ``SelectionCriteria`` dict. It receives ``ids`` plus every extra
             option as keyword args; defaults to an optional ``Ids`` list.
+        criteria_limits: optional ``{SelectionCriteria key: max count}`` dict
+            enforced via :func:`enforce_criteria_array_limits` (command name
+            ``"<group> get"``) before the request is built.
+        require_criteria_message: optional i18n key; when set, an empty
+            ``SelectionCriteria`` raises ``UsageError`` with this message
+            (the "provide at least one filter" guard).
 
     Returns:
         The registered Click command.
@@ -85,6 +116,12 @@ def make_get_command(
             default_fields_key
         )
         criteria = build_criteria(ids, **kwargs)
+        if criteria_limits:
+            enforce_criteria_array_limits(
+                criteria, criteria_limits, command_name=f"{svc} get"
+            )
+        if require_criteria_message and not criteria:
+            raise click.UsageError(t(require_criteria_message))
         params = build_common_params(
             criteria=criteria, field_names=field_names, limit=limit
         )

--- a/direct_cli/commands/_get.py
+++ b/direct_cli/commands/_get.py
@@ -103,6 +103,10 @@ def make_get_command(
     Returns:
         The registered Click command.
     """
+    # svc doubles as the client service attribute (``getattr(client, svc)``) and
+    # the ``criteria_limits`` error prefix (``f"{svc} get"``); both assume the
+    # group name matches the API service name, which holds for every current
+    # resource module.
     svc = group.name
     module_name = group.callback.__module__
     build_criteria = criteria_builder or (lambda ids, **_: _default_ids_criteria(ids))

--- a/direct_cli/commands/dynamicads.py
+++ b/direct_cli/commands/dynamicads.py
@@ -4,21 +4,15 @@ DynamicAds (Webpages) commands
 
 import click
 
-from ..api import client_from_ctx, create_client
+from ..api import create_client
 from ..i18n import t
-from ..output import format_output, handle_api_errors
+from ..output import handle_api_errors
 from ._execute import execute_request
+from ._get import ids_adgroup_campaign_states_criteria, make_get_command
 from ._lifecycle import register_lifecycle_commands
 from ..utils import (
     MICRO_RUBLES,
-    build_common_params,
-    enforce_criteria_array_limits,
-    get_default_fields,
-    get_options,
     parse_condition_specs,
-    parse_csv_strings,
-    parse_csv_upper,
-    parse_ids,
 )
 
 # dynamicads.get (DynamicTextAdTargets) caps SelectionCriteria.CampaignIds at 2
@@ -34,69 +28,21 @@ def dynamicads():
     """Manage dynamic ad targets"""
 
 
-@dynamicads.command()
-@click.option("--ids", help="Comma-separated target IDs")
-@click.option("--adgroup-ids", help="Comma-separated ad group IDs")
-@click.option("--campaign-ids", help="Comma-separated campaign IDs")
-@click.option("--states", help="Comma-separated states")
-@get_options
-@click.pass_context
-@handle_api_errors
-def get(
-    ctx,
-    ids,
-    adgroup_ids,
-    campaign_ids,
-    states,
-    limit,
-    fetch_all,
-    output_format,
-    output,
-    fields,
-    dry_run,
-):
-    """Get dynamic ad targets"""
-    client = client_from_ctx(ctx, create_client)
-
-    field_names = parse_csv_strings(fields) or get_default_fields("dynamicads")
-
-    criteria = {}
-    if ids:
-        criteria["Ids"] = parse_ids(ids)
-    if adgroup_ids:
-        criteria["AdGroupIds"] = parse_ids(adgroup_ids)
-    if campaign_ids:
-        criteria["CampaignIds"] = parse_ids(campaign_ids)
-    if states:
-        criteria["States"] = parse_csv_upper(states) or []
-
-    enforce_criteria_array_limits(
-        criteria, DYNAMICADS_GET_CRITERIA_LIMITS, command_name="dynamicads get"
-    )
-
-    if not criteria:
-        raise click.UsageError(t("Provide at least one typed filter"))
-
-    params = build_common_params(
-        criteria=criteria, field_names=field_names, limit=limit
-    )
-
-    body = {"method": "get", "params": params}
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    result = client.dynamicads().post(data=body)
-
-    if fetch_all:
-        items = []
-        for item in result().iter_items():
-            items.append(item)
-        format_output(items, output_format, output)
-    else:
-        data = result().extract()
-        format_output(data, output_format, output)
+get = make_get_command(
+    dynamicads,
+    create_client,
+    default_fields_key="dynamicads",
+    help_text="Get dynamic ad targets",
+    ids_help="Comma-separated target IDs",
+    extra_options=(
+        click.option("--adgroup-ids", help="Comma-separated ad group IDs"),
+        click.option("--campaign-ids", help="Comma-separated campaign IDs"),
+        click.option("--states", help="Comma-separated states"),
+    ),
+    criteria_builder=ids_adgroup_campaign_states_criteria,
+    criteria_limits=DYNAMICADS_GET_CRITERIA_LIMITS,
+    require_criteria_message="Provide at least one typed filter",
+)
 
 
 @dynamicads.command()

--- a/direct_cli/commands/dynamicfeedadtargets.py
+++ b/direct_cli/commands/dynamicfeedadtargets.py
@@ -2,25 +2,17 @@
 DynamicFeedAdTargets commands
 """
 
-from typing import Any
-
 import click
 
-from ..api import client_from_ctx, create_client
+from ..api import create_client
 from ..i18n import t
-from ..output import format_output, handle_api_errors
+from ..output import handle_api_errors
 from ._execute import execute_request
+from ._get import ids_adgroup_campaign_states_criteria, make_get_command
 from ._lifecycle import register_lifecycle_commands
 from ..utils import (
     MICRO_RUBLES,
-    build_common_params,
-    enforce_criteria_array_limits,
-    get_default_fields,
-    get_options,
     parse_condition_specs,
-    parse_csv_strings,
-    parse_csv_upper,
-    parse_ids,
 )
 
 # Yandex Direct dynamicfeedadtargets.get caps SelectionCriteria arrays at
@@ -37,73 +29,21 @@ def dynamicfeedadtargets():
     """Manage dynamic feed ad targets"""
 
 
-@dynamicfeedadtargets.command()
-@click.option("--ids", help="Comma-separated target IDs")
-@click.option("--adgroup-ids", help="Comma-separated ad group IDs")
-@click.option("--campaign-ids", help="Comma-separated campaign IDs")
-@click.option("--states", help="Comma-separated states")
-@get_options
-@click.pass_context
-@handle_api_errors
-def get(
-    ctx,
-    ids,
-    adgroup_ids,
-    campaign_ids,
-    states,
-    limit,
-    fetch_all,
-    output_format,
-    output,
-    fields,
-    dry_run,
-):
-    """Get dynamic feed ad targets"""
-    client = client_from_ctx(ctx, create_client)
-
-    field_names = parse_csv_strings(fields) or get_default_fields(
-        "dynamicfeedadtargets"
-    )
-
-    criteria: dict[str, Any] = {}
-    if ids:
-        criteria["Ids"] = parse_ids(ids)
-    if adgroup_ids:
-        criteria["AdGroupIds"] = parse_ids(adgroup_ids)
-    if campaign_ids:
-        criteria["CampaignIds"] = parse_ids(campaign_ids)
-    if states:
-        criteria["States"] = parse_csv_upper(states) or []
-
-    enforce_criteria_array_limits(
-        criteria,
-        DYNAMICFEEDADTARGETS_GET_CRITERIA_LIMITS,
-        command_name="dynamicfeedadtargets get",
-    )
-
-    if not criteria:
-        raise click.UsageError(t("Provide at least one typed filter"))
-
-    params = build_common_params(
-        criteria=criteria, field_names=field_names, limit=limit
-    )
-
-    body = {"method": "get", "params": params}
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    result = client.dynamicfeedadtargets().post(data=body)
-
-    if fetch_all:
-        items = []
-        for item in result().iter_items():
-            items.append(item)
-        format_output(items, output_format, output)
-    else:
-        data = result().extract()
-        format_output(data, output_format, output)
+get = make_get_command(
+    dynamicfeedadtargets,
+    create_client,
+    default_fields_key="dynamicfeedadtargets",
+    help_text="Get dynamic feed ad targets",
+    ids_help="Comma-separated target IDs",
+    extra_options=(
+        click.option("--adgroup-ids", help="Comma-separated ad group IDs"),
+        click.option("--campaign-ids", help="Comma-separated campaign IDs"),
+        click.option("--states", help="Comma-separated states"),
+    ),
+    criteria_builder=ids_adgroup_campaign_states_criteria,
+    criteria_limits=DYNAMICFEEDADTARGETS_GET_CRITERIA_LIMITS,
+    require_criteria_message="Provide at least one typed filter",
+)
 
 
 @dynamicfeedadtargets.command()

--- a/direct_cli/commands/smartadtargets.py
+++ b/direct_cli/commands/smartadtargets.py
@@ -4,21 +4,15 @@ SmartAdTargets commands
 
 import click
 
-from ..api import client_from_ctx, create_client
+from ..api import create_client
 from ..i18n import t
-from ..output import format_output, handle_api_errors
+from ..output import handle_api_errors
 from ._execute import execute_request
+from ._get import ids_adgroup_campaign_states_criteria, make_get_command
 from ._lifecycle import register_lifecycle_commands
 from ..utils import (
     MICRO_RUBLES,
-    build_common_params,
-    enforce_criteria_array_limits,
-    get_default_fields,
-    get_options,
     parse_condition_specs,
-    parse_csv_strings,
-    parse_csv_upper,
-    parse_ids,
 )
 
 # smartadtargets.get caps SelectionCriteria.CampaignIds at 2 (the WSDL declares
@@ -33,69 +27,21 @@ def smartadtargets():
     """Manage smart ad targets"""
 
 
-@smartadtargets.command()
-@click.option("--ids", help="Comma-separated target IDs")
-@click.option("--adgroup-ids", help="Comma-separated ad group IDs")
-@click.option("--campaign-ids", help="Comma-separated campaign IDs")
-@click.option("--states", help="Comma-separated states")
-@get_options
-@click.pass_context
-@handle_api_errors
-def get(
-    ctx,
-    ids,
-    adgroup_ids,
-    campaign_ids,
-    states,
-    limit,
-    fetch_all,
-    output_format,
-    output,
-    fields,
-    dry_run,
-):
-    """Get smart ad targets"""
-    client = client_from_ctx(ctx, create_client)
-
-    field_names = parse_csv_strings(fields) or get_default_fields("smartadtargets")
-
-    criteria = {}
-    if ids:
-        criteria["Ids"] = parse_ids(ids)
-    if adgroup_ids:
-        criteria["AdGroupIds"] = parse_ids(adgroup_ids)
-    if campaign_ids:
-        criteria["CampaignIds"] = parse_ids(campaign_ids)
-    if states:
-        criteria["States"] = parse_csv_upper(states) or []
-
-    enforce_criteria_array_limits(
-        criteria, SMARTADTARGETS_GET_CRITERIA_LIMITS, command_name="smartadtargets get"
-    )
-
-    if not criteria:
-        raise click.UsageError(t("Provide at least one typed filter"))
-
-    params = build_common_params(
-        criteria=criteria, field_names=field_names, limit=limit
-    )
-
-    body = {"method": "get", "params": params}
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    result = client.smartadtargets().post(data=body)
-
-    if fetch_all:
-        items = []
-        for item in result().iter_items():
-            items.append(item)
-        format_output(items, output_format, output)
-    else:
-        data = result().extract()
-        format_output(data, output_format, output)
+get = make_get_command(
+    smartadtargets,
+    create_client,
+    default_fields_key="smartadtargets",
+    help_text="Get smart ad targets",
+    ids_help="Comma-separated target IDs",
+    extra_options=(
+        click.option("--adgroup-ids", help="Comma-separated ad group IDs"),
+        click.option("--campaign-ids", help="Comma-separated campaign IDs"),
+        click.option("--states", help="Comma-separated states"),
+    ),
+    criteria_builder=ids_adgroup_campaign_states_criteria,
+    criteria_limits=SMARTADTARGETS_GET_CRITERIA_LIMITS,
+    require_criteria_message="Provide at least one typed filter",
+)
 
 
 @smartadtargets.command()


### PR DESCRIPTION
## What

Migrate `dynamicads get`, `smartadtargets get` and `dynamicfeedadtargets get` — three byte-for-byte identical hand-rolled command bodies — onto the shared `make_get_command` factory (`direct_cli/commands/_get.py`), following the dedup epic #584 / factory introduced in #582.

Net **−131 lines** (91 added, 222 removed).

## Factory extension (two generic optional params)

- **`criteria_limits`** — `{SelectionCriteria key: max count}` dict, forwarded to the existing `enforce_criteria_array_limits` util. Command name for the error is derived as `f"{group.name} get"` (== the previous hardcoded `"dynamicads get"` etc.).
- **`require_criteria_message`** — i18n key; an empty `SelectionCriteria` raises `UsageError` with this message (the "provide at least one filter" guard).
- New shared `ids_adgroup_campaign_states_criteria` builder for the `Ids`/`AdGroupIds`/`CampaignIds`/`States` selection shape (composes on the existing `_default_ids_criteria`).

Both new params default to `None`, so the 5 existing factory callers (advideos/businesses/turbopages/vcards/negativekeywordsharedsets) are untouched.

## Byte-identity (hard invariant of #587)

Verified each command against pre-migration baselines — **all 15 snapshots identical**:
- `--help` (option order, i18n keys)
- `--dry-run` payload (typed-flags + states)
- over-limit error (`CampaignIds` cap)
- empty-criteria error
- per-module `create_client` patchability (via `resolve_module_create_client`)

## Tests

- Full offline suite green (2552 passed); `test_dry_run`, `test_api_coverage`, `test_comprehensive`, `test_read_cassettes` included.
- `ruff check` clean (dead imports from the removed `get` bodies dropped).

## Scope

**Part of #587** — Group 3 (criteria-limits commands). The remaining work follows in a separate PR:
- Group 2 (nested `*FieldNames`): adextensions, adimages, leads, retargeting, sitelinks, feeds, clients, agencyclients.
- No-`--ids` / nested-field hybrids: `bids`, `keywordbids`, `bidmodifiers` (need factory support for omitting the mandatory `--ids` and/or `nested_field_options`).
- `reports get` is intentionally excluded (custom TSV-stream endpoint, not a SOAP `get`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)