### PR TITLE
feat(masters): resolve --region-id via GeoRegions dictionary (#652)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+**Added — `direct masters add --region-id` (#652):**
+
+- New `--region-id` option resolves a numeric `RegionId` to Yandex's
+  canonical `GeoRegionName` via the `GeoRegions` dictionary
+  (`dictionaries.getGeoRegions`), instead of requiring the user to guess the
+  exact wording the "Регион показов" widget accepts. Repeat for multiple
+  regions, same as `--region`. Combines with `--region` — resolved names are
+  appended to any `--region` values given.
+- At least one of `--region`/`--region-id` is now required (previously only
+  `--region`, always required); an unknown `RegionId` raises a `UsageError`
+  pointing at `direct dictionaries get-geo-regions`.
+- Unlike the rest of `direct masters` (which needs no Yandex Direct API
+  credentials — see module docstring), resolving `--region-id` does need
+  valid API credentials, since it makes one `dictionaries.getGeoRegions`
+  call before opening the browser session.
+- Not a breaking change: `--region`'s existing text-based behavior is
+  unchanged.
+
 **Fixed — `direct masters add`: URL field selector (#650):**
 
 - Yandex replaced step 1's plain `<input placeholder="...">` with a Combobox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,15 @@
   pointing at `direct dictionaries get-geo-regions`.
 - Unlike the rest of `direct masters` (which needs no Yandex Direct API
   credentials — see module docstring), resolving `--region-id` does need
-  valid API credentials, since it makes one `dictionaries.getGeoRegions`
-  call before opening the browser session.
+  valid API credentials, since it makes `dictionaries.getGeoRegions`
+  call(s) before opening the browser session.
+- `GeoRegionName` values are not globally unique in Yandex's dictionary
+  (distinct `RegionId`s under different parents can share a name); since
+  the browser-side region widget matches by exact name text with no
+  `RegionId`/parent verification, a `--region-id` that resolves to an
+  ambiguous name now raises a `UsageError` instead of silently risking a
+  live launch against the wrong geography — use `--region` with the fully
+  qualified text for such names.
 - Not a breaking change: `--region`'s existing text-based behavior is
   unchanged.
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ direct masters archive 72349978
 direct masters update 72349978 --weekly-budget 95000
 direct masters update 72349978 --promotion-goal max-clicks --no-directs-helps
 direct masters add https://example.com/ --headline "Заголовок 1" --headline "Заголовок 2" --text "Текст объявления" --region Москва --weekly-budget 50000 --draft
+direct masters add https://example.com/ --headline "Заголовок 1" --text "Текст объявления" --region-id 213 --weekly-budget 50000 --draft
 ```
 
 `masters list` filters by status with `--status`
@@ -87,11 +88,19 @@ suspend/resume above.
 same create wizard a human uses. **It is NOT idempotent** — running it twice
 with the same arguments creates a *second* campaign, not an update to the
 first, since Мастер кампаний has no API-level duplicate detection the way
-`campaigns add` does. `--headline`/`--text`/`--region` are required (repeat
-the flag for multiple values): even though Yandex's own wizard can
-auto-generate headlines/texts by scanning the landing page, `add` refuses to
-silently publish AI-written ad copy you never reviewed — pass the text you
-actually want published. By default the campaign launches immediately; pass
+`campaigns add` does. `--headline`/`--text` are required (repeat the flag
+for multiple values): even though Yandex's own wizard can auto-generate
+headlines/texts by scanning the landing page, `add` refuses to silently
+publish AI-written ad copy you never reviewed — pass the text you actually
+want published. At least one of `--region`/`--region-id` is required
+(repeat for multiple regions, and they combine): `--region` takes Yandex's
+exact region wording as free text, while `--region-id` (issue #652) takes a
+numeric `RegionId` and resolves it to the canonical name via the
+`GeoRegions` dictionary (`direct dictionaries get-geo-regions`) — use
+`--region-id` to avoid guessing the widget's exact text. Unlike the rest of
+`masters`, resolving `--region-id` requires valid Yandex Direct API
+credentials (same chain as any other command). By default the campaign
+launches immediately; pass
 `--draft` to save it as a draft instead (Сохранить как черновик) without
 going live. There is **no `--sandbox`** for this command either — verify with
 `--draft` first and check the result in the web UI before launching for real.
@@ -1121,6 +1130,7 @@ direct masters archive 72349978
 direct masters update 72349978 --weekly-budget 95000
 direct masters update 72349978 --promotion-goal max-clicks --no-directs-helps
 direct masters add https://example.com/ --headline "Заголовок 1" --headline "Заголовок 2" --text "Текст объявления" --region Москва --weekly-budget 50000 --draft
+direct masters add https://example.com/ --headline "Заголовок 1" --text "Текст объявления" --region-id 213 --weekly-budget 50000 --draft
 ```
 
 `masters list` фильтрует по статусу через `--status`
@@ -1172,12 +1182,21 @@ suspend/resume выше.
 wizard создания, что и человек в браузере. **Команда НЕ идемпотентна** —
 повторный запуск с теми же аргументами создаст ВТОРУЮ кампанию, а не обновит
 первую: у Мастера кампаний нет API-уровня для дедупликации, в отличие от
-`campaigns add`. `--headline`/`--text`/`--region` обязательны (повторяйте
-флаг для нескольких значений): хотя wizard Яндекса умеет сам сгенерировать
+`campaigns add`. `--headline`/`--text` обязательны (повторяйте флаг для
+нескольких значений): хотя wizard Яндекса умеет сам сгенерировать
 заголовки/тексты, сканируя посадочную страницу, `add` не станет молча
 публиковать AI-сгенерированный текст, который вы не проверили — передавайте
-явно тот текст, который хотите опубликовать. По умолчанию кампания
-запускается сразу; передайте `--draft`, чтобы сохранить её как черновик
+явно тот текст, который хотите опубликовать. Нужен хотя бы один из
+`--region`/`--region-id` (повторяйте для нескольких регионов, значения
+объединяются): `--region` принимает точную формулировку Яндекса как
+свободный текст, а `--region-id` (issue #652) — числовой `RegionId`,
+который резолвится в каноническое имя через словарь `GeoRegions` (`direct
+dictionaries get-geo-regions`) — используйте `--region-id`, чтобы не
+угадывать точный текст виджета. В отличие от остальных команд `masters`,
+резолвинг `--region-id` требует действительных учётных данных Yandex Direct
+API (та же цепочка приоритетов, что и у любой другой команды). По умолчанию
+кампания запускается сразу; передайте `--draft`, чтобы сохранить её как
+черновик
 («Сохранить как черновик») без запуска. У этой команды тоже **нет
 `--sandbox`** — сначала проверьте с `--draft` и посмотрите результат в
 веб-интерфейсе, прежде чем запускать по-настоящему.

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -736,7 +736,37 @@ def _resolve_region_ids(ctx: click.Context, region_ids: "tuple[int, ...]") -> li
             f"{', '.join(str(m) for m in missing)} — check `direct "
             "dictionaries get-geo-regions` for valid IDs."
         )
-    return [found[rid] for rid in region_ids]
+
+    # Yandex's GeoRegions names are not globally unique (distinct IDs under
+    # different parents can share a name, e.g. several "Сосновка" entries).
+    # `_set_region` matches the browser widget's autocomplete by exact name
+    # text and clicks the first visible option with no RegionId/parent
+    # verification, so a resolved name that is ambiguous in the full
+    # dictionary could silently select the wrong region before an immediate
+    # live launch (issue #652 follow-up). Check each resolved name against
+    # every GeoRegions entry (not just the requested IDs) and refuse rather
+    # than guess.
+    all_regions = client.dictionaries().post(
+        data={
+            "method": "getGeoRegions",
+            "params": {"FieldNames": ["GeoRegionId", "GeoRegionName"]},
+        }
+    )
+    name_owners = {}
+    for item in all_regions.data["result"]["GeoRegions"]:
+        name_owners.setdefault(item["GeoRegionName"], set()).add(item["GeoRegionId"])
+
+    resolved = [found[rid] for rid in region_ids]
+    ambiguous = sorted({name for name in resolved if len(name_owners[name]) > 1})
+    if ambiguous:
+        raise click.UsageError(
+            "--region-id resolved to ambiguous region name(s): "
+            f"{', '.join(ambiguous)} — multiple RegionIds share this name "
+            "in Yandex's GeoRegions dictionary, so the region widget cannot "
+            "be matched reliably. Use --region with the fully qualified "
+            "text instead."
+        )
+    return resolved
 
 
 @masters.command()

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -743,20 +743,25 @@ def _resolve_region_ids(ctx: click.Context, region_ids: "tuple[int, ...]") -> li
     # text and clicks the first visible option with no RegionId/parent
     # verification, so a resolved name that is ambiguous in the full
     # dictionary could silently select the wrong region before an immediate
-    # live launch (issue #652 follow-up). Check each resolved name against
-    # every GeoRegions entry (not just the requested IDs) and refuse rather
-    # than guess.
-    all_regions = client.dictionaries().post(
+    # live launch (issue #652 follow-up). Look up every GeoRegions entry
+    # sharing one of the resolved names (SelectionCriteria is mandatory per
+    # the WSDL — GetGeoRegionsRequest.SelectionCriteria has minOccurs=1 — so
+    # ExactNames must be supplied) and refuse rather than guess if any name
+    # has more than one distinct owning RegionId.
+    resolved = [found[rid] for rid in region_ids]
+    name_check = client.dictionaries().post(
         data={
             "method": "getGeoRegions",
-            "params": {"FieldNames": ["GeoRegionId", "GeoRegionName"]},
+            "params": {
+                "FieldNames": ["GeoRegionId", "GeoRegionName"],
+                "SelectionCriteria": {"ExactNames": sorted(set(resolved))},
+            },
         }
     )
     name_owners = {}
-    for item in all_regions.data["result"]["GeoRegions"]:
+    for item in name_check.data["result"]["GeoRegions"]:
         name_owners.setdefault(item["GeoRegionName"], set()).add(item["GeoRegionId"])
 
-    resolved = [found[rid] for rid in region_ids]
     ambiguous = sorted({name for name in resolved if len(name_owners[name]) > 1})
     if ambiguous:
         raise click.UsageError(

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -62,6 +62,7 @@ from typing import Optional
 import click
 from click.core import ParameterSource
 
+from ..api import client_from_ctx, create_client
 from ..browser.masters import PROMOTION_GOAL_CHOICES as _PROMOTION_GOAL_CHOICES
 from ..output import (
     format_output,
@@ -703,6 +704,41 @@ def archive(
         )
 
 
+def _resolve_region_ids(ctx: click.Context, region_ids: "tuple[int, ...]") -> list:
+    """Resolve RegionId values to Yandex's canonical GeoRegionName via the
+    GeoRegions dictionary — the exact text the Мастер кампаний region widget
+    accepts, so callers don't have to guess Yandex's own wording (issue #652).
+
+    Unlike the rest of this group (see module docstring — masters needs no
+    Yandex Direct API credentials), this one lookup does require valid API
+    credentials, resolved the same way as any other command: it is only
+    reached when the caller actually passes ``--region-id``.
+    """
+    if not region_ids:
+        return []
+    client = client_from_ctx(ctx, create_client)
+    body = {
+        "method": "getGeoRegions",
+        "params": {
+            "FieldNames": ["GeoRegionId", "GeoRegionName"],
+            "SelectionCriteria": {"RegionIds": list(region_ids)},
+        },
+    }
+    result = client.dictionaries().post(data=body)
+    found = {
+        item["GeoRegionId"]: item["GeoRegionName"]
+        for item in result.data["result"]["GeoRegions"]
+    }
+    missing = [rid for rid in region_ids if rid not in found]
+    if missing:
+        raise click.UsageError(
+            "Unknown --region-id value(s): "
+            f"{', '.join(str(m) for m in missing)} — check `direct "
+            "dictionaries get-geo-regions` for valid IDs."
+        )
+    return [found[rid] for rid in region_ids]
+
+
 @masters.command()
 @click.argument("url")
 @click.option(
@@ -723,8 +759,18 @@ def archive(
     "--region",
     "regions",
     multiple=True,
-    required=True,
-    help="Display region (Регион показов) — repeat for multiple",
+    help="Display region (Регион показов) by exact Yandex wording — repeat "
+    "for multiple. At least one of --region/--region-id is required.",
+)
+@click.option(
+    "--region-id",
+    "region_ids",
+    multiple=True,
+    type=int,
+    help="Display region by RegionId (GeoRegions dictionary) — repeat for "
+    "multiple, resolved to Yandex's canonical region name via `direct "
+    "dictionaries get-geo-regions`. Requires Yandex Direct API credentials "
+    "(unlike the rest of `masters`). Combines with --region.",
 )
 @click.option(
     "--weekly-budget",
@@ -747,6 +793,7 @@ def add(
     headlines,
     texts,
     regions,
+    region_ids,
     weekly_budget,
     draft,
     headful,
@@ -761,7 +808,8 @@ def add(
     SECOND campaign, not an update to the first — Мастер кампаний has no
     API-level duplicate detection the way `campaigns add` does. There is no
     sandbox and no rollback for Мастер кампаний mutations (issue #632) —
-    double check --region/--headline/--text before running this for real.
+    double check --region/--region-id/--headline/--text before running this
+    for real.
 
     --headline/--text are required even though Yandex's own wizard can
     auto-generate them by scanning the landing page: this command refuses
@@ -769,11 +817,22 @@ def add(
     the AI-suggested text, open the wizard once in a browser, copy what it
     proposes, and pass it back explicitly.
 
+    At least one of --region/--region-id is required. --region-id is
+    resolved to Yandex's canonical region name via the GeoRegions dictionary
+    (issue #652) — use it instead of --region to avoid guessing the exact
+    wording the region widget expects; it requires Yandex Direct API
+    credentials, unlike the rest of this command.
+
     By default the campaign is launched immediately (--launch). Pass
     --draft to save it as a draft instead (Сохранить как черновик) without
     going live.
     """
     from ..browser.masters import create_master
+
+    if not regions and not region_ids:
+        raise click.UsageError("At least one of --region/--region-id is required.")
+
+    all_regions = list(regions) + _resolve_region_ids(ctx, region_ids)
 
     result = _with_session(
         ctx,
@@ -785,7 +844,7 @@ def add(
             url,
             headlines=list(headlines),
             texts=list(texts),
-            regions=list(regions),
+            regions=all_regions,
             weekly_budget=weekly_budget,
             launch=not draft,
         ),

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -3597,6 +3597,13 @@ class TestResolveRegionIds(unittest.TestCase):
         self.assertIn("Сосновка", str(cm.exception))
         self.assertIn("--region", str(cm.exception))
 
+        second_call_body = service.post.call_args_list[1].kwargs["data"]
+        self.assertIn("SelectionCriteria", second_call_body["params"])
+        self.assertEqual(
+            second_call_body["params"]["SelectionCriteria"]["ExactNames"],
+            ["Сосновка"],
+        )
+
     def test_unique_region_name_resolves_normally(self):
         """A RegionId whose name has no duplicates elsewhere in the full
         dictionary must still resolve without raising."""

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -21,7 +21,7 @@ additions below for how that replay is faked.
 import json
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import click
 import pytest
@@ -3391,6 +3391,172 @@ class TestMastersAddCommand(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, result.output)
         _, kwargs = mock_create.call_args
         self.assertEqual(kwargs["weekly_budget"], 50000)
+
+    def test_region_or_region_id_is_required(self):
+        result = self.runner.invoke(
+            cli,
+            [
+                "masters",
+                "add",
+                "https://ksamata.ru/",
+                "--headline",
+                "h",
+                "--text",
+                "t",
+            ],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("--region/--region-id", result.output)
+
+    def test_region_id_resolves_via_geo_regions_dictionary(self):
+        service = Mock()
+        service.post.return_value = Mock(
+            data={
+                "result": {
+                    "GeoRegions": [{"GeoRegionId": 213, "GeoRegionName": "Москва"}]
+                }
+            }
+        )
+        client = Mock()
+        client.dictionaries.return_value = service
+
+        with (
+            patch("direct_cli.browser.masters.create_master") as mock_create,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+            patch("direct_cli.commands.masters.create_client", return_value=client),
+        ):
+            mock_create.return_value = {"Launched": True}
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            result = self.runner.invoke(
+                cli,
+                [
+                    "masters",
+                    "add",
+                    "https://ksamata.ru/",
+                    "--headline",
+                    "h",
+                    "--text",
+                    "t",
+                    "--region-id",
+                    "213",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        service.post.assert_called_once()
+        body = service.post.call_args.kwargs["data"]
+        self.assertEqual(body["method"], "getGeoRegions")
+        self.assertEqual(body["params"]["SelectionCriteria"]["RegionIds"], [213])
+        _, kwargs = mock_create.call_args
+        self.assertEqual(kwargs["regions"], ["Москва"])
+
+    def test_region_and_region_id_combine(self):
+        service = Mock()
+        service.post.return_value = Mock(
+            data={
+                "result": {
+                    "GeoRegions": [
+                        {"GeoRegionId": 2, "GeoRegionName": "Санкт-Петербург"}
+                    ]
+                }
+            }
+        )
+        client = Mock()
+        client.dictionaries.return_value = service
+
+        with (
+            patch("direct_cli.browser.masters.create_master") as mock_create,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+            patch("direct_cli.commands.masters.create_client", return_value=client),
+        ):
+            mock_create.return_value = {"Launched": True}
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            result = self.runner.invoke(
+                cli,
+                [
+                    "masters",
+                    "add",
+                    "https://ksamata.ru/",
+                    "--headline",
+                    "h",
+                    "--text",
+                    "t",
+                    "--region",
+                    "Москва",
+                    "--region-id",
+                    "2",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        _, kwargs = mock_create.call_args
+        self.assertEqual(kwargs["regions"], ["Москва", "Санкт-Петербург"])
+
+    def test_unknown_region_id_raises_usage_error(self):
+        service = Mock()
+        service.post.return_value = Mock(data={"result": {"GeoRegions": []}})
+        client = Mock()
+        client.dictionaries.return_value = service
+
+        with (
+            patch("direct_cli.browser.masters.create_master") as mock_create,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+            patch("direct_cli.commands.masters.create_client", return_value=client),
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            result = self.runner.invoke(
+                cli,
+                [
+                    "masters",
+                    "add",
+                    "https://ksamata.ru/",
+                    "--headline",
+                    "h",
+                    "--text",
+                    "t",
+                    "--region-id",
+                    "999999",
+                ],
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Unknown --region-id value(s): 999999", result.output)
+        mock_create.assert_not_called()
+
+
+class TestResolveRegionIds(unittest.TestCase):
+    """Unit tests for `_resolve_region_ids` (issue #652)."""
+
+    def test_empty_region_ids_skips_api_call(self):
+        from direct_cli.commands.masters import _resolve_region_ids
+
+        with patch("direct_cli.commands.masters.create_client") as mock_create_client:
+            result = _resolve_region_ids(Mock(), ())
+
+        self.assertEqual(result, [])
+        mock_create_client.assert_not_called()
+
+    def test_resolves_multiple_ids_preserving_order(self):
+        from direct_cli.commands.masters import _resolve_region_ids
+
+        service = Mock()
+        service.post.return_value = Mock(
+            data={
+                "result": {
+                    "GeoRegions": [
+                        {"GeoRegionId": 2, "GeoRegionName": "Санкт-Петербург"},
+                        {"GeoRegionId": 213, "GeoRegionName": "Москва"},
+                    ]
+                }
+            }
+        )
+        client = Mock()
+        client.dictionaries.return_value = service
+
+        with patch("direct_cli.commands.masters.create_client", return_value=client):
+            result = _resolve_region_ids(Mock(), (213, 2))
+
+        self.assertEqual(result, ["Москва", "Санкт-Петербург"])
 
 
 if __name__ == "__main__":

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -3443,8 +3443,7 @@ class TestMastersAddCommand(unittest.TestCase):
             )
 
         self.assertEqual(result.exit_code, 0, result.output)
-        service.post.assert_called_once()
-        body = service.post.call_args.kwargs["data"]
+        body = service.post.call_args_list[0].kwargs["data"]
         self.assertEqual(body["method"], "getGeoRegions")
         self.assertEqual(body["params"]["SelectionCriteria"]["RegionIds"], [213])
         _, kwargs = mock_create.call_args
@@ -3557,6 +3556,79 @@ class TestResolveRegionIds(unittest.TestCase):
             result = _resolve_region_ids(Mock(), (213, 2))
 
         self.assertEqual(result, ["Москва", "Санкт-Петербург"])
+
+    def test_ambiguous_region_name_raises_usage_error(self):
+        """Two distinct RegionIds sharing one GeoRegionName must not resolve
+        silently — `_set_region`'s browser-side exact-name match would click
+        whichever same-named option appears first, risking a live launch
+        against the wrong geography (issue #652 follow-up)."""
+        from direct_cli.commands.masters import _resolve_region_ids
+
+        service = Mock()
+        service.post.side_effect = [
+            Mock(
+                data={
+                    "result": {
+                        "GeoRegions": [
+                            {"GeoRegionId": 111, "GeoRegionName": "Сосновка"}
+                        ]
+                    }
+                }
+            ),
+            Mock(
+                data={
+                    "result": {
+                        "GeoRegions": [
+                            {"GeoRegionId": 111, "GeoRegionName": "Сосновка"},
+                            {"GeoRegionId": 222, "GeoRegionName": "Сосновка"},
+                        ]
+                    }
+                }
+            ),
+        ]
+        client = Mock()
+        client.dictionaries.return_value = service
+
+        with patch("direct_cli.commands.masters.create_client", return_value=client):
+            with self.assertRaises(click.UsageError) as cm:
+                _resolve_region_ids(Mock(), (111,))
+
+        self.assertIn("ambiguous", str(cm.exception).lower())
+        self.assertIn("Сосновка", str(cm.exception))
+        self.assertIn("--region", str(cm.exception))
+
+    def test_unique_region_name_resolves_normally(self):
+        """A RegionId whose name has no duplicates elsewhere in the full
+        dictionary must still resolve without raising."""
+        from direct_cli.commands.masters import _resolve_region_ids
+
+        service = Mock()
+        service.post.side_effect = [
+            Mock(
+                data={
+                    "result": {
+                        "GeoRegions": [{"GeoRegionId": 213, "GeoRegionName": "Москва"}]
+                    }
+                }
+            ),
+            Mock(
+                data={
+                    "result": {
+                        "GeoRegions": [
+                            {"GeoRegionId": 213, "GeoRegionName": "Москва"},
+                            {"GeoRegionId": 2, "GeoRegionName": "Санкт-Петербург"},
+                        ]
+                    }
+                }
+            ),
+        ]
+        client = Mock()
+        client.dictionaries.return_value = service
+
+        with patch("direct_cli.commands.masters.create_client", return_value=client):
+            result = _resolve_region_ids(Mock(), (213,))
+
+        self.assertEqual(result, ["Москва"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `masters add --region` required the caller to guess Yandex's exact autocomplete wording for the "Регион показов" widget. Adds `--region-id` (repeatable, numeric `RegionId`), resolved to the canonical `GeoRegionName` via `dictionaries.getGeoRegions` — mirroring the numeric-`RegionId` pattern already used by `adgroups add/update --region-ids`.
- `--region-id` combines with `--region` (resolved names are appended); at least one of the two is now required (previously `--region` alone was `required=True`).
- Unknown `RegionId` raises a `UsageError` pointing at `direct dictionaries get-geo-regions`.
- Not a breaking change: `--region`'s existing free-text behavior is unchanged.

## Why draft
This is scoped to the CLI/resolver layer only — `_set_region` itself (the browser-side widget interaction in `direct_cli/browser/masters.py`) is untouched. Issue #653 (branch `fix/653-masters-add-step2-selectors`) is expected to replace that text-combobox widget with a tree-based `RegionsTreeEditor` selector; at time of writing #653 has not yet touched `_set_region` (only step 1's URL field). Keeping this draft until #653 lands or its region-widget shape is confirmed, so the integration point (resolved name vs. tree node/path) can be re-checked before merge.

## Test plan
- [x] `pytest tests/test_masters.py -q` — 174 passed (includes 6 new tests for `_resolve_region_ids` and CLI wiring)
- [x] `pytest -q --ignore=tests/test_read_cassettes.py --ignore=tests/test_integration_write.py` — full offline suite green (the two ignored modules have pre-existing unrelated `AttributeError` failures confirmed present on `main` before this change)
- [x] `black`/`flake8` clean on changed files
- [ ] Live browser smoke — deferred until #653's `_set_region` shape is known

Closes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)