### PR TITLE
fix(wsdl): restore XSD-import size-check bypass (regression of #608)

### DIFF
--- a/direct_cli/wsdl_coverage.py
+++ b/direct_cli/wsdl_coverage.py
@@ -174,17 +174,27 @@ def _assert_real_wsdl(url: str, xml_text: str) -> None:
             f"Yandex returned a captcha page for WSDL endpoint {url!r}. "
             "Verify that WSDL_BASE_URL is still canonical."
         )
-    if len(xml_text) < _WSDL_MIN_SIZE:
-        raise RuntimeError(
-            f"WSDL response for {url!r} is suspiciously small ({len(xml_text)} bytes "
-            f"< {_WSDL_MIN_SIZE}). Real Yandex WSDLs are well above 10 KB."
-        )
+    # Structural validation first — more reliable than a size heuristic.
     for marker in _WSDL_REQUIRED_MARKERS:
         if marker not in xml_text:
             raise RuntimeError(
                 f"WSDL response for {url!r} missing required marker {marker!r}. "
                 "Likely an HTML error page rather than an XML schema."
             )
+    # Allow small WSDL files that import types via XSD. Services such as
+    # adextensions, advideos, businesses, clients, keywordsresearch, leads,
+    # sitelinks and turbopages pull their types from external XSDs instead of
+    # inlining them, so they are legitimately below the 10 KB size floor that
+    # guards monolithic WSDLs (regression of #608 / #626).
+    if "xsd:import" in xml_text or "xsd:include" in xml_text:
+        return
+    # Only apply the size floor to monolithic WSDLs without XSD imports.
+    if len(xml_text) < _WSDL_MIN_SIZE:
+        raise RuntimeError(
+            f"WSDL response for {url!r} is suspiciously small ({len(xml_text)} bytes "
+            f"without XSD imports. Real monolithic Yandex WSDLs are well above "
+            f"{_WSDL_MIN_SIZE} bytes."
+        )
 
 
 def fetch_wsdl(service_name: str, use_cache: bool = True) -> str:

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -2357,6 +2357,74 @@ class TestWsdlCacheFreshness:
             assert "schema" in text, f"{path.name} missing schema element"
 
 
+class TestAssertRealWsdl:
+    """Regression guard for the XSD-import size-check bypass (#608 / #626).
+
+    PR #585 dropped the bypass that #608 added, so 8 services with small
+    WSDLs (adextensions, advideos, businesses, clients, keywordsresearch,
+    leads, sitelinks, turbopages) were silently rejected by the 10 KB size
+    floor. These tests fail the moment the bypass is removed again.
+    """
+
+    def test_accepts_small_wsdl_with_xsd_import(self):
+        # A sub-10KB WSDL that imports types via XSD is valid and must not be
+        # rejected by the size floor (the bypass short-circuits before it).
+        from direct_cli.wsdl_coverage import _assert_real_wsdl
+
+        small_import_wsdl = (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            '<wsdl:definitions xmlns:xsd="http://www.w3.org/2001/XMLSchema">'
+            '<xsd:import namespace="http://direct.yandex.ru"/>'
+            "</wsdl:definitions>"
+        )
+        assert len(small_import_wsdl) < 10_000  # precondition: genuinely small
+        # Must not raise.
+        _assert_real_wsdl("https://example.test/import?wsdl", small_import_wsdl)
+
+    def test_accepts_small_wsdl_with_xsd_include(self):
+        from direct_cli.wsdl_coverage import _assert_real_wsdl
+
+        small_include_wsdl = (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            '<wsdl:definitions xmlns:xsd="http://www.w3.org/2001/XMLSchema">'
+            '<xsd:schema><xsd:include schemaLocation="types.xsd"/></xsd:schema>'
+            "</wsdl:definitions>"
+        )
+        assert len(small_include_wsdl) < 10_000  # precondition: genuinely small
+        # Must not raise.
+        _assert_real_wsdl("https://example.test/include?wsdl", small_include_wsdl)
+
+    def test_rejects_small_monolithic_wsdl_without_imports(self):
+        # A small WSDL with no XSD imports is still suspicious — the size floor
+        # must keep guarding monolithic WSDLs.
+        from direct_cli.wsdl_coverage import _assert_real_wsdl
+
+        small_monolith = (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            "<wsdl:definitions></wsdl:definitions>"
+        )
+        assert len(small_monolith) < 10_000  # precondition: genuinely small
+        with pytest.raises(RuntimeError, match="suspiciously small"):
+            _assert_real_wsdl("https://example.test/monolith?wsdl", small_monolith)
+
+    def test_accepts_cached_xsdl_import_service(self):
+        # End-to-end guard against the 8 real affected services: the committed
+        # lead/turbopage caches are < 10 KB but carry xsd:import, so they must
+        # pass _assert_real_wsdl unchanged. If the bypass regresses, this raises.
+        from pathlib import Path
+
+        from direct_cli.wsdl_coverage import _assert_real_wsdl
+
+        cache_dir = Path(__file__).resolve().parent / "wsdl_cache"
+        for name in ("adextensions", "leads", "turbopages"):
+            xml = (cache_dir / f"{name}.xml").read_text(encoding="utf-8")
+            assert len(xml) < 10_000, f"{name}.xml grew past the size floor — revisit"
+            assert (
+                "xsd:import" in xml or "xsd:include" in xml
+            ), f"{name}.xml no longer uses XSD imports — bypass may be obsolete"
+            _assert_real_wsdl(f"https://example.test/{name}?wsdl", xml)
+
+
 class TestReportsParseFilter:
     """Unit tests for _parse_filter helper."""
 
@@ -2619,9 +2687,12 @@ def test_every_nested_fieldnames_param_has_cli_option():
     """
     missing: list[str] = []
 
-    for cli_group, api_service, operation, param_name in (
-        _iter_get_operation_fieldnames()
-    ):
+    for (
+        cli_group,
+        api_service,
+        operation,
+        param_name,
+    ) in _iter_get_operation_fieldnames():
         if param_name == "FieldNames":
             # Handled by the top-level ``--fields`` option on every get
             # subcommand. Coverage for ``--fields`` is enforced by the

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -2407,7 +2407,7 @@ class TestAssertRealWsdl:
         with pytest.raises(RuntimeError, match="suspiciously small"):
             _assert_real_wsdl("https://example.test/monolith?wsdl", small_monolith)
 
-    def test_accepts_cached_xsdl_import_service(self):
+    def test_accepts_cached_xsd_import_service(self):
         # End-to-end guard against the 8 real affected services: the committed
         # lead/turbopage caches are < 10 KB but carry xsd:import, so they must
         # pass _assert_real_wsdl unchanged. If the bypass regresses, this raises.


### PR DESCRIPTION
## Summary

REGRESSION of #608. PR #585 (captcha-registry refactor, `68eb2e1`) silently dropped the XSD-import size-check bypass that #608 (`472abd3`) added to `direct_cli/wsdl_coverage.py::_assert_real_wsdl`. As a result, `scripts/check_wsdl_drift.py` fails immediately on 8 valid services that import types via external XSDs and are legitimately below the 10 KB size floor:

`adextensions`, `advideos`, `businesses`, `clients`, `keywordsresearch`, `leads`, `sitelinks`, `turbopages` (28% of the API surface).

WSDL drift detection was blind for these services — Yandex could modify them and CI would never notice.

## Fix

Re-apply the bypass in `_assert_real_wsdl`, **after** captcha detection and structural markers, **before** the size floor:

```python
if "xsd:import" in xml_text or "xsd:include" in xml_text:
    return
if len(xml_text) < _WSDL_MIN_SIZE:
    raise RuntimeError(...)
```

The size floor now only guards monolithic WSDLs without imports. #585's captcha extraction into `_captcha.py` (`find_captcha_marker`) is **preserved untouched** — this PR only restores the bypass, it does not revert the refactor.

## Regression test (the part #608 was missing)

This is exactly why the bug came back: #608 had no test that fails when the bypass is removed. Added `TestAssertRealWsdl` in `tests/test_api_coverage.py`:

- `test_accepts_small_wsdl_with_xsd_import` — a sub-10 KB WSDL with `xsd:import` must pass (fails without the bypass).
- `test_accepts_small_wsdl_with_xsd_include` — same for `xsd:include`.
- `test_rejects_small_monolithic_wsdl_without_imports` — a small WSDL with **no** imports is still rejected (the size floor keeps guarding monolithic WSDLs).
- `test_accepts_cached_xsdl_import_service` — end-to-end guard against the real affected services (`adextensions`, `leads`, `turbopages` committed caches are < 10 KB but carry `xsd:import`).

Verified the suite goes **red without the bypass** (3 of 4 fail) and **green with it**.

## Tests run

- `python scripts/check_wsdl_drift.py` → exit 0, `drift_count: 0`, `imported_xsd_drift_count: 0` (previously crashed on `adextensions`).
- `pytest tests/test_api_coverage.py tests/test_wsdl_parity_gate.py` → 267 passed, 6 skipped.
- Full offline suite → 2525 passed, 8 skipped (excluding `test_read_cassettes.py` / `test_integration_write.py`, which fail on **clean HEAD** too due to a local `aiohttp`/`vcr` version mismatch — `AttributeError: module 'aiohttp.streams' has no attribute 'AsyncStreamReaderMixin'`; unrelated to this change).
- `black tests/test_api_coverage.py` → clean.
- `flake8 direct_cli/wsdl_coverage.py` → clean (only pre-existing N817/PIE786 warnings).

## Risks / follow-ups

- The 10 KB floor is now skipped for any WSDL containing `xsd:import`/`xsd:include`. A captcha gateway that happened to embed those substrings could slip through — but captcha detection (`find_captcha_marker`) runs first, and structural markers (`<?xml`, `wsdl:definitions`) run before the bypass, so the risk is low.
- Local `ruff` is 0.16.0 while the project pins `ruff<0.16`; its output is noisy environment drift, not project lint. Project lint is `flake8`/`black`, both clean on the changed files.

Closes #626
Reopens #608

🤖 Generated with [Claude Code](https://claude.com/claude-code)