### PR TITLE
refactor: migrate agencyclients/adextensions get to make_get_command (part of #587)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+**Internal — `make_get_command` covers the no-`--ids` / wire-quirk `get`s (part of #587):**
+
+- `agencyclients get` (no `--ids`; filters by `--logins` / `--archived`) and
+  `adextensions get` now register through the shared `make_get_command` factory.
+  The factory gained two more optional parameters: `include_ids` (set `False`
+  for resources with no id filter — the command supplies a custom
+  `criteria_builder` from its own options) and `adextensions_wire_layout` (a
+  single-command flag that reproduces adextensions' exact recorded wire layout:
+  always emit `SelectionCriteria` even when empty, and order nested
+  `*FieldNames` before `Page`). The empty `SelectionCriteria` is a recorded API
+  contract — the `adextensions_get` read cassette replays it and the API accepts
+  it, unlike adgroups/ads/keywords.
+- No CLI surface change: `--help`, `--dry-run` payloads (incl. the empty-criteria
+  and nested-before-`Page` cases) and the read cassettes are byte-identical
+  (verified against pre-migration baselines). Remaining carve-out: `leads get`,
+  whose `--datetime-from` / `--datetime-to` options sit between `--limit` and
+  `--fetch-all` — a bespoke option order that doesn't fit the shared
+  `get_options` stack, so it stays hand-rolled.
+
 **Internal — `make_get_command` covers the nested-`*FieldNames` `get`s (part of #587):**
 
 - `adimages get`, `retargeting get`, `sitelinks get`, `feeds get` and

--- a/direct_cli/commands/_get.py
+++ b/direct_cli/commands/_get.py
@@ -81,6 +81,8 @@ def make_get_command(
     nested_field_options=(),
     ids_criteria_key="Ids",
     fields_help="Comma-separated field names",
+    include_ids=True,
+    adextensions_wire_layout=False,
 ):
     """Build and register a v5 ``get`` command on *group*.
 
@@ -120,6 +122,20 @@ def make_get_command(
             Ignored when a custom *criteria_builder* is given.
         fields_help: help text for the ``--fields`` option (a few resources use
             a resource-specific wording instead of the shared default).
+        include_ids: whether to render the ``--ids`` option (``True`` by
+            default). Set ``False`` for resources with no id filter
+            (``agencyclients`` filters by ``--logins`` / ``--archived``); the
+            command then needs a custom *criteria_builder* built from
+            *extra_options* only.
+        adextensions_wire_layout: reproduce ``adextensions``'s exact wire
+            layout — always emit ``SelectionCriteria`` (even empty) and order
+            nested ``*FieldNames`` before ``Page`` (the default builds params via
+            :func:`build_common_params`, which omits an empty criteria and puts
+            ``Page`` before the nested fields). This is a recorded API contract,
+            not a tidy-up target: the ``adextensions_get`` read cassette replays
+            ``"SelectionCriteria":{}`` and adextensions is deliberately excluded
+            from ``test_dry_run._SELECTION_CRITERIA_REQUIRED_GET_COMMANDS`` (the
+            live API accepts an empty criteria here, unlike adgroups/ads/keywords).
 
     Returns:
         The registered Click command.
@@ -143,7 +159,15 @@ def make_get_command(
     @click.pass_context
     @handle_api_errors
     def get(
-        ctx, ids, limit, fetch_all, output_format, output, fields, dry_run, **kwargs
+        ctx,
+        limit,
+        fetch_all,
+        output_format,
+        output,
+        fields,
+        dry_run,
+        ids=None,
+        **kwargs,
     ):
         field_names = parse_csv_strings(fields) or get_default_fields(
             default_fields_key
@@ -155,14 +179,23 @@ def make_get_command(
             )
         if require_criteria_message and not criteria:
             raise click.UsageError(t(require_criteria_message))
-        params = build_common_params(
-            criteria=criteria, field_names=field_names, limit=limit
-        )
+        if adextensions_wire_layout:
+            # Emit SelectionCriteria even when empty (a recorded API contract;
+            # see the param docstring) and hold Page until after the nested
+            # fields below.
+            params = {"SelectionCriteria": criteria, "FieldNames": field_names}
+        else:
+            params = build_common_params(
+                criteria=criteria, field_names=field_names, limit=limit
+            )
         if nested_specs:
             raw_nested = tuple(
                 (wsdl_key, kwargs[kwarg]) for wsdl_key, kwarg in nested_specs
             )
             params.update(parse_nested_field_names(raw_nested))
+        if adextensions_wire_layout and limit:
+            # Page after the nested *FieldNames, matching adextensions' layout.
+            params["Page"] = {"Limit": limit}
         body = {"method": "get", "params": params}
 
         if dry_run:
@@ -197,5 +230,6 @@ def make_get_command(
     get = get_options(get, nested_options=nested_click_options, fields_help=fields_help)
     for option in reversed(extra_options):
         get = option(get)
-    get = click.option("--ids", required=ids_required, help=ids_help)(get)
+    if include_ids:
+        get = click.option("--ids", required=ids_required, help=ids_help)(get)
     return group.command(name="get", help=help_text)(get)

--- a/direct_cli/commands/adextensions.py
+++ b/direct_cli/commands/adextensions.py
@@ -4,12 +4,12 @@ AdExtensions commands
 
 import click
 
-from ..api import client_from_ctx, create_client
-from ..i18n import t
-from ..output import format_output, handle_api_errors
+from ..api import create_client
+from ..output import handle_api_errors
 from ._execute import execute_request
+from ._get import make_get_command
 from ._lifecycle import make_lifecycle_command
-from ..utils import add_criteria_csv, get_default_fields, parse_csv_strings, parse_ids
+from ..utils import add_criteria_csv, parse_ids
 
 
 @click.group()
@@ -17,49 +17,11 @@ def adextensions():
     """Manage ad extensions"""
 
 
-@adextensions.command()
-@click.option("--ids", help="Comma-separated extension IDs")
-@click.option("--types", help="Filter by types")
-@click.option("--states", help="Comma-separated states")
-@click.option("--statuses", help="Comma-separated statuses")
-@click.option("--modified-since", help="ModifiedSince datetime")
-@click.option("--limit", type=int, help="Limit number of results")
-@click.option("--fetch-all", is_flag=True, help="Fetch all pages")
-@click.option("--format", "output_format", default="json", help="Output format")
-@click.option("--output", help="Output file")
-@click.option("--fields", help="Comma-separated field names")
-@click.option(
-    "--callout-field-names",
-    help="Comma-separated CalloutFieldNames (e.g. CalloutText)",
-)
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def get(
-    ctx,
-    ids,
-    types,
-    states,
-    statuses,
-    modified_since,
-    limit,
-    fetch_all,
-    output_format,
-    output,
-    fields,
-    callout_field_names,
-    dry_run,
+def _adextensions_criteria(
+    ids, types=None, states=None, statuses=None, modified_since=None, **_
 ):
-    """Get ad extensions"""
-    client = client_from_ctx(ctx, create_client)
-
-    field_names = parse_csv_strings(fields) or get_default_fields("adextensions")
-    parsed_callout_field_names = parse_csv_strings(callout_field_names)
-    if callout_field_names is not None and not parsed_callout_field_names:
-        raise click.UsageError(
-            t("Provide a non-empty comma-separated CalloutFieldNames list.")
-        )
-
+    """SelectionCriteria for ``adextensions get``: ``Ids`` + upper-cased
+    ``Types``/``States``/``Statuses`` + a ``ModifiedSince`` scalar."""
     criteria = {}
     if ids:
         criteria["Ids"] = parse_ids(ids)
@@ -68,30 +30,31 @@ def get(
     add_criteria_csv(criteria, "Statuses", statuses, upper=True)
     if modified_since:
         criteria["ModifiedSince"] = modified_since
+    return criteria
 
-    params = {"SelectionCriteria": criteria, "FieldNames": field_names}
-    if parsed_callout_field_names:
-        params["CalloutFieldNames"] = parsed_callout_field_names
 
-    if limit:
-        params["Page"] = {"Limit": limit}
-
-    body = {"method": "get", "params": params}
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    result = client.adextensions().post(data=body)
-
-    if fetch_all:
-        items = []
-        for item in result().iter_items():
-            items.append(item)
-        format_output(items, output_format, output)
-    else:
-        data = result().extract()
-        format_output(data, output_format, output)
+get = make_get_command(
+    adextensions,
+    create_client,
+    default_fields_key="adextensions",
+    help_text="Get ad extensions",
+    ids_help="Comma-separated extension IDs",
+    adextensions_wire_layout=True,
+    extra_options=(
+        click.option("--types", help="Filter by types"),
+        click.option("--states", help="Comma-separated states"),
+        click.option("--statuses", help="Comma-separated statuses"),
+        click.option("--modified-since", help="ModifiedSince datetime"),
+    ),
+    criteria_builder=_adextensions_criteria,
+    nested_field_options=(
+        (
+            "--callout-field-names",
+            "CalloutFieldNames",
+            "Comma-separated CalloutFieldNames (e.g. CalloutText)",
+        ),
+    ),
+)
 
 
 @adextensions.command()

--- a/direct_cli/commands/agencyclients.py
+++ b/direct_cli/commands/agencyclients.py
@@ -4,21 +4,19 @@ AgencyClients commands
 
 import click
 
-from ..api import client_from_ctx, create_client
+from ..api import create_client
 from ._execute import execute_request
+from ._get import make_get_command
 from ..i18n import t
-from ..output import format_output, handle_api_errors, print_error
+from ..output import handle_api_errors, print_error
 from ..utils import (
     assert_not_runtime_deprecated,
     build_client_update_item,
-    build_common_params,
     build_notification_update,
-    get_default_fields,
     parse_client_setting_specs,
     parse_csv_strings,
     parse_email_subscription_specs,
     parse_grant_specs,
-    parse_nested_field_names,
     parse_tin_info,
 )
 
@@ -61,121 +59,83 @@ def agencyclients():
     """Manage agency clients"""
 
 
-@agencyclients.command()
-@click.option("--logins", help="Comma-separated client logins")
-@click.option(
-    "--archived",
-    type=click.Choice(["YES", "NO"]),
-    default="NO",
-    show_default=True,
-    help="Filter archived clients",
-)
-@click.option("--limit", type=int, help="Limit number of results")
-@click.option("--fetch-all", is_flag=True, help="Fetch all pages")
-@click.option("--format", "output_format", default="json", help="Output format")
-@click.option("--output", help="Output file")
-@click.option("--fields", help="Comma-separated field names")
-@click.option(
-    "--contract-field-names",
-    help=(
-        "Comma-separated ContractFieldNames "
-        "(e.g. Number,Date,Price,Type,ActionType). "
-        "Sent as separate top-level request parameter per the "
-        "AgencyClientsGetRequest WSDL."
-    ),
-)
-@click.option(
-    "--contragent-field-names",
-    help=(
-        "Comma-separated ContragentFieldNames "
-        "(e.g. Name,Phone,EpayNumber,RegNumber). "
-        "Sent as separate top-level request parameter per the "
-        "AgencyClientsGetRequest WSDL."
-    ),
-)
-@click.option(
-    "--contragent-tin-info-field-names",
-    help=(
-        "Comma-separated ContragentTinInfoFieldNames (e.g. TinType,Tin). "
-        "Sent as separate top-level request parameter per the "
-        "AgencyClientsGetRequest WSDL."
-    ),
-)
-@click.option(
-    "--organization-field-names",
-    help=(
-        "Comma-separated OrganizationFieldNames "
-        "(e.g. Name,EpayNumber,RegNumber,OkvedCode). "
-        "Sent as separate top-level request parameter per the "
-        "AgencyClientsGetRequest WSDL."
-    ),
-)
-@click.option(
-    "--tin-info-field-names",
-    help=(
-        "Comma-separated TinInfoFieldNames (e.g. TinType,Tin). "
-        "Sent as separate top-level request parameter per the "
-        "AgencyClientsGetRequest WSDL."
-    ),
-)
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def get(
-    ctx,
-    logins,
-    archived,
-    limit,
-    fetch_all,
-    output_format,
-    output,
-    fields,
-    contract_field_names,
-    contragent_field_names,
-    contragent_tin_info_field_names,
-    organization_field_names,
-    tin_info_field_names,
-    dry_run,
-):
-    """Get agency clients"""
-    client = client_from_ctx(ctx, create_client)
-
-    field_names = parse_csv_strings(fields) or get_default_fields("agencyclients")
-
-    raw_nested = (
-        ("ContractFieldNames", contract_field_names),
-        ("ContragentFieldNames", contragent_field_names),
-        ("ContragentTinInfoFieldNames", contragent_tin_info_field_names),
-        ("OrganizationFieldNames", organization_field_names),
-        ("TinInfoFieldNames", tin_info_field_names),
-    )
-    parsed_nested = parse_nested_field_names(raw_nested)
-
+def _agencyclients_criteria(ids, logins=None, archived=None, **_):
+    """SelectionCriteria for ``agencyclients get``: mandatory ``Archived`` plus
+    an optional ``Logins`` list (this resource has no ``--ids`` filter)."""
     criteria = {"Archived": archived}
     if logins:
         criteria["Logins"] = parse_csv_strings(logins)
+    return criteria
 
-    params = build_common_params(
-        criteria=criteria, field_names=field_names, limit=limit
-    )
-    params.update(parsed_nested)
 
-    body = {"method": "get", "params": params}
-
-    if dry_run:
-        format_output(body, "json", None)
-        return
-
-    result = client.agencyclients().post(data=body)
-
-    if fetch_all:
-        items = []
-        for item in result().iter_items():
-            items.append(item)
-        format_output(items, output_format, output)
-    else:
-        data = result().extract()
-        format_output(data, output_format, output)
+get = make_get_command(
+    agencyclients,
+    create_client,
+    default_fields_key="agencyclients",
+    help_text="Get agency clients",
+    include_ids=False,
+    extra_options=(
+        click.option("--logins", help="Comma-separated client logins"),
+        click.option(
+            "--archived",
+            type=click.Choice(["YES", "NO"]),
+            default="NO",
+            show_default=True,
+            help="Filter archived clients",
+        ),
+    ),
+    criteria_builder=_agencyclients_criteria,
+    nested_field_options=(
+        (
+            "--contract-field-names",
+            "ContractFieldNames",
+            (
+                "Comma-separated ContractFieldNames "
+                "(e.g. Number,Date,Price,Type,ActionType). "
+                "Sent as separate top-level request parameter per the "
+                "AgencyClientsGetRequest WSDL."
+            ),
+        ),
+        (
+            "--contragent-field-names",
+            "ContragentFieldNames",
+            (
+                "Comma-separated ContragentFieldNames "
+                "(e.g. Name,Phone,EpayNumber,RegNumber). "
+                "Sent as separate top-level request parameter per the "
+                "AgencyClientsGetRequest WSDL."
+            ),
+        ),
+        (
+            "--contragent-tin-info-field-names",
+            "ContragentTinInfoFieldNames",
+            (
+                "Comma-separated ContragentTinInfoFieldNames (e.g. TinType,Tin). "
+                "Sent as separate top-level request parameter per the "
+                "AgencyClientsGetRequest WSDL."
+            ),
+        ),
+        (
+            "--organization-field-names",
+            "OrganizationFieldNames",
+            (
+                "Comma-separated OrganizationFieldNames "
+                "(e.g. Name,EpayNumber,RegNumber,OkvedCode). "
+                "Sent as separate top-level request parameter per the "
+                "AgencyClientsGetRequest WSDL."
+            ),
+        ),
+        (
+            "--tin-info-field-names",
+            "TinInfoFieldNames",
+            (
+                "Comma-separated TinInfoFieldNames (e.g. TinType,Tin). "
+                "Sent as separate top-level request parameter per the "
+                "AgencyClientsGetRequest WSDL."
+            ),
+        ),
+    ),
+)
 
 
 @agencyclients.command()


### PR DESCRIPTION
## What

Finish the #587 `get` migration with the two structurally-divergent carve-outs. Follows #597 (criteria-limits) and #598 (nested `*FieldNames`).

Two more optional factory parameters:
- **`include_ids`** (default `True`) — set `False` for resources with no id filter. `agencyclients get` filters by `--logins` / `--archived` and has no `--ids`; it supplies a custom `criteria_builder` building `{Archived, Logins?}` from its own options.
- **`adextensions_wire_layout`** (default `False`) — a single-command flag reproducing `adextensions`'s exact recorded wire layout: always emit `SelectionCriteria` (even empty) and order nested `*FieldNames` before `Page`.

The `get` callback signature moves `ids` to a trailing defaulted kwarg so both `include_ids` modes work (Click passes by keyword; absent `--ids` → `None`).

## Why the empty SelectionCriteria is preserved (not "fixed")

It's a **recorded API contract**, not a latent bug:
- `tests/cassettes/test_read_cassettes/test_read_command[adextensions_get].yaml` replays `{"method":"get","params":{"SelectionCriteria":{},"FieldNames":[...]}}`.
- `adextensions` is **deliberately excluded** from `test_dry_run._SELECTION_CRITERIA_REQUIRED_GET_COMMANDS` — the live API accepts an empty criteria here, unlike adgroups/ads/keywords (which 4001 on it).

So `adextensions_wire_layout` preserves a contract; the docstring and code comments flag it as a do-not-normalize target.

## Byte-identity

Verified each command against pre-migration baselines — **all 11 snapshots identical**, including the empty-`SelectionCriteria` case, the nested-`*FieldNames`-before-`Page` ordering, the `--archived [YES|NO] [default: NO]` rendering, and the provided-but-empty `*FieldNames` `UsageError`.

## Tests

- Full offline suite green (2552 passed); `test_read_cassettes`, `test_dry_run`, `test_api_coverage`, `test_comprehensive` included.
- `ruff check` clean.

## Remaining carve-out

- `leads get` — its `--datetime-from` / `--datetime-to` options sit **between** `--limit` and `--fetch-all`, a bespoke option order the shared `get_options` stack can't reproduce without a one-off insertion slot. Not worth contorting the factory for a single command; it stays hand-rolled. With this PR, `make_get_command` covers 10 of the 11 `get` commands in #587's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)