### PR TITLE
feat(masters): add `direct masters copy` — clone Мастер кампаний (#659)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@
   clone form, and a separate gap found during recon — `masters get`/
   `archive`/`suspend`/`resume` do not yet work against a freshly created
   `DRAFT`-status campaign (issue #660).
+- If the saved browser session is invalidated in the narrow window between
+  the clone's terminal-button click and its post-click grid verification,
+  `copy_master` now surfaces a plain error naming the already-created
+  campaign instead of letting `_with_session`'s auth-retry silently
+  re-run the whole clone (which would create a second copy — or, with
+  `--launch`, a second live campaign — with no trace of the first).
 
 **Added — `direct masters add --region-id` (#652):**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## Unreleased
 
+**Added — `direct masters copy` (#659):**
+
+- New `direct masters copy <CAMPAIGN_ID>` clones an existing Мастер кампаний
+  via the overview page's "⋮" menu → "Клонировать" (`CampaignHeader.Menu.clone`,
+  confirmed live), the same action a human uses in the web UI. Yandex
+  pre-fills the new campaign end to end from the source (headlines, texts,
+  images, video, display region, Metrika counters, target actions, weekly
+  budget) — including the display region **verbatim**, which sidesteps the
+  region text-matching issues `add --region`/`--region-id` can hit (issues
+  #652/#656/#657) entirely, since nothing is retyped or re-matched.
+- Live-verified end to end (campaign 107707079 → draft copy 713231614,
+  confirmed both via the post-click URL redirect to the new campaign's
+  overview page and via a `fetch_masters_list` grid diff before reporting
+  success).
+- `--draft`/`--launch` mirror `masters add`'s flag, but with the opposite,
+  safer default: the copy is saved as a draft unless `--launch` is passed
+  explicitly.
+- Scope is intentionally narrow: `copy` is a 1:1 mirror of the web UI's
+  clone action only — it does not rename, retarget, or edit any field on the
+  copy beyond what Yandex itself does (it appends " — N" to the name). Use
+  `masters update` afterwards for any further changes.
+- **Not idempotent**, same as `add`: running it twice creates a SECOND copy,
+  not an update to the first. No `--sandbox` — Мастер кампаний has no API at
+  all, so there is no isolated test copy.
+- Follow-up (not in this change): flags to override individual fields on the
+  clone form, and a separate gap found during recon — `masters get`/
+  `archive`/`suspend`/`resume` do not yet work against a freshly created
+  `DRAFT`-status campaign (issue #660).
+
 **Added — `direct masters add --region-id` (#652):**
 
 - New `--region-id` option resolves a numeric `RegionId` to Yandex's

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ direct masters update 72349978 --weekly-budget 95000
 direct masters update 72349978 --promotion-goal max-clicks --no-directs-helps
 direct masters add https://example.com/ --headline "Заголовок 1" --headline "Заголовок 2" --text "Текст объявления" --region Москва --weekly-budget 50000 --draft
 direct masters add https://example.com/ --headline "Заголовок 1" --text "Текст объявления" --region-id 213 --weekly-budget 50000 --draft
+direct masters copy 72349978
+direct masters copy 72349978 --launch
 ```
 
 `masters list` filters by status with `--status`
@@ -104,6 +106,19 @@ launches immediately; pass
 `--draft` to save it as a draft instead (Сохранить как черновик) without
 going live. There is **no `--sandbox`** for this command either — verify with
 `--draft` first and check the result in the web UI before launching for real.
+
+`copy` clones an existing Мастер кампаний via the overview page's "⋮" menu →
+"Клонировать" — the same action a human uses in the web UI. Yandex pre-fills
+the new campaign from the source's headlines, texts, images, budget, and
+**display region verbatim**, which sidesteps the region text-matching issues
+`add --region`/`--region-id` can hit (issues #652/#656/#657) since nothing is
+retyped or re-matched. Nothing on the copy is renamed or edited beyond what
+Yandex itself does (it appends " — N" to the name) — this command is
+intentionally a 1:1 mirror of the web UI's clone action; use `masters update`
+afterwards for any further changes. **Not idempotent**, same as `add`:
+running it twice creates a SECOND copy, not an update to the first. By
+default the copy is saved as a draft (`--draft`); pass `--launch` to launch
+it immediately in production instead. Same no-`--sandbox` caveat as `add`.
 
 **Browser session (optional but recommended):** `direct masters` decrypts
 your Chrome cookies fresh on every call by default, which means a Keychain
@@ -1131,6 +1146,8 @@ direct masters update 72349978 --weekly-budget 95000
 direct masters update 72349978 --promotion-goal max-clicks --no-directs-helps
 direct masters add https://example.com/ --headline "Заголовок 1" --headline "Заголовок 2" --text "Текст объявления" --region Москва --weekly-budget 50000 --draft
 direct masters add https://example.com/ --headline "Заголовок 1" --text "Текст объявления" --region-id 213 --weekly-budget 50000 --draft
+direct masters copy 72349978
+direct masters copy 72349978 --launch
 ```
 
 `masters list` фильтрует по статусу через `--status`
@@ -1200,6 +1217,20 @@ API (та же цепочка приоритетов, что и у любой д
 («Сохранить как черновик») без запуска. У этой команды тоже **нет
 `--sandbox`** — сначала проверьте с `--draft` и посмотрите результат в
 веб-интерфейсе, прежде чем запускать по-настоящему.
+
+`copy` клонирует существующий Мастер кампаний через меню «⋮» на странице
+обзора → «Клонировать» — то же действие, что и у человека в веб-интерфейсе.
+Яндекс сам предзаполняет новую кампанию заголовками, текстами, изображениями,
+бюджетом и **регионом показов в исходном виде** — это полностью обходит
+проблемы матчинга региона по тексту у `add --region`/`--region-id` (issues
+#652/#656/#657), потому что регион нигде заново не набирается и не матчится.
+Копия не переименовывается и не редактируется сверх того, что делает сам
+Яндекс (он добавляет суффикс «— N» к названию) — команда намеренно 1:1
+повторяет действие клонирования из веб-интерфейса; для дальнейших правок
+используйте `masters update`. **Команда НЕ идемпотентна**, как и `add`:
+повторный запуск создаст ВТОРУЮ копию, а не обновит первую. По умолчанию
+копия сохраняется как черновик (`--draft`); передайте `--launch`, чтобы
+запустить её сразу в продакшене. Тот же отказ от `--sandbox`, что и у `add`.
 
 **Браузерная сессия (опционально, но рекомендуется):** по умолчанию `direct
 masters` расшифровывает куки Chrome заново при каждом вызове — на macOS это

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -166,7 +166,12 @@ import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from ..output import print_warning
-from .session import BrowserSessionError, assert_authenticated, assert_not_captcha
+from .session import (
+    BrowserAuthError,
+    BrowserSessionError,
+    assert_authenticated,
+    assert_not_captcha,
+)
 
 if TYPE_CHECKING:
     from playwright.sync_api import Page
@@ -998,13 +1003,32 @@ def copy_master(
             "before retrying (this is not idempotent)."
         )
 
+    # The clone/terminal-button click above already happened — irreversible,
+    # not idempotent (a retry would re-click and create a SECOND copy). If
+    # the saved session is invalidated in exactly this window,
+    # fetch_masters_list's own assert_authenticated raises BrowserAuthError;
+    # letting that propagate as-is would make _with_session
+    # (direct_cli/commands/masters.py) retry this ENTIRE function under a
+    # fresh session, silently duplicating the campaign. Re-raise as a plain
+    # BrowserSessionError so that retry does not trigger, and name new_id so
+    # the caller can check the clone that already exists instead of losing
+    # track of it.
     updated = None
     deadline = time.monotonic() + _CLONE_VERIFY_TIMEOUT_MS / 1000
-    while time.monotonic() < deadline:
-        updated = _find_master_row(page, new_id, status="all")
-        if updated is not None:
-            break
-        page.wait_for_timeout(250)
+    try:
+        while time.monotonic() < deadline:
+            updated = _find_master_row(page, new_id, status="all")
+            if updated is not None:
+                break
+            page.wait_for_timeout(250)
+    except BrowserAuthError as exc:
+        raise BrowserSessionError(
+            f"Yandex redirected to campaign {new_id} after cloning "
+            f"{campaign_id}, but the session was invalidated while "
+            "verifying it in the campaigns grid — the clone was likely "
+            f"created; check campaign {new_id} manually rather than "
+            "retrying (this is not idempotent)."
+        ) from exc
 
     if updated is None:
         raise BrowserSessionError(

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -127,10 +127,41 @@ auto-expands every ancestor/descendant of a match — see ``_set_region``.
 Weekly budget, "Директ помогает", and "Цель продвижения" were re-confirmed
 live to still use their pre-#653 heading-proximity XPaths unchanged (they
 were not affected by this markup migration).
+
+``copy_master`` (issue #659, live-verified end to end against campaign
+107707079 — a draft copy, 713231614, was actually created and confirmed in
+the campaigns grid during recon). The overview menu's "Клонировать" item
+(``CampaignHeader.Menu.clone``, confirmed live alongside
+``CampaignHeader.Menu.archive`` — see the ``archive_master`` note above) does
+NOT clone instantly: it navigates to ``WIZARD_CREATE_URL``, landing on the
+same step-2 form ``create_master`` uses, pre-filled end to end from the
+source campaign (headlines, texts, images, video, display region, Metrika
+counters, target actions, weekly budget) — Yandex itself appends " — N" to
+the cloned campaign's name. ``_wait_for_step2`` (already used by
+``create_master``) is reused as-is: the pre-fill is server-side and just as
+slow (confirmed live ~14s), and the clone form's "Регион показов" heading is
+the same marker. The same two terminal buttons apply
+(``_LAUNCH_BUTTON_TEXT``/``_SAVE_DRAFT_BUTTON_TEXT`` via
+``_click_terminal_button``) — ``copy_master`` defaults to the draft button,
+mirroring ``create_master``'s CLI-level ``--draft`` default. After clicking,
+Yandex redirects ``page.url`` to ``WIZARD_OVERVIEW_URL`` with the new
+campaign's ID (confirmed live, ~7s after the click) — the primary ID source
+— and this is cross-checked against a ``fetch_masters_list`` grid diff
+(confirmed to agree during recon) before reporting success, following the
+module's "never trust the click alone" convention.
+
+**Not fixed here (see issue #660):** a freshly created ``DRAFT`` campaign's
+overview page turned out, live, to be the editable wizard form itself (no
+"⋮" menu, no ``CampaignHeader.MenuTrigger``) rather than the
+stats-dashboard overview every other status renders — so ``masters get``/
+``archive``/``suspend``/``resume`` (untested against ``DRAFT`` until this
+recon) cannot yet read or act on a campaign in that state. ``copy_master``
+itself does not depend on any of those working.
 """
 
 import contextlib
 import json
+import re
 import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
@@ -212,10 +243,22 @@ _STATUS_CHANGE_TIMEOUT_MS = 10_000
 # a live account's DOM, not guessed.
 _MENU_TRIGGER_SELECTOR = '[data-testid="CampaignHeader.MenuTrigger"]'
 _ARCHIVE_MENU_ITEM_SELECTOR = '[data-testid="CampaignHeader.Menu.archive"]'
+# Confirmed live (issue #659) alongside the archive item above — same menu,
+# same testid convention.
+_CLONE_MENU_ITEM_SELECTOR = '[data-testid="CampaignHeader.Menu.clone"]'
 
 # How long to wait, after clicking Архивировать, for the grid API to report
 # the campaign as ARCHIVED before giving up (see archive_master).
 _ARCHIVE_VERIFY_TIMEOUT_MS = 10_000
+
+# How long to wait, after clicking the clone form's terminal button, for
+# Yandex to redirect page.url to the new campaign's overview URL (confirmed
+# live ~7s, issue #659) before giving up on copy_master.
+_CLONE_VERIFY_TIMEOUT_MS = 20_000
+
+# Matches WIZARD_OVERVIEW_URL's {campaign_id} once Yandex redirects there
+# after a successful clone save/launch (see copy_master).
+_WIZARD_OVERVIEW_URL_ID_RE = re.compile(r"/wizard/campaigns/(\d+)/")
 
 # "Цель продвижения" dropdown options, confirmed live by opening the dropdown
 # on the edit page — exactly these two rows exist, no others (see
@@ -876,6 +919,105 @@ def archive_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
         )
 
     return updated
+
+
+def copy_master(
+    page: "Page", campaign_id: int, *, launch: bool = False
+) -> Dict[str, Any]:
+    """Clone a Мастер кампаний via the overview menu's "Клонировать" item.
+
+    Live-verified end to end (issue #659, campaign 107707079 → draft copy
+    713231614 — see module docstring). "Клонировать" does not clone
+    instantly: it navigates to the same step-2 create form ``create_master``
+    uses, pre-filled from the source campaign (headlines, texts, images,
+    region, budget, ...). Not idempotent, like ``create_master``: calling
+    this twice creates a SECOND copy, not an update to the first — there is
+    no rollback for Мастер кампаний.
+
+    ``launch=False`` (default) clicks "Сохранить как черновик" — the copy is
+    created but not launched, mirroring ``masters add``'s ``--draft``
+    default. ``launch=True`` clicks "Запустить кампанию" instead, launching
+    the copy immediately in production.
+    """
+    existing = _find_master_row(page, campaign_id)
+    if existing is None:
+        raise BrowserSessionError(
+            f"Could not find Мастер кампаний {campaign_id} in the campaigns "
+            "grid — check the ID, or it may already be gone."
+        )
+
+    url = WIZARD_OVERVIEW_URL.format(campaign_id=campaign_id)
+    page.goto(url, wait_until="domcontentloaded")
+    assert_not_captcha(page.content())
+    assert_authenticated(page.content())
+
+    menu_trigger = page.locator(_MENU_TRIGGER_SELECTOR).first
+    try:
+        menu_trigger.click()
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            f"Could not open the campaign menu for {campaign_id} "
+            f"({_MENU_TRIGGER_SELECTOR!r} not found/clickable) — Yandex may "
+            "have changed the overview page's markup."
+        ) from exc
+
+    clone_item = page.locator(_CLONE_MENU_ITEM_SELECTOR).first
+    try:
+        clone_item.click()
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            f"Could not find/click 'Клонировать' for campaign {campaign_id} "
+            f"({_CLONE_MENU_ITEM_SELECTOR!r} not found) — Yandex may have "
+            "changed the overview page's menu."
+        ) from exc
+
+    _wait_for_step2(page)
+    _click_terminal_button(
+        page, _LAUNCH_BUTTON_TEXT if launch else _SAVE_DRAFT_BUTTON_TEXT
+    )
+
+    deadline = time.monotonic() + _CLONE_VERIFY_TIMEOUT_MS / 1000
+    new_id: Optional[int] = None
+    while time.monotonic() < deadline:
+        match = _WIZARD_OVERVIEW_URL_ID_RE.search(page.url)
+        # Must be a DIFFERENT campaign ID than the source: page.url still
+        # holds the source's own overview URL from the goto() above until
+        # Yandex actually redirects to the clone's, so matching the source's
+        # ID here is not evidence of anything having happened yet.
+        if match and int(match.group(1)) != campaign_id:
+            new_id = int(match.group(1))
+            break
+        page.wait_for_timeout(250)
+
+    if new_id is None:
+        raise BrowserSessionError(
+            f"Clicked '{_LAUNCH_BUTTON_TEXT if launch else _SAVE_DRAFT_BUTTON_TEXT}' "
+            f"after cloning campaign {campaign_id}, but Yandex did not "
+            f"redirect to the new campaign's overview page within "
+            f"{_CLONE_VERIFY_TIMEOUT_MS / 1000:.0f}s — verify manually "
+            "before retrying (this is not idempotent)."
+        )
+
+    updated = None
+    deadline = time.monotonic() + _CLONE_VERIFY_TIMEOUT_MS / 1000
+    while time.monotonic() < deadline:
+        updated = _find_master_row(page, new_id, status="all")
+        if updated is not None:
+            break
+        page.wait_for_timeout(250)
+
+    if updated is None:
+        raise BrowserSessionError(
+            f"Yandex redirected to campaign {new_id} after cloning "
+            f"{campaign_id}, but it did not appear in the campaigns grid "
+            f"within {_CLONE_VERIFY_TIMEOUT_MS / 1000:.0f}s — verify "
+            "manually before retrying (this is not idempotent)."
+        )
+
+    result = dict(updated)
+    result["SourceCampaignId"] = campaign_id
+    result["Launched"] = launch
+    return result
 
 
 def _set_weekly_budget(page: "Page", amount: int) -> None:

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -704,6 +704,59 @@ def archive(
         )
 
 
+@masters.command()
+@click.argument("campaign_id", type=int)
+@click.option(
+    "--launch/--draft",
+    "launch",
+    default=False,
+    help="Launch the clone immediately (Запустить кампанию) instead of "
+    "saving it as a draft (Сохранить как черновик, the default)",
+)
+@_masters_browser_options
+@click.pass_context
+@handle_api_errors
+def copy(
+    ctx,
+    campaign_id,
+    launch,
+    headful,
+    profile_dir,
+    chrome_profile,
+    output_format,
+    output,
+):
+    """Clone an existing Мастер кампаний by ID (Клонировать)
+
+    Mirrors the web UI's overview-page "⋮" menu → "Клонировать": Yandex
+    pre-fills a new campaign from the source's headlines, texts, images,
+    region, budget, and everything else — including the display region
+    verbatim, which sidesteps the text-matching issues `masters add
+    --region`/`--region-id` can hit (issues #652/#656/#657). Nothing on the
+    copy is renamed or edited beyond what Yandex itself does (it appends
+    " — N" to the name) — use `masters update` afterwards for any further
+    changes.
+
+    NOT idempotent: running this twice creates a SECOND copy, not an update
+    to the first — there is no sandbox and no rollback for Мастер кампаний
+    mutations.
+
+    By default the copy is saved as a draft (--draft) without going live.
+    Pass --launch to launch it immediately in production instead.
+    """
+    from ..browser.masters import copy_master
+
+    result = _with_session(
+        ctx,
+        headful,
+        profile_dir,
+        chrome_profile,
+        lambda page: copy_master(page, campaign_id, launch=launch),
+    )
+
+    format_output(result, output_format, output)
+
+
 def _resolve_region_ids(ctx: click.Context, region_ids: "tuple[int, ...]") -> list:
     """Resolve RegionId values to Yandex's canonical GeoRegionName via the
     GeoRegions dictionary — the exact text the Мастер кампаний region widget

--- a/direct_cli/smoke_matrix.py
+++ b/direct_cli/smoke_matrix.py
@@ -202,6 +202,11 @@ SMOKE_MATRIX = {
         # configured campaign in the account with no automated rollback.
         # Manual-only, per scripts/test_dangerous_commands.sh.
         "masters.add",
+        # Clones an existing Мастер кампаний (issue #659) — same risk
+        # profile as masters.add: no API surface, no sandbox, and NOT
+        # idempotent (a second run creates a second copy, not an update).
+        # Manual-only, per scripts/test_dangerous_commands.sh.
+        "masters.copy",
         # Interactive, human-in-the-loop login (issue #635) -- opens a
         # visible browser window and blocks for up to --timeout seconds
         # waiting for a person to sign in by hand. Cannot run unattended in

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -48,6 +48,7 @@ DRY_RUN_EXCEPTIONS = {
     "masters.suspend",
     "masters.update",
     "masters.add",
+    "masters.copy",
 }
 
 FORBIDDEN_HELP_TEXT = (

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -30,6 +30,7 @@ from click.testing import CliRunner
 from direct_cli.browser import masters as browser_masters
 from direct_cli.browser.masters import PlaywrightError
 from direct_cli.browser.session import (
+    BrowserAuthError,
     BrowserCaptchaError,
     BrowserSessionError,
 )
@@ -2050,6 +2051,46 @@ class TestCopyMaster(unittest.TestCase):
                 browser_masters.copy_master(page, self.SOURCE_ID)
 
         self.assertIn("did not appear in the campaigns grid", str(ctx.exception))
+
+    def test_auth_error_during_post_click_verification_is_not_retried(self):
+        # The clone/terminal-button click has ALREADY happened (irreversible,
+        # not idempotent) by the time verification runs. If the saved session
+        # is invalidated exactly in that window, fetch_masters_list's own
+        # assert_authenticated raises BrowserAuthError -- which _with_session
+        # (direct_cli/commands/masters.py) would otherwise catch and retry
+        # the WHOLE copy_master call under a fresh session, re-clicking
+        # Клонировать and the terminal button and creating a SECOND copy (or,
+        # with --launch, a second live campaign spending real budget). This
+        # must surface as a plain BrowserSessionError (not BrowserAuthError),
+        # so _with_session's retry-on-BrowserAuthError does not fire, and the
+        # error message must reference NEW_ID so the caller can check
+        # manually instead of losing track of the clone that already exists.
+        page = self._page(
+            menu_trigger=_FakeLocatorHandle(),
+            clone_item=_FakeLocatorHandle(),
+            terminal_button_text=browser_masters._SAVE_DRAFT_BUTTON_TEXT,
+        )
+
+        calls = []
+
+        def _fetch_masters_list(page, status="all"):
+            # First call (before the click) looks up the source campaign and
+            # must succeed; only the post-click lookup (finding new_id) hits
+            # the invalidated session.
+            calls.append(status)
+            if len(calls) == 1:
+                return [self._source_row()]
+            raise BrowserAuthError("stale session, detected mid-body")
+
+        with patch(
+            "direct_cli.browser.masters.fetch_masters_list",
+            side_effect=_fetch_masters_list,
+        ):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters.copy_master(page, self.SOURCE_ID)
+
+        self.assertNotIsInstance(ctx.exception, BrowserAuthError)
+        self.assertIn(str(self.NEW_ID), str(ctx.exception))
 
 
 class TestMastersCopyCommand(unittest.TestCase):

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -366,6 +366,11 @@ class FakePage:
         self.navigated_to = []
         self.goto_wait_until = None
         self.closed = False
+        # Mutated by goto() and settable directly by a test's on_click
+        # callback to simulate Yandex's post-click redirect (see
+        # TestCopyMaster) — copy_master polls this the same way
+        # archive_master polls fetch_masters_list.
+        self.url = ""
         # If set, matched by expect_response()'s predicate once goto() has
         # been called inside its `with` block — models the grid firing its
         # GridCampaigns XHR during navigation.
@@ -387,6 +392,7 @@ class FakePage:
     def goto(self, url, wait_until=None):
         self.navigated_to.append(url)
         self.goto_wait_until = wait_until
+        self.url = url
 
     def close(self):
         self.closed = True
@@ -1856,6 +1862,233 @@ class TestMastersArchiveCommand(unittest.TestCase):
         self.assertIn("ARCHIVED", result.output)
         self.assertIn("2", result.output)
         self.assertIn("boom on id 3", result.output)
+
+
+class TestCopyMaster(unittest.TestCase):
+    """``copy_master`` (issue #659): click Клонировать, then the clone form's
+
+    terminal button, verified via both the post-click URL redirect and the
+    campaigns grid — live-verified end to end (see module docstring, campaign
+    107707079 -> draft copy 713231614).
+    """
+
+    SOURCE_ID = 42
+    NEW_ID = 4200
+
+    def _source_row(self, status="STOPPED"):
+        return {
+            "CampaignId": self.SOURCE_ID,
+            "Name": "Мастер тестовый",
+            "Status": status,
+            "Type": "TEXT",
+            "StartDate": "2025-01-01",
+        }
+
+    def _new_row(self, status="DRAFT"):
+        return {
+            "CampaignId": self.NEW_ID,
+            "Name": "Мастер тестовый — 2",
+            "Status": status,
+            "Type": "TEXT",
+            "StartDate": "2026-08-02",
+        }
+
+    def _page(
+        self,
+        menu_trigger=None,
+        clone_item=None,
+        region_heading=True,
+        terminal_button_text=None,
+        redirect_on_click=True,
+    ):
+        locators = {}
+        if menu_trigger is not None:
+            locators[browser_masters._MENU_TRIGGER_SELECTOR] = _FakeLocator(
+                [menu_trigger]
+            )
+        if clone_item is not None:
+            locators[browser_masters._CLONE_MENU_ITEM_SELECTOR] = _FakeLocator(
+                [clone_item]
+            )
+
+        text_buttons = {}
+        if region_heading:
+            text_buttons["Регион показов"] = _FakeGetByTextLocator(
+                [_FakeTextLocatorHandle()]
+            )
+
+        page = FakePage(locators=locators, text_buttons=text_buttons)
+
+        if terminal_button_text is not None:
+
+            def _on_terminal_click():
+                if redirect_on_click:
+                    page.url = browser_masters.WIZARD_OVERVIEW_URL.format(
+                        campaign_id=self.NEW_ID
+                    )
+
+            page._role_elements = [
+                (
+                    "button",
+                    terminal_button_text,
+                    _FakeTextLocatorHandle(visible=True, on_click=_on_terminal_click),
+                )
+            ]
+        return page
+
+    def test_copies_saves_as_draft_by_default_and_verifies(self):
+        page = self._page(
+            menu_trigger=_FakeLocatorHandle(),
+            clone_item=_FakeLocatorHandle(),
+            terminal_button_text=browser_masters._SAVE_DRAFT_BUTTON_TEXT,
+        )
+
+        with patch(
+            "direct_cli.browser.masters.fetch_masters_list",
+            side_effect=lambda page, status="all": [
+                self._source_row(),
+                self._new_row(),
+            ],
+        ):
+            result = browser_masters.copy_master(page, self.SOURCE_ID)
+
+        self.assertEqual(result["SourceCampaignId"], self.SOURCE_ID)
+        self.assertEqual(result["CampaignId"], self.NEW_ID)
+        self.assertEqual(result["Status"], "DRAFT")
+        self.assertFalse(result["Launched"])
+        self.assertEqual(
+            page.navigated_to[0],
+            browser_masters.WIZARD_OVERVIEW_URL.format(campaign_id=self.SOURCE_ID),
+        )
+
+    def test_launch_true_clicks_launch_button(self):
+        page = self._page(
+            menu_trigger=_FakeLocatorHandle(),
+            clone_item=_FakeLocatorHandle(),
+            terminal_button_text=browser_masters._LAUNCH_BUTTON_TEXT,
+        )
+
+        with patch(
+            "direct_cli.browser.masters.fetch_masters_list",
+            side_effect=lambda page, status="all": [
+                self._source_row(),
+                self._new_row(status="ACTIVE"),
+            ],
+        ):
+            result = browser_masters.copy_master(page, self.SOURCE_ID, launch=True)
+
+        self.assertTrue(result["Launched"])
+        self.assertEqual(result["Status"], "ACTIVE")
+
+    def test_raises_when_source_campaign_not_found(self):
+        page = self._page()
+
+        with patch("direct_cli.browser.masters.fetch_masters_list", return_value=[]):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters.copy_master(page, self.SOURCE_ID)
+
+        self.assertIn("Could not find", str(ctx.exception))
+
+    def test_raises_when_menu_trigger_not_found(self):
+        page = self._page()  # no menu_trigger locator registered
+
+        with patch(
+            "direct_cli.browser.masters.fetch_masters_list",
+            return_value=[self._source_row()],
+        ):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters.copy_master(page, self.SOURCE_ID)
+
+        self.assertIn("Could not open the campaign menu", str(ctx.exception))
+
+    def test_raises_when_clone_menu_item_not_found(self):
+        page = self._page(menu_trigger=_FakeLocatorHandle())
+
+        with patch(
+            "direct_cli.browser.masters.fetch_masters_list",
+            return_value=[self._source_row()],
+        ):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters.copy_master(page, self.SOURCE_ID)
+
+        self.assertIn("Клонировать", str(ctx.exception))
+
+    def test_raises_when_no_redirect_after_terminal_click(self):
+        # The terminal button is clicked but Yandex never redirects -- must
+        # not report success on the click alone (not idempotent, so a false
+        # success here is expensive to clean up).
+        page = self._page(
+            menu_trigger=_FakeLocatorHandle(),
+            clone_item=_FakeLocatorHandle(),
+            terminal_button_text=browser_masters._SAVE_DRAFT_BUTTON_TEXT,
+            redirect_on_click=False,
+        )
+
+        with patch(
+            "direct_cli.browser.masters.fetch_masters_list",
+            return_value=[self._source_row()],
+        ):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters.copy_master(page, self.SOURCE_ID)
+
+        self.assertIn("did not redirect", str(ctx.exception))
+
+    def test_raises_when_new_campaign_never_appears_in_grid(self):
+        # The redirect happens (page.url changes) but the grid never reports
+        # the new campaign -- must not trust the URL alone either.
+        page = self._page(
+            menu_trigger=_FakeLocatorHandle(),
+            clone_item=_FakeLocatorHandle(),
+            terminal_button_text=browser_masters._SAVE_DRAFT_BUTTON_TEXT,
+        )
+
+        with patch(
+            "direct_cli.browser.masters.fetch_masters_list",
+            return_value=[self._source_row()],  # never includes NEW_ID
+        ):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters.copy_master(page, self.SOURCE_ID)
+
+        self.assertIn("did not appear in the campaigns grid", str(ctx.exception))
+
+
+class TestMastersCopyCommand(unittest.TestCase):
+    """CLI wiring for `masters copy` (issue #659)."""
+
+    def setUp(self):
+        self.runner = CliRunner()
+
+    def test_copy_registered(self):
+        result = self.runner.invoke(cli, ["masters", "copy", "--help"])
+        self.assertEqual(result.exit_code, 0)
+
+    def test_copy_has_no_login_option(self):
+        result = self.runner.invoke(cli, ["masters", "copy", "--help"])
+        self.assertNotIn("--login", result.output)
+
+    def test_copy_defaults_to_draft(self):
+        with (
+            patch("direct_cli.browser.masters.copy_master") as mock_copy,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_copy.return_value = {"CampaignId": 99, "SourceCampaignId": 42}
+            result = self.runner.invoke(cli, ["masters", "copy", "42"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        mock_copy.assert_called_once_with(mock_copy.call_args[0][0], 42, launch=False)
+
+    def test_copy_launch_flag_passes_through(self):
+        with (
+            patch("direct_cli.browser.masters.copy_master") as mock_copy,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_copy.return_value = {"CampaignId": 99, "SourceCampaignId": 42}
+            result = self.runner.invoke(cli, ["masters", "copy", "42", "--launch"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        mock_copy.assert_called_once_with(mock_copy.call_args[0][0], 42, launch=True)
 
 
 class TestSetWeeklyBudget(unittest.TestCase):


### PR DESCRIPTION
## Summary

- New `direct masters copy <CAMPAIGN_ID> [--launch/--draft]` clones an existing Мастер кампаний via the overview page's "⋮" menu → "Клонировать" (`CampaignHeader.Menu.clone`, confirmed live) — the same action a human uses in the web UI.
- Yandex pre-fills the new campaign end to end from the source (headlines, texts, images, video, **display region verbatim**, Metrika counters, target actions, weekly budget) — this sidesteps the region text-matching issues `masters add --region`/`--region-id` can hit entirely (#652/#656/#657), since nothing is retyped or re-matched.
- Live-verified end to end: campaign 107707079 → draft copy 713231614, confirmed via both the post-click URL redirect to the new campaign's overview page and a `fetch_masters_list` grid diff before reporting success — never trusting the click alone, matching the module's existing convention.
- Scope intentionally narrow: `copy` is a 1:1 mirror of the web UI's clone action only, not a field-override tool. Nothing is renamed/edited beyond what Yandex itself does (it appends " — N" to the name); further changes go through the existing `masters update`.
- `--draft`/`--launch` default to `--draft` (safer than `masters add`'s launch-by-default).
- Classified `DANGEROUS` in `smoke_matrix.py` like `masters add`: no API surface, no sandbox, **not idempotent** (repeated calls create additional copies).

## Follow-up (not in this PR)

Recon also surfaced a pre-existing, unrelated gap: a freshly created `DRAFT` campaign's overview page turns out to be the editable wizard form itself (no "⋮" menu, no `CampaignHeader.MenuTrigger`) rather than the stats-dashboard overview every other status renders — so `masters get`/`archive`/`suspend`/`resume` don't work against `DRAFT` campaigns yet. Filed as #660.

## Test plan

- [x] `pytest tests/test_masters.py tests/test_smoke_matrix.py tests/test_cli_contract.py tests/test_comprehensive.py -q` — 251 passed
- [x] `black`/`flake8` clean on all touched files
- [x] `direct masters copy --help` — verified via real CLI invocation
- [x] Live end-to-end verification against production (no sandbox exists for Мастер кампаний): campaign 107707079 → draft copy 713231614, confirmed via both URL redirect and grid diff
- [ ] CI green

Closes #659