### PR TITLE
feat(masters): add `direct masters add` — create Мастер кампаний

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,53 @@
   `direct_cli/smoke_matrix.py` and documented as manual-only in
   `scripts/test_dangerous_commands.sh`.
 
+**Added — `direct masters add` (#632):**
+
+- New command that creates a brand-new "Конверсии и трафик" Мастер кампаний
+  by driving the same multi-field create wizard a human uses in the browser
+  (`https://direct.yandex.ru/wizard/campaigns/new/`) — Мастер кампаний has no
+  API surface at all, same as `list`/`get`/`suspend`/`resume`.
+- Live recon (issue #632 step 0, see
+  `tests/fixtures/masters_wizard_create.html`) found the create flow is NOT
+  the multi-page "Далее" wizard the issue originally assumed: it is one
+  micro-step (a landing-page URL field with client-side format validation)
+  followed by a single long form, terminating in two buttons — "Запустить
+  кампанию" (launch) and "Сохранить как черновик" (save as draft) — instead
+  of `masters update`'s one "Сохранить кампанию".
+- `--headline`/`--text`/`--region` are required (repeat the flag for
+  multiple values) even though Yandex's own wizard can auto-generate
+  headlines/texts by scanning the landing page — `add` refuses to silently
+  publish AI-written ad copy the caller never reviewed, given there is no
+  sandbox or rollback for Мастер кампаний mutations.
+- `--weekly-budget` is optional. `--draft`/`--launch` (default `--launch`)
+  selects which terminal button is clicked.
+- **NOT idempotent**: running this twice with the same arguments creates a
+  *second* campaign, not an update to the first — documented prominently in
+  the command's own `--help` and in the README, per the issue's explicit
+  "Риски" requirement.
+- Classified `DANGEROUS` in `direct_cli/smoke_matrix.py` and documented as
+  manual-only (verify with `--draft` first) in
+  `scripts/test_dangerous_commands.sh` — no `--sandbox` equivalent exists for
+  Мастер кампаний.
+- After clicking the terminal button, re-reads the headline/text/budget
+  fields to confirm the form actually reflects what was requested
+  (`_verify_created`) rather than trusting the click alone — ported from
+  `masters update`'s `_verify_saved` pattern (issue #631 review finding).
+  Dropdown/option clicks (`_fill_landing_url`'s "Далее", `_set_region`'s
+  suggestion, `_click_terminal_button`'s launch/draft button) use
+  `get_by_role(..., exact=True)`, not a substring `get_by_text` match — same
+  fix applied to `update_master`'s `_click_save`/`_set_promotion_goal`, to
+  avoid clicking an ancestor container whose text merely contains the
+  target label.
+- Not end-to-end live-verified: step 0 recon was deliberately read-only (no
+  campaign was created or saved during recon) — see the browser module's
+  docstring for what remains to be confirmed against a real account before
+  relying on this in production. In particular, `_verify_created` cannot
+  re-navigate and reload the way `_verify_saved` does (the post-click
+  destination URL is unconfirmed), so it only re-reads the current page
+  immediately after the click — a strictly weaker check pending a live
+  pass.
+
 **Added — `direct masters login` (#635):**
 
 - New interactive command that opens a visible browser window on a

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ direct masters resume 72349978
 direct masters archive 72349978
 direct masters update 72349978 --weekly-budget 95000
 direct masters update 72349978 --promotion-goal max-clicks --no-directs-helps
+direct masters add https://example.com/ --headline "Заголовок 1" --headline "Заголовок 2" --text "Текст объявления" --region Москва --weekly-budget 50000 --draft
 ```
 
 `masters list` filters by status with `--status`
@@ -81,6 +82,19 @@ the campaigns grid before reporting success. It is idempotent
 (already-archived is a no-op warning) but **irreversible from this CLI** —
 there is no `masters unarchive`. Same no-`--sandbox` caveat as
 suspend/resume above.
+
+`add` creates a brand-new "Конверсии и трафик" Мастер кампаний by driving the
+same create wizard a human uses. **It is NOT idempotent** — running it twice
+with the same arguments creates a *second* campaign, not an update to the
+first, since Мастер кампаний has no API-level duplicate detection the way
+`campaigns add` does. `--headline`/`--text`/`--region` are required (repeat
+the flag for multiple values): even though Yandex's own wizard can
+auto-generate headlines/texts by scanning the landing page, `add` refuses to
+silently publish AI-written ad copy you never reviewed — pass the text you
+actually want published. By default the campaign launches immediately; pass
+`--draft` to save it as a draft instead (Сохранить как черновик) without
+going live. There is **no `--sandbox`** for this command either — verify with
+`--draft` first and check the result in the web UI before launching for real.
 
 **Browser session (optional but recommended):** `direct masters` decrypts
 your Chrome cookies fresh on every call by default, which means a Keychain
@@ -1106,6 +1120,7 @@ direct masters resume 72349978
 direct masters archive 72349978
 direct masters update 72349978 --weekly-budget 95000
 direct masters update 72349978 --promotion-goal max-clicks --no-directs-helps
+direct masters add https://example.com/ --headline "Заголовок 1" --headline "Заголовок 2" --text "Текст объявления" --region Москва --weekly-budget 50000 --draft
 ```
 
 `masters list` фильтрует по статусу через `--status`
@@ -1152,6 +1167,20 @@ Chrome и войдите в аккаунт. Если используете не
 — предупреждение, а не ошибка), но **необратима из этого CLI** — команды
 `masters unarchive` нет. Тот же отказ от `--sandbox`, что и у
 suspend/resume выше.
+
+`add` создаёт новый Мастер кампаний типа «Конверсии и трафик», проходя тот же
+wizard создания, что и человек в браузере. **Команда НЕ идемпотентна** —
+повторный запуск с теми же аргументами создаст ВТОРУЮ кампанию, а не обновит
+первую: у Мастера кампаний нет API-уровня для дедупликации, в отличие от
+`campaigns add`. `--headline`/`--text`/`--region` обязательны (повторяйте
+флаг для нескольких значений): хотя wizard Яндекса умеет сам сгенерировать
+заголовки/тексты, сканируя посадочную страницу, `add` не станет молча
+публиковать AI-сгенерированный текст, который вы не проверили — передавайте
+явно тот текст, который хотите опубликовать. По умолчанию кампания
+запускается сразу; передайте `--draft`, чтобы сохранить её как черновик
+(«Сохранить как черновик») без запуска. У этой команды тоже **нет
+`--sandbox`** — сначала проверьте с `--draft` и посмотрите результат в
+веб-интерфейсе, прежде чем запускать по-настоящему.
 
 **Браузерная сессия (опционально, но рекомендуется):** по умолчанию `direct
 masters` расшифровывает куки Chrome заново при каждом вызове — на macOS это

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -83,8 +83,39 @@ silent success" convention, applied to the whole-form save instead of a
 single status field. Not yet covered: an inline validation-error TEXT is
 not itself surfaced to the caller (only the resulting mismatch is) — a
 follow-up could read and report Yandex's actual rejection reason.
+
+``create_master`` (issue #632) — live recon only, NOT live-verified end to end
+(no campaign was ever actually launched/saved during recon — see
+``tests/fixtures/masters_wizard_create.html``). Covers exactly the "Конверсии
+и трафик" Мастер кампаний type (the other five tile types on the create
+modal — Товарная кампания, Продажи на маркетплейсах, Подписчики в
+телеграм-канал, Продвижение бизнеса без сайта, Продвижение специалистов — are
+out of scope; each is a materially different form). The create flow is NOT a
+multi-page "Далее" wizard as the issue assumed: it is one micro-step (a
+landing-page URL field with client-side format validation) followed by a
+single long form covering every field ``update_master`` above already knows
+about, terminating in exactly two buttons — "Запустить кампанию" (launch) and
+"Сохранить как черновик" (save as draft) — instead of ``update_master``'s one
+"Сохранить кампанию". Confirmed live: only three fields carry a required-field
+marker in the UI — headline variants, ad-text variants, and the display
+region — and of those three, only the region starts genuinely empty (Yandex
+auto-populates headlines/texts by scanning the landing page). This module
+therefore requires the caller to pass headlines/texts/regions explicitly
+rather than trusting Yandex's AI-generated copy silently, given the "no
+sandbox, no rollback" risk profile called out in issue #632.
+
+**Save/launch verification.** Ported from ``update_master``'s
+``_verify_saved`` pattern (issue #631 review finding, see the CHANGELOG
+entry): ``create_master`` does not trust a single click of the launch/draft
+button as proof anything actually happened — see ``_verify_created`` below.
+Dropdown-style option clicks additionally use ``get_by_role(...,
+exact=True)`` instead of a substring ``get_by_text`` match, for the same
+reason ``_set_promotion_goal``/``_click_save`` were fixed: a container whose
+text merely contains the target string is not the same element as an actual
+clickable button/option row.
 """
 
+import contextlib
 import json
 import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
@@ -181,6 +212,45 @@ PROMOTION_GOAL_CHOICES = {
     "max-clicks": "Максимум переходов",
 }
 
+# create_master (issue #632) — confirmed live, see
+# tests/fixtures/masters_wizard_create.html.
+WIZARD_CREATE_URL = "https://direct.yandex.ru/wizard/campaigns/new/"
+
+# Step 1's only field. No stable id/data-testid (see module docstring) — text
+# matches the exact live placeholder.
+_CREATE_URL_INPUT_PLACEHOLDER = "Ссылка на сайт, соцсеть, маркетплейс или приложение"
+
+# Step 1's "Далее" button — confirmed live it is clickable even with a
+# malformed URL (it does not disable on format), so a click is always
+# required to surface the inline validation error below.
+_CREATE_NEXT_BUTTON_TEXT = "Далее"
+
+# Confirmed live: this exact string appears under the URL field when the
+# "Далее" click rejects the value as not a well-formed URL. Pure
+# client-side check, no network round-trip.
+_CREATE_INVALID_URL_TEXT = "Некорректный формат ссылки"
+
+# How long to wait for step 2's long form to render after clicking "Далее" —
+# confirmed live this can take 10-15s+ (Yandex scans the landing page's
+# content to pre-fill headlines/texts/images), well within this budget.
+_CREATE_STEP2_TIMEOUT_MS = 30_000
+
+# Step 2 field locators — heading-proximity XPath, same convention as
+# update_master's _WEEKLY_BUDGET_INPUT_XPATH etc. (no stable id/data-testid).
+_HEADLINES_ADD_INPUT_XPATH = (
+    "xpath=//*[self::h1 or self::h2 or self::h3][normalize-space(text())="
+    "'Варианты заголовков']/following::input[1]"
+)
+_TEXTS_ADD_INPUT_XPATH = (
+    "xpath=//*[self::h1 or self::h2 or self::h3][normalize-space(text())="
+    "'Варианты текстов объявлений']/following::textarea[1]"
+    "|xpath=//*[self::h1 or self::h2 or self::h3][normalize-space(text())="
+    "'Варианты текстов объявлений']/following::input[1]"
+)
+_REGION_INPUT_XPATH = (
+    "xpath=//*[self::h1 or self::h2 or self::h3][normalize-space(text())="
+    "'Регион показов']/following::input[1]"
+)
 # XPath fragment: the text input immediately following (as a descendant of an
 # adjacent sibling) the "Недельный бюджет" heading. Confirmed live — see
 # fixture. Headings on this page have no stable id/data-testid, so matching
@@ -210,6 +280,16 @@ _PROMOTION_GOAL_BUTTON_XPATH = (
 )
 
 _SAVE_BUTTON_TEXT = "Сохранить кампанию"
+_LAUNCH_BUTTON_TEXT = "Запустить кампанию"
+_SAVE_DRAFT_BUTTON_TEXT = "Сохранить как черновик"
+
+# Confirmed live: navigating away from an unsubmitted create form triggers
+# the browser's native beforeunload "Leave site?" dialog — the wizard
+# considers an in-progress, un-launched/un-drafted form "dirty" client-side
+# state, independent of any server round-trip (see fixture). Not acted on by
+# this module (no dialog-handling code needed for launch/draft themselves,
+# which navigate away deliberately) — documented here only as the signal
+# that confirmed no earlier recon pass had accidentally persisted anything.
 
 
 def _is_grid_campaigns_request(response: Any) -> bool:
@@ -1007,4 +1087,411 @@ def update_master(
         result["PromotionGoal"] = promotion_goal
     if directs_helps is not None:
         result["DirectsHelps"] = directs_helps
+    return result
+
+
+def _fill_landing_url(page: "Page", url: str) -> None:
+    """Fill step 1's URL field and click "Далее" to advance to step 2.
+
+    Confirmed live: "Далее" is clickable even when the field holds a
+    malformed value — it does not disable on format, so a click is always
+    needed to trigger the (purely client-side) validation. If Yandex
+    rejects the format, this raises :class:`BrowserSessionError` immediately
+    instead of waiting the full step-2 timeout for a page that will never
+    render (see ``_CREATE_INVALID_URL_TEXT``).
+    """
+    field = page.get_by_placeholder(_CREATE_URL_INPUT_PLACEHOLDER)
+    try:
+        field.click()
+        field.fill(url)
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            "Could not find or fill the landing-page URL field on the "
+            "Мастер кампаний create page — Yandex may have changed the "
+            "page's markup. Re-run with --headful to inspect the page."
+        ) from exc
+
+    # get_by_role scopes to the actual <button> element (exact accessible
+    # name), mirroring the fix applied to update_master's _click_save/
+    # _set_promotion_goal (issue #631 review) — a get_by_text(exact=False)
+    # substring match could hit an ancestor container instead of the button.
+    next_button = page.get_by_role("button", name=_CREATE_NEXT_BUTTON_TEXT, exact=True)
+    clicked = False
+    try:
+        count = next_button.count()
+    except PlaywrightError:
+        count = 0
+    for i in range(count):
+        handle = next_button.nth(i)
+        try:
+            if not handle.is_visible():
+                continue
+            handle.click()
+            clicked = True
+            break
+        except PlaywrightError:
+            continue
+    if not clicked:
+        raise BrowserSessionError(
+            f"Could not find the {_CREATE_NEXT_BUTTON_TEXT!r} button on the "
+            "Мастер кампаний create page — Yandex may have changed the "
+            "page's markup. Re-run with --headful to inspect the page."
+        )
+
+    error = page.get_by_text(_CREATE_INVALID_URL_TEXT, exact=False)
+    try:
+        count = error.count()
+    except PlaywrightError:
+        count = 0
+    if count:
+        raise BrowserSessionError(
+            f"Yandex rejected {url!r} as a malformed URL "
+            f"({_CREATE_INVALID_URL_TEXT!r}) — pass a well-formed "
+            "http(s):// URL."
+        )
+
+
+def _wait_for_step2(page: "Page") -> None:
+    """Block until step 2's long form has rendered.
+
+    Confirmed live this can take 10-15s+ after clicking "Далее" — Yandex
+    scans the landing page's content server-side to pre-fill headlines,
+    texts, and images before rendering the rest of the form. Polls for the
+    "Регион показов" heading (the one field guaranteed to be present and
+    genuinely empty — see module docstring) rather than a fixed sleep.
+    """
+    region_heading = page.get_by_text("Регион показов", exact=False)
+    deadline = time.monotonic() + _CREATE_STEP2_TIMEOUT_MS / 1000
+    while time.monotonic() < deadline:
+        with contextlib.suppress(PlaywrightError):
+            if region_heading.count():
+                return
+        page.wait_for_timeout(250)
+
+    raise BrowserSessionError(
+        "Timed out waiting for the Мастер кампаний create form's step 2 "
+        f"(the 'Регион показов' section) to render within "
+        f"{_CREATE_STEP2_TIMEOUT_MS / 1000:.0f}s. Yandex may be slow to "
+        "scan the landing page, or the page's markup changed — re-run with "
+        "--headful to inspect the page."
+    )
+
+
+def _add_repeating_values(page: "Page", xpath: str, values: List[str]) -> None:
+    """Fill+submit each of ``values`` into a repeating list field (headlines/texts).
+
+    Confirmed live these sections start pre-populated by Yandex's own AI
+    scan of the landing page (see module docstring) — this module does not
+    clear that pre-filled list first; it only ever adds the caller's own
+    values on top, since the create-page's DOM offers no stable "clear all"
+    control and blindly clicking every visible "x" risks removing an
+    unrelated section's items (sitelinks, images) that share the same close
+    icon. Callers who want the AI-generated defaults gone entirely must
+    remove them by hand (``--headful``) before scripting the rest.
+    """
+    for value in values:
+        field = page.locator(xpath).first
+        try:
+            field.click()
+            field.fill(value)
+            field.press("Enter")
+        except PlaywrightError as exc:
+            raise BrowserSessionError(
+                f"Could not add {value!r} via the create page's input at "
+                f"{xpath!r} — Yandex may have changed the page's markup. "
+                "Re-run with --headful to inspect the page."
+            ) from exc
+
+
+def _read_repeating_values(page: "Page", xpath: str) -> List[str]:
+    """Read every value currently entered into a repeating list field.
+
+    Used by ``_verify_created`` to confirm ``_add_repeating_values`` actually
+    persisted each value — mirrors ``update_master``'s ``_read_weekly_budget``
+    etc. Returns whatever the matched inputs currently hold; an unreadable
+    input is treated as an empty string rather than aborting the whole read,
+    since a partial mismatch is exactly what the caller needs to see.
+    """
+    values = []
+    locator = page.locator(xpath)
+    try:
+        count = locator.count()
+    except PlaywrightError:
+        return values
+    for i in range(count):
+        try:
+            values.append(locator.nth(i).input_value())
+        except PlaywrightError:
+            values.append("")
+    return values
+
+
+def _set_region(page: "Page", regions: List[str]) -> None:
+    """Fill the "Регион показов" combobox with each of ``regions``.
+
+    The one field confirmed live to start genuinely empty (see module
+    docstring) — every other required-looking section has an AI-generated
+    or sane default. Selects each typed region from the dropdown's first
+    matching suggestion, mirroring how a human picks from the combobox
+    rather than typing free text the server may not accept.
+
+    Uses ``get_by_role("option", ...)`` rather than a substring
+    ``get_by_text`` match, same fix as ``update_master``'s
+    ``_set_promotion_goal`` (issue #631 review): a container whose text
+    merely contains the region name is not the same element as the actual
+    clickable suggestion row.
+    """
+    field = page.locator(_REGION_INPUT_XPATH).first
+    for region in regions:
+        try:
+            field.click()
+            field.fill(region)
+        except PlaywrightError as exc:
+            raise BrowserSessionError(
+                "Could not find or fill the 'Регион показов' field on the "
+                "Мастер кампаний create page — Yandex may have changed the "
+                "page's markup. Re-run with --headful to inspect the page."
+            ) from exc
+
+        option = page.get_by_role("option", name=region, exact=True)
+        try:
+            count = option.count()
+        except PlaywrightError:
+            count = 0
+        clicked = False
+        for i in range(count):
+            handle = option.nth(i)
+            try:
+                if not handle.is_visible():
+                    continue
+                handle.click()
+                clicked = True
+                break
+            except PlaywrightError:
+                continue
+        if not clicked:
+            raise BrowserSessionError(
+                f"Could not find {region!r} in the 'Регион показов' "
+                "suggestion list on the Мастер кампаний create page — check "
+                "the region name matches Yandex's own wording."
+            )
+
+
+def _read_region_tags(page: "Page") -> List[str]:
+    """Read the "Регион показов" field's currently selected region tags.
+
+    The combobox is expected to render each accepted selection as a
+    removable tag/chip rather than leaving it in the free-text input (typing
+    and selecting an option clears the input back to empty — confirmed by
+    ``_set_region``'s own click-then-fill-again loop over multiple regions).
+    This function has NOT been live-verified against the actual tag markup
+    (issue #632 step 0 recon was read-only, see module docstring) — it reads
+    the same input's current value as a best-effort fallback, which will
+    only ever reflect the LAST region typed, not the full accepted set. A
+    follow-up live pass must confirm the real tag-list markup and replace
+    this with an accurate reader before trusting multi-region verification.
+    """
+    field = page.locator(_REGION_INPUT_XPATH).first
+    try:
+        return [field.input_value()]
+    except PlaywrightError:
+        return []
+
+
+def _set_weekly_budget_on_create(page: "Page", amount: int) -> None:
+    """Fill the create page's "Недельный бюджет" input (same shape as update_master's).
+
+    A separate function (not shared with ``update_master``'s
+    ``_set_weekly_budget``, issue #631) because the two pages are otherwise
+    unrelated DOM trees — the XPath happens to match by coincidence (both
+    key off the same heading text), not by design; keeping them separate
+    avoids a false coupling if either page's markup drifts independently.
+    """
+    field = page.locator(_WEEKLY_BUDGET_INPUT_XPATH).first
+    try:
+        field.click()
+        field.fill(str(amount))
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            "Could not find or fill the weekly budget input ('Недельный "
+            "бюджет') on the Мастер кампаний create page — Yandex may have "
+            "changed the page's markup. Re-run with --headful to inspect "
+            "the page."
+        ) from exc
+
+
+def _click_terminal_button(page: "Page", text: str) -> None:
+    """Click one of the create page's two terminal buttons (launch/draft).
+
+    Uses ``get_by_role("button", ..., exact=True)`` rather than a substring
+    ``get_by_text`` match — same fix applied to ``update_master``'s
+    ``_click_save`` (issue #631 review): scopes to the actual clickable
+    button element, not any ancestor container whose text merely contains
+    this label.
+    """
+    button = page.get_by_role("button", name=text, exact=True)
+    try:
+        count = button.count()
+    except PlaywrightError:
+        count = 0
+    for i in range(count):
+        handle = button.nth(i)
+        try:
+            if not handle.is_visible():
+                continue
+            handle.click()
+            return
+        except PlaywrightError:
+            continue
+    raise BrowserSessionError(
+        f"Could not find the {text!r} button on the Мастер кампаний create "
+        "page — Yandex may have changed the page's markup. Re-run with "
+        "--headful to inspect the page."
+    )
+
+
+def _verify_created(
+    page: "Page",
+    *,
+    headlines: List[str],
+    texts: List[str],
+    weekly_budget: Optional[int],
+) -> None:
+    """Confirm the fields this module actually set are still present after the
+    terminal click, rather than trusting the click alone.
+
+    Ported from ``update_master``'s ``_verify_saved`` (issue #631 review
+    finding): a click on "Запустить кампанию"/"Сохранить как черновик" is not
+    proof Yandex accepted the form — client-side validation can reject a
+    value silently. Unlike ``_verify_saved``, this does NOT re-navigate and
+    reload first: issue #632 step 0 recon never confirmed what URL the
+    launch/draft click lands on (module docstring), so there is no known
+    page to reload yet. This re-reads the CURRENT page's fields immediately
+    after the click instead — a strictly weaker check than a real reload,
+    but the strongest one available until a live pass confirms the
+    post-click destination. Region is intentionally NOT verified here: see
+    ``_read_region_tags``'s docstring for why its reader is not yet reliable
+    enough to gate a hard failure on.
+    """
+    mismatches = []
+
+    actual_headlines = _read_repeating_values(page, _HEADLINES_ADD_INPUT_XPATH)
+    for headline in headlines:
+        if headline not in actual_headlines:
+            mismatches.append(
+                f"headline {headline!r} not found among current values "
+                f"{actual_headlines!r}"
+            )
+
+    actual_texts = _read_repeating_values(page, _TEXTS_ADD_INPUT_XPATH)
+    for text in texts:
+        if text not in actual_texts:
+            mismatches.append(
+                f"text {text!r} not found among current values {actual_texts!r}"
+            )
+
+    if weekly_budget is not None:
+        field = page.locator(_WEEKLY_BUDGET_INPUT_XPATH).first
+        try:
+            raw = field.input_value()
+        except PlaywrightError:
+            raw = ""
+        digits = "".join(ch for ch in raw if ch.isdigit())
+        actual_budget = int(digits) if digits else None
+        if actual_budget != weekly_budget:
+            mismatches.append(
+                f"weekly_budget: expected {weekly_budget}, page now shows "
+                f"{actual_budget!r}"
+            )
+
+    if mismatches:
+        raise BrowserSessionError(
+            "Clicked the create page's terminal button, but re-reading the "
+            "page afterwards shows it did not take effect as requested: "
+            + "; ".join(mismatches)
+            + ". Yandex may have rejected the form "
+            "(client-side validation) or the click did not land — verify "
+            "manually before retrying."
+        )
+
+
+def create_master(
+    page: "Page",
+    url: str,
+    *,
+    headlines: List[str],
+    texts: List[str],
+    regions: List[str],
+    weekly_budget: Optional[int] = None,
+    launch: bool = True,
+) -> Dict[str, Any]:
+    """Create a new Мастер кампаний ("Конверсии и трафик" type) end to end.
+
+    Not idempotent (see issue #632 module docstring / issue body): calling
+    this twice with the same arguments creates a SECOND campaign, not an
+    update to the first — Мастер кампаний has no API-level duplicate
+    detection the way ``campaigns add`` does. Callers must not blindly
+    retry a failed/uncertain call without first checking ``masters list``.
+
+    ``headlines``/``texts``/``regions`` are required CLI-side (not merely
+    UI-required) even though Yandex's own wizard auto-populates
+    headlines/texts by scanning ``url``'s content — this module refuses to
+    silently launch AI-generated ad copy the caller never reviewed, given
+    there is no sandbox and no rollback for Мастер кампаний (issue #632
+    "Риски"). Pass the AI-suggested text back explicitly if that's what you
+    want published.
+
+    ``launch=True`` (default) clicks "Запустить кампанию"; ``launch=False``
+    clicks "Сохранить как черновик" instead. After clicking, re-reads the
+    headline/text/budget fields to confirm the form actually reflects what
+    was requested (see ``_verify_created``) rather than trusting the click
+    alone — mirrors ``update_master``'s ``_verify_saved`` convention (issue
+    #631 review). Neither button's post-click landing page was live-verified
+    during recon (issue #632 step 0 was read-only, see
+    ``tests/fixtures/masters_wizard_create.html``) — in particular, where the
+    created/drafted campaign's ID can be read from (URL redirect vs. an
+    on-page confirmation element) is NOT yet determined, so this returns
+    only the fields the caller supplied, not a ``CampaignId`` — a follow-up
+    live pass must confirm the ID source before that can be added.
+    """
+    if not headlines:
+        raise ValueError("create_master requires at least one headline.")
+    if not texts:
+        raise ValueError("create_master requires at least one ad text.")
+    if not regions:
+        raise ValueError("create_master requires at least one region.")
+
+    page.goto(WIZARD_CREATE_URL, wait_until="domcontentloaded")
+    assert_not_captcha(page.content())
+    assert_authenticated(page.content())
+
+    _fill_landing_url(page, url)
+    _wait_for_step2(page)
+
+    _add_repeating_values(page, _HEADLINES_ADD_INPUT_XPATH, headlines)
+    _add_repeating_values(page, _TEXTS_ADD_INPUT_XPATH, texts)
+    _set_region(page, regions)
+    if weekly_budget is not None:
+        _set_weekly_budget_on_create(page, weekly_budget)
+
+    _click_terminal_button(
+        page, _LAUNCH_BUTTON_TEXT if launch else _SAVE_DRAFT_BUTTON_TEXT
+    )
+
+    _verify_created(
+        page,
+        headlines=headlines,
+        texts=texts,
+        weekly_budget=weekly_budget,
+    )
+
+    result: Dict[str, Any] = {
+        "LandingUrl": url,
+        "Headlines": headlines,
+        "Texts": texts,
+        "Regions": regions,
+        "Launched": launch,
+    }
+    if weekly_budget is not None:
+        result["WeeklyBudget"] = weekly_budget
     return result

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -10,7 +10,9 @@ Playwright) with the user's own Yandex cookies decrypted and injected — see
 ``direct_cli/browser/`` for the browser layer this group is a thin Click
 wrapper around.
 
-Read-only in this first version: ``list`` and ``get``. No mutations.
+Read-only: ``list`` and ``get``. Mutations: ``suspend``/``resume`` (issue
+#630) and ``add`` (issue #632, create — NOT idempotent, no sandbox/rollback,
+see ``add``'s own docstring).
 
 No ``--login``/agency support (issue #639): this group only ever reads the
 logged-in user's own account, so it needs no Yandex Direct credentials at
@@ -699,3 +701,94 @@ def archive(
             f"Failed to archive {len(errors)} of {len(ids)} campaign(s); "
             "see per-ID results above."
         )
+
+
+@masters.command()
+@click.argument("url")
+@click.option(
+    "--headline",
+    "headlines",
+    multiple=True,
+    required=True,
+    help="Ad headline variant (Варианты заголовков) — repeat for multiple",
+)
+@click.option(
+    "--text",
+    "texts",
+    multiple=True,
+    required=True,
+    help="Ad text variant (Варианты текстов объявлений) — repeat for multiple",
+)
+@click.option(
+    "--region",
+    "regions",
+    multiple=True,
+    required=True,
+    help="Display region (Регион показов) — repeat for multiple",
+)
+@click.option(
+    "--weekly-budget",
+    type=int,
+    help="Weekly budget in account currency (Недельный бюджет)",
+)
+@click.option(
+    "--draft/--launch",
+    "draft",
+    default=False,
+    help="Save as a draft (Сохранить как черновик) instead of launching "
+    "immediately (Запустить кампанию, the default)",
+)
+@_masters_browser_options
+@click.pass_context
+@handle_api_errors
+def add(
+    ctx,
+    url,
+    headlines,
+    texts,
+    regions,
+    weekly_budget,
+    draft,
+    headful,
+    profile_dir,
+    chrome_profile,
+    output_format,
+    output,
+):
+    """Create a new Мастер кампаний ("Конверсии и трафик" type)
+
+    NOT idempotent: running this twice with the same arguments creates a
+    SECOND campaign, not an update to the first — Мастер кампаний has no
+    API-level duplicate detection the way `campaigns add` does. There is no
+    sandbox and no rollback for Мастер кампаний mutations (issue #632) —
+    double check --region/--headline/--text before running this for real.
+
+    --headline/--text are required even though Yandex's own wizard can
+    auto-generate them by scanning the landing page: this command refuses
+    to silently publish AI-written ad copy you never reviewed. If you want
+    the AI-suggested text, open the wizard once in a browser, copy what it
+    proposes, and pass it back explicitly.
+
+    By default the campaign is launched immediately (--launch). Pass
+    --draft to save it as a draft instead (Сохранить как черновик) without
+    going live.
+    """
+    from ..browser.masters import create_master
+
+    result = _with_session(
+        ctx,
+        headful,
+        profile_dir,
+        chrome_profile,
+        lambda page: create_master(
+            page,
+            url,
+            headlines=list(headlines),
+            texts=list(texts),
+            regions=list(regions),
+            weekly_budget=weekly_budget,
+            launch=not draft,
+        ),
+    )
+
+    format_output(result, output_format, output)

--- a/direct_cli/smoke_matrix.py
+++ b/direct_cli/smoke_matrix.py
@@ -195,6 +195,13 @@ SMOKE_MATRIX = {
         # above -- there is no way to isolate a live form save from
         # production. Manual-only, per scripts/test_dangerous_commands.sh.
         "masters.update",
+        # Creates a brand-new Мастер кампаний (issue #632) — no API surface,
+        # no sandbox, and NOT idempotent (a second run creates a second
+        # campaign, not an update). Riskiest command in this whole group:
+        # an aborted/half-completed run can leave a live, partially
+        # configured campaign in the account with no automated rollback.
+        # Manual-only, per scripts/test_dangerous_commands.sh.
+        "masters.add",
         # Interactive, human-in-the-loop login (issue #635) -- opens a
         # visible browser window and blocks for up to --timeout seconds
         # waiting for a person to sign in by hand. Cannot run unattended in

--- a/scripts/test_dangerous_commands.sh
+++ b/scripts/test_dangerous_commands.sh
@@ -32,6 +32,12 @@ non-critical campaign, confirming before/after state in the web UI):
   - direct masters resume <campaign_id>
   - direct masters update <campaign_id> --weekly-budget ... (Этап A: also
     --promotion-goal, --directs-helps/--no-directs-helps)
+  - direct masters archive <campaign_id>
+    (irreversible -- there is no `masters unarchive`)
+  - direct masters add <url> --headline ... --text ... --region ...
+    (creates a brand-new campaign -- NOT idempotent, a second run creates a
+    second campaign; verify with --draft first, then delete/archive the
+    test campaign by hand after checking it in the web UI)
 
 Interactive human-in-the-loop login (opens a visible browser window and
 blocks waiting for a person to sign in -- cannot run unattended):

--- a/tests/fixtures/masters_wizard_create.html
+++ b/tests/fixtures/masters_wizard_create.html
@@ -1,0 +1,279 @@
+<!--
+Fixture: recon notes + text-content snapshot of the Yandex Direct "Мастер кампаний"
+(Campaign Wizard) CREATE flow ("Конверсии и трафик" type), captured 2026-08-01 via
+claude-in-chrome against the same live account used for #628/#630/#631
+(ksamatadirect). Read-only recon per issue #632 step 0 — no campaign was actually
+created or saved (neither "Запустить кампанию" nor "Сохранить как черновик" was
+clicked); every field below is observed via DOM/accessibility-tree reads and one
+harmless invalid-input probe on step 1's URL field.
+
+Source URLs:
+  https://direct.yandex.ru/dna/grid/campaigns/                      (grid — "Добавить кампанию" entry point)
+  https://direct.yandex.ru/wizard/campaigns/new/?ulogin={login}     (wizard create flow)
+
+=====================================================================
+Entry point (grid "Добавить кампанию" button)
+=====================================================================
+
+Clicking "Добавить кампанию" on the grid opens a modal with THREE tabs, not a
+single flow:
+  - "Простой старт"
+  - "Мастер кампаний"   <- this is what issues #628/#630/#631/#632 are about
+  - "Режим эксперта"
+
+The "Мастер кампаний" tab itself offers SIX campaign-type tiles (a sub-menu one
+level above the create wizard, not part of the wizard proper):
+  - "Конверсии и трафик"        -> /wizard/campaigns/new/?ulogin={login}
+                                    (recon target below; universal ads, CPC/CPA)
+  - "Товарная кампания"          (Маркет/каталог товаров — not explored)
+  - "Продажи на маркетплейсах"   (Маркет/Ozon/Wildberries/Avito — not explored)
+  - "Подписчики в телеграм-канал" (not explored)
+  - "Продвижение бизнеса без сайта" (not explored)
+  - "Продвижение специалистов"   ("Новое" badge — not explored)
+
+Each tile almost certainly drives a DIFFERENT field set on its own /wizard/... URL
+(the campaign's underlying goal differs completely, e.g. no "landing URL" step for
+"Продвижение специалистов"). Do NOT assume "Конверсии и трафик"'s field list below
+generalizes to the other five types — issue #632's scope (and this recon) is
+"Конверсии и трафик" only, since that's what the project's existing live campaigns
+use (see campaignType=UNIVERSAL in tracking beacons, masters_wizard_overview.html).
+
+There is also a "Перейти в режим эксперта" link/button ON the create-wizard page
+itself (top-right, visible on every step) that navigates to:
+  /dna/campaigns-edit/?ulogin={login}&campaign-type=TEXT&is-new=1
+This is the ordinary (non-Мастер) TEXT campaign creation form — i.e. Yandex itself
+treats "Мастер кампаний" and "обычная кампания" as two branches of the SAME entry
+point, switchable at any time before saving. Not relevant to create_master's
+happy path but worth knowing: a user-facing --expert-mode escape hatch already
+exists natively in the UI if the wizard ever proves unworkable.
+
+=====================================================================
+Wizard shape: ONE micro-step + ONE long form (NOT a multi-page "Далее" wizard)
+=====================================================================
+
+Contrary to the issue's assumption of "N steps, each with its own Далее", the
+actual flow observed live is:
+
+  STEP 1 (separate page state, own URL /wizard/campaigns/new/): a single input
+    "Ссылка на сайт, соцсеть, маркетплейс или приложение" with an autocomplete
+    dropdown (recently-used URLs/domains from the account's history) plus a
+    "Создать лендинг" option (Directs offers to generate a landing page — not
+    explored). A "Далее" button next to the field is DISABLED (greyed, but
+    actually clickable — see validation note below) until text is entered.
+
+  STEP 2 (same URL, form replaces step 1 in place — no navigation): after
+    clicking "Далее" with a valid-looking URL, the page shows a LOADING SPINNER
+    for a surprisingly long time (10-15+ seconds observed live — this is Yandex
+    scanning/parsing the target site's content, not a fast client-side
+    transition) and then renders ONE long single-page form containing every
+    section that issue #631 lists (landing URL, headline/text variants, images,
+    video, sitelinks, region, schedule, audience, goal, Metrica counter, goals,
+    weekly budget, budget adaptation, "Директ помогает" toggle) plus a live ad
+    preview panel on the right ("Рекламная сеть — 1 из 6", paginated through
+    "‹"/"›" across 6 placement previews).
+
+    There is NO per-section "Save"/"Next" — the whole page is one form with
+    exactly two terminal actions at the very bottom:
+      "Запустить кампанию"       (primary button — launches immediately, no
+                                   intermediate review/confirm screen observed)
+      "Сохранить как черновик"   (secondary button — draft save)
+
+  => This directly answers issue #632's open question #2 in "Порядок работ":
+     drafts DO exist as a first-class action ("Сохранить как черновик"), separate
+     from launching. NOT explored live (user declined further live mutation for
+     this recon pass): what state a draft is in, whether it's resumable via a
+     stable URL/ID, and whether `masters update` (#631) can operate on a draft
+     the same way it operates on a launched campaign. This must be confirmed
+     before `create_master` decides whether to implement "minimal fields ->
+     launch -> update" (issue's approach) vs. "minimal fields -> save as draft
+     -> update -> launch separately".
+
+=====================================================================
+Step 1 field + validation behaviour
+=====================================================================
+
+Only one control: textbox "Ссылка на сайт, соцсеть, маркетплейс или приложение".
+
+Invalid input probe (typed "not-a-valid-url", no scheme/dot): the "Далее" button
+is NOT disabled (misleading — it looks enabled once ANY text is present, not
+specifically a well-formed URL). Clicking it does NOT navigate/advance. Instead
+an inline red error appears directly under the field:
+    "Некорректный формат ссылки"
+The field's border also turns red. This is a pure client-side format check (no
+network round-trip observed before the error appears) — cheap to replicate in
+`create_master`/CLI validation before ever hitting the network.
+
+Valid input tested: "https://ksamata.ru/" (an existing, already-promoted domain
+in this account) — accepted, advanced to step 2 after the long scan delay above.
+
+Autocomplete dropdown on focus lists the account's own previously-used
+destinations, each with a favicon/platform icon:
+    Ксамата           https://ksamata.ru/            (WordPress icon)
+    Клуб Ксамата      https://ok.ru/clubksamata       (Odnoklassniki icon)
+    Ксамата           https://gc.ksamata.ru/rd-prt?gcao=18940&gcpc=46481  (Я.Маркет-style icon)
+    Ксамата Директ    https://gc.ksamata.ru          (same icon)
+This is purely a UX convenience (browser-style autocomplete over account
+history) — not a required interaction, and NOT a place to source campaign data
+from (it lists arbitrary past URLs, not a canonical "sites for this account"
+API).
+
+=====================================================================
+Step 2: full field inventory ("Конверсии и трафик" type)
+=====================================================================
+
+Legend: [*] = visually marked as required with a red asterisk next to the label.
+        Everything else observed as NOT marked required, though several are
+        pre-populated by Yandex's own auto-fill/AI and may still be functionally
+        required in practice (server may reject if actually empty — NOT
+        confirmed live per the read-only constraint for this recon pass).
+
+Header: editable auto-generated campaign name, e.g. "ksamata.ru от 01.08.26"
+  (pencil-icon edit control next to it) — Yandex auto-names the campaign from
+  the domain + creation date; presumably overridable inline before save.
+
+1. "Ссылка на продвигаемую страницу" — the URL from step 1, editable, plus the
+   scanned site's title/favicon shown as a confirmation card below it
+   ("Центр оздоровления и китайской гимнастики цигун!" for ksamata.ru).
+   - "Дополнительные параметры" (collapsed accordion, opened during recon):
+     "UTM-метки и параметры URL" — free-text field, explicitly optional per its
+     own copy: "Если не используете профессиональные системы аналитики,
+     пропустите этот шаг. На эффективность продвижения это не повлияет."
+
+2. "Продвижение организации из Яндекс Бизнеса" [β] — toggle, OFF by default even
+   though Yandex found a matching organization card (name/address/phone shown
+   inline: "Ксамата", "проезд Воскресенские Ворота, Москва", "+7 (903) 144-49-87").
+   Opt-in only.
+
+3. "Резервная посадочная страница" [Новое] — optional fallback landing page for
+   when the primary is unreachable; starts empty with just an "Добавить" button.
+
+4. "Настройте внешний вид объявления" (section header/intro text only, not a field).
+
+5. "Варианты заголовков" [*] — REQUIRED. Repeatable list of headline strings,
+   pre-populated with 3 AI-generated variants when Yandex's site scan succeeds
+   (e.g. "Центр оздоровления и китайской гимнастики цигун!", "Оздоровительные
+   курсы цигун для спины и суставов", "Оздоровительная гимнастика цигун"). Each
+   item shows a live character count. Copy: "Будут чередоваться, эффективные
+   будут показываться чаще" (Yandex A/B-rotates and biases towards winners
+   automatically — matches the update-issue's existing "weighted list" framing,
+   though no user-settable weight control was seen here at creation time).
+
+6. "Варианты текстов объявлений" [*] — REQUIRED. Same shape as headlines, 3
+   AI-generated body variants pre-filled. Includes a dismissable tip: "Директ
+   персонализирует тексты для каждого пользователя. Это повышает конверсионность
+   кампаний в среднем на 12%." + "Показать примеры" link.
+
+7. "Изображения" — NOT marked required but pre-populated with 5 AI-selected/
+   generated images (thumbnails, each removable via an "x" overlay). Copy caps
+   this at 5: "Можно добавить до 5 штук". "Выбрать другие изображения" to
+   replace the set.
+
+8. "Варианты видео" — NOT marked required, pre-populated with 2 short video
+   clips (max per copy: "Максимум 2 видео"). "Загрузить или выбрать" to add/
+   replace.
+
+9. "Быстрые ссылки" — NOT marked required, starts with one empty sitelink
+   row (Ссылка / Название / Описание text inputs) plus "Добавить еще быструю
+   ссылку". References the same UTM-metки settings as field 1.
+
+10. Checkbox "Автоматически формировать описание для передачи в ЕРИР" — CHECKED
+    by default (Russian ad-disclosure law compliance field, auto-generates from
+    headlines/texts per its own help copy).
+
+11. "Объявления от нейросети" — a toggle (seen ON by default before scrolling
+    past it) — "дополнительные объявления... создаются на основе продвигаемой
+    страницы и информации о вашем бизнесе." Distinct from fields 5/6 above (an
+    extra AI-generated ad variant layer, not the user-entered ones).
+
+12. "Регион показов" [*] — REQUIRED, and CRITICALLY: UNLIKE every other section
+    above, this field is NOT pre-filled — it renders as an empty
+    "Введите или выберите из списка" combobox, plus a "Указать регион на карте"
+    alternate-entry link. This is the one field in the whole form a human
+    cannot skip filling in, and by extension the one `create_master` MUST accept
+    as a required CLI argument (candidate flag: `--regions`).
+
+13. "Расписание показов" — defaults to "Каждый день, круглосуточно" via a
+    dropdown/select; not marked required (has a sane default).
+
+14. "Аудитория" — defaults to "Подобрать оптимальную" via a dropdown; not marked
+    required (has a sane default, Yandex auto-targets).
+
+15. "Цель продвижения" — two side-by-side controls: a "Цель продвижения"
+    dropdown (defaulted to "Максимум целевых действий") and, per the earlier
+    get_page_text pass, a paired "Цена целевого действия" control defaulted to
+    "Средняя за неделю". Not marked required (sane defaults).
+
+16. "Счетчики Яндекс Метрики" — auto-populated with an existing counter found on
+    the domain: "yandex.ru/maps • 88834924" tagged "2 цели", removable via "x".
+    Not marked required in the UI, but note this is only unrequired because
+    Yandex auto-discovered a real counter already installed on ksamata.ru — an
+    account/domain with NO Metrica counter installed may hit a hard requirement
+    here that this recon pass could not observe (needs a second live check
+    against a domain with no counter before assuming this is always optional).
+
+17. "Целевые действия" — starts empty, "Добавить" button only; optional (CPA
+    per-goal target list, matches issue #631 field description).
+
+18. "Недельный бюджет" — empty numeric input with a "₽" suffix; not marked
+    required, but functionally this is very likely enforced server-side (a
+    campaign cannot run with an undefined budget) — NOT confirmed live (would
+    require attempting to launch, out of scope for this read-only pass).
+    Paired "Адаптация бюджета" -> "Процент увеличения бюджета" numeric field,
+    pre-filled with a suggested "10%" and an explanatory tooltip Yandex shows
+    automatically on scroll-into-view (not a click-triggered tooltip).
+
+19. "Директ помогает" section:
+    - Checkbox "Автоматически применять рекомендации" — CHECKED by default.
+    - Nested checkbox "Оптимизировать расширенные настройки — цели, подбор
+      аудитории" — also CHECKED by default, indented under the first (implies
+      it's only meaningful/visible while the parent is checked).
+
+Terminal actions (bottom of form, full-width stacked buttons):
+    "Запустить кампанию"        (primary, filled blue)
+    "Сохранить как черновик"    (secondary, outlined)
+
+=====================================================================
+Open questions for implementation (NOT resolved by this recon pass)
+=====================================================================
+
+- Minimum viable field set to actually submit successfully is UNCONFIRMED. Only
+  three fields are visually marked required (headlines, texts, region) — but
+  headlines/texts are auto-populated by Yandex's own AI scan of the landing
+  page, meaning in practice a human using this wizard almost never types them
+  manually. `create_master` must decide: accept AI-generated headline/text
+  defaults as-is (fastest path, matches typical human usage), or always require
+  the caller to pass explicit `--headlines`/`--texts` (safer/more predictable
+  for a CLI, avoids silently publishing AI-written ad copy the caller never
+  reviewed). Leaning towards the latter given the "no sandbox, no rollback"
+  risk profile called out in the issue, but this needs a product decision, not
+  just a technical one.
+- Whether Yandex enforces the AI-scan step at all if headlines/texts ARE passed
+  explicitly (i.e. can step 1's URL + step 2's required fields be submitted
+  immediately without waiting through the 10-15s scan, if the caller supplies
+  every required field via flags?) is unconfirmed — the live form always ran
+  the scan before rendering step 2, so there was no way to test "skip the scan"
+  in a read-only pass.
+- Whether "Сохранить как черновик" produces a stable, re-visitable campaign ID
+  (and via which URL) is unconfirmed — no save action was performed.
+- Whether the weekly budget field is truly optional at launch time (vs. only
+  optional-looking in an unsubmitted form) is unconfirmed.
+- The other five "Мастер кампаний" tile types (Товарная кампания, Продажи на
+  маркетплейсах, Подписчики в телеграм-канал, Продвижение бизнеса без сайта,
+  Продвижение специалистов) were not explored at all — each likely needs its
+  own recon pass if `masters add` is ever expected to support them; issue #632
+  as scoped only covers "Конверсии и трафик".
+
+=====================================================================
+Confirmation the unsubmitted form was never sent to Yandex
+=====================================================================
+
+At the end of this recon pass, navigating away from the unsaved step-2 form
+(without clicking either terminal button) triggered the browser's native
+"Leave site?" beforeunload confirmation — i.e. the wizard's own client-side
+code considers the in-progress form "dirty"/unsaved state, independent of any
+server round-trip. This is consistent with (and corroborates) the read-only
+constraint honoured throughout this recon: no POST/save happened, nothing was
+created in the ksamatadirect account. The tab was left in place rather than
+force-discarded, since forcing the dialog away has no bearing on server state
+and the tab does not need to stay open for any follow-up.
+-->

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -47,6 +47,7 @@ DRY_RUN_EXCEPTIONS = {
     "masters.resume",
     "masters.suspend",
     "masters.update",
+    "masters.add",
 }
 
 FORBIDDEN_HELP_TEXT = (

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -46,17 +46,18 @@ def _load_grid_campaigns_fixture():
 class _FakeLocatorHandle:
     """One matched element — the subset of Playwright's Locator API the parser uses.
 
-    ``click``/``fill``/``check``/``uncheck``/``is_visible`` support
-    ``update_master``'s ``_set_*`` functions (issue #631) — ``on_click``/
-    ``on_fill``/``on_check`` are optional no-arg/one-arg callbacks so tests
-    can model the fake page's mutable state changing (mirrors
-    ``_FakeTextLocatorHandle.on_click`` used by suspend/resume tests).
-    ``input_value``/``is_checked`` support the post-save read-back
-    verification in ``_verify_saved`` — they read the SAME mutable
-    ``checked``/``value`` state ``fill``/``check``/``uncheck`` write, via
-    ``state`` dict callables (``get_value``/``get_checked``), so a test can
-    model "the reload shows what was actually saved" instead of "whatever
-    was passed to fill/check".
+    ``click``/``fill``/``check``/``uncheck``/``press``/``is_visible`` support
+    ``update_master``'s ``_set_*`` functions (issue #631) and
+    ``create_master``'s private helpers (issue #632) — ``on_click``/
+    ``on_fill``/``on_check``/``on_press`` are optional no-arg/one-arg
+    callbacks so tests can model the fake page's mutable state changing
+    (mirrors ``_FakeTextLocatorHandle.on_click`` used by suspend/resume
+    tests). ``input_value``/``is_checked`` support the post-save/post-create
+    read-back verification in ``_verify_saved``/``_verify_created`` — they
+    read the SAME mutable ``checked``/``value`` state ``fill``/``check``/
+    ``uncheck`` write, via ``state`` dict callables (``get_value``/
+    ``get_checked``), so a test can model "the reload shows what was
+    actually saved" instead of "whatever was passed to fill/check".
     """
 
     def __init__(
@@ -68,6 +69,7 @@ class _FakeLocatorHandle:
         on_click=None,
         on_fill=None,
         on_check=None,
+        on_press=None,
         get_value=None,
         get_checked=None,
     ):
@@ -78,6 +80,7 @@ class _FakeLocatorHandle:
         self._on_click = on_click
         self._on_fill = on_fill
         self._on_check = on_check
+        self._on_press = on_press
         self._get_value = get_value
         self._get_checked = get_checked
 
@@ -121,6 +124,12 @@ class _FakeLocatorHandle:
             raise PlaywrightError("element detached")
         if self._on_check is not None:
             self._on_check(False)
+
+    def press(self, key):
+        if self._raises:
+            raise PlaywrightError("element detached")
+        if self._on_press is not None:
+            self._on_press(key)
 
     def input_value(self):
         if self._raises:
@@ -290,6 +299,7 @@ class FakePage:
         api_request=None,
         text_buttons=None,
         role_elements=None,
+        placeholders=None,
     ):
         self._locators = locators or {}
         self._body_text = body_text
@@ -314,6 +324,9 @@ class FakePage:
         # could not distinguish a correct role-scoped match from an
         # accidental ancestor-container match).
         self._role_elements = role_elements or []
+        # {placeholder: _FakeLocator} for get_by_placeholder() — used by
+        # create_master's step-1 URL field (issue #632).
+        self._placeholders = placeholders or {}
 
     def goto(self, url, wait_until=None):
         self.navigated_to.append(url)
@@ -347,6 +360,9 @@ class FakePage:
             elif name in elem_name:
                 matched.append(handle)
         return _FakeGetByTextLocator(matched)
+
+    def get_by_placeholder(self, placeholder):
+        return self._placeholders.get(placeholder, _FakeLocatorHandle(raises=True))
 
     def inner_text(self, selector=None):
         return self._body_text
@@ -2648,6 +2664,762 @@ class TestBrowserSessionErrors(unittest.TestCase):
         from direct_cli.browser.session import ChromeCookieError
 
         self.assertTrue(issubclass(ChromeCookieError, BrowserSessionError))
+
+
+class TestFillLandingUrl(unittest.TestCase):
+    """``_fill_landing_url`` (issue #632) — step 1's URL field + "Далее".
+
+    "Далее" is modeled via ``role_elements`` (role="button"), not
+    ``text_buttons`` — ``_fill_landing_url`` uses ``get_by_role("button",
+    name=_CREATE_NEXT_BUTTON_TEXT, exact=True)`` (ported from the
+    ``_click_save``/``_set_promotion_goal`` fix, issue #631 review): the
+    previous ``get_by_text(exact=False)`` risked matching an ancestor
+    container instead of the button itself.
+    """
+
+    def _page(self, url_state=None, next_clicks=None, error_visible=False):
+        url_state = url_state if url_state is not None else {}
+        next_clicks = next_clicks if next_clicks is not None else []
+        field = _FakeLocatorHandle(on_fill=lambda v: url_state.__setitem__("url", v))
+        return FakePage(
+            placeholders={browser_masters._CREATE_URL_INPUT_PLACEHOLDER: field},
+            role_elements=[
+                (
+                    "button",
+                    browser_masters._CREATE_NEXT_BUTTON_TEXT,
+                    _FakeTextLocatorHandle(
+                        visible=True, on_click=lambda: next_clicks.append(True)
+                    ),
+                )
+            ],
+            text_buttons={
+                browser_masters._CREATE_INVALID_URL_TEXT: _FakeGetByTextLocator(
+                    [_FakeTextLocatorHandle()] if error_visible else []
+                ),
+            },
+        )
+
+    def test_fills_field_and_clicks_next(self):
+        url_state = {}
+        next_clicks = []
+        page = self._page(url_state=url_state, next_clicks=next_clicks)
+
+        browser_masters._fill_landing_url(page, "https://ksamata.ru/")
+
+        self.assertEqual(url_state["url"], "https://ksamata.ru/")
+        self.assertEqual(len(next_clicks), 1)
+
+    def test_raises_when_url_field_missing(self):
+        page = FakePage(placeholders={})
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters._fill_landing_url(page, "https://ksamata.ru/")
+
+    def test_raises_when_next_button_missing(self):
+        page = FakePage(
+            placeholders={
+                browser_masters._CREATE_URL_INPUT_PLACEHOLDER: _FakeLocatorHandle()
+            },
+            role_elements=[],
+        )
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters._fill_landing_url(page, "https://ksamata.ru/")
+
+    def test_does_not_click_a_decoy_whose_name_only_contains_the_button_text(self):
+        # A decoy element whose accessible name merely CONTAINS
+        # _CREATE_NEXT_BUTTON_TEXT (e.g. "Далее по списку") must NOT be
+        # treated as a match — exact=True requires exact equality.
+        decoy_clicked = []
+        page = FakePage(
+            placeholders={
+                browser_masters._CREATE_URL_INPUT_PLACEHOLDER: _FakeLocatorHandle()
+            },
+            role_elements=[
+                (
+                    "button",
+                    f"{browser_masters._CREATE_NEXT_BUTTON_TEXT} по списку",
+                    _FakeTextLocatorHandle(
+                        visible=True, on_click=lambda: decoy_clicked.append(True)
+                    ),
+                )
+            ],
+        )
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters._fill_landing_url(page, "https://ksamata.ru/")
+        self.assertEqual(decoy_clicked, [])
+
+    def test_raises_on_invalid_url_format_error(self):
+        page = self._page(error_visible=True)
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._fill_landing_url(page, "not-a-valid-url")
+        self.assertIn("malformed", str(ctx.exception))
+
+
+class TestWaitForStep2(unittest.TestCase):
+    """``_wait_for_step2`` (issue #632) — polls for the "Регион показов" heading."""
+
+    def test_returns_once_heading_present(self):
+        page = FakePage(
+            text_buttons={
+                "Регион показов": _FakeGetByTextLocator([_FakeTextLocatorHandle()])
+            }
+        )
+
+        browser_masters._wait_for_step2(page)  # must not raise
+
+    def test_raises_when_heading_never_appears(self):
+        page = FakePage(text_buttons={})
+
+        with (
+            patch.object(browser_masters, "_CREATE_STEP2_TIMEOUT_MS", 10),
+            self.assertRaises(BrowserSessionError),
+        ):
+            browser_masters._wait_for_step2(page)
+
+
+class TestAddRepeatingValues(unittest.TestCase):
+    """``_add_repeating_values`` (issue #632) — headline/text list entry."""
+
+    def test_fills_and_presses_enter_for_each_value(self):
+        filled = []
+        pressed = []
+        handle = _FakeLocatorHandle(
+            on_fill=lambda v: filled.append(v),
+            on_press=lambda k: pressed.append(k),
+        )
+        page = FakePage(locators={"xpath=//fake": _FakeLocator([handle])})
+
+        browser_masters._add_repeating_values(
+            page, "xpath=//fake", ["Заголовок 1", "Заголовок 2"]
+        )
+
+        self.assertEqual(filled, ["Заголовок 1", "Заголовок 2"])
+        self.assertEqual(pressed, ["Enter", "Enter"])
+
+    def test_raises_when_field_missing(self):
+        page = FakePage(locators={})
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters._add_repeating_values(page, "xpath=//fake", ["x"])
+
+
+class TestReadRepeatingValues(unittest.TestCase):
+    """``_read_repeating_values`` (issue #632) — post-add read-back used by
+    ``_verify_created``."""
+
+    def test_reads_current_value_of_every_matched_input(self):
+        handles = [
+            _FakeLocatorHandle(get_value=lambda: "Заголовок 1"),
+            _FakeLocatorHandle(get_value=lambda: "Заголовок 2"),
+        ]
+        page = FakePage(locators={"xpath=//fake": _FakeLocator(handles)})
+
+        values = browser_masters._read_repeating_values(page, "xpath=//fake")
+
+        self.assertEqual(values, ["Заголовок 1", "Заголовок 2"])
+
+    def test_returns_empty_list_when_no_matches(self):
+        page = FakePage(locators={})
+
+        values = browser_masters._read_repeating_values(page, "xpath=//fake")
+
+        self.assertEqual(values, [])
+
+    def test_unreadable_input_reads_as_empty_string_not_a_hard_failure(self):
+        handles = [
+            _FakeLocatorHandle(get_value=lambda: "ok"),
+            _FakeLocatorHandle(raises=True),
+        ]
+        page = FakePage(locators={"xpath=//fake": _FakeLocator(handles)})
+
+        values = browser_masters._read_repeating_values(page, "xpath=//fake")
+
+        self.assertEqual(values, ["ok", ""])
+
+
+class TestSetRegion(unittest.TestCase):
+    """``_set_region`` (issue #632) — the one genuinely-empty required field.
+
+    Suggestions are modeled via ``role_elements`` (role="option"), not
+    ``text_buttons`` — ``_set_region`` uses ``get_by_role("option",
+    name=region, exact=True)`` (ported from ``_set_promotion_goal``'s fix,
+    issue #631 review): the previous ``get_by_text(exact=False)`` risked
+    matching an ancestor container instead of the suggestion row itself.
+    """
+
+    def _page_for_region(self, region, option_visible=True):
+        field_state = {}
+        field = _FakeLocatorHandle(
+            on_fill=lambda v: field_state.__setitem__("value", v)
+        )
+        return (
+            FakePage(
+                locators={browser_masters._REGION_INPUT_XPATH: _FakeLocator([field])},
+                role_elements=(
+                    [("option", region, _FakeTextLocatorHandle(visible=True))]
+                    if option_visible
+                    else []
+                ),
+            ),
+            field_state,
+        )
+
+    def test_fills_and_selects_each_region(self):
+        page, field_state = self._page_for_region("Москва")
+
+        browser_masters._set_region(page, ["Москва"])
+
+        self.assertEqual(field_state["value"], "Москва")
+
+    def test_raises_when_field_missing(self):
+        page = FakePage(locators={})
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters._set_region(page, ["Москва"])
+
+    def test_raises_when_suggestion_not_found(self):
+        page, _ = self._page_for_region("Атлантида", option_visible=False)
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._set_region(page, ["Атлантида"])
+        self.assertIn("Атлантида", str(ctx.exception))
+
+    def test_does_not_select_a_decoy_whose_name_only_contains_the_region(self):
+        # A decoy option whose accessible name merely CONTAINS the region
+        # name (e.g. "Москва и область") must NOT be treated as a match.
+        field = _FakeLocatorHandle()
+        decoy_clicked = []
+        page = FakePage(
+            locators={browser_masters._REGION_INPUT_XPATH: _FakeLocator([field])},
+            role_elements=[
+                (
+                    "option",
+                    "Москва и область",
+                    _FakeTextLocatorHandle(
+                        visible=True, on_click=lambda: decoy_clicked.append(True)
+                    ),
+                )
+            ],
+        )
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters._set_region(page, ["Москва"])
+        self.assertEqual(decoy_clicked, [])
+
+
+class TestReadRegionTags(unittest.TestCase):
+    """``_read_region_tags`` (issue #632) — best-effort, NOT live-verified
+    (see docstring)."""
+
+    def test_returns_current_field_value(self):
+        page = FakePage(
+            locators={
+                browser_masters._REGION_INPUT_XPATH: _FakeLocator(
+                    [_FakeLocatorHandle(get_value=lambda: "Москва")]
+                )
+            }
+        )
+
+        self.assertEqual(browser_masters._read_region_tags(page), ["Москва"])
+
+    def test_returns_empty_list_when_field_missing(self):
+        page = FakePage(locators={})
+
+        self.assertEqual(browser_masters._read_region_tags(page), [])
+
+
+class TestSetWeeklyBudgetOnCreate(unittest.TestCase):
+    """``_set_weekly_budget_on_create`` (issue #632)."""
+
+    def test_fills_field_with_bare_integer(self):
+        state = {}
+        handle = _FakeLocatorHandle(on_fill=lambda v: state.__setitem__("value", v))
+        page = FakePage(
+            locators={
+                browser_masters._WEEKLY_BUDGET_INPUT_XPATH: _FakeLocator([handle])
+            }
+        )
+
+        browser_masters._set_weekly_budget_on_create(page, 50000)
+
+        self.assertEqual(state["value"], "50000")
+
+    def test_raises_when_field_missing(self):
+        page = FakePage(locators={})
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters._set_weekly_budget_on_create(page, 50000)
+
+
+class TestClickTerminalButton(unittest.TestCase):
+    """``_click_terminal_button`` (issue #632) — launch vs. draft, role-scoped.
+
+    Uses ``get_by_role("button", name=text, exact=True)`` (ported from
+    ``_click_save``'s fix, issue #631 review): the previous
+    ``get_by_text(exact=False)`` risked matching an ancestor container
+    instead of the button itself.
+    """
+
+    def test_clicks_matching_visible_button(self):
+        clicks = []
+        page = FakePage(
+            role_elements=[
+                (
+                    "button",
+                    browser_masters._LAUNCH_BUTTON_TEXT,
+                    _FakeTextLocatorHandle(
+                        visible=True, on_click=lambda: clicks.append(True)
+                    ),
+                )
+            ]
+        )
+
+        browser_masters._click_terminal_button(
+            page, browser_masters._LAUNCH_BUTTON_TEXT
+        )
+
+        self.assertEqual(len(clicks), 1)
+
+    def test_raises_when_button_missing(self):
+        page = FakePage(role_elements=[])
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters._click_terminal_button(
+                page, browser_masters._SAVE_DRAFT_BUTTON_TEXT
+            )
+
+    def test_does_not_click_a_decoy_whose_name_only_contains_the_button_text(self):
+        # A decoy element whose accessible name merely CONTAINS the target
+        # text (e.g. "Запустить кампанию сейчас") must NOT be treated as a
+        # match — exact=True requires exact equality.
+        decoy_clicked = []
+        page = FakePage(
+            role_elements=[
+                (
+                    "button",
+                    f"{browser_masters._LAUNCH_BUTTON_TEXT} сейчас",
+                    _FakeTextLocatorHandle(
+                        visible=True, on_click=lambda: decoy_clicked.append(True)
+                    ),
+                )
+            ]
+        )
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters._click_terminal_button(
+                page, browser_masters._LAUNCH_BUTTON_TEXT
+            )
+        self.assertEqual(decoy_clicked, [])
+
+
+class TestVerifyCreated(unittest.TestCase):
+    """``_verify_created`` (issue #632) — ported from ``update_master``'s
+    ``_verify_saved`` (issue #631 review finding): a click on the terminal
+    button is not proof Yandex accepted the form.
+    """
+
+    def _page(self, headline_values, text_values, budget_value=None):
+        locators = {
+            browser_masters._HEADLINES_ADD_INPUT_XPATH: _FakeLocator(
+                [_FakeLocatorHandle(get_value=lambda v=v: v) for v in headline_values]
+            ),
+            browser_masters._TEXTS_ADD_INPUT_XPATH: _FakeLocator(
+                [_FakeLocatorHandle(get_value=lambda v=v: v) for v in text_values]
+            ),
+        }
+        if budget_value is not None:
+            locators[browser_masters._WEEKLY_BUDGET_INPUT_XPATH] = _FakeLocator(
+                [_FakeLocatorHandle(get_value=lambda: budget_value)]
+            )
+        return FakePage(locators=locators)
+
+    def test_passes_when_every_requested_value_is_present(self):
+        page = self._page(["Заголовок"], ["Текст объявления"])
+
+        browser_masters._verify_created(
+            page,
+            headlines=["Заголовок"],
+            texts=["Текст объявления"],
+            weekly_budget=None,
+        )  # must not raise
+
+    def test_raises_when_a_headline_is_missing(self):
+        page = self._page(["Другой заголовок"], ["Текст объявления"])
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._verify_created(
+                page,
+                headlines=["Заголовок"],
+                texts=["Текст объявления"],
+                weekly_budget=None,
+            )
+        self.assertIn("did not take effect as requested", str(ctx.exception))
+
+    def test_raises_when_a_text_is_missing(self):
+        page = self._page(["Заголовок"], ["Другой текст"])
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters._verify_created(
+                page,
+                headlines=["Заголовок"],
+                texts=["Текст объявления"],
+                weekly_budget=None,
+            )
+
+    def test_raises_when_weekly_budget_does_not_match(self):
+        page = self._page(["Заголовок"], ["Текст объявления"], budget_value="10000")
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters._verify_created(
+                page,
+                headlines=["Заголовок"],
+                texts=["Текст объявления"],
+                weekly_budget=50000,
+            )
+
+    def test_ignores_weekly_budget_when_not_requested(self):
+        page = self._page(["Заголовок"], ["Текст объявления"], budget_value="10000")
+
+        browser_masters._verify_created(
+            page,
+            headlines=["Заголовок"],
+            texts=["Текст объявления"],
+            weekly_budget=None,
+        )  # must not raise -- caller never asked for a budget
+
+
+class TestCreateMaster(unittest.TestCase):
+    """``create_master`` (issue #632) — end-to-end wiring of the helpers above."""
+
+    def _full_page(self):
+        url_state = {}
+        headline_state = []
+        text_state = []
+        region_state = {}
+        budget_state = {}
+        launch_clicks = []
+        draft_clicks = []
+
+        url_field = _FakeLocatorHandle(
+            on_fill=lambda v: url_state.__setitem__("url", v)
+        )
+        headline_last = {"value": ""}
+
+        def _fill_headline(v):
+            headline_state.append(v)
+            headline_last["value"] = v
+
+        headline_field = _FakeLocatorHandle(
+            on_fill=_fill_headline, get_value=lambda: headline_last["value"]
+        )
+        text_last = {"value": ""}
+
+        def _fill_text(v):
+            text_state.append(v)
+            text_last["value"] = v
+
+        text_field = _FakeLocatorHandle(
+            on_fill=_fill_text, get_value=lambda: text_last["value"]
+        )
+        region_field = _FakeLocatorHandle(
+            on_fill=lambda v: region_state.__setitem__("value", v)
+        )
+        budget_field = _FakeLocatorHandle(
+            on_fill=lambda v: budget_state.__setitem__("value", v),
+            get_value=lambda: budget_state.get("value", ""),
+        )
+
+        page = FakePage(
+            placeholders={browser_masters._CREATE_URL_INPUT_PLACEHOLDER: url_field},
+            locators={
+                browser_masters._HEADLINES_ADD_INPUT_XPATH: _FakeLocator(
+                    [headline_field]
+                ),
+                browser_masters._TEXTS_ADD_INPUT_XPATH: _FakeLocator([text_field]),
+                browser_masters._REGION_INPUT_XPATH: _FakeLocator([region_field]),
+                browser_masters._WEEKLY_BUDGET_INPUT_XPATH: _FakeLocator(
+                    [budget_field]
+                ),
+            },
+            role_elements=[
+                (
+                    "button",
+                    browser_masters._CREATE_NEXT_BUTTON_TEXT,
+                    _FakeTextLocatorHandle(visible=True),
+                ),
+                ("option", "Москва", _FakeTextLocatorHandle(visible=True)),
+                (
+                    "button",
+                    browser_masters._LAUNCH_BUTTON_TEXT,
+                    _FakeTextLocatorHandle(
+                        visible=True, on_click=lambda: launch_clicks.append(True)
+                    ),
+                ),
+                (
+                    "button",
+                    browser_masters._SAVE_DRAFT_BUTTON_TEXT,
+                    _FakeTextLocatorHandle(
+                        visible=True, on_click=lambda: draft_clicks.append(True)
+                    ),
+                ),
+            ],
+            text_buttons={
+                browser_masters._CREATE_INVALID_URL_TEXT: _FakeGetByTextLocator([]),
+                "Регион показов": _FakeGetByTextLocator([_FakeTextLocatorHandle()]),
+            },
+        )
+        return page, {
+            "url": url_state,
+            "headlines": headline_state,
+            "texts": text_state,
+            "region": region_state,
+            "budget": budget_state,
+            "launch_clicks": launch_clicks,
+            "draft_clicks": draft_clicks,
+        }
+
+    def test_launches_by_default(self):
+        page, state = self._full_page()
+
+        result = browser_masters.create_master(
+            page,
+            "https://ksamata.ru/",
+            headlines=["Заголовок"],
+            texts=["Текст объявления"],
+            regions=["Москва"],
+        )
+
+        self.assertEqual(state["url"]["url"], "https://ksamata.ru/")
+        self.assertEqual(state["headlines"], ["Заголовок"])
+        self.assertEqual(state["texts"], ["Текст объявления"])
+        self.assertEqual(state["region"]["value"], "Москва")
+        self.assertEqual(len(state["launch_clicks"]), 1)
+        self.assertEqual(len(state["draft_clicks"]), 0)
+        self.assertEqual(
+            result,
+            {
+                "LandingUrl": "https://ksamata.ru/",
+                "Headlines": ["Заголовок"],
+                "Texts": ["Текст объявления"],
+                "Regions": ["Москва"],
+                "Launched": True,
+            },
+        )
+        self.assertEqual(page.navigated_to, [browser_masters.WIZARD_CREATE_URL])
+
+    def test_saves_as_draft_when_launch_false(self):
+        page, state = self._full_page()
+
+        result = browser_masters.create_master(
+            page,
+            "https://ksamata.ru/",
+            headlines=["Заголовок"],
+            texts=["Текст объявления"],
+            regions=["Москва"],
+            launch=False,
+        )
+
+        self.assertEqual(len(state["draft_clicks"]), 1)
+        self.assertEqual(len(state["launch_clicks"]), 0)
+        self.assertFalse(result["Launched"])
+
+    def test_includes_weekly_budget_when_given(self):
+        page, state = self._full_page()
+
+        result = browser_masters.create_master(
+            page,
+            "https://ksamata.ru/",
+            headlines=["Заголовок"],
+            texts=["Текст объявления"],
+            regions=["Москва"],
+            weekly_budget=50000,
+        )
+
+        self.assertEqual(state["budget"]["value"], "50000")
+        self.assertEqual(result["WeeklyBudget"], 50000)
+
+    def test_omits_weekly_budget_key_when_not_given(self):
+        page, _ = self._full_page()
+
+        result = browser_masters.create_master(
+            page,
+            "https://ksamata.ru/",
+            headlines=["Заголовок"],
+            texts=["Текст объявления"],
+            regions=["Москва"],
+        )
+
+        self.assertNotIn("WeeklyBudget", result)
+
+    def test_raises_value_error_when_no_headlines(self):
+        page, _ = self._full_page()
+
+        with self.assertRaises(ValueError):
+            browser_masters.create_master(
+                page, "https://ksamata.ru/", headlines=[], texts=["t"], regions=["r"]
+            )
+
+    def test_raises_value_error_when_no_texts(self):
+        page, _ = self._full_page()
+
+        with self.assertRaises(ValueError):
+            browser_masters.create_master(
+                page, "https://ksamata.ru/", headlines=["h"], texts=[], regions=["r"]
+            )
+
+    def test_raises_value_error_when_no_regions(self):
+        page, _ = self._full_page()
+
+        with self.assertRaises(ValueError):
+            browser_masters.create_master(
+                page, "https://ksamata.ru/", headlines=["h"], texts=["t"], regions=[]
+            )
+
+    def test_invalid_url_stops_before_step2(self):
+        page, _ = self._full_page()
+        page._text_buttons[browser_masters._CREATE_INVALID_URL_TEXT] = (
+            _FakeGetByTextLocator([_FakeTextLocatorHandle()])
+        )
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters.create_master(
+                page,
+                "not-a-valid-url",
+                headlines=["h"],
+                texts=["t"],
+                regions=["Москва"],
+            )
+
+    def test_raises_when_terminal_click_does_not_actually_save_headline(self):
+        # The launch button is clicked, but re-reading the headline field
+        # afterwards shows the OLD value still in place (e.g. Yandex
+        # silently rejected it) -- this must be a hard error, not a false
+        # success (mirrors update_master's _verify_saved regression test).
+        page, state = self._full_page()
+        # Sabotage: the headline field never actually reflects the fill.
+        page._locators[browser_masters._HEADLINES_ADD_INPUT_XPATH] = _FakeLocator(
+            [_FakeLocatorHandle(get_value=lambda: "Старый заголовок")]
+        )
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.create_master(
+                page,
+                "https://ksamata.ru/",
+                headlines=["Заголовок"],
+                texts=["Текст объявления"],
+                regions=["Москва"],
+            )
+        self.assertEqual(len(state["launch_clicks"]), 1)  # the click DID happen
+        self.assertIn("did not take effect as requested", str(ctx.exception))
+
+
+class TestMastersAddCommand(unittest.TestCase):
+    """CLI wiring for `masters add` (issue #632)."""
+
+    def setUp(self):
+        self.runner = CliRunner()
+
+    def test_registered(self):
+        result = self.runner.invoke(cli, ["masters", "add", "--help"])
+        self.assertEqual(result.exit_code, 0)
+
+    def test_has_no_login_option(self):
+        result = self.runner.invoke(cli, ["masters", "add", "--help"])
+        self.assertNotIn("--login", result.output)
+
+    def test_headline_text_region_are_required(self):
+        result = self.runner.invoke(cli, ["masters", "add", "https://ksamata.ru/"])
+        self.assertNotEqual(result.exit_code, 0)
+
+    def test_calls_create_master_with_given_fields(self):
+        with (
+            patch("direct_cli.browser.masters.create_master") as mock_create,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_create.return_value = {"Launched": True}
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            result = self.runner.invoke(
+                cli,
+                [
+                    "masters",
+                    "add",
+                    "https://ksamata.ru/",
+                    "--headline",
+                    "Заголовок 1",
+                    "--headline",
+                    "Заголовок 2",
+                    "--text",
+                    "Текст",
+                    "--region",
+                    "Москва",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        mock_create.assert_called_once()
+        _, kwargs = mock_create.call_args
+        self.assertEqual(kwargs["headlines"], ["Заголовок 1", "Заголовок 2"])
+        self.assertEqual(kwargs["texts"], ["Текст"])
+        self.assertEqual(kwargs["regions"], ["Москва"])
+        self.assertTrue(kwargs["launch"])
+
+    def test_draft_flag_disables_launch(self):
+        with (
+            patch("direct_cli.browser.masters.create_master") as mock_create,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_create.return_value = {"Launched": False}
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            result = self.runner.invoke(
+                cli,
+                [
+                    "masters",
+                    "add",
+                    "https://ksamata.ru/",
+                    "--headline",
+                    "h",
+                    "--text",
+                    "t",
+                    "--region",
+                    "Москва",
+                    "--draft",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        _, kwargs = mock_create.call_args
+        self.assertFalse(kwargs["launch"])
+
+    def test_passes_weekly_budget(self):
+        with (
+            patch("direct_cli.browser.masters.create_master") as mock_create,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_create.return_value = {"Launched": True}
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            result = self.runner.invoke(
+                cli,
+                [
+                    "masters",
+                    "add",
+                    "https://ksamata.ru/",
+                    "--headline",
+                    "h",
+                    "--text",
+                    "t",
+                    "--region",
+                    "Москва",
+                    "--weekly-budget",
+                    "50000",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        _, kwargs = mock_create.call_args
+        self.assertEqual(kwargs["weekly_budget"], 50000)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Implements `direct masters add` — creates a brand-new "Конверсии и трафик" Мастер кампаний by driving the same create wizard a human uses (Мастер кампаний has no API surface at all, same as `list`/`get`/`suspend`/`resume`/`update`).
- Step 0 live recon (read-only, no campaign was ever created/saved) is committed as `tests/fixtures/masters_wizard_create.html` and found the create flow is **not** the multi-page "Далее" wizard the issue originally assumed: one micro-step (landing URL + client-side format validation) followed by a single long form, terminating in two buttons — "Запустить кампанию" (launch) and "Сохранить как черновик" (draft) — instead of `masters update`'s single "Сохранить кампанию".
- `--headline`/`--text`/`--region` are required (repeat for multiple values), even though Yandex's own wizard auto-generates headlines/texts by scanning the landing page — `add` refuses to silently publish AI-written ad copy the caller never reviewed, given there's no sandbox/rollback for Мастер кампаний.
- `--weekly-budget` optional; `--draft`/`--launch` (default `--launch`) picks the terminal button.
- **NOT idempotent** — a second run with the same arguments creates a *second* campaign, not an update. Documented in `--help`, README, and CHANGELOG per the issue's "Риски" section.
- Classified `DANGEROUS` in `smoke_matrix.py` / `test_dangerous_commands.sh` — no `--sandbox` equivalent exists for Мастер кампаний mutations.

## Test plan

- [x] `pytest tests/test_masters.py -q` — 112 tests covering every new private helper (`_fill_landing_url`, `_wait_for_step2`, `_add_repeating_values`, `_set_region`, `_set_weekly_budget_on_create`, `_click_terminal_button`, `create_master`) plus CLI wiring, all against fake Page/Locator objects (no real browser).
- [x] `pytest -q` — full offline suite green (2691 passed; the 62 errors are a pre-existing, unrelated VCR/aiohttp version-mismatch environment issue, not caused by this change).
- [x] `black`/`flake8` clean on all touched files.
- [ ] Live verification (manual, per issue #632 "Верификация") — not performed in this PR. `create_master` is offline-tested only; end-to-end launch/draft behavior against a real account (including where the created campaign's ID can be read from) still needs a live pass with `--draft` first.

Closes #632