### PR TITLE
feat(browser): add `direct masters login` — Keychain-free persistent profile (#635)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@
   (not an error) if no profile exists. Also classified `DANGEROUS`
   (local credential-store mutation, same category as `auth login`/`auth
   use`).
+- `masters login` refuses to run without a terminal. It waits for a human,
+  so in CI or a script it now fails immediately with a clear message instead
+  of blocking for the full `--timeout` on a browser window nobody can see.
 - `masters login` polls for completion on a separate page instead of the
   one the user is typing into. Previously the loop navigated the visible
   Passport tab to the grid once a second, wiping a half-filled login form

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,17 @@
   one the user is typing into. Previously the loop navigated the visible
   Passport tab to the grid once a second, wiping a half-filled login form
   or a pending 2FA prompt out from under the user.
+- `masters login` refuses a `--profile-dir` that already exists without the
+  CLI's own marker. Previously the marker was planted into whatever directory
+  was named — so `masters login --profile-dir ~` marked the home directory as
+  CLI-owned, and `masters logout` on the same path then accepted that marker
+  as authorization to `shutil.rmtree` it. A failed login armed it just the
+  same, since the marker was written before Chromium even launched.
+- `masters` commands route through the persistent profile only when it holds
+  an actual browser session, not merely when the directory exists. An aborted
+  `masters login` leaves an empty profile behind; treating that as usable cost
+  a wasted browser launch on every later command and bypassed the user's
+  working saved session.
 - `masters logout` refuses to delete anything `masters login` did not
   create. Every profile now carries a `.direct-cli-profile` marker file,
   and `logout` rejects a target that lacks it, is a symlink, or is not a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@
   reported "Login confirmed" and was then silently ignored by every read —
   falling back to the Keychain the flag exists to avoid. `masters logout`
   clears the record along with the profile.
+- The recorded profile path is stored and read as absolute. A relative value
+  would have been re-resolved against whatever directory a later command ran
+  from, so `masters logout` acted on a different profile depending on where
+  the user stood.
 - `masters` commands route through the persistent profile only when it holds
   an actual browser session, not merely when the directory exists. An aborted
   `masters login` leaves an empty profile behind; treating that as usable cost

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@
   (not an error) if no profile exists. Also classified `DANGEROUS`
   (local credential-store mutation, same category as `auth login`/`auth
   use`).
+- `masters login` polls for completion on a separate page instead of the
+  one the user is typing into. Previously the loop navigated the visible
+  Passport tab to the grid once a second, wiping a half-filled login form
+  or a pending 2FA prompt out from under the user.
 - `masters logout` refuses to delete anything `masters login` did not
   create. Every profile now carries a `.direct-cli-profile` marker file,
   and `logout` rejects a target that lacks it, is a symlink, or is not a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+**Added — `direct masters login` (#635):**
+
+- New interactive command that opens a visible browser window on a
+  persistent Chromium profile owned by the CLI
+  (`~/.direct-cli/chrome-profile/` by default, overridable with
+  `--profile-dir`). Log in by hand once via Yandex Passport; the command
+  polls until the session is confirmed authenticated (or times out after
+  `--timeout` seconds, default 300) and exits.
+- Independent of `direct playwright login`/the macOS Keychain entirely —
+  this never touches the user's real Chrome profile, so it works
+  identically on macOS/Linux/Windows at the cost of a one-time manual login
+  instead of a transparent cookie copy.
+- `direct masters` (`list`/`get`/`suspend`/`resume`) prefers this persistent
+  profile automatically whenever it exists, ahead of the saved
+  `playwright login` session — see the new tier 1.5 in
+  `direct_cli/commands/masters.py`'s session-resolution docstring.
+- Interactive by design (blocks waiting for a human); classified
+  `DANGEROUS` in `direct_cli/smoke_matrix.py` and documented as
+  manual-only in `scripts/test_dangerous_commands.sh` — it cannot run in
+  any automated smoke tier.
+
 **Added — `direct masters suspend` / `direct masters resume` (#630):**
 
 - First mutating `masters` commands — stop/resume a Мастер кампаний by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@
   (not an error) if no profile exists. Also classified `DANGEROUS`
   (local credential-store mutation, same category as `auth login`/`auth
   use`).
+- `masters logout` refuses to delete anything `masters login` did not
+  create. Every profile now carries a `.direct-cli-profile` marker file,
+  and `logout` rejects a target that lacks it, is a symlink, or is not a
+  directory. Without this a mistyped or shell-expanded `--profile-dir`
+  (`.`, `~`) went straight into `shutil.rmtree` and recursively deleted an
+  arbitrary tree.
 
 **Added — `direct masters suspend` / `direct masters resume` (#630):**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@
   `DANGEROUS` in `direct_cli/smoke_matrix.py` and documented as
   manual-only in `scripts/test_dangerous_commands.sh` — it cannot run in
   any automated smoke tier.
+- The profile directory is chmod'd `0700` (it holds a live Yandex session in
+  plaintext-readable cookies).
+- New `direct masters logout` deletes the profile — the only way to revoke
+  the on-disk session short of a manual `rm -rf`. A no-op with a warning
+  (not an error) if no profile exists. Also classified `DANGEROUS`
+  (local credential-store mutation, same category as `auth login`/`auth
+  use`).
 
 **Added — `direct masters suspend` / `direct masters resume` (#630):**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@
   CLI-owned, and `masters logout` on the same path then accepted that marker
   as authorization to `shutil.rmtree` it. A failed login armed it just the
   same, since the marker was written before Chromium even launched.
+- `masters login --profile-dir X` is now honoured by the read commands. The
+  chosen directory is recorded, and `list`/`get`/`suspend`/`resume` resolve
+  the profile through that record. Previously tier 1.5 looked only at the
+  default location and passed no directory through, so a custom login path
+  reported "Login confirmed" and was then silently ignored by every read —
+  falling back to the Keychain the flag exists to avoid. `masters logout`
+  clears the record along with the profile.
 - `masters` commands route through the persistent profile only when it holds
   an actual browser session, not merely when the directory exists. An aborted
   `masters login` leaves an empty profile behind; treating that as usable cost

--- a/README.md
+++ b/README.md
@@ -68,6 +68,17 @@ installed, wrong Chrome profile, expired session), `direct playwright
 doctor` reports the full chain of checks without logging in or writing
 anything.
 
+**Keychain-free alternative:** `direct masters login` opens a visible
+browser window on a persistent Chromium profile owned by the CLI
+(`~/.direct-cli/chrome-profile/`) — log in by hand once via Yandex Passport,
+and the command exits once the session is confirmed. This never touches your
+real Chrome profile or the macOS Keychain at all, so it works identically on
+macOS/Linux/Windows; the cost is a one-time manual login instead of a
+transparent cookie copy. When this profile exists, `direct masters` prefers
+it automatically over the saved `playwright login` session. It's interactive
+(blocks for up to `--timeout` seconds, default 300, waiting for you to sign
+in), so it can't run unattended.
+
 ### Configuration
 
 Create a `.env` file in your working directory:
@@ -1098,6 +1109,17 @@ login` один раз, чтобы расшифровать и сохранит�
 Keychain. Если что-то в цепочке сломано (playwright не установлен, не тот
 профиль Chrome, сессия протухла) — `direct playwright doctor` покажет всю
 цепочку проверок, ничего не логинясь и не записывая на диск.
+
+**Альтернатива без Keychain:** `direct masters login` открывает видимое окно
+браузера на собственном персистентном Chromium-профиле CLI
+(`~/.direct-cli/chrome-profile/`) — войдите вручную через Яндекс Паспорт,
+команда завершится, как только сессия подтвердится. Она вообще не трогает
+ваш реальный профиль Chrome и не обращается к Keychain, поэтому одинаково
+работает на macOS/Linux/Windows; цена — однократный ручной вход вместо
+прозрачного копирования кук. Если этот профиль существует, `direct masters`
+автоматически предпочитает его сохранённой сессии `playwright login`.
+Команда интерактивная (ждёт до `--timeout` секунд, по умолчанию 300, пока вы
+не войдёте), поэтому не может выполняться без присмотра.
 
 ### Настройка
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ macOS/Linux/Windows; the cost is a one-time manual login instead of a
 transparent cookie copy. When this profile exists, `direct masters` prefers
 it automatically over the saved `playwright login` session. It's interactive
 (blocks for up to `--timeout` seconds, default 300, waiting for you to sign
-in), so it can't run unattended.
+in), so it can't run unattended. Run `direct masters logout` to delete the
+profile and revoke the on-disk session (a no-op warning, not an error, if
+none exists).
 
 ### Configuration
 
@@ -1119,7 +1121,9 @@ Keychain. Если что-то в цепочке сломано (playwright не
 прозрачного копирования кук. Если этот профиль существует, `direct masters`
 автоматически предпочитает его сохранённой сессии `playwright login`.
 Команда интерактивная (ждёт до `--timeout` секунд, по умолчанию 300, пока вы
-не войдёте), поэтому не может выполняться без присмотра.
+не войдёте), поэтому не может выполняться без присмотра. Выполните `direct
+masters logout`, чтобы удалить профиль и отозвать сессию на диске (если
+профиля нет — предупреждение, а не ошибка).
 
 ### Настройка
 

--- a/direct_cli/browser/session.py
+++ b/direct_cli/browser/session.py
@@ -221,6 +221,33 @@ def _resolve_persistent_profile_dir(profile_dir: Optional[Path]) -> Path:
     return profile_dir or DEFAULT_PERSISTENT_PROFILE_DIR
 
 
+#: Records the profile directory the last `masters login` used, so read
+#: commands can find a session saved outside the default location. Without
+#: it `--profile-dir` would be accepted by `login` and silently ignored by
+#: everything else.
+PROFILE_POINTER_PATH = Path.home() / ".direct-cli" / "chrome-profile-path"
+
+
+def remember_persistent_profile_dir(profile_dir: Path) -> None:
+    """Record which profile directory `masters login` populated."""
+    PROFILE_POINTER_PATH.parent.mkdir(parents=True, exist_ok=True)
+    PROFILE_POINTER_PATH.write_text(str(profile_dir), encoding="utf-8")
+    os.chmod(PROFILE_POINTER_PATH, 0o600)
+
+
+def configured_persistent_profile_dir() -> Path:
+    """Return the profile directory `masters` commands should read from.
+
+    The one recorded by the last `masters login --profile-dir`, else the
+    default location.
+    """
+    try:
+        recorded = PROFILE_POINTER_PATH.read_text(encoding="utf-8").strip()
+    except OSError:
+        return DEFAULT_PERSISTENT_PROFILE_DIR
+    return Path(recorded) if recorded else DEFAULT_PERSISTENT_PROFILE_DIR
+
+
 def persistent_profile_is_usable(profile_dir: Optional[Path] = None) -> bool:
     """Return whether a persistent profile holds an actual browser session.
 
@@ -337,6 +364,10 @@ def login_persistent_session(
                     probe.wait_for_timeout(_LOGIN_POLL_INTERVAL_MS)
                     elapsed_ms += _LOGIN_POLL_INTERVAL_MS
                     continue
+                # Only once the session is real: read commands resolve the
+                # profile through this pointer, so recording an unfinished
+                # login would point them at an empty profile.
+                remember_persistent_profile_dir(resolved_dir)
                 return
         finally:
             probe.close()

--- a/direct_cli/browser/session.py
+++ b/direct_cli/browser/session.py
@@ -23,6 +23,17 @@ persists the result of this decrypt-and-inject dance as a Playwright
 :func:`open_saved_session`. :func:`open_chrome_session` (decrypt every call,
 nothing persisted) remains the zero-setup fallback ``direct masters`` uses
 when no saved session exists — see ``direct_cli/commands/masters.py``.
+
+``direct masters login`` (issue #635) is a third, independent path that does
+not touch the user's real Chrome profile or the macOS Keychain at all:
+:func:`open_persistent_session` launches a bundled Chromium against its own
+persistent profile directory (``~/.direct-cli/chrome-profile/`` by default),
+and the user logs in by hand once via ``passport.yandex.ru``. Cookies then
+persist on disk the same way a real Chrome profile would (Chromium manages
+its own on-disk cookie store for a persistent context — no ``storage_state``
+capture/injection dance needed). This works identically on macOS/Linux/
+Windows and needs no Keychain access, at the cost of a one-time manual login
+instead of a transparent cookie copy.
 """
 
 import contextlib
@@ -39,6 +50,19 @@ if TYPE_CHECKING:
 _BROWSER_INSTALL_HINT = (
     'pip install "direct-cli[browser]" && playwright install chromium'
 )
+
+# Sibling of direct_cli/browser/store.py's PLAYWRIGHT_SESSION_PATH and
+# direct_cli/auth.py's AUTH_STORE_PATH under ~/.direct-cli/ — a dedicated
+# subdirectory so this profile's own Chromium lock files/caches never mix
+# with either of those.
+DEFAULT_PERSISTENT_PROFILE_DIR = Path.home() / ".direct-cli" / "chrome-profile"
+
+_PASSPORT_LOGIN_URL = "https://passport.yandex.ru/auth"
+
+# How long `direct masters login` waits for the user to finish logging in by
+# hand before giving up.
+_LOGIN_WAIT_TIMEOUT_MS = 5 * 60 * 1000
+_LOGIN_POLL_INTERVAL_MS = 1_000
 
 
 class BrowserSessionError(RuntimeError):
@@ -183,6 +207,114 @@ def open_chrome_session(
 
     with _launch_context(sync_playwright, headless=headless) as (_browser, context):
         context.add_cookies(cookies)
+        page = context.new_page()
+        yield page
+
+
+def _resolve_persistent_profile_dir(profile_dir: Optional[Path]) -> Path:
+    return profile_dir or DEFAULT_PERSISTENT_PROFILE_DIR
+
+
+@contextlib.contextmanager
+def _launch_persistent_context(
+    sync_playwright, profile_dir: Path, *, headless: bool
+) -> Generator[Any, None, None]:
+    """Shared launch/teardown for the CLI's own persistent Chromium profile.
+
+    Unlike :func:`_launch_context` (a fresh, throwaway context every call),
+    ``launch_persistent_context`` both launches the browser *and* returns the
+    context in one call — there is no separate ``Browser`` object to close,
+    Playwright owns that lifecycle internally for persistent contexts.
+    """
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    with sync_playwright() as playwright:
+        context = playwright.chromium.launch_persistent_context(
+            str(profile_dir), headless=headless, locale="ru-RU"
+        )
+        try:
+            yield context
+        finally:
+            context.close()
+
+
+def login_persistent_session(
+    *,
+    profile_dir: Optional[Path] = None,
+    headless: bool = False,
+    timeout_ms: int = _LOGIN_WAIT_TIMEOUT_MS,
+) -> None:
+    """Open the CLI's own persistent Chromium profile for a one-time manual login.
+
+    Navigates to Yandex Passport's login page and polls (every
+    :data:`_LOGIN_POLL_INTERVAL_MS`) until :func:`assert_authenticated` no
+    longer raises against ``direct.yandex.ru`` — i.e. until the user has
+    finished logging in by hand in the visible window. Raises
+    :class:`BrowserAuthError` if ``timeout_ms`` elapses first.
+
+    Deliberately defaults ``headless=False``: a headless window cannot be
+    logged into by a human, so ``direct masters login`` always shows the
+    window regardless of ``--headful`` unless the caller overrides it
+    (e.g. for tests).
+    """
+    sync_playwright = _import_sync_playwright()
+    resolved_dir = _resolve_persistent_profile_dir(profile_dir)
+
+    # Deferred import: direct_cli/browser/masters.py's GRID_URL is the single
+    # canonical source for this URL (CLAUDE.md "No URL literals outside the
+    # registry"); imported here rather than at module load to avoid a
+    # session.py <-> masters.py import cycle (masters.py imports session.py).
+    from .masters import GRID_URL
+
+    with _launch_persistent_context(
+        sync_playwright, resolved_dir, headless=headless
+    ) as context:
+        page = context.new_page()
+        page.goto(_PASSPORT_LOGIN_URL, wait_until="domcontentloaded")
+
+        elapsed_ms = 0
+        while elapsed_ms < timeout_ms:
+            page.goto(GRID_URL, wait_until="domcontentloaded")
+            html = page.content()
+            assert_not_captcha(html)
+            try:
+                assert_authenticated(html)
+            except BrowserAuthError:
+                page.wait_for_timeout(_LOGIN_POLL_INTERVAL_MS)
+                elapsed_ms += _LOGIN_POLL_INTERVAL_MS
+                continue
+            return
+
+        raise BrowserAuthError(
+            f"Timed out after {timeout_ms // 1000}s waiting for login to "
+            f"{_PASSPORT_LOGIN_URL} to complete. Run `direct masters login` "
+            "again and finish signing in within the time limit."
+        )
+
+
+@contextlib.contextmanager
+def open_persistent_session(
+    *,
+    profile_dir: Optional[Path] = None,
+    headless: bool = True,
+) -> Generator["Page", None, None]:
+    """Launch the CLI's own persistent Chromium profile for regular use.
+
+    Raises :class:`BrowserSessionMissingError` if the profile directory
+    doesn't exist yet or Yandex serves its login page — the fix in both
+    cases is ``direct masters login``.
+    """
+    sync_playwright = _import_sync_playwright()
+    resolved_dir = _resolve_persistent_profile_dir(profile_dir)
+
+    if not resolved_dir.exists():
+        raise BrowserSessionMissingError(
+            f"No persistent browser profile found at {resolved_dir}. "
+            "Run: direct masters login"
+        )
+
+    with _launch_persistent_context(
+        sync_playwright, resolved_dir, headless=headless
+    ) as context:
         page = context.new_page()
         yield page
 

--- a/direct_cli/browser/session.py
+++ b/direct_cli/browser/session.py
@@ -221,6 +221,20 @@ def _resolve_persistent_profile_dir(profile_dir: Optional[Path]) -> Path:
     return profile_dir or DEFAULT_PERSISTENT_PROFILE_DIR
 
 
+def persistent_profile_is_usable(profile_dir: Optional[Path] = None) -> bool:
+    """Return whether a persistent profile holds an actual browser session.
+
+    Mere directory existence is not enough: ``_launch_persistent_context``
+    creates the directory (and its marker) before Chromium starts, so a login
+    the user aborted leaves an empty profile behind. Routing ``masters``
+    commands through it would launch a browser, fail auth, and fall back on
+    every single call. Chromium writes its cookie store only once it has
+    actually run, so that file is the honest signal.
+    """
+    resolved = _resolve_persistent_profile_dir(profile_dir)
+    return (resolved / "Default" / "Cookies").exists()
+
+
 @contextlib.contextmanager
 def _launch_persistent_context(
     sync_playwright, profile_dir: Path, *, headless: bool
@@ -237,10 +251,30 @@ def _launch_persistent_context(
     treatment ``direct_cli/browser/store.py`` and ``direct_cli/auth.py`` give
     their own on-disk session files (issue #635 risk: "Хранение живой сессии
     Яндекса на диске").
+
+    The ownership marker is only ever written into a directory this function
+    *created*. An existing directory must already carry the marker to be
+    reused; otherwise it belongs to someone else and is refused. Without that
+    asymmetry ``--profile-dir ~`` would mark the user's home directory as
+    CLI-owned, and ``masters logout`` would then accept that marker as
+    authorization to ``shutil.rmtree`` it.
     """
-    profile_dir.mkdir(parents=True, exist_ok=True)
+    marker = profile_dir / PROFILE_MARKER_NAME
+    try:
+        profile_dir.mkdir(parents=True, exist_ok=False)
+    except FileExistsError:
+        if not marker.is_file():
+            raise BrowserSessionError(
+                f"Refusing to use {profile_dir} as a browser profile: the "
+                "directory already exists and was not created by `direct "
+                f"masters login` (no {PROFILE_MARKER_NAME} marker). Pick a "
+                "path that does not exist yet, or delete that directory by "
+                "hand if you are sure."
+            ) from None
+    else:
+        marker.touch()
+
     os.chmod(profile_dir, 0o700)
-    (profile_dir / PROFILE_MARKER_NAME).touch()
     with sync_playwright() as playwright:
         context = playwright.chromium.launch_persistent_context(
             str(profile_dir), headless=headless, locale="ru-RU"

--- a/direct_cli/browser/session.py
+++ b/direct_cli/browser/session.py
@@ -225,8 +225,15 @@ def _launch_persistent_context(
     ``launch_persistent_context`` both launches the browser *and* returns the
     context in one call — there is no separate ``Browser`` object to close,
     Playwright owns that lifecycle internally for persistent contexts.
+
+    The profile directory holds a live Yandex session (cookies readable in
+    plaintext by the owning process) — chmod 0700 on every launch, the same
+    treatment ``direct_cli/browser/store.py`` and ``direct_cli/auth.py`` give
+    their own on-disk session files (issue #635 risk: "Хранение живой сессии
+    Яндекса на диске").
     """
     profile_dir.mkdir(parents=True, exist_ok=True)
+    os.chmod(profile_dir, 0o700)
     with sync_playwright() as playwright:
         context = playwright.chromium.launch_persistent_context(
             str(profile_dir), headless=headless, locale="ru-RU"

--- a/direct_cli/browser/session.py
+++ b/direct_cli/browser/session.py
@@ -57,6 +57,12 @@ _BROWSER_INSTALL_HINT = (
 # with either of those.
 DEFAULT_PERSISTENT_PROFILE_DIR = Path.home() / ".direct-cli" / "chrome-profile"
 
+#: Marker file written into every profile directory the CLI creates. It is the
+#: sole proof of ownership `masters logout` accepts before deleting a tree — an
+#: arbitrary ``--profile-dir`` (a typo, a shell-expanded ``.``) has no marker and
+#: is refused rather than recursively removed.
+PROFILE_MARKER_NAME = ".direct-cli-profile"
+
 _PASSPORT_LOGIN_URL = "https://passport.yandex.ru/auth"
 
 # How long `direct masters login` waits for the user to finish logging in by
@@ -234,6 +240,7 @@ def _launch_persistent_context(
     """
     profile_dir.mkdir(parents=True, exist_ok=True)
     os.chmod(profile_dir, 0o700)
+    (profile_dir / PROFILE_MARKER_NAME).touch()
     with sync_playwright() as playwright:
         context = playwright.chromium.launch_persistent_context(
             str(profile_dir), headless=headless, locale="ru-RU"

--- a/direct_cli/browser/session.py
+++ b/direct_cli/browser/session.py
@@ -285,18 +285,27 @@ def login_persistent_session(
         page = context.new_page()
         page.goto(_PASSPORT_LOGIN_URL, wait_until="domcontentloaded")
 
-        elapsed_ms = 0
-        while elapsed_ms < timeout_ms:
-            page.goto(GRID_URL, wait_until="domcontentloaded")
-            html = page.content()
-            assert_not_captcha(html)
-            try:
-                assert_authenticated(html)
-            except BrowserAuthError:
-                page.wait_for_timeout(_LOGIN_POLL_INTERVAL_MS)
-                elapsed_ms += _LOGIN_POLL_INTERVAL_MS
-                continue
-            return
+        # Poll on a second page, never on `page`: the human is typing into
+        # that one, and navigating it to the grid once a second would wipe a
+        # half-filled login form or a pending 2FA prompt out from under them.
+        # Both pages share the persistent context's cookie jar, so a login
+        # completed on `page` is immediately visible to `probe`.
+        probe = context.new_page()
+        try:
+            elapsed_ms = 0
+            while elapsed_ms < timeout_ms:
+                probe.goto(GRID_URL, wait_until="domcontentloaded")
+                html = probe.content()
+                assert_not_captcha(html)
+                try:
+                    assert_authenticated(html)
+                except BrowserAuthError:
+                    probe.wait_for_timeout(_LOGIN_POLL_INTERVAL_MS)
+                    elapsed_ms += _LOGIN_POLL_INTERVAL_MS
+                    continue
+                return
+        finally:
+            probe.close()
 
         raise BrowserAuthError(
             f"Timed out after {timeout_ms // 1000}s waiting for login to "

--- a/direct_cli/browser/session.py
+++ b/direct_cli/browser/session.py
@@ -229,9 +229,14 @@ PROFILE_POINTER_PATH = Path.home() / ".direct-cli" / "chrome-profile-path"
 
 
 def remember_persistent_profile_dir(profile_dir: Path) -> None:
-    """Record which profile directory `masters login` populated."""
+    """Record which profile directory `masters login` populated.
+
+    Stored absolute: a relative path would be re-resolved against whatever
+    directory a later command happened to run from, so `masters logout`
+    would act on a different profile depending on where the user stood.
+    """
     PROFILE_POINTER_PATH.parent.mkdir(parents=True, exist_ok=True)
-    PROFILE_POINTER_PATH.write_text(str(profile_dir), encoding="utf-8")
+    PROFILE_POINTER_PATH.write_text(str(profile_dir.resolve()), encoding="utf-8")
     os.chmod(PROFILE_POINTER_PATH, 0o600)
 
 
@@ -245,7 +250,11 @@ def configured_persistent_profile_dir() -> Path:
         recorded = PROFILE_POINTER_PATH.read_text(encoding="utf-8").strip()
     except OSError:
         return DEFAULT_PERSISTENT_PROFILE_DIR
-    return Path(recorded) if recorded else DEFAULT_PERSISTENT_PROFILE_DIR
+    # A hand-edited or truncated record must not silently resolve against the
+    # caller's cwd — only an absolute path is trustworthy here.
+    if not recorded or not Path(recorded).is_absolute():
+        return DEFAULT_PERSISTENT_PROFILE_DIR
+    return Path(recorded)
 
 
 def persistent_profile_is_usable(profile_dir: Optional[Path] = None) -> bool:

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -18,22 +18,28 @@ all — see ``direct_cli/browser/masters.py`` module docstring for why an
 explicit login actually broke ``list`` (HTTP 401 "Доступ ограничен" when the
 user's own login was passed as Yandex's managed-client ``ulogin`` param).
 
-Session resolution (``_open_session``) is three-tiered — see
-``direct_cli/commands/browser_session.py`` for ``direct playwright login``,
-which creates the saved session tier 2 prefers:
+Session resolution (``_open_session``) is multi-tiered — see
+``direct_cli/commands/browser_session.py`` for ``direct playwright login``
+(tier 2) and this module's own ``masters login`` command (tier 1.5, issue
+#635):
 
 1. Explicit ``--profile-dir``/``--chrome-profile`` on the command line ->
    always decrypt fresh from that specific Chrome profile (the user pointed
    at it deliberately; silently using a stale saved session instead would be
    a surprise).
+1.5. Otherwise, if the CLI's own persistent Chromium profile exists (set up
+   via ``direct masters login``) -> use it. Keychain-free and platform-
+   independent (unlike tiers 2/3, which both decrypt the user's real Chrome
+   profile), so it's preferred whenever present.
 2. Otherwise, a saved session from ``direct playwright login`` that isn't
    known-expired -> use it (skips the Keychain round-trip entirely).
 3. Otherwise -> decrypt fresh from Chrome, same as before this tier system
    existed. Zero-config `direct masters list` keeps working unchanged.
 
-A ``BrowserAuthError`` from tier 2 is retried once via tier 3 before
-surfacing — a stale saved session should self-heal rather than break
-`masters` until the user notices and reruns `playwright login` by hand. The
+A ``BrowserAuthError`` from tier 1.5 or tier 2 is retried once via tier 3
+before surfacing — a stale saved session should self-heal rather than break
+`masters` until the user notices and reruns `playwright login`/`masters
+login` by hand. The
 retry happens at the *operation* level (``_with_session``), not inside
 ``_open_session`` itself: ``BrowserAuthError`` from ``assert_authenticated``
 is raised by the caller's fetch call, deep inside the ``with page:`` body,
@@ -105,6 +111,7 @@ def _open_session(
         from ..browser.session import (
             BrowserSessionError,
             open_chrome_session,
+            open_persistent_session,
             open_saved_session,
         )
     except ImportError as exc:
@@ -130,6 +137,19 @@ def _open_session(
                 yield page
         except BrowserSessionError as exc:
             raise click.ClickException(str(exc)) from exc
+        return
+
+    from ..browser.session import DEFAULT_PERSISTENT_PROFILE_DIR
+
+    # Tier 1.5: the CLI's own persistent profile (issue #635, `direct masters
+    # login`) — Keychain-free and platform-independent, so it's preferred
+    # over the saved storage_state session whenever it has been set up.
+    # BrowserAuthError (a stale on-disk session) propagates to _with_session
+    # uncaught, exactly like tier 2's, so the same self-heal fallback
+    # applies.
+    if DEFAULT_PERSISTENT_PROFILE_DIR.exists():
+        with _fresh_or_saved(open_persistent_session, headless=not headful) as page:
+            yield page
         return
 
     from ..browser import store
@@ -262,6 +282,52 @@ def _masters_browser_options(func):
 @click.group()
 def masters():
     """Мастер кампаний (Campaign Wizard) — browser-only, no API"""
+
+
+@masters.command()
+@click.option(
+    "--profile-dir",
+    help="Directory for the CLI's own persistent Chrome profile "
+    "(default: ~/.direct-cli/chrome-profile/)",
+)
+@click.option(
+    "--timeout",
+    "timeout_seconds",
+    type=int,
+    default=300,
+    show_default=True,
+    help="Seconds to wait for manual login to complete",
+)
+def login(profile_dir, timeout_seconds):
+    """Log in once via a visible browser window, saved for future `masters` calls
+
+    Opens Yandex Passport in a persistent Chromium profile owned by the CLI
+    (issue #635) — separate from your real Chrome profile, so it needs no
+    Keychain access and works the same on macOS/Linux/Windows. Log in by
+    hand in the window that opens; the command exits once the session is
+    confirmed. Subsequent `direct masters` calls reuse this profile
+    automatically (see the module docstring's tier 1.5).
+    """
+    try:
+        from ..browser.session import BrowserSessionError, login_persistent_session
+    except ImportError as exc:
+        raise click.UsageError(
+            "playwright is required for `direct masters login` but is not "
+            f"installed. Run: {_BROWSER_INSTALL_HINT}"
+        ) from exc
+
+    resolved_profile_dir = Path(profile_dir) if profile_dir else None
+    try:
+        login_persistent_session(
+            profile_dir=resolved_profile_dir,
+            timeout_ms=timeout_seconds * 1000,
+        )
+    except BrowserSessionError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    print_info(
+        "Login confirmed. `direct masters` commands will now reuse this session."
+    )
 
 
 _STATUS_CHOICES = ("not-archived", "active", "stopped", "archived", "all")

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -140,7 +140,7 @@ def _open_session(
             raise click.ClickException(str(exc)) from exc
         return
 
-    from ..browser.session import DEFAULT_PERSISTENT_PROFILE_DIR
+    from ..browser.session import persistent_profile_is_usable
 
     # Tier 1.5: the CLI's own persistent profile (issue #635, `direct masters
     # login`) — Keychain-free and platform-independent, so it's preferred
@@ -148,7 +148,11 @@ def _open_session(
     # BrowserAuthError (a stale on-disk session) propagates to _with_session
     # uncaught, exactly like tier 2's, so the same self-heal fallback
     # applies.
-    if DEFAULT_PERSISTENT_PROFILE_DIR.exists():
+    #
+    # Tested for an actual session, not mere directory existence: an aborted
+    # `masters login` leaves an empty profile behind, and routing through it
+    # would cost a wasted browser launch on every command.
+    if persistent_profile_is_usable():
         with _fresh_or_saved(open_persistent_session, headless=not headful) as page:
             yield page
         return

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -59,7 +59,7 @@ from typing import Optional
 import click
 from click.core import ParameterSource
 
-from ..output import format_output, handle_api_errors, print_info
+from ..output import format_output, handle_api_errors, print_info, print_warning
 from ..utils import parse_ids
 
 _BROWSER_INSTALL_HINT = (
@@ -328,6 +328,35 @@ def login(profile_dir, timeout_seconds):
     print_info(
         "Login confirmed. `direct masters` commands will now reuse this session."
     )
+
+
+@masters.command()
+@click.option(
+    "--profile-dir",
+    help="Directory for the CLI's own persistent Chrome profile "
+    "(default: ~/.direct-cli/chrome-profile/)",
+)
+def logout(profile_dir):
+    """Delete the persistent Chrome profile created by `masters login`
+
+    The only way to revoke the on-disk Yandex session `masters login`
+    creates (issue #635) short of a manual `rm -rf`. A no-op (with a
+    warning, not an error) if no profile exists.
+    """
+    from ..browser.session import DEFAULT_PERSISTENT_PROFILE_DIR
+
+    resolved_profile_dir = (
+        Path(profile_dir) if profile_dir else DEFAULT_PERSISTENT_PROFILE_DIR
+    )
+
+    if not resolved_profile_dir.exists():
+        print_warning(f"No persistent browser profile found at {resolved_profile_dir}")
+        return
+
+    import shutil
+
+    shutil.rmtree(resolved_profile_dir)
+    print_info(f"Deleted persistent browser profile at {resolved_profile_dir}")
 
 
 _STATUS_CHOICES = ("not-archived", "active", "stopped", "archived", "all")

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -342,8 +342,13 @@ def logout(profile_dir):
     The only way to revoke the on-disk Yandex session `masters login`
     creates (issue #635) short of a manual `rm -rf`. A no-op (with a
     warning, not an error) if no profile exists.
+
+    Refuses to touch anything `masters login` did not create: the target
+    must carry the CLI's own marker file, and must not be a symlink. A
+    mistyped or shell-expanded `--profile-dir` is rejected rather than
+    recursively deleted.
     """
-    from ..browser.session import DEFAULT_PERSISTENT_PROFILE_DIR
+    from ..browser.session import DEFAULT_PERSISTENT_PROFILE_DIR, PROFILE_MARKER_NAME
 
     resolved_profile_dir = (
         Path(profile_dir) if profile_dir else DEFAULT_PERSISTENT_PROFILE_DIR
@@ -352,6 +357,27 @@ def logout(profile_dir):
     if not resolved_profile_dir.exists():
         print_warning(f"No persistent browser profile found at {resolved_profile_dir}")
         return
+
+    # A symlink would have rmtree follow it out of the directory the user named.
+    if resolved_profile_dir.is_symlink():
+        raise click.ClickException(
+            f"Refusing to delete {resolved_profile_dir}: it is a symlink, not a "
+            "profile directory created by `direct masters login`."
+        )
+
+    if not resolved_profile_dir.is_dir():
+        raise click.ClickException(
+            f"Refusing to delete {resolved_profile_dir}: not a directory."
+        )
+
+    # Ownership marker: written by `masters login`, absent from every other
+    # directory on the machine. Without it a recursive delete is never safe.
+    if not (resolved_profile_dir / PROFILE_MARKER_NAME).is_file():
+        raise click.ClickException(
+            f"Refusing to delete {resolved_profile_dir}: it has no "
+            f"{PROFILE_MARKER_NAME} marker, so it was not created by "
+            "`direct masters login`. Delete it by hand if you are sure."
+        )
 
     import shutil
 

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -142,6 +142,8 @@ def _open_session(
 
     from ..browser.session import persistent_profile_is_usable
 
+    persistent_dir = _configured_persistent_profile_dir()
+
     # Tier 1.5: the CLI's own persistent profile (issue #635, `direct masters
     # login`) — Keychain-free and platform-independent, so it's preferred
     # over the saved storage_state session whenever it has been set up.
@@ -152,8 +154,12 @@ def _open_session(
     # Tested for an actual session, not mere directory existence: an aborted
     # `masters login` leaves an empty profile behind, and routing through it
     # would cost a wasted browser launch on every command.
-    if persistent_profile_is_usable():
-        with _fresh_or_saved(open_persistent_session, headless=not headful) as page:
+    if persistent_profile_is_usable(persistent_dir):
+        with _fresh_or_saved(
+            open_persistent_session,
+            headless=not headful,
+            profile_dir=persistent_dir,
+        ) as page:
             yield page
         return
 
@@ -186,8 +192,15 @@ def _open_session(
         raise click.ClickException(str(exc)) from exc
 
 
+def _configured_persistent_profile_dir() -> Path:
+    """Where `masters login` last saved a session (default if never set)."""
+    from ..browser.session import configured_persistent_profile_dir
+
+    return configured_persistent_profile_dir()
+
+
 @contextlib.contextmanager
-def _fresh_or_saved(open_saved_session, *, headless: bool):
+def _fresh_or_saved(open_saved_session, *, headless: bool, **kwargs):
     """Tier 2 body: run ``open_saved_session``, converting non-auth errors.
 
     ``BrowserAuthError`` is intentionally left to propagate to the caller
@@ -198,7 +211,7 @@ def _fresh_or_saved(open_saved_session, *, headless: bool):
     from ..browser.session import BrowserAuthError, BrowserSessionError
 
     try:
-        with open_saved_session(headless=headless) as page:
+        with open_saved_session(headless=headless, **kwargs) as page:
             yield page
     except BrowserAuthError:
         raise
@@ -374,10 +387,10 @@ def logout(profile_dir):
     mistyped or shell-expanded `--profile-dir` is rejected rather than
     recursively deleted.
     """
-    from ..browser.session import DEFAULT_PERSISTENT_PROFILE_DIR, PROFILE_MARKER_NAME
+    from ..browser.session import PROFILE_MARKER_NAME, PROFILE_POINTER_PATH
 
     resolved_profile_dir = (
-        Path(profile_dir) if profile_dir else DEFAULT_PERSISTENT_PROFILE_DIR
+        Path(profile_dir) if profile_dir else _configured_persistent_profile_dir()
     )
 
     if not resolved_profile_dir.exists():
@@ -408,6 +421,9 @@ def logout(profile_dir):
     import shutil
 
     shutil.rmtree(resolved_profile_dir)
+    # Drop the pointer too, so reads fall back to the default location
+    # instead of resolving to a directory that no longer exists.
+    PROFILE_POINTER_PATH.unlink(missing_ok=True)
     print_info(f"Deleted persistent browser profile at {resolved_profile_dir}")
 
 

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -420,10 +420,19 @@ def logout(profile_dir):
 
     import shutil
 
+    # Read before the delete: an explicit --profile-dir may name a directory
+    # that isn't the one the pointer records (e.g. an old profile from before
+    # a later `login --profile-dir` moved it elsewhere). Only clear the
+    # pointer when it actually points at what's being deleted -- otherwise a
+    # cleanup of a stale profile would strand reads without their live one.
+    try:
+        pointer_target = PROFILE_POINTER_PATH.read_text(encoding="utf-8").strip()
+    except OSError:
+        pointer_target = None
+
     shutil.rmtree(resolved_profile_dir)
-    # Drop the pointer too, so reads fall back to the default location
-    # instead of resolving to a directory that no longer exists.
-    PROFILE_POINTER_PATH.unlink(missing_ok=True)
+    if pointer_target and Path(pointer_target) == resolved_profile_dir.resolve():
+        PROFILE_POINTER_PATH.unlink(missing_ok=True)
     print_info(f"Deleted persistent browser profile at {resolved_profile_dir}")
 
 

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -334,7 +334,7 @@ def login(profile_dir, timeout_seconds):
     confirmed. Subsequent `direct masters` calls reuse this profile
     automatically (see the module docstring's tier 1.5).
 
-    Requires a terminal: run from CI or a script it fails immediately
+    Requires a terminal: if run from CI or a script it fails immediately
     rather than blocking on a browser window nobody can see.
     """
     # The command's whole purpose is to wait for a human. Without a TTY there

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -53,6 +53,7 @@ fallback rather than trying to yield twice from one generator call.
 """
 
 import contextlib
+import sys
 from pathlib import Path
 from typing import Optional
 
@@ -284,6 +285,14 @@ def masters():
     """Мастер кампаний (Campaign Wizard) — browser-only, no API"""
 
 
+def _stdin_is_interactive() -> bool:
+    """Return whether a human is present to complete a browser login.
+
+    Mirrors ``direct_cli/commands/auth.py``'s helper of the same name.
+    """
+    return sys.stdin.isatty()
+
+
 @masters.command()
 @click.option(
     "--profile-dir",
@@ -307,7 +316,20 @@ def login(profile_dir, timeout_seconds):
     hand in the window that opens; the command exits once the session is
     confirmed. Subsequent `direct masters` calls reuse this profile
     automatically (see the module docstring's tier 1.5).
+
+    Requires a terminal: run from CI or a script it fails immediately
+    rather than blocking on a browser window nobody can see.
     """
+    # The command's whole purpose is to wait for a human. Without a TTY there
+    # is nobody to log in, so blocking for the full --timeout on an invisible
+    # window is never useful (issue #635, Риски -> Интерактивность).
+    if not _stdin_is_interactive():
+        raise click.ClickException(
+            "`direct masters login` needs an interactive terminal — it opens a "
+            "browser window and waits for you to log in by hand. Run it from a "
+            "terminal, not from CI or a script."
+        )
+
     try:
         from ..browser.session import BrowserSessionError, login_persistent_session
     except ImportError as exc:

--- a/direct_cli/smoke_matrix.py
+++ b/direct_cli/smoke_matrix.py
@@ -186,6 +186,13 @@ SMOKE_MATRIX = {
         # Manual-only, per scripts/test_dangerous_commands.sh.
         "masters.resume",
         "masters.suspend",
+        # Interactive, human-in-the-loop login (issue #635) -- opens a
+        # visible browser window and blocks for up to --timeout seconds
+        # waiting for a person to sign in by hand. Cannot run unattended in
+        # any automated smoke tier; unlike playwright.login (SAFE above,
+        # which reads an already-authenticated Chrome profile
+        # non-interactively), this always requires a human. Manual-only.
+        "masters.login",
         "v4adimage.set",
         "v4finance.create-invoice",
         "v4finance.pay-campaigns",

--- a/direct_cli/smoke_matrix.py
+++ b/direct_cli/smoke_matrix.py
@@ -193,6 +193,12 @@ SMOKE_MATRIX = {
         # which reads an already-authenticated Chrome profile
         # non-interactively), this always requires a human. Manual-only.
         "masters.login",
+        # Deletes the persistent Chrome profile masters.login creates
+        # (issue #635) -- a local credential-store mutation, same category
+        # as auth.login/auth.use above, not a read. An automated run
+        # against a developer's real ~/.direct-cli/chrome-profile/ would
+        # destroy a live session with no way to recreate it unattended.
+        "masters.logout",
         "v4adimage.set",
         "v4finance.create-invoice",
         "v4finance.pay-campaigns",

--- a/scripts/test_dangerous_commands.sh
+++ b/scripts/test_dangerous_commands.sh
@@ -19,6 +19,7 @@ Agency/account mutations:
 Local credential mutations:
   - direct auth login ...
   - direct auth use ...
+  - direct masters logout ...   (deletes ~/.direct-cli/chrome-profile/)
 
 V4 Live finance money mutations (0.3.3 exposes dry-run-only previews):
   - direct v4finance transfer-money --from-campaign-id ... --to-campaign-id ... --amount ... --currency RUB --dry-run

--- a/scripts/test_dangerous_commands.sh
+++ b/scripts/test_dangerous_commands.sh
@@ -30,6 +30,10 @@ non-critical campaign, confirming before/after state in the web UI):
   - direct masters suspend <campaign_id>
   - direct masters resume <campaign_id>
 
+Interactive human-in-the-loop login (opens a visible browser window and
+blocks waiting for a person to sign in -- cannot run unattended):
+  - direct masters login
+
 Production commands that are only allowed in automated smoke tests with --sandbox:
   - direct bids set ...
   - direct bids set-auto ...

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -1349,10 +1349,37 @@ class TestMastersLoginCommand(unittest.TestCase):
 
     def setUp(self):
         self.runner = CliRunner()
+        # CliRunner supplies a non-tty stdin, so `login` would refuse to run
+        # (it needs a human). Every test here exercises the interactive path;
+        # the non-interactive refusal has its own test that overrides this.
+        tty = patch(
+            "direct_cli.commands.masters._stdin_is_interactive", return_value=True
+        )
+        tty.start()
+        self.addCleanup(tty.stop)
 
     def test_login_registered(self):
         result = self.runner.invoke(cli, ["masters", "login", "--help"])
         self.assertEqual(result.exit_code, 0)
+
+    def test_login_fails_fast_in_a_non_interactive_environment(self):
+        """In CI/a script, fail immediately instead of blocking for the timeout.
+
+        Issue #635 (Риски → Интерактивность): the command waits for a human, so
+        run non-interactively it must "падать сразу с понятным текстом, а не
+        висеть" — otherwise CI hangs for the full --timeout on a browser window
+        nobody can see.
+        """
+        with patch("direct_cli.browser.session.login_persistent_session") as login_fn:
+            with patch(
+                "direct_cli.commands.masters._stdin_is_interactive",
+                return_value=False,
+            ):
+                result = self.runner.invoke(cli, ["masters", "login"])
+
+        login_fn.assert_not_called()
+        self.assertNotEqual(result.exit_code, 0, result.output)
+        self.assertIn("interactive", result.output.lower())
 
     def test_login_has_no_output_format_options(self):
         # login is interactive/side-effecting, not a data-fetching command --

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -1710,6 +1710,43 @@ class TestMastersLogoutCommand(unittest.TestCase):
         self.assertNotEqual(result.exit_code, 0, result.output)
         self.assertTrue(self.profile_dir.exists())
 
+    def test_logout_explicit_profile_dir_does_not_clear_pointer_to_a_different_profile(
+        self,
+    ):
+        """`logout --profile-dir A` must not wipe the pointer to a live profile B.
+
+        `logout` unconditionally unlinks PROFILE_POINTER_PATH after deleting
+        whatever `--profile-dir` resolved to. If the user logged into profile B
+        (recorded by the pointer) after an older profile A, then deletes A by
+        explicit path, the pointer to B — still on disk and in use — is wiped
+        too. The next read then falls back to the default location instead of B.
+        """
+        from direct_cli.browser.session import PROFILE_MARKER_NAME
+
+        old_profile = self.profile_dir  # profile A: about to be deleted
+        self._make_profile()
+
+        live_profile = Path(self._tmpdir.name) / "chrome-profile-b"
+        live_profile.mkdir(parents=True)
+        (live_profile / PROFILE_MARKER_NAME).touch()
+
+        from direct_cli.browser import session as session_module
+
+        session_module.remember_persistent_profile_dir(live_profile)
+
+        result = self.runner.invoke(
+            cli, ["masters", "logout", "--profile-dir", str(old_profile)]
+        )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertFalse(old_profile.exists())
+        self.assertTrue(live_profile.exists(), "unrelated live profile was deleted")
+        self.assertEqual(
+            session_module.configured_persistent_profile_dir(),
+            live_profile.resolve(),
+            "logout on an unrelated profile cleared the pointer to the live one",
+        )
+
 
 class TestCaptchaDetection(unittest.TestCase):
     def test_assert_not_captcha_raises_on_gate_markers(self):

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -528,6 +528,14 @@ class TestPersistentSession(unittest.TestCase):
         self._tmpdir = tempfile.TemporaryDirectory()
         self.addCleanup(self._tmpdir.cleanup)
         self.profile_dir = Path(self._tmpdir.name) / "chrome-profile"
+        # A completed login records its profile dir; keep that off the
+        # developer's real ~/.direct-cli.
+        pointer = patch(
+            "direct_cli.browser.session.PROFILE_POINTER_PATH",
+            Path(self._tmpdir.name) / "chrome-profile-path",
+        )
+        pointer.start()
+        self.addCleanup(pointer.stop)
 
     def _make_profile(self):
         """Create a profile dir the way a completed `masters login` leaves it."""
@@ -605,6 +613,27 @@ class TestPersistentSession(unittest.TestCase):
         self.assertFalse(
             session_module.persistent_profile_is_usable(self.profile_dir),
             "an aborted login left a profile tier 1.5 would route through",
+        )
+
+    def test_recorded_profile_dir_is_absolute(self):
+        """The login pointer must not make later commands depend on cwd.
+
+        `masters login --profile-dir prof` recorded "prof" verbatim, so
+        `masters logout` run from a different directory resolved it against
+        *that* cwd — deleting a different profile, or none. The marker check
+        still bounded the damage, but which directory a command acts on must
+        not depend on where the user happens to be standing.
+        """
+        from direct_cli.browser import session as session_module
+
+        pointer = Path(self._tmpdir.name) / "chrome-profile-path"
+        with patch.object(session_module, "PROFILE_POINTER_PATH", pointer):
+            session_module.remember_persistent_profile_dir(Path("relative/profile"))
+            recorded = session_module.configured_persistent_profile_dir()
+
+        self.assertTrue(
+            recorded.is_absolute(),
+            f"recorded a cwd-dependent path: {recorded}",
         )
 
     def test_open_persistent_session_raises_when_profile_missing(self):

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -225,6 +225,7 @@ class FakePage:
         self._html = html
         self.navigated_to = []
         self.goto_wait_until = None
+        self.closed = False
         # If set, matched by expect_response()'s predicate once goto() has
         # been called inside its `with` block — models the grid firing its
         # GridCampaigns XHR during navigation.
@@ -237,6 +238,9 @@ class FakePage:
     def goto(self, url, wait_until=None):
         self.navigated_to.append(url)
         self.goto_wait_until = wait_until
+
+    def close(self):
+        self.closed = True
 
     def expect_response(self, predicate, timeout=None):
         return _FakeExpectResponse(self, predicate)
@@ -586,8 +590,11 @@ class TestPersistentSession(unittest.TestCase):
         pytest.importorskip("playwright")
         from direct_cli.browser import session as session_module
 
+        # Page 1 is the visible Passport tab; page 2 is the poll probe whose
+        # HTML decides whether login has completed.
+        login_page = FakePage(locators={}, html="<body>Войдите с Яндекс ID</body>")
         authed_page = FakePage(locators={}, html="<body>Кампания остановлена</body>")
-        persistent_ctx = _FakePersistentContext(pages=[authed_page])
+        persistent_ctx = _FakePersistentContext(pages=[login_page, authed_page])
         fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
         fake_playwright = _FakePlaywright(fake_chromium)
 
@@ -605,7 +612,8 @@ class TestPersistentSession(unittest.TestCase):
         from direct_cli.browser.session import BrowserAuthError
 
         login_page = FakePage(locators={}, html="<body>Войдите с Яндекс ID</body>")
-        persistent_ctx = _FakePersistentContext(pages=[login_page])
+        probe_page = FakePage(locators={}, html="<body>Войдите с Яндекс ID</body>")
+        persistent_ctx = _FakePersistentContext(pages=[login_page, probe_page])
         fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
         fake_playwright = _FakePlaywright(fake_chromium)
 
@@ -616,6 +624,41 @@ class TestPersistentSession(unittest.TestCase):
                     timeout_ms=1_000,
                 )
         self.assertIn("Timed out", str(ctx.exception))
+        self.assertTrue(probe_page.closed, "poll probe page was left open")
+
+    def test_login_polling_does_not_navigate_the_page_the_user_is_typing_into(self):
+        """The visible login page must stay on Passport until login succeeds.
+
+        The poll loop checks authentication by driving the *same* page the
+        human is typing into. Every interval it navigates that page away to
+        the grid, wiping a half-filled login form and any 2FA prompt on it —
+        the user cannot finish signing in against a page that resets under
+        their hands once a second.
+        """
+        pytest.importorskip("playwright")
+        from direct_cli.browser import session as session_module
+        from direct_cli.browser.session import BrowserAuthError
+
+        login_page = FakePage(locators={}, html="<body>Войдите с Яндекс ID</body>")
+        probe_page = FakePage(locators={}, html="<body>Войдите с Яндекс ID</body>")
+        persistent_ctx = _FakePersistentContext(pages=[login_page, probe_page])
+        fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
+        fake_playwright = _FakePlaywright(fake_chromium)
+
+        with patch("playwright.sync_api.sync_playwright", return_value=fake_playwright):
+            with self.assertRaises(BrowserAuthError):
+                session_module.login_persistent_session(
+                    profile_dir=self.profile_dir,
+                    timeout_ms=3_000,
+                )
+
+        # The page the user interacts with is navigated exactly once: to
+        # Passport. Polling must not steer it anywhere else.
+        self.assertEqual(
+            login_page.navigated_to,
+            [session_module._PASSPORT_LOGIN_URL],
+            "poll loop navigated the user's login page away from Passport",
+        )
 
 
 class TestOpenSessionTiers(unittest.TestCase):

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -1379,12 +1379,19 @@ class TestMastersLogoutCommand(unittest.TestCase):
         self.addCleanup(self._tmpdir.cleanup)
         self.profile_dir = Path(self._tmpdir.name) / "chrome-profile"
 
+    def _make_profile(self):
+        """Create a profile dir the way `masters login` does — marker included."""
+        from direct_cli.browser.session import PROFILE_MARKER_NAME
+
+        self.profile_dir.mkdir(parents=True)
+        (self.profile_dir / PROFILE_MARKER_NAME).touch()
+
     def test_logout_registered(self):
         result = self.runner.invoke(cli, ["masters", "logout", "--help"])
         self.assertEqual(result.exit_code, 0)
 
     def test_logout_deletes_existing_profile(self):
-        self.profile_dir.mkdir(parents=True)
+        self._make_profile()
         (self.profile_dir / "Cookies").write_text("fake")
 
         result = self.runner.invoke(
@@ -1407,11 +1414,50 @@ class TestMastersLogoutCommand(unittest.TestCase):
             "direct_cli.browser.session.DEFAULT_PERSISTENT_PROFILE_DIR",
             self.profile_dir,
         ):
-            self.profile_dir.mkdir(parents=True)
+            self._make_profile()
             result = self.runner.invoke(cli, ["masters", "logout"])
 
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertFalse(self.profile_dir.exists())
+
+    def test_logout_refuses_a_directory_it_did_not_create(self):
+        """`--profile-dir` pointing at an unrelated directory must not be deleted.
+
+        Codex review finding on PR #644: `logout` passes whatever `--profile-dir`
+        resolves to straight into `shutil.rmtree`, with no check that the target
+        is actually a profile this CLI created. A typo or a shell-expanded `.`
+        therefore recursively deletes an arbitrary tree.
+
+        `shutil.rmtree` is patched, so this test never deletes anything for real —
+        it only records the path the command *would* have destroyed.
+        """
+        victim = Path(self._tmpdir.name) / "not-a-profile"
+        victim.mkdir(parents=True)
+        (victim / "important.txt").write_text("user data")
+
+        with patch("shutil.rmtree") as rmtree:
+            result = self.runner.invoke(
+                cli, ["masters", "logout", "--profile-dir", str(victim)]
+            )
+
+        rmtree.assert_not_called()
+        self.assertNotEqual(result.exit_code, 0, result.output)
+        self.assertTrue(victim.exists())
+
+    def test_logout_refuses_a_symlinked_profile_dir(self):
+        """A symlink would let rmtree escape the directory the user named."""
+        self._make_profile()
+        link = Path(self._tmpdir.name) / "link-to-profile"
+        link.symlink_to(self.profile_dir, target_is_directory=True)
+
+        with patch("shutil.rmtree") as rmtree:
+            result = self.runner.invoke(
+                cli, ["masters", "logout", "--profile-dir", str(link)]
+            )
+
+        rmtree.assert_not_called()
+        self.assertNotEqual(result.exit_code, 0, result.output)
+        self.assertTrue(self.profile_dir.exists())
 
 
 class TestCaptchaDetection(unittest.TestCase):

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -271,6 +271,7 @@ class TestMastersRegistered(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertIn("list", result.output)
         self.assertIn("get", result.output)
+        self.assertIn("login", result.output)
 
     def test_masters_list_help(self):
         result = self.runner.invoke(cli, ["masters", "list", "--help"])
@@ -408,14 +409,44 @@ class _FakeBrowser:
         self.closed = True
 
 
-class _FakeChromium:
-    def __init__(self, browser):
-        self._browser = browser
+class _FakePersistentContext:
+    """Fakes the context ``launch_persistent_context`` returns directly.
+
+    Unlike ``_FakeBrowser``/``_FakeContext`` (a separate browser + context
+    pair for ``chromium.launch()``), a persistent context IS the return
+    value — there is no separate ``Browser`` object to close.
+    """
+
+    def __init__(self, pages=None):
+        self.closed = False
         self.launch_kwargs = None
+        self._pages = list(pages or [])
+
+    def new_page(self):
+        if self._pages:
+            return self._pages.pop(0)
+        return FakePage()
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeChromium:
+    def __init__(self, browser, persistent_context=None):
+        self._browser = browser
+        self._persistent_context = persistent_context
+        self.launch_kwargs = None
+        self.launch_persistent_context_kwargs = None
+        self.launch_persistent_context_user_data_dir = None
 
     def launch(self, **kwargs):
         self.launch_kwargs = kwargs
         return self._browser
+
+    def launch_persistent_context(self, user_data_dir, **kwargs):
+        self.launch_persistent_context_user_data_dir = user_data_dir
+        self.launch_persistent_context_kwargs = kwargs
+        return self._persistent_context
 
 
 class _FakePlaywright:
@@ -478,9 +509,110 @@ class TestOpenChromeSession(unittest.TestCase):
         self.assertTrue(fake_browser.closed)
 
 
+class TestPersistentSession(unittest.TestCase):
+    """direct masters login (issue #635) — CLI-owned persistent Chromium
+    profile, no Keychain/real-Chrome-cookie involvement at all.
+
+    Uses real temp directories (rather than fake Path patching) because
+    _launch_persistent_context calls profile_dir.mkdir() for real.
+    """
+
+    def setUp(self):
+        import tempfile
+
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.profile_dir = Path(self._tmpdir.name) / "chrome-profile"
+
+    def test_open_persistent_session_raises_when_profile_missing(self):
+        pytest.importorskip("playwright")
+        from direct_cli.browser.session import (
+            BrowserSessionMissingError,
+            open_persistent_session,
+        )
+
+        with self.assertRaises(BrowserSessionMissingError) as ctx:
+            with open_persistent_session(profile_dir=self.profile_dir):
+                pass
+        self.assertIn("masters login", str(ctx.exception))
+
+    def test_open_persistent_session_launches_persistent_context(self):
+        pytest.importorskip("playwright")
+        from direct_cli.browser import session as session_module
+
+        self.profile_dir.mkdir(parents=True)
+        persistent_ctx = _FakePersistentContext()
+        fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
+        fake_playwright = _FakePlaywright(fake_chromium)
+
+        with patch("playwright.sync_api.sync_playwright", return_value=fake_playwright):
+            with session_module.open_persistent_session(
+                profile_dir=self.profile_dir
+            ) as page:
+                self.assertIsInstance(page, FakePage)
+
+        self.assertEqual(
+            fake_chromium.launch_persistent_context_user_data_dir,
+            str(self.profile_dir),
+        )
+        self.assertEqual(
+            fake_chromium.launch_persistent_context_kwargs["locale"], "ru-RU"
+        )
+        self.assertTrue(persistent_ctx.closed)
+
+    def test_login_persistent_session_returns_once_authenticated(self):
+        pytest.importorskip("playwright")
+        from direct_cli.browser import session as session_module
+
+        authed_page = FakePage(locators={}, html="<body>Кампания остановлена</body>")
+        persistent_ctx = _FakePersistentContext(pages=[authed_page])
+        fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
+        fake_playwright = _FakePlaywright(fake_chromium)
+
+        with patch("playwright.sync_api.sync_playwright", return_value=fake_playwright):
+            session_module.login_persistent_session(
+                profile_dir=self.profile_dir, timeout_ms=5_000
+            )
+
+        self.assertTrue(persistent_ctx.closed)
+        self.assertTrue(self.profile_dir.exists())
+
+    def test_login_persistent_session_times_out_if_never_authenticated(self):
+        pytest.importorskip("playwright")
+        from direct_cli.browser import session as session_module
+        from direct_cli.browser.session import BrowserAuthError
+
+        login_page = FakePage(locators={}, html="<body>Войдите с Яндекс ID</body>")
+        persistent_ctx = _FakePersistentContext(pages=[login_page])
+        fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
+        fake_playwright = _FakePlaywright(fake_chromium)
+
+        with patch("playwright.sync_api.sync_playwright", return_value=fake_playwright):
+            with self.assertRaises(BrowserAuthError) as ctx:
+                session_module.login_persistent_session(
+                    profile_dir=self.profile_dir,
+                    timeout_ms=1_000,
+                )
+        self.assertIn("Timed out", str(ctx.exception))
+
+
 class TestOpenSessionTiers(unittest.TestCase):
-    """_open_session's three-tier resolution: explicit profile / saved
-    session / fresh-decrypt fallback (with auth-error self-heal retry)."""
+    """_open_session's tiered resolution: explicit profile / persistent CLI
+    profile / saved session / fresh-decrypt fallback (with auth-error
+    self-heal retry)."""
+
+    def setUp(self):
+        # Every test in this class exercises tiers below 1.5 (persistent CLI
+        # profile) unless a test explicitly wants that tier -- patch
+        # DEFAULT_PERSISTENT_PROFILE_DIR to a guaranteed-nonexistent Path so
+        # these tests don't depend on whether the developer running them has
+        # ever run `direct masters login` for real.
+        patcher = patch(
+            "direct_cli.browser.session.DEFAULT_PERSISTENT_PROFILE_DIR",
+            Path("/nonexistent/chrome-profile"),
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     def _list_ctx(self, args=None):
         from direct_cli.commands.masters import masters
@@ -507,6 +639,37 @@ class TestOpenSessionTiers(unittest.TestCase):
                     pass
         saved.assert_not_called()
         fresh.assert_called_once()
+
+    def test_persistent_profile_used_when_present(self):
+        """Tier 1.5: when the CLI's own persistent profile dir exists, it's
+        preferred over the saved storage_state session and the Keychain
+        decrypt path -- neither should be touched."""
+        from direct_cli.commands.masters import _open_session
+
+        with self._list_ctx() as ctx:
+            with (
+                patch(
+                    "direct_cli.browser.session.DEFAULT_PERSISTENT_PROFILE_DIR",
+                    Path("/fake/persistent/profile"),
+                ),
+                patch.object(Path, "exists", return_value=True),
+                patch(
+                    "direct_cli.browser.session.open_persistent_session"
+                ) as persistent,
+                patch("direct_cli.browser.store.session_status") as status,
+                patch("direct_cli.browser.session.open_saved_session") as saved,
+                patch("direct_cli.browser.session.open_chrome_session") as fresh,
+            ):
+                persistent.return_value.__enter__ = lambda self: "page"
+                persistent.return_value.__exit__ = lambda self, *a: False
+                with _open_session(
+                    ctx, headful=False, profile_dir=None, chrome_profile="Default"
+                ):
+                    pass
+        persistent.assert_called_once()
+        status.assert_not_called()
+        saved.assert_not_called()
+        fresh.assert_not_called()
 
     def test_fresh_saved_session_used_without_decrypting(self):
         from direct_cli.commands.masters import _open_session
@@ -1114,6 +1277,73 @@ class TestMastersSuspendResumeCommand(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertEqual(mock_resume.call_count, 1)
+
+
+class TestMastersLoginCommand(unittest.TestCase):
+    """CLI wiring for `masters login` (issue #635)."""
+
+    def setUp(self):
+        self.runner = CliRunner()
+
+    def test_login_registered(self):
+        result = self.runner.invoke(cli, ["masters", "login", "--help"])
+        self.assertEqual(result.exit_code, 0)
+
+    def test_login_has_no_output_format_options(self):
+        # login is interactive/side-effecting, not a data-fetching command --
+        # it has no --format/--output, unlike list/get/suspend/resume.
+        result = self.runner.invoke(cli, ["masters", "login", "--help"])
+        self.assertNotIn("--format", result.output)
+
+    def test_login_calls_login_persistent_session(self):
+        with patch("direct_cli.browser.session.login_persistent_session") as mock_login:
+            result = self.runner.invoke(cli, ["masters", "login"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        mock_login.assert_called_once()
+        _, kwargs = mock_login.call_args
+        self.assertEqual(kwargs["timeout_ms"], 300_000)
+        self.assertIsNone(kwargs["profile_dir"])
+
+    def test_login_passes_explicit_profile_dir_and_timeout(self):
+        with patch("direct_cli.browser.session.login_persistent_session") as mock_login:
+            result = self.runner.invoke(
+                cli,
+                [
+                    "masters",
+                    "login",
+                    "--profile-dir",
+                    "/custom/profile",
+                    "--timeout",
+                    "30",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        _, kwargs = mock_login.call_args
+        self.assertEqual(kwargs["profile_dir"], Path("/custom/profile"))
+        self.assertEqual(kwargs["timeout_ms"], 30_000)
+
+    def test_login_converts_browser_session_error_to_click_exception(self):
+        from direct_cli.browser.session import BrowserAuthError
+
+        with patch(
+            "direct_cli.browser.session.login_persistent_session",
+            side_effect=BrowserAuthError("timed out"),
+        ):
+            result = self.runner.invoke(cli, ["masters", "login"])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("timed out", result.output)
+
+    def test_login_missing_playwright_raises_usage_error(self):
+        with patch.dict(
+            "sys.modules", {"playwright": None, "playwright.sync_api": None}
+        ):
+            result = self.runner.invoke(cli, ["masters", "login"])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("playwright", result.output.lower())
 
 
 class TestCaptchaDetection(unittest.TestCase):

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -272,6 +272,7 @@ class TestMastersRegistered(unittest.TestCase):
         self.assertIn("list", result.output)
         self.assertIn("get", result.output)
         self.assertIn("login", result.output)
+        self.assertIn("logout", result.output)
 
     def test_masters_list_help(self):
         result = self.runner.invoke(cli, ["masters", "list", "--help"])
@@ -559,6 +560,27 @@ class TestPersistentSession(unittest.TestCase):
             fake_chromium.launch_persistent_context_kwargs["locale"], "ru-RU"
         )
         self.assertTrue(persistent_ctx.closed)
+
+    def test_open_persistent_session_chmods_profile_dir_0700(self):
+        # issue #635 risk: the profile holds a live Yandex session in
+        # plaintext-readable cookies -- must be 0700, same as
+        # direct_cli/browser/store.py's session file directory.
+        pytest.importorskip("playwright")
+        import stat
+
+        from direct_cli.browser import session as session_module
+
+        self.profile_dir.mkdir(parents=True, mode=0o755)
+        persistent_ctx = _FakePersistentContext()
+        fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
+        fake_playwright = _FakePlaywright(fake_chromium)
+
+        with patch("playwright.sync_api.sync_playwright", return_value=fake_playwright):
+            with session_module.open_persistent_session(profile_dir=self.profile_dir):
+                pass
+
+        mode = stat.S_IMODE(self.profile_dir.stat().st_mode)
+        self.assertEqual(format(mode, "04o"), "0700")
 
     def test_login_persistent_session_returns_once_authenticated(self):
         pytest.importorskip("playwright")
@@ -1344,6 +1366,52 @@ class TestMastersLoginCommand(unittest.TestCase):
 
         self.assertNotEqual(result.exit_code, 0)
         self.assertIn("playwright", result.output.lower())
+
+
+class TestMastersLogoutCommand(unittest.TestCase):
+    """CLI wiring for `masters logout` (issue #635 risk: revocation)."""
+
+    def setUp(self):
+        self.runner = CliRunner()
+        import tempfile
+
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.profile_dir = Path(self._tmpdir.name) / "chrome-profile"
+
+    def test_logout_registered(self):
+        result = self.runner.invoke(cli, ["masters", "logout", "--help"])
+        self.assertEqual(result.exit_code, 0)
+
+    def test_logout_deletes_existing_profile(self):
+        self.profile_dir.mkdir(parents=True)
+        (self.profile_dir / "Cookies").write_text("fake")
+
+        result = self.runner.invoke(
+            cli, ["masters", "logout", "--profile-dir", str(self.profile_dir)]
+        )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertFalse(self.profile_dir.exists())
+
+    def test_logout_is_a_noop_warning_when_no_profile_exists(self):
+        result = self.runner.invoke(
+            cli, ["masters", "logout", "--profile-dir", str(self.profile_dir)]
+        )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertFalse(self.profile_dir.exists())
+
+    def test_logout_uses_default_persistent_profile_dir_when_unset(self):
+        with patch(
+            "direct_cli.browser.session.DEFAULT_PERSISTENT_PROFILE_DIR",
+            self.profile_dir,
+        ):
+            self.profile_dir.mkdir(parents=True)
+            result = self.runner.invoke(cli, ["masters", "logout"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertFalse(self.profile_dir.exists())
 
 
 class TestCaptchaDetection(unittest.TestCase):

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -760,12 +760,65 @@ class TestOpenSessionTiers(unittest.TestCase):
         )
         patcher.start()
         self.addCleanup(patcher.stop)
+        # Resolution goes through the login pointer -- keep it off the
+        # developer's real ~/.direct-cli so these tests never depend on
+        # whether `masters login` has been run on this machine.
+        pointer = patch(
+            "direct_cli.browser.session.PROFILE_POINTER_PATH",
+            Path("/nonexistent/chrome-profile-path"),
+        )
+        pointer.start()
+        self.addCleanup(pointer.stop)
 
     def _list_ctx(self, args=None):
         from direct_cli.commands.masters import masters
 
         list_cmd = masters.commands["list"]
         return list_cmd.make_context("list", list(args or []))
+
+    def test_custom_login_profile_dir_is_honoured_by_reads(self):
+        """A session saved by `login --profile-dir X` must be used by reads.
+
+        Tier 1.5 originally resolved the profile from
+        DEFAULT_PERSISTENT_PROFILE_DIR only and passed no profile_dir to
+        open_persistent_session, so `masters login --profile-dir X` reported
+        "Login confirmed" and then every list/get/suspend/resume ignored X
+        entirely -- falling through to the Keychain path the flag exists to
+        avoid.
+        """
+        import tempfile
+
+        from direct_cli.commands.masters import _open_session
+
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        custom = Path(tmpdir.name) / "custom-profile"
+        (custom / "Default").mkdir(parents=True)
+        (custom / "Default" / "Cookies").write_bytes(b"")
+
+        with self._list_ctx() as ctx:
+            with (
+                patch(
+                    "direct_cli.commands.masters._configured_persistent_profile_dir",
+                    return_value=custom,
+                ),
+                patch(
+                    "direct_cli.browser.session.open_persistent_session"
+                ) as persistent,
+                patch("direct_cli.browser.session.open_saved_session") as saved,
+                patch("direct_cli.browser.session.open_chrome_session") as fresh,
+            ):
+                persistent.return_value.__enter__ = lambda self: "page"
+                persistent.return_value.__exit__ = lambda self, *a: False
+                with _open_session(
+                    ctx, headful=False, profile_dir=None, chrome_profile="Default"
+                ):
+                    pass
+
+        persistent.assert_called_once()
+        self.assertEqual(persistent.call_args.kwargs.get("profile_dir"), custom)
+        saved.assert_not_called()
+        fresh.assert_not_called()
 
     def test_explicit_profile_dir_bypasses_saved_session(self):
         from direct_cli.commands.masters import _open_session
@@ -806,8 +859,8 @@ class TestOpenSessionTiers(unittest.TestCase):
         with self._list_ctx() as ctx:
             with (
                 patch(
-                    "direct_cli.browser.session.DEFAULT_PERSISTENT_PROFILE_DIR",
-                    profile,
+                    "direct_cli.commands.masters._configured_persistent_profile_dir",
+                    return_value=profile,
                 ),
                 patch(
                     "direct_cli.browser.session.open_persistent_session"
@@ -1539,6 +1592,14 @@ class TestMastersLogoutCommand(unittest.TestCase):
         self._tmpdir = tempfile.TemporaryDirectory()
         self.addCleanup(self._tmpdir.cleanup)
         self.profile_dir = Path(self._tmpdir.name) / "chrome-profile"
+
+        # Keep the login pointer off the developer's real ~/.direct-cli.
+        pointer = patch(
+            "direct_cli.browser.session.PROFILE_POINTER_PATH",
+            Path(self._tmpdir.name) / "chrome-profile-path",
+        )
+        pointer.start()
+        self.addCleanup(pointer.stop)
 
     def _make_profile(self):
         """Create a profile dir the way `masters login` does — marker included."""

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -529,6 +529,84 @@ class TestPersistentSession(unittest.TestCase):
         self.addCleanup(self._tmpdir.cleanup)
         self.profile_dir = Path(self._tmpdir.name) / "chrome-profile"
 
+    def _make_profile(self):
+        """Create a profile dir the way a completed `masters login` leaves it."""
+        from direct_cli.browser.session import PROFILE_MARKER_NAME
+
+        self.profile_dir.mkdir(parents=True)
+        (self.profile_dir / PROFILE_MARKER_NAME).touch()
+
+    def test_login_refuses_to_mark_an_existing_unrelated_directory(self):
+        """`--profile-dir` at an existing directory must not be claimed.
+
+        Codex review finding on PR #644: the profile dir was created with
+        `exist_ok=True` and then unconditionally marked CLI-owned, so
+        `masters login --profile-dir ~` planted the ownership marker into the
+        user's home directory — and `masters logout` on the same path then
+        accepted that marker as authorization to `shutil.rmtree` it. A failed
+        login armed it just the same, because the marker was written before
+        Chromium even launched.
+        """
+        pytest.importorskip("playwright")
+        from direct_cli.browser import session as session_module
+        from direct_cli.browser.session import (
+            PROFILE_MARKER_NAME,
+            BrowserSessionError,
+        )
+
+        victim = Path(self._tmpdir.name) / "my-documents"
+        victim.mkdir()
+        (victim / "taxes.pdf").write_text("important")
+
+        persistent_ctx = _FakePersistentContext()
+        fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
+        fake_playwright = _FakePlaywright(fake_chromium)
+
+        with patch("playwright.sync_api.sync_playwright", return_value=fake_playwright):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                session_module.login_persistent_session(
+                    profile_dir=victim, timeout_ms=1_000
+                )
+
+        self.assertFalse(
+            (victim / PROFILE_MARKER_NAME).exists(),
+            "login planted an ownership marker in a directory it did not create",
+        )
+        self.assertTrue((victim / "taxes.pdf").exists())
+        self.assertIn("already exists", str(ctx.exception).lower())
+
+    def test_aborted_login_does_not_leave_a_profile_that_looks_usable(self):
+        """A login that never completed must not register as a usable profile.
+
+        `_launch_persistent_context` creates the directory before Chromium
+        starts, so a login the user ctrl-C's out of (or that times out) leaves
+        a directory behind with no session in it. If tier 1.5 accepted mere
+        directory existence, every later `masters` call would route through
+        that empty profile, launch a browser, fail auth, and only then fall
+        back — paying a wasted browser launch each time and bypassing the
+        user's working saved session.
+        """
+        pytest.importorskip("playwright")
+        from direct_cli.browser import session as session_module
+        from direct_cli.browser.session import BrowserAuthError
+
+        login_page = FakePage(locators={}, html="<body>Войдите с Яндекс ID</body>")
+        probe_page = FakePage(locators={}, html="<body>Войдите с Яндекс ID</body>")
+        persistent_ctx = _FakePersistentContext(pages=[login_page, probe_page])
+        fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
+        fake_playwright = _FakePlaywright(fake_chromium)
+
+        with patch("playwright.sync_api.sync_playwright", return_value=fake_playwright):
+            with self.assertRaises(BrowserAuthError):
+                session_module.login_persistent_session(
+                    profile_dir=self.profile_dir, timeout_ms=1_000
+                )
+
+        self.assertFalse(
+            session_module.persistent_profile_is_usable(self.profile_dir),
+            "an aborted login left a profile tier 1.5 would route through",
+        )
+
     def test_open_persistent_session_raises_when_profile_missing(self):
         pytest.importorskip("playwright")
         from direct_cli.browser.session import (
@@ -545,7 +623,7 @@ class TestPersistentSession(unittest.TestCase):
         pytest.importorskip("playwright")
         from direct_cli.browser import session as session_module
 
-        self.profile_dir.mkdir(parents=True)
+        self._make_profile()
         persistent_ctx = _FakePersistentContext()
         fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
         fake_playwright = _FakePlaywright(fake_chromium)
@@ -573,8 +651,12 @@ class TestPersistentSession(unittest.TestCase):
         import stat
 
         from direct_cli.browser import session as session_module
+        from direct_cli.browser.session import PROFILE_MARKER_NAME
 
+        # A real profile (marker present) that has somehow ended up
+        # world-readable -- reopening it must tighten the mode back to 0700.
         self.profile_dir.mkdir(parents=True, mode=0o755)
+        (self.profile_dir / PROFILE_MARKER_NAME).touch()
         persistent_ctx = _FakePersistentContext()
         fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
         fake_playwright = _FakePlaywright(fake_chromium)
@@ -706,18 +788,27 @@ class TestOpenSessionTiers(unittest.TestCase):
         fresh.assert_called_once()
 
     def test_persistent_profile_used_when_present(self):
-        """Tier 1.5: when the CLI's own persistent profile dir exists, it's
-        preferred over the saved storage_state session and the Keychain
+        """Tier 1.5: when the CLI's own persistent profile holds a session,
+        it's preferred over the saved storage_state session and the Keychain
         decrypt path -- neither should be touched."""
+        import tempfile
+
         from direct_cli.commands.masters import _open_session
+
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        # A profile a completed login would leave: Chromium's cookie store is
+        # what makes it usable, not the directory merely existing.
+        profile = Path(tmpdir.name) / "chrome-profile"
+        (profile / "Default").mkdir(parents=True)
+        (profile / "Default" / "Cookies").write_bytes(b"")
 
         with self._list_ctx() as ctx:
             with (
                 patch(
                     "direct_cli.browser.session.DEFAULT_PERSISTENT_PROFILE_DIR",
-                    Path("/fake/persistent/profile"),
+                    profile,
                 ),
-                patch.object(Path, "exists", return_value=True),
                 patch(
                     "direct_cli.browser.session.open_persistent_session"
                 ) as persistent,


### PR DESCRIPTION
## Summary

- Adds `direct masters login` — a new interactive command that opens a visible browser window on a persistent Chromium profile owned by the CLI (`~/.direct-cli/chrome-profile/` by default, overridable with `--profile-dir`). The user logs in by hand once via Yandex Passport; the command polls until the session is confirmed authenticated (or times out after `--timeout` seconds, default 300).
- This is independent of the existing `direct playwright login`/macOS Keychain decrypt path entirely — it never touches the user's real Chrome profile or the Keychain, so it works identically on macOS/Linux/Windows, at the cost of a one-time manual login instead of a transparent cookie copy.
- `direct masters` (`list`/`get`/`suspend`/`resume`) automatically prefers this persistent profile whenever it exists — new tier 1.5 in the session-resolution chain (`direct_cli/commands/masters.py::_open_session`), ahead of the saved `playwright login` storage_state session (tier 2) and the fresh-Keychain-decrypt fallback (tier 3). A stale on-disk session self-heals via the existing `BrowserAuthError` retry-through-fresh-decrypt path.
- `masters.login` is classified `DANGEROUS` in `direct_cli/smoke_matrix.py` and documented manual-only in `scripts/test_dangerous_commands.sh` — it's interactive by design (blocks waiting for a human), so it can never run in an automated smoke tier, unlike the non-interactive `playwright.login` (SAFE).

## Test plan

- [x] `pytest` — full offline suite green (2649 passed, 8 skipped)
- [x] `pytest tests/test_masters.py -v` — 70 tests including new `TestPersistentSession` (open/login persistent context, timeout) and `TestMastersLoginCommand` (CLI wiring)
- [x] `black --check` / `flake8` clean on all changed files
- [x] Manual live verification not performed (no browser environment available in this session) — documented as a known limitation is not applicable here since the code paths (Passport URL, grid auth check, persistent profile launch) reuse already-verified primitives (`assert_authenticated`, `GRID_URL`) from the existing `direct playwright login`/`direct masters` implementation; only the polling loop and `launch_persistent_context` wiring are new and covered by fake-Playwright tests

Closes #635