### PR TITLE
feat(masters): add `direct masters update` — Этап A (issue #631)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,33 @@
   `suspend`/`resume`): Мастер кампаний has no API and thus no `--sandbox`
   isolation, so any exercise of this command hits a real account.
 
+**Added — `direct masters update` (#631, Этап A):**
+
+- New command that edits a single Мастер кампаний's settings page
+  (`/wizard/campaigns/{id}/edit/`). This first stage covers exactly three
+  simple scalar fields: `--weekly-budget` (integer, Недельный бюджет),
+  `--promotion-goal` (`max-conversions`/`max-clicks`, Цель продвижения), and
+  `--directs-helps`/`--no-directs-helps` (Директ помогает — auto-apply
+  Yandex recommendations). At least one flag is required.
+- Live investigation (see `tests/fixtures/masters_wizard_edit_stage_a.html`)
+  found the edit page is a single form with one "Сохранить кампанию" button
+  — there is no per-section independent save. `update_master` therefore
+  submits the whole form on every call; fields not passed as flags are left
+  untouched (their current on-page value is preserved simply by never
+  filling/toggling their input).
+- New `direct_cli/browser/masters.py` functions: `update_master` plus
+  private `_set_weekly_budget`/`_set_directs_helps`/`_set_promotion_goal`
+  setters, following the module's existing "click, then verify the change
+  actually took effect" convention (`_suspend_or_resume`) rather than
+  trusting a click alone.
+- Later Этап (B/C/D) fields — headline/text variant lists, sitelinks,
+  audience, Metrika counters/goals, budget adaptation, images/video — are
+  tracked separately in issue #631 and not implemented here.
+- No `--sandbox` equivalent exists for this browser-driven mutation (same
+  rationale as `masters suspend`/`resume`, #630) — classified `DANGEROUS` in
+  `direct_cli/smoke_matrix.py` and documented as manual-only in
+  `scripts/test_dangerous_commands.sh`.
+
 **Added — `direct masters login` (#635):**
 
 - New interactive command that opens a visible browser window on a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,13 @@
   filling/toggling their input).
 - New `direct_cli/browser/masters.py` functions: `update_master` plus
   private `_set_weekly_budget`/`_set_directs_helps`/`_set_promotion_goal`
-  setters, following the module's existing "click, then verify the change
-  actually took effect" convention (`_suspend_or_resume`) rather than
-  trusting a click alone.
+  setters. Each field setter follows the module's existing "click, then
+  verify the change actually took effect" convention (`_suspend_or_resume`)
+  rather than trusting a click alone — but the final `_click_save` step does
+  not: it confirms the save button was clickable, not that Yandex actually
+  saved the change. See the known-gap note in the module docstring; a
+  follow-up live investigation of post-save DOM behaviour is needed before
+  this can be closed.
 - Later Этап (B/C/D) fields — headline/text variant lists, sitelinks,
   audience, Metrika counters/goals, budget adaptation, images/video — are
   tracked separately in issue #631 and not implemented here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,11 +40,17 @@
   private `_set_weekly_budget`/`_set_directs_helps`/`_set_promotion_goal`
   setters. Each field setter follows the module's existing "click, then
   verify the change actually took effect" convention (`_suspend_or_resume`)
-  rather than trusting a click alone — but the final `_click_save` step does
-  not: it confirms the save button was clickable, not that Yandex actually
-  saved the change. See the known-gap note in the module docstring; a
-  follow-up live investigation of post-save DOM behaviour is needed before
-  this can be closed.
+  rather than trusting a click alone. `update_master` itself also verifies:
+  after clicking save it re-navigates to the edit page and re-reads every
+  requested field (`_verify_saved`), raising `BrowserSessionError` on any
+  mismatch instead of reporting a false success — so a click that doesn't
+  actually persist (rejected validation, session/redirect failure) is a
+  hard error, not a silent success.
+- `_click_save` and `_set_promotion_goal`'s option click use
+  `get_by_role(..., exact=True)`, not a substring `get_by_text` match — an
+  exact accessible-name match, scoped to the actual button/option role,
+  avoids clicking an ancestor container whose text merely contains the
+  target label.
 - Later Этап (B/C/D) fields — headline/text variant lists, sitelinks,
   audience, Metrika counters/goals, budget adaptation, images/video — are
   tracked separately in issue #631 and not implemented here.

--- a/README.md
+++ b/README.md
@@ -37,12 +37,25 @@ direct masters get 72349978
 direct masters suspend 72349978
 direct masters resume 72349978
 direct masters archive 72349978
+direct masters update 72349978 --weekly-budget 95000
+direct masters update 72349978 --promotion-goal max-clicks --no-directs-helps
 ```
 
 `masters list` filters by status with `--status`
 (`not-archived`/`active`/`stopped`/`archived`/`all`, default `not-archived`).
 It always reads the logged-in browser session's own account — there is no
 `--login`/agency support for managed clients.
+
+`masters update` edits a single Мастер кампаний's settings page. It currently
+covers only the simplest scalar fields (Этап A of a larger, staged rollout —
+see `direct_cli/browser/masters.py` module docstring): `--weekly-budget`
+(integer), `--promotion-goal` (`max-conversions`/`max-clicks`), and
+`--directs-helps`/`--no-directs-helps` (auto-apply recommendations). At least
+one flag is required. The settings page is a single form with one save
+button — passing only some flags leaves every other field at its current
+value; it does not send a partial payload to a separate per-field endpoint.
+Later fields (headline/text variants, sitelinks, audience, Metrika
+counters/goals, budget adaptation, images/video) aren't implemented yet.
 
 If you see "Found no Yandex cookies", open https://direct.yandex.ru in Chrome
 and log in first. If you use a non-default Chrome profile, pass
@@ -1091,6 +1104,8 @@ direct masters get 72349978
 direct masters suspend 72349978
 direct masters resume 72349978
 direct masters archive 72349978
+direct masters update 72349978 --weekly-budget 95000
+direct masters update 72349978 --promotion-goal max-clicks --no-directs-helps
 ```
 
 `masters list` фильтрует по статусу через `--status`
@@ -1098,6 +1113,19 @@ direct masters archive 72349978
 `not-archived`). Команда всегда читает свой собственный кабинет, в котором
 авторизован браузер — доступа к обслуживаемым клиентам (`--login`/агентство)
 нет.
+
+`masters update` редактирует настройки одного «Мастера кампаний». Пока
+поддерживаются только простые скалярные поля (Этап A поэтапного плана — см.
+докстринг модуля `direct_cli/browser/masters.py`): `--weekly-budget`
+(недельный бюджет, целое число), `--promotion-goal`
+(`max-conversions`/`max-clicks` — цель продвижения) и
+`--directs-helps`/`--no-directs-helps` (автоприменение рекомендаций «Директ
+помогает»). Нужно указать хотя бы один флаг. Страница настроек — единая
+форма с одной кнопкой сохранения: если указать не все флаги, остальные поля
+останутся с текущим значением — это не частичный запрос к отдельному
+API-эндпоинту на каждое поле. Остальные поля (варианты заголовков/текстов,
+быстрые ссылки, аудитория, счётчики Метрики/цели, адаптация бюджета,
+изображения/видео) пока не реализованы.
 
 Если видите «Found no Yandex cookies», откройте https://direct.yandex.ru в
 Chrome и войдите в аккаунт. Если используете не дефолтный профиль Chrome —

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -54,6 +54,20 @@ API's ``primaryStatus``), not the overview page's status text — no
 archived-campaign overview fixture has been captured, so there is no
 confirmed status-text marker for "archived" on that page the way there is
 for "Кампания остановлена"/"активна".
+
+``update_master`` (issue #631, Этап A only) — live-verified against campaign
+107707079 (see ``tests/fixtures/masters_wizard_edit_stage_a.html`` for the
+full investigation notes). Covers exactly three fields: weekly budget,
+promotion goal, and the "Директ помогает" auto-recommendations toggle.
+Later stages (headline/text lists, sitelinks, audience, media uploads) are
+tracked separately in issue #631 and are NOT implemented here.
+
+Confirmed live: the edit page (``/wizard/campaigns/{id}/edit/``) is a single
+form with exactly one "Сохранить кампанию" button at the bottom — there is no
+per-section independent save. A partial ``update_master`` call (only some
+kwargs passed) therefore still submits the whole form; fields the caller
+didn't ask to change are simply left as their current on-page value by never
+touching their input, not via any server-side partial-update semantics.
 """
 
 import json
@@ -74,6 +88,7 @@ except ImportError:  # pragma: no cover - exercised only when playwright is abse
 GRID_URL = "https://direct.yandex.ru/dna/grid/campaigns/"
 GRID_API_URL = "https://direct.yandex.ru/web-api/grid/api"
 WIZARD_OVERVIEW_URL = "https://direct.yandex.ru/wizard/campaigns/{campaign_id}/"
+WIZARD_EDIT_URL = "https://direct.yandex.ru/wizard/campaigns/{campaign_id}/edit/"
 
 # The grid's own data call identifies itself via this query parameter.
 _GRID_CAMPAIGNS_OPERATION = "GridCampaigns"
@@ -141,6 +156,45 @@ _ARCHIVE_MENU_ITEM_SELECTOR = '[data-testid="CampaignHeader.Menu.archive"]'
 # How long to wait, after clicking Архивировать, for the grid API to report
 # the campaign as ARCHIVED before giving up (see archive_master).
 _ARCHIVE_VERIFY_TIMEOUT_MS = 10_000
+
+# "Цель продвижения" dropdown options, confirmed live by opening the dropdown
+# on the edit page — exactly these two rows exist, no others (see
+# tests/fixtures/masters_wizard_edit_stage_a.html). CLI-facing enum keys are
+# kebab-case (this field has no WSDL to mirror, unlike the rest of the CLI).
+PROMOTION_GOAL_CHOICES = {
+    "max-conversions": "Максимум целевых действий",
+    "max-clicks": "Максимум переходов",
+}
+
+# XPath fragment: the text input immediately following (as a descendant of an
+# adjacent sibling) the "Недельный бюджет" heading. Confirmed live — see
+# fixture. Headings on this page have no stable id/data-testid, so matching
+# is by heading text, same fragility class as _extract_*/_click_action_button.
+_WEEKLY_BUDGET_INPUT_XPATH = (
+    "xpath=//*[self::h1 or self::h2 or self::h3][normalize-space(text())="
+    "'Недельный бюджет']/following::input[1]"
+)
+
+# XPath fragment: the checkbox immediately following the "Директ помогает"
+# heading. Confirmed live — a plain HTML checkbox, not a custom toggle
+# component (see fixture). Deliberately scoped to the FIRST following
+# checkbox only, so the nested "Оптимизировать расширенные настройки..."
+# checkbox that appears once this one is checked is never touched.
+_DIRECT_HELPS_CHECKBOX_XPATH = (
+    "xpath=//*[self::h1 or self::h2 or self::h3][normalize-space(text())="
+    "'Директ помогает']/following::input[@type='checkbox'][1]"
+)
+
+# XPath fragment: the "Цель продвижения" dropdown's trigger button. Confirmed
+# live via accessibility-tree read: its accessible name is the static label
+# "Цель продвижения" (not the current selection) — it is the first <button>
+# following the section heading of the same name.
+_PROMOTION_GOAL_BUTTON_XPATH = (
+    "xpath=//*[self::h1 or self::h2 or self::h3][normalize-space(text())="
+    "'Цель продвижения']/following::button[1]"
+)
+
+_SAVE_BUTTON_TEXT = "Сохранить кампанию"
 
 
 def _is_grid_campaigns_request(response: Any) -> bool:
@@ -606,3 +660,185 @@ def archive_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
         )
 
     return updated
+
+
+def _set_weekly_budget(page: "Page", amount: int) -> None:
+    """Fill the "Недельный бюджет" input with ``amount`` (bare integer, no grouping).
+
+    Located by heading-proximity XPath (see ``_WEEKLY_BUDGET_INPUT_XPATH``) —
+    the input has no stable id/data-testid (see module docstring).
+    """
+    field = page.locator(_WEEKLY_BUDGET_INPUT_XPATH).first
+    try:
+        field.click()
+        field.fill(str(amount))
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            "Could not find or fill the weekly budget input ('Недельный "
+            "бюджет') on the campaign edit page — Yandex may have changed "
+            "the page's markup. Re-run with --headful to inspect the page."
+        ) from exc
+
+
+def _set_directs_helps(page: "Page", enabled: bool) -> None:
+    """Check/uncheck the "Директ помогает" auto-recommendations checkbox.
+
+    Scoped to the FIRST checkbox following the "Директ помогает" heading only
+    (see ``_DIRECT_HELPS_CHECKBOX_XPATH``) — checking it reveals a second,
+    nested checkbox ("Оптимизировать расширенные настройки...") that is out
+    of scope for Этап A and must be left untouched.
+    """
+    checkbox = page.locator(_DIRECT_HELPS_CHECKBOX_XPATH).first
+    try:
+        if enabled:
+            checkbox.check()
+        else:
+            checkbox.uncheck()
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            "Could not find or toggle the 'Директ помогает' checkbox "
+            "('Автоматически применять рекомендации') on the campaign edit "
+            "page — Yandex may have changed the page's markup. Re-run with "
+            "--headful to inspect the page."
+        ) from exc
+
+
+def _set_promotion_goal(page: "Page", goal: str) -> None:
+    """Select ``goal`` (a key of ``PROMOTION_GOAL_CHOICES``) in the "Цель
+    продвижения" dropdown.
+
+    Opens the dropdown (click the trigger button), clicks the option row
+    whose text matches the target Russian label, then verifies the trigger
+    button's own text now reflects the new selection — mirrors
+    ``_suspend_or_resume``'s "never trust the click alone" convention.
+    """
+    label = PROMOTION_GOAL_CHOICES.get(goal)
+    if label is None:
+        raise ValueError(
+            f"Unknown promotion goal {goal!r}; expected one of "
+            f"{sorted(PROMOTION_GOAL_CHOICES)}."
+        )
+
+    trigger = page.locator(_PROMOTION_GOAL_BUTTON_XPATH).first
+    try:
+        trigger.click()
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            "Could not find or open the 'Цель продвижения' dropdown on the "
+            "campaign edit page — Yandex may have changed the page's "
+            "markup. Re-run with --headful to inspect the page."
+        ) from exc
+
+    option = page.get_by_text(label, exact=False)
+    clicked = False
+    try:
+        count = option.count()
+    except PlaywrightError:
+        count = 0
+    for i in range(count):
+        handle = option.nth(i)
+        try:
+            if not handle.is_visible():
+                continue
+            handle.click()
+            clicked = True
+            break
+        except PlaywrightError:
+            continue
+
+    if not clicked:
+        raise BrowserSessionError(
+            f"Could not find the {label!r} option in the 'Цель продвижения' "
+            "dropdown on the campaign edit page — Yandex may have changed "
+            "the page's markup. Re-run with --headful to inspect the page."
+        )
+
+    try:
+        current = trigger.inner_text().strip()
+    except PlaywrightError:
+        current = ""
+    if label not in current:
+        raise BrowserSessionError(
+            f"Clicked the {label!r} option for 'Цель продвижения', but the "
+            f"dropdown still does not show it (shows {current!r}). The "
+            "click may not have hit the right element — verify manually "
+            "before retrying."
+        )
+
+
+def _click_save(page: "Page", campaign_id: int) -> None:
+    """Click the edit page's single "Сохранить кампанию" button.
+
+    Confirmed live: the whole edit page is one form with exactly one save
+    button at the bottom (see module docstring) — there is no per-section
+    save to target instead.
+    """
+    save_button = page.get_by_text(_SAVE_BUTTON_TEXT, exact=False)
+    try:
+        count = save_button.count()
+    except PlaywrightError:
+        count = 0
+    for i in range(count):
+        handle = save_button.nth(i)
+        try:
+            if not handle.is_visible():
+                continue
+            handle.click()
+            return
+        except PlaywrightError:
+            continue
+    raise BrowserSessionError(
+        f"Could not find the '{_SAVE_BUTTON_TEXT}' button on the edit page "
+        f"for campaign {campaign_id} — Yandex may have changed the page's "
+        "markup. Re-run with --headful to inspect the page."
+    )
+
+
+def update_master(
+    page: "Page",
+    campaign_id: int,
+    *,
+    weekly_budget: Optional[int] = None,
+    promotion_goal: Optional[str] = None,
+    directs_helps: Optional[bool] = None,
+) -> Dict[str, Any]:
+    """Update one or more Этап A fields of a Мастер кампаний and save.
+
+    Only fields passed as non-``None`` are touched — see module docstring for
+    why this is safe despite the page having a single whole-form save (fields
+    left alone keep their current on-page value simply by never having their
+    input touched). Raises ``ValueError`` if no field is provided, mirroring
+    the rest of the CLI's "nothing to update" guard for partial updates.
+
+    Later Этап (B/C/D) fields — headline/text lists, sitelinks, audience,
+    Metrika counters/goals, budget adaptation, media — are out of scope for
+    this function; see issue #631.
+    """
+    if weekly_budget is None and promotion_goal is None and directs_helps is None:
+        raise ValueError(
+            "update_master requires at least one field to update "
+            "(weekly_budget, promotion_goal, directs_helps)."
+        )
+
+    url = WIZARD_EDIT_URL.format(campaign_id=campaign_id)
+    page.goto(url, wait_until="domcontentloaded")
+    assert_not_captcha(page.content())
+    assert_authenticated(page.content())
+
+    if weekly_budget is not None:
+        _set_weekly_budget(page, weekly_budget)
+    if promotion_goal is not None:
+        _set_promotion_goal(page, promotion_goal)
+    if directs_helps is not None:
+        _set_directs_helps(page, directs_helps)
+
+    _click_save(page, campaign_id)
+
+    result: Dict[str, Any] = {"CampaignId": campaign_id}
+    if weekly_budget is not None:
+        result["WeeklyBudget"] = weekly_budget
+    if promotion_goal is not None:
+        result["PromotionGoal"] = promotion_goal
+    if directs_helps is not None:
+        result["DirectsHelps"] = directs_helps
+    return result

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -68,6 +68,21 @@ per-section independent save. A partial ``update_master`` call (only some
 kwargs passed) therefore still submits the whole form; fields the caller
 didn't ask to change are simply left as their current on-page value by never
 touching their input, not via any server-side partial-update semantics.
+
+**Save verification.** ``_click_save`` only confirms the button was
+clickable — a click alone is not proof Yandex actually saved the change
+(client-side validation can silently reject a value and leave the form open
+with an inline error this module has no stable way to read, see issue
+#631's "Валидация на стороне Яндекса непрозрачна" risk). ``update_master``
+therefore re-navigates to the edit page after saving and re-reads every
+requested field via ``_verify_saved`` — if a field still doesn't match what
+was requested after a real reload, it raises ``BrowserSessionError`` rather
+than reporting false success. This mirrors ``_suspend_or_resume``'s
+"a click that doesn't visibly change the state is a hard error, not a
+silent success" convention, applied to the whole-form save instead of a
+single status field. Not yet covered: an inline validation-error TEXT is
+not itself surfaced to the caller (only the resulting mismatch is) — a
+follow-up could read and report Yandex's actual rejection reason.
 """
 
 import json
@@ -729,7 +744,11 @@ def _set_promotion_goal(page: "Page", goal: str) -> None:
             "markup. Re-run with --headful to inspect the page."
         ) from exc
 
-    option = page.get_by_text(label, exact=False)
+    # get_by_role scopes to actual clickable option rows (not any container
+    # whose text happens to contain the label as a substring) — see the
+    # cycle-review finding this fixed: the previous get_by_text(exact=False)
+    # could match an ancestor wrapper instead of the option itself.
+    option = page.get_by_role("option", name=label, exact=True)
     clicked = False
     try:
         count = option.count()
@@ -753,11 +772,14 @@ def _set_promotion_goal(page: "Page", goal: str) -> None:
             "the page's markup. Re-run with --headful to inspect the page."
         )
 
+    # Exact match, not substring: an exact accessible name is either the new
+    # selection or it isn't — a substring check could pass on unrelated text
+    # that merely contains part of the label.
     try:
         current = trigger.inner_text().strip()
     except PlaywrightError:
         current = ""
-    if label not in current:
+    if current != label:
         raise BrowserSessionError(
             f"Clicked the {label!r} option for 'Цель продвижения', but the "
             f"dropdown still does not show it (shows {current!r}). The "
@@ -773,7 +795,10 @@ def _click_save(page: "Page", campaign_id: int) -> None:
     button at the bottom (see module docstring) — there is no per-section
     save to target instead.
     """
-    save_button = page.get_by_text(_SAVE_BUTTON_TEXT, exact=False)
+    # get_by_role scopes to the actual <button> element (exact accessible
+    # name), not any ancestor container whose text merely contains this
+    # substring — see the cycle-review finding this fixed.
+    save_button = page.get_by_role("button", name=_SAVE_BUTTON_TEXT, exact=True)
     try:
         count = save_button.count()
     except PlaywrightError:
@@ -794,6 +819,111 @@ def _click_save(page: "Page", campaign_id: int) -> None:
     )
 
 
+def _read_weekly_budget(page: "Page") -> Optional[int]:
+    """Read the "Недельный бюджет" input's current bare-integer value.
+
+    Returns ``None`` if the field can't be found/read — the caller treats
+    that as "verification inconclusive", not as a specific budget value.
+    """
+    field = page.locator(_WEEKLY_BUDGET_INPUT_XPATH).first
+    try:
+        raw = field.input_value()
+    except PlaywrightError:
+        return None
+    digits = "".join(ch for ch in raw if ch.isdigit())
+    if not digits:
+        return None
+    try:
+        return int(digits)
+    except ValueError:
+        return None
+
+
+def _read_directs_helps(page: "Page") -> Optional[bool]:
+    """Read the "Директ помогает" checkbox's current checked state.
+
+    Returns ``None`` if the field can't be found/read (inconclusive).
+    """
+    checkbox = page.locator(_DIRECT_HELPS_CHECKBOX_XPATH).first
+    try:
+        return checkbox.is_checked()
+    except PlaywrightError:
+        return None
+
+
+def _read_promotion_goal_label(page: "Page") -> Optional[str]:
+    """Read the "Цель продвижения" dropdown trigger's current text.
+
+    Returns ``None`` if the trigger can't be found/read (inconclusive).
+    """
+    trigger = page.locator(_PROMOTION_GOAL_BUTTON_XPATH).first
+    try:
+        return trigger.inner_text().strip()
+    except PlaywrightError:
+        return None
+
+
+def _verify_saved(
+    page: "Page",
+    campaign_id: int,
+    *,
+    weekly_budget: Optional[int],
+    promotion_goal: Optional[str],
+    directs_helps: Optional[bool],
+) -> None:
+    """Reload the edit page and confirm every requested field actually saved.
+
+    Never trust the save-button click alone (mirrors ``_suspend_or_resume``'s
+    "a click that doesn't visibly change the state is a hard error, not a
+    silent success" convention) — Yandex's client-side validation can reject
+    a value and leave the form open with an inline error that this module
+    has no stable way to read (see module docstring's "known gap" note,
+    issue #631's own "Валидация... непрозрачна" risk). Re-navigating and
+    re-reading each touched field is the only reliable signal available:
+    if a field still doesn't match after a real reload, the save did not
+    take effect and this raises rather than reporting false success.
+    """
+    url = WIZARD_EDIT_URL.format(campaign_id=campaign_id)
+    page.goto(url, wait_until="domcontentloaded")
+    assert_not_captcha(page.content())
+    assert_authenticated(page.content())
+
+    mismatches = []
+
+    if weekly_budget is not None:
+        actual = _read_weekly_budget(page)
+        if actual != weekly_budget:
+            mismatches.append(
+                f"weekly_budget: expected {weekly_budget}, page now shows {actual!r}"
+            )
+
+    if directs_helps is not None:
+        actual_checked = _read_directs_helps(page)
+        if actual_checked != directs_helps:
+            mismatches.append(
+                f"directs_helps: expected {directs_helps}, page now shows "
+                f"{actual_checked!r}"
+            )
+
+    if promotion_goal is not None:
+        expected_label = PROMOTION_GOAL_CHOICES[promotion_goal]
+        actual_label = _read_promotion_goal_label(page)
+        if actual_label != expected_label:
+            mismatches.append(
+                f"promotion_goal: expected {expected_label!r}, page now shows "
+                f"{actual_label!r}"
+            )
+
+    if mismatches:
+        raise BrowserSessionError(
+            f"Clicked '{_SAVE_BUTTON_TEXT}' for campaign {campaign_id}, but "
+            "re-reading the edit page after reload shows it did not save "
+            "as requested: " + "; ".join(mismatches) + ". Yandex may have "
+            "rejected the value (client-side validation) or the save did "
+            "not complete — verify manually before retrying."
+        )
+
+
 def update_master(
     page: "Page",
     campaign_id: int,
@@ -809,6 +939,11 @@ def update_master(
     left alone keep their current on-page value simply by never having their
     input touched). Raises ``ValueError`` if no field is provided, mirroring
     the rest of the CLI's "nothing to update" guard for partial updates.
+
+    After clicking save, reloads the edit page and re-reads every requested
+    field to confirm it actually saved (see ``_verify_saved``) — a click
+    that doesn't visibly change the saved state is reported as a hard error,
+    not a silent success, mirroring ``_suspend_or_resume``.
 
     Later Этап (B/C/D) fields — headline/text lists, sitelinks, audience,
     Metrika counters/goals, budget adaptation, media — are out of scope for
@@ -833,6 +968,14 @@ def update_master(
         _set_directs_helps(page, directs_helps)
 
     _click_save(page, campaign_id)
+
+    _verify_saved(
+        page,
+        campaign_id,
+        weekly_budget=weekly_budget,
+        promotion_goal=promotion_goal,
+        directs_helps=directs_helps,
+    )
 
     result: Dict[str, Any] = {"CampaignId": campaign_id}
     if weekly_budget is not None:

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -718,6 +718,25 @@ def _set_directs_helps(page: "Page", enabled: bool) -> None:
         ) from exc
 
 
+def _trigger_shows_selection(trigger, label: str) -> bool:
+    """True if the "Цель продвижения" trigger button currently shows ``label``.
+
+    Confirmed live (2026-08-01 re-investigation, see
+    ``tests/fixtures/masters_wizard_edit_stage_a.html``): the trigger's
+    ``inner_text()`` is TWO lines — the static section label first, then the
+    current selection on its own line (unlike the accessibility-tree
+    computed NAME, which stays static and never carries the selection). An
+    exact match against the whole two-line string can therefore never
+    succeed; only the LAST line reflects the live selection.
+    """
+    try:
+        text = trigger.inner_text().strip()
+    except PlaywrightError:
+        return False
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    return bool(lines) and lines[-1] == label
+
+
 def _set_promotion_goal(page: "Page", goal: str) -> None:
     """Select ``goal`` (a key of ``PROMOTION_GOAL_CHOICES``) in the "Цель
     продвижения" dropdown.
@@ -772,14 +791,11 @@ def _set_promotion_goal(page: "Page", goal: str) -> None:
             "the page's markup. Re-run with --headful to inspect the page."
         )
 
-    # Exact match, not substring: an exact accessible name is either the new
-    # selection or it isn't — a substring check could pass on unrelated text
-    # that merely contains part of the label.
-    try:
-        current = trigger.inner_text().strip()
-    except PlaywrightError:
-        current = ""
-    if current != label:
+    if not _trigger_shows_selection(trigger, label):
+        try:
+            current = trigger.inner_text().strip()
+        except PlaywrightError:
+            current = ""
         raise BrowserSessionError(
             f"Clicked the {label!r} option for 'Цель продвижения', but the "
             f"dropdown still does not show it (shows {current!r}). The "
@@ -852,15 +868,22 @@ def _read_directs_helps(page: "Page") -> Optional[bool]:
 
 
 def _read_promotion_goal_label(page: "Page") -> Optional[str]:
-    """Read the "Цель продвижения" dropdown trigger's current text.
+    """Read the "Цель продвижения" dropdown trigger's current selection.
 
-    Returns ``None`` if the trigger can't be found/read (inconclusive).
+    The trigger's ``inner_text()`` is two lines — the static section label,
+    then the current selection on its own line (see
+    ``_trigger_shows_selection``) — so this returns only the LAST line, not
+    the raw two-line text, to compare directly against a bare
+    ``PROMOTION_GOAL_CHOICES`` value. Returns ``None`` if the trigger can't
+    be found/read (inconclusive).
     """
     trigger = page.locator(_PROMOTION_GOAL_BUTTON_XPATH).first
     try:
-        return trigger.inner_text().strip()
+        text = trigger.inner_text().strip()
     except PlaywrightError:
         return None
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    return lines[-1] if lines else None
 
 
 def _verify_saved(
@@ -877,9 +900,9 @@ def _verify_saved(
     "a click that doesn't visibly change the state is a hard error, not a
     silent success" convention) — Yandex's client-side validation can reject
     a value and leave the form open with an inline error that this module
-    has no stable way to read (see module docstring's "known gap" note,
-    issue #631's own "Валидация... непрозрачна" risk). Re-navigating and
-    re-reading each touched field is the only reliable signal available:
+    has no stable way to read (see module docstring's "Save verification"
+    note, issue #631's own "Валидация... непрозрачна" risk). Re-navigating
+    and re-reading each touched field is the only reliable signal available:
     if a field still doesn't match after a real reload, the save did not
     take effect and this raises rather than reporting false success.
     """

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -60,6 +60,7 @@ from typing import Optional
 import click
 from click.core import ParameterSource
 
+from ..browser.masters import PROMOTION_GOAL_CHOICES as _PROMOTION_GOAL_CHOICES
 from ..output import (
     format_output,
     handle_api_errors,
@@ -531,6 +532,74 @@ def suspend(
     results = _with_session(ctx, headful, profile_dir, chrome_profile, _suspend_all)
 
     format_output(results if len(results) != 1 else results[0], output_format, output)
+
+
+@masters.command()
+@click.argument("campaign_id", type=int)
+@click.option(
+    "--weekly-budget",
+    type=int,
+    help="Weekly budget in account currency (Недельный бюджет)",
+)
+@click.option(
+    "--promotion-goal",
+    type=click.Choice(sorted(_PROMOTION_GOAL_CHOICES)),
+    help="Promotion goal (Цель продвижения)",
+)
+@click.option(
+    "--directs-helps/--no-directs-helps",
+    "directs_helps",
+    default=None,
+    help="Auto-apply Yandex recommendations (Директ помогает)",
+)
+@_masters_browser_options
+@click.pass_context
+@handle_api_errors
+def update(
+    ctx,
+    campaign_id,
+    weekly_budget,
+    promotion_goal,
+    directs_helps,
+    headful,
+    profile_dir,
+    chrome_profile,
+    output_format,
+    output,
+):
+    """Update settings of one Мастер кампаний (Этап A fields only)
+
+    Covers exactly three fields: weekly budget, promotion goal, and the
+    "Директ помогает" auto-recommendations toggle. The edit page has a
+    single whole-form save (no per-section save) — see
+    ``direct_cli/browser/masters.py`` module docstring — so only the fields
+    passed here are changed; every other on-page field keeps its current
+    value. Later fields (headlines/texts, sitelinks, audience, media) are
+    tracked separately, see issue #631.
+    """
+    from ..browser.masters import update_master
+
+    if weekly_budget is None and promotion_goal is None and directs_helps is None:
+        raise click.UsageError(
+            "Provide at least one of --weekly-budget, --promotion-goal, "
+            "--directs-helps/--no-directs-helps."
+        )
+
+    result = _with_session(
+        ctx,
+        headful,
+        profile_dir,
+        chrome_profile,
+        lambda page: update_master(
+            page,
+            campaign_id,
+            weekly_budget=weekly_budget,
+            promotion_goal=promotion_goal,
+            directs_helps=directs_helps,
+        ),
+    )
+
+    format_output(result, output_format, output)
 
 
 @masters.command()

--- a/direct_cli/smoke_matrix.py
+++ b/direct_cli/smoke_matrix.py
@@ -190,6 +190,11 @@ SMOKE_MATRIX = {
         "masters.archive",
         "masters.resume",
         "masters.suspend",
+        # Browser-driven form mutation against Мастер кампаний (issue #631,
+        # Этап A). Same no-sandbox-equivalent rationale as suspend/resume
+        # above -- there is no way to isolate a live form save from
+        # production. Manual-only, per scripts/test_dangerous_commands.sh.
+        "masters.update",
         # Interactive, human-in-the-loop login (issue #635) -- opens a
         # visible browser window and blocks for up to --timeout seconds
         # waiting for a person to sign in by hand. Cannot run unattended in

--- a/scripts/test_dangerous_commands.sh
+++ b/scripts/test_dangerous_commands.sh
@@ -30,6 +30,8 @@ equivalent -- these always hit a real Yandex account; verify on one
 non-critical campaign, confirming before/after state in the web UI):
   - direct masters suspend <campaign_id>
   - direct masters resume <campaign_id>
+  - direct masters update <campaign_id> --weekly-budget ... (Этап A: also
+    --promotion-goal, --directs-helps/--no-directs-helps)
 
 Interactive human-in-the-loop login (opens a visible browser window and
 blocks waiting for a person to sign in -- cannot run unattended):

--- a/tests/fixtures/masters_wizard_edit_stage_a.html
+++ b/tests/fixtures/masters_wizard_edit_stage_a.html
@@ -1,0 +1,106 @@
+<!--
+Fixture: DOM/accessibility-tree findings for the Yandex Direct "Мастер кампаний" (Campaign
+Wizard) settings/edit page, Этап A only (issue #631) — captured 2026-08-01 via
+claude-in-chrome against a live account (campaign 107707079, "Мастер ИЖ Источник Жизни
+(холодный) 16.06", status: Остановлена). PII scrubbed (account name kept — already visible
+product UI, no secret value).
+
+Source URL:
+  https://direct.yandex.ru/wizard/campaigns/{id}/edit/?ulogin={login}
+
+Same server-side-rendered wizard as tests/fixtures/masters_wizard_overview.html's Настройки
+section — this fixture adds the accessibility-tree element shapes (tag/role, not just text)
+needed to implement mutating `_set_*` functions, which masters_wizard_overview.html's
+text-only capture didn't need for read-only `get`.
+
+Key finding — SINGLE FORM, SINGLE SAVE: the whole edit page is one form. There is exactly one
+"Сохранить кампанию" button at the very bottom (with "Отмена" beside it) that submits every
+section at once — there is NO per-section independent save. This resolves the open risk in
+issue #631's "Риски" section ("Нужно подтвердить... сохраняет ли форма все секции разом").
+Consequence for `update_master`: a partial update (only some fields passed) must still submit
+the whole form — every other field's current on-page value is left untouched by simply not
+touching its input before clicking save, not by any server-side partial-update semantics.
+
+Confirmed via accessibility-tree read (read_page, filter=interactive) plus targeted zoom
+screenshots before/after click (state was restored to original after the investigation — no
+live mutation was saved):
+
+1. Недельный бюджет (weekly budget) — plain text input.
+   - Located via `find`: `textbox "80 000"` under heading "Недельный бюджет".
+   - `page.get_by_role("heading", name="Недельный бюджет")` -> sibling/following textbox is the
+     amount. Value is the bare number with thousands grouping (e.g. "80 000"), currency
+     suffix "₽" is rendered OUTSIDE the input as adjacent static text, not part of the value.
+   - Setting: click, select-all, type the new bare integer (no grouping needed on input —
+     unconfirmed whether the widget re-formats on blur; safest is to type digits only, e.g.
+     "95000", and treat any comma/space grouping in the pre-fill as display-only).
+   - Sibling row: "Адаптация бюджета" (Процент увеличения бюджета / Не увеличивать бюджет) —
+     OUT OF SCOPE for Этап A (issue explicitly limits Этап A to weekly budget only, not budget
+     adaptation).
+
+2. "Директ помогает" (auto-apply recommendations) — plain HTML checkbox, NOT a custom
+   toggle-switch component.
+   - Located via `find`: `checkbox "Автоматически применять рекомендации"`, directly under
+     heading "Директ помогает".
+   - Confirmed via click + zoom screenshot: unchecked -> click -> renders as a filled blue
+     square with a checkmark (checked) -> click again -> reverts to an empty outlined square
+     (unchecked). Standard `Locator.check()`/`.uncheck()` semantics apply directly (idempotent,
+     unlike the suspend/resume buttons which need pre/post status verification because they
+     have no boolean form-field to query).
+   - IMPORTANT side effect discovered live: when checked, the page reveals a SECOND, dependent
+     checkbox — "Оптимизировать расширенные настройки — цели, подбор аудитории" — nested
+     directly below it. This nested checkbox is OUT OF SCOPE for Этап A (issue's Этап A list is
+     exactly: недельный бюджет, цель продвижения, "Директ помогает" toggle) but must be left
+     alone (not auto-toggled) by `_set_directs_helps` — do not blindly click "everything under
+     the heading".
+   - This section sits directly above the page's single "Сохранить кампанию"/"Отмена" button
+     pair (last section on the page).
+
+3. "Цель продвижения" (promotion goal) — custom combobox/dropdown, not a native <select>.
+   - Located via `find`: `button "Цель продвижения"` (the dropdown trigger). NOTE: the tool's
+     natural-language description initially read as "current value as its accessible name",
+     but the accessibility-tree text is the STATIC section label "Цель продвижения", not the
+     current selection — confirmed by re-reading the raw `read_page` node
+     (`button "Цель продвижения" [ref_166] type="button"`, unchanged across dropdown states).
+     The implementation locates this button via heading-proximity XPath (first `<button>`
+     following the "Цель продвижения" heading), not by matching a value string that changes.
+     Paired with a same-labelled `textbox` (search/filter input inside the dropdown, not the
+     value holder itself).
+   - Click the button to open the dropdown; it renders exactly TWO options as a list of
+     clickable rows, each with a title + one-line description:
+       - "Максимум целевых действий" — "Если хотите получать больше звонков и сообщений от
+         клиентов" — tagged "Рекомендуем" (badge) — this is the default in the fixture
+         campaign; current selection shows a checkmark beside it.
+       - "Максимум переходов" — "Если хотите получать больше кликов по объявлениям и
+         увеличить охват аудитории"
+   - No other enum values exist behind this control — confirmed by opening the dropdown and
+     reading its full option list, not by inference from partial text.
+   - CLI enum mapping (kebab-case per project convention, no WSDL to mirror since this has no
+     API surface): `--promotion-goal {max-conversions,max-clicks}` ->
+       max-conversions -> "Максимум целевых действий"
+       max-clicks      -> "Максимум переходов"
+   - Setting: click the button to open, click the row whose title text-matches the target
+     Russian label, and verify post-click that the button's accessible text now shows the
+     target label (mirrors the module's existing pattern of verifying a mutation actually took
+     effect rather than trusting the click alone — see `_suspend_or_resume`).
+   - Sibling control in the same "Цель продвижения" section: a second dropdown, "Цена целевого
+     действия" (e.g. "Средняя за неделю") — OUT OF SCOPE for Этап A (not listed in the issue's
+     Этап A field list).
+
+Accessibility-tree ref shape observed for the "Цель продвижения" section (`read_page`,
+filter=interactive, at the point in the page where this section renders):
+
+  textbox [ref] type="text"                       (unlabelled, adjacent to weekly-budget field)
+  button [ref] type="button"                       (Расписание показов dropdown, unrelated)
+  textbox [ref]
+  button [ref] type="button"                       (Аудитория dropdown, unrelated)
+  textbox [ref]
+  button "Цель продвижения" [ref] type="button"     <-- promotion-goal dropdown trigger
+  textbox [ref]                                      <-- promotion-goal dropdown's own filter input
+  button "Цена целевого действия" [ref] type="button" (out of scope)
+
+None of these controls expose a stable `id`/`name`/`data-testid` attribute in the accessibility
+tree snapshot — matching is by heading proximity (`find`-equivalent: nearest preceding
+`heading` node) or by the button/checkbox's own accessible name text, same fragility class
+already documented for `_extract_*`/`_click_action_button` in
+`direct_cli/browser/masters.py`'s module docstring. No stability guarantee from Yandex.
+-->

--- a/tests/fixtures/masters_wizard_edit_stage_a.html
+++ b/tests/fixtures/masters_wizard_edit_stage_a.html
@@ -84,7 +84,38 @@ live mutation was saved):
      effect rather than trusting the click alone — see `_suspend_or_resume`).
    - Sibling control in the same "Цель продвижения" section: a second dropdown, "Цена целевого
      действия" (e.g. "Средняя за неделю") — OUT OF SCOPE for Этап A (not listed in the issue's
-     Этап A field list).
+     Этап A field list). Side effect confirmed live (2026-08-01 re-investigation): switching
+     the promotion goal to "Максимум переходов" relabels this sibling control's static text
+     from "Цена целевого действия" to "Цена перехода" too — not acted on by `_set_promotion_goal`
+     (out of scope), documented here only so a future stage isn't surprised by it.
+
+   **RE-INVESTIGATED LIVE 2026-08-01 (cycle-review follow-up, issue #631 PR #646): accessible
+   name vs. `innerText` — these are DIFFERENT and do NOT agree; the current exact-match
+   verification code is WRONG as a result — see below.** The paragraph above (captured in Step
+   0) is correct about the accessibility-tree computed NAME staying static — verified again via
+   `read_page`: `button "Цель продвижения" [ref_19]`, unchanged whether the dropdown shows
+   "Максимум целевых действий" or "Максимум переходов". But `_set_promotion_goal`'s
+   verification calls Playwright's `Locator.inner_text()`, a DIFFERENT API that reads the
+   element's rendered DOM text content, not its computed accessibility name — and these
+   genuinely diverge here. Confirmed via `element.innerText` read directly (before AND after
+   clicking the alternate option, on the live trigger button):
+     - Before any click: `innerText` = `"Цель продвижения\nМаксимум целевых действий"` (TWO
+       lines — the static section label first, then the current selection on its own line).
+     - After clicking "Максимум переходов": `innerText` = `"Цель продвижения\nМаксимум
+       переходов"` — the second line DID change to reflect the new selection.
+   So `inner_text()` DOES carry the live selection and CAN be used to verify a selection took
+   effect. BUT the current code compares the WHOLE two-line string for exact equality
+   (`current != label`, where `label` is the bare one-line value like `"Максимум переходов"`)
+   — that exact comparison can NEVER succeed, since `current` always has the static label line
+   prepended too. This is a real bug introduced by the cycle-review fix that switched from a
+   substring check (`label not in current`, which DID work — the bare label is a substring of
+   the two-line text) to an exact-equality check as a "tighten the match" fix for a DIFFERENT
+   finding (ancestor/decoy-text false positives) — exact-equality was the wrong tool for THIS
+   comparison; the fix should instead check that the LAST LINE of `current` equals `label`
+   (splitting on the header line), not that the whole string equals it. Same bug applies to
+   `_verify_saved`'s `_read_promotion_goal_label` read-back comparison. State was restored
+   live (clicked back to "Максимум целевых действий") and the edit page was left via a plain
+   navigation with NO unsaved-changes warning, confirming no live mutation was saved.
 
 Accessibility-tree ref shape observed for the "Цель продвижения" section (`read_page`,
 filter=interactive, at the point in the page where this section renders):

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -46,6 +46,7 @@ DRY_RUN_EXCEPTIONS = {
     "masters.archive",
     "masters.resume",
     "masters.suspend",
+    "masters.update",
 }
 
 FORBIDDEN_HELP_TEXT = (

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -44,13 +44,32 @@ def _load_grid_campaigns_fixture():
 
 
 class _FakeLocatorHandle:
-    """One matched element — the subset of Playwright's Locator API the parser uses."""
+    """One matched element — the subset of Playwright's Locator API the parser uses.
 
-    def __init__(self, text="", attrs=None, raises=False, on_click=None):
+    ``click``/``fill``/``check``/``uncheck``/``is_visible`` support
+    ``update_master``'s ``_set_*`` functions (issue #631) — ``on_click``/
+    ``on_fill``/``on_check`` are optional no-arg/one-arg callbacks so tests
+    can model the fake page's mutable state changing (mirrors
+    ``_FakeTextLocatorHandle.on_click`` used by suspend/resume tests).
+    """
+
+    def __init__(
+        self,
+        text="",
+        attrs=None,
+        raises=False,
+        visible=True,
+        on_click=None,
+        on_fill=None,
+        on_check=None,
+    ):
         self._text = text
         self._attrs = attrs or {}
         self._raises = raises
+        self._visible = visible
         self._on_click = on_click
+        self._on_fill = on_fill
+        self._on_check = on_check
 
     def inner_text(self):
         if self._raises:
@@ -63,12 +82,35 @@ class _FakeLocatorHandle:
     def get_attribute(self, name):
         return self._attrs.get(name)
 
+    def is_visible(self):
+        if self._raises:
+            raise PlaywrightError("element detached")
+        return self._visible
+
     def click(self):
         if self._raises:
-            raise PlaywrightError("element not found")
+            raise PlaywrightError("element detached")
         if self._on_click is not None:
             self._on_click()
 
+    def fill(self, value):
+        if self._raises:
+            raise PlaywrightError("element detached")
+        self._text = value
+        if self._on_fill is not None:
+            self._on_fill(value)
+
+    def check(self):
+        if self._raises:
+            raise PlaywrightError("element detached")
+        if self._on_check is not None:
+            self._on_check(True)
+
+    def uncheck(self):
+        if self._raises:
+            raise PlaywrightError("element detached")
+        if self._on_check is not None:
+            self._on_check(False)
 
 class _FakeLocator:
     """A Locator for one selector — holds every matched handle for that selector."""
@@ -1700,6 +1742,352 @@ class TestMastersArchiveCommand(unittest.TestCase):
         self.assertIn("ARCHIVED", result.output)
         self.assertIn("2", result.output)
         self.assertIn("boom on id 3", result.output)
+
+
+class TestSetWeeklyBudget(unittest.TestCase):
+    """``_set_weekly_budget`` (issue #631, Этап A) — fills the budget input."""
+
+    def test_fills_field_with_bare_integer(self):
+        state = {}
+        handle = _FakeLocatorHandle(
+            text="80 000", on_fill=lambda v: state.__setitem__("value", v)
+        )
+        page = FakePage(
+            locators={
+                browser_masters._WEEKLY_BUDGET_INPUT_XPATH: _FakeLocator([handle])
+            }
+        )
+
+        browser_masters._set_weekly_budget(page, 95000)
+
+        self.assertEqual(state["value"], "95000")
+
+    def test_raises_browser_session_error_when_field_missing(self):
+        page = FakePage(locators={})
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters._set_weekly_budget(page, 95000)
+
+
+class TestSetDirectsHelps(unittest.TestCase):
+    """``_set_directs_helps`` (issue #631, Этап A) — check/uncheck, idempotent API."""
+
+    def test_enables_checkbox(self):
+        state = {"checked": False}
+        handle = _FakeLocatorHandle(on_check=lambda v: state.__setitem__("checked", v))
+        page = FakePage(
+            locators={
+                browser_masters._DIRECT_HELPS_CHECKBOX_XPATH: _FakeLocator([handle])
+            }
+        )
+
+        browser_masters._set_directs_helps(page, True)
+
+        self.assertTrue(state["checked"])
+
+    def test_disables_checkbox(self):
+        state = {"checked": True}
+        handle = _FakeLocatorHandle(on_check=lambda v: state.__setitem__("checked", v))
+        page = FakePage(
+            locators={
+                browser_masters._DIRECT_HELPS_CHECKBOX_XPATH: _FakeLocator([handle])
+            }
+        )
+
+        browser_masters._set_directs_helps(page, False)
+
+        self.assertFalse(state["checked"])
+
+    def test_raises_browser_session_error_when_checkbox_missing(self):
+        page = FakePage(locators={})
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters._set_directs_helps(page, True)
+
+
+class TestSetPromotionGoal(unittest.TestCase):
+    """``_set_promotion_goal`` (issue #631, Этап A) — open dropdown, click, verify."""
+
+    def _page_for_goal_selection(self, target_label, trigger_text_after_click):
+        state = {"trigger_text": "Цель продвижения"}
+
+        def _select():
+            state["trigger_text"] = trigger_text_after_click
+
+        trigger = _FakeLocatorHandle(text="Цель продвижения")
+        # inner_text() must reflect the mutable state set by clicking the option.
+        trigger.inner_text = lambda: state["trigger_text"]
+
+        return FakePage(
+            locators={
+                browser_masters._PROMOTION_GOAL_BUTTON_XPATH: _FakeLocator([trigger])
+            },
+            text_buttons={
+                target_label: _FakeGetByTextLocator(
+                    [_FakeTextLocatorHandle(visible=True, on_click=_select)]
+                )
+            },
+        )
+
+    def test_selects_option_and_verifies(self):
+        page = self._page_for_goal_selection("Максимум переходов", "Максимум переходов")
+
+        browser_masters._set_promotion_goal(page, "max-clicks")
+
+    def test_raises_on_unknown_goal_key(self):
+        page = FakePage()
+
+        with self.assertRaises(ValueError):
+            browser_masters._set_promotion_goal(page, "not-a-real-goal")
+
+    def test_raises_when_dropdown_trigger_missing(self):
+        page = FakePage(locators={})
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters._set_promotion_goal(page, "max-clicks")
+
+    def test_raises_when_option_not_found(self):
+        trigger = _FakeLocatorHandle(text="Цель продвижения")
+        page = FakePage(
+            locators={
+                browser_masters._PROMOTION_GOAL_BUTTON_XPATH: _FakeLocator([trigger])
+            },
+            text_buttons={},
+        )
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters._set_promotion_goal(page, "max-clicks")
+
+    def test_raises_when_click_does_not_change_trigger_text(self):
+        # Option is clicked but the trigger's text never reflects the change.
+        page = self._page_for_goal_selection(
+            "Максимум переходов", "Цель продвижения"  # unchanged
+        )
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._set_promotion_goal(page, "max-clicks")
+        self.assertIn("does not show it", str(ctx.exception))
+
+
+class TestUpdateMaster(unittest.TestCase):
+    """``update_master`` (issue #631, Этап A) — partial updates, one whole-form save."""
+
+    def _page_with_save_button(self, extra_locators=None, extra_text_buttons=None):
+        save_clicks = []
+        save_handle = _FakeTextLocatorHandle(
+            visible=True, on_click=lambda: save_clicks.append(True)
+        )
+        text_buttons = {
+            browser_masters._SAVE_BUTTON_TEXT: _FakeGetByTextLocator([save_handle])
+        }
+        text_buttons.update(extra_text_buttons or {})
+        page = FakePage(
+            locators=extra_locators or {},
+            text_buttons=text_buttons,
+        )
+        return page, save_clicks
+
+    def test_updates_only_weekly_budget(self):
+        budget_state = {}
+        budget_handle = _FakeLocatorHandle(
+            on_fill=lambda v: budget_state.__setitem__("value", v)
+        )
+        page, save_clicks = self._page_with_save_button(
+            extra_locators={
+                browser_masters._WEEKLY_BUDGET_INPUT_XPATH: _FakeLocator(
+                    [budget_handle]
+                )
+            }
+        )
+
+        result = browser_masters.update_master(page, 107707079, weekly_budget=95000)
+
+        self.assertEqual(budget_state["value"], "95000")
+        self.assertEqual(len(save_clicks), 1)
+        self.assertEqual(result, {"CampaignId": 107707079, "WeeklyBudget": 95000})
+        self.assertEqual(
+            page.navigated_to,
+            [browser_masters.WIZARD_EDIT_URL.format(campaign_id=107707079)],
+        )
+
+    def test_updates_only_directs_helps(self):
+        checkbox_state = {"checked": False}
+        checkbox_handle = _FakeLocatorHandle(
+            on_check=lambda v: checkbox_state.__setitem__("checked", v)
+        )
+        page, save_clicks = self._page_with_save_button(
+            extra_locators={
+                browser_masters._DIRECT_HELPS_CHECKBOX_XPATH: _FakeLocator(
+                    [checkbox_handle]
+                )
+            }
+        )
+
+        result = browser_masters.update_master(page, 42, directs_helps=True)
+
+        self.assertTrue(checkbox_state["checked"])
+        self.assertEqual(len(save_clicks), 1)
+        self.assertEqual(result, {"CampaignId": 42, "DirectsHelps": True})
+
+    def test_updates_multiple_fields_in_one_call(self):
+        budget_state = {}
+        budget_handle = _FakeLocatorHandle(
+            on_fill=lambda v: budget_state.__setitem__("value", v)
+        )
+        checkbox_state = {"checked": False}
+        checkbox_handle = _FakeLocatorHandle(
+            on_check=lambda v: checkbox_state.__setitem__("checked", v)
+        )
+        page, save_clicks = self._page_with_save_button(
+            extra_locators={
+                browser_masters._WEEKLY_BUDGET_INPUT_XPATH: _FakeLocator(
+                    [budget_handle]
+                ),
+                browser_masters._DIRECT_HELPS_CHECKBOX_XPATH: _FakeLocator(
+                    [checkbox_handle]
+                ),
+            }
+        )
+
+        result = browser_masters.update_master(
+            page, 42, weekly_budget=50000, directs_helps=False
+        )
+
+        self.assertEqual(budget_state["value"], "50000")
+        self.assertFalse(checkbox_state["checked"])
+        self.assertEqual(len(save_clicks), 1)
+        self.assertEqual(
+            result,
+            {"CampaignId": 42, "WeeklyBudget": 50000, "DirectsHelps": False},
+        )
+
+    def test_raises_value_error_when_no_field_provided(self):
+        page = FakePage()
+
+        with self.assertRaises(ValueError):
+            browser_masters.update_master(page, 42)
+
+    def test_does_not_click_save_when_field_setter_fails(self):
+        # No locator registered for the budget field -> _set_weekly_budget
+        # raises before _click_save is ever reached.
+        page, save_clicks = self._page_with_save_button(extra_locators={})
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters.update_master(page, 42, weekly_budget=1000)
+
+        self.assertEqual(save_clicks, [])
+
+    def test_raises_when_save_button_missing(self):
+        page = FakePage(
+            locators={
+                browser_masters._WEEKLY_BUDGET_INPUT_XPATH: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                )
+            },
+            text_buttons={},
+        )
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters.update_master(page, 42, weekly_budget=1000)
+
+
+class TestMastersUpdateCommand(unittest.TestCase):
+    """CLI wiring for `masters update` (issue #631, Этап A)."""
+
+    def setUp(self):
+        self.runner = CliRunner()
+
+    def test_registered(self):
+        result = self.runner.invoke(cli, ["masters", "update", "--help"])
+        self.assertEqual(result.exit_code, 0)
+
+    def test_has_no_login_option(self):
+        result = self.runner.invoke(cli, ["masters", "update", "--help"])
+        self.assertNotIn("--login", result.output)
+
+    def test_documents_stage_a_flags(self):
+        result = self.runner.invoke(cli, ["masters", "update", "--help"])
+        self.assertIn("--weekly-budget", result.output)
+        self.assertIn("--promotion-goal", result.output)
+        self.assertIn("--directs-helps", result.output)
+
+    def test_calls_update_master_with_given_fields(self):
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42, "WeeklyBudget": 95000}
+            result = self.runner.invoke(
+                cli, ["masters", "update", "42", "--weekly-budget", "95000"]
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        mock_update.assert_called_once()
+        args, kwargs = mock_update.call_args
+        self.assertEqual(args[1], 42)
+        self.assertEqual(kwargs["weekly_budget"], 95000)
+        self.assertIsNone(kwargs["promotion_goal"])
+        self.assertIsNone(kwargs["directs_helps"])
+
+    def test_passes_promotion_goal_choice(self):
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42}
+            result = self.runner.invoke(
+                cli,
+                ["masters", "update", "42", "--promotion-goal", "max-clicks"],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(mock_update.call_args.kwargs["promotion_goal"], "max-clicks")
+
+    def test_rejects_unknown_promotion_goal(self):
+        result = self.runner.invoke(
+            cli, ["masters", "update", "42", "--promotion-goal", "bogus"]
+        )
+        self.assertNotEqual(result.exit_code, 0)
+
+    def test_passes_directs_helps_flag(self):
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42}
+            result = self.runner.invoke(
+                cli, ["masters", "update", "42", "--directs-helps"]
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertTrue(mock_update.call_args.kwargs["directs_helps"])
+
+    def test_passes_no_directs_helps_flag(self):
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42}
+            result = self.runner.invoke(
+                cli, ["masters", "update", "42", "--no-directs-helps"]
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertFalse(mock_update.call_args.kwargs["directs_helps"])
+
+    def test_errors_when_no_field_given(self):
+        result = self.runner.invoke(cli, ["masters", "update", "42"])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("at least one", result.output)
+
+    def test_does_not_call_update_master_when_no_field_given(self):
+        with patch("direct_cli.browser.masters.update_master") as mock_update:
+            self.runner.invoke(cli, ["masters", "update", "42"])
+        mock_update.assert_not_called()
 
 
 class TestMastersLoginCommand(unittest.TestCase):

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -1860,17 +1860,27 @@ class TestSetPromotionGoal(unittest.TestCase):
     container instead of the option row itself). Using ``role_elements``
     here means these tests actually exercise the same exact-name matching
     the real code performs, instead of matching by an opaque dict key.
+
+    The trigger's ``inner_text()`` is modeled as TWO lines (static section
+    label, then the current selection) — confirmed live 2026-08-01 (see
+    ``tests/fixtures/masters_wizard_edit_stage_a.html``). A single-line fake
+    would not have caught the regression where the verification code
+    compared the WHOLE two-line ``inner_text()`` for exact equality against
+    the bare one-line label (always false) instead of just its last line.
     """
 
-    def _page_for_goal_selection(self, target_label, trigger_text_after_click):
-        state = {"trigger_text": "Цель продвижения"}
+    _TRIGGER_LABEL = "Цель продвижения"
+
+    def _page_for_goal_selection(self, target_label, selected_line_after_click):
+        state = {"selected_line": "Максимум целевых действий"}
 
         def _select():
-            state["trigger_text"] = trigger_text_after_click
+            state["selected_line"] = selected_line_after_click
 
-        trigger = _FakeLocatorHandle(text="Цель продвижения")
-        # inner_text() must reflect the mutable state set by clicking the option.
-        trigger.inner_text = lambda: state["trigger_text"]
+        trigger = _FakeLocatorHandle(text=self._TRIGGER_LABEL)
+        # inner_text() must reflect the mutable state set by clicking the
+        # option — two lines, matching the live-confirmed shape.
+        trigger.inner_text = lambda: f"{self._TRIGGER_LABEL}\n{state['selected_line']}"
 
         return FakePage(
             locators={
@@ -1891,7 +1901,7 @@ class TestSetPromotionGoal(unittest.TestCase):
         browser_masters._set_promotion_goal(page, "max-clicks")
 
         trigger = page.locator(browser_masters._PROMOTION_GOAL_BUTTON_XPATH).first
-        self.assertEqual(trigger.inner_text(), "Максимум переходов")
+        self.assertEqual(trigger.inner_text(), "Цель продвижения\nМаксимум переходов")
 
     def test_does_not_match_option_whose_name_only_contains_label_as_substring(self):
         # A decoy element whose accessible name merely CONTAINS the target
@@ -1946,14 +1956,63 @@ class TestSetPromotionGoal(unittest.TestCase):
             browser_masters._set_promotion_goal(page, "max-clicks")
 
     def test_raises_when_click_does_not_change_trigger_text(self):
-        # Option is clicked but the trigger's text never reflects the change.
+        # Option is clicked but the trigger's selected line never changes.
         page = self._page_for_goal_selection(
-            "Максимум переходов", "Цель продвижения"  # unchanged
+            "Максимум переходов",
+            "Максимум целевых действий",  # unchanged
         )
 
         with self.assertRaises(BrowserSessionError) as ctx:
             browser_masters._set_promotion_goal(page, "max-clicks")
         self.assertIn("does not show it", str(ctx.exception))
+
+
+class TestClickSave(unittest.TestCase):
+    """``_click_save`` (issue #631, Этап A) — role-scoped, exact-name button match.
+
+    ``_click_save`` uses ``get_by_role("button", name=_SAVE_BUTTON_TEXT,
+    exact=True)`` (cycle-review fix: the previous ``get_by_text(exact=False)``
+    risked matching an ancestor container instead of the button itself).
+    """
+
+    def test_does_not_click_a_decoy_whose_name_only_contains_the_button_text(self):
+        # A decoy element whose accessible name merely CONTAINS
+        # _SAVE_BUTTON_TEXT (e.g. an ancestor wrapper with extra text) must
+        # NOT be treated as a match — exact=True requires exact equality.
+        decoy_clicked = []
+        page = FakePage(
+            role_elements=[
+                (
+                    "button",
+                    f"{browser_masters._SAVE_BUTTON_TEXT} и отмена",
+                    _FakeTextLocatorHandle(
+                        visible=True, on_click=lambda: decoy_clicked.append(True)
+                    ),
+                )
+            ],
+        )
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters._click_save(page, 42)
+        self.assertEqual(decoy_clicked, [])
+
+    def test_clicks_the_exact_match_button(self):
+        clicks = []
+        page = FakePage(
+            role_elements=[
+                (
+                    "button",
+                    browser_masters._SAVE_BUTTON_TEXT,
+                    _FakeTextLocatorHandle(
+                        visible=True, on_click=lambda: clicks.append(True)
+                    ),
+                )
+            ],
+        )
+
+        browser_masters._click_save(page, 42)
+
+        self.assertEqual(clicks, [True])
 
 
 class TestUpdateMaster(unittest.TestCase):
@@ -2132,10 +2191,17 @@ class TestUpdateMaster(unittest.TestCase):
     def test_raises_when_saved_promotion_goal_does_not_match_requested(self):
         # The goal setter's own post-click check passes (trigger text
         # updates immediately), but the post-save reload shows the OLD
-        # goal still selected -- _verify_saved must still catch this.
-        trigger_states = iter(["Максимум переходов", "Максимум целевых действий"])
+        # goal still selected -- _verify_saved must still catch this. The
+        # trigger's inner_text() is modeled as two lines (static label +
+        # selection), matching the live-confirmed shape.
+        trigger_texts = iter(
+            [
+                "Цель продвижения\nМаксимум переходов",
+                "Цель продвижения\nМаксимум целевых действий",
+            ]
+        )
         trigger = _FakeLocatorHandle(text="Цель продвижения")
-        trigger.inner_text = lambda: next(trigger_states)
+        trigger.inner_text = lambda: next(trigger_texts)
         save_handle = _FakeTextLocatorHandle(visible=True)
         page = FakePage(
             locators={

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -51,6 +51,12 @@ class _FakeLocatorHandle:
     ``on_fill``/``on_check`` are optional no-arg/one-arg callbacks so tests
     can model the fake page's mutable state changing (mirrors
     ``_FakeTextLocatorHandle.on_click`` used by suspend/resume tests).
+    ``input_value``/``is_checked`` support the post-save read-back
+    verification in ``_verify_saved`` — they read the SAME mutable
+    ``checked``/``value`` state ``fill``/``check``/``uncheck`` write, via
+    ``state`` dict callables (``get_value``/``get_checked``), so a test can
+    model "the reload shows what was actually saved" instead of "whatever
+    was passed to fill/check".
     """
 
     def __init__(
@@ -62,6 +68,8 @@ class _FakeLocatorHandle:
         on_click=None,
         on_fill=None,
         on_check=None,
+        get_value=None,
+        get_checked=None,
     ):
         self._text = text
         self._attrs = attrs or {}
@@ -70,6 +78,8 @@ class _FakeLocatorHandle:
         self._on_click = on_click
         self._on_fill = on_fill
         self._on_check = on_check
+        self._get_value = get_value
+        self._get_checked = get_checked
 
     def inner_text(self):
         if self._raises:
@@ -111,6 +121,17 @@ class _FakeLocatorHandle:
             raise PlaywrightError("element detached")
         if self._on_check is not None:
             self._on_check(False)
+
+    def input_value(self):
+        if self._raises:
+            raise PlaywrightError("element detached")
+        return self._get_value() if self._get_value is not None else self._text
+
+    def is_checked(self):
+        if self._raises:
+            raise PlaywrightError("element detached")
+        return self._get_checked() if self._get_checked is not None else False
+
 
 class _FakeLocator:
     """A Locator for one selector — holds every matched handle for that selector."""
@@ -268,6 +289,7 @@ class FakePage:
         grid_response=None,
         api_request=None,
         text_buttons=None,
+        role_elements=None,
     ):
         self._locators = locators or {}
         self._body_text = body_text
@@ -283,6 +305,15 @@ class FakePage:
         # {text: _FakeGetByTextLocator} for get_by_text() — used by
         # suspend_master/resume_master's action-button click.
         self._text_buttons = text_buttons or {}
+        # [(role, accessible_name, handle), ...] for get_by_role() — honors
+        # `exact` the same way real Playwright does (substring vs. equality
+        # against `accessible_name`), so a fake test can actually catch a
+        # get_by_role() call whose `exact`/`name` doesn't match the real
+        # element, instead of always matching by selector-string identity
+        # (issue #631 cycle-review: the previous get_by_text-based fakes
+        # could not distinguish a correct role-scoped match from an
+        # accidental ancestor-container match).
+        self._role_elements = role_elements or []
 
     def goto(self, url, wait_until=None):
         self.navigated_to.append(url)
@@ -302,6 +333,20 @@ class FakePage:
 
     def get_by_text(self, text, exact=False):
         return self._text_buttons.get(text, _FakeGetByTextLocator([]))
+
+    def get_by_role(self, role, name=None, exact=False):
+        matched = []
+        for elem_role, elem_name, handle in self._role_elements:
+            if elem_role != role:
+                continue
+            if name is None:
+                matched.append(handle)
+            elif exact:
+                if elem_name == name:
+                    matched.append(handle)
+            elif name in elem_name:
+                matched.append(handle)
+        return _FakeGetByTextLocator(matched)
 
     def inner_text(self, selector=None):
         return self._body_text
@@ -1806,7 +1851,16 @@ class TestSetDirectsHelps(unittest.TestCase):
 
 
 class TestSetPromotionGoal(unittest.TestCase):
-    """``_set_promotion_goal`` (issue #631, Этап A) — open dropdown, click, verify."""
+    """``_set_promotion_goal`` (issue #631, Этап A) — open dropdown, click, verify.
+
+    Options are modeled via ``role_elements`` (role="option"), not
+    ``text_buttons`` — ``_set_promotion_goal`` uses
+    ``get_by_role("option", name=label, exact=True)`` (cycle-review fix: the
+    previous ``get_by_text(exact=False)`` risked matching an ancestor
+    container instead of the option row itself). Using ``role_elements``
+    here means these tests actually exercise the same exact-name matching
+    the real code performs, instead of matching by an opaque dict key.
+    """
 
     def _page_for_goal_selection(self, target_label, trigger_text_after_click):
         state = {"trigger_text": "Цель продвижения"}
@@ -1822,17 +1876,50 @@ class TestSetPromotionGoal(unittest.TestCase):
             locators={
                 browser_masters._PROMOTION_GOAL_BUTTON_XPATH: _FakeLocator([trigger])
             },
-            text_buttons={
-                target_label: _FakeGetByTextLocator(
-                    [_FakeTextLocatorHandle(visible=True, on_click=_select)]
+            role_elements=[
+                (
+                    "option",
+                    target_label,
+                    _FakeTextLocatorHandle(visible=True, on_click=_select),
                 )
-            },
+            ],
         )
 
     def test_selects_option_and_verifies(self):
         page = self._page_for_goal_selection("Максимум переходов", "Максимум переходов")
 
         browser_masters._set_promotion_goal(page, "max-clicks")
+
+        trigger = page.locator(browser_masters._PROMOTION_GOAL_BUTTON_XPATH).first
+        self.assertEqual(trigger.inner_text(), "Максимум переходов")
+
+    def test_does_not_match_option_whose_name_only_contains_label_as_substring(self):
+        # A decoy element whose accessible name merely CONTAINS the target
+        # label (e.g. an ancestor wrapper with extra description text) must
+        # NOT be treated as a match — get_by_role(..., exact=True) requires
+        # an exact accessible-name equality, not a substring.
+        state = {"trigger_text": "Цель продвижения"}
+        trigger = _FakeLocatorHandle(text="Цель продвижения")
+        trigger.inner_text = lambda: state["trigger_text"]
+        decoy_clicked = []
+        page = FakePage(
+            locators={
+                browser_masters._PROMOTION_GOAL_BUTTON_XPATH: _FakeLocator([trigger])
+            },
+            role_elements=[
+                (
+                    "option",
+                    "Максимум переходов — если хотите получать больше кликов",
+                    _FakeTextLocatorHandle(
+                        visible=True, on_click=lambda: decoy_clicked.append(True)
+                    ),
+                )
+            ],
+        )
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters._set_promotion_goal(page, "max-clicks")
+        self.assertEqual(decoy_clicked, [])
 
     def test_raises_on_unknown_goal_key(self):
         page = FakePage()
@@ -1852,7 +1939,7 @@ class TestSetPromotionGoal(unittest.TestCase):
             locators={
                 browser_masters._PROMOTION_GOAL_BUTTON_XPATH: _FakeLocator([trigger])
             },
-            text_buttons={},
+            role_elements=[],
         )
 
         with self.assertRaises(BrowserSessionError):
@@ -1870,34 +1957,55 @@ class TestSetPromotionGoal(unittest.TestCase):
 
 
 class TestUpdateMaster(unittest.TestCase):
-    """``update_master`` (issue #631, Этап A) — partial updates, one whole-form save."""
+    """``update_master`` (issue #631, Этап A) — partial updates, one whole-form save.
 
-    def _page_with_save_button(self, extra_locators=None, extra_text_buttons=None):
+    ``update_master`` now re-navigates and re-reads every requested field
+    after clicking save (``_verify_saved``, cycle-review fix for "reports
+    success without confirming the save actually took") — so these fakes
+    model persistent mutable state (``budget_state``/``checkbox_state``)
+    that BOTH the fill/check handles AND the post-reload read-back handles
+    share, via ``get_value``/``get_checked`` callables. A test that wants to
+    simulate "Yandex silently rejected the value" sets that shared state to
+    something OTHER than what was requested, independent of what ``fill``
+    was called with.
+    """
+
+    def _page_with_save_button(
+        self, extra_locators=None, weekly_budget_state=None, directs_helps_state=None
+    ):
         save_clicks = []
         save_handle = _FakeTextLocatorHandle(
             visible=True, on_click=lambda: save_clicks.append(True)
         )
-        text_buttons = {
-            browser_masters._SAVE_BUTTON_TEXT: _FakeGetByTextLocator([save_handle])
-        }
-        text_buttons.update(extra_text_buttons or {})
+        locators = dict(extra_locators or {})
+
+        if weekly_budget_state is not None:
+            budget_handle = _FakeLocatorHandle(
+                on_fill=lambda v: weekly_budget_state.__setitem__("value", v),
+                get_value=lambda: weekly_budget_state.get("value", ""),
+            )
+            locators[browser_masters._WEEKLY_BUDGET_INPUT_XPATH] = _FakeLocator(
+                [budget_handle]
+            )
+        if directs_helps_state is not None:
+            checkbox_handle = _FakeLocatorHandle(
+                on_check=lambda v: directs_helps_state.__setitem__("checked", v),
+                get_checked=lambda: directs_helps_state.get("checked", False),
+            )
+            locators[browser_masters._DIRECT_HELPS_CHECKBOX_XPATH] = _FakeLocator(
+                [checkbox_handle]
+            )
+
         page = FakePage(
-            locators=extra_locators or {},
-            text_buttons=text_buttons,
+            locators=locators,
+            role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
         )
         return page, save_clicks
 
     def test_updates_only_weekly_budget(self):
         budget_state = {}
-        budget_handle = _FakeLocatorHandle(
-            on_fill=lambda v: budget_state.__setitem__("value", v)
-        )
         page, save_clicks = self._page_with_save_button(
-            extra_locators={
-                browser_masters._WEEKLY_BUDGET_INPUT_XPATH: _FakeLocator(
-                    [budget_handle]
-                )
-            }
+            weekly_budget_state=budget_state
         )
 
         result = browser_masters.update_master(page, 107707079, weekly_budget=95000)
@@ -1907,20 +2015,16 @@ class TestUpdateMaster(unittest.TestCase):
         self.assertEqual(result, {"CampaignId": 107707079, "WeeklyBudget": 95000})
         self.assertEqual(
             page.navigated_to,
-            [browser_masters.WIZARD_EDIT_URL.format(campaign_id=107707079)],
+            [
+                browser_masters.WIZARD_EDIT_URL.format(campaign_id=107707079),
+                browser_masters.WIZARD_EDIT_URL.format(campaign_id=107707079),
+            ],
         )
 
     def test_updates_only_directs_helps(self):
         checkbox_state = {"checked": False}
-        checkbox_handle = _FakeLocatorHandle(
-            on_check=lambda v: checkbox_state.__setitem__("checked", v)
-        )
         page, save_clicks = self._page_with_save_button(
-            extra_locators={
-                browser_masters._DIRECT_HELPS_CHECKBOX_XPATH: _FakeLocator(
-                    [checkbox_handle]
-                )
-            }
+            directs_helps_state=checkbox_state
         )
 
         result = browser_masters.update_master(page, 42, directs_helps=True)
@@ -1931,22 +2035,9 @@ class TestUpdateMaster(unittest.TestCase):
 
     def test_updates_multiple_fields_in_one_call(self):
         budget_state = {}
-        budget_handle = _FakeLocatorHandle(
-            on_fill=lambda v: budget_state.__setitem__("value", v)
-        )
         checkbox_state = {"checked": False}
-        checkbox_handle = _FakeLocatorHandle(
-            on_check=lambda v: checkbox_state.__setitem__("checked", v)
-        )
         page, save_clicks = self._page_with_save_button(
-            extra_locators={
-                browser_masters._WEEKLY_BUDGET_INPUT_XPATH: _FakeLocator(
-                    [budget_handle]
-                ),
-                browser_masters._DIRECT_HELPS_CHECKBOX_XPATH: _FakeLocator(
-                    [checkbox_handle]
-                ),
-            }
+            weekly_budget_state=budget_state, directs_helps_state=checkbox_state
         )
 
         result = browser_masters.update_master(
@@ -1970,7 +2061,7 @@ class TestUpdateMaster(unittest.TestCase):
     def test_does_not_click_save_when_field_setter_fails(self):
         # No locator registered for the budget field -> _set_weekly_budget
         # raises before _click_save is ever reached.
-        page, save_clicks = self._page_with_save_button(extra_locators={})
+        page, save_clicks = self._page_with_save_button()
 
         with self.assertRaises(BrowserSessionError):
             browser_masters.update_master(page, 42, weekly_budget=1000)
@@ -1981,14 +2072,84 @@ class TestUpdateMaster(unittest.TestCase):
         page = FakePage(
             locators={
                 browser_masters._WEEKLY_BUDGET_INPUT_XPATH: _FakeLocator(
-                    [_FakeLocatorHandle()]
+                    [_FakeLocatorHandle(get_value=lambda: "1000")]
                 )
             },
-            text_buttons={},
+            role_elements=[],
         )
 
         with self.assertRaises(BrowserSessionError):
             browser_masters.update_master(page, 42, weekly_budget=1000)
+
+    def test_raises_when_saved_value_does_not_match_requested(self):
+        # Save button is clicked, but the reload shows the OLD budget still
+        # in place (e.g. Yandex silently rejected the value) — this must be
+        # reported as a hard error, not a false success.
+        budget_state = {"value": "80000"}  # never actually updated to 95000
+        save_clicks = []
+        save_handle = _FakeTextLocatorHandle(
+            visible=True, on_click=lambda: save_clicks.append(True)
+        )
+        budget_handle = _FakeLocatorHandle(
+            on_fill=lambda v: None,  # the fill "succeeds" but doesn't persist
+            get_value=lambda: budget_state["value"],
+        )
+        page = FakePage(
+            locators={
+                browser_masters._WEEKLY_BUDGET_INPUT_XPATH: _FakeLocator(
+                    [budget_handle]
+                )
+            },
+            role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
+        )
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(page, 42, weekly_budget=95000)
+
+        self.assertEqual(len(save_clicks), 1)  # save WAS clicked
+        self.assertIn("did not save as requested", str(ctx.exception))
+
+    def test_raises_when_saved_directs_helps_does_not_match_requested(self):
+        checkbox_state = {"checked": False}  # never actually flips to True
+        save_handle = _FakeTextLocatorHandle(visible=True)
+        checkbox_handle = _FakeLocatorHandle(
+            on_check=lambda v: None,
+            get_checked=lambda: checkbox_state["checked"],
+        )
+        page = FakePage(
+            locators={
+                browser_masters._DIRECT_HELPS_CHECKBOX_XPATH: _FakeLocator(
+                    [checkbox_handle]
+                )
+            },
+            role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
+        )
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(page, 42, directs_helps=True)
+        self.assertIn("did not save as requested", str(ctx.exception))
+
+    def test_raises_when_saved_promotion_goal_does_not_match_requested(self):
+        # The goal setter's own post-click check passes (trigger text
+        # updates immediately), but the post-save reload shows the OLD
+        # goal still selected -- _verify_saved must still catch this.
+        trigger_states = iter(["Максимум переходов", "Максимум целевых действий"])
+        trigger = _FakeLocatorHandle(text="Цель продвижения")
+        trigger.inner_text = lambda: next(trigger_states)
+        save_handle = _FakeTextLocatorHandle(visible=True)
+        page = FakePage(
+            locators={
+                browser_masters._PROMOTION_GOAL_BUTTON_XPATH: _FakeLocator([trigger])
+            },
+            role_elements=[
+                ("option", "Максимум переходов", _FakeTextLocatorHandle(visible=True)),
+                ("button", browser_masters._SAVE_BUTTON_TEXT, save_handle),
+            ],
+        )
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(page, 42, promotion_goal="max-clicks")
+        self.assertIn("did not save as requested", str(ctx.exception))
 
 
 class TestMastersUpdateCommand(unittest.TestCase):


### PR DESCRIPTION
## Summary

Implements Этап A of issue #631 — `direct masters update`, editing the three simplest scalar fields on the Мастер кампаний (Campaign Wizard) settings page:

- `--weekly-budget` (Недельный бюджет)
- `--promotion-goal` (`max-conversions`/`max-clicks`, Цель продвижения)
- `--directs-helps`/`--no-directs-helps` (Директ помогает — auto-apply recommendations)

Later stages (headline/text variant lists, sitelinks, audience, Metrika counters/goals, budget adaptation, images/video) remain tracked in #631 and are **not** implemented here — this PR closes only the Этап A portion.

## Live investigation (Step 0)

Drove `/wizard/campaigns/{id}/edit/` live via `claude-in-chrome` against campaign 107707079 (stopped, non-critical). Findings captured in `tests/fixtures/masters_wizard_edit_stage_a.html`:

- **Single form, single save** — resolves the open risk noted in #631: the whole edit page is one form with exactly one "Сохранить кампанию" button at the bottom. No per-section independent save exists, so `update_master` submits the whole form on every call; fields not passed as flags are left at their current on-page value simply by never touching their input.
- **Недельный бюджет** — plain text input, located by heading-proximity XPath.
- **Директ помогает** — a plain HTML checkbox (not a custom toggle component). Checking it reveals a second, nested checkbox ("Оптимизировать расширенные настройки...") that is explicitly left untouched (out of scope for Этап A).
- **Цель продвижения** — custom dropdown with exactly two options confirmed live: "Максимум целевых действий" (default) and "Максимум переходов". No other values exist.
- All state changes were reverted before leaving the page (no live campaign was actually mutated by the investigation).

## Implementation

- `direct_cli/browser/masters.py`: `update_master(page, campaign_id, *, weekly_budget=None, promotion_goal=None, directs_helps=None)` plus private `_set_weekly_budget`/`_set_directs_helps`/`_set_promotion_goal`/`_click_save`, following the module's existing "click, then verify it actually took effect" convention (mirrors `_suspend_or_resume`).
- `direct_cli/commands/masters.py`: new `masters update <campaign_id>` command; requires at least one of the three flags.
- `direct_cli/smoke_matrix.py`: `masters.update` classified `DANGEROUS` (no `--sandbox` equivalent for browser-driven mutations, same rationale as `masters suspend`/`resume` from #630).
- `scripts/test_dangerous_commands.sh`, `README.md` (EN+RU), `CHANGELOG.md` updated.
- `tests/test_cli_contract.py`: added `masters.update` to `DRY_RUN_EXCEPTIONS` (browser click, no request payload to preview).

## Test plan

- [x] `pytest` (offline suite) — 2689 passed, 8 skipped (pre-existing `test_read_cassettes.py`/`test_integration_write.py` errors are an unrelated environment issue: `vcrpy`/`aiohttp` incompatibility, confirmed present on `main` too via `git stash`)
- [x] 26 new offline tests against fake Page/Locator objects, one per `_set_*` function plus `update_master` (partial updates, multi-field updates, error paths) and CLI wiring
- [x] `black --check` / `flake8` clean on all changed files
- [ ] Manual live verification (per issue's "Верификация" section — no sandbox exists for this mutation)

Closes #631 (Этап A only — B/C/D remain open as follow-up work per the issue's own staged plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrEMYPNW55Ywi6eQL8EA8K