### PR TITLE
refactor(campaigns): extract MOBILE_APP_CAMPAIGN to _campaigns_mobile_app.py (#614, step 2 of #602)

### DIFF
--- a/direct_cli/commands/_campaigns_mobile_app.py
+++ b/direct_cli/commands/_campaigns_mobile_app.py
@@ -6,8 +6,6 @@ Extracted verbatim from the former inline ``elif campaign_type_norm ==
 unchanged — ``campaigns.py`` delegates here.
 """
 
-from typing import Dict
-
 from .._bidding_strategy import get_bidding_strategy_builder
 from ..utils import parse_setting_specs
 from ._campaigns_base import (
@@ -98,7 +96,7 @@ def build_add_block(
                 "BiddingStrategyType": ((network_strategy or "SERVING_OFF").upper())
             },
         }
-    mobile_campaign: Dict[str, object] = {"BiddingStrategy": mobile_bidding_strategy}
+    mobile_campaign: dict[str, object] = {"BiddingStrategy": mobile_bidding_strategy}
     if parsed_settings:
         mobile_campaign["Settings"] = parsed_settings
     if negative_keyword_shared_set_ids_obj is not None:

--- a/direct_cli/commands/_campaigns_mobile_app.py
+++ b/direct_cli/commands/_campaigns_mobile_app.py
@@ -1,0 +1,200 @@
+"""MOBILE_APP_CAMPAIGN payload composition for ``campaigns add``/``update``.
+
+Extracted verbatim from the former inline ``elif campaign_type_norm ==
+"MOBILE_APP_CAMPAIGN":`` branches of ``direct_cli/commands/campaigns.py``
+(issue #602, step 2 of the per-campaign-type split). The CLI surface is
+unchanged — ``campaigns.py`` delegates here.
+"""
+
+from typing import Dict
+
+from .._bidding_strategy import get_bidding_strategy_builder
+from ..utils import parse_setting_specs
+from ._campaigns_base import (
+    NEGATIVE_KEYWORD_SHARED_SET_IDS_MAX_ITEMS,
+    _array_of_integer_option,
+)
+
+
+def build_add_block(
+    p,
+    campaign_data,
+    parsed_settings,
+    negative_keyword_shared_set_ids_obj,
+):
+    """Compose ``campaign_data['MobileAppCampaign']`` for ``campaigns add``.
+
+    ``p`` is a snapshot of every CLI parameter of the ``add`` command
+    (``dict(locals())``); only the mobile-app-relevant flags are pulled out
+    below.
+    """
+    search_strategy = p["search_strategy"]
+    network_strategy = p["network_strategy"]
+    mobile_search_weekly_spend_limit = p["mobile_search_weekly_spend_limit"]
+    mobile_search_bid_ceiling = p["mobile_search_bid_ceiling"]
+    mobile_search_custom_period_spend_limit = p[
+        "mobile_search_custom_period_spend_limit"
+    ]
+    mobile_search_custom_period_start_date = p["mobile_search_custom_period_start_date"]
+    mobile_search_custom_period_end_date = p["mobile_search_custom_period_end_date"]
+    mobile_search_custom_period_auto_continue = p[
+        "mobile_search_custom_period_auto_continue"
+    ]
+    mobile_search_average_cpc = p["mobile_search_average_cpc"]
+    mobile_search_average_cpi = p["mobile_search_average_cpi"]
+    mobile_search_clicks_per_week = p["mobile_search_clicks_per_week"]
+    mobile_network_weekly_spend_limit = p["mobile_network_weekly_spend_limit"]
+    mobile_network_bid_ceiling = p["mobile_network_bid_ceiling"]
+    mobile_network_custom_period_spend_limit = p[
+        "mobile_network_custom_period_spend_limit"
+    ]
+    mobile_network_custom_period_start_date = p[
+        "mobile_network_custom_period_start_date"
+    ]
+    mobile_network_custom_period_end_date = p["mobile_network_custom_period_end_date"]
+    mobile_network_custom_period_auto_continue = p[
+        "mobile_network_custom_period_auto_continue"
+    ]
+    mobile_network_average_cpc = p["mobile_network_average_cpc"]
+    mobile_network_average_cpi = p["mobile_network_average_cpi"]
+    mobile_network_clicks_per_week = p["mobile_network_clicks_per_week"]
+    mobile_network_limit_percent = p["mobile_network_limit_percent"]
+
+    mobile_builder = get_bidding_strategy_builder("MOBILE_APP_CAMPAIGN", "add", "full")
+    if mobile_builder is not None:
+        mobile_bidding_strategy = mobile_builder(
+            search_strategy,
+            mobile_search_weekly_spend_limit,
+            mobile_search_bid_ceiling,
+            mobile_search_custom_period_spend_limit,
+            mobile_search_custom_period_start_date,
+            mobile_search_custom_period_end_date,
+            mobile_search_custom_period_auto_continue,
+            mobile_search_average_cpc,
+            mobile_search_average_cpi,
+            mobile_search_clicks_per_week,
+            None,
+            network_strategy,
+            mobile_network_weekly_spend_limit,
+            mobile_network_bid_ceiling,
+            mobile_network_custom_period_spend_limit,
+            mobile_network_custom_period_start_date,
+            mobile_network_custom_period_end_date,
+            mobile_network_custom_period_auto_continue,
+            mobile_network_average_cpc,
+            mobile_network_average_cpi,
+            mobile_network_clicks_per_week,
+            mobile_network_limit_percent,
+            None,
+            include_defaults=True,
+            is_update=False,
+        )
+    else:
+        mobile_bidding_strategy = {
+            "Search": {
+                "BiddingStrategyType": ((search_strategy or "HIGHEST_POSITION").upper())
+            },
+            "Network": {
+                "BiddingStrategyType": ((network_strategy or "SERVING_OFF").upper())
+            },
+        }
+    mobile_campaign: Dict[str, object] = {"BiddingStrategy": mobile_bidding_strategy}
+    if parsed_settings:
+        mobile_campaign["Settings"] = parsed_settings
+    if negative_keyword_shared_set_ids_obj is not None:
+        mobile_campaign["NegativeKeywordSharedSetIds"] = (
+            negative_keyword_shared_set_ids_obj
+        )
+    campaign_data["MobileAppCampaign"] = mobile_campaign
+
+
+def build_update_block(p, sub_block):
+    """Fill ``sub_block`` for the MobileAppCampaign subtype of ``campaigns update``.
+
+    ``p`` is a snapshot of every CLI parameter of the ``update`` command.
+    """
+    search_strategy = p["search_strategy"]
+    network_strategy = p["network_strategy"]
+    mobile_search_weekly_spend_limit = p["mobile_search_weekly_spend_limit"]
+    mobile_search_bid_ceiling = p["mobile_search_bid_ceiling"]
+    mobile_search_custom_period_spend_limit = p[
+        "mobile_search_custom_period_spend_limit"
+    ]
+    mobile_search_custom_period_start_date = p["mobile_search_custom_period_start_date"]
+    mobile_search_custom_period_end_date = p["mobile_search_custom_period_end_date"]
+    mobile_search_custom_period_auto_continue = p[
+        "mobile_search_custom_period_auto_continue"
+    ]
+    mobile_search_average_cpc = p["mobile_search_average_cpc"]
+    mobile_search_average_cpi = p["mobile_search_average_cpi"]
+    mobile_search_clicks_per_week = p["mobile_search_clicks_per_week"]
+    mobile_search_budget_type = p["mobile_search_budget_type"]
+    mobile_network_weekly_spend_limit = p["mobile_network_weekly_spend_limit"]
+    mobile_network_bid_ceiling = p["mobile_network_bid_ceiling"]
+    mobile_network_custom_period_spend_limit = p[
+        "mobile_network_custom_period_spend_limit"
+    ]
+    mobile_network_custom_period_start_date = p[
+        "mobile_network_custom_period_start_date"
+    ]
+    mobile_network_custom_period_end_date = p["mobile_network_custom_period_end_date"]
+    mobile_network_custom_period_auto_continue = p[
+        "mobile_network_custom_period_auto_continue"
+    ]
+    mobile_network_average_cpc = p["mobile_network_average_cpc"]
+    mobile_network_average_cpi = p["mobile_network_average_cpi"]
+    mobile_network_clicks_per_week = p["mobile_network_clicks_per_week"]
+    mobile_network_limit_percent = p["mobile_network_limit_percent"]
+    mobile_network_budget_type = p["mobile_network_budget_type"]
+    settings = p["settings"]
+    negative_keyword_shared_set_ids = p["negative_keyword_shared_set_ids"]
+
+    parsed_settings = parse_setting_specs(list(settings))
+    if parsed_settings:
+        sub_block["Settings"] = parsed_settings
+    mobile_builder = get_bidding_strategy_builder(
+        "MOBILE_APP_CAMPAIGN", "update", "full"
+    )
+    if mobile_builder is not None:
+        mobile_bidding_strategy = mobile_builder(
+            search_strategy,
+            mobile_search_weekly_spend_limit,
+            mobile_search_bid_ceiling,
+            mobile_search_custom_period_spend_limit,
+            mobile_search_custom_period_start_date,
+            mobile_search_custom_period_end_date,
+            mobile_search_custom_period_auto_continue,
+            mobile_search_average_cpc,
+            mobile_search_average_cpi,
+            mobile_search_clicks_per_week,
+            mobile_search_budget_type,
+            network_strategy,
+            mobile_network_weekly_spend_limit,
+            mobile_network_bid_ceiling,
+            mobile_network_custom_period_spend_limit,
+            mobile_network_custom_period_start_date,
+            mobile_network_custom_period_end_date,
+            mobile_network_custom_period_auto_continue,
+            mobile_network_average_cpc,
+            mobile_network_average_cpi,
+            mobile_network_clicks_per_week,
+            mobile_network_limit_percent,
+            mobile_network_budget_type,
+            include_defaults=False,
+            is_update=True,
+        )
+    else:
+        mobile_bidding_strategy = (
+            {"Search": {"BiddingStrategyType": search_strategy.upper()}}
+            if search_strategy is not None
+            else None
+        )
+    if mobile_bidding_strategy is not None:
+        sub_block["BiddingStrategy"] = mobile_bidding_strategy
+    negative_keyword_shared_set_ids_obj = _array_of_integer_option(
+        "--negative-keyword-shared-set-ids",
+        negative_keyword_shared_set_ids,
+        max_items=NEGATIVE_KEYWORD_SHARED_SET_IDS_MAX_ITEMS,
+    )
+    if negative_keyword_shared_set_ids_obj is not None:
+        sub_block["NegativeKeywordSharedSetIds"] = negative_keyword_shared_set_ids_obj

--- a/direct_cli/commands/campaigns.py
+++ b/direct_cli/commands/campaigns.py
@@ -90,7 +90,7 @@ from ._lifecycle import register_lifecycle_commands
 
 # Per-campaign-type payload builders (issue #602 per-type split). Each module
 # owns the add/update subtype-block composition for one campaign type.
-from . import _campaigns_mobile_app as mobile_app  # noqa: E402,F401
+from . import _campaigns_mobile_app as mobile_app
 
 
 @click.group()

--- a/direct_cli/commands/campaigns.py
+++ b/direct_cli/commands/campaigns.py
@@ -88,6 +88,10 @@ from ._campaigns_base import (
 from ._execute import execute_request
 from ._lifecycle import register_lifecycle_commands
 
+# Per-campaign-type payload builders (issue #602 per-type split). Each module
+# owns the add/update subtype-block composition for one campaign type.
+from . import _campaigns_mobile_app as mobile_app  # noqa: E402,F401
+
 
 @click.group()
 def campaigns():
@@ -1507,6 +1511,10 @@ def add(
     dry_run,
 ):
     """Add new campaign"""
+    # Snapshot every CLI parameter once so the per-type payload builders can
+    # pull exactly the flags they need without a 200-argument call signature
+    # (issue #602 per-campaign-type split).
+    p = dict(locals())
     campaign_type_norm = (campaign_type or "TEXT_CAMPAIGN").upper().replace("-", "_")
     supported_types = {
         "TEXT_CAMPAIGN",
@@ -3388,58 +3396,12 @@ def add(
             smart_campaign["TrackingParams"] = tracking_params
         campaign_data["SmartCampaign"] = smart_campaign
     elif campaign_type_norm == "MOBILE_APP_CAMPAIGN":
-        mobile_builder = get_bidding_strategy_builder(
-            "MOBILE_APP_CAMPAIGN", "add", "full"
+        mobile_app.build_add_block(
+            p,
+            campaign_data,
+            parsed_settings,
+            negative_keyword_shared_set_ids_obj,
         )
-        if mobile_builder is not None:
-            mobile_bidding_strategy = mobile_builder(
-                search_strategy,
-                mobile_search_weekly_spend_limit,
-                mobile_search_bid_ceiling,
-                mobile_search_custom_period_spend_limit,
-                mobile_search_custom_period_start_date,
-                mobile_search_custom_period_end_date,
-                mobile_search_custom_period_auto_continue,
-                mobile_search_average_cpc,
-                mobile_search_average_cpi,
-                mobile_search_clicks_per_week,
-                None,
-                network_strategy,
-                mobile_network_weekly_spend_limit,
-                mobile_network_bid_ceiling,
-                mobile_network_custom_period_spend_limit,
-                mobile_network_custom_period_start_date,
-                mobile_network_custom_period_end_date,
-                mobile_network_custom_period_auto_continue,
-                mobile_network_average_cpc,
-                mobile_network_average_cpi,
-                mobile_network_clicks_per_week,
-                mobile_network_limit_percent,
-                None,
-                include_defaults=True,
-                is_update=False,
-            )
-        else:
-            mobile_bidding_strategy = {
-                "Search": {
-                    "BiddingStrategyType": (
-                        (search_strategy or "HIGHEST_POSITION").upper()
-                    )
-                },
-                "Network": {
-                    "BiddingStrategyType": ((network_strategy or "SERVING_OFF").upper())
-                },
-            }
-        mobile_campaign: dict[str, object] = {
-            "BiddingStrategy": mobile_bidding_strategy
-        }
-        if parsed_settings:
-            mobile_campaign["Settings"] = parsed_settings
-        if negative_keyword_shared_set_ids_obj is not None:
-            mobile_campaign["NegativeKeywordSharedSetIds"] = (
-                negative_keyword_shared_set_ids_obj
-            )
-        campaign_data["MobileAppCampaign"] = mobile_campaign
     elif campaign_type_norm == "CPM_BANNER_CAMPAIGN":
         cpm_builder = get_bidding_strategy_builder("CPM_BANNER_CAMPAIGN", "add", "full")
         if cpm_builder is not None:
@@ -4722,6 +4684,9 @@ def update(
     dry_run,
 ):
     """Update campaign"""
+    # Snapshot every CLI parameter once for the per-type payload builders
+    # (issue #602 per-campaign-type split).
+    p = dict(locals())
     campaign_data: dict[str, Any] = {"Id": campaign_id}
 
     if name:
@@ -6338,57 +6303,7 @@ def update(
                     bidding_strategy["Network"] = smart_network_block
                 sub_block["BiddingStrategy"] = bidding_strategy
         elif campaign_type_norm == "MOBILE_APP_CAMPAIGN":
-            parsed_settings = parse_setting_specs(list(settings))
-            if parsed_settings:
-                sub_block["Settings"] = parsed_settings
-            mobile_builder = get_bidding_strategy_builder(
-                "MOBILE_APP_CAMPAIGN", "update", "full"
-            )
-            if mobile_builder is not None:
-                mobile_bidding_strategy = mobile_builder(
-                    search_strategy,
-                    mobile_search_weekly_spend_limit,
-                    mobile_search_bid_ceiling,
-                    mobile_search_custom_period_spend_limit,
-                    mobile_search_custom_period_start_date,
-                    mobile_search_custom_period_end_date,
-                    mobile_search_custom_period_auto_continue,
-                    mobile_search_average_cpc,
-                    mobile_search_average_cpi,
-                    mobile_search_clicks_per_week,
-                    mobile_search_budget_type,
-                    network_strategy,
-                    mobile_network_weekly_spend_limit,
-                    mobile_network_bid_ceiling,
-                    mobile_network_custom_period_spend_limit,
-                    mobile_network_custom_period_start_date,
-                    mobile_network_custom_period_end_date,
-                    mobile_network_custom_period_auto_continue,
-                    mobile_network_average_cpc,
-                    mobile_network_average_cpi,
-                    mobile_network_clicks_per_week,
-                    mobile_network_limit_percent,
-                    mobile_network_budget_type,
-                    include_defaults=False,
-                    is_update=True,
-                )
-            else:
-                mobile_bidding_strategy = (
-                    {"Search": {"BiddingStrategyType": search_strategy.upper()}}
-                    if search_strategy is not None
-                    else None
-                )
-            if mobile_bidding_strategy is not None:
-                sub_block["BiddingStrategy"] = mobile_bidding_strategy
-            negative_keyword_shared_set_ids_obj = _array_of_integer_option(
-                "--negative-keyword-shared-set-ids",
-                negative_keyword_shared_set_ids,
-                max_items=NEGATIVE_KEYWORD_SHARED_SET_IDS_MAX_ITEMS,
-            )
-            if negative_keyword_shared_set_ids_obj is not None:
-                sub_block["NegativeKeywordSharedSetIds"] = (
-                    negative_keyword_shared_set_ids_obj
-                )
+            mobile_app.build_update_block(p, sub_block)
         elif campaign_type_norm == "CPM_BANNER_CAMPAIGN":
             parsed_settings = parse_setting_specs(list(settings))
             if parsed_settings:


### PR DESCRIPTION
Closes #614. Part of #602 (campaigns.py per-campaign-type split, step 2).

Extracted the `MOBILE_APP_CAMPAIGN` `add`/`update` subtype-block composition
(the former inline `elif campaign_type_norm == "MOBILE_APP_CAMPAIGN":`
branches) into a new sibling module
`direct_cli/commands/_campaigns_mobile_app.py` (`build_add_block` /
`build_update_block`). Both commands now snapshot their CLI parameters once
(`p = dict(locals())`) and delegate. The CLI surface, every flag and every
`--dry-run` payload is byte-for-byte identical. Pattern follows the
CPM_BANNER extraction (PR #619) 1:1.

## Tests

- 2521 offline tests passed, 8 skipped
- 30 `test_campaigns_*mobile*` dry-run fixtures green (byte-identical payloads)
- WSDL parity gate + API coverage: 263 passed, 6 skipped
- `black` + `flake8` clean (new module; `campaigns.py` E501s are pre-existing)

## Changes

- `direct_cli/commands/_campaigns_mobile_app.py` (new) — `build_add_block` / `build_update_block`
- `direct_cli/commands/campaigns.py` — import + `p=locals()` snapshots + delegation calls (-102 lines, +19 lines)
