### PR TITLE
fix(masters): update URL field selector for combobox markup change (#650)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Unreleased
+
+**Fixed — `direct masters add`: URL field selector (#650):**
+
+- Yandex replaced step 1's plain `<input placeholder="...">` with a Combobox
+  whose text control is a `contenteditable` `<div role="textbox">` — the
+  placeholder text itself is unchanged, but Playwright's
+  `get_by_placeholder()` only matches `<input>`/`<textarea>` elements, so it
+  silently stopped finding the field and every `masters add` call failed
+  with "Could not find or fill the landing-page URL field".
+- Live re-recon (2026-08-02) found the field now carries a stable
+  `data-testid="CampaignFormUrl.Textinput"`, and the "Далее" button next to
+  it carries `data-testid="CampaignFormUrl.button"` — both selected directly
+  now instead of by placeholder text / accessible name. The field is filled
+  via `.type()` (keystroke simulation) instead of `.fill()`, since `.fill()`
+  does not work on a `contenteditable` element.
+- Also confirmed live: unlike before, the "Далее" button only renders once
+  the field has text — Playwright's own click-time actionability wait
+  handles this without extra polling.
+
 ## 0.5.1
 
 **Added — `direct masters archive` (#633):**

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -216,14 +216,19 @@ PROMOTION_GOAL_CHOICES = {
 # tests/fixtures/masters_wizard_create.html.
 WIZARD_CREATE_URL = "https://direct.yandex.ru/wizard/campaigns/new/"
 
-# Step 1's only field. No stable id/data-testid (see module docstring) — text
-# matches the exact live placeholder.
-_CREATE_URL_INPUT_PLACEHOLDER = "Ссылка на сайт, соцсеть, маркетплейс или приложение"
+# Step 1's only field (issue #650 re-recon, 2026-08-02): Yandex replaced the
+# plain <input placeholder="..."> with a Combobox whose text control is a
+# contenteditable <div role="textbox"> — confirmed live it still carries the
+# same placeholder text, but Playwright's get_by_placeholder() only matches
+# <input>/<textarea> elements, so it silently stopped finding this field.
+# The field DOES carry a stable data-testid now, unlike most of this page
+# (see module docstring) — confirmed live via page.content().
+_CREATE_URL_INPUT_TESTID = '[data-testid="CampaignFormUrl.Textinput"]'
 
-# Step 1's "Далее" button — confirmed live it is clickable even with a
-# malformed URL (it does not disable on format), so a click is always
-# required to surface the inline validation error below.
-_CREATE_NEXT_BUTTON_TEXT = "Далее"
+# Step 1's "Далее" button — confirmed live (issue #650 re-recon) it now also
+# carries a stable data-testid, and only renders/becomes clickable after the
+# URL field has text (unlike the old always-present button this replaced).
+_CREATE_NEXT_BUTTON_TESTID = '[data-testid="CampaignFormUrl.button"]'
 
 # Confirmed live: this exact string appears under the URL field when the
 # "Далее" click rejects the value as not a well-formed URL. Pure
@@ -1093,17 +1098,30 @@ def update_master(
 def _fill_landing_url(page: "Page", url: str) -> None:
     """Fill step 1's URL field and click "Далее" to advance to step 2.
 
-    Confirmed live: "Далее" is clickable even when the field holds a
-    malformed value — it does not disable on format, so a click is always
-    needed to trigger the (purely client-side) validation. If Yandex
-    rejects the format, this raises :class:`BrowserSessionError` immediately
-    instead of waiting the full step-2 timeout for a page that will never
-    render (see ``_CREATE_INVALID_URL_TEXT``).
+    Field located by ``_CREATE_URL_INPUT_TESTID`` (issue #650 re-recon,
+    2026-08-02) — Yandex replaced the plain ``<input placeholder="...">``
+    with a Combobox whose text control is a ``contenteditable`` ``<div
+    role="textbox">`` that ``get_by_placeholder()`` (matches only
+    ``<input>``/``<textarea>``) can no longer find, even though the
+    placeholder text itself is unchanged. ``.fill()`` does not work on a
+    contenteditable div, so this types the URL via keyboard events instead
+    (also what triggers the "Далее" button to render — see below).
+
+    Confirmed live: unlike the old always-present button this replaced, the
+    "Далее" button now only renders once the field has text — this waits
+    for it via Playwright's own actionability check (``click()`` auto-waits
+    for the element to appear and become visible) rather than an immediate
+    ``count()``. It is clickable even when the field holds a malformed
+    value — it does not disable on format, so a click is always needed to
+    trigger the (purely client-side) validation. If Yandex rejects the
+    format, this raises :class:`BrowserSessionError` immediately instead of
+    waiting the full step-2 timeout for a page that will never render (see
+    ``_CREATE_INVALID_URL_TEXT``).
     """
-    field = page.get_by_placeholder(_CREATE_URL_INPUT_PLACEHOLDER)
+    field = page.locator(_CREATE_URL_INPUT_TESTID).first
     try:
         field.click()
-        field.fill(url)
+        field.type(url)
     except PlaywrightError as exc:
         raise BrowserSessionError(
             "Could not find or fill the landing-page URL field on the "
@@ -1111,32 +1129,15 @@ def _fill_landing_url(page: "Page", url: str) -> None:
             "page's markup. Re-run with --headful to inspect the page."
         ) from exc
 
-    # get_by_role scopes to the actual <button> element (exact accessible
-    # name), mirroring the fix applied to update_master's _click_save/
-    # _set_promotion_goal (issue #631 review) — a get_by_text(exact=False)
-    # substring match could hit an ancestor container instead of the button.
-    next_button = page.get_by_role("button", name=_CREATE_NEXT_BUTTON_TEXT, exact=True)
-    clicked = False
+    next_button = page.locator(_CREATE_NEXT_BUTTON_TESTID).first
     try:
-        count = next_button.count()
-    except PlaywrightError:
-        count = 0
-    for i in range(count):
-        handle = next_button.nth(i)
-        try:
-            if not handle.is_visible():
-                continue
-            handle.click()
-            clicked = True
-            break
-        except PlaywrightError:
-            continue
-    if not clicked:
+        next_button.click()
+    except PlaywrightError as exc:
         raise BrowserSessionError(
-            f"Could not find the {_CREATE_NEXT_BUTTON_TEXT!r} button on the "
-            "Мастер кампаний create page — Yandex may have changed the "
-            "page's markup. Re-run with --headful to inspect the page."
-        )
+            "Could not find or click the 'Далее' button on the Мастер "
+            "кампаний create page — Yandex may have changed the page's "
+            "markup. Re-run with --headful to inspect the page."
+        ) from exc
 
     error = page.get_by_text(_CREATE_INVALID_URL_TEXT, exact=False)
     try:

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -113,6 +113,13 @@ class _FakeLocatorHandle:
         if self._on_fill is not None:
             self._on_fill(value)
 
+    def type(self, value, delay=None):  # noqa: A003 - mirrors Playwright's Locator.type
+        # Same fake behaviour as fill() — _fill_landing_url uses type()
+        # instead of fill() because the real element is a contenteditable
+        # <div>, not an <input>/<textarea> (issue #650), but the fake only
+        # needs to record what was entered.
+        self.fill(value)
+
     def check(self):
         if self._raises:
             raise PlaywrightError("element detached")
@@ -299,7 +306,6 @@ class FakePage:
         api_request=None,
         text_buttons=None,
         role_elements=None,
-        placeholders=None,
     ):
         self._locators = locators or {}
         self._body_text = body_text
@@ -324,9 +330,6 @@ class FakePage:
         # could not distinguish a correct role-scoped match from an
         # accidental ancestor-container match).
         self._role_elements = role_elements or []
-        # {placeholder: _FakeLocator} for get_by_placeholder() — used by
-        # create_master's step-1 URL field (issue #632).
-        self._placeholders = placeholders or {}
 
     def goto(self, url, wait_until=None):
         self.navigated_to.append(url)
@@ -360,9 +363,6 @@ class FakePage:
             elif name in elem_name:
                 matched.append(handle)
         return _FakeGetByTextLocator(matched)
-
-    def get_by_placeholder(self, placeholder):
-        return self._placeholders.get(placeholder, _FakeLocatorHandle(raises=True))
 
     def inner_text(self, selector=None):
         return self._body_text
@@ -2667,31 +2667,27 @@ class TestBrowserSessionErrors(unittest.TestCase):
 
 
 class TestFillLandingUrl(unittest.TestCase):
-    """``_fill_landing_url`` (issue #632) — step 1's URL field + "Далее".
+    """``_fill_landing_url`` (issue #632, re-recon issue #650) — step 1's URL
+    field + "Далее".
 
-    "Далее" is modeled via ``role_elements`` (role="button"), not
-    ``text_buttons`` — ``_fill_landing_url`` uses ``get_by_role("button",
-    name=_CREATE_NEXT_BUTTON_TEXT, exact=True)`` (ported from the
-    ``_click_save``/``_set_promotion_goal`` fix, issue #631 review): the
-    previous ``get_by_text(exact=False)`` risked matching an ancestor
-    container instead of the button itself.
+    Both the URL field and the "Далее" button are located via
+    ``page.locator(...)`` on their ``data-testid`` (issue #650 re-recon,
+    2026-08-02) — Yandex replaced the plain ``<input placeholder="...">``
+    with a Combobox whose text control is a ``contenteditable`` ``<div
+    role="textbox">`` that ``get_by_placeholder()``/``get_by_role()`` can no
+    longer find the same way.
     """
 
     def _page(self, url_state=None, next_clicks=None, error_visible=False):
         url_state = url_state if url_state is not None else {}
         next_clicks = next_clicks if next_clicks is not None else []
         field = _FakeLocatorHandle(on_fill=lambda v: url_state.__setitem__("url", v))
+        next_button = _FakeLocatorHandle(on_click=lambda: next_clicks.append(True))
         return FakePage(
-            placeholders={browser_masters._CREATE_URL_INPUT_PLACEHOLDER: field},
-            role_elements=[
-                (
-                    "button",
-                    browser_masters._CREATE_NEXT_BUTTON_TEXT,
-                    _FakeTextLocatorHandle(
-                        visible=True, on_click=lambda: next_clicks.append(True)
-                    ),
-                )
-            ],
+            locators={
+                browser_masters._CREATE_URL_INPUT_TESTID: _FakeLocator([field]),
+                browser_masters._CREATE_NEXT_BUTTON_TESTID: _FakeLocator([next_button]),
+            },
             text_buttons={
                 browser_masters._CREATE_INVALID_URL_TEXT: _FakeGetByTextLocator(
                     [_FakeTextLocatorHandle()] if error_visible else []
@@ -2710,45 +2706,22 @@ class TestFillLandingUrl(unittest.TestCase):
         self.assertEqual(len(next_clicks), 1)
 
     def test_raises_when_url_field_missing(self):
-        page = FakePage(placeholders={})
+        page = FakePage(locators={})
 
         with self.assertRaises(BrowserSessionError):
             browser_masters._fill_landing_url(page, "https://ksamata.ru/")
 
     def test_raises_when_next_button_missing(self):
         page = FakePage(
-            placeholders={
-                browser_masters._CREATE_URL_INPUT_PLACEHOLDER: _FakeLocatorHandle()
+            locators={
+                browser_masters._CREATE_URL_INPUT_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                ),
             },
-            role_elements=[],
         )
 
         with self.assertRaises(BrowserSessionError):
             browser_masters._fill_landing_url(page, "https://ksamata.ru/")
-
-    def test_does_not_click_a_decoy_whose_name_only_contains_the_button_text(self):
-        # A decoy element whose accessible name merely CONTAINS
-        # _CREATE_NEXT_BUTTON_TEXT (e.g. "Далее по списку") must NOT be
-        # treated as a match — exact=True requires exact equality.
-        decoy_clicked = []
-        page = FakePage(
-            placeholders={
-                browser_masters._CREATE_URL_INPUT_PLACEHOLDER: _FakeLocatorHandle()
-            },
-            role_elements=[
-                (
-                    "button",
-                    f"{browser_masters._CREATE_NEXT_BUTTON_TEXT} по списку",
-                    _FakeTextLocatorHandle(
-                        visible=True, on_click=lambda: decoy_clicked.append(True)
-                    ),
-                )
-            ],
-        )
-
-        with self.assertRaises(BrowserSessionError):
-            browser_masters._fill_landing_url(page, "https://ksamata.ru/")
-        self.assertEqual(decoy_clicked, [])
 
     def test_raises_on_invalid_url_format_error(self):
         page = self._page(error_visible=True)
@@ -3132,9 +3105,12 @@ class TestCreateMaster(unittest.TestCase):
             get_value=lambda: budget_state.get("value", ""),
         )
 
+        next_button = _FakeLocatorHandle()
+
         page = FakePage(
-            placeholders={browser_masters._CREATE_URL_INPUT_PLACEHOLDER: url_field},
             locators={
+                browser_masters._CREATE_URL_INPUT_TESTID: _FakeLocator([url_field]),
+                browser_masters._CREATE_NEXT_BUTTON_TESTID: _FakeLocator([next_button]),
                 browser_masters._HEADLINES_ADD_INPUT_XPATH: _FakeLocator(
                     [headline_field]
                 ),
@@ -3145,11 +3121,6 @@ class TestCreateMaster(unittest.TestCase):
                 ),
             },
             role_elements=[
-                (
-                    "button",
-                    browser_masters._CREATE_NEXT_BUTTON_TEXT,
-                    _FakeTextLocatorHandle(visible=True),
-                ),
                 ("option", "Москва", _FakeTextLocatorHandle(visible=True)),
                 (
                     "button",


### PR DESCRIPTION
## Summary
- `direct masters add` failed with "Could not find or fill the landing-page URL field" because Yandex replaced step 1's plain `<input placeholder="...">` with a Combobox whose text control is a `contenteditable <div role="textbox">` — `get_by_placeholder()` only matches `<input>`/`<textarea>`, so it silently stopped finding the field.
- Live re-recon (2026-08-02, via `direct playwright login` saved session + confirmed visually with claude-in-chrome) found stable `data-testid` attributes: `CampaignFormUrl.Textinput` for the field, `CampaignFormUrl.button` for "Далее". Switched `_fill_landing_url` to locate both by testid instead of placeholder text/accessible name, and to `.type()` instead of `.fill()` since `.fill()` doesn't work on a contenteditable element.
- Confirmed live: unlike before, "Далее" only renders once the field has text — Playwright's own click-time actionability wait handles this without extra polling, so no explicit wait was added.

## Test plan
- [x] `pytest tests/test_masters.py` (168 passed)
- [x] `pytest` full offline suite (2747 passed, 8 skipped — 62 pre-existing vcrpy/aiohttp errors unrelated to this change, confirmed identical on `main`)
- [x] `black`/`flake8` clean on changed files
- [x] Live read-only recon confirming the new selector against the real create page (no campaign created/saved)

Closes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SJdSi9cJPSdPcqbTsxT8s