### PR TITLE
refactor(campaigns): extract CPM_BANNER_CAMPAIGN to _campaigns_cpm_banner.py (#613)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+**Internal — campaigns.py split, step 1 — CPM_BANNER (#613, part of #602):**
+
+- Extracted the `CPM_BANNER_CAMPAIGN` `add`/`update` subtype-block composition
+  (the former inline `elif campaign_type_norm == "CPM_BANNER_CAMPAIGN":`
+  branches) into a new sibling module
+  `direct_cli/commands/_campaigns_cpm_banner.py` (`build_add_block` /
+  `build_update_block`). Both commands now snapshot their CLI parameters once
+  (`p = dict(locals())`) and delegate. The CLI surface, every flag and every
+  `--dry-run` payload is byte-for-byte identical (28 `test_campaigns_*cpm*`
+  fixtures green).
+
 **Internal — campaigns.py split, step 3 (#615):**
 
 - Extracted the `SMART_CAMPAIGN` add/update subtype-block composition

--- a/direct_cli/commands/_campaigns_cpm_banner.py
+++ b/direct_cli/commands/_campaigns_cpm_banner.py
@@ -1,0 +1,127 @@
+"""CPM_BANNER_CAMPAIGN payload composition for ``campaigns add``/``update``.
+
+Extracted verbatim from the former inline ``elif campaign_type_norm ==
+"CPM_BANNER_CAMPAIGN":`` branches of ``direct_cli/commands/campaigns.py``
+(issue #602, step 1 of the per-campaign-type split). The CLI surface is
+unchanged — ``campaigns.py`` delegates here.
+"""
+
+from .._bidding_strategy import get_bidding_strategy_builder
+from ..utils import parse_setting_specs
+from ._campaigns_base import _array_of_integer_option, _build_frequency_cap
+
+
+def build_add_block(
+    p, campaign_data, parsed_settings, counter_ids_obj, frequency_cap_obj
+):
+    """Compose ``campaign_data['CpmBannerCampaign']`` for ``campaigns add``.
+
+    ``p`` is a snapshot of every CLI parameter of the ``add`` command
+    (``dict(locals())``); only the CPM-relevant flags are pulled out below.
+    """
+    search_strategy = p["search_strategy"]
+    network_strategy = p["network_strategy"]
+    average_cpm = p["average_cpm"]
+    average_cpv = p["average_cpv"]
+    strategy_spend_limit = p["strategy_spend_limit"]
+    strategy_start_date = p["strategy_start_date"]
+    strategy_end_date = p["strategy_end_date"]
+    strategy_auto_continue = p["strategy_auto_continue"]
+    video_target = p["video_target"]
+
+    cpm_builder = get_bidding_strategy_builder("CPM_BANNER_CAMPAIGN", "add", "full")
+    if cpm_builder is not None:
+        cpm_bidding_strategy = cpm_builder(
+            search_strategy,
+            network_strategy,
+            average_cpm,
+            average_cpv,
+            strategy_spend_limit,
+            strategy_start_date,
+            strategy_end_date,
+            strategy_auto_continue,
+            include_defaults=True,
+        )
+    else:
+        cpm_bidding_strategy = {
+            "Search": {
+                "BiddingStrategyType": ((search_strategy or "SERVING_OFF").upper())
+            },
+            "Network": {
+                "BiddingStrategyType": ((network_strategy or "MANUAL_CPM").upper())
+            },
+        }
+    cpm_campaign: dict[str, object] = {"BiddingStrategy": cpm_bidding_strategy}
+    if parsed_settings:
+        cpm_campaign["Settings"] = parsed_settings
+    if counter_ids_obj is not None:
+        cpm_campaign["CounterIds"] = counter_ids_obj
+    if frequency_cap_obj is not None:
+        cpm_campaign["FrequencyCap"] = frequency_cap_obj
+    if video_target:
+        cpm_campaign["VideoTarget"] = video_target.upper()
+    campaign_data["CpmBannerCampaign"] = cpm_campaign
+
+
+def build_update_block(p, sub_block):
+    """Fill ``sub_block`` for the CpmBannerCampaign subtype of ``campaigns update``.
+
+    ``p`` is a snapshot of every CLI parameter of the ``update`` command.
+    """
+    search_strategy = p["search_strategy"]
+    network_strategy = p["network_strategy"]
+    average_cpm = p["average_cpm"]
+    average_cpv = p["average_cpv"]
+    strategy_spend_limit = p["strategy_spend_limit"]
+    strategy_start_date = p["strategy_start_date"]
+    strategy_end_date = p["strategy_end_date"]
+    strategy_auto_continue = p["strategy_auto_continue"]
+    settings = p["settings"]
+    counter_ids = p["counter_ids"]
+    frequency_cap_impressions = p["frequency_cap_impressions"]
+    frequency_cap_period_days = p["frequency_cap_period_days"]
+    frequency_cap_period_all = p["frequency_cap_period_all"]
+    video_target = p["video_target"]
+
+    parsed_settings = parse_setting_specs(list(settings))
+    if parsed_settings:
+        sub_block["Settings"] = parsed_settings
+    cpm_builder = get_bidding_strategy_builder("CPM_BANNER_CAMPAIGN", "update", "full")
+    if cpm_builder is not None:
+        cpm_bidding_strategy = cpm_builder(
+            search_strategy,
+            network_strategy,
+            average_cpm,
+            average_cpv,
+            strategy_spend_limit,
+            strategy_start_date,
+            strategy_end_date,
+            strategy_auto_continue,
+            include_defaults=False,
+        )
+    else:
+        cpm_bidding_strategy = None
+        if search_strategy is not None or network_strategy is not None:
+            cpm_bidding_strategy = {}
+            if search_strategy is not None:
+                cpm_bidding_strategy["Search"] = {
+                    "BiddingStrategyType": search_strategy.upper()
+                }
+            if network_strategy is not None:
+                cpm_bidding_strategy["Network"] = {
+                    "BiddingStrategyType": network_strategy.upper()
+                }
+    if cpm_bidding_strategy is not None:
+        sub_block["BiddingStrategy"] = cpm_bidding_strategy
+    counter_ids_obj = _array_of_integer_option("--counter-ids", counter_ids)
+    if counter_ids_obj is not None:
+        sub_block["CounterIds"] = counter_ids_obj
+    frequency_cap_obj = _build_frequency_cap(
+        frequency_cap_impressions,
+        frequency_cap_period_days,
+        frequency_cap_period_all,
+    )
+    if frequency_cap_obj is not None:
+        sub_block["FrequencyCap"] = frequency_cap_obj
+    if video_target:
+        sub_block["VideoTarget"] = video_target.upper()

--- a/direct_cli/commands/campaigns.py
+++ b/direct_cli/commands/campaigns.py
@@ -99,6 +99,10 @@ from . import _campaigns_smart as smart
 # owns the add/update subtype-block composition for one campaign type.
 from . import _campaigns_mobile_app as mobile_app
 
+# Per-campaign-type payload builders (issue #602 per-type split). Each module
+# owns the add/update subtype-block composition for one campaign type.
+from . import _campaigns_cpm_banner as cpm_banner
+
 
 @click.group()
 def campaigns():
@@ -2719,38 +2723,13 @@ def add(
             negative_keyword_shared_set_ids_obj,
         )
     elif campaign_type_norm == "CPM_BANNER_CAMPAIGN":
-        cpm_builder = get_bidding_strategy_builder("CPM_BANNER_CAMPAIGN", "add", "full")
-        if cpm_builder is not None:
-            cpm_bidding_strategy = cpm_builder(
-                search_strategy,
-                network_strategy,
-                average_cpm,
-                average_cpv,
-                strategy_spend_limit,
-                strategy_start_date,
-                strategy_end_date,
-                strategy_auto_continue,
-                include_defaults=True,
-            )
-        else:
-            cpm_bidding_strategy = {
-                "Search": {
-                    "BiddingStrategyType": ((search_strategy or "SERVING_OFF").upper())
-                },
-                "Network": {
-                    "BiddingStrategyType": ((network_strategy or "MANUAL_CPM").upper())
-                },
-            }
-        cpm_campaign: dict[str, object] = {"BiddingStrategy": cpm_bidding_strategy}
-        if parsed_settings:
-            cpm_campaign["Settings"] = parsed_settings
-        if counter_ids_obj is not None:
-            cpm_campaign["CounterIds"] = counter_ids_obj
-        if frequency_cap_obj is not None:
-            cpm_campaign["FrequencyCap"] = frequency_cap_obj
-        if video_target:
-            cpm_campaign["VideoTarget"] = video_target.upper()
-        campaign_data["CpmBannerCampaign"] = cpm_campaign
+        cpm_banner.build_add_block(
+            p,
+            campaign_data,
+            parsed_settings,
+            counter_ids_obj,
+            frequency_cap_obj,
+        )
 
     if budget:
         campaign_data["DailyBudget"] = {
@@ -5505,50 +5484,7 @@ def update(
         elif campaign_type_norm == "MOBILE_APP_CAMPAIGN":
             mobile_app.build_update_block(p, sub_block)
         elif campaign_type_norm == "CPM_BANNER_CAMPAIGN":
-            parsed_settings = parse_setting_specs(list(settings))
-            if parsed_settings:
-                sub_block["Settings"] = parsed_settings
-            cpm_builder = get_bidding_strategy_builder(
-                "CPM_BANNER_CAMPAIGN", "update", "full"
-            )
-            if cpm_builder is not None:
-                cpm_bidding_strategy = cpm_builder(
-                    search_strategy,
-                    network_strategy,
-                    average_cpm,
-                    average_cpv,
-                    strategy_spend_limit,
-                    strategy_start_date,
-                    strategy_end_date,
-                    strategy_auto_continue,
-                    include_defaults=False,
-                )
-            else:
-                cpm_bidding_strategy = None
-                if search_strategy is not None or network_strategy is not None:
-                    cpm_bidding_strategy = {}
-                    if search_strategy is not None:
-                        cpm_bidding_strategy["Search"] = {
-                            "BiddingStrategyType": search_strategy.upper()
-                        }
-                    if network_strategy is not None:
-                        cpm_bidding_strategy["Network"] = {
-                            "BiddingStrategyType": network_strategy.upper()
-                        }
-            if cpm_bidding_strategy is not None:
-                sub_block["BiddingStrategy"] = cpm_bidding_strategy
-            counter_ids_obj = _array_of_integer_option("--counter-ids", counter_ids)
-            if counter_ids_obj is not None:
-                sub_block["CounterIds"] = counter_ids_obj
-            frequency_cap_obj = _build_frequency_cap(
-                frequency_cap_impressions,
-                frequency_cap_period_days,
-                frequency_cap_period_all,
-            )
-            if frequency_cap_obj is not None:
-                sub_block["FrequencyCap"] = frequency_cap_obj
-            if video_target:
-                sub_block["VideoTarget"] = video_target.upper()
+            cpm_banner.build_update_block(p, sub_block)
         if tracking_params:
             sub_block["TrackingParams"] = tracking_params
         if not sub_block:


### PR DESCRIPTION
## Summary

Step 2 of the incremental `campaigns.py` split (epic #602). **Stacked on PR #612** (Step 0 — shared helpers). Extracts the `CPM_BANNER_CAMPAIGN` add/update subtype-block composition into a new sibling module.

Smallest campaign type → validates the per-type extraction mechanics before the larger types.

### What moved

The former inline `elif campaign_type_norm == "CPM_BANNER_CAMPAIGN":` branches in `add` (~34 lines) and `update` (~45 lines) → new module `direct_cli/commands/_campaigns_cpm_banner.py`:
- `build_add_block(p, campaign_data, parsed_settings, counter_ids_obj, frequency_cap_obj)`
- `build_update_block(p, sub_block)`

Both commands now snapshot their CLI parameters once (`p = dict(locals())`) and delegate; the per-type builder pulls only the CPM-relevant flags from `p`.

## CLI surface

**No breaking changes.** Every flag, every `--dry-run` payload byte-for-byte identical. Pure internal relocation — no legacy aliases, strict WSDL parity preserved.

## Tests run

- `pytest tests/test_dry_run.py -k cpm`: **28 passed**
- `pytest` (full offline tier): **2507 passed, 8 skipped** (identical to baseline)
- `pytest tests/test_wsdl_parity_gate.py tests/test_api_coverage.py`: **263 passed, 6 skipped** (green)
- `black` + `flake8` — my files clean (only pre-existing E501 long-line warnings)

## Risks / follow-ups

- `COMMAND_WSDL_MAP` **not touched**.
- This PR is stacked on #612 — rebase/retarget to `main` after #612 merges.
- Per-type extraction pattern established here will be reused for the remaining types (#614 mobile_app → #615 smart → #616/#617/#618 text family).

Closes #613. Part of #602.

🤖 Generated with [Claude Code](https://claude.com/claude-code)