### PR TITLE
fix(masters): recognize Yandex Passport's new /pwl-yandex login page

### DIFF
--- a/direct_cli/browser/session.py
+++ b/direct_cli/browser/session.py
@@ -111,7 +111,22 @@ class BrowserSessionMissingError(BrowserSessionError):
 # Direct page. Declared once, ``_captcha.py``-style, rather than duplicated
 # across call sites (see CLAUDE.md "No URL literals outside the registry" and
 # the #426 post-mortem it cites).
-_LOGIN_PAGE_MARKERS = ("passport.yandex.ru/auth", "Войдите с Яндекс ID")
+#
+# issue #666: Yandex migrated the login page from ``/auth`` to
+# ``/pwl-yandex`` and dropped "Войдите с Яндекс ID" from the HTML entirely —
+# live-confirmed 2026-08-02 via a real expired saved session redirected to
+# ``passport.yandex.ru/pwl-yandex?...&cause=auth&...``. Both original markers
+# went stale at once, so ``assert_authenticated`` silently treated a real
+# login page as authenticated, turning an expired/invalid session into an
+# opaque grid-request timeout instead of a clear ``BrowserAuthError``. The
+# old markers are kept alongside the new one rather than replaced outright —
+# Yandex could roll the URL back, and a marker that's merely unused costs
+# nothing.
+_LOGIN_PAGE_MARKERS = (
+    "passport.yandex.ru/auth",
+    "passport.yandex.ru/pwl-yandex",
+    "Войдите с Яндекс ID",
+)
 
 
 def default_chrome_profile_dir() -> Optional[Path]:

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -3054,6 +3054,27 @@ class TestAuthDetection(unittest.TestCase):
             with self.assertRaises(BrowserAuthError):
                 assert_authenticated(marker_html)
 
+    def test_assert_authenticated_raises_on_current_pwl_yandex_login_page(self):
+        # Live re-recon 2026-08-02 (issue #666): Yandex Passport's login page
+        # has migrated from /auth to /pwl-yandex, and no longer renders the
+        # "Войдите с Яндекс ID" text anywhere in the HTML — confirmed via a
+        # real open_saved_session() + goto(GRID_URL) against an actual
+        # expired/invalid saved session. Both #634 markers went stale at the
+        # same time, so assert_authenticated silently passed a real login
+        # page through as "authenticated", turning an expired session into
+        # an opaque `masters list` timeout ("waiting for event 'response'")
+        # instead of a clear BrowserAuthError.
+        from direct_cli.browser.session import BrowserAuthError, assert_authenticated
+
+        html = (
+            "<title>Авторизация</title>"
+            "<script>window.__CONSTANTS__ = {'baseUrl':'/pwl-yandex',"
+            "'authUrl':'https://passport.yandex.ru/pwl-yandex?retpath=..."
+            "&origin=direct', ...};</script>"
+        )
+        with self.assertRaises(BrowserAuthError):
+            assert_authenticated(html)
+
     def test_assert_authenticated_passes_on_real_content(self):
         from direct_cli.browser.session import assert_authenticated
 


### PR DESCRIPTION
## Summary

- Yandex migrated Passport's login page from `passport.yandex.ru/auth` to `/pwl-yandex` and dropped the text "Войдите с Яндекс ID" from the HTML entirely. Both markers `assert_authenticated` relied on (issue #634) went stale at the same time.
- As a result, `assert_authenticated` silently treated a real login page as authenticated. A stale/invalid saved session no longer failed with a clear `BrowserAuthError` — instead every `masters` command that depends on it (confirmed live: `masters list`) hung for the full 30s waiting for a network event that could never fire (the page was Passport's login form, not the campaigns grid), then surfaced as an opaque `Timeout 30000ms exceeded while waiting for event "response"`.
- Fix: added `"passport.yandex.ru/pwl-yandex"` to `_LOGIN_PAGE_MARKERS` (`direct_cli/browser/session.py`), alongside the old markers (kept in case Yandex reverts — a merely-unused marker costs nothing).
- Found and root-caused via a live read-only recon (`open_saved_session` + `goto(GRID_URL)` against an actual expired session) while investigating the user's real `masters list` timeout — not a synthetic repro.

## Test plan (TDD, per `/fix`)

- **Red**: `test_assert_authenticated_raises_on_current_pwl_yandex_login_page` failed with `BrowserAuthError not raised` against the live-captured login page HTML, before the fix.
- **Green**: `pytest tests/test_masters.py -q` — 208/208 pass. Live-confirmed `BrowserAuthError` is now raised on the captured login-page HTML via a standalone repro script.
- **Mutation**: manually reverted the marker addition and re-ran the new test — it failed as expected, confirming it actually catches the regression (`mutmut` is not installed in this environment).
- `black`/`flake8` clean on both touched files.

Closes #666