### PR TITLE
fix(masters): update `masters add` step-2 selectors for new markup (#653)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,50 @@
   the field has text — Playwright's own click-time actionability wait
   handles this without extra polling.
 
+**Fixed — `direct masters add`: step 2 selectors (#653):**
+
+- With #650's step-1 fix in place, `masters add` reached step 2 and failed
+  there instead: headlines, texts and the region field had all migrated to
+  new markup. Live re-recon (2026-08-02) confirmed each one.
+- **Headlines/texts** are no longer a single "current variant" input plus an
+  "add another" control. Yandex now pre-renders a FIXED set of
+  `contenteditable` slots (5 headlines, 3 texts) addressed by stable
+  `data-testid`s (`CampaignTitles{N}.textarea` / `CampaignTexts{N}.textarea`),
+  mostly AI-pre-filled from the landing page. Each value is now typed into
+  its own slot by index, and read back via `inner_text()` (a
+  `contenteditable` `<div>` has no `value`). Passing more values than there
+  are slots is now a clear error instead of a silent drop.
+- Each slot is **cleared before typing**: it arrives pre-filled with Yandex's
+  AI-generated copy and `.type()` appends from wherever the click left the
+  caret, so without this the value was spliced into the middle of Yandex's
+  text (confirmed live as `Центр оздоровления и китайско<typed>й гимнастики
+  цигун!`) and the campaign would have been drafted with mangled ad copy.
+- **Region** moved from a text combobox with autocomplete to a tree/tag-group
+  widget (`RegionsTreeTagGroup`), which needed a genuinely different
+  selection flow, not a new selector for the old one: open the popup via its
+  launcher, type into the separate filter field that only exists while the
+  popup is open, then tick the checkbox whose label is an EXACT match —
+  typing a region auto-expands its parents and children, so a "contains"
+  match would select the wrong node. Selected regions are read back from the
+  widget's tags rather than from an input's value.
+- The region click targets the **label**, not the `<input>` it wraps: the
+  input resolves and even reports `is_visible() == True`, but clicking it
+  times out on Playwright's actionability check, since the real hit target is
+  the styled label. The input is still used to read state back — a label
+  click toggles, so the read-back confirms the region really ended up
+  selected instead of silently unchecking an already-selected one.
+- The open→filter→select sequence is retried, and each retry starts from a
+  known state: the launcher toggles the popup (so it is only clicked when the
+  popup is closed) and typing appends to a `contenteditable` (so the filter
+  field is cleared before every retype). Without both, retries could only
+  ever be no-ops.
+- A step-2 timeout now reports whether the page is still on step 1 (Yandex
+  still scanning the landing page) or already past it (markup change),
+  instead of leaving `--headful` as the only way to tell.
+- Re-verified live and left unchanged: weekly budget, "Директ помогает" and
+  "Цель продвижения" still render under real headings, so their existing
+  heading-proximity locators were not broken by this migration.
+
 ## 0.5.1
 
 **Added — `direct masters archive` (#633):**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,17 @@
 - The `browser` extra now requires **`playwright>=1.44`** (was `>=1.40`):
   clearing a slot uses the `ControlOrMeta` modifier, which older versions
   reject server-side with `Unknown modifier`.
+- A click failure on an **unused** slot (no caller-supplied value for it) is
+  now fatal too, not a soft skip — a click failure does not distinguish
+  "not rendered" from "obstructed but still holding AI-generated copy".
+- The headline/text state check now runs **before** the terminal
+  "Запустить кампанию"/"Сохранить как черновик" click, not only after: a
+  clear that reports success without exception (a prevented Backspace, a
+  lost selection, a rerender) can leave a slot's stale text intact, and
+  `.type()` would append onto it rather than replace it. `create_master`
+  now refuses to click the terminal button at all if the headline/text
+  slots don't already match what was requested, instead of publishing the
+  mismatch and only reporting it afterward.
 - **Region** moved from a text combobox with autocomplete to a tree/tag-group
   widget (`RegionsTreeTagGroup`), which needed a genuinely different
   selection flow, not a new selector for the old one: open the popup via its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,11 +33,26 @@
   its own slot by index, and read back via `inner_text()` (a
   `contenteditable` `<div>` has no `value`). Passing more values than there
   are slots is now a clear error instead of a silent drop.
-- Each slot is **cleared before typing**: it arrives pre-filled with Yandex's
-  AI-generated copy and `.type()` appends from wherever the click left the
-  caret, so without this the value was spliced into the middle of Yandex's
-  text (confirmed live as `Центр оздоровления и китайско<typed>й гимнастики
-  цигун!`) and the campaign would have been drafted with mangled ad copy.
+- **Every** slot is **cleared before typing** — not just the ones being
+  filled. Two separate hazards: `.type()` appends from wherever the click
+  left the caret, so an uncleared slot got the value spliced into the middle
+  of Yandex's text (confirmed live as `Центр оздоровления и китайско<typed>й
+  гимнастики цигун!`); and every non-empty slot is a *published ad variant*,
+  so leaving the unused ones pre-filled meant a single `--headline` launched
+  that headline plus four AI-written ones the caller never reviewed. Both
+  violate this module's contract of never publishing unreviewed copy on a
+  page with no sandbox and no rollback.
+- A slot that cannot be cleared is now a **hard error** instead of a silent
+  best-effort skip: the terminal "Запустить кампанию" click happens before
+  any read-back, so a swallowed clear failure would have shipped mangled
+  copy and only reported an uncertain result afterwards.
+- `_verify_created` now also rejects **unrequested** headline/text variants,
+  not just missing ones. The previous membership-only check ("is each
+  requested value present?") passed while AI-generated leftovers sat in the
+  remaining slots.
+- The `browser` extra now requires **`playwright>=1.44`** (was `>=1.40`):
+  clearing a slot uses the `ControlOrMeta` modifier, which older versions
+  reject server-side with `Unknown modifier`.
 - **Region** moved from a text combobox with autocomplete to a tree/tag-group
   widget (`RegionsTreeTagGroup`), which needed a genuinely different
   selection flow, not a new selector for the old one: open the popup via its

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -352,7 +352,7 @@ def _xpath_literal(value: str) -> str:
     return "concat(" + ', "\'", '.join(f"'{part}'" for part in parts) + ")"
 
 
-def _clear_text_field(field: Any) -> None:
+def _clear_text_field(field: Any) -> bool:
     """Empty a focused contenteditable field via select-all + Backspace.
 
     ``.fill("")`` does not work on the ``contenteditable`` ``<div
@@ -360,15 +360,25 @@ def _clear_text_field(field: Any) -> None:
     ``.type()`` over ``.fill()`` everywhere else in this module), and
     ``.type()`` APPENDS — so any retry that re-types into a field must clear
     it first or it accumulates text (``"МоскваМосква"``) that matches
-    nothing. ``ControlOrMeta`` keeps this correct on both macOS and Linux.
+    nothing. ``ControlOrMeta`` keeps this correct on both macOS and Linux,
+    but it only exists from Playwright 1.44 — older versions reject it
+    server-side with ``Unknown modifier`` (hence the floor in
+    ``pyproject.toml``).
 
-    Best-effort: a field that refuses the key presses is left as-is rather
-    than aborting the caller, since the caller's own poll/verify step is
-    what ultimately decides success.
+    Returns whether the field was actually cleared. Callers that go on to
+    ``.type()`` into a PRE-FILLED slot must treat ``False`` as fatal: typing
+    after a failed clear splices the caller's value into Yandex's own copy,
+    and ``create_master`` clicks Launch before it re-reads anything, so the
+    mangled variant would ship on a page with no rollback (issue #655
+    review). Callers that merely re-type into a scratch filter field (the
+    region popup) can retry instead, since their own poll decides success.
     """
-    with contextlib.suppress(PlaywrightError):
+    try:
         field.press("ControlOrMeta+a")
         field.press("Backspace")
+    except PlaywrightError:
+        return False
+    return True
 
 
 # XPath fragment: the checkbox immediately following the "Директ помогает"
@@ -1315,13 +1325,24 @@ def _add_repeating_values(
     slot in order via ``.click()`` + ``.type()`` instead.
 
     Confirmed live these sections start pre-populated by Yandex's own AI
-    scan of the landing page (see module docstring), so each slot is CLEARED
-    before typing — ``.type()`` appends from wherever the click left the
-    caret, which otherwise splices the caller's value into the middle of
-    Yandex's copy instead of replacing it. Callers
-    whose values would overflow ``slot_count`` (more values than available
-    slots) get a hard error rather than a silent drop, since Мастер
-    кампаний has no rollback (module docstring's "no sandbox" risk).
+    scan of the landing page (see module docstring), so EVERY slot is
+    CLEARED — not just the ``len(values)`` being written. Two distinct
+    reasons, both found by the issue #655 review:
+
+    * ``.type()`` appends from wherever the click left the caret, so a slot
+      that is not cleared first gets the caller's value spliced into the
+      middle of Yandex's copy rather than replacing it.
+    * every non-empty slot is a PUBLISHED ad variant, so leaving the unused
+      trailing slots pre-filled would launch the caller's headline plus the
+      leftover AI-written ones they never reviewed — precisely what
+      ``create_master``'s contract refuses to do.
+
+    A slot that cannot be cleared is fatal rather than best-effort: typing
+    after a failed clear produces mangled copy, and ``create_master`` clicks
+    the terminal button before it re-reads anything. Callers whose values
+    would overflow ``slot_count`` (more values than available slots) get a
+    hard error rather than a silent drop, since Мастер кампаний has no
+    rollback (module docstring's "no sandbox" risk).
     """
     if len(values) > slot_count:
         raise BrowserSessionError(
@@ -1331,16 +1352,50 @@ def _add_repeating_values(
             "hand first (--headful)."
         )
 
-    for index, value in enumerate(values):
+    # EVERY slot is cleared, not just the ``len(values)`` being filled: each
+    # non-empty slot is a published ad variant, and most of them arrive
+    # pre-filled with Yandex's AI scan of the landing page. Clearing only the
+    # slots we write would launch the caller's headline PLUS the leftover
+    # AI-written ones they never reviewed — exactly what this module's
+    # contract refuses to do (see create_master's docstring), on a page with
+    # no sandbox and no rollback (issue #655 review).
+    for index in range(slot_count):
         selector = f'[data-testid="{testid_template.format(index=index)}"]'
         field = page.locator(selector).first
+        value = values[index] if index < len(values) else None
         try:
             field.click()
             # The slot arrives pre-filled with Yandex's AI-generated copy and
             # type() appends from wherever the click put the caret, so without
             # this the value lands INSIDE the existing text (confirmed live:
             # "Центр оздоровления и китайско<typed>й гимнастики цигун!").
-            _clear_text_field(field)
+            cleared = _clear_text_field(field)
+        except PlaywrightError as exc:
+            if value is None:
+                # A trailing slot that cannot even be focused is not
+                # necessarily fatal — it may simply not be rendered. Verify
+                # below catches it if it did hold copy.
+                continue
+            raise BrowserSessionError(
+                f"Could not add {value!r} via the create page's field at "
+                f"{selector!r} — Yandex may have changed the page's markup. "
+                "Re-run with --headful to inspect the page."
+            ) from exc
+
+        if not cleared:
+            raise BrowserSessionError(
+                f"Could not clear the create page's field at {selector!r} "
+                "before typing. Typing into a slot that still holds Yandex's "
+                "AI-generated copy would splice the two together and launch "
+                "ad copy you never reviewed, so this aborts instead. This "
+                "usually means Playwright is older than 1.44 (the version "
+                "that added the 'ControlOrMeta' modifier) — upgrade with "
+                "'pip install -U playwright'."
+            )
+
+        if value is None:
+            continue
+        try:
             field.type(value)
         except PlaywrightError as exc:
             raise BrowserSessionError(
@@ -1625,6 +1680,11 @@ def _verify_created(
     """
     mismatches = []
 
+    # Both directions matter. A missing value means the form did not take
+    # what was asked for; an EXTRA non-empty value means a slot still holds
+    # Yandex's AI-generated copy, which ships as a published ad variant the
+    # caller never reviewed (issue #655 review). Checking only membership
+    # let the latter through silently.
     actual_headlines = _read_repeating_values(
         page, _HEADLINES_TESTID_TEMPLATE, _HEADLINES_SLOT_COUNT
     )
@@ -1634,6 +1694,13 @@ def _verify_created(
                 f"headline {headline!r} not found among current values "
                 f"{actual_headlines!r}"
             )
+    extra_headlines = [v for v in actual_headlines if v and v not in headlines]
+    if extra_headlines:
+        mismatches.append(
+            f"unrequested headline variants still on the page: "
+            f"{extra_headlines!r} — these are Yandex's AI-generated copy and "
+            "would be published alongside yours"
+        )
 
     actual_texts = _read_repeating_values(
         page, _TEXTS_TESTID_TEMPLATE, _TEXTS_SLOT_COUNT
@@ -1643,6 +1710,13 @@ def _verify_created(
             mismatches.append(
                 f"text {text!r} not found among current values {actual_texts!r}"
             )
+    extra_texts = [v for v in actual_texts if v and v not in texts]
+    if extra_texts:
+        mismatches.append(
+            f"unrequested ad-text variants still on the page: {extra_texts!r} "
+            "— these are Yandex's AI-generated copy and would be published "
+            "alongside yours"
+        )
 
     if weekly_budget is not None:
         field = page.locator(_WEEKLY_BUDGET_INPUT_XPATH).first

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -1662,37 +1662,32 @@ def _click_terminal_button(page: "Page", text: str) -> None:
     )
 
 
-def _verify_created(
-    page: "Page",
-    *,
-    headlines: List[str],
-    texts: List[str],
-    weekly_budget: Optional[int],
-) -> None:
-    """Confirm the fields this module actually set are still present after the
-    terminal click, rather than trusting the click alone.
+def _repeating_values_mismatches(
+    page: "Page", *, headlines: List[str], texts: List[str]
+) -> List[str]:
+    """Compare the create page's CURRENT headline/text slot contents against
+    what the caller asked for — the one check both a pre-click gate and the
+    post-click ``_verify_created`` backstop need (issue #655 round-3 review).
 
-    Ported from ``update_master``'s ``_verify_saved`` (issue #631 review
-    finding): a click on "Запустить кампанию"/"Сохранить как черновик" is not
-    proof Yandex accepted the form — client-side validation can reject a
-    value silently. Unlike ``_verify_saved``, this does NOT re-navigate and
-    reload first: issue #632 step 0 recon never confirmed what URL the
-    launch/draft click lands on (module docstring), so there is no known
-    page to reload yet. This re-reads the CURRENT page's fields immediately
-    after the click instead — a strictly weaker check than a real reload,
-    but the strongest one available until a live pass confirms the
-    post-click destination. Region is intentionally NOT verified here even
-    though ``_read_region_tags`` is now live-verified (issue #653): a
-    reload-based verification (mirroring ``_verify_saved``) is a bigger,
-    separately-scoped change than this issue's markup fix.
+    Every round of this issue's review found a NEW way for a slot's true
+    content to diverge from what ``_add_repeating_values`` believes it
+    wrote (a click failure, an unused slot, a keypress that succeeds
+    without actually clearing anything) — but this comparison itself was
+    correct from the start each time. The actual defect was never the
+    check, it was that ``create_master`` only ran it AFTER
+    ``_click_terminal_button`` had already launched the campaign. Sharing
+    this one function between a pre-click gate and the existing post-click
+    read lets one fix close every variant, instead of patching each new
+    way to reach a stale slot one at a time.
+
+    Both directions matter. A missing value means the form did not take
+    what was asked for; an EXTRA non-empty value means a slot still holds
+    Yandex's AI-generated copy, which ships as a published ad variant the
+    caller never reviewed. Checking only membership let the latter through
+    silently (issue #655 review).
     """
     mismatches = []
 
-    # Both directions matter. A missing value means the form did not take
-    # what was asked for; an EXTRA non-empty value means a slot still holds
-    # Yandex's AI-generated copy, which ships as a published ad variant the
-    # caller never reviewed (issue #655 review). Checking only membership
-    # let the latter through silently.
     actual_headlines = _read_repeating_values(
         page, _HEADLINES_TESTID_TEMPLATE, _HEADLINES_SLOT_COUNT
     )
@@ -1725,6 +1720,42 @@ def _verify_created(
             "— these are Yandex's AI-generated copy and would be published "
             "alongside yours"
         )
+
+    return mismatches
+
+
+def _verify_created(
+    page: "Page",
+    *,
+    headlines: List[str],
+    texts: List[str],
+    weekly_budget: Optional[int],
+) -> None:
+    """Confirm the fields this module actually set are still present after the
+    terminal click, rather than trusting the click alone.
+
+    Ported from ``update_master``'s ``_verify_saved`` (issue #631 review
+    finding): a click on "Запустить кампанию"/"Сохранить как черновик" is not
+    proof Yandex accepted the form — client-side validation can reject a
+    value silently. Unlike ``_verify_saved``, this does NOT re-navigate and
+    reload first: issue #632 step 0 recon never confirmed what URL the
+    launch/draft click lands on (module docstring), so there is no known
+    page to reload yet. This re-reads the CURRENT page's fields immediately
+    after the click instead — a strictly weaker check than a real reload,
+    but the strongest one available until a live pass confirms the
+    post-click destination. Region is intentionally NOT verified here even
+    though ``_read_region_tags`` is now live-verified (issue #653): a
+    reload-based verification (mirroring ``_verify_saved``) is a bigger,
+    separately-scoped change than this issue's markup fix.
+
+    This is the BACKSTOP for divergences that only appear as a side effect
+    of the click itself (e.g. Yandex's own post-click validation reverting
+    a field) — ``create_master`` also runs
+    ``_repeating_values_mismatches`` BEFORE the click, which catches every
+    divergence that already existed at click time (see that function's
+    docstring).
+    """
+    mismatches = _repeating_values_mismatches(page, headlines=headlines, texts=texts)
 
     if weekly_budget is not None:
         field = page.locator(_WEEKLY_BUDGET_INPUT_XPATH).first
@@ -1811,6 +1842,26 @@ def create_master(
     _set_region(page, regions)
     if weekly_budget is not None:
         _set_weekly_budget_on_create(page, weekly_budget)
+
+    # Gate the click, don't just report on it afterwards (issue #655
+    # round-3 review): _add_repeating_values believing it wrote the right
+    # values is not the same as the page actually holding them — a click
+    # failure, an unused slot, or a keypress that succeeds without clearing
+    # anything can all leave a slot stale without _add_repeating_values
+    # itself raising. Checking here, before the terminal button, means an
+    # already-live discrepancy is caught before anything is published,
+    # instead of only being reported on by _verify_created afterwards.
+    pre_click_mismatches = _repeating_values_mismatches(
+        page, headlines=headlines, texts=texts
+    )
+    if pre_click_mismatches:
+        raise BrowserSessionError(
+            "Refusing to click the create page's terminal button: before "
+            "clicking, the headline/text slots do not currently hold what "
+            "was requested: " + "; ".join(pre_click_mismatches) + ". Yandex "
+            "may have changed the page's markup, or a slot silently failed "
+            "to clear — re-run with --headful to inspect the page."
+        )
 
     _click_terminal_button(
         page, _LAUNCH_BUTTON_TEXT if launch else _SAVE_DRAFT_BUTTON_TEXT

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -1337,12 +1337,17 @@ def _add_repeating_values(
       leftover AI-written ones they never reviewed — precisely what
       ``create_master``'s contract refuses to do.
 
-    A slot that cannot be cleared is fatal rather than best-effort: typing
-    after a failed clear produces mangled copy, and ``create_master`` clicks
-    the terminal button before it re-reads anything. Callers whose values
-    would overflow ``slot_count`` (more values than available slots) get a
-    hard error rather than a silent drop, since Мастер кампаний has no
-    rollback (module docstring's "no sandbox" risk).
+    A slot that cannot even be clicked, or cannot be cleared, is fatal for
+    EVERY slot — including one with no caller-supplied value. A click
+    failure does not distinguish "not rendered" from "obstructed but still
+    holding Yandex's AI copy" (issue #655 round-2 review, Codex): treating
+    it as safe-to-skip once let a click failure on a populated slot slip
+    through, and ``create_master`` clicks the terminal LAUNCH button before
+    ``_verify_created`` ever re-reads the page — so a skipped-but-populated
+    slot would publish unreviewed copy from a live campaign before anyone
+    found out, with no rollback. Callers whose values would overflow
+    ``slot_count`` (more values than available slots) get a hard error
+    rather than a silent drop, for the same reason.
     """
     if len(values) > slot_count:
         raise BrowserSessionError(
@@ -1371,13 +1376,16 @@ def _add_repeating_values(
             # "Центр оздоровления и китайско<typed>й гимнастики цигун!").
             cleared = _clear_text_field(field)
         except PlaywrightError as exc:
-            if value is None:
-                # A trailing slot that cannot even be focused is not
-                # necessarily fatal — it may simply not be rendered. Verify
-                # below catches it if it did hold copy.
-                continue
+            # Fatal even for an unused slot (``value is None``): a click
+            # failure does not distinguish "not rendered" from "obstructed
+            # but still holding Yandex's AI copy" (issue #655 round-2
+            # review, Codex) — and ``create_master`` clicks the terminal
+            # LAUNCH button before ``_verify_created`` ever re-reads the
+            # page, so a skipped-but-populated slot would publish unreviewed
+            # copy from a live, no-rollback campaign before anyone finds out.
+            target = f"{value!r}" if value is not None else "an unused slot"
             raise BrowserSessionError(
-                f"Could not add {value!r} via the create page's field at "
+                f"Could not add {target} via the create page's field at "
                 f"{selector!r} — Yandex may have changed the page's markup. "
                 "Re-run with --headful to inspect the page."
             ) from exc

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -113,6 +113,20 @@ exact=True)`` instead of a substring ``get_by_text`` match, for the same
 reason ``_set_promotion_goal``/``_click_save`` were fixed: a container whose
 text merely contains the target string is not the same element as an actual
 clickable button/option row.
+
+**Step 2 markup migration (issue #653, re-recon 2026-08-02).** Following
+#650's URL-field fix, live testing found the rest of step 2 had ALSO
+migrated to new markup — headlines/texts moved from a "single current-
+variant input, fill + Enter" flow to a FIXED set of pre-rendered
+contenteditable slots (``CampaignTitles{N}.textarea``/
+``CampaignTexts{N}.textarea``, 5/3 slots respectively, most pre-filled with
+Yandex's AI-generated copy — see ``_add_repeating_values``), and the region
+picker moved from a text combobox with an autocomplete dropdown to a
+tree/tag-group widget (``RegionsTreeEditor``) whose typed filter
+auto-expands every ancestor/descendant of a match — see ``_set_region``.
+Weekly budget, "Директ помогает", and "Цель продвижения" were re-confirmed
+live to still use their pre-#653 heading-proximity XPaths unchanged (they
+were not affected by this markup migration).
 """
 
 import contextlib
@@ -240,30 +254,122 @@ _CREATE_INVALID_URL_TEXT = "Некорректный формат ссылки"
 # content to pre-fill headlines/texts/images), well within this budget.
 _CREATE_STEP2_TIMEOUT_MS = 30_000
 
-# Step 2 field locators — heading-proximity XPath, same convention as
-# update_master's _WEEKLY_BUDGET_INPUT_XPATH etc. (no stable id/data-testid).
-_HEADLINES_ADD_INPUT_XPATH = (
-    "xpath=//*[self::h1 or self::h2 or self::h3][normalize-space(text())="
-    "'Варианты заголовков']/following::input[1]"
+# Step 2 field locators for headlines/texts (issue #653 re-recon,
+# 2026-08-02): Yandex replaced the single "current variant input + Enter"
+# flow with a FIXED set of pre-rendered slots, each its own contenteditable
+# <div role="textbox"> carrying a stable data-testid
+# ``CampaignTitles{N}.textarea``/``CampaignTexts{N}.textarea`` (N = 0-based
+# slot index) — confirmed live via ``document.querySelectorAll('[data-testid]')``
+# on the create page. Confirmed live: exactly 5 headline slots and 3 text
+# slots render, no "add another" control exists — most slots start
+# pre-filled with Yandex's own AI-generated copy from scanning the landing
+# page (see module docstring), only the trailing slots are genuinely empty.
+# The old heading-proximity XPath (matched only h1/h2/h3) silently stopped
+# matching because "Варианты заголовков"/"Варианты текстов объявлений" are
+# plain text nodes on this page, not headings.
+_HEADLINES_SLOT_COUNT = 5
+_TEXTS_SLOT_COUNT = 3
+_HEADLINES_TESTID_TEMPLATE = "CampaignTitles{index}.textarea"
+_TEXTS_TESTID_TEMPLATE = "CampaignTexts{index}.textarea"
+
+# Region picker (issue #653 re-recon, 2026-08-02): Yandex replaced the old
+# text-combobox-with-suggestions flow with a tree/tag-group widget
+# (``data-testid="RegionsTreeEditor"``). Confirmed live: the tag group's
+# ``RegionsTreeTagGroup.launcher`` is a <button>, not a text field — clicking
+# it opens the tree popup AND reveals a SEPARATE contenteditable filter field
+# (``RegionsTreeTagGroup.editor``, only present in the DOM once the popup is
+# open) that must be typed into. Typing filters the tree AND auto-expands
+# every ancestor/descendant of a match (e.g. typing "Москва" also renders
+# "Москва и область" and every district inside Москва) — so selection must
+# scope to a checkbox (``RegionsTreeNode.Checkbox.input``, a real HTML
+# checkbox with a stable ``id="region-node-<id>"`` but no stable id known
+# ahead of time by name) whose LABEL text is an EXACT match, not merely
+# contains the typed region name, same fix class as
+# _set_promotion_goal's get_by_role(exact=True). A selected region renders
+# as a removable tag inside ``RegionsTreeTagGroup.tags-wrapper``.
+_REGION_LAUNCHER_TESTID = '[data-testid="RegionsTreeTagGroup.launcher"]'
+_REGION_EDITOR_TESTID = '[data-testid="RegionsTreeTagGroup.editor"]'
+_REGION_CHECKBOX_TESTID = "RegionsTreeNode.Checkbox.input"
+# How long to poll for the tree's checkbox list after typing a filter —
+# the tree re-filters asynchronously (debounced), so an immediate count()
+# can race it and see zero matches for a region that does exist.
+_REGION_FILTER_TIMEOUT_MS = 8_000
+# How long to wait for the editor field to appear after clicking the
+# launcher (live testing, issue #653: this can occasionally not render on
+# the first click under real network conditions).
+_REGION_EDITOR_APPEAR_TIMEOUT_MS = 3_000
+# How many times to retry the whole open-popup→type→poll sequence per
+# region before giving up — live testing found a single attempt is
+# occasionally not enough (see docstring). Each retry must be IDEMPOTENT to
+# be worth anything: the launcher toggles the popup (so re-clicking it while
+# open closes it) and type() appends to a contenteditable (so re-typing
+# without clearing yields "МоскваМосква", matching nothing) — _set_region
+# therefore only clicks the launcher when the editor is absent, and clears
+# the field via _clear_text_field before every type(). Don't "simplify" that
+# back into an unconditional click + type: it turns attempts 2..N into
+# guaranteed no-ops that only add latency.
+_REGION_OPEN_ATTEMPTS = 3
+# Each accepted region tag also renders a same-prefixed close button
+# (``RegionsTreeTagGroup.tag.{N}.close``, confirmed live) — the
+# ``:not([data-testid$=".close"])`` exclusion keeps _read_region_tags from
+# reading the close button (empty text) as a phantom extra tag.
+_REGION_TAGS_WRAPPER_TESTID = '[data-testid="RegionsTreeTagGroup.tags-wrapper"]'
+_REGION_TAG_TESTID_PATTERN = (
+    '[data-testid^="RegionsTreeTagGroup.tag."]:not([data-testid$=".close"])'
 )
-_TEXTS_ADD_INPUT_XPATH = (
-    "xpath=//*[self::h1 or self::h2 or self::h3][normalize-space(text())="
-    "'Варианты текстов объявлений']/following::textarea[1]"
-    "|xpath=//*[self::h1 or self::h2 or self::h3][normalize-space(text())="
-    "'Варианты текстов объявлений']/following::input[1]"
-)
-_REGION_INPUT_XPATH = (
-    "xpath=//*[self::h1 or self::h2 or self::h3][normalize-space(text())="
-    "'Регион показов']/following::input[1]"
-)
-# XPath fragment: the text input immediately following (as a descendant of an
-# adjacent sibling) the "Недельный бюджет" heading. Confirmed live — see
-# fixture. Headings on this page have no stable id/data-testid, so matching
-# is by heading text, same fragility class as _extract_*/_click_action_button.
+
+# Weekly budget / "Директ помогает" / "Цель продвижения" (issue #653
+# re-recon, 2026-08-02): confirmed live these three still render under
+# genuine h1/h2/h3 headings on the create page (unlike headlines/texts/
+# region above), so the pre-existing heading-proximity XPaths continue to
+# match the correct element — re-confirmed by comparing the XPath match
+# against each field's own data-testid
+# (``BudgetWithSuggest.PriceTextInput``,
+# ``CampaignRecommendationsEditor.AcceptRecommendations.input``,
+# ``CampaignTargetSelect.TargetSelect``) via a live DOM read. Left as-is
+# (heading-proximity XPath, same convention as update_master's
+# _WEEKLY_BUDGET_INPUT_XPATH) rather than switched to data-testid, since
+# they were not broken by the markup change that broke headlines/texts/
+# region.
 _WEEKLY_BUDGET_INPUT_XPATH = (
     "xpath=//*[self::h1 or self::h2 or self::h3][normalize-space(text())="
     "'Недельный бюджет']/following::input[1]"
 )
+
+
+def _xpath_literal(value: str) -> str:
+    """Render ``value`` as a safely-quoted XPath 1.0 string literal.
+
+    XPath 1.0 has no string-escaping mechanism — a value containing both
+    ``'`` and ``"`` cannot be quoted directly. Region names are not expected
+    to contain quotes, but ``concat()``-splitting on ``'`` keeps this
+    correct even if one ever does, rather than building a query that could
+    break out of the literal.
+    """
+    if "'" not in value:
+        return f"'{value}'"
+    parts = value.split("'")
+    return "concat(" + ', "\'", '.join(f"'{part}'" for part in parts) + ")"
+
+
+def _clear_text_field(field: Any) -> None:
+    """Empty a focused contenteditable field via select-all + Backspace.
+
+    ``.fill("")`` does not work on the ``contenteditable`` ``<div
+    role="textbox">`` elements this page uses (same constraint that forces
+    ``.type()`` over ``.fill()`` everywhere else in this module), and
+    ``.type()`` APPENDS — so any retry that re-types into a field must clear
+    it first or it accumulates text (``"МоскваМосква"``) that matches
+    nothing. ``ControlOrMeta`` keeps this correct on both macOS and Linux.
+
+    Best-effort: a field that refuses the key presses is left as-is rather
+    than aborting the caller, since the caller's own poll/verify step is
+    what ultimately decides success.
+    """
+    with contextlib.suppress(PlaywrightError):
+        field.press("ControlOrMeta+a")
+        field.press("Backspace")
+
 
 # XPath fragment: the checkbox immediately following the "Директ помогает"
 # heading. Confirmed live — a plain HTML checkbox, not a custom toggle
@@ -1169,134 +1275,276 @@ def _wait_for_step2(page: "Page") -> None:
                 return
         page.wait_for_timeout(250)
 
+    # Which step the page is actually stuck on changes the diagnosis
+    # entirely, and re-running --headful just to find out is expensive on a
+    # page with no sandbox — so report it in the error itself. Step 1's URL
+    # field is gone from the DOM once step 2 renders, so its presence means
+    # "Далее" never advanced the form.
+    still_on_step1 = False
+    with contextlib.suppress(PlaywrightError):
+        still_on_step1 = bool(page.locator(_CREATE_URL_INPUT_TESTID).count())
+    where = (
+        "The page is still showing step 1 (the URL field), so 'Далее' never "
+        "advanced the form — Yandex may still be scanning the landing page."
+        if still_on_step1
+        else "The page has left step 1, so step 2 rendered but without the "
+        "expected 'Регион показов' section — its markup may have changed."
+    )
+
     raise BrowserSessionError(
         "Timed out waiting for the Мастер кампаний create form's step 2 "
         f"(the 'Регион показов' section) to render within "
-        f"{_CREATE_STEP2_TIMEOUT_MS / 1000:.0f}s. Yandex may be slow to "
-        "scan the landing page, or the page's markup changed — re-run with "
+        f"{_CREATE_STEP2_TIMEOUT_MS / 1000:.0f}s. {where} Re-run with "
         "--headful to inspect the page."
     )
 
 
-def _add_repeating_values(page: "Page", xpath: str, values: List[str]) -> None:
-    """Fill+submit each of ``values`` into a repeating list field (headlines/texts).
+def _add_repeating_values(
+    page: "Page", testid_template: str, slot_count: int, values: List[str]
+) -> None:
+    """Fill each of ``values`` into successive slots of a fixed-size repeating
+    list field (headlines/texts) — issue #653 re-recon, 2026-08-02.
+
+    Yandex replaced the old "single current-variant input, fill + Enter"
+    flow with a FIXED set of pre-rendered contenteditable ``<div
+    role="textbox">`` slots (``testid_template.format(index=N)``, confirmed
+    live via ``CampaignTitles{N}.textarea``/``CampaignTexts{N}.textarea``) —
+    there is no "add another" control, and ``.fill()``/``.press("Enter")``
+    do not work on a contenteditable div (same class of markup change as
+    ``_fill_landing_url``'s URL field, issue #650). This types into each
+    slot in order via ``.click()`` + ``.type()`` instead.
 
     Confirmed live these sections start pre-populated by Yandex's own AI
-    scan of the landing page (see module docstring) — this module does not
-    clear that pre-filled list first; it only ever adds the caller's own
-    values on top, since the create-page's DOM offers no stable "clear all"
-    control and blindly clicking every visible "x" risks removing an
-    unrelated section's items (sitelinks, images) that share the same close
-    icon. Callers who want the AI-generated defaults gone entirely must
-    remove them by hand (``--headful``) before scripting the rest.
+    scan of the landing page (see module docstring), so each slot is CLEARED
+    before typing — ``.type()`` appends from wherever the click left the
+    caret, which otherwise splices the caller's value into the middle of
+    Yandex's copy instead of replacing it. Callers
+    whose values would overflow ``slot_count`` (more values than available
+    slots) get a hard error rather than a silent drop, since Мастер
+    кампаний has no rollback (module docstring's "no sandbox" risk).
     """
-    for value in values:
-        field = page.locator(xpath).first
+    if len(values) > slot_count:
+        raise BrowserSessionError(
+            f"Cannot add {len(values)} values — the create page only "
+            f"renders {slot_count} slots for this field. Reduce the number "
+            "of values, or clear some of Yandex's AI-generated defaults by "
+            "hand first (--headful)."
+        )
+
+    for index, value in enumerate(values):
+        selector = f'[data-testid="{testid_template.format(index=index)}"]'
+        field = page.locator(selector).first
         try:
             field.click()
-            field.fill(value)
-            field.press("Enter")
+            # The slot arrives pre-filled with Yandex's AI-generated copy and
+            # type() appends from wherever the click put the caret, so without
+            # this the value lands INSIDE the existing text (confirmed live:
+            # "Центр оздоровления и китайско<typed>й гимнастики цигун!").
+            _clear_text_field(field)
+            field.type(value)
         except PlaywrightError as exc:
             raise BrowserSessionError(
-                f"Could not add {value!r} via the create page's input at "
-                f"{xpath!r} — Yandex may have changed the page's markup. "
+                f"Could not add {value!r} via the create page's field at "
+                f"{selector!r} — Yandex may have changed the page's markup. "
                 "Re-run with --headful to inspect the page."
             ) from exc
 
 
-def _read_repeating_values(page: "Page", xpath: str) -> List[str]:
-    """Read every value currently entered into a repeating list field.
+def _read_repeating_values(
+    page: "Page", testid_template: str, slot_count: int
+) -> List[str]:
+    """Read every value currently held by a fixed-size repeating list field.
 
     Used by ``_verify_created`` to confirm ``_add_repeating_values`` actually
     persisted each value — mirrors ``update_master``'s ``_read_weekly_budget``
-    etc. Returns whatever the matched inputs currently hold; an unreadable
-    input is treated as an empty string rather than aborting the whole read,
-    since a partial mismatch is exactly what the caller needs to see.
+    etc. Reads each slot's ``.textarea`` contenteditable div via
+    ``inner_text()`` (not ``input_value()`` — a contenteditable div has no
+    ``value`` attribute, same as ``_fill_landing_url``'s field). An
+    unreadable/missing slot is treated as an empty string rather than
+    aborting the whole read, since a partial mismatch is exactly what the
+    caller needs to see.
     """
     values = []
-    locator = page.locator(xpath)
-    try:
-        count = locator.count()
-    except PlaywrightError:
-        return values
-    for i in range(count):
+    for index in range(slot_count):
+        selector = f'[data-testid="{testid_template.format(index=index)}"]'
+        field = page.locator(selector).first
         try:
-            values.append(locator.nth(i).input_value())
+            values.append(field.inner_text())
         except PlaywrightError:
             values.append("")
     return values
 
 
 def _set_region(page: "Page", regions: List[str]) -> None:
-    """Fill the "Регион показов" combobox with each of ``regions``.
+    """Select each of ``regions`` in the "Регион показов" tree/tag widget.
 
-    The one field confirmed live to start genuinely empty (see module
-    docstring) — every other required-looking section has an AI-generated
-    or sane default. Selects each typed region from the dropdown's first
-    matching suggestion, mirroring how a human picks from the combobox
-    rather than typing free text the server may not accept.
+    Issue #653 re-recon, 2026-08-02: Yandex replaced the old text-combobox
+    (a single input with an autocomplete dropdown) with a tree/tag-group
+    widget (``RegionsTreeEditor``/``RegionsTreeTagGroup``) — confirmed live
+    this is the one field that still starts genuinely empty (see module
+    docstring). Clicks the launcher button to open the tree popup (this
+    reveals a SEPARATE contenteditable filter field, ``RegionsTreeTagGroup
+    .editor`` — confirmed live it does not exist in the DOM until the popup
+    is open), types the region name into that field (confirmed live this
+    filters the tree and auto-expands every ancestor/descendant of a text
+    match — e.g. typing "Москва" also renders the parent "Москва и область"
+    and every district inside Москва), then checks the checkbox whose LABEL
+    text is an EXACT match — same fix class as ``update_master``'s
+    ``_set_promotion_goal`` (issue #631 review): a checkbox whose label
+    merely CONTAINS the region name (a parent or child in the auto-expanded
+    tree) is not the same node as the region itself.
 
-    Uses ``get_by_role("option", ...)`` rather than a substring
-    ``get_by_text`` match, same fix as ``update_master``'s
-    ``_set_promotion_goal`` (issue #631 review): a container whose text
-    merely contains the region name is not the same element as the actual
-    clickable suggestion row.
+    The click targets the LABEL, not the ``<input>`` it wraps: confirmed live
+    the input resolves and reports ``is_visible() == True`` but is not
+    actionable (Playwright's click times out on it), since the real hit
+    target is the styled label. The input is still used to READ state — a
+    label click toggles, so an already-checked region would be unchecked, and
+    the read-back confirms the region really ended up selected.
+
+    The open→type→poll sequence is retried up to ``_REGION_OPEN_ATTEMPTS``
+    times, and each retry is idempotent by construction — see that
+    constant's comment for why an unconditional re-click + re-type would
+    make attempts 2..N guaranteed no-ops.
     """
-    field = page.locator(_REGION_INPUT_XPATH).first
     for region in regions:
-        try:
-            field.click()
-            field.fill(region)
-        except PlaywrightError as exc:
-            raise BrowserSessionError(
-                "Could not find or fill the 'Регион показов' field on the "
-                "Мастер кампаний create page — Yandex may have changed the "
-                "page's markup. Re-run with --headful to inspect the page."
-            ) from exc
+        # XPath, not a plain data-testid selector: the tree auto-expands
+        # every ancestor/descendant of a text match (see docstring), so
+        # multiple RegionsTreeNode.Checkbox.label elements can be on screen
+        # at once — this scopes to the one whose FULL text (normalize-space
+        # of the element, not merely its direct text-node children — the
+        # region name is confirmed live to sit inside a nested <span>, so
+        # normalize-space(text()) always evaluates empty and never matches)
+        # equals the target region exactly, then descends to its checkbox.
+        label_xpath = (
+            "xpath=//label[@data-testid='RegionsTreeNode.Checkbox.label']"
+            f"[normalize-space(.)={_xpath_literal(region)}]"
+        )
+        # Click the LABEL, read state from the <input>. Confirmed live (issue
+        # #653): the <input type="checkbox" id="region-node-213"> the label
+        # wraps resolves and even reports is_visible() == True, but clicking
+        # it times out on Playwright's actionability check — it is a custom
+        # control whose real hit target is the styled label, not the input.
+        # Targeting the input directly is exactly why this failed with
+        # "Could not find 'Москва'" even though the locator matched.
+        label = page.locator(label_xpath)
+        checkbox = page.locator(
+            f"{label_xpath}//input[@data-testid='{_REGION_CHECKBOX_TESTID}']"
+        )
 
-        option = page.get_by_role("option", name=region, exact=True)
-        try:
-            count = option.count()
-        except PlaywrightError:
-            count = 0
+        # Live testing (issue #653) found opening the popup and filtering
+        # the tree is flaky under real network conditions — the popup can
+        # fail to render the editor field on the first launcher click, and
+        # the debounced filter can take longer than one poll window to
+        # settle. Rather than a single click + single poll window, this
+        # retries the whole open→type→poll sequence up to
+        # _REGION_OPEN_ATTEMPTS times, so a single stuck attempt doesn't
+        # fail the whole call.
+        #
+        # Each attempt must start from a KNOWN state, not from the previous
+        # attempt's leftovers, or the retry is worse than no retry at all:
+        #   * the launcher toggles the popup, so clicking it again while the
+        #     popup is already open CLOSES it (or is swallowed by the popup
+        #     overlay) — only click it when the editor is absent;
+        #   * type() APPENDS to a contenteditable, so a second type(region)
+        #     on an uncleared field yields "МоскваМосква", which filters the
+        #     tree down to zero nodes and can never match.
         clicked = False
-        for i in range(count):
-            handle = option.nth(i)
+        last_open_exc = None
+        for _ in range(_REGION_OPEN_ATTEMPTS):
+            launcher = page.locator(_REGION_LAUNCHER_TESTID).first
+            editor = page.locator(_REGION_EDITOR_TESTID).first
             try:
-                if not handle.is_visible():
-                    continue
-                handle.click()
-                clicked = True
-                break
-            except PlaywrightError:
+                # The editor only exists in the DOM while the popup is open
+                # (confirmed live), so its presence is the open/closed test.
+                if not editor.count():
+                    launcher.click()
+                editor.click(timeout=_REGION_EDITOR_APPEAR_TIMEOUT_MS)
+                _clear_text_field(editor)
+                editor.type(region)
+            except PlaywrightError as exc:
+                last_open_exc = exc
                 continue
+
+            # The tree re-filters asynchronously (debounced) after typing,
+            # so an immediate count() can race the filter and see zero
+            # matches even for a region that does exist — poll briefly
+            # instead of checking once.
+            deadline = time.monotonic() + _REGION_FILTER_TIMEOUT_MS / 1000
+            count = 0
+            while time.monotonic() < deadline:
+                try:
+                    count = label.count()
+                except PlaywrightError:
+                    count = 0
+                if count:
+                    break
+                page.wait_for_timeout(100)
+            for i in range(count):
+                handle = label.nth(i)
+                try:
+                    if not handle.is_visible():
+                        continue
+                    handle.click()
+                except PlaywrightError:
+                    continue
+                # Clicking a label that is already checked would UNCHECK the
+                # region, so confirm the input actually ended up checked
+                # rather than trusting the click — same read-back convention
+                # as _verify_created/_verify_saved.
+                with contextlib.suppress(PlaywrightError):
+                    if checkbox.nth(i).is_checked():
+                        clicked = True
+                        break
+            if clicked:
+                break
+
         if not clicked:
+            if (
+                last_open_exc is not None
+                and not page.locator(_REGION_LAUNCHER_TESTID).count()
+            ):
+                raise BrowserSessionError(
+                    "Could not find or open the 'Регион показов' field on "
+                    "the Мастер кампаний create page — Yandex may have "
+                    "changed the page's markup. Re-run with --headful to "
+                    "inspect the page."
+                ) from last_open_exc
             raise BrowserSessionError(
-                f"Could not find {region!r} in the 'Регион показов' "
-                "suggestion list on the Мастер кампаний create page — check "
-                "the region name matches Yandex's own wording."
+                f"Could not find {region!r} in the 'Регион показов' tree on "
+                "the Мастер кампаний create page — check the region name "
+                "matches Yandex's own wording."
             )
 
 
 def _read_region_tags(page: "Page") -> List[str]:
-    """Read the "Регион показов" field's currently selected region tags.
+    """Read the "Регион показов" widget's currently selected region tags.
 
-    The combobox is expected to render each accepted selection as a
-    removable tag/chip rather than leaving it in the free-text input (typing
-    and selecting an option clears the input back to empty — confirmed by
-    ``_set_region``'s own click-then-fill-again loop over multiple regions).
-    This function has NOT been live-verified against the actual tag markup
-    (issue #632 step 0 recon was read-only, see module docstring) — it reads
-    the same input's current value as a best-effort fallback, which will
-    only ever reflect the LAST region typed, not the full accepted set. A
-    follow-up live pass must confirm the real tag-list markup and replace
-    this with an accurate reader before trusting multi-region verification.
+    Issue #653 re-recon, 2026-08-02: confirmed live each accepted selection
+    renders as a removable tag inside ``RegionsTreeTagGroup.tags-wrapper``
+    (``RegionsTreeTagGroup.tag.{N}``), replacing the earlier
+    single-input-value best-effort fallback (issue #632 step 0, never
+    live-verified) — this now reads the full accepted set, not just the
+    last region typed.
     """
-    field = page.locator(_REGION_INPUT_XPATH).first
+    wrapper = page.locator(_REGION_TAGS_WRAPPER_TESTID)
     try:
-        return [field.input_value()]
+        count = wrapper.count()
     except PlaywrightError:
         return []
+    if not count:
+        return []
+    tags = page.locator(_REGION_TAG_TESTID_PATTERN)
+    try:
+        tag_count = tags.count()
+    except PlaywrightError:
+        return []
+    values = []
+    for i in range(tag_count):
+        try:
+            values.append(tags.nth(i).inner_text())
+        except PlaywrightError:
+            values.append("")
+    return values
 
 
 def _set_weekly_budget_on_create(page: "Page", amount: int) -> None:
@@ -1370,13 +1618,16 @@ def _verify_created(
     page to reload yet. This re-reads the CURRENT page's fields immediately
     after the click instead — a strictly weaker check than a real reload,
     but the strongest one available until a live pass confirms the
-    post-click destination. Region is intentionally NOT verified here: see
-    ``_read_region_tags``'s docstring for why its reader is not yet reliable
-    enough to gate a hard failure on.
+    post-click destination. Region is intentionally NOT verified here even
+    though ``_read_region_tags`` is now live-verified (issue #653): a
+    reload-based verification (mirroring ``_verify_saved``) is a bigger,
+    separately-scoped change than this issue's markup fix.
     """
     mismatches = []
 
-    actual_headlines = _read_repeating_values(page, _HEADLINES_ADD_INPUT_XPATH)
+    actual_headlines = _read_repeating_values(
+        page, _HEADLINES_TESTID_TEMPLATE, _HEADLINES_SLOT_COUNT
+    )
     for headline in headlines:
         if headline not in actual_headlines:
             mismatches.append(
@@ -1384,7 +1635,9 @@ def _verify_created(
                 f"{actual_headlines!r}"
             )
 
-    actual_texts = _read_repeating_values(page, _TEXTS_ADD_INPUT_XPATH)
+    actual_texts = _read_repeating_values(
+        page, _TEXTS_TESTID_TEMPLATE, _TEXTS_SLOT_COUNT
+    )
     for text in texts:
         if text not in actual_texts:
             mismatches.append(
@@ -1469,8 +1722,10 @@ def create_master(
     _fill_landing_url(page, url)
     _wait_for_step2(page)
 
-    _add_repeating_values(page, _HEADLINES_ADD_INPUT_XPATH, headlines)
-    _add_repeating_values(page, _TEXTS_ADD_INPUT_XPATH, texts)
+    _add_repeating_values(
+        page, _HEADLINES_TESTID_TEMPLATE, _HEADLINES_SLOT_COUNT, headlines
+    )
+    _add_repeating_values(page, _TEXTS_TESTID_TEMPLATE, _TEXTS_SLOT_COUNT, texts)
     _set_region(page, regions)
     if weekly_budget is not None:
         _set_weekly_budget_on_create(page, weekly_budget)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,12 @@ dev = [
     "types-tabulate",
 ]
 browser = [
-    "playwright>=1.40",
+    # >=1.44: `direct masters add` clears the create page's pre-filled
+    # contenteditable slots via the "ControlOrMeta" modifier, which older
+    # versions reject server-side with "Unknown modifier" (issue #655
+    # review). A failed clear there would splice the caller's ad copy into
+    # Yandex's AI-generated text on a page with no rollback.
+    "playwright>=1.44",
     "cryptography>=41",
 ]
 

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -3765,24 +3765,85 @@ class TestCreateMaster(unittest.TestCase):
                 regions=["Москва"],
             )
 
-    def test_raises_when_terminal_click_does_not_actually_save_headline(self):
-        # The launch button is clicked, but re-reading the headline field
-        # afterwards shows the OLD value still in place (e.g. Yandex
-        # silently rejected it) -- this must be a hard error, not a false
-        # success (mirrors update_master's _verify_saved regression test).
+    def test_raises_before_launch_when_a_headline_slot_did_not_actually_clear(
+        self,
+    ):
+        """The terminal button must NOT be clicked if pre-click state is
+        already wrong (issue #655 round-3 review, Codex).
+
+        Every round of this issue's review (1, 2, 3) found a new way for a
+        slot's true content to diverge from what ``_add_repeating_values``
+        believes it wrote — a click failure, an unused slot, a no-op
+        keypress that succeeds without exception. ``_verify_created``
+        already re-reads and compares state correctly; the actual defect was
+        never in the check, it was that ``create_master`` only ran that
+        check AFTER ``_click_terminal_button`` already launched the
+        campaign. This pins the fix at the level that closes ALL variants:
+        the state check must gate the click, not just report on it
+        afterwards.
+
+        Sabotage: slot 0's ``press()`` succeeds without raising (models a
+        prevented Backspace / lost selection / re-render race — issue #655
+        round-3 finding) but never actually clears the field, so
+        ``.type()`` appends onto the stale AI copy instead of replacing it.
+        """
         page, state = self._full_page()
-        # Sabotage: slot 0's headline field never actually reflects the
-        # type() — inner_text() always reads back the stale value, even
-        # though click()/type() succeed without raising (mirrors "Yandex
-        # silently rejected it" — the click alone is not proof of anything).
         stuck_handle = _FakeLocatorHandle(text="Старый заголовок")
-        stuck_handle.type = lambda value, delay=None: None
+        stuck_handle.press = lambda key: None  # succeeds, does nothing
+        stuck_handle.type = lambda value, delay=None: None  # never reflects
         headline_selector = (
             '[data-testid="'
             + browser_masters._HEADLINES_TESTID_TEMPLATE.format(index=0)
             + '"]'
         )
         page._locators[headline_selector] = _FakeLocator([stuck_handle])
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.create_master(
+                page,
+                "https://ksamata.ru/",
+                headlines=["Заголовок"],
+                texts=["Текст объявления"],
+                regions=["Москва"],
+            )
+        # The whole point: caught BEFORE the irreversible click, not after.
+        self.assertEqual(len(state["launch_clicks"]), 0)
+        self.assertIn("before clicking", str(ctx.exception))
+
+    def test_raises_when_terminal_click_does_not_actually_save_headline(self):
+        # The headline field reflects correctly right up until the click,
+        # but Yandex's OWN post-click processing (client-side validation on
+        # submit, not on type) reverts it — the pre-click gate above cannot
+        # catch this, since the field looked correct at check time and only
+        # diverges as a side effect of the click itself. _verify_created
+        # remains the backstop for this case.
+        page, state = self._full_page()
+        stuck_handle = _FakeLocatorHandle(text="Старый заголовок")
+
+        def _type(value, delay=None):
+            stuck_handle._text = value
+
+        stuck_handle.type = _type
+        headline_selector = (
+            '[data-testid="'
+            + browser_masters._HEADLINES_TESTID_TEMPLATE.format(index=0)
+            + '"]'
+        )
+        page._locators[headline_selector] = _FakeLocator([stuck_handle])
+
+        launch_handle = next(
+            handle
+            for role, name, handle in page._role_elements
+            if role == "button" and name == browser_masters._LAUNCH_BUTTON_TEXT
+        )
+        real_on_click = launch_handle._on_click
+
+        def _revert_then_click():
+            stuck_handle._text = "Старый заголовок"
+            if real_on_click is not None:
+                real_on_click()
+
+        launch_handle._on_click = _revert_then_click
 
         with self.assertRaises(BrowserSessionError) as ctx:
             browser_masters.create_master(

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -100,7 +100,7 @@ class _FakeLocatorHandle:
             raise PlaywrightError("element detached")
         return self._visible
 
-    def click(self):
+    def click(self, timeout=None):
         if self._raises:
             raise PlaywrightError("element detached")
         if self._on_click is not None:
@@ -147,6 +147,15 @@ class _FakeLocatorHandle:
         if self._raises:
             raise PlaywrightError("element detached")
         return self._get_checked() if self._get_checked is not None else False
+
+    def count(self):
+        # Playwright's `Locator.first` is itself a Locator, so `.first.count()`
+        # is legal and answers "did the selector match anything?" — 0 when it
+        # matched nothing (which is what `raises=True` models here, since
+        # `_FakeLocator.first` hands back a raising handle for an empty match),
+        # 1 otherwise. `_set_region` uses exactly this to decide whether the
+        # region popup is already open before clicking the launcher again.
+        return 0 if self._raises else 1
 
 
 class _FakeLocator:
@@ -2752,153 +2761,399 @@ class TestWaitForStep2(unittest.TestCase):
         ):
             browser_masters._wait_for_step2(page)
 
+    def test_timeout_message_says_the_page_is_still_on_step_1(self):
+        # Issue #653: which step the page is stuck on changes the diagnosis
+        # entirely, and re-running --headful just to find out is expensive on
+        # a page with no sandbox — so the error must say it. Step 1's URL
+        # field still being in the DOM means "Далее" never advanced the form.
+        page = FakePage(
+            text_buttons={},
+            locators={
+                browser_masters._CREATE_URL_INPUT_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                )
+            },
+        )
+
+        with (
+            patch.object(browser_masters, "_CREATE_STEP2_TIMEOUT_MS", 10),
+            self.assertRaises(BrowserSessionError) as ctx,
+        ):
+            browser_masters._wait_for_step2(page)
+        self.assertIn("still showing step 1", str(ctx.exception))
+
+    def test_timeout_message_says_the_page_left_step_1(self):
+        # The other branch: step 1's URL field is gone, so step 2 rendered but
+        # without the expected section — that points at a markup change.
+        page = FakePage(text_buttons={}, locators={})
+
+        with (
+            patch.object(browser_masters, "_CREATE_STEP2_TIMEOUT_MS", 10),
+            self.assertRaises(BrowserSessionError) as ctx,
+        ):
+            browser_masters._wait_for_step2(page)
+        self.assertIn("has left step 1", str(ctx.exception))
+
 
 class TestAddRepeatingValues(unittest.TestCase):
-    """``_add_repeating_values`` (issue #632) — headline/text list entry."""
+    """``_add_repeating_values`` (issue #632, re-recon #653) — headline/text
+    fixed-slot entry.
 
-    def test_fills_and_presses_enter_for_each_value(self):
-        filled = []
-        pressed = []
-        handle = _FakeLocatorHandle(
-            on_fill=lambda v: filled.append(v),
-            on_press=lambda k: pressed.append(k),
+    Issue #653 re-recon (2026-08-02): Yandex replaced the old "single
+    current-variant input, fill + Enter" flow with a FIXED set of
+    pre-rendered contenteditable ``<div role="textbox">`` slots, each its
+    own ``data-testid`` (``CampaignTitles{N}.textarea`` etc.) — so the fake
+    now keys ``page._locators`` by per-slot selector, and the function
+    types via ``.click()`` + ``.type()`` (contenteditable divs have no
+    ``.fill()``/Enter-to-submit semantics) instead of pressing Enter.
+    """
+
+    def test_types_into_each_slot_by_index(self):
+        typed = []
+        handles = {
+            0: _FakeLocatorHandle(on_fill=lambda v: typed.append((0, v))),
+            1: _FakeLocatorHandle(on_fill=lambda v: typed.append((1, v))),
+        }
+        page = FakePage(
+            locators={
+                '[data-testid="fake0.textarea"]': _FakeLocator([handles[0]]),
+                '[data-testid="fake1.textarea"]': _FakeLocator([handles[1]]),
+            }
         )
-        page = FakePage(locators={"xpath=//fake": _FakeLocator([handle])})
 
         browser_masters._add_repeating_values(
-            page, "xpath=//fake", ["Заголовок 1", "Заголовок 2"]
+            page, "fake{index}.textarea", 2, ["Заголовок 1", "Заголовок 2"]
         )
 
-        self.assertEqual(filled, ["Заголовок 1", "Заголовок 2"])
-        self.assertEqual(pressed, ["Enter", "Enter"])
+        self.assertEqual(typed, [(0, "Заголовок 1"), (1, "Заголовок 2")])
+
+    def test_clears_each_slot_before_typing(self):
+        """Slots arrive PRE-FILLED with Yandex's AI copy (issue #653).
+
+        ``.type()`` appends from wherever the click left the caret, so
+        without an explicit clear the caller's value is spliced into the
+        middle of Yandex's text — confirmed live as
+        ``'Центр оздоровления и китайско<typed>й гимнастики цигун!'``.
+        """
+        events = []
+        field = _FakeLocatorHandle(
+            text="Центр оздоровления и китайской гимнастики цигун!",
+            on_press=lambda key: events.append(("press", key)),
+            on_fill=lambda v: events.append(("type", v)),
+        )
+        page = FakePage(
+            locators={'[data-testid="fake0.textarea"]': _FakeLocator([field])}
+        )
+
+        browser_masters._add_repeating_values(
+            page, "fake{index}.textarea", 1, ["Тест фикса 653"]
+        )
+
+        # The clear must happen BEFORE the type, not after.
+        self.assertEqual(
+            events,
+            [
+                ("press", "ControlOrMeta+a"),
+                ("press", "Backspace"),
+                ("type", "Тест фикса 653"),
+            ],
+        )
 
     def test_raises_when_field_missing(self):
         page = FakePage(locators={})
 
         with self.assertRaises(BrowserSessionError):
-            browser_masters._add_repeating_values(page, "xpath=//fake", ["x"])
+            browser_masters._add_repeating_values(
+                page, "fake{index}.textarea", 1, ["x"]
+            )
+
+    def test_raises_when_more_values_than_slots(self):
+        page = FakePage(locators={})
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._add_repeating_values(
+                page, "fake{index}.textarea", 1, ["a", "b"]
+            )
+        self.assertIn("only renders 1 slots", str(ctx.exception))
 
 
 class TestReadRepeatingValues(unittest.TestCase):
-    """``_read_repeating_values`` (issue #632) — post-add read-back used by
-    ``_verify_created``."""
+    """``_read_repeating_values`` (issue #632, re-recon #653) — post-add
+    read-back used by ``_verify_created``.
 
-    def test_reads_current_value_of_every_matched_input(self):
-        handles = [
-            _FakeLocatorHandle(get_value=lambda: "Заголовок 1"),
-            _FakeLocatorHandle(get_value=lambda: "Заголовок 2"),
-        ]
-        page = FakePage(locators={"xpath=//fake": _FakeLocator(handles)})
+    Reads each slot's contenteditable div via ``inner_text()``, not
+    ``input_value()`` (a contenteditable div has no ``value`` attribute).
+    """
 
-        values = browser_masters._read_repeating_values(page, "xpath=//fake")
+    def test_reads_inner_text_of_every_slot(self):
+        handles = {
+            0: _FakeLocatorHandle(text="Заголовок 1"),
+            1: _FakeLocatorHandle(text="Заголовок 2"),
+        }
+        page = FakePage(
+            locators={
+                '[data-testid="fake0.textarea"]': _FakeLocator([handles[0]]),
+                '[data-testid="fake1.textarea"]': _FakeLocator([handles[1]]),
+            }
+        )
+
+        values = browser_masters._read_repeating_values(page, "fake{index}.textarea", 2)
 
         self.assertEqual(values, ["Заголовок 1", "Заголовок 2"])
 
-    def test_returns_empty_list_when_no_matches(self):
+    def test_missing_slot_reads_as_empty_string(self):
         page = FakePage(locators={})
 
-        values = browser_masters._read_repeating_values(page, "xpath=//fake")
+        values = browser_masters._read_repeating_values(page, "fake{index}.textarea", 2)
 
-        self.assertEqual(values, [])
+        self.assertEqual(values, ["", ""])
 
-    def test_unreadable_input_reads_as_empty_string_not_a_hard_failure(self):
-        handles = [
-            _FakeLocatorHandle(get_value=lambda: "ok"),
-            _FakeLocatorHandle(raises=True),
-        ]
-        page = FakePage(locators={"xpath=//fake": _FakeLocator(handles)})
+    def test_unreadable_slot_reads_as_empty_string_not_a_hard_failure(self):
+        handles = {
+            0: _FakeLocatorHandle(text="ok"),
+            1: _FakeLocatorHandle(raises=True),
+        }
+        page = FakePage(
+            locators={
+                '[data-testid="fake0.textarea"]': _FakeLocator([handles[0]]),
+                '[data-testid="fake1.textarea"]': _FakeLocator([handles[1]]),
+            }
+        )
 
-        values = browser_masters._read_repeating_values(page, "xpath=//fake")
+        values = browser_masters._read_repeating_values(page, "fake{index}.textarea", 2)
 
         self.assertEqual(values, ["ok", ""])
 
 
 class TestSetRegion(unittest.TestCase):
-    """``_set_region`` (issue #632) — the one genuinely-empty required field.
+    """``_set_region`` (issue #632, re-recon #653) — the one genuinely-empty
+    required field.
 
-    Suggestions are modeled via ``role_elements`` (role="option"), not
-    ``text_buttons`` — ``_set_region`` uses ``get_by_role("option",
-    name=region, exact=True)`` (ported from ``_set_promotion_goal``'s fix,
-    issue #631 review): the previous ``get_by_text(exact=False)`` risked
-    matching an ancestor container instead of the suggestion row itself.
+    Issue #653 re-recon (2026-08-02): Yandex replaced the old text-combobox
+    with a tree/tag-group widget. The fake models: clicking the launcher
+    (``_REGION_LAUNCHER_TESTID``) reveals a separate filter field
+    (``_REGION_EDITOR_TESTID``), typing into it is a no-op on the fake page
+    (the real tree-filtering is server/client-state this fake does not
+    model), and the node is matched by an XPath string built from
+    ``_xpath_literal(region)`` — the fake's ``locator()`` keys on that exact
+    XPath string, same convention ``_REGION_INPUT_XPATH`` used pre-#653.
+
+    The fake models the real toggle semantics confirmed live: the LABEL is
+    what gets clicked (the ``<input>`` it wraps is not actionable), and the
+    input's checked state is what gets read back — so a label click flips the
+    input, exactly like the real control.
     """
 
-    def _page_for_region(self, region, option_visible=True):
-        field_state = {}
-        field = _FakeLocatorHandle(
-            on_fill=lambda v: field_state.__setitem__("value", v)
-        )
+    def _label_xpath(self, region):
         return (
-            FakePage(
-                locators={browser_masters._REGION_INPUT_XPATH: _FakeLocator([field])},
-                role_elements=(
-                    [("option", region, _FakeTextLocatorHandle(visible=True))]
-                    if option_visible
-                    else []
-                ),
-            ),
-            field_state,
+            "xpath=//label[@data-testid='RegionsTreeNode.Checkbox.label']"
+            f"[normalize-space(.)={browser_masters._xpath_literal(region)}]"
         )
 
+    def _checkbox_xpath(self, region):
+        return (
+            f"{self._label_xpath(region)}"
+            f"//input[@data-testid='{browser_masters._REGION_CHECKBOX_TESTID}']"
+        )
+
+    def _region_node(self, region, checked, visible=True):
+        """A (label, input) pair whose label click toggles the input."""
+        state = {"checked": False}
+
+        def _toggle():
+            state["checked"] = not state["checked"]
+            if state["checked"]:
+                checked.append(region)
+
+        label = _FakeLocatorHandle(visible=visible, on_click=_toggle)
+        box = _FakeLocatorHandle(get_checked=lambda: state["checked"])
+        return label, box
+
+    def _page_for_region(self, region, checkbox_visible=True):
+        launcher = _FakeLocatorHandle()
+        editor = _FakeLocatorHandle()
+        locators = {
+            browser_masters._REGION_LAUNCHER_TESTID: _FakeLocator([launcher]),
+            browser_masters._REGION_EDITOR_TESTID: _FakeLocator([editor]),
+        }
+        checked = []
+        if checkbox_visible:
+            label, box = self._region_node(region, checked)
+            locators[self._label_xpath(region)] = _FakeLocator([label])
+            locators[self._checkbox_xpath(region)] = _FakeLocator([box])
+        return FakePage(locators=locators), checked
+
     def test_fills_and_selects_each_region(self):
-        page, field_state = self._page_for_region("Москва")
+        page, checked = self._page_for_region("Москва")
 
         browser_masters._set_region(page, ["Москва"])
 
-        self.assertEqual(field_state["value"], "Москва")
+        self.assertEqual(checked, ["Москва"])
 
-    def test_raises_when_field_missing(self):
+    def test_raises_when_launcher_missing(self):
         page = FakePage(locators={})
 
         with self.assertRaises(BrowserSessionError):
             browser_masters._set_region(page, ["Москва"])
 
-    def test_raises_when_suggestion_not_found(self):
-        page, _ = self._page_for_region("Атлантида", option_visible=False)
+    def test_raises_when_checkbox_not_found(self):
+        page, _ = self._page_for_region("Атлантида", checkbox_visible=False)
 
-        with self.assertRaises(BrowserSessionError) as ctx:
+        with (
+            patch.object(browser_masters, "_REGION_FILTER_TIMEOUT_MS", 10),
+            self.assertRaises(BrowserSessionError) as ctx,
+        ):
             browser_masters._set_region(page, ["Атлантида"])
         self.assertIn("Атлантида", str(ctx.exception))
 
     def test_does_not_select_a_decoy_whose_name_only_contains_the_region(self):
-        # A decoy option whose accessible name merely CONTAINS the region
-        # name (e.g. "Москва и область") must NOT be treated as a match.
-        field = _FakeLocatorHandle()
+        # A decoy checkbox whose label merely CONTAINS the region name
+        # (e.g. "Москва и область") must NOT be treated as a match — the
+        # fake only registers a locator for the EXACT-match XPath, so a
+        # lookup for "Москва" never finds "Москва и область"'s checkbox.
+        launcher = _FakeLocatorHandle()
+        editor = _FakeLocatorHandle()
         decoy_clicked = []
         page = FakePage(
-            locators={browser_masters._REGION_INPUT_XPATH: _FakeLocator([field])},
-            role_elements=[
-                (
-                    "option",
-                    "Москва и область",
-                    _FakeTextLocatorHandle(
-                        visible=True, on_click=lambda: decoy_clicked.append(True)
-                    ),
-                )
-            ],
+            locators={
+                browser_masters._REGION_LAUNCHER_TESTID: _FakeLocator([launcher]),
+                browser_masters._REGION_EDITOR_TESTID: _FakeLocator([editor]),
+                self._label_xpath("Москва и область"): _FakeLocator(
+                    [
+                        _FakeLocatorHandle(
+                            visible=True, on_click=lambda: decoy_clicked.append(True)
+                        )
+                    ]
+                ),
+            },
         )
 
-        with self.assertRaises(BrowserSessionError):
+        with (
+            patch.object(browser_masters, "_REGION_FILTER_TIMEOUT_MS", 10),
+            self.assertRaises(BrowserSessionError),
+        ):
             browser_masters._set_region(page, ["Москва"])
         self.assertEqual(decoy_clicked, [])
 
+    def test_retry_does_not_reclick_launcher_and_clears_before_retyping(self):
+        """A retry must start from a known state, not the previous attempt's.
 
-class TestReadRegionTags(unittest.TestCase):
-    """``_read_region_tags`` (issue #632) — best-effort, NOT live-verified
-    (see docstring)."""
+        Issue #653 live testing: the launcher TOGGLES the popup, so clicking
+        it again while the popup is open closes it, and ``type()`` APPENDS to
+        a contenteditable, so re-typing without clearing yields
+        "МоскваМосква" — which filters the tree to zero nodes and can never
+        match. Either mistake turns attempts 2..N into guaranteed no-ops that
+        only add latency, so both are pinned here.
 
-    def test_returns_current_field_value(self):
+        The fake models the popup already being open (the editor locator
+        matches from the start) and the checkbox only appearing on the second
+        attempt.
+        """
+        launcher_clicks = []
+        launcher = _FakeLocatorHandle(on_click=lambda: launcher_clicks.append(True))
+        typed = []
+        presses = []
+        editor = _FakeLocatorHandle(on_fill=typed.append, on_press=presses.append)
+
+        checked = []
+        label, box = self._region_node("Москва", checked)
+
+        class _FlakyLabelLocator:
+            """Matches nothing on the first attempt, one label afterwards.
+
+            Keyed on how many times the region was TYPED (one per attempt) —
+            not on how many times ``count()`` was called, which the caller
+            polls repeatedly within a single attempt.
+            """
+
+            def count(self):
+                return 0 if len(typed) <= 1 else 1
+
+            def nth(self, i):
+                return label
+
         page = FakePage(
             locators={
-                browser_masters._REGION_INPUT_XPATH: _FakeLocator(
-                    [_FakeLocatorHandle(get_value=lambda: "Москва")]
-                )
+                browser_masters._REGION_LAUNCHER_TESTID: _FakeLocator([launcher]),
+                browser_masters._REGION_EDITOR_TESTID: _FakeLocator([editor]),
+                self._label_xpath("Москва"): _FlakyLabelLocator(),
+                self._checkbox_xpath("Москва"): _FakeLocator([box]),
+            },
+        )
+
+        with patch.object(browser_masters, "_REGION_FILTER_TIMEOUT_MS", 10):
+            browser_masters._set_region(page, ["Москва"])
+
+        self.assertEqual(checked, ["Москва"])
+        # The popup was already open, so the launcher must never be clicked
+        # (clicking it would have closed the popup).
+        self.assertEqual(launcher_clicks, [])
+        # Two attempts typed the region — each preceded by a clear, so the
+        # editor never accumulates "МоскваМосква".
+        self.assertEqual(typed, ["Москва", "Москва"])
+        self.assertEqual(
+            presses, ["ControlOrMeta+a", "Backspace", "ControlOrMeta+a", "Backspace"]
+        )
+
+    def test_clicks_launcher_when_popup_is_not_open(self):
+        # Mirror of the test above: when the editor is absent (popup closed),
+        # the launcher MUST be clicked to open it.
+        launcher_clicks = []
+        launcher = _FakeLocatorHandle(on_click=lambda: launcher_clicks.append(True))
+        page = FakePage(
+            locators={
+                browser_masters._REGION_LAUNCHER_TESTID: _FakeLocator([launcher]),
+                # No _REGION_EDITOR_TESTID entry -> `.first` raises -> count()==0.
+                self._label_xpath("Москва"): _FakeLocator([]),
+            },
+        )
+
+        with (
+            patch.object(browser_masters, "_REGION_FILTER_TIMEOUT_MS", 10),
+            self.assertRaises(BrowserSessionError),
+        ):
+            browser_masters._set_region(page, ["Москва"])
+
+        self.assertEqual(len(launcher_clicks), browser_masters._REGION_OPEN_ATTEMPTS)
+
+
+class TestXpathLiteral(unittest.TestCase):
+    """``_xpath_literal`` — safe XPath 1.0 string-literal quoting."""
+
+    def test_quotes_a_plain_value(self):
+        self.assertEqual(browser_masters._xpath_literal("Москва"), "'Москва'")
+
+    def test_handles_a_value_containing_a_single_quote(self):
+        result = browser_masters._xpath_literal("O'Brien")
+        # Must not naively produce 'O'Brien' (invalid XPath) — concat() form.
+        self.assertNotEqual(result, "'O'Brien'")
+        self.assertTrue(result.startswith("concat("))
+
+
+class TestReadRegionTags(unittest.TestCase):
+    """``_read_region_tags`` (issue #632, re-recon #653) — live-verified tag
+    reader for the tree/tag-group widget's accepted selections."""
+
+    def test_returns_every_tag_when_wrapper_present(self):
+        page = FakePage(
+            locators={
+                browser_masters._REGION_TAGS_WRAPPER_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                ),
+                browser_masters._REGION_TAG_TESTID_PATTERN: _FakeLocator(
+                    [
+                        _FakeLocatorHandle(text="Москва"),
+                        _FakeLocatorHandle(text="Санкт-Петербург"),
+                    ]
+                ),
             }
         )
 
-        self.assertEqual(browser_masters._read_region_tags(page), ["Москва"])
+        self.assertEqual(
+            browser_masters._read_region_tags(page), ["Москва", "Санкт-Петербург"]
+        )
 
-    def test_returns_empty_list_when_field_missing(self):
+    def test_returns_empty_list_when_wrapper_missing(self):
         page = FakePage(locators={})
 
         self.assertEqual(browser_masters._read_region_tags(page), [])
@@ -2995,14 +3250,21 @@ class TestVerifyCreated(unittest.TestCase):
     """
 
     def _page(self, headline_values, text_values, budget_value=None):
-        locators = {
-            browser_masters._HEADLINES_ADD_INPUT_XPATH: _FakeLocator(
-                [_FakeLocatorHandle(get_value=lambda v=v: v) for v in headline_values]
-            ),
-            browser_masters._TEXTS_ADD_INPUT_XPATH: _FakeLocator(
-                [_FakeLocatorHandle(get_value=lambda v=v: v) for v in text_values]
-            ),
-        }
+        locators = {}
+        for index, value in enumerate(headline_values):
+            selector = (
+                '[data-testid="'
+                + browser_masters._HEADLINES_TESTID_TEMPLATE.format(index=index)
+                + '"]'
+            )
+            locators[selector] = _FakeLocator([_FakeLocatorHandle(text=value)])
+        for index, value in enumerate(text_values):
+            selector = (
+                '[data-testid="'
+                + browser_masters._TEXTS_TESTID_TEMPLATE.format(index=index)
+                + '"]'
+            )
+            locators[selector] = _FakeLocator([_FakeLocatorHandle(text=value)])
         if budget_value is not None:
             locators[browser_masters._WEEKLY_BUDGET_INPUT_XPATH] = _FakeLocator(
                 [_FakeLocatorHandle(get_value=lambda: budget_value)]
@@ -3067,11 +3329,11 @@ class TestVerifyCreated(unittest.TestCase):
 class TestCreateMaster(unittest.TestCase):
     """``create_master`` (issue #632) — end-to-end wiring of the helpers above."""
 
-    def _full_page(self):
+    def _full_page(self, region="Москва"):
         url_state = {}
         headline_state = []
         text_state = []
-        region_state = {}
+        region_checked = []
         budget_state = {}
         launch_clicks = []
         draft_clicks = []
@@ -3097,9 +3359,8 @@ class TestCreateMaster(unittest.TestCase):
         text_field = _FakeLocatorHandle(
             on_fill=_fill_text, get_value=lambda: text_last["value"]
         )
-        region_field = _FakeLocatorHandle(
-            on_fill=lambda v: region_state.__setitem__("value", v)
-        )
+        region_launcher = _FakeLocatorHandle()
+        region_editor = _FakeLocatorHandle()
         budget_field = _FakeLocatorHandle(
             on_fill=lambda v: budget_state.__setitem__("value", v),
             get_value=lambda: budget_state.get("value", ""),
@@ -3107,21 +3368,54 @@ class TestCreateMaster(unittest.TestCase):
 
         next_button = _FakeLocatorHandle()
 
+        headline_selector = (
+            '[data-testid="'
+            + browser_masters._HEADLINES_TESTID_TEMPLATE.format(index=0)
+            + '"]'
+        )
+        text_selector = (
+            '[data-testid="'
+            + browser_masters._TEXTS_TESTID_TEMPLATE.format(index=0)
+            + '"]'
+        )
+        region_label_xpath = (
+            "xpath=//label[@data-testid='RegionsTreeNode.Checkbox.label']"
+            f"[normalize-space(.)={browser_masters._xpath_literal(region)}]"
+        )
+        region_checkbox_xpath = (
+            f"{region_label_xpath}"
+            f"//input[@data-testid='{browser_masters._REGION_CHECKBOX_TESTID}']"
+        )
+        # The label is what gets clicked; the input is what gets read back
+        # (confirmed live — see _set_region). Model the real toggle.
+        region_state = {"checked": False}
+
+        def _toggle_region():
+            region_state["checked"] = not region_state["checked"]
+            if region_state["checked"]:
+                region_checked.append(region)
+
         page = FakePage(
             locators={
                 browser_masters._CREATE_URL_INPUT_TESTID: _FakeLocator([url_field]),
                 browser_masters._CREATE_NEXT_BUTTON_TESTID: _FakeLocator([next_button]),
-                browser_masters._HEADLINES_ADD_INPUT_XPATH: _FakeLocator(
-                    [headline_field]
+                headline_selector: _FakeLocator([headline_field]),
+                text_selector: _FakeLocator([text_field]),
+                browser_masters._REGION_LAUNCHER_TESTID: _FakeLocator(
+                    [region_launcher]
                 ),
-                browser_masters._TEXTS_ADD_INPUT_XPATH: _FakeLocator([text_field]),
-                browser_masters._REGION_INPUT_XPATH: _FakeLocator([region_field]),
+                browser_masters._REGION_EDITOR_TESTID: _FakeLocator([region_editor]),
+                region_label_xpath: _FakeLocator(
+                    [_FakeLocatorHandle(visible=True, on_click=_toggle_region)]
+                ),
+                region_checkbox_xpath: _FakeLocator(
+                    [_FakeLocatorHandle(get_checked=lambda: region_state["checked"])]
+                ),
                 browser_masters._WEEKLY_BUDGET_INPUT_XPATH: _FakeLocator(
                     [budget_field]
                 ),
             },
             role_elements=[
-                ("option", "Москва", _FakeTextLocatorHandle(visible=True)),
                 (
                     "button",
                     browser_masters._LAUNCH_BUTTON_TEXT,
@@ -3146,7 +3440,7 @@ class TestCreateMaster(unittest.TestCase):
             "url": url_state,
             "headlines": headline_state,
             "texts": text_state,
-            "region": region_state,
+            "region_checked": region_checked,
             "budget": budget_state,
             "launch_clicks": launch_clicks,
             "draft_clicks": draft_clicks,
@@ -3166,7 +3460,7 @@ class TestCreateMaster(unittest.TestCase):
         self.assertEqual(state["url"]["url"], "https://ksamata.ru/")
         self.assertEqual(state["headlines"], ["Заголовок"])
         self.assertEqual(state["texts"], ["Текст объявления"])
-        self.assertEqual(state["region"]["value"], "Москва")
+        self.assertEqual(state["region_checked"], ["Москва"])
         self.assertEqual(len(state["launch_clicks"]), 1)
         self.assertEqual(len(state["draft_clicks"]), 0)
         self.assertEqual(
@@ -3270,10 +3564,18 @@ class TestCreateMaster(unittest.TestCase):
         # silently rejected it) -- this must be a hard error, not a false
         # success (mirrors update_master's _verify_saved regression test).
         page, state = self._full_page()
-        # Sabotage: the headline field never actually reflects the fill.
-        page._locators[browser_masters._HEADLINES_ADD_INPUT_XPATH] = _FakeLocator(
-            [_FakeLocatorHandle(get_value=lambda: "Старый заголовок")]
+        # Sabotage: slot 0's headline field never actually reflects the
+        # type() — inner_text() always reads back the stale value, even
+        # though click()/type() succeed without raising (mirrors "Yandex
+        # silently rejected it" — the click alone is not proof of anything).
+        stuck_handle = _FakeLocatorHandle(text="Старый заголовок")
+        stuck_handle.type = lambda value, delay=None: None
+        headline_selector = (
+            '[data-testid="'
+            + browser_masters._HEADLINES_TESTID_TEMPLATE.format(index=0)
+            + '"]'
         )
+        page._locators[headline_selector] = _FakeLocator([stuck_handle])
 
         with self.assertRaises(BrowserSessionError) as ctx:
             browser_masters.create_master(

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -2985,6 +2985,43 @@ class TestAddRepeatingValues(unittest.TestCase):
         )
         self.assertIn("clear", str(ctx.exception).lower())
 
+    def test_aborts_when_an_unused_slot_cannot_be_clicked(self):
+        """A click failure on an UNUSED slot must not be a soft skip
+        (issue #655 round-2 review, Codex).
+
+        The previous fix treated ``value is None`` (a trailing slot with no
+        caller-supplied value) as safe to skip on a click failure, reasoning
+        the slot "may simply not be rendered". But a click can also fail on
+        a slot that IS rendered and IS still holding Yandex's AI copy — an
+        overlay, a transient obstruction, anything short of "truly absent".
+        ``create_master`` clicks the terminal LAUNCH button before
+        ``_verify_created`` ever re-reads the page, so skipping here risks
+        publishing unreviewed copy from a live, no-rollback campaign and
+        only discovering it after the fact. Must fail before any click.
+        """
+        slot0 = _FakeContentEditableHandle(text="")
+        slot1 = _FakeLocatorHandle(text="Центр оздоровления и китайской гимнастики!")
+        slot1.click = lambda timeout=None: (_ for _ in ()).throw(
+            PlaywrightError("intercepted: element obscured")
+        )
+        page = FakePage(
+            locators={
+                '[data-testid="fake0.textarea"]': _FakeLocator([slot0]),
+                '[data-testid="fake1.textarea"]': _FakeLocator([slot1]),
+            }
+        )
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters._add_repeating_values(
+                page, "fake{index}.textarea", 2, ["Мой заголовок"]
+            )
+
+        # slot1's AI copy must survive untouched — the whole point is that
+        # this must fail loudly instead of silently leaving it live.
+        self.assertEqual(
+            slot1.inner_text(), "Центр оздоровления и китайской гимнастики!"
+        )
+
 
 class TestReadRepeatingValues(unittest.TestCase):
     """``_read_repeating_values`` (issue #632, re-recon #653) — post-add
@@ -3517,6 +3554,13 @@ class TestCreateMaster(unittest.TestCase):
 
         next_button = _FakeLocatorHandle()
 
+        # The real page always renders every slot (issue #653 recon: exactly
+        # 5 headline / 3 text slots, no "add another" control) — registering
+        # only slot 0 was unrealistic and hid the issue #655 round-2 finding
+        # that a click failure on an UNUSED slot must still be fatal. Slot 0
+        # is the caller-filled one (headline_field/text_field, wired to
+        # headline_state/text_state below); the rest start genuinely empty,
+        # same as the real create page's trailing slots.
         headline_selector = (
             '[data-testid="'
             + browser_masters._HEADLINES_TESTID_TEMPLATE.format(index=0)
@@ -3527,6 +3571,18 @@ class TestCreateMaster(unittest.TestCase):
             + browser_masters._TEXTS_TESTID_TEMPLATE.format(index=0)
             + '"]'
         )
+        extra_headline_selectors = {
+            '[data-testid="'
+            + browser_masters._HEADLINES_TESTID_TEMPLATE.format(index=i)
+            + '"]': _FakeLocator([_FakeContentEditableHandle(text="")])
+            for i in range(1, browser_masters._HEADLINES_SLOT_COUNT)
+        }
+        extra_text_selectors = {
+            '[data-testid="'
+            + browser_masters._TEXTS_TESTID_TEMPLATE.format(index=i)
+            + '"]': _FakeLocator([_FakeContentEditableHandle(text="")])
+            for i in range(1, browser_masters._TEXTS_SLOT_COUNT)
+        }
         region_label_xpath = (
             "xpath=//label[@data-testid='RegionsTreeNode.Checkbox.label']"
             f"[normalize-space(.)={browser_masters._xpath_literal(region)}]"
@@ -3550,6 +3606,8 @@ class TestCreateMaster(unittest.TestCase):
                 browser_masters._CREATE_NEXT_BUTTON_TESTID: _FakeLocator([next_button]),
                 headline_selector: _FakeLocator([headline_field]),
                 text_selector: _FakeLocator([text_field]),
+                **extra_headline_selectors,
+                **extra_text_selectors,
                 browser_masters._REGION_LAUNCHER_TESTID: _FakeLocator(
                     [region_launcher]
                 ),

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -158,6 +158,50 @@ class _FakeLocatorHandle:
         return 0 if self._raises else 1
 
 
+class _FakeContentEditableHandle(_FakeLocatorHandle):
+    """A slot that models the REAL contenteditable semantics (issue #655 review).
+
+    ``_FakeLocatorHandle.type()`` delegates to ``fill()``, which REPLACES the
+    field's content — real ``Locator.type()`` on a ``contenteditable``
+    APPENDS from the caret, which is the entire reason ``_clear_text_field``
+    exists. A fake that replaces cannot observe a missing/failed clear, so it
+    silently passes code that would splice the caller's value into Yandex's
+    AI-generated copy (or leave that copy in place entirely).
+
+    ``supports_modifier`` models Playwright <1.44, where ``ControlOrMeta`` is
+    rejected server-side with ``Unknown modifier`` — the failure mode that
+    makes the suppressed clear a no-op on the versions ``pyproject.toml``
+    permits.
+    """
+
+    def __init__(self, *args, supports_modifier=True, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._supports_modifier = supports_modifier
+        self._selected_all = False
+
+    def type(self, value, delay=None):  # noqa: A003 - mirrors Locator.type
+        if self._raises:
+            raise PlaywrightError("element detached")
+        # APPEND, exactly like the real contenteditable.
+        self._text = self._text + value
+        if self._on_fill is not None:
+            self._on_fill(value)
+
+    def press(self, key):
+        if self._raises:
+            raise PlaywrightError("element detached")
+        if key == "ControlOrMeta+a":
+            if not self._supports_modifier:
+                # Playwright <1.44 throws this from input.ts, server-side.
+                raise PlaywrightError("Unknown modifier ControlOrMeta")
+            self._selected_all = True
+        elif key == "Backspace" and self._selected_all:
+            self._text = ""
+            self._selected_all = False
+        if self._on_press is not None:
+            self._on_press(key)
+
+
 class _FakeLocator:
     """A Locator for one selector — holds every matched handle for that selector."""
 
@@ -2876,6 +2920,71 @@ class TestAddRepeatingValues(unittest.TestCase):
             )
         self.assertIn("only renders 1 slots", str(ctx.exception))
 
+    def test_clears_every_slot_not_just_the_ones_being_filled(self):
+        """Unused slots must not keep Yandex's AI copy (issue #655 review).
+
+        The page renders a FIXED set of slots, most pre-filled by Yandex's
+        AI scan. Filling only the first ``len(values)`` of them leaves the
+        rest populated, and every non-empty slot is a published ad variant —
+        so a single ``--headline`` would launch that headline PLUS four
+        AI-written ones the caller never reviewed. That directly violates
+        this module's stated contract ("refuses to silently launch
+        AI-generated ad copy the caller never reviewed", see create_master's
+        docstring) on a page with no sandbox and no rollback.
+        """
+        slots = {
+            0: _FakeContentEditableHandle(text=""),
+            1: _FakeContentEditableHandle(
+                text="Центр оздоровления и китайской гимнастики!"
+            ),
+            2: _FakeContentEditableHandle(text="Цигун в Москве — записаться"),
+        }
+        page = FakePage(
+            locators={
+                f'[data-testid="fake{i}.textarea"]': _FakeLocator([handle])
+                for i, handle in slots.items()
+            }
+        )
+
+        browser_masters._add_repeating_values(
+            page, "fake{index}.textarea", 3, ["Мой заголовок"]
+        )
+
+        self.assertEqual(slots[0].inner_text(), "Мой заголовок")
+        # The AI-generated leftovers must be GONE, not merely un-touched.
+        self.assertEqual(slots[1].inner_text(), "")
+        self.assertEqual(slots[2].inner_text(), "")
+
+    def test_aborts_when_a_slot_cannot_be_cleared(self):
+        """A failed clear must abort BEFORE anything is typed (issue #655).
+
+        ``pyproject.toml`` permits ``playwright>=1.40``, but ``ControlOrMeta``
+        only exists from 1.44 — on 1.40-1.43 the modifier press throws
+        ``Unknown modifier`` server-side. Silently swallowing that leaves the
+        slot pre-filled and ``.type()`` then splices the caller's value into
+        Yandex's copy; ``create_master`` clicks Launch before it re-reads
+        anything, so the mangled variant ships. Failing loudly is the only
+        safe outcome on a page with no rollback.
+        """
+        slot = _FakeContentEditableHandle(
+            text="Центр оздоровления и китайской гимнастики!",
+            supports_modifier=False,
+        )
+        page = FakePage(
+            locators={'[data-testid="fake0.textarea"]': _FakeLocator([slot])}
+        )
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._add_repeating_values(
+                page, "fake{index}.textarea", 1, ["Мой заголовок"]
+            )
+
+        # The pre-filled copy must be left untouched rather than spliced into.
+        self.assertEqual(
+            slot.inner_text(), "Центр оздоровления и китайской гимнастики!"
+        )
+        self.assertIn("clear", str(ctx.exception).lower())
+
 
 class TestReadRepeatingValues(unittest.TestCase):
     """``_read_repeating_values`` (issue #632, re-recon #653) — post-add
@@ -3280,6 +3389,46 @@ class TestVerifyCreated(unittest.TestCase):
             texts=["Текст объявления"],
             weekly_budget=None,
         )  # must not raise
+
+    def test_raises_when_an_unrequested_headline_variant_survives(self):
+        """Extra non-empty slots are published variants (issue #655 review).
+
+        The membership-only check this replaced ("is each requested value
+        present?") passed happily while four AI-written headlines sat in the
+        remaining slots. Every non-empty slot ships as an ad variant, so a
+        leftover the clear missed must be a hard failure — this is the
+        defense-in-depth layer behind ``_add_repeating_values``' clear.
+        """
+        page = self._page(
+            ["Заголовок", "Центр оздоровления и китайской гимнастики!"],
+            ["Текст объявления"],
+        )
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._verify_created(
+                page,
+                headlines=["Заголовок"],
+                texts=["Текст объявления"],
+                weekly_budget=None,
+            )
+        self.assertIn("unrequested headline variants", str(ctx.exception))
+        self.assertIn("Центр оздоровления", str(ctx.exception))
+
+    def test_raises_when_an_unrequested_text_variant_survives(self):
+        # Same invariant on the ad-text slots.
+        page = self._page(
+            ["Заголовок"],
+            ["Текст объявления", "Приходите на пробное занятие цигун!"],
+        )
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._verify_created(
+                page,
+                headlines=["Заголовок"],
+                texts=["Текст объявления"],
+                weekly_budget=None,
+            )
+        self.assertIn("unrequested ad-text variants", str(ctx.exception))
 
     def test_raises_when_a_headline_is_missing(self):
         page = self._page(["Другой заголовок"], ["Текст объявления"])


### PR DESCRIPTION
## Проблема

После фикса шага 1 (#650, уже в main) `direct masters add` доходил до шага 2 и падал там: заголовки, тексты и поле региона тоже мигрировали на новую разметку.

Каждое поле подтверждено **живой разведкой**, а не только диагностикой из issue.

## Что изменено

**Заголовки/тексты.** Вместо одного «текущего варианта» + кнопки «добавить ещё» Яндекс теперь пререндерит ФИКСИРОВАННЫЙ набор contenteditable-слотов (`CampaignTitles{N}.textarea` / `CampaignTexts{N}.textarea`, 5 и 3), в основном предзаполненных AI по лендингу. Значения вводятся по индексу слота, читаются обратно через `inner_text()`. Передача большего числа значений, чем слотов, — теперь явная ошибка, а не тихая потеря.

**Слот очищается перед вводом.** Найдено живьём: слот приходит с текстом Яндекса, а `.type()` дописывает от места каретки — без очистки значение вставлялось в СЕРЕДИНУ чужого текста (`Центр оздоровления и китайско<введённое>й гимнастики цигун!`), и кампания ушла бы в черновик с искажённым объявлением.

**Регион.** Текстовый combobox заменён на дерево/тег-группу — потребовался другой алгоритм выбора, а не новый селектор к старому флоу: открыть попап, ввести в фильтр (он существует только при открытом попапе), затем кликнуть метку с ТОЧНЫМ совпадением (ввод региона авто-раскрывает родителей и детей, так что «contains» выбрал бы не тот узел).

**Клик по метке, а не по `<input>`.** Живьём: `<input type="checkbox" id="region-node-213">` резолвится и даже отдаёт `is_visible() == True`, но клик по нему таймаутится на actionability — реальная зона клика это стилизованная метка. Именно поэтому падало `Could not find 'Москва'`, хотя локатор находил элемент. Состояние по-прежнему читается из `<input>`: клик по метке переключает, поэтому read-back подтверждает, что регион действительно выбран, а не снят.

**Retry стал идемпотентным.** Launcher переключает попап, а `.type()` дописывает — поэтому launcher кликается только при закрытом попапе, а фильтр очищается перед каждым повторным вводом. Без обоих условий попытки 2..N были гарантированными холостыми ходами, лишь удлиняя каждый неуспех.

**Диагностика таймаута шага 2** теперь сообщает, застряла ли страница на шаге 1 или уже прошла его, вместо того чтобы оставлять `--headful` единственным способом это узнать.

**Перепроверено живьём и НЕ менялось:** недельный бюджет, «Директ помогает», «Цель продвижения» — их heading-proximity XPath миграция не сломала.

## Проверка

- `pytest tests/test_masters.py` — 176 тестов, зелёные (было 171; добавлены тесты на очистку слота, идемпотентность retry и оба ветвления сообщения таймаута шага 2).
- Полный офлайн-прогон: 2755 passed. 62 error в `test_read_cassettes.py`/`test_integration_write.py` — **pre-existing**, из-за расхождения версий vcr/aiohttp (`AttributeError: module 'aiohttp.streams' has no attribute 'AsyncStreamReaderMixin'`); подтверждено через `git stash`, к этой ветке отношения не имеет.
- `black` / `flake8` — чисто.
- **Живой end-to-end с `--draft`, без публикации** — полный create-флоу проходит до конца, пост-проверка подтверждает, что форма содержит переданные значения:

```json
{
  "LandingUrl": "https://ksamata.ru",
  "Headlines": ["Тест фикса 653"],
  "Texts": ["Тестовый текст объявления фикс 653"],
  "Regions": ["Москва"],
  "Launched": false,
  "WeeklyBudget": 5000
}
```

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195A4c66PNzPzby9P2CXTQc