### PR TITLE
feat(masters): add `direct masters suspend`/`resume` (#630)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+**Added — `direct masters suspend` / `direct masters resume` (#630):**
+
+- First mutating `masters` commands — stop/resume a Мастер кампаний by
+  clicking its overview page's action button, then re-reading the status to
+  confirm the change actually took effect (the click alone is never treated
+  as success). Both are idempotent: a campaign already in the target status
+  is a no-op with a warning, not an error. Neither has a `--sandbox`
+  equivalent — Мастер кампаний has no API surface at all, so there is no
+  isolated test copy; every mutation hits the real account (classified
+  `DANGEROUS` in `direct_cli/smoke_matrix.py`, manual-only per
+  `scripts/test_dangerous_commands.sh`).
+- **Not live-verified:** the resume button's text ("Возобновить кампанию")
+  is confirmed against a live account; the suspend/stop button's exact text
+  is not — `direct_cli/browser/masters.py` tries a short list of plausible
+  Russian labels and raises a clear error (suggesting `--headful`) if none
+  match, rather than clicking the wrong element.
+
 **BREAKING CHANGES — `direct masters` no longer accepts `--login` (#639):**
 
 - `direct masters list`/`get` dropped the `--login` option. Passing your own

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ playwright install chromium
 direct masters list
 direct masters list --status archived
 direct masters get 72349978
+direct masters suspend 72349978
+direct masters resume 72349978
 ```
 
 `masters list` filters by status with `--status`
@@ -45,9 +47,16 @@ If you see "Found no Yandex cookies", open https://direct.yandex.ru in Chrome
 and log in first. If you use a non-default Chrome profile, pass
 `--chrome-profile "Profile 1"`.
 
-Read-only for now (`list`/`get`); since this data has no API contract, the
-parser degrades per-section (a warning, not a hard failure) if Yandex changes
-the page markup, rather than failing the whole command.
+Since this data has no API contract, the parser degrades per-section (a
+warning, not a hard failure) if Yandex changes the page markup, rather than
+failing the whole command.
+
+`suspend`/`resume` click the campaign overview page's stop/start button and
+verify the status actually changed before reporting success — never trusting
+the click alone. They're idempotent (already-suspended/-active is a no-op
+warning, not an error). There is **no `--sandbox` for these** — Мастер
+кампаний has no API at all, so there is no isolated test copy; any mutation
+hits your real account.
 
 **Browser session (optional but recommended):** `direct masters` decrypts
 your Chrome cookies fresh on every call by default, which means a Keychain
@@ -1055,6 +1064,8 @@ playwright install chromium
 direct masters list
 direct masters list --status archived
 direct masters get 72349978
+direct masters suspend 72349978
+direct masters resume 72349978
 ```
 
 `masters list` фильтрует по статусу через `--status`
@@ -1067,9 +1078,16 @@ direct masters get 72349978
 Chrome и войдите в аккаунт. Если используете не дефолтный профиль Chrome —
 передайте `--chrome-profile "Profile 1"`.
 
-Пока только чтение (`list`/`get`); поскольку у этих данных нет API-контракта,
-парсер деградирует посекционно (предупреждение, а не жёсткий отказ), если
-Яндекс изменит вёрстку страницы.
+Поскольку у этих данных нет API-контракта, парсер деградирует посекционно
+(предупреждение, а не жёсткий отказ), если Яндекс изменит вёрстку страницы.
+
+`suspend`/`resume` кликают по кнопке остановки/возобновления на странице
+обзора кампании и проверяют, что статус реально изменился, прежде чем
+сообщить об успехе — сам факт клика успехом не считается. Обе команды
+идемпотентны (кампания уже в нужном статусе — предупреждение, а не ошибка).
+У этих команд **нет `--sandbox`** — у «Мастера кампаний» нет API вообще,
+поэтому нет изолированной тестовой копии; любая мутация идёт в боевой
+аккаунт.
 
 **Браузерная сессия (опционально, но рекомендуется):** по умолчанию `direct
 masters` расшифровывает куки Chrome заново при каждом вызове — на macOS это

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -1,5 +1,5 @@
 """
-Мастер кампаний (Campaign Wizard) read-only browser scraping.
+Мастер кампаний (Campaign Wizard) browser scraping and mutations.
 
 Мастер кампаний has no API surface at all — see the package docstring in
 ``direct_cli/browser/__init__.py``. ``get`` (per-campaign overview) reads the
@@ -24,10 +24,25 @@ grid's own campaign-type fields (``type``, ``metaType``, ``__typename`` are
 identical between a Мастер campaign and an ordinary one of the same type).
 The one field that does distinguish them, confirmed live against a real
 account, is ``source == "UAC"``.
+
+``suspend_master``/``resume_master`` (issue #630) — **not live-verified**.
+The overview page's "Возобновить кампанию" (resume) button text is confirmed
+live (see the fixture). The suspend-side button text is NOT confirmed live —
+this module tries a short list of plausible Russian labels
+(``_SUSPEND_BUTTON_TEXTS``) via Playwright's text-based locator matching
+(case-insensitive substring), and either action re-reads the page's status
+text after clicking to verify the change actually happened (never trusting
+the click alone — see ``_click_action_button``). If Yandex's real button text
+isn't in that list, both functions raise ``BrowserSessionError`` with a
+message asking the caller to re-run with ``--headful`` and report the actual
+text, rather than clicking the wrong element. Re-confirm the exact button
+text/behaviour against a live account before relying on this in production;
+update ``_SUSPEND_BUTTON_TEXTS``/``_RESUME_BUTTON_TEXTS`` accordingly.
 """
 
 import json
-from typing import TYPE_CHECKING, Any, Dict, List
+import time
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from ..output import print_warning
 from .session import BrowserSessionError, assert_authenticated, assert_not_captcha
@@ -88,6 +103,17 @@ _STAT_TILE_LABELS = {
     "За конверсию": "cost_per_conversion",
     "Расход": "cost",
 }
+
+# Overview-page action button text for resume/suspend (see module docstring:
+# resume is confirmed live via the fixture, suspend is NOT — this is a
+# best-effort candidate list of plausible Russian labels, matched
+# case-insensitively as a substring against every button's text).
+_RESUME_BUTTON_TEXTS = ("Возобновить кампанию", "Возобновить")
+_SUSPEND_BUTTON_TEXTS = ("Остановить кампанию", "Приостановить кампанию", "Остановить")
+
+# How long to wait, after clicking the action button, for the status text to
+# actually change before giving up and reporting a possible false success.
+_STATUS_CHANGE_TIMEOUT_MS = 10_000
 
 
 def _is_grid_campaigns_request(response: Any) -> bool:
@@ -339,3 +365,137 @@ def _extract_stat_tiles(page: "Page", result: Dict[str, Any]) -> None:
         print_warning(
             f"Could not read overview stat tiles for campaign {result['CampaignId']}."
         )
+
+
+def _read_status_text(page: "Page") -> Optional[str]:
+    """Return ``"SUSPENDED"``/``"ACTIVE"``/``None`` from the current page body.
+
+    Shares the same marker text as ``_extract_status`` but returns the value
+    directly instead of writing into a result dict — used by
+    ``suspend_master``/``resume_master`` both before and after clicking, to
+    verify the action actually changed the status rather than trusting the
+    click alone.
+    """
+    try:
+        body_text = page.inner_text("body")
+    except PlaywrightError:
+        return None
+    if "Кампания остановлена" in body_text:
+        return "SUSPENDED"
+    if "Кампания активна" in body_text or "Кампания включена" in body_text:
+        return "ACTIVE"
+    return None
+
+
+def _click_action_button(page: "Page", candidate_texts: Tuple[str, ...]) -> None:
+    """Click the first visible button matching one of ``candidate_texts``.
+
+    Raises :class:`BrowserSessionError` if none of the candidates match any
+    visible button — this deliberately does NOT fall back to clicking an
+    unrelated element, since suspend/resume is a real account mutation (see
+    module docstring: the suspend-side button text is not live-confirmed).
+    """
+    for text in candidate_texts:
+        locator = page.get_by_text(text, exact=False)
+        try:
+            count = locator.count()
+        except PlaywrightError:
+            continue
+        for i in range(count):
+            handle = locator.nth(i)
+            try:
+                if not handle.is_visible():
+                    continue
+                handle.click()
+                return
+            except PlaywrightError:
+                continue
+    raise BrowserSessionError(
+        "Could not find an action button matching any of "
+        f"{candidate_texts!r} on the campaign overview page. Yandex may "
+        "have changed the button's text — re-run with --headful to "
+        "inspect the page and report the actual text."
+    )
+
+
+def _suspend_or_resume(
+    page: "Page",
+    campaign_id: int,
+    *,
+    target_status: str,
+    button_texts: Tuple[str, ...],
+) -> Dict[str, Any]:
+    """Shared body for ``suspend_master``/``resume_master``.
+
+    Idempotent: if the campaign is already in ``target_status``, does not
+    click anything and returns the current state with a warning (mirrors the
+    rest of the CLI's suspend/resume convention). Otherwise clicks the
+    matching action button and re-reads the status to confirm the mutation
+    actually took effect — a click that doesn't visibly change the status is
+    reported as a hard error, not a silent success.
+    """
+    url = WIZARD_OVERVIEW_URL.format(campaign_id=campaign_id)
+    page.goto(url, wait_until="domcontentloaded")
+    assert_not_captcha(page.content())
+    assert_authenticated(page.content())
+
+    current_status = _read_status_text(page)
+    if current_status is None:
+        raise BrowserSessionError(
+            f"Could not determine current status for campaign {campaign_id} "
+            "(unrecognised status text) — refusing to click blind."
+        )
+    if current_status == target_status:
+        print_warning(
+            f"Campaign {campaign_id} is already {target_status}; not clicking."
+        )
+        return {"CampaignId": campaign_id, "Status": current_status}
+
+    _click_action_button(page, button_texts)
+
+    deadline = time.monotonic() + _STATUS_CHANGE_TIMEOUT_MS / 1000
+    new_status = current_status
+    while time.monotonic() < deadline:
+        new_status = _read_status_text(page)
+        if new_status == target_status:
+            break
+        page.wait_for_timeout(250)
+
+    if new_status != target_status:
+        raise BrowserSessionError(
+            f"Clicked the action button for campaign {campaign_id}, but its "
+            f"status did not change to {target_status} within "
+            f"{_STATUS_CHANGE_TIMEOUT_MS / 1000:.0f}s (still {new_status!r}). "
+            "The click may not have hit the right element, or Yandex is "
+            "slow to apply it — verify manually before retrying."
+        )
+
+    return {"CampaignId": campaign_id, "Status": new_status}
+
+
+def suspend_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
+    """Stop (suspend) a Мастер кампаний, verifying the status actually changed.
+
+    See module docstring: the "stop" button's exact text is NOT confirmed
+    live — ``_SUSPEND_BUTTON_TEXTS`` is a best-effort candidate list.
+    """
+    return _suspend_or_resume(
+        page,
+        campaign_id,
+        target_status="SUSPENDED",
+        button_texts=_SUSPEND_BUTTON_TEXTS,
+    )
+
+
+def resume_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
+    """Resume a stopped Мастер кампаний, verifying the status actually changed.
+
+    "Возобновить кампанию" is confirmed live (see module docstring /
+    ``tests/fixtures/masters_wizard_overview.html``).
+    """
+    return _suspend_or_resume(
+        page,
+        campaign_id,
+        target_status="ACTIVE",
+        button_texts=_RESUME_BUTTON_TEXTS,
+    )

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -261,7 +261,7 @@ def _masters_browser_options(func):
 
 @click.group()
 def masters():
-    """Read Мастер кампаний (Campaign Wizard) — browser-only, no API"""
+    """Мастер кампаний (Campaign Wizard) — browser-only, no API"""
 
 
 _STATUS_CHOICES = ("not-archived", "active", "stopped", "archived", "all")
@@ -317,5 +317,72 @@ def get(
         return [fetch_master(page, campaign_id) for campaign_id in ids]
 
     results = _with_session(ctx, headful, profile_dir, chrome_profile, _fetch_all)
+
+    format_output(results if len(results) != 1 else results[0], output_format, output)
+
+
+@masters.command()
+@click.argument("campaign_ids")
+@_masters_browser_options
+@click.pass_context
+@handle_api_errors
+def suspend(
+    ctx,
+    campaign_ids,
+    headful,
+    profile_dir,
+    chrome_profile,
+    output_format,
+    output,
+):
+    """Stop one or more Мастер кампаний by ID (comma-separated)
+
+    Not live-verified (issue #630): clicks the overview page's stop button,
+    matched by a best-effort list of candidate Russian labels — see
+    ``direct_cli/browser/masters.py`` module docstring. Verifies the status
+    actually changed before reporting success; idempotent if already
+    stopped.
+    """
+    from ..browser.masters import suspend_master
+
+    ids = parse_ids(campaign_ids) or []
+
+    def _suspend_all(page):
+        return [suspend_master(page, campaign_id) for campaign_id in ids]
+
+    results = _with_session(ctx, headful, profile_dir, chrome_profile, _suspend_all)
+
+    format_output(results if len(results) != 1 else results[0], output_format, output)
+
+
+@masters.command()
+@click.argument("campaign_ids")
+@_masters_browser_options
+@click.pass_context
+@handle_api_errors
+def resume(
+    ctx,
+    campaign_ids,
+    headful,
+    profile_dir,
+    chrome_profile,
+    output_format,
+    output,
+):
+    """Resume one or more stopped Мастер кампаний by ID (comma-separated)
+
+    Clicks the overview page's "Возобновить кампанию" button (confirmed
+    live — see ``direct_cli/browser/masters.py`` module docstring). Verifies
+    the status actually changed before reporting success; idempotent if
+    already active.
+    """
+    from ..browser.masters import resume_master
+
+    ids = parse_ids(campaign_ids) or []
+
+    def _resume_all(page):
+        return [resume_master(page, campaign_id) for campaign_id in ids]
+
+    results = _with_session(ctx, headful, profile_dir, chrome_profile, _resume_all)
 
     format_output(results if len(results) != 1 else results[0], output_format, output)

--- a/direct_cli/smoke_matrix.py
+++ b/direct_cli/smoke_matrix.py
@@ -178,6 +178,14 @@ SMOKE_MATRIX = {
         "agencyclients.update",
         "auth.login",
         "auth.use",
+        # Browser-driven mutations against Мастер кампаний (issue #630).
+        # Мастер кампаний has no API surface at all, so there is no
+        # --sandbox equivalent to isolate these from a real Yandex
+        # account — unlike API-backed suspend/resume (WRITE_SANDBOX
+        # above), any smoke exercise of these two hits production.
+        # Manual-only, per scripts/test_dangerous_commands.sh.
+        "masters.resume",
+        "masters.suspend",
         "v4adimage.set",
         "v4finance.create-invoice",
         "v4finance.pay-campaigns",

--- a/scripts/test_dangerous_commands.sh
+++ b/scripts/test_dangerous_commands.sh
@@ -24,6 +24,12 @@ V4 Live finance money mutations (0.3.3 exposes dry-run-only previews):
   - direct v4finance transfer-money --from-campaign-id ... --to-campaign-id ... --amount ... --currency RUB --dry-run
   - direct v4finance pay-campaigns --campaign-ids ... --amount ... --contract-id ... --pay-method Bank --currency RUB --dry-run
 
+Browser-driven Мастер кампаний mutations (no API surface, no --sandbox
+equivalent -- these always hit a real Yandex account; verify on one
+non-critical campaign, confirming before/after state in the web UI):
+  - direct masters suspend <campaign_id>
+  - direct masters resume <campaign_id>
+
 Production commands that are only allowed in automated smoke tests with --sandbox:
   - direct bids set ...
   - direct bids set-auto ...

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -40,6 +40,11 @@ MUTATING_COMMANDS = {
 DRY_RUN_EXCEPTIONS = {
     # This command rejects locally because the API has no delete operation.
     "agencyclients.delete",
+    # Мастер кампаний (issue #630) has no API surface at all -- these click a
+    # button in a real browser session against production, there is no
+    # request payload to preview. See direct_cli/browser/masters.py.
+    "masters.resume",
+    "masters.suspend",
 }
 
 FORBIDDEN_HELP_TEXT = (

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -170,6 +170,44 @@ class _FakeExpectResponse:
         return False
 
 
+class _FakeTextLocatorHandle:
+    """One matched element for ``get_by_text`` — supports ``is_visible``/``click``.
+
+    ``on_click`` is an optional no-arg callback invoked when ``click()`` is
+    called — used to model a suspend/resume click flipping the fake page's
+    status text.
+    """
+
+    def __init__(self, visible=True, on_click=None, raises=False):
+        self._visible = visible
+        self._on_click = on_click
+        self._raises = raises
+
+    def is_visible(self):
+        if self._raises:
+            raise PlaywrightError("element detached")
+        return self._visible
+
+    def click(self):
+        if self._raises:
+            raise PlaywrightError("element detached")
+        if self._on_click is not None:
+            self._on_click()
+
+
+class _FakeGetByTextLocator:
+    """Fakes ``page.get_by_text(text, exact=False)`` — one handle list per text."""
+
+    def __init__(self, handles):
+        self._handles = handles
+
+    def count(self):
+        return len(self._handles)
+
+    def nth(self, i):
+        return self._handles[i]
+
+
 class FakePage:
     """A Page whose ``locator(selector)`` result is pre-scripted per selector."""
 
@@ -180,6 +218,7 @@ class FakePage:
         html="<html></html>",
         grid_response=None,
         api_request=None,
+        text_buttons=None,
     ):
         self._locators = locators or {}
         self._body_text = body_text
@@ -191,6 +230,9 @@ class FakePage:
         # GridCampaigns XHR during navigation.
         self._grid_response = grid_response
         self.request = api_request or _FakeApiRequestContext()
+        # {text: _FakeGetByTextLocator} for get_by_text() — used by
+        # suspend_master/resume_master's action-button click.
+        self._text_buttons = text_buttons or {}
 
     def goto(self, url, wait_until=None):
         self.navigated_to.append(url)
@@ -205,11 +247,17 @@ class FakePage:
     def locator(self, selector):
         return self._locators.get(selector, _FakeLocator([]))
 
+    def get_by_text(self, text, exact=False):
+        return self._text_buttons.get(text, _FakeGetByTextLocator([]))
+
     def inner_text(self, selector=None):
         return self._body_text
 
     def content(self):
         return self._html
+
+    def wait_for_timeout(self, timeout):
+        pass
 
 
 class TestMastersRegistered(unittest.TestCase):
@@ -909,6 +957,163 @@ class TestFetchMaster(unittest.TestCase):
 
         self.assertEqual(result, {"CampaignId": 999})
         self.assertGreaterEqual(warn.call_count, 3)  # name, status, landing, stats
+
+
+class TestSuspendResumeMaster(unittest.TestCase):
+    """suspend_master/resume_master (issue #630): click + verify, idempotent.
+
+    See direct_cli/browser/masters.py module docstring: the suspend-side
+    button text is NOT live-confirmed, only a best-effort candidate list --
+    these tests exercise the click/verify/idempotency mechanics against that
+    candidate list, not a live-verified button text.
+    """
+
+    def _page_with_button(
+        self, status_text, button_text, next_status_text=None, visible=True
+    ):
+        state = {"status": status_text}
+
+        def _flip():
+            state["status"] = next_status_text
+
+        page = FakePage(
+            text_buttons={
+                button_text: _FakeGetByTextLocator(
+                    [_FakeTextLocatorHandle(visible=visible, on_click=_flip)]
+                )
+            },
+        )
+        # inner_text("body") must reflect the current (mutable) status, so
+        # override the FakePage method rather than passing a fixed body_text.
+        page.inner_text = lambda selector=None: state["status"]
+        return page
+
+    def test_resume_clicks_confirmed_button_and_verifies(self):
+        page = self._page_with_button(
+            "Кампания остановлена",
+            "Возобновить кампанию",
+            next_status_text="Кампания активна",
+        )
+
+        result = browser_masters.resume_master(page, 42)
+
+        self.assertEqual(result, {"CampaignId": 42, "Status": "ACTIVE"})
+        self.assertEqual(
+            page.navigated_to,
+            [browser_masters.WIZARD_OVERVIEW_URL.format(campaign_id=42)],
+        )
+
+    def test_suspend_clicks_candidate_button_and_verifies(self):
+        page = self._page_with_button(
+            "Кампания активна",
+            "Остановить кампанию",
+            next_status_text="Кампания остановлена",
+        )
+
+        result = browser_masters.suspend_master(page, 42)
+
+        self.assertEqual(result, {"CampaignId": 42, "Status": "SUSPENDED"})
+
+    def test_resume_idempotent_when_already_active(self):
+        page = FakePage(body_text="Кампания активна")
+
+        with patch("direct_cli.browser.masters.print_warning") as warn:
+            result = browser_masters.resume_master(page, 7)
+
+        self.assertEqual(result, {"CampaignId": 7, "Status": "ACTIVE"})
+        warn.assert_called_once()
+        self.assertIn("already", warn.call_args[0][0])
+
+    def test_suspend_idempotent_when_already_suspended(self):
+        page = FakePage(body_text="Кампания остановлена")
+
+        with patch("direct_cli.browser.masters.print_warning"):
+            result = browser_masters.suspend_master(page, 7)
+
+        self.assertEqual(result, {"CampaignId": 7, "Status": "SUSPENDED"})
+
+    def test_resume_raises_when_no_candidate_button_found(self):
+        # None of _RESUME_BUTTON_TEXTS is present -- must not silently no-op.
+        page = FakePage(body_text="Кампания остановлена", text_buttons={})
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.resume_master(page, 7)
+        self.assertIn("--headful", str(ctx.exception))
+
+    def test_suspend_raises_when_click_does_not_change_status(self):
+        # The button is found and clicked, but the status text never flips --
+        # must not report success on the click alone (module docstring).
+        page = self._page_with_button(
+            "Кампания активна",
+            "Остановить кампанию",
+            next_status_text="Кампания активна",  # unchanged after "click"
+        )
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.suspend_master(page, 42)
+        self.assertIn("did not change", str(ctx.exception))
+
+    def test_resume_raises_when_current_status_unrecognised(self):
+        page = FakePage(body_text="something Yandex changed the markup to")
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.resume_master(page, 7)
+        self.assertIn("Could not determine current status", str(ctx.exception))
+
+    def test_suspend_button_invisible_is_skipped(self):
+        # An invisible match (e.g. a hidden template) must not be clicked --
+        # falls through to the "not found" error since it's the only handle.
+        page = self._page_with_button(
+            "Кампания активна", "Остановить кампанию", visible=False
+        )
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters.suspend_master(page, 42)
+
+
+class TestMastersSuspendResumeCommand(unittest.TestCase):
+    """CLI wiring for `masters suspend`/`masters resume`."""
+
+    def setUp(self):
+        self.runner = CliRunner()
+
+    def test_suspend_registered(self):
+        result = self.runner.invoke(cli, ["masters", "suspend", "--help"])
+        self.assertEqual(result.exit_code, 0)
+
+    def test_resume_registered(self):
+        result = self.runner.invoke(cli, ["masters", "resume", "--help"])
+        self.assertEqual(result.exit_code, 0)
+
+    def test_suspend_has_no_login_option(self):
+        result = self.runner.invoke(cli, ["masters", "suspend", "--help"])
+        self.assertNotIn("--login", result.output)
+
+    def test_resume_has_no_login_option(self):
+        result = self.runner.invoke(cli, ["masters", "resume", "--help"])
+        self.assertNotIn("--login", result.output)
+
+    def test_suspend_calls_suspend_master_per_id(self):
+        with (
+            patch("direct_cli.browser.masters.suspend_master") as mock_suspend,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            result = self.runner.invoke(cli, ["masters", "suspend", "1,2"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(mock_suspend.call_count, 2)
+
+    def test_resume_calls_resume_master_per_id(self):
+        with (
+            patch("direct_cli.browser.masters.resume_master") as mock_resume,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            result = self.runner.invoke(cli, ["masters", "resume", "1"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(mock_resume.call_count, 1)
 
 
 class TestCaptchaDetection(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Adds `direct masters suspend`/`direct masters resume`: click the campaign overview page's action button, then re-read the status to confirm the mutation actually took effect (never trusting the click alone).
- Idempotent: a campaign already in the target status is a no-op with a warning, not an error.
- Classified `DANGEROUS` in `smoke_matrix.py` — Мастер кампаний has no API surface at all, so there's no `--sandbox` equivalent to isolate these from a real Yandex account.

## Not live-verified (important caveat)
Issue #630's step 0 calls for live confirmation of the exact stop-button text and post-click behavior before implementing. I do not currently have a live Chrome session with a real Мастер кампаний account available, so:
- The **resume** button text (`"Возобновить кампанию"`) is confirmed live — it's already in `tests/fixtures/masters_wizard_overview.html`.
- The **suspend/stop** button text is NOT confirmed live. `direct_cli/browser/masters.py::_SUSPEND_BUTTON_TEXTS` tries a short list of plausible Russian labels (`"Остановить кампанию"`, `"Приостановить кампанию"`, `"Остановить"`). If none match, the command fails with a clear error suggesting `--headful` rather than clicking the wrong element.
- Both `suspend_master`/`resume_master` verify the status text actually flips after the click (10s poll) before reporting success, so even with the wrong candidate list, a broken click surfaces as an explicit error, not silent data corruption.

**Before relying on this in production**, please live-verify the suspend button's exact text against a real stopped/active Мастер кампаний and update `_SUSPEND_BUTTON_TEXTS` if needed (or confirm it already matches).

## Test plan
- [x] `pytest tests/test_masters.py -q` — 59 passed, including new `TestSuspendResumeMaster` (click+verify, idempotency, no-candidate-found, click-without-status-change) and `TestMastersSuspendResumeCommand` (CLI wiring)
- [x] `pytest -q --ignore=tests/test_read_cassettes.py --ignore=tests/test_integration_write.py` — 2638 passed, 8 skipped
- [x] `black --check` / `flake8` on all changed files
- [ ] Manual live smoke test on one non-critical campaign (see `scripts/test_dangerous_commands.sh`) — not run in this PR per the above caveat

Closes #630