### PR TITLE
refactor: migrate nested-*FieldNames get to make_get_command (part of #587)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+**Internal — `make_get_command` covers the nested-`*FieldNames` `get`s (part of #587):**
+
+- `adimages get`, `retargeting get`, `sitelinks get`, `feeds get` and
+  `clients get` now register through the shared `make_get_command` factory
+  (net −175 lines). The factory gained three optional, generic parameters:
+  `nested_field_options` (a tuple of `(flag, WSDL key, help)` for nested
+  `*FieldNames` projections, parsed via the existing `parse_nested_field_names`
+  and rendered between `--fields` and `--dry-run`), `ids_criteria_key` (the
+  SelectionCriteria key for `--ids`; `clients` uses `ClientIds`), and
+  `fields_help` (a resource-specific `--fields` wording, e.g. sitelinks'
+  "Comma-separated SitelinksSet FieldNames"). The shared `get_options` decorator
+  (`utils.py`) gained matching `nested_options` / `fields_help` hooks, both
+  defaulting to current behavior so its other callers are unchanged.
+- No CLI surface change: `--help` (option order, the nested-field option
+  position, the custom `--fields` help), `--dry-run` payloads (including the
+  `ClientIds` key and nested-field params), and the provided-but-empty
+  `*FieldNames` `UsageError` are byte-identical (verified against
+  pre-migration baselines). Deferred to a follow-up: `adextensions` (emits an
+  empty `SelectionCriteria` + Page-before-nested key order), and `leads` /
+  `agencyclients` (no `--ids`; bespoke required criteria).
+
 **Internal — `make_get_command` covers the criteria-limit ad-target `get`s (part of #587):**
 
 - `dynamicads get`, `smartadtargets get` and `dynamicfeedadtargets get` — three

--- a/direct_cli/commands/_get.py
+++ b/direct_cli/commands/_get.py
@@ -98,6 +98,8 @@ def make_get_command(
         extra_options: extra ``click.option`` decorators for resource criteria,
             given in ``--help`` display order. They are applied between ``--ids``
             and the shared :func:`get_options` stack so the option order is kept.
+            Supply a matching *criteria_builder* to read them: the default
+            builder only maps ``--ids`` and discards every other option.
         criteria_builder: callable mapping the parsed options to a
             ``SelectionCriteria`` dict. It receives ``ids`` plus every extra
             option as keyword args; defaults to an optional ``Ids`` list.

--- a/direct_cli/commands/_get.py
+++ b/direct_cli/commands/_get.py
@@ -30,14 +30,19 @@ from ..utils import (
     parse_csv_strings,
     parse_csv_upper,
     parse_ids,
+    parse_nested_field_names,
 )
 
 
-def _default_ids_criteria(ids):
-    """Standard SelectionCriteria: an optional integer ``Ids`` list."""
+def _default_ids_criteria(ids, key="Ids"):
+    """Standard SelectionCriteria: an optional integer id list under *key*.
+
+    *key* is ``"Ids"`` for almost every resource; ``clients`` labels the same
+    ``--ids`` option ``ClientIds`` in its SelectionCriteria.
+    """
     criteria = {}
     if ids:
-        criteria["Ids"] = parse_ids(ids)
+        criteria[key] = parse_ids(ids)
     return criteria
 
 
@@ -73,6 +78,9 @@ def make_get_command(
     criteria_builder=None,
     criteria_limits=None,
     require_criteria_message=None,
+    nested_field_options=(),
+    ids_criteria_key="Ids",
+    fields_help="Comma-separated field names",
 ):
     """Build and register a v5 ``get`` command on *group*.
 
@@ -99,6 +107,17 @@ def make_get_command(
         require_criteria_message: optional i18n key; when set, an empty
             ``SelectionCriteria`` raises ``UsageError`` with this message
             (the "provide at least one filter" guard).
+        nested_field_options: tuple of ``(flag, WSDL key, help)`` for nested
+            ``*FieldNames`` projections (e.g. ``("--sitelink-field-names",
+            "SitelinkFieldNames", "…")``). Each renders a ``click.option``
+            between ``--fields`` and ``--dry-run`` and is parsed via
+            :func:`parse_nested_field_names` (which rejects a provided-but-empty
+            CSV), then merged into the request params after the common params.
+        ids_criteria_key: SelectionCriteria key for the default ``--ids``
+            builder (``"Ids"`` by default; ``clients`` uses ``"ClientIds"``).
+            Ignored when a custom *criteria_builder* is given.
+        fields_help: help text for the ``--fields`` option (a few resources use
+            a resource-specific wording instead of the shared default).
 
     Returns:
         The registered Click command.
@@ -109,7 +128,15 @@ def make_get_command(
     # resource module.
     svc = group.name
     module_name = group.callback.__module__
-    build_criteria = criteria_builder or (lambda ids, **_: _default_ids_criteria(ids))
+    build_criteria = criteria_builder or (
+        lambda ids, **_: _default_ids_criteria(ids, ids_criteria_key)
+    )
+    # (WSDL key, callback kwarg) for each nested *FieldNames option; Click maps
+    # ``--sitelink-field-names`` to the ``sitelink_field_names`` kwarg.
+    nested_specs = tuple(
+        (wsdl_key, flag[2:].replace("-", "_"))
+        for flag, wsdl_key, _help in nested_field_options
+    )
 
     @click.pass_context
     @handle_api_errors
@@ -129,6 +156,11 @@ def make_get_command(
         params = build_common_params(
             criteria=criteria, field_names=field_names, limit=limit
         )
+        if nested_specs:
+            raw_nested = tuple(
+                (wsdl_key, kwargs[kwarg]) for wsdl_key, kwarg in nested_specs
+            )
+            params.update(parse_nested_field_names(raw_nested))
         body = {"method": "get", "params": params}
 
         if dry_run:
@@ -153,8 +185,14 @@ def make_get_command(
             format_output(result().extract(), output_format, output)
 
     # Apply the option decorators in the original stack order so ``--help`` lists
-    # ``--ids``, then any resource options, then the six ``get_options`` entries.
-    get = get_options(get)
+    # ``--ids``, then any resource options, then the ``get_options`` entries (with
+    # any nested ``*FieldNames`` options rendered between ``--fields`` and
+    # ``--dry-run``).
+    nested_click_options = tuple(
+        click.option(flag, help=help_text)
+        for flag, _wsdl_key, help_text in nested_field_options
+    )
+    get = get_options(get, nested_options=nested_click_options, fields_help=fields_help)
     for option in reversed(extra_options):
         get = option(get)
     get = click.option("--ids", required=ids_required, help=ids_help)(get)

--- a/direct_cli/commands/adimages.py
+++ b/direct_cli/commands/adimages.py
@@ -4,18 +4,15 @@ AdImages commands
 
 import click
 
-from ..api import client_from_ctx, create_client
+from ..api import create_client
 from ..i18n import t
-from ..output import format_output, handle_api_errors
+from ..output import handle_api_errors
 from ._execute import execute_request
+from ._get import make_get_command
 from ._lifecycle import make_lifecycle_command
 from ..utils import (
     add_criteria_csv,
-    build_common_params,
-    get_default_fields,
-    get_options,
     load_base64_file,
-    parse_csv_strings,
     parse_ids,
 )
 
@@ -25,57 +22,32 @@ def adimages():
     """Manage ad images"""
 
 
-@adimages.command()
-@click.option("--ids", help="Comma-separated image IDs")
-@click.option("--image-hashes", help="Comma-separated ad image hashes")
-@click.option("--associated", type=click.Choice(["YES", "NO"], case_sensitive=False))
-@get_options
-@click.pass_context
-@handle_api_errors
-def get(
-    ctx,
-    ids,
-    image_hashes,
-    associated,
-    limit,
-    fetch_all,
-    output_format,
-    output,
-    fields,
-    dry_run,
-):
-    """Get ad images"""
-    client = client_from_ctx(ctx, create_client)
-
-    field_names = parse_csv_strings(fields) or get_default_fields("adimages")
-
+def _adimages_criteria(ids, image_hashes=None, associated=None, **_):
+    """SelectionCriteria for ``adimages get``: ``Ids`` + ``AdImageHashes`` +
+    ``Associated``."""
     criteria = {}
     if ids:
         criteria["Ids"] = parse_ids(ids)
     add_criteria_csv(criteria, "AdImageHashes", image_hashes)
     if associated:
         criteria["Associated"] = associated.upper()
+    return criteria
 
-    params = build_common_params(
-        criteria=criteria, field_names=field_names, limit=limit
-    )
 
-    body = {"method": "get", "params": params}
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    result = client.adimages().post(data=body)
-
-    if fetch_all:
-        items = []
-        for item in result().iter_items():
-            items.append(item)
-        format_output(items, output_format, output)
-    else:
-        data = result().extract()
-        format_output(data, output_format, output)
+get = make_get_command(
+    adimages,
+    create_client,
+    default_fields_key="adimages",
+    help_text="Get ad images",
+    ids_help="Comma-separated image IDs",
+    extra_options=(
+        click.option("--image-hashes", help="Comma-separated ad image hashes"),
+        click.option(
+            "--associated", type=click.Choice(["YES", "NO"], case_sensitive=False)
+        ),
+    ),
+    criteria_builder=_adimages_criteria,
+)
 
 
 @adimages.command()

--- a/direct_cli/commands/clients.py
+++ b/direct_cli/commands/clients.py
@@ -4,13 +4,13 @@ Clients commands
 
 import click
 
-from ..api import client_from_ctx, create_client
+from ..api import create_client
 from ._execute import execute_request
+from ._get import make_get_command
 from ..i18n import t
-from ..output import format_output, handle_api_errors
+from ..output import handle_api_errors
 from ..utils import (
     build_client_update_item,
-    build_common_params,
     build_erir_attributes,
     build_erir_contragent,
     build_erir_contract,
@@ -19,12 +19,8 @@ from ..utils import (
     CONTRACT_ACTION_TYPES,
     CONTRACT_SUBJECT_TYPES,
     CONTRACT_TYPES,
-    get_default_fields,
     parse_client_setting_specs,
-    parse_csv_strings,
     parse_email_subscription_specs,
-    parse_ids,
-    parse_nested_field_names,
     parse_positive_decimal_amount,
     parse_tin_info,
 )
@@ -35,113 +31,64 @@ def clients():
     """Manage clients"""
 
 
-@clients.command()
-@click.option("--ids", help="Comma-separated client IDs")
-@click.option("--limit", type=int, help="Limit number of results")
-@click.option("--fetch-all", is_flag=True, help="Fetch all pages")
-@click.option("--format", "output_format", default="json", help="Output format")
-@click.option("--output", help="Output file")
-@click.option("--fields", help="Comma-separated field names")
-@click.option(
-    "--contract-field-names",
-    help=(
-        "Comma-separated ContractFieldNames "
-        "(e.g. Number,Date,Price,Type,ActionType). "
-        "Sent as separate top-level request parameter per the "
-        "ClientsGetRequest WSDL."
+get = make_get_command(
+    clients,
+    create_client,
+    default_fields_key="clients",
+    help_text="Get clients",
+    ids_help="Comma-separated client IDs",
+    ids_criteria_key="ClientIds",
+    nested_field_options=(
+        (
+            "--contract-field-names",
+            "ContractFieldNames",
+            (
+                "Comma-separated ContractFieldNames "
+                "(e.g. Number,Date,Price,Type,ActionType). "
+                "Sent as separate top-level request parameter per the "
+                "ClientsGetRequest WSDL."
+            ),
+        ),
+        (
+            "--contragent-field-names",
+            "ContragentFieldNames",
+            (
+                "Comma-separated ContragentFieldNames "
+                "(e.g. Name,Phone,EpayNumber,RegNumber). "
+                "Sent as separate top-level request parameter per the "
+                "ClientsGetRequest WSDL."
+            ),
+        ),
+        (
+            "--contragent-tin-info-field-names",
+            "ContragentTinInfoFieldNames",
+            (
+                "Comma-separated ContragentTinInfoFieldNames (e.g. TinType,Tin). "
+                "Sent as separate top-level request parameter per the "
+                "ClientsGetRequest WSDL."
+            ),
+        ),
+        (
+            "--organization-field-names",
+            "OrganizationFieldNames",
+            (
+                "Comma-separated OrganizationFieldNames "
+                "(e.g. Name,EpayNumber,RegNumber,OkvedCode). "
+                "Sent as separate top-level request parameter per the "
+                "ClientsGetRequest WSDL."
+            ),
+        ),
+        (
+            "--tin-info-field-names",
+            "TinInfoFieldNames",
+            (
+                "Comma-separated TinInfoFieldNames (e.g. TinType,Tin). "
+                "Sent as separate top-level request parameter per the "
+                "ClientsGetRequest WSDL."
+            ),
+        ),
     ),
 )
-@click.option(
-    "--contragent-field-names",
-    help=(
-        "Comma-separated ContragentFieldNames "
-        "(e.g. Name,Phone,EpayNumber,RegNumber). "
-        "Sent as separate top-level request parameter per the "
-        "ClientsGetRequest WSDL."
-    ),
-)
-@click.option(
-    "--contragent-tin-info-field-names",
-    help=(
-        "Comma-separated ContragentTinInfoFieldNames (e.g. TinType,Tin). "
-        "Sent as separate top-level request parameter per the "
-        "ClientsGetRequest WSDL."
-    ),
-)
-@click.option(
-    "--organization-field-names",
-    help=(
-        "Comma-separated OrganizationFieldNames "
-        "(e.g. Name,EpayNumber,RegNumber,OkvedCode). "
-        "Sent as separate top-level request parameter per the "
-        "ClientsGetRequest WSDL."
-    ),
-)
-@click.option(
-    "--tin-info-field-names",
-    help=(
-        "Comma-separated TinInfoFieldNames (e.g. TinType,Tin). "
-        "Sent as separate top-level request parameter per the "
-        "ClientsGetRequest WSDL."
-    ),
-)
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def get(
-    ctx,
-    ids,
-    limit,
-    fetch_all,
-    output_format,
-    output,
-    fields,
-    contract_field_names,
-    contragent_field_names,
-    contragent_tin_info_field_names,
-    organization_field_names,
-    tin_info_field_names,
-    dry_run,
-):
-    """Get clients"""
-    client = client_from_ctx(ctx, create_client)
-
-    field_names = parse_csv_strings(fields) or get_default_fields("clients")
-
-    raw_nested = (
-        ("ContractFieldNames", contract_field_names),
-        ("ContragentFieldNames", contragent_field_names),
-        ("ContragentTinInfoFieldNames", contragent_tin_info_field_names),
-        ("OrganizationFieldNames", organization_field_names),
-        ("TinInfoFieldNames", tin_info_field_names),
-    )
-    parsed_nested = parse_nested_field_names(raw_nested)
-
-    criteria = {}
-    if ids:
-        criteria["ClientIds"] = parse_ids(ids)
-
-    params = build_common_params(
-        criteria=criteria, field_names=field_names, limit=limit
-    )
-    params.update(parsed_nested)
-
-    body = {"method": "get", "params": params}
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    result = client.clients().post(data=body)
-
-    if fetch_all:
-        items = []
-        for item in result().iter_items():
-            items.append(item)
-        format_output(items, output_format, output)
-    else:
-        data = result().extract()
-        format_output(data, output_format, output)
 
 
 @clients.command()

--- a/direct_cli/commands/feeds.py
+++ b/direct_cli/commands/feeds.py
@@ -8,17 +8,12 @@ from typing import Dict, Optional
 
 import click
 
-from ..api import client_from_ctx, create_client
+from ..api import create_client
 from ..i18n import t
-from ..output import format_output, handle_api_errors
+from ..output import handle_api_errors
 from ._execute import execute_request
+from ._get import make_get_command
 from ._lifecycle import make_lifecycle_command
-from ..utils import (
-    build_common_params,
-    get_default_fields,
-    parse_csv_strings,
-    parse_ids,
-)
 
 _YES_NO = ["YES", "NO"]
 # Yandex Direct docs cap FileFeed.Data by total request size. This
@@ -122,89 +117,33 @@ def feeds():
     """Manage feeds"""
 
 
-@feeds.command()
-@click.option("--ids", help="Comma-separated feed IDs")
-@click.option("--limit", type=int, help="Limit number of results")
-@click.option("--fetch-all", is_flag=True, help="Fetch all pages")
-@click.option("--format", "output_format", default="json", help="Output format")
-@click.option("--output", help="Output file")
-@click.option("--fields", help="Comma-separated field names")
-@click.option(
-    "--file-feed-field-names",
-    help=(
-        "Comma-separated FileFeedFieldNames (e.g. Filename). "
-        "Sent as separate top-level request parameter per the "
-        "FeedsGetRequest WSDL."
+get = make_get_command(
+    feeds,
+    create_client,
+    default_fields_key="feeds",
+    help_text="Get feeds",
+    ids_help="Comma-separated feed IDs",
+    nested_field_options=(
+        (
+            "--file-feed-field-names",
+            "FileFeedFieldNames",
+            (
+                "Comma-separated FileFeedFieldNames (e.g. Filename). "
+                "Sent as separate top-level request parameter per the "
+                "FeedsGetRequest WSDL."
+            ),
+        ),
+        (
+            "--url-feed-field-names",
+            "UrlFeedFieldNames",
+            (
+                "Comma-separated UrlFeedFieldNames (e.g. Login,Url,RemoveUtmTags). "
+                "Sent as separate top-level request parameter per the "
+                "FeedsGetRequest WSDL."
+            ),
+        ),
     ),
 )
-@click.option(
-    "--url-feed-field-names",
-    help=(
-        "Comma-separated UrlFeedFieldNames (e.g. Login,Url,RemoveUtmTags). "
-        "Sent as separate top-level request parameter per the "
-        "FeedsGetRequest WSDL."
-    ),
-)
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def get(
-    ctx,
-    ids,
-    limit,
-    fetch_all,
-    output_format,
-    output,
-    fields,
-    file_feed_field_names,
-    url_feed_field_names,
-    dry_run,
-):
-    """Get feeds"""
-    client = client_from_ctx(ctx, create_client)
-
-    field_names = parse_csv_strings(fields) or get_default_fields("feeds")
-
-    parsed_file_feed_field_names = parse_csv_strings(file_feed_field_names)
-    if file_feed_field_names is not None and not parsed_file_feed_field_names:
-        raise click.UsageError(
-            t("Provide a non-empty comma-separated FileFeedFieldNames list.")
-        )
-
-    parsed_url_feed_field_names = parse_csv_strings(url_feed_field_names)
-    if url_feed_field_names is not None and not parsed_url_feed_field_names:
-        raise click.UsageError(
-            t("Provide a non-empty comma-separated UrlFeedFieldNames list.")
-        )
-
-    criteria = {}
-    if ids:
-        criteria["Ids"] = parse_ids(ids)
-
-    params = build_common_params(
-        criteria=criteria, field_names=field_names, limit=limit
-    )
-    if parsed_file_feed_field_names:
-        params["FileFeedFieldNames"] = parsed_file_feed_field_names
-    if parsed_url_feed_field_names:
-        params["UrlFeedFieldNames"] = parsed_url_feed_field_names
-
-    body = {"method": "get", "params": params}
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    result = client.feeds().post(data=body)
-
-    if fetch_all:
-        items = []
-        for item in result().iter_items():
-            items.append(item)
-        format_output(items, output_format, output)
-    else:
-        data = result().extract()
-        format_output(data, output_format, output)
 
 
 @feeds.command()

--- a/direct_cli/commands/retargeting.py
+++ b/direct_cli/commands/retargeting.py
@@ -6,17 +6,14 @@ from typing import Optional
 
 import click
 
-from ..api import client_from_ctx, create_client
+from ..api import create_client
 from ..i18n import t
-from ..output import format_output, handle_api_errors
+from ..output import handle_api_errors
 from ._execute import execute_request
+from ._get import make_get_command
 from ._lifecycle import make_lifecycle_command
 from ..utils import (
     add_criteria_csv,
-    build_common_params,
-    get_default_fields,
-    get_options,
-    parse_csv_strings,
     parse_ids,
     parse_retargeting_rule_specs,
 )
@@ -27,53 +24,24 @@ def retargeting():
     """Manage retargeting lists"""
 
 
-@retargeting.command()
-@click.option("--ids", help="Comma-separated list IDs")
-@click.option("--types", help="Filter by types")
-@get_options
-@click.pass_context
-@handle_api_errors
-def get(
-    ctx,
-    ids,
-    types,
-    limit,
-    fetch_all,
-    output_format,
-    output,
-    fields,
-    dry_run,
-):
-    """Get retargeting lists"""
-    client = client_from_ctx(ctx, create_client)
-
-    field_names = parse_csv_strings(fields) or get_default_fields("retargetinglists")
-
+def _retargeting_criteria(ids, types=None, **_):
+    """SelectionCriteria for ``retargeting get``: optional ``Ids`` + ``Types``."""
     criteria = {}
     if ids:
         criteria["Ids"] = parse_ids(ids)
     add_criteria_csv(criteria, "Types", types, upper=True)
+    return criteria
 
-    params = build_common_params(
-        criteria=criteria, field_names=field_names, limit=limit
-    )
 
-    body = {"method": "get", "params": params}
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    result = client.retargeting().post(data=body)
-
-    if fetch_all:
-        items = []
-        for item in result().iter_items():
-            items.append(item)
-        format_output(items, output_format, output)
-    else:
-        data = result().extract()
-        format_output(data, output_format, output)
+get = make_get_command(
+    retargeting,
+    create_client,
+    default_fields_key="retargetinglists",
+    help_text="Get retargeting lists",
+    ids_help="Comma-separated list IDs",
+    extra_options=(click.option("--types", help="Filter by types"),),
+    criteria_builder=_retargeting_criteria,
+)
 
 
 _RETARGETING_LIST_TYPES = ["RETARGETING", "AUDIENCE"]

--- a/direct_cli/commands/sitelinks.py
+++ b/direct_cli/commands/sitelinks.py
@@ -8,16 +8,13 @@ from typing import Any, Dict, List
 
 import click
 
-from ..api import client_from_ctx, create_client
+from ..api import create_client
 from ..i18n import t
-from ..output import format_output, handle_api_errors
+from ..output import handle_api_errors
 from ._execute import execute_request
+from ._get import make_get_command
 from ._lifecycle import make_lifecycle_command
 from ..utils import (
-    build_common_params,
-    get_default_fields,
-    parse_csv_strings,
-    parse_ids,
     parse_sitelink_specs,
 )
 
@@ -127,72 +124,26 @@ def sitelinks():
     """Manage sitelinks"""
 
 
-@sitelinks.command()
-@click.option("--ids", help="Comma-separated sitelink IDs")
-@click.option("--limit", type=int, help="Limit number of results")
-@click.option("--fetch-all", is_flag=True, help="Fetch all pages")
-@click.option("--format", "output_format", default="json", help="Output format")
-@click.option("--output", help="Output file")
-@click.option("--fields", help="Comma-separated SitelinksSet FieldNames")
-@click.option(
-    "--sitelink-field-names",
-    help=(
-        "Comma-separated SitelinkFieldNames controlling nested "
-        "Sitelinks[] item field selection (e.g. Title,Href,Description,"
-        "TurboPageId). Sent as a separate top-level request parameter "
-        "alongside FieldNames per the SitelinksGetRequest WSDL."
+get = make_get_command(
+    sitelinks,
+    create_client,
+    default_fields_key="sitelinks",
+    help_text="Get sitelinks",
+    ids_help="Comma-separated sitelink IDs",
+    fields_help="Comma-separated SitelinksSet FieldNames",
+    nested_field_options=(
+        (
+            "--sitelink-field-names",
+            "SitelinkFieldNames",
+            (
+                "Comma-separated SitelinkFieldNames controlling nested "
+                "Sitelinks[] item field selection (e.g. Title,Href,Description,"
+                "TurboPageId). Sent as a separate top-level request parameter "
+                "alongside FieldNames per the SitelinksGetRequest WSDL."
+            ),
+        ),
     ),
 )
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def get(
-    ctx,
-    ids,
-    limit,
-    fetch_all,
-    output_format,
-    output,
-    fields,
-    sitelink_field_names,
-    dry_run,
-):
-    """Get sitelinks"""
-    client = client_from_ctx(ctx, create_client)
-
-    field_names = parse_csv_strings(fields) or get_default_fields("sitelinks")
-    parsed_sitelink_field_names = parse_csv_strings(sitelink_field_names)
-    if sitelink_field_names is not None and not parsed_sitelink_field_names:
-        raise click.UsageError(
-            t("Provide a non-empty comma-separated SitelinkFieldNames list.")
-        )
-
-    criteria = {}
-    if ids:
-        criteria["Ids"] = parse_ids(ids)
-
-    params = build_common_params(
-        criteria=criteria, field_names=field_names, limit=limit
-    )
-    if parsed_sitelink_field_names:
-        params["SitelinkFieldNames"] = parsed_sitelink_field_names
-
-    body = {"method": "get", "params": params}
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    result = client.sitelinks().post(data=body)
-
-    if fetch_all:
-        items = []
-        for item in result().iter_items():
-            items.append(item)
-        format_output(items, output_format, output)
-    else:
-        data = result().extract()
-        format_output(data, output_format, output)
 
 
 @sitelinks.command()

--- a/direct_cli/utils.py
+++ b/direct_cli/utils.py
@@ -1019,7 +1019,7 @@ def get_docs_pages(service: str) -> Dict[str, str]:
     return dict(docs_pages) if docs_pages else {}
 
 
-def get_options(func):
+def get_options(func, *, nested_options=(), fields_help="Comma-separated field names"):
     """Apply the shared read/pagination option stack of a ``get`` command.
 
     Equivalent to writing, in this exact top-to-bottom order::
@@ -1029,19 +1029,29 @@ def get_options(func):
         @click.option("--format", "output_format", default="json", help="Output format")
         @click.option("--output", help="Output file")
         @click.option("--fields", help="Comma-separated field names")
+        # <nested_options here, in given order>
         @click.option("--dry-run", is_flag=True, help="Show request without sending")
 
     Click applies decorators bottom-up, so the options are added here in
-    reverse to keep ``--help`` listing them in the order above. Only commands
-    whose six shared options are contiguous and use exactly these definitions
-    use this decorator; commands with a divergent ``--fields`` help string,
-    interleaved resource options, or a different option subset keep their
-    explicit stack so the CLI surface stays byte-identical.
+    reverse to keep ``--help`` listing them in the order above. Commands whose
+    six shared options are contiguous and use exactly these definitions use this
+    decorator directly; ``make_get_command`` calls it with two keyword hooks so
+    a command with a divergent ``--fields`` help string (``fields_help``) or
+    nested ``*FieldNames`` options interleaved between ``--fields`` and
+    ``--dry-run`` (``nested_options``) still produces a byte-identical surface:
+
+    - ``fields_help``: the ``--fields`` help text (default ``"Comma-separated
+      field names"``).
+    - ``nested_options``: extra ``click.option`` decorators rendered after
+      ``--fields`` and before ``--dry-run`` (the position sitelinks/feeds/clients
+      put their ``*FieldNames`` options).
     """
     func = click.option("--dry-run", is_flag=True, help="Show request without sending")(
         func
     )
-    func = click.option("--fields", help="Comma-separated field names")(func)
+    for option in reversed(nested_options):
+        func = option(func)
+    func = click.option("--fields", help=fields_help)(func)
     func = click.option("--output", help="Output file")(func)
     func = click.option(
         "--format", "output_format", default="json", help="Output format"


### PR DESCRIPTION
## What

Migrate `adimages get`, `retargeting get`, `sitelinks get`, `feeds get` and `clients get` onto the shared `make_get_command` factory (dedup epic #584). Follows PR #597 (Group 3 / criteria-limits).

Net **−175 lines** (205 added, 380 removed).

## Factory extension (three generic optional params)

- **`nested_field_options`** — tuple of `(flag, WSDL key, help)` for nested `*FieldNames` projections (e.g. `("--sitelink-field-names", "SitelinkFieldNames", "…")`). Each renders a `click.option` **between `--fields` and `--dry-run`** (the position these commands use) and is parsed via the existing `parse_nested_field_names`, which rejects a provided-but-empty CSV with the same `UsageError` the inline code raised. Merged into the request params after the common params.
- **`ids_criteria_key`** (default `"Ids"`) — SelectionCriteria key for the default `--ids` builder; `clients` maps `--ids` to `ClientIds`.
- **`fields_help`** (default `"Comma-separated field names"`) — resource-specific `--fields` wording; `sitelinks` uses `"Comma-separated SitelinksSet FieldNames"`.

The shared `get_options` decorator (`utils.py`) gains matching `nested_options` / `fields_help` hooks, both defaulting to current behavior so its ~15 other `@get_options` callers are byte-identical.

`adimages` / `retargeting` (no nested fields, extra criteria) migrate with a small per-module `criteria_builder`; `sitelinks` / `feeds` / `clients` use the default builder plus `nested_field_options` (+ `ids_criteria_key` / `fields_help` where they diverge).

## Byte-identity (hard invariant of #587)

Verified each command against pre-migration baselines — **all 21 snapshots identical**: `--help` (option order, the nested-field option position, the custom `--fields` help), `--dry-run` payloads (incl. the `ClientIds` key and 1/2/5 nested-field params), the provided-but-empty `*FieldNames` `UsageError`, and the empty/limit cases.

## Tests

- Full offline suite green (2552 passed); `test_dry_run`, `test_api_coverage`, `test_comprehensive`, `test_read_cassettes` included.
- `ruff check` clean (dead imports from the removed `get` bodies dropped).

## Scope / carve-outs (deferred follow-up)

- `adextensions` — its inline params always emit an empty `SelectionCriteria` and order `*FieldNames` before `Page`; reproducing those exact wire bytes needs a quirk flag, so it's intentionally left for later rather than bandaided.
- `leads` / `agencyclients` — no `--ids` (bespoke required `--turbo-page-ids` / `--logins`+`--archived`); they'd need a future `include_ids=False` factory option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)