### PR TITLE
feat(masters): add `direct masters archive` (#633)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+**Added — `direct masters archive` (#633):**
+
+- New command that archives a Мастер кампаний. Live recon confirmed Yandex's
+  UI has **no separate "delete" action** for it — neither the campaigns
+  grid's row menu nor the overview page's own menu has a "Удалить" item,
+  only "Архивировать" (issue #633 comment documents the DOM structure
+  found live). This is the closest thing to delete Мастер кампаний has.
+- Clicks the overview page's "⋮" menu then "Архивировать" — both selected
+  via stable, confirmed-live `data-testid` attributes
+  (`CampaignHeader.MenuTrigger`/`CampaignHeader.Menu.archive`), unlike
+  `suspend`/`resume`'s best-effort text-matched candidate buttons.
+- Verifies success by re-reading the campaigns grid (`fetch_masters_list`)
+  and confirming the status actually became `ARCHIVED`, rather than
+  trusting the click alone. Idempotent: an already-archived campaign is a
+  no-op warning, not an error.
+- **Irreversible from this CLI** — there is no `masters unarchive`.
+  Classified `DANGEROUS` in `direct_cli/smoke_matrix.py` (same as
+  `suspend`/`resume`): Мастер кампаний has no API and thus no `--sandbox`
+  isolation, so any exercise of this command hits a real account.
+
 **Added — `direct masters login` (#635):**
 
 - New interactive command that opens a visible browser window on a

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ direct masters list --status archived
 direct masters get 72349978
 direct masters suspend 72349978
 direct masters resume 72349978
+direct masters archive 72349978
 ```
 
 `masters list` filters by status with `--status`
@@ -57,6 +58,16 @@ the click alone. They're idempotent (already-suspended/-active is a no-op
 warning, not an error). There is **no `--sandbox` for these** — Мастер
 кампаний has no API at all, so there is no isolated test copy; any mutation
 hits your real account.
+
+`archive` is the closest thing to "delete" Мастер кампаний has: a live
+recon (issue #633) confirmed there is **no separate delete action** in
+Yandex's UI for it, neither in the campaigns grid's row menu nor the
+overview page's own menu — only "Архивировать". `masters archive` clicks
+that menu item and verifies the campaign actually shows up as archived in
+the campaigns grid before reporting success. It is idempotent
+(already-archived is a no-op warning) but **irreversible from this CLI** —
+there is no `masters unarchive`. Same no-`--sandbox` caveat as
+suspend/resume above.
 
 **Browser session (optional but recommended):** `direct masters` decrypts
 your Chrome cookies fresh on every call by default, which means a Keychain
@@ -1079,6 +1090,7 @@ direct masters list --status archived
 direct masters get 72349978
 direct masters suspend 72349978
 direct masters resume 72349978
+direct masters archive 72349978
 ```
 
 `masters list` фильтрует по статусу через `--status`
@@ -1101,6 +1113,17 @@ Chrome и войдите в аккаунт. Если используете не
 У этих команд **нет `--sandbox`** — у «Мастера кампаний» нет API вообще,
 поэтому нет изолированной тестовой копии; любая мутация идёт в боевой
 аккаунт.
+
+`archive` — это ближайший аналог «удаления» для «Мастера кампаний»: живая
+разведка (issue #633) подтвердила, что отдельного действия «удалить» в
+интерфейсе Яндекса для него **нет** — ни в меню строки на странице списка
+кампаний, ни в меню страницы обзора конкретного МК, только
+«Архивировать». `masters archive` кликает по этому пункту меню и
+проверяет через список кампаний, что кампания реально стала архивной,
+прежде чем сообщить об успехе. Команда идемпотентна (уже архивная кампания
+— предупреждение, а не ошибка), но **необратима из этого CLI** — команды
+`masters unarchive` нет. Тот же отказ от `--sandbox`, что и у
+suspend/resume выше.
 
 **Браузерная сессия (опционально, но рекомендуется):** по умолчанию `direct
 masters` расшифровывает куки Chrome заново при каждом вызове — на macOS это

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -38,6 +38,22 @@ message asking the caller to re-run with ``--headful`` and report the actual
 text, rather than clicking the wrong element. Re-confirm the exact button
 text/behaviour against a live account before relying on this in production;
 update ``_SUSPEND_BUTTON_TEXTS``/``_RESUME_BUTTON_TEXTS`` accordingly.
+
+``archive_master`` (issue #633, live-recon confirmed no separate "delete"
+exists for Мастер кампаний — only archive; see the issue comment). Both
+the campaigns-grid row menu and the overview page's own "⋮" menu were
+inspected live: neither has a "Удалить" item, only "Архивировать" (grid
+row menu also has Перейти/Редактировать/Статистика/Запустить-Остановить;
+overview menu has only Клонировать/Архивировать). Confirmed live,
+stable ``data-testid`` attributes back the overview menu:
+``CampaignHeader.MenuTrigger`` (opens the "⋮" dropdown) and
+``CampaignHeader.Menu.archive`` (the "Архивировать" menu item) — unlike
+suspend/resume's text-based matching, this does not depend on Russian
+button copy. Archiving is verified via ``fetch_masters_list`` (the grid
+API's ``primaryStatus``), not the overview page's status text — no
+archived-campaign overview fixture has been captured, so there is no
+confirmed status-text marker for "archived" on that page the way there is
+for "Кампания остановлена"/"активна".
 """
 
 import json
@@ -114,6 +130,17 @@ _SUSPEND_BUTTON_TEXTS = ("Остановить кампанию", "Приост�
 # How long to wait, after clicking the action button, for the status text to
 # actually change before giving up and reporting a possible false success.
 _STATUS_CHANGE_TIMEOUT_MS = 10_000
+
+# Overview page's "⋮" menu, confirmed live (issue #633) — see module
+# docstring. Unlike _RESUME_BUTTON_TEXTS/_SUSPEND_BUTTON_TEXTS these are
+# selectors, not text-matched candidates: both testids were read directly off
+# a live account's DOM, not guessed.
+_MENU_TRIGGER_SELECTOR = '[data-testid="CampaignHeader.MenuTrigger"]'
+_ARCHIVE_MENU_ITEM_SELECTOR = '[data-testid="CampaignHeader.Menu.archive"]'
+
+# How long to wait, after clicking Архивировать, for the grid API to report
+# the campaign as ARCHIVED before giving up (see archive_master).
+_ARCHIVE_VERIFY_TIMEOUT_MS = 10_000
 
 
 def _is_grid_campaigns_request(response: Any) -> bool:
@@ -499,3 +526,83 @@ def resume_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
         target_status="ACTIVE",
         button_texts=_RESUME_BUTTON_TEXTS,
     )
+
+
+def _find_master_row(
+    page: "Page", campaign_id: int, *, status: str = "all"
+) -> Optional[Dict[str, Any]]:
+    """Return this campaign's row from ``fetch_masters_list``, or ``None``."""
+    for row in fetch_masters_list(page, status=status):
+        if row["CampaignId"] == campaign_id:
+            return row
+    return None
+
+
+def archive_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
+    """Archive a Мастер кампаний, verifying the grid actually reports it archived.
+
+    There is no separate "delete" for Мастер кампаний (issue #633 live
+    recon, documented in the module docstring) — this is the only
+    destructive/lifecycle action beyond suspend/resume. Idempotent: if the
+    campaign is already archived, does not click anything and returns the
+    current row with a warning (mirrors ``suspend_master``/``resume_master``).
+
+    Opens the campaign's overview page, clicks the "⋮" menu trigger, then the
+    "Архивировать" item (both selected via confirmed-live ``data-testid``
+    attributes, not guessed text — see module docstring), and re-reads the
+    campaigns grid via ``fetch_masters_list`` to confirm ``Status ==
+    "ARCHIVED"`` before reporting success — never trusting the click alone.
+    """
+    existing = _find_master_row(page, campaign_id)
+    if existing is None:
+        raise BrowserSessionError(
+            f"Could not find Мастер кампаний {campaign_id} in the campaigns "
+            "grid — check the ID, or it may already be gone."
+        )
+    if existing["Status"] == "ARCHIVED":
+        print_warning(f"Campaign {campaign_id} is already archived; not clicking.")
+        return existing
+
+    url = WIZARD_OVERVIEW_URL.format(campaign_id=campaign_id)
+    page.goto(url, wait_until="domcontentloaded")
+    assert_not_captcha(page.content())
+    assert_authenticated(page.content())
+
+    menu_trigger = page.locator(_MENU_TRIGGER_SELECTOR).first
+    try:
+        menu_trigger.click()
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            f"Could not open the campaign menu for {campaign_id} "
+            f"({_MENU_TRIGGER_SELECTOR!r} not found/clickable) — Yandex may "
+            "have changed the overview page's markup."
+        ) from exc
+
+    archive_item = page.locator(_ARCHIVE_MENU_ITEM_SELECTOR).first
+    try:
+        archive_item.click()
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            f"Could not find/click 'Архивировать' for campaign {campaign_id} "
+            f"({_ARCHIVE_MENU_ITEM_SELECTOR!r} not found) — Yandex may have "
+            "changed the overview page's menu."
+        ) from exc
+
+    deadline = time.monotonic() + _ARCHIVE_VERIFY_TIMEOUT_MS / 1000
+    updated = existing
+    while time.monotonic() < deadline:
+        updated = _find_master_row(page, campaign_id)
+        if updated is not None and updated["Status"] == "ARCHIVED":
+            break
+        page.wait_for_timeout(250)
+
+    if updated is None or updated["Status"] != "ARCHIVED":
+        raise BrowserSessionError(
+            f"Clicked 'Архивировать' for campaign {campaign_id}, but the "
+            f"campaigns grid did not report it as ARCHIVED within "
+            f"{_ARCHIVE_VERIFY_TIMEOUT_MS / 1000:.0f}s. The click may not "
+            "have hit the right element, or Yandex is slow to apply it — "
+            "verify manually before retrying."
+        )
+
+    return updated

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -558,3 +558,41 @@ def resume(
     results = _with_session(ctx, headful, profile_dir, chrome_profile, _resume_all)
 
     format_output(results if len(results) != 1 else results[0], output_format, output)
+
+
+@masters.command()
+@click.argument("campaign_ids")
+@_masters_browser_options
+@click.pass_context
+@handle_api_errors
+def archive(
+    ctx,
+    campaign_ids,
+    headful,
+    profile_dir,
+    chrome_profile,
+    output_format,
+    output,
+):
+    """Archive one or more Мастер кампаний by ID (comma-separated)
+
+    Мастер кампаний has no separate "delete" — archiving is the only
+    destructive/lifecycle action beyond suspend/resume (issue #633 live
+    recon: neither the campaigns-grid row menu nor the overview page's menu
+    has a "Удалить" item, only "Архивировать"). Irreversible from this CLI:
+    there is no `masters unarchive`. Clicks the overview page's "⋮" menu then
+    "Архивировать" (both confirmed live via stable `data-testid` attributes —
+    see `direct_cli/browser/masters.py` module docstring), and verifies via
+    the campaigns grid that the status actually became ARCHIVED before
+    reporting success; idempotent if already archived.
+    """
+    from ..browser.masters import archive_master
+
+    ids = parse_ids(campaign_ids) or []
+
+    def _archive_all(page):
+        return [archive_master(page, campaign_id) for campaign_id in ids]
+
+    results = _with_session(ctx, headful, profile_dir, chrome_profile, _archive_all)
+
+    format_output(results if len(results) != 1 else results[0], output_format, output)

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -60,7 +60,13 @@ from typing import Optional
 import click
 from click.core import ParameterSource
 
-from ..output import format_output, handle_api_errors, print_info, print_warning
+from ..output import (
+    format_output,
+    handle_api_errors,
+    print_error,
+    print_info,
+    print_warning,
+)
 from ..utils import parse_ids
 
 _BROWSER_INSTALL_HINT = (
@@ -585,14 +591,42 @@ def archive(
     see `direct_cli/browser/masters.py` module docstring), and verifies via
     the campaigns grid that the status actually became ARCHIVED before
     reporting success; idempotent if already archived.
+
+    Every ID is attempted even if an earlier one fails: since archiving is
+    irreversible, a naive fail-fast loop would silently lose the report that
+    earlier IDs were already archived in production before a later one
+    errored (issue #645 review). Each ID's outcome (the archived row, or its
+    error) is reported; if any ID failed, the command exits non-zero after
+    printing every outcome, never just the last error.
     """
     from ..browser.masters import archive_master
 
     ids = parse_ids(campaign_ids) or []
 
     def _archive_all(page):
-        return [archive_master(page, campaign_id) for campaign_id in ids]
+        from ..browser.session import BrowserSessionError
+        from ..browser.masters import PlaywrightError
 
-    results = _with_session(ctx, headful, profile_dir, chrome_profile, _archive_all)
+        results = []
+        errors = []
+        for campaign_id in ids:
+            try:
+                results.append(archive_master(page, campaign_id))
+            except (BrowserSessionError, PlaywrightError) as exc:
+                errors.append((campaign_id, exc))
+                results.append({"CampaignId": campaign_id, "Error": str(exc)})
+        return results, errors
+
+    results, errors = _with_session(
+        ctx, headful, profile_dir, chrome_profile, _archive_all
+    )
 
     format_output(results if len(results) != 1 else results[0], output_format, output)
+
+    if errors:
+        for campaign_id, exc in errors:
+            print_error(f"Campaign {campaign_id}: {exc}")
+        raise click.ClickException(
+            f"Failed to archive {len(errors)} of {len(ids)} campaign(s); "
+            "see per-ID results above."
+        )

--- a/direct_cli/smoke_matrix.py
+++ b/direct_cli/smoke_matrix.py
@@ -178,12 +178,16 @@ SMOKE_MATRIX = {
         "agencyclients.update",
         "auth.login",
         "auth.use",
-        # Browser-driven mutations against Мастер кампаний (issue #630).
-        # Мастер кампаний has no API surface at all, so there is no
+        # Browser-driven mutations against Мастер кампаний (issues #630,
+        # #633). Мастер кампаний has no API surface at all, so there is no
         # --sandbox equivalent to isolate these from a real Yandex
         # account — unlike API-backed suspend/resume (WRITE_SANDBOX
-        # above), any smoke exercise of these two hits production.
+        # above), any smoke exercise of these hits production.
+        # masters.archive is also irreversible from this CLI (no
+        # `masters unarchive` — Мастер кампаний has no separate "delete",
+        # only archive; see issue #633).
         # Manual-only, per scripts/test_dangerous_commands.sh.
+        "masters.archive",
         "masters.resume",
         "masters.suspend",
         # Interactive, human-in-the-loop login (issue #635) -- opens a

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -40,9 +40,10 @@ MUTATING_COMMANDS = {
 DRY_RUN_EXCEPTIONS = {
     # This command rejects locally because the API has no delete operation.
     "agencyclients.delete",
-    # Мастер кампаний (issue #630) has no API surface at all -- these click a
-    # button in a real browser session against production, there is no
-    # request payload to preview. See direct_cli/browser/masters.py.
+    # Мастер кампаний (issues #630, #633) has no API surface at all -- these
+    # click a button in a real browser session against production, there is
+    # no request payload to preview. See direct_cli/browser/masters.py.
+    "masters.archive",
     "masters.resume",
     "masters.suspend",
 }

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -46,10 +46,11 @@ def _load_grid_campaigns_fixture():
 class _FakeLocatorHandle:
     """One matched element — the subset of Playwright's Locator API the parser uses."""
 
-    def __init__(self, text="", attrs=None, raises=False):
+    def __init__(self, text="", attrs=None, raises=False, on_click=None):
         self._text = text
         self._attrs = attrs or {}
         self._raises = raises
+        self._on_click = on_click
 
     def inner_text(self):
         if self._raises:
@@ -61,6 +62,12 @@ class _FakeLocatorHandle:
 
     def get_attribute(self, name):
         return self._attrs.get(name)
+
+    def click(self):
+        if self._raises:
+            raise PlaywrightError("element not found")
+        if self._on_click is not None:
+            self._on_click()
 
 
 class _FakeLocator:
@@ -1515,6 +1522,155 @@ class TestMastersSuspendResumeCommand(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertEqual(mock_resume.call_count, 1)
+
+
+class TestArchiveMaster(unittest.TestCase):
+    """archive_master (issue #633): click + verify via the campaigns grid.
+
+    Мастер кампаний has no separate "delete" (live recon, see module
+    docstring) — archive is the only destructive/lifecycle action left.
+    Unlike suspend/resume's text-matched candidate buttons, the overview
+    page's "⋮" menu and its "Архивировать" item are confirmed live via
+    stable ``data-testid`` selectors, so these tests exercise exact-selector
+    clicks rather than a candidate-list fallback.
+    """
+
+    def _row(self, status):
+        return {
+            "CampaignId": 42,
+            "Name": "Мастер тестовый",
+            "Status": status,
+            "Type": "TEXT",
+            "StartDate": "2025-01-01",
+        }
+
+    def _page_with_menu(self, menu_trigger=None, archive_item=None):
+        locators = {}
+        if menu_trigger is not None:
+            locators[browser_masters._MENU_TRIGGER_SELECTOR] = _FakeLocator(
+                [menu_trigger]
+            )
+        if archive_item is not None:
+            locators[browser_masters._ARCHIVE_MENU_ITEM_SELECTOR] = _FakeLocator(
+                [archive_item]
+            )
+        return FakePage(locators=locators)
+
+    def test_archives_and_verifies_via_grid(self):
+        state = {"status": "STOPPED"}
+
+        def _flip():
+            state["status"] = "ARCHIVED"
+
+        page = self._page_with_menu(
+            menu_trigger=_FakeLocatorHandle(),
+            archive_item=_FakeLocatorHandle(on_click=_flip),
+        )
+
+        with patch(
+            "direct_cli.browser.masters.fetch_masters_list",
+            side_effect=lambda page, status="all": [self._row(state["status"])],
+        ):
+            result = browser_masters.archive_master(page, 42)
+
+        self.assertEqual(result, self._row("ARCHIVED"))
+        self.assertEqual(
+            page.navigated_to,
+            [browser_masters.WIZARD_OVERVIEW_URL.format(campaign_id=42)],
+        )
+
+    def test_idempotent_when_already_archived(self):
+        page = self._page_with_menu()
+
+        with (
+            patch(
+                "direct_cli.browser.masters.fetch_masters_list",
+                return_value=[self._row("ARCHIVED")],
+            ),
+            patch("direct_cli.browser.masters.print_warning") as warn,
+        ):
+            result = browser_masters.archive_master(page, 42)
+
+        self.assertEqual(result, self._row("ARCHIVED"))
+        self.assertEqual(page.navigated_to, [])  # not clicking -> no navigation either
+        warn.assert_called_once()
+        self.assertIn("already archived", warn.call_args[0][0])
+
+    def test_raises_when_campaign_not_found_in_grid(self):
+        page = self._page_with_menu()
+
+        with patch("direct_cli.browser.masters.fetch_masters_list", return_value=[]):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters.archive_master(page, 42)
+
+        self.assertIn("Could not find", str(ctx.exception))
+
+    def test_raises_when_menu_trigger_not_found(self):
+        page = self._page_with_menu()  # no menu_trigger locator registered
+
+        with patch(
+            "direct_cli.browser.masters.fetch_masters_list",
+            return_value=[self._row("STOPPED")],
+        ):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters.archive_master(page, 42)
+
+        self.assertIn("Could not open the campaign menu", str(ctx.exception))
+
+    def test_raises_when_archive_menu_item_not_found(self):
+        page = self._page_with_menu(menu_trigger=_FakeLocatorHandle())
+
+        with patch(
+            "direct_cli.browser.masters.fetch_masters_list",
+            return_value=[self._row("STOPPED")],
+        ):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters.archive_master(page, 42)
+
+        self.assertIn("Архивировать", str(ctx.exception))
+
+    def test_raises_when_status_never_becomes_archived(self):
+        # The click succeeds but the grid keeps reporting STOPPED -- must not
+        # report success on the click alone.
+        page = self._page_with_menu(
+            menu_trigger=_FakeLocatorHandle(),
+            archive_item=_FakeLocatorHandle(),
+        )
+
+        with patch(
+            "direct_cli.browser.masters.fetch_masters_list",
+            return_value=[self._row("STOPPED")],
+        ):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters.archive_master(page, 42)
+
+        self.assertIn("did not report it as ARCHIVED", str(ctx.exception))
+
+
+class TestMastersArchiveCommand(unittest.TestCase):
+    """CLI wiring for `masters archive` (issue #633)."""
+
+    def setUp(self):
+        self.runner = CliRunner()
+
+    def test_archive_registered(self):
+        result = self.runner.invoke(cli, ["masters", "archive", "--help"])
+        self.assertEqual(result.exit_code, 0)
+
+    def test_archive_has_no_login_option(self):
+        result = self.runner.invoke(cli, ["masters", "archive", "--help"])
+        self.assertNotIn("--login", result.output)
+
+    def test_archive_calls_archive_master_per_id(self):
+        with (
+            patch("direct_cli.browser.masters.archive_master") as mock_archive,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            result = self.runner.invoke(cli, ["masters", "archive", "1,2"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(mock_archive.call_count, 2)
 
 
 class TestMastersLoginCommand(unittest.TestCase):

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -1672,6 +1672,35 @@ class TestMastersArchiveCommand(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertEqual(mock_archive.call_count, 2)
 
+    def test_archive_reports_earlier_successes_when_a_later_id_fails(self):
+        # Regression: archive is irreversible (no `masters unarchive`) -- a
+        # naive list comprehension that aborts on the first exception would
+        # silently lose the report that ids 1/2 were already archived in
+        # production before id 3 failed. The per-ID outcome for every ID
+        # must reach the user, not just the last error.
+        def _fake_archive(page, campaign_id):
+            if campaign_id == 3:
+                raise BrowserSessionError("boom on id 3")
+            return {"CampaignId": campaign_id, "Status": "ARCHIVED"}
+
+        with (
+            patch(
+                "direct_cli.browser.masters.archive_master", side_effect=_fake_archive
+            ) as mock_archive,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            result = self.runner.invoke(cli, ["masters", "archive", "1,2,3,4"])
+
+        # All four IDs must be attempted -- a failure on id 3 must not skip
+        # id 4, and must not discard the already-mutated 1/2 from the report.
+        self.assertEqual(mock_archive.call_count, 4)
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("1", result.output)
+        self.assertIn("ARCHIVED", result.output)
+        self.assertIn("2", result.output)
+        self.assertIn("boom on id 3", result.output)
+
 
 class TestMastersLoginCommand(unittest.TestCase):
     """CLI wiring for `masters login` (issue #635)."""


### PR DESCRIPTION
## Summary

- Adds `direct masters archive <ids>` — the closest thing to "delete" Мастер кампаний has.
- Live recon (documented in the [issue #633 comment](https://github.com/axisrow/direct-cli/issues/633#issuecomment-5151772152)) confirmed via `claude-in-chrome` against a real account that Yandex's UI has **no separate delete action** for Мастер кампаний — neither the campaigns grid's row menu (Перейти/Редактировать/Статистика/Запустить-Остановить/**Архивировать**) nor the overview page's own "⋮" menu (**Клонировать**/**Архивировать**) has a "Удалить" item.
- `archive_master` clicks the overview page's "⋮" menu then the "Архивировать" item, using confirmed-live `data-testid` selectors (`CampaignHeader.MenuTrigger` / `CampaignHeader.Menu.archive`) rather than text-matched candidates like `suspend`/`resume` use — these were read directly off the live DOM, not guessed.
- Verifies success by re-reading the campaigns grid (`fetch_masters_list`) and confirming `Status == "ARCHIVED"`, rather than trusting the click alone — mirrors the `suspend`/`resume` "click + verify" convention from #630.
- Idempotent (already-archived campaign → warning, no click).
- **Irreversible from this CLI** — there is no `masters unarchive`. Classified `DANGEROUS` in `smoke_matrix.py`, same category as `suspend`/`resume` (no API ⇒ no `--sandbox` isolation).
- README (EN+RU) and CHANGELOG updated.

Closes #633

## Test plan

- [x] `pytest -q` — 2672 passed, 0 failed (62 pre-existing cassette-fixture errors unrelated to this change, confirmed present on `main` too)
- [x] `pytest tests/test_masters.py -n0` — 101 passed (new `TestArchiveMaster`/`TestMastersArchiveCommand` classes: click+verify, idempotency, not-found, menu-trigger-missing, archive-item-missing, status-never-changes)
- [x] `black --check` / `flake8` clean on all changed files
- [x] Live browser recon only (read-only menu inspection via `claude-in-chrome`) — no live mutation was exercised; `masters archive` itself is untested against a real account (no disposable test campaign yet, see #632 dependency noted in the original issue)