### PR TITLE
chore: apply black formatting across accumulated drift

### DIFF
--- a/direct_cli/commands/creatives.py
+++ b/direct_cli/commands/creatives.py
@@ -36,9 +36,7 @@ get = make_get_command(
     default_fields_key="creatives",
     help_text="Get creatives",
     ids_help="Comma-separated creative IDs",
-    extra_options=(
-        click.option("--types", help="Comma-separated creative types"),
-    ),
+    extra_options=(click.option("--types", help="Comma-separated creative types"),),
     criteria_builder=_creatives_get_criteria,
     require_criteria_message="Provide at least one typed filter",
     nested_field_options=(

--- a/tests/test_audit_wire_shape.py
+++ b/tests/test_audit_wire_shape.py
@@ -13,7 +13,6 @@ from pathlib import Path
 
 import pytest
 
-
 REPO_ROOT = Path(__file__).resolve().parent.parent
 _AUDIT_PATH = REPO_ROOT / "scripts" / "audit_wire_shape.py"
 
@@ -65,9 +64,9 @@ Sum Сумма. Да Currency Валюта. Да
 def test_extract_request_section_skips_toc_and_keeps_body():
     section = audit.extract_request_section(_MOCK_LIVE_PAGE)
     assert "PayCampElement" in section
-    assert "ResultCode" not in section, (
-        "response-side fields must NOT leak into the request section"
-    )
+    assert (
+        "ResultCode" not in section
+    ), "response-side fields must NOT leak into the request section"
 
 
 def test_parse_schema_blocks_captures_paycampelement_with_currency():
@@ -100,12 +99,8 @@ def test_parse_live4_hints_extracts_newly_required():
 
 def test_collect_example_keys_walks_nested_lists_and_dicts():
     example = {
-        "FromCampaigns": [
-            {"CampaignID": 1, "Sum": 1.0, "Currency": "RUB"}
-        ],
-        "ToCampaigns": [
-            {"CampaignID": 2, "Sum": 1.0, "Currency": "RUB"}
-        ],
+        "FromCampaigns": [{"CampaignID": 1, "Sum": 1.0, "Currency": "RUB"}],
+        "ToCampaigns": [{"CampaignID": 2, "Sum": 1.0, "Currency": "RUB"}],
     }
     keys = audit._collect_example_keys(example)
     assert keys == {
@@ -169,9 +164,7 @@ def test_audit_v5_treats_wsdl_base_as_single_group_target(monkeypatch):
 
     def fake_fetch_doc(url, retries, pause):
         fetched_urls.append(url)
-        return audit.FetchResult(
-            url=url, status="thin", html=wsdl_body, attempts=3
-        )
+        return audit.FetchResult(url=url, status="thin", html=wsdl_body, attempts=3)
 
     monkeypatch.setattr(audit, "fetch_doc", fake_fetch_doc)
     monkeypatch.setattr(

--- a/tests/test_cassette_integrity.py
+++ b/tests/test_cassette_integrity.py
@@ -33,9 +33,7 @@ def test_retargeting_cassette_records_full_lifecycle() -> None:
     update/delete coverage. This guard fails if any lifecycle method is missing,
     catching that regression offline.
     """
-    body = _cassette_body(
-        "test_v5_live_draft_retargeting_add_update_delete.yaml"
-    )
+    body = _cassette_body("test_v5_live_draft_retargeting_add_update_delete.yaml")
     for method in ('"method":"add"', '"method":"update"', '"method":"delete"'):
         assert method in body, (
             f"retargeting cassette is missing {method} — it looks re-recorded "
@@ -53,9 +51,7 @@ def test_audiencetargets_add_delete_cassette_records_full_lifecycle() -> None:
     full lifecycle to a skip-only, add-rejected cassette. This guard fails offline
     if either lifecycle method is missing.
     """
-    body = _cassette_body(
-        "test_v5_live_draft_audiencetargets_add_delete.yaml"
-    )
+    body = _cassette_body("test_v5_live_draft_audiencetargets_add_delete.yaml")
     for method in ('"method":"add"', '"method":"delete"'):
         assert method in body, (
             f"audiencetargets add/delete cassette is missing {method} — it looks "
@@ -71,9 +67,7 @@ def test_audiencetargets_suspend_resume_cassette_records_full_lifecycle() -> Non
     re-record turns the add+delete+suspend+resume lifecycle into a skip-only
     recording. This guard fails offline if any lifecycle method is missing.
     """
-    body = _cassette_body(
-        "test_v5_live_draft_audiencetargets_suspend_resume.yaml"
-    )
+    body = _cassette_body("test_v5_live_draft_audiencetargets_suspend_resume.yaml")
     for method in (
         '"method":"add"',
         '"method":"delete"',

--- a/tests/test_dry_run_strategy_smart.py
+++ b/tests/test_dry_run_strategy_smart.py
@@ -6,7 +6,6 @@ See :mod:`tests.test_dry_run_shared` for the shared invocation helpers and
 ``tests/test_dry_run.py`` for the rationale behind the whole suite.
 """
 
-
 from tests.test_dry_run_shared import _dry_run, _rejected
 
 

--- a/tests/test_dry_run_strategy_unified.py
+++ b/tests/test_dry_run_strategy_unified.py
@@ -5,7 +5,6 @@ See :mod:`tests.test_dry_run_shared` for the shared invocation helpers and
 ``tests/test_dry_run.py`` for the rationale behind the whole suite.
 """
 
-
 import pytest
 from click.testing import CliRunner
 

--- a/tests/test_integration_write.py
+++ b/tests/test_integration_write.py
@@ -571,9 +571,9 @@ class TestWriteBidModifiersSet:
             "bidmodifiers set unexpectedly succeeded without --id; it must "
             "reject the legacy CampaignId + Type shape locally."
         )
-        assert "legacy --campaign-id/--type shape is not supported" in r.output, (
-            f"Unexpected failure mode from bidmodifiers set: {r.output[:500]}"
-        )
+        assert (
+            "legacy --campaign-id/--type shape is not supported" in r.output
+        ), f"Unexpected failure mode from bidmodifiers set: {r.output[:500]}"
 
 
 # ── feeds ────────────────────────────────────────────────────────────────
@@ -876,9 +876,9 @@ class TestWriteAdImages:
             pytest.fail(f"adimages add failed (CLI regression?): {r.output[:500]}")
 
         data = json.loads(r.output)
-        assert isinstance(data, list) and data, (
-            f"adimages add returned empty result: {r.output[:200]}"
-        )
+        assert (
+            isinstance(data, list) and data
+        ), f"adimages add returned empty result: {r.output[:200]}"
         first = data[0]
         if "Errors" in first and first["Errors"]:
             err_text = str(first["Errors"])

--- a/tests/test_reports_parsing.py
+++ b/tests/test_reports_parsing.py
@@ -9,7 +9,6 @@ from direct_cli._vendor.tapi_yandex_direct.tapi_yandex_direct import (
     YandexDirectClientAdapter,
 )
 
-
 FIELD_NAMES = ["Month", "Impressions", "Clicks", "Cost"]
 REPORT_ROWS = [
     ["2026-03-01", "10", "2", "1500000"],

--- a/tests/test_transport_contract.py
+++ b/tests/test_transport_contract.py
@@ -19,9 +19,9 @@ def test_dependency_uses_axisrow_fork():
         Path(__file__).resolve().parent.parent
         / "direct_cli/_vendor/tapi_yandex_direct/__init__.py"
     )
-    assert vendor_init.exists(), (
-        "Vendored tapi_yandex_direct not found in direct_cli/_vendor/"
-    )
+    assert (
+        vendor_init.exists()
+    ), "Vendored tapi_yandex_direct not found in direct_cli/_vendor/"
 
 
 def test_tapi_transport_exposes_cli_resource_executors():

--- a/tests/test_v4_live_contracts.py
+++ b/tests/test_v4_live_contracts.py
@@ -282,9 +282,9 @@ def test_v4_live_wordstat_lifecycle_opt_in_write():
         "CreateNewWordstatReport",
         {"Phrases": ["купить ноутбук"], "GeoID": [0]},
     )
-    assert isinstance(report_id, int) and report_id > 0, (
-        f"unexpected CreateNewWordstatReport response: {report_id!r}"
-    )
+    assert (
+        isinstance(report_id, int) and report_id > 0
+    ), f"unexpected CreateNewWordstatReport response: {report_id!r}"
     _orphan_store.add("v4wordstat", report_id)
     try:
         reports = call_v4(client, "GetWordstatReportList")
@@ -320,9 +320,9 @@ def test_v4_live_forecast_lifecycle_opt_in_write():
         "CreateNewForecast",
         {"Phrases": ["купить ноутбук"], "GeoID": [213], "Currency": "RUB"},
     )
-    assert isinstance(forecast_id, int) and forecast_id > 0, (
-        f"unexpected CreateNewForecast response: {forecast_id!r}"
-    )
+    assert (
+        isinstance(forecast_id, int) and forecast_id > 0
+    ), f"unexpected CreateNewForecast response: {forecast_id!r}"
     _orphan_store.add("v4forecast", forecast_id)
     try:
         forecasts = call_v4(client, "GetForecastList")

--- a/tests/test_v5_live_write.py
+++ b/tests/test_v5_live_write.py
@@ -203,9 +203,9 @@ def _extract_first_id(output: str, key: str = "AddResults") -> int | str:
 
     assert items, f"No result items in response: {output[:500]}"
     first = items[0]
-    assert "Errors" not in first or not first["Errors"], (
-        f"API rejected add: {first.get('Errors')}"
-    )
+    assert (
+        "Errors" not in first or not first["Errors"]
+    ), f"API rejected add: {first.get('Errors')}"
     assert "Id" in first, f"No Id in add result: {first}"
     raw = first["Id"]
     try:
@@ -227,9 +227,9 @@ def _extract_field(output: str, field: str = "Id", key: str = "AddResults") -> A
 
     assert items, f"No result items in response: {output[:500]}"
     first = items[0]
-    assert "Errors" not in first or not first["Errors"], (
-        f"API rejected request: {first.get('Errors')}"
-    )
+    assert (
+        "Errors" not in first or not first["Errors"]
+    ), f"API rejected request: {first.get('Errors')}"
     assert field in first, f"No {field} in result: {first}"
     return first[field]
 
@@ -473,9 +473,9 @@ def test_v5_live_draft_adimages_add_get_delete() -> None:
             result_data = data.get("result", data)
             images = result_data.get("AdImages", [])
         hashes_in_response = {img.get("AdImageHash") for img in images}
-        assert img_hash in hashes_in_response, (
-            f"Uploaded image hash {img_hash} not found in get response"
-        )
+        assert (
+            img_hash in hashes_in_response
+        ), f"Uploaded image hash {img_hash} not found in get response"
     finally:
         r = _invoke_live("adimages", "delete", "--hash", str(img_hash))
         if r.exit_code != 0:
@@ -924,9 +924,9 @@ def test_v5_live_draft_dynamicads_add_delete() -> None:
         else:
             result_data = data.get("result", data)
             targets = result_data.get("DynamicTextAdTargets", [])
-        assert any(t.get("Id") == did for t in targets), (
-            f"Dynamic ad target {did} not found in get response"
-        )
+        assert any(
+            t.get("Id") == did for t in targets
+        ), f"Dynamic ad target {did} not found in get response"
     finally:
         if did is not None:
             _invoke_live("dynamicads", "delete", "--id", str(did))


### PR DESCRIPTION
## Summary
- \`black --check\` had accumulated 10 unformatted files in the project (not in \`direct_cli/_vendor/\`, which is overwritten wholesale by \`scripts/update_vendor.sh\` and shouldn't be hand-formatted here).
- Pure formatting, no logic changes.

## Test plan
- [x] \`black --check direct_cli tests --exclude '_vendor'\` — clean
- [x] \`pytest -q --ignore=tests/test_read_cassettes.py --ignore=tests/test_integration_write.py\` — 2624 passed, 8 skipped

## Follow-up
flake8 has a much larger, pre-existing backlog (~200+ findings, mostly E501 line-length across dozens of files, plus PIE786/SIM105/SIM102/N806/N817/B042) that is not enforced in CI. Left untouched here — filed as a separate follow-up issue rather than risking behavior changes (some SIM105/PIE786 findings touch live-test exception handling) in a pure-formatting PR.