### PR TITLE
feat(masters): add masters update --headline/--text — Этап B point-replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@
   this only replaces variants that already exist, it does not add new
   ones. Deleting a variant (clearing a slot) and editing variant weights
   are tracked as separate follow-ups, not implemented here.
+- An out-of-range slot number (`--headline "6="`, `--text "4=x"`) is
+  rejected at the CLI boundary too, with the bounds imported from the
+  browser layer's own `_HEADLINES_SLOT_COUNT`/`_TEXTS_SLOT_COUNT` so the
+  two can't drift. Previously only `_set_repeating_value` caught it, so a
+  purely invalid argument launched a browser (and possibly an auth prompt)
+  before failing as a `BrowserSessionError` instead of a `UsageError`.
 - An empty or whitespace-only replacement (`--headline "1="`) is likewise
   refused, at the CLI boundary before any browser session opens and again
   in `_set_repeating_value` for non-CLI callers. Blanking a slot is a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@
   this only replaces variants that already exist, it does not add new
   ones. Deleting a variant (clearing a slot) and editing variant weights
   are tracked as separate follow-ups, not implemented here.
+- An empty or whitespace-only replacement (`--headline "1="`) is likewise
+  refused, at the CLI boundary before any browser session opens and again
+  in `_set_repeating_value` for non-CLI callers. Blanking a slot is a
+  *delete*, not a replace, and it would have failed silently: the slot is
+  cleared, `""` typed, the form saved, and the post-save check compares the
+  re-read slot against the requested value — `"" == ""` matches, so the
+  deletion of a live ad variant would have been reported as a successful
+  update (found in review by both reviewers).
 - The edit page's slots (`CampaignTitles{N}.textarea`/
   `CampaignTexts{N}.textarea`, 5/3 slots) turned out identical in shape and
   count to the create page's (#653), confirmed via a read-only recon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,61 @@
 
 ## Unreleased
 
+**Added — `direct masters update --headline`/`--text` (#665, Этап B):**
+
+- New `--headline "N=text"` / `--text "N=text"` flags on `direct masters
+  update <CAMPAIGN_ID>` replace one existing headline/ad-text variant slot
+  at a time (N is the 1-based slot shown on the edit page — 1-5 for
+  headlines, 1-3 for ad text). Repeatable for multiple slots in one call.
+- **Deliberate departure from this CLI's dominant list-field convention**:
+  everywhere else, `update` replaces the WHOLE array in one call (e.g.
+  `campaigns update --negative-keywords`, built on
+  `_campaigns_base.py::_array_of_string_option`, which never reads the
+  existing array before overwriting it). Мастер кампаний has no API at all
+  — every mutation is a live page edit through a small, fixed set of slots
+  — and forcing every variant to be re-typed to fix one typo would defeat
+  the point of a partial update. A future refactor may want to unify this
+  with the rest of the CLI's convention, but that isn't settled and is out
+  of scope here. See `direct_cli/browser/masters.py::_set_repeating_value`
+  for the full rationale.
+- Writing to a slot that is currently empty is refused (`UsageError`) —
+  this only replaces variants that already exist, it does not add new
+  ones. Deleting a variant (clearing a slot) and editing variant weights
+  are tracked as separate follow-ups, not implemented here.
+- The edit page's slots (`CampaignTitles{N}.textarea`/
+  `CampaignTexts{N}.textarea`, 5/3 slots) turned out identical in shape and
+  count to the create page's (#653), confirmed via a read-only recon
+  against campaign 107707079 before writing any code — see
+  `tests/fixtures/masters_wizard_edit_stage_b.html`.
+- Reuses `_clear_text_field`/`_read_repeating_values` from the create-page
+  implementation as-is; does NOT reuse `_add_repeating_values` (that
+  function's contract — clear and rewrite every slot — is the opposite of
+  a point replacement).
+- Live-verified end to end against a real DRAFT campaign (713231614): a
+  headline slot was replaced, confirmed saved via reload, then reverted to
+  its original text the same way.
+
+**Fixed — `direct masters update` on DRAFT campaigns (#668):**
+
+- A DRAFT campaign's edit page has no "Сохранить кампанию" button at all —
+  only `CampaignFormControls.saveDraft.button`/`.save.button` (the latter
+  labelled "Запустить кампанию" here, which PUBLISHES the campaign — same
+  testid suffix as the non-DRAFT save button, different label and
+  consequence). `update_master` now detects DRAFT via the presence of
+  `saveDraft.button` and clicks it by default (keeping DRAFT status); pass
+  `--launch` to publish while saving instead. Previously `update` failed
+  cleanly on any DRAFT campaign (issue #660's original gap) — this closes
+  that gap for `update` specifically (`get`/`archive`/`suspend`/`resume`
+  on DRAFT remain tracked separately in #660).
+- Live-recon (2026-08-02, campaign 713231614) found the draft-save click
+  redirects away from `/edit/` to the campaign's overview page, and NOT
+  instantly (~5s observed) — `update_master`'s original immediate
+  post-click reload raced this redirect and produced a false "did not save
+  as requested" error even though the edit WAS actually saved server-side.
+  Fixed by polling `page.url` until it leaves `/edit/` before re-navigating
+  to verify, mirroring the pattern `copy_master` already uses for its own
+  post-click redirect.
+
 **Added — `direct masters update --name` (#663):**
 
 - New `--name` flag on `direct masters update <CAMPAIGN_ID>` renames a Мастер

--- a/README.md
+++ b/README.md
@@ -76,8 +76,10 @@ be large, and forcing every variant to be re-typed just to fix one typo would
 defeat the point of a partial update — see
 `direct_cli/browser/masters.py::_set_repeating_value` for the full rationale.
 Writing to a slot that is currently empty is refused (`UsageError`) — this
-only edits variants that already exist, it does not add new ones; deleting a
-variant and editing variant weights aren't implemented yet. Later fields
+only edits variants that already exist, it does not add new ones. An empty or
+whitespace-only replacement (`--headline "1="`) is refused for the mirror-image
+reason: blanking a slot would delete a live ad variant, not replace it.
+Deleting a variant and editing variant weights aren't implemented yet. Later fields
 (sitelinks, audience, Metrika counters/goals, budget adaptation, images/
 video) aren't implemented yet either.
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ direct masters archive 72349978
 direct masters update 72349978 --weekly-budget 95000
 direct masters update 72349978 --promotion-goal max-clicks --no-directs-helps
 direct masters update 72349978 --name "Мастер ИЖ Источник Жизни (тёплый)"
+direct masters update 72349978 --headline "2=Новый заголовок" --text "1=Новый текст"
 direct masters add https://example.com/ --headline "Заголовок 1" --headline "Заголовок 2" --text "Текст объявления" --region Москва --weekly-budget 50000 --draft
 direct masters add https://example.com/ --headline "Заголовок 1" --text "Текст объявления" --region-id 213 --weekly-budget 50000 --draft
 direct masters copy 72349978
@@ -53,18 +54,37 @@ It always reads the logged-in browser session's own account — there is no
 
 `masters update` edits a single Мастер кампаний's settings page. It currently
 covers the simplest scalar fields (Этап A of a larger, staged rollout — see
-`direct_cli/browser/masters.py` module docstring) plus the campaign name:
+`direct_cli/browser/masters.py` module docstring), the campaign name, and
+point-replacement of individual headline/ad-text variants (Этап B):
 `--weekly-budget` (integer), `--promotion-goal`
 (`max-conversions`/`max-clicks`), `--directs-helps`/`--no-directs-helps`
-(auto-apply recommendations), and `--name` (Название кампании). At least one
+(auto-apply recommendations), `--name` (Название кампании), and
+`--headline`/`--text` (repeatable `"N=text"`, N is the 1-based variant slot
+shown on the edit page — 1-5 for headlines, 1-3 for ad text). At least one
 flag is required. The settings page is a single form with one save button —
 passing only some flags leaves every other field at its current value; it
 does not send a partial payload to a separate per-field endpoint. Unlike the
-other three fields, `--name` is edited through a separate header modal, not
-a plain form input — but it is still persisted only by that same terminal
-save button, not by the modal's own "Применить". Later fields (headline/text
-variants, sitelinks, audience, Metrika counters/goals, budget adaptation,
-images/video) aren't implemented yet.
+other fields, `--name` is edited through a separate header modal, not a plain
+form input — but it is still persisted only by that same terminal save
+button, not by the modal's own "Применить".
+
+`--headline`/`--text` **replace one existing variant at a time** rather than
+the whole variant list — a deliberate departure from this CLI's usual
+list-field convention (e.g. `campaigns update --negative-keywords` replaces
+the entire array in one call). Мастер кампаний has no API, variant sets can
+be large, and forcing every variant to be re-typed just to fix one typo would
+defeat the point of a partial update — see
+`direct_cli/browser/masters.py::_set_repeating_value` for the full rationale.
+Writing to a slot that is currently empty is refused (`UsageError`) — this
+only edits variants that already exist, it does not add new ones; deleting a
+variant and editing variant weights aren't implemented yet. Later fields
+(sitelinks, audience, Metrika counters/goals, budget adaptation, images/
+video) aren't implemented yet either.
+
+A DRAFT campaign's edit page has no "Сохранить кампанию" button at all —
+`masters update` on a DRAFT saves it via "Сохранить как черновик" by
+default, keeping it a DRAFT; pass `--launch` to publish it while saving
+instead ("Запустить кампанию"). Has no effect on a non-DRAFT campaign.
 
 If you see "Found no Yandex cookies", open https://direct.yandex.ru in Chrome
 and log in first. If you use a non-default Chrome profile, pass
@@ -1150,6 +1170,7 @@ direct masters archive 72349978
 direct masters update 72349978 --weekly-budget 95000
 direct masters update 72349978 --promotion-goal max-clicks --no-directs-helps
 direct masters update 72349978 --name "Мастер ИЖ Источник Жизни (тёплый)"
+direct masters update 72349978 --headline "2=Новый заголовок" --text "1=Новый текст"
 direct masters add https://example.com/ --headline "Заголовок 1" --headline "Заголовок 2" --text "Текст объявления" --region Москва --weekly-budget 50000 --draft
 direct masters add https://example.com/ --headline "Заголовок 1" --text "Текст объявления" --region-id 213 --weekly-budget 50000 --draft
 direct masters copy 72349978
@@ -1164,19 +1185,40 @@ direct masters copy 72349978 --launch
 
 `masters update` редактирует настройки одного «Мастера кампаний». Пока
 поддерживаются простые скалярные поля (Этап A поэтапного плана — см.
-докстринг модуля `direct_cli/browser/masters.py`) и название кампании:
+докстринг модуля `direct_cli/browser/masters.py`), название кампании и
+точечная замена отдельных вариантов заголовков/текстов (Этап B):
 `--weekly-budget` (недельный бюджет, целое число), `--promotion-goal`
 (`max-conversions`/`max-clicks` — цель продвижения),
 `--directs-helps`/`--no-directs-helps` (автоприменение рекомендаций «Директ
-помогает») и `--name` (Название кампании). Нужно указать хотя бы один флаг.
-Страница настроек — единая форма с одной кнопкой сохранения: если указать не
-все флаги, остальные поля останутся с текущим значением — это не частичный
-запрос к отдельному API-эндпоинту на каждое поле. В отличие от трёх
-остальных полей, `--name` редактируется через отдельную модалку в шапке, а
-не обычное поле формы — но сохраняется всё той же общей кнопкой, а не
-собственной кнопкой «Применить» модалки. Остальные поля (варианты
-заголовков/текстов, быстрые ссылки, аудитория, счётчики Метрики/цели,
-адаптация бюджета, изображения/видео) пока не реализованы.
+помогает»), `--name` (Название кампании) и `--headline`/`--text`
+(повторяемые, формат `"N=текст"`, N — номер слота варианта на странице
+редактирования, 1-based: 1-5 для заголовков, 1-3 для текстов). Нужно указать
+хотя бы один флаг. Страница настроек — единая форма с одной кнопкой
+сохранения: если указать не все флаги, остальные поля останутся с текущим
+значением — это не частичный запрос к отдельному API-эндпоинту на каждое
+поле. В отличие от остальных полей, `--name` редактируется через отдельную
+модалку в шапке, а не обычное поле формы — но сохраняется всё той же общей
+кнопкой, а не собственной кнопкой «Применить» модалки.
+
+`--headline`/`--text` **заменяют один существующий вариант за раз**, а не
+весь набор целиком — это сознательное отступление от обычной конвенции CLI
+для list-полей (например, `campaigns update --negative-keywords` заменяет
+весь массив одним вызовом). У Мастера кампаний нет API, наборы вариантов
+могут быть большими, и заставлять перепечатывать все варианты ради
+исправления одной опечатки противоречило бы смыслу частичного обновления —
+полное обоснование см. в
+`direct_cli/browser/masters.py::_set_repeating_value`. Запись в пустой слот
+запрещена (`UsageError`) — команда только редактирует уже существующие
+варианты, а не добавляет новые; удаление варианта и редактирование весов
+вариантов пока не реализованы. Остальные поля (быстрые ссылки, аудитория,
+счётчики Метрики/цели, адаптация бюджета, изображения/видео) тоже пока не
+реализованы.
+
+У черновика («DRAFT») страница редактирования вообще не имеет кнопки
+«Сохранить кампанию» — `masters update` на черновике по умолчанию сохраняет
+через «Сохранить как черновик» (статус DRAFT сохраняется); чтобы вместо
+этого опубликовать кампанию при сохранении, передайте `--launch`
+(«Запустить кампанию»). На не-черновиковой кампании флаг не имеет эффекта.
 
 Если видите «Found no Yandex cookies», откройте https://direct.yandex.ru в
 Chrome и войдите в аккаунт. Если используете не дефолтный профиль Chrome —

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -55,12 +55,23 @@ archived-campaign overview fixture has been captured, so there is no
 confirmed status-text marker for "archived" on that page the way there is
 for "Кампания остановлена"/"активна".
 
-``update_master`` (issue #631, Этап A only) — live-verified against campaign
+``update_master`` (issue #631, Этап A) — live-verified against campaign
 107707079 (see ``tests/fixtures/masters_wizard_edit_stage_a.html`` for the
 full investigation notes). Covers exactly three fields: weekly budget,
 promotion goal, and the "Директ помогает" auto-recommendations toggle.
-Later stages (headline/text lists, sitelinks, audience, media uploads) are
-tracked separately in issue #631 and are NOT implemented here.
+
+``update_master`` headlines/texts (issue #665, Этап B) — live-verified
+against campaign 107707079 (see
+``tests/fixtures/masters_wizard_edit_stage_b.html``). Replaces the text of
+ONE existing headline/text slot at a time (``_set_repeating_value``), NOT
+the whole variant list — a deliberate departure from this CLI's usual
+"update replaces the whole array" list-field convention (see
+``_set_repeating_value``'s own docstring for the rationale). Writing to an
+empty slot (adding a brand-new variant) is refused; deleting a variant and
+editing variant weights are both tracked as separate follow-ups, not
+implemented here. Later stages (sitelinks, audience, Metrika counters/goals,
+budget adaptation, media uploads) are tracked in issue #648 and are NOT
+implemented here.
 
 ``name`` (issue #663) — live-verified against campaigns 713231614 (DRAFT)
 and 107707079 (non-draft, read-only recon) — see
@@ -71,11 +82,24 @@ above, the name is edited via a separate modal
 "Применить" only updates the page's optimistic/local state — the rename is
 persisted only by the same terminal save action every other field here
 relies on, so this module never trusts the modal click alone (verified via
-the header's displayed name after a real reload). Same pre-existing DRAFT
-limitation as issue #660 applies (no "Сохранить кампанию" button on a DRAFT
-campaign) — ``update_master`` fails cleanly via ``_click_save``'s existing
-error rather than corrupting the name; fixing DRAFT support is out of scope
-for #663, see #660.
+the header's displayed name after a real reload).
+
+**DRAFT support** (issue #668). A DRAFT campaign's edit page renders NO
+"Сохранить кампанию" button at all — only
+``CampaignFormControls.saveDraft.button`` ("Сохранить как черновик") and
+``CampaignFormControls.save.button`` (labelled "Запустить кампанию" here,
+NOT "Сохранить кампанию" — same testid suffix as the non-DRAFT save button,
+different label and consequence: this one publishes the draft). Confirmed
+live against campaign 713231614 (2026-08-02, read-only recon before any
+code change). ``_is_draft_edit_page`` detects DRAFT by the presence of
+``saveDraft.button`` itself, so the detection and the click it gates can
+never disagree about what "DRAFT" means. ``update_master``'s ``launch``
+kwarg (CLI: ``masters update --launch``) defaults to ``False`` — saving a
+DRAFT keeps it a DRAFT unless the caller explicitly asks to publish it,
+mirroring ``create_master``/``copy_master``'s own draft-preserving
+defaults. Originally out of scope for #663 (see #660's initial gap report);
+#665's live verification needed a working DRAFT save path to exercise, so
+it was implemented here instead of deferred further.
 
 Confirmed live: the edit page (``/wizard/campaigns/{id}/edit/``) is a single
 form with exactly one "Сохранить кампанию" button at the bottom — there is no
@@ -276,6 +300,11 @@ _ARCHIVE_VERIFY_TIMEOUT_MS = 10_000
 # live ~7s, issue #659) before giving up on copy_master.
 _CLONE_VERIFY_TIMEOUT_MS = 20_000
 
+# How long to wait for the DRAFT edit page's saveDraft/launch click to
+# redirect away from /edit/ (issue #668) — live-confirmed ~5s in one recon,
+# generous headroom for a slower response.
+_DRAFT_SAVE_REDIRECT_TIMEOUT_MS = 20_000
+
 # Matches WIZARD_OVERVIEW_URL's {campaign_id} once Yandex redirects there
 # after a successful clone save/launch (see copy_master).
 _WIZARD_OVERVIEW_URL_ID_RE = re.compile(r"/wizard/campaigns/(\d+)/")
@@ -471,6 +500,20 @@ _NAME_MODAL_ACCEPT_SELECTOR = '[data-testid="AcceptButton"]'
 _SAVE_BUTTON_TEXT = "Сохранить кампанию"
 _LAUNCH_BUTTON_TEXT = "Запустить кампанию"
 _SAVE_DRAFT_BUTTON_TEXT = "Сохранить как черновик"
+
+# DRAFT edit page's terminal buttons (issue #668, live-confirmed 2026-08-02
+# against campaign 713231614 — see the module docstring's "DRAFT support"
+# note). A DRAFT edit page has NO "Сохранить кампанию" button at all — only
+# these two, under a shared testid prefix. Matched by data-testid rather than
+# accessible-name text (unlike ``_click_save``/``_click_terminal_button``)
+# because ``CampaignFormControls.save.button``'s TEXT is "Запустить
+# кампанию" here — the same testid suffix (``save.button``) that means
+# "Сохранить кампанию" on a non-DRAFT page means "publish this draft" on a
+# DRAFT one, so the label alone can't disambiguate; the testid can.
+_DRAFT_SAVE_DRAFT_BUTTON_TESTID = (
+    '[data-testid="CampaignFormControls.saveDraft.button"]'
+)
+_DRAFT_LAUNCH_BUTTON_TESTID = '[data-testid="CampaignFormControls.save.button"]'
 
 # Confirmed live: navigating away from an unsubmitted create form triggers
 # the browser's native beforeunload "Leave site?" dialog — the wizard
@@ -1214,13 +1257,97 @@ def _set_promotion_goal(page: "Page", goal: str) -> None:
         )
 
 
-def _click_save(page: "Page", campaign_id: int) -> None:
-    """Click the edit page's single "Сохранить кампанию" button.
+def _click_draft_terminal_button(
+    page: "Page", campaign_id: int, *, launch: bool
+) -> None:
+    """Click a DRAFT edit page's save-as-draft/launch button (issue #668).
 
-    Confirmed live: the whole edit page is one form with exactly one save
-    button at the bottom (see module docstring) — there is no per-section
-    save to target instead.
+    A DRAFT campaign's edit page has no "Сохранить кампанию" button at all
+    — only ``CampaignFormControls.saveDraft.button`` ("Сохранить как
+    черновик") and ``CampaignFormControls.save.button`` ("Запустить
+    кампанию", which PUBLISHES the campaign — a real, no-rollback mutation).
+    Matched by ``data-testid``, not accessible-name text, because the same
+    testid SUFFIX (``save.button``) carries a different label — and a
+    different consequence — depending on whether the page is DRAFT or not
+    (see the constants' own comment). ``launch`` defaults to ``False`` at
+    every call site in this module; only an explicit ``masters update
+    --launch`` sets it, mirroring ``create_master``/``copy_master``'s
+    draft-preserving defaults.
+
+    **Live-confirmed 2026-08-02 (real mutation against campaign 713231614,
+    reverted immediately after observing this):** unlike the non-DRAFT
+    "Сохранить кампанию" button, this click redirects the page away from
+    ``/edit/`` to the campaign's overview page (``page.url`` becomes
+    ``/wizard/campaigns/{id}/...``, no longer ``/edit/``) — and NOT
+    instantly; ~5s elapsed before the redirect completed in this recon. The
+    edit itself WAS actually saved server-side (confirmed by reloading
+    ``/edit/`` afterwards), but ``update_master``'s original ``_click_save``
+    → immediate ``_verify_saved`` reload raced this redirect and read a
+    transitional state, producing a false "did not save as requested"
+    error. This function therefore waits for ``page.url`` to actually leave
+    ``/edit/`` before returning, so the caller's subsequent re-navigation to
+    the edit URL lands after Yandex's own redirect has settled, not during
+    it — same "poll page.url until it actually changes" pattern
+    ``copy_master`` already uses for its own post-click redirect.
     """
+    selector = (
+        _DRAFT_LAUNCH_BUTTON_TESTID if launch else _DRAFT_SAVE_DRAFT_BUTTON_TESTID
+    )
+    button_label = _LAUNCH_BUTTON_TEXT if launch else _SAVE_DRAFT_BUTTON_TEXT
+    handle = page.locator(selector).first
+    try:
+        handle.click()
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            f"Could not find the {button_label!r} button on the DRAFT edit "
+            f"page for campaign {campaign_id} — Yandex may have changed "
+            "the page's markup. Re-run with --headful to inspect the page."
+        ) from exc
+
+    deadline = time.monotonic() + _DRAFT_SAVE_REDIRECT_TIMEOUT_MS / 1000
+    while time.monotonic() < deadline:
+        if "/edit/" not in page.url:
+            return
+        page.wait_for_timeout(250)
+
+    raise BrowserSessionError(
+        f"Clicked {button_label!r} for DRAFT campaign {campaign_id}, but "
+        "Yandex did not redirect away from the edit page within "
+        f"{_DRAFT_SAVE_REDIRECT_TIMEOUT_MS / 1000:.0f}s — the edit may not "
+        "have saved. Verify manually before retrying."
+    )
+
+
+def _is_draft_edit_page(page: "Page") -> bool:
+    """True if the edit page currently open is a DRAFT campaign's.
+
+    Detected by the presence of ``CampaignFormControls.saveDraft.button`` —
+    the one control that exists ONLY on a DRAFT edit page (issue #668,
+    confirmed live: a non-DRAFT edit page has no draft-save button at all,
+    only "Сохранить кампанию"). Detecting via the very button
+    ``_click_draft_terminal_button`` would click keeps this check and that
+    click from ever disagreeing about what "DRAFT" means here.
+    """
+    try:
+        return page.locator(_DRAFT_SAVE_DRAFT_BUTTON_TESTID).first.count() > 0
+    except PlaywrightError:
+        return False
+
+
+def _click_save(page: "Page", campaign_id: int, *, launch: bool = False) -> None:
+    """Click the edit page's save button — "Сохранить кампанию" on a
+    non-DRAFT campaign, or the DRAFT-specific save-as-draft/launch button.
+
+    Confirmed live: the whole non-DRAFT edit page is one form with exactly
+    one save button at the bottom (see module docstring) — there is no
+    per-section save to target instead. A DRAFT campaign's edit page has a
+    DIFFERENT pair of terminal buttons entirely (issue #668) — see
+    ``_click_draft_terminal_button``.
+    """
+    if _is_draft_edit_page(page):
+        _click_draft_terminal_button(page, campaign_id, launch=launch)
+        return
+
     # get_by_role scopes to the actual <button> element (exact accessible
     # name), not any ancestor container whose text merely contains this
     # substring — see the cycle-review finding this fixed.
@@ -1308,6 +1435,34 @@ def _read_campaign_name(page: "Page") -> Optional[str]:
         return None
 
 
+def _verify_repeating_value_mismatches(
+    page: "Page",
+    *,
+    testid_template: str,
+    slot_count: int,
+    label: str,
+    requested: Optional[Dict[int, str]],
+) -> List[str]:
+    """Re-read only the slots ``update_master`` was asked to change and
+    report any that don't match — unlike ``_repeating_values_mismatches``
+    (the create-page check), slots NOT in ``requested`` are never flagged:
+    leftover variants are the normal, intentional state of a partial update,
+    not evidence something went wrong (issue #665).
+    """
+    if not requested:
+        return []
+    actual = _read_repeating_values(page, testid_template, slot_count)
+    mismatches = []
+    for index, expected in requested.items():
+        current = actual[index] if index < len(actual) else ""
+        if current != expected:
+            mismatches.append(
+                f"{label} slot {index + 1}: expected {expected!r}, page now "
+                f"shows {current!r}"
+            )
+    return mismatches
+
+
 def _verify_saved(
     page: "Page",
     campaign_id: int,
@@ -1316,6 +1471,9 @@ def _verify_saved(
     promotion_goal: Optional[str],
     directs_helps: Optional[bool],
     name: Optional[str] = None,
+    headlines: Optional[Dict[int, str]] = None,
+    texts: Optional[Dict[int, str]] = None,
+    clicked_button_label: str = _SAVE_BUTTON_TEXT,
 ) -> None:
     """Reload the edit page and confirm every requested field actually saved.
 
@@ -1355,13 +1513,32 @@ def _verify_saved(
                 f"{label}: expected {expected!r}, page now shows {actual!r}"
             )
 
+    mismatches.extend(
+        _verify_repeating_value_mismatches(
+            page,
+            testid_template=_HEADLINES_TESTID_TEMPLATE,
+            slot_count=_HEADLINES_SLOT_COUNT,
+            label="headline",
+            requested=headlines,
+        )
+    )
+    mismatches.extend(
+        _verify_repeating_value_mismatches(
+            page,
+            testid_template=_TEXTS_TESTID_TEMPLATE,
+            slot_count=_TEXTS_SLOT_COUNT,
+            label="text",
+            requested=texts,
+        )
+    )
+
     if mismatches:
         raise BrowserSessionError(
-            f"Clicked '{_SAVE_BUTTON_TEXT}' for campaign {campaign_id}, but "
-            "re-reading the edit page after reload shows it did not save "
-            "as requested: " + "; ".join(mismatches) + ". Yandex may have "
-            "rejected the value (client-side validation) or the save did "
-            "not complete — verify manually before retrying."
+            f"Clicked '{clicked_button_label}' for campaign {campaign_id}, "
+            "but re-reading the edit page after reload shows it did not "
+            "save as requested: " + "; ".join(mismatches) + ". Yandex may "
+            "have rejected the value (client-side validation) or the save "
+            "did not complete — verify manually before retrying."
         )
 
 
@@ -1373,8 +1550,11 @@ def update_master(
     promotion_goal: Optional[str] = None,
     directs_helps: Optional[bool] = None,
     name: Optional[str] = None,
+    headlines: Optional[Dict[int, str]] = None,
+    texts: Optional[Dict[int, str]] = None,
+    launch: bool = False,
 ) -> Dict[str, Any]:
-    """Update one or more Этап A fields (plus the campaign name) and save.
+    """Update one or more Этап A/B fields (plus the campaign name) and save.
 
     Only fields passed as non-``None`` are touched — see module docstring for
     why this is safe despite the page having a single whole-form save (fields
@@ -1386,6 +1566,16 @@ def update_master(
     rather than a plain form field — see module docstring — but is persisted
     by the same terminal ``_click_save`` as every other field here.
 
+    ``headlines``/``texts`` (issue #665, Этап B) map a 0-based slot index to
+    its replacement text and REPLACE ONLY THOSE SLOTS — every other headline/
+    text variant on the campaign is left exactly as it was. This is a
+    deliberate departure from this CLI's dominant list-field convention
+    (``campaigns update --negative-keywords`` and similar replace the WHOLE
+    array in one shot) — see ``_set_repeating_value``'s docstring for why a
+    full-array rewrite doesn't fit here. Writing to a slot that is currently
+    empty raises ``BrowserSessionError`` — adding a brand-new variant is a
+    different operation, not covered here (see issue #665's follow-ups).
+
     After clicking save, reloads the edit page and re-reads every requested
     field to confirm it actually saved (see ``_verify_saved``) — a click
     that doesn't visibly change the saved state is reported as a hard error,
@@ -1394,19 +1584,30 @@ def update_master(
     ``copy_master`` this function needs no extra guard against
     ``_with_session``'s whole-operation retry on ``BrowserAuthError``.
 
-    Later Этап (B/C/D) fields — headline/text lists, sitelinks, audience,
-    Metrika counters/goals, budget adaptation, media — are out of scope for
-    this function; see issue #631.
+    Later Этап (C/D) fields — sitelinks, audience, Metrika counters/goals,
+    budget adaptation, media — are out of scope for this function; see
+    issue #648.
+
+    ``launch`` (issue #668) matters only when ``campaign_id`` is currently a
+    DRAFT: that edit page has no "Сохранить кампанию" button at all, only a
+    save-as-draft/launch pair (see ``_click_save``/``_is_draft_edit_page``).
+    Defaults to ``False`` — DRAFT stays DRAFT unless the caller explicitly
+    asks to publish it, mirroring ``create_master``/``copy_master``'s own
+    draft-preserving defaults. Has no effect on a non-DRAFT campaign, which
+    always uses the single "Сохранить кампанию" button regardless.
     """
     if (
         weekly_budget is None
         and promotion_goal is None
         and directs_helps is None
         and name is None
+        and not headlines
+        and not texts
     ):
         raise ValueError(
             "update_master requires at least one field to update "
-            "(weekly_budget, promotion_goal, directs_helps, name)."
+            "(weekly_budget, promotion_goal, directs_helps, name, "
+            "headlines, texts)."
         )
 
     url = WIZARD_EDIT_URL.format(campaign_id=campaign_id)
@@ -1422,8 +1623,26 @@ def update_master(
         _set_promotion_goal(page, promotion_goal)
     if directs_helps is not None:
         _set_directs_helps(page, directs_helps)
+    for index, value in (headlines or {}).items():
+        _set_repeating_value(
+            page, _HEADLINES_TESTID_TEMPLATE, _HEADLINES_SLOT_COUNT, index, value
+        )
+    for index, value in (texts or {}).items():
+        _set_repeating_value(
+            page, _TEXTS_TESTID_TEMPLATE, _TEXTS_SLOT_COUNT, index, value
+        )
 
-    _click_save(page, campaign_id)
+    # Determined BEFORE clicking, while the page still reflects what's about
+    # to be clicked — after the click, _verify_saved's own reload leaves no
+    # way to tell which button this run actually used.
+    if _is_draft_edit_page(page):
+        clicked_button_label = (
+            _LAUNCH_BUTTON_TEXT if launch else _SAVE_DRAFT_BUTTON_TEXT
+        )
+    else:
+        clicked_button_label = _SAVE_BUTTON_TEXT
+
+    _click_save(page, campaign_id, launch=launch)
 
     _verify_saved(
         page,
@@ -1432,6 +1651,9 @@ def update_master(
         promotion_goal=promotion_goal,
         directs_helps=directs_helps,
         name=name,
+        headlines=headlines,
+        texts=texts,
+        clicked_button_label=clicked_button_label,
     )
 
     result: Dict[str, Any] = {"CampaignId": campaign_id}
@@ -1443,6 +1665,10 @@ def update_master(
         result["DirectsHelps"] = directs_helps
     if name is not None:
         result["Name"] = name
+    if headlines:
+        result["Headlines"] = headlines
+    if texts:
+        result["Texts"] = texts
     return result
 
 
@@ -1671,6 +1897,106 @@ def _read_repeating_values(
         except PlaywrightError:
             values.append("")
     return values
+
+
+def _set_repeating_value(
+    page: "Page", testid_template: str, slot_count: int, index: int, value: str
+) -> None:
+    """Replace the value in ONE existing slot of a fixed-size repeating list
+    field (headlines/texts), leaving every other slot untouched.
+
+    Issue #665 (Этап B, part of the #648 umbrella). This is a DIFFERENT
+    contract from ``_add_repeating_values``: that function clears and
+    rewrites every slot (create-page semantics — Yandex pre-fills every slot
+    with AI-generated copy, so a partial write there would publish leftover
+    unreviewed variants). ``update_master`` is a partial-update command by
+    project convention, and headline/text variant sets on a live campaign can
+    be large — forcing the caller to re-type every other variant just to fix
+    one typo is the opposite of what "partial update" means. So this module
+    deliberately does NOT reuse ``_add_repeating_values`` here; it edits
+    exactly the one requested slot.
+
+    This is also a deliberate departure from this CLI's dominant list-field
+    convention, where ``update`` commands replace the ENTIRE array in one
+    shot (e.g. ``campaigns update --negative-keywords``, built via
+    ``_array_of_string_option`` — see ``direct_cli/commands/
+    _campaigns_base.py``). That convention exists because those fields go
+    through the WSDL API's ``ArrayOfString`` semantics, where a full-array
+    write is cheap and the array is typically short. Мастер кампаний has no
+    API at all — every mutation is a live page edit — and forcing a
+    full-list rewrite through five/three fixed slots would be both more
+    error-prone (misordering a variant silently changes ad copy) and no
+    safer than a targeted slot write. A future refactor MAY want to
+    unify this with the rest of the CLI's list-update convention, but that
+    is not settled and is explicitly out of scope here.
+
+    Confirmed live (2026-08-02, campaign 107707079, read-only recon — see
+    ``tests/fixtures/masters_wizard_edit_stage_b.html``) that the edit page's
+    slots are IDENTICAL in shape and count to the create page's: same
+    ``testid_template``, same ``slot_count`` (5 headlines / 3 texts), same
+    contenteditable ``<div role="textbox">`` shape ``_clear_text_field``/
+    ``_read_repeating_values`` already handle correctly.
+
+    Writing to an EMPTY slot is refused (``BrowserSessionError``) rather
+    than treated as "add a new variant" — that is a materially different
+    operation (publishing a variant that did not exist before, on a page
+    with no sandbox/rollback) tracked as a separate follow-up, not silently
+    folded into "update an existing one".
+    """
+    if index >= slot_count:
+        raise BrowserSessionError(
+            f"Slot index {index + 1} is out of range — this field only has "
+            f"{slot_count} slots on the edit page."
+        )
+
+    selector = f'[data-testid="{testid_template.format(index=index)}"]'
+    field = page.locator(selector).first
+
+    try:
+        current = field.inner_text()
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            f"Could not read the current value of slot {index + 1} at "
+            f"{selector!r} — Yandex may have changed the page's markup. "
+            "Re-run with --headful to inspect the page."
+        ) from exc
+
+    if not current:
+        raise BrowserSessionError(
+            f"Slot {index + 1} at {selector!r} is currently empty. Writing "
+            "to an empty slot would add a new ad variant, which this "
+            "command does not support — only replacing an existing "
+            "variant's text."
+        )
+
+    try:
+        field.click()
+        cleared = _clear_text_field(field)
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            f"Could not replace slot {index + 1}'s value via the edit "
+            f"page's field at {selector!r} — Yandex may have changed the "
+            "page's markup. Re-run with --headful to inspect the page."
+        ) from exc
+
+    if not cleared:
+        raise BrowserSessionError(
+            f"Could not clear slot {index + 1}'s existing value at "
+            f"{selector!r} before typing the replacement. Typing without "
+            "clearing would splice the new text into the old one. This "
+            "usually means Playwright is older than 1.44 (the version that "
+            "added the 'ControlOrMeta' modifier) — upgrade with "
+            "'pip install -U playwright'."
+        )
+
+    try:
+        field.type(value)
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            f"Could not type the replacement value into slot {index + 1} "
+            f"at {selector!r} — Yandex may have changed the page's markup. "
+            "Re-run with --headful to inspect the page."
+        ) from exc
 
 
 def _set_region(page: "Page", regions: List[str]) -> None:

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -1949,6 +1949,22 @@ def _set_repeating_value(
             f"{slot_count} slots on the edit page."
         )
 
+    # Checked BEFORE the field is read or cleared: an empty replacement is a
+    # DELETE, not a replace, and deleting a variant is out of scope for Этап
+    # B (issue #665). It is also the silent kind of damage — the slot would
+    # be cleared, "" typed, the form saved, and
+    # ``_verify_repeating_value_mismatches`` would then compare the re-read
+    # slot against the REQUESTED value, find "" == "", and report the
+    # deletion as a successful update. The CLI refuses this earlier
+    # (``_parse_repeating_slot_options``); this guard keeps the browser layer
+    # safe for any other caller too.
+    if not value.strip():
+        raise BrowserSessionError(
+            f"Refusing to write an empty value to slot {index + 1}: that "
+            "would delete the existing ad variant rather than replace it, "
+            "which this command does not support."
+        )
+
     selector = f'[data-testid="{testid_template.format(index=index)}"]'
     field = page.locator(selector).first
 

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -573,6 +573,13 @@ def _parse_repeating_slot_options(
             raise click.UsageError(
                 f"{option_name} slot {slot_number} was specified more than " "once."
             )
+        if not text.strip():
+            raise click.UsageError(
+                f"{option_name} slot {slot_number} was given an empty "
+                "replacement, which would DELETE that ad variant rather than "
+                "replace it. Removing a variant is not supported — pass the "
+                "replacement text, or edit the campaign with --headful."
+            )
         parsed[index] = text
     return parsed
 

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -538,7 +538,7 @@ def suspend(
 
 
 def _parse_repeating_slot_options(
-    option_name: str, values: "tuple[str, ...]"
+    option_name: str, values: "tuple[str, ...]", slot_count: int
 ) -> "dict[int, str]":
     """Parse repeated ``"N=text"`` CLI values into a 0-based slot index map.
 
@@ -549,6 +549,14 @@ def _parse_repeating_slot_options(
     conversion happens here, at the CLI boundary. All format errors are
     raised as ``click.UsageError`` before any browser session is opened,
     rather than surfacing mid-session as a ``BrowserSessionError``.
+
+    ``slot_count`` is the number of slots the page actually renders for this
+    field (5 headlines / 3 texts), taken from the browser layer's own
+    constants so the two can't drift apart. The upper bound is enforced here
+    as well as in ``_set_repeating_value``: an oversized slot number is a
+    purely invalid CLI argument, and letting it through would launch a
+    browser (and possibly an auth prompt) only to fail with a
+    ``BrowserSessionError`` — contradicting this helper's fail-fast contract.
     """
     parsed: "dict[int, str]" = {}
     for raw in values:
@@ -566,7 +574,13 @@ def _parse_repeating_slot_options(
             )
         if slot_number < 1:
             raise click.UsageError(
-                f"{option_name} slot number {slot_number} must be 1 or " "greater."
+                f"{option_name} slot number {slot_number} must be 1 or "
+                f"greater (this field has slots 1-{slot_count})."
+            )
+        if slot_number > slot_count:
+            raise click.UsageError(
+                f"{option_name} slot number {slot_number} is out of range — "
+                f"this field has {slot_count} slots (1-{slot_count})."
             )
         index = slot_number - 1
         if index in parsed:
@@ -697,8 +711,15 @@ def update(
             "--directs-helps/--no-directs-helps, --name, --headline, --text."
         )
 
-    parsed_headlines = _parse_repeating_slot_options("--headline", headlines)
-    parsed_texts = _parse_repeating_slot_options("--text", texts)
+    # Slot counts come from the browser layer's own constants (imported here
+    # rather than at module load, matching this module's other deferred
+    # browser imports) so the CLI's bound can't drift from the page's.
+    from ..browser.masters import _HEADLINES_SLOT_COUNT, _TEXTS_SLOT_COUNT
+
+    parsed_headlines = _parse_repeating_slot_options(
+        "--headline", headlines, _HEADLINES_SLOT_COUNT
+    )
+    parsed_texts = _parse_repeating_slot_options("--text", texts, _TEXTS_SLOT_COUNT)
 
     result = _with_session(
         ctx,

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -537,6 +537,46 @@ def suspend(
     format_output(results if len(results) != 1 else results[0], output_format, output)
 
 
+def _parse_repeating_slot_options(
+    option_name: str, values: "tuple[str, ...]"
+) -> "dict[int, str]":
+    """Parse repeated ``"N=text"`` CLI values into a 0-based slot index map.
+
+    N is the 1-based slot number shown to the user (matches how a person
+    would count "headline 1, headline 2, ..." reading the edit page); the
+    browser layer (``update_master``/``_set_repeating_value``) works in
+    0-based indices like the rest of ``masters.py``'s slot machinery, so the
+    conversion happens here, at the CLI boundary. All format errors are
+    raised as ``click.UsageError`` before any browser session is opened,
+    rather than surfacing mid-session as a ``BrowserSessionError``.
+    """
+    parsed: "dict[int, str]" = {}
+    for raw in values:
+        if "=" not in raw:
+            raise click.UsageError(
+                f'{option_name} value {raw!r} must be in the form "N=text" '
+                '(e.g. "2=New headline").'
+            )
+        index_part, text = raw.split("=", 1)
+        try:
+            slot_number = int(index_part.strip())
+        except ValueError:
+            raise click.UsageError(
+                f"{option_name} slot number {index_part!r} must be an " "integer."
+            )
+        if slot_number < 1:
+            raise click.UsageError(
+                f"{option_name} slot number {slot_number} must be 1 or " "greater."
+            )
+        index = slot_number - 1
+        if index in parsed:
+            raise click.UsageError(
+                f"{option_name} slot {slot_number} was specified more than " "once."
+            )
+        parsed[index] = text
+    return parsed
+
+
 @masters.command()
 @click.argument("campaign_id", type=int)
 @click.option(
@@ -559,6 +599,39 @@ def suspend(
     "--name",
     help="New campaign name (Название кампании)",
 )
+@click.option(
+    "--headline",
+    "headlines",
+    multiple=True,
+    help=(
+        'Replace an EXISTING headline variant: "N=text" where N is the '
+        "1-based slot number (1-5). Repeat for multiple slots. Writing to "
+        "an empty slot is refused — this only replaces variants that "
+        "already exist, it does not add new ones. Other headline variants "
+        "are left untouched."
+    ),
+)
+@click.option(
+    "--text",
+    "texts",
+    multiple=True,
+    help=(
+        'Replace an EXISTING ad-text variant: "N=text" where N is the '
+        "1-based slot number (1-3). Repeat for multiple slots. Writing to "
+        "an empty slot is refused — this only replaces variants that "
+        "already exist, it does not add new ones. Other ad-text variants "
+        "are left untouched."
+    ),
+)
+@click.option(
+    "--launch",
+    is_flag=True,
+    default=False,
+    help=(
+        "If CAMPAIGN_ID is currently a DRAFT, publish it while saving "
+        "(default: keep it a DRAFT). Has no effect on a non-DRAFT campaign."
+    ),
+)
 @_masters_browser_options
 @click.pass_context
 @handle_api_errors
@@ -569,21 +642,38 @@ def update(
     promotion_goal,
     directs_helps,
     name,
+    headlines,
+    texts,
+    launch,
     headful,
     profile_dir,
     chrome_profile,
     output_format,
     output,
 ):
-    """Update settings of one Мастер кампаний (Этап A fields, plus name)
+    """Update settings of one Мастер кампаний (Этап A/B fields, plus name)
 
-    Covers exactly four fields: weekly budget, promotion goal, the "Директ
-    помогает" auto-recommendations toggle, and the campaign name. The edit
-    page has a single whole-form save (no per-section save) — see
-    ``direct_cli/browser/masters.py`` module docstring — so only the fields
-    passed here are changed; every other on-page field keeps its current
-    value. Later fields (headlines/texts, sitelinks, audience, media) are
-    tracked separately, see issue #631.
+    Covers weekly budget, promotion goal, the "Директ помогает"
+    auto-recommendations toggle, the campaign name, and per-slot headline/
+    ad-text variant replacement. The edit page has a single whole-form save
+    (no per-section save) — see ``direct_cli/browser/masters.py`` module
+    docstring — so only the fields passed here are changed; every other
+    on-page field keeps its current value.
+
+    ``--headline``/``--text`` replace ONE variant slot at a time rather than
+    the whole variant list — unlike this CLI's usual list-field convention
+    (e.g. ``campaigns update --negative-keywords``, which replaces the
+    entire array). This is deliberate: Мастер кампаний has no API, variant
+    sets can be large, and forcing every variant to be re-typed to fix one
+    typo defeats the point of a partial update — see
+    ``direct_cli/browser/masters.py::_set_repeating_value`` for the full
+    rationale. Later fields (sitelinks, audience, Metrika counters/goals,
+    budget adaptation, media) are tracked separately, see issue #648.
+
+    A DRAFT campaign's edit page has no "Сохранить кампанию" button at all —
+    only a save-as-draft/launch pair (issue #668). ``update`` saves it as a
+    draft by default (keeping DRAFT status); pass ``--launch`` to publish it
+    instead while saving. Has no effect on a non-DRAFT campaign.
     """
     from ..browser.masters import update_master
 
@@ -592,11 +682,16 @@ def update(
         and promotion_goal is None
         and directs_helps is None
         and name is None
+        and not headlines
+        and not texts
     ):
         raise click.UsageError(
             "Provide at least one of --weekly-budget, --promotion-goal, "
-            "--directs-helps/--no-directs-helps, --name."
+            "--directs-helps/--no-directs-helps, --name, --headline, --text."
         )
+
+    parsed_headlines = _parse_repeating_slot_options("--headline", headlines)
+    parsed_texts = _parse_repeating_slot_options("--text", texts)
 
     result = _with_session(
         ctx,
@@ -610,6 +705,9 @@ def update(
             promotion_goal=promotion_goal,
             directs_helps=directs_helps,
             name=name,
+            headlines=parsed_headlines,
+            texts=parsed_texts,
+            launch=launch,
         ),
     )
 

--- a/tests/fixtures/masters_wizard_edit_stage_b.html
+++ b/tests/fixtures/masters_wizard_edit_stage_b.html
@@ -1,0 +1,86 @@
+<!--
+Fixture: DOM findings for editing headline/text variants on the Yandex Direct
+"Мастер кампаний" (Campaign Wizard) edit page, Этап B (issue #665, part of the
+#648 umbrella) — captured 2026-08-02 via claude-in-chrome, read-only, against
+campaign 107707079 ("Мастер ИЖ Источник Жизни (холодный) 16.06", status:
+Остановлена). No campaign was mutated — no field was clicked/typed into, no
+save button was pressed; the recon read `data-testid`/`innerText` via
+`document.querySelector` only, then navigated away.
+
+Source URL:
+  https://direct.yandex.ru/wizard/campaigns/{id}/edit/?ulogin={login}
+
+Note: navigating WITHOUT `?ulogin=<login>` on this account redirected to
+Yandex Passport's account-chooser login page instead of the edit form —
+`?ulogin=<login>` was required to land on the edit page directly in this
+browser session (unrelated to the CLI's own session handling, which already
+appends `ulogin` server-side per the module docstring).
+
+KEY FINDING — edit-page slots are IDENTICAL in shape and count to the
+create-page slots #653 already documented (module docstring's "Step 2 markup
+migration" note, `_HEADLINES_TESTID_TEMPLATE`/`_TEXTS_TESTID_TEMPLATE`,
+`_HEADLINES_SLOT_COUNT=5`/`_TEXTS_SLOT_COUNT=3`, browser/masters.py:333-336).
+This was NOT assumed — it needed live confirmation, since #650/#653 both found
+the create page's markup drifted from prior recons without any project-visible
+signal. Confirmed via `document.querySelectorAll('[data-testid]')`:
+
+  CampaignTitles0, CampaignTitles0.textarea, CampaignTitles0.clear
+  CampaignTitles1, CampaignTitles1.textarea, CampaignTitles1.clear
+  CampaignTitles2, CampaignTitles2.textarea, CampaignTitles2.clear
+  CampaignTitles3, CampaignTitles3.textarea, CampaignTitles3.clear
+  CampaignTitles4, CampaignTitles4.textarea, CampaignTitles4.clear
+  CampaignTexts0, CampaignTexts0.textarea, CampaignTexts0.clear
+  CampaignTexts1, CampaignTexts1.textarea, CampaignTexts1.clear
+  CampaignTexts2, CampaignTexts2.textarea, CampaignTexts2.clear
+
+Exactly 5 headline slots (index 0-4) and 3 text slots (index 0-2) — matches
+`_HEADLINES_SLOT_COUNT`/`_TEXTS_SLOT_COUNT` exactly. The existing constants
+and templates (`_HEADLINES_TESTID_TEMPLATE`, `_TEXTS_TESTID_TEMPLATE`,
+`_read_repeating_values`, `_clear_text_field`) apply to the edit page
+unchanged — no new `_EDIT_*` constants needed.
+
+Each `.textarea` element, confirmed via direct DOM inspection:
+  tag: DIV
+  role: "textbox"
+  contenteditable: "true"
+  childElementCount: 0 (no nested markup — innerText/textContent are clean,
+    no character-counter or other UI noise sharing the node)
+
+This is the SAME markup shape `_clear_text_field`/`_read_repeating_values`
+already handle for the create page — no new read/clear logic needed, only a
+new point-replacement setter (`_set_repeating_value`, issue #665) that reuses
+both.
+
+BONUS FINDING (not in scope for #665, useful for a future "delete variant"
+issue): each slot also renders its own `{prefix}{N}.clear` button
+(`CampaignTitlesN.clear` / `CampaignTextsN.clear`) — a per-slot clear control,
+not present in `_add_repeating_values`'s docstring notes on the create page
+(create page slots don't need individual clear buttons since every slot gets
+cleared unconditionally there). Not investigated further — out of scope here.
+
+Slot contents observed live (all slots pre-filled on this real campaign — a
+good target for Этап B's live verification, since a point-replacement setter
+that refuses to write to an EMPTY slot needs a filled slot to exercise the
+success path):
+
+  CampaignTitles0: "1 упражнение для сердца и вен! Онлайн-курс ценой 0₽"
+  CampaignTitles1: "Источник Жизни: 3-дневный бесплатный онлайн-курс"
+  CampaignTitles2: "Забытые секреты для сердца, сосудов и вен!"
+  CampaignTitles3: "Упражнения для вен! Бесплатный онлайн курс гимнастики!"
+  CampaignTitles4: "Упражнения для сердца, сосудов и вен! Бесплатно!"
+  CampaignTexts0: "Бесплатно и эффективно занимайтесь Цигун дома!"
+  CampaignTexts1: "Практические упражнения всего 5 минут в день! Эффективно
+    делать дома!"
+  CampaignTexts2: "Узнайте упражнения, которые эффективно выполнять в
+    домашних условиях!"
+
+No weight/priority control was found near these slots in this recon (only
+`.textarea` and `.clear` per slot) — consistent with
+`masters_wizard_create.html`'s finding that Yandex auto-rotates variants
+without a user-settable weight widget. Not investigated further here; left
+for a separate issue per the #665 plan.
+
+No live mutation occurred: navigated away via a plain URL change (back to the
+campaigns grid), not the page's own save/cancel controls, and no field was
+ever typed into or cleared.
+-->

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -2358,6 +2358,190 @@ class TestClickSave(unittest.TestCase):
         self.assertEqual(clicks, [True])
 
 
+class TestDraftEditPageSave(unittest.TestCase):
+    """``_is_draft_edit_page``/``_click_save`` DRAFT path (issue #668).
+
+    A DRAFT campaign's edit page has NO "Сохранить кампанию" button at all
+    — only ``CampaignFormControls.saveDraft.button``/``.save.button``, the
+    latter labelled "Запустить кампанию" (publishes) here, unlike the
+    non-DRAFT page's "Сохранить кампанию" — live-confirmed against campaign
+    713231614, see the module docstring's "DRAFT support" note.
+    """
+
+    def test_is_draft_edit_page_true_when_save_draft_button_present(self):
+        page = FakePage(
+            locators={
+                browser_masters._DRAFT_SAVE_DRAFT_BUTTON_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                )
+            }
+        )
+
+        self.assertTrue(browser_masters._is_draft_edit_page(page))
+
+    def test_is_draft_edit_page_false_when_absent(self):
+        page = FakePage(locators={})
+
+        self.assertFalse(browser_masters._is_draft_edit_page(page))
+
+    def test_click_save_on_draft_clicks_save_draft_button_by_default(self):
+        clicks = []
+        page = FakePage(
+            locators={
+                browser_masters._DRAFT_SAVE_DRAFT_BUTTON_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle(on_click=lambda: clicks.append("draft"))]
+                ),
+                browser_masters._DRAFT_LAUNCH_BUTTON_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle(on_click=lambda: clicks.append("launch"))]
+                ),
+            }
+        )
+
+        browser_masters._click_save(page, 713231614)
+
+        # The publish button must never be touched unless --launch was
+        # explicitly requested.
+        self.assertEqual(clicks, ["draft"])
+
+    def test_click_save_on_draft_clicks_launch_button_when_requested(self):
+        clicks = []
+        page = FakePage(
+            locators={
+                browser_masters._DRAFT_SAVE_DRAFT_BUTTON_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle(on_click=lambda: clicks.append("draft"))]
+                ),
+                browser_masters._DRAFT_LAUNCH_BUTTON_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle(on_click=lambda: clicks.append("launch"))]
+                ),
+            }
+        )
+
+        browser_masters._click_save(page, 713231614, launch=True)
+
+        self.assertEqual(clicks, ["launch"])
+
+    def test_click_save_on_draft_raises_when_button_missing(self):
+        page = FakePage(
+            locators={
+                browser_masters._DRAFT_SAVE_DRAFT_BUTTON_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                )
+                # _DRAFT_LAUNCH_BUTTON_TESTID deliberately absent.
+            }
+        )
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters._click_save(page, 713231614, launch=True)
+
+    def test_click_save_prefers_non_draft_path_when_save_draft_button_absent(self):
+        # Regression guard: a non-DRAFT page must keep using the plain
+        # "Сохранить кампанию" role-scoped match, not the DRAFT testid path.
+        clicks = []
+        page = FakePage(
+            locators={},
+            role_elements=[
+                (
+                    "button",
+                    browser_masters._SAVE_BUTTON_TEXT,
+                    _FakeTextLocatorHandle(
+                        visible=True, on_click=lambda: clicks.append(True)
+                    ),
+                )
+            ],
+        )
+
+        browser_masters._click_save(page, 42)
+
+        self.assertEqual(clicks, [True])
+
+
+class TestUpdateMasterDraftSupport(unittest.TestCase):
+    """``update_master`` end to end on a DRAFT campaign (issue #668)."""
+
+    def _draft_page_with_headline_slot(self, *, saved_text_after_save):
+        # _verify_saved re-navigates to the SAME edit URL after saving —
+        # FakePage's goto() is a no-op that just records the URL, so the
+        # same locator objects (and their mutable state) are seen both
+        # before and after the "reload", exactly like the non-DRAFT
+        # TestUpdateMaster fakes above.
+        #
+        # _click_draft_terminal_button (issue #668 live-recon fix) polls
+        # page.url until it leaves "/edit/" before returning, mirroring the
+        # click's real ~5s redirect to the overview page — on_click here
+        # mutates page.url the same way TestCopyMaster's fakes do, so the
+        # poll resolves immediately instead of burning the real timeout.
+        slot = _FakeContentEditableHandle(text="Старый заголовок")
+        draft_clicks = []
+        selector = (
+            f"[data-testid="
+            f'"{browser_masters._HEADLINES_TESTID_TEMPLATE.format(index=0)}"]'
+        )
+
+        def _on_draft_click():
+            draft_clicks.append(True)
+            page.url = browser_masters.WIZARD_OVERVIEW_URL.format(campaign_id=713231614)
+
+        page = FakePage(
+            locators={
+                browser_masters._DRAFT_SAVE_DRAFT_BUTTON_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle(on_click=_on_draft_click)]
+                ),
+                selector: _FakeLocator([slot]),
+            }
+        )
+        page.url = browser_masters.WIZARD_EDIT_URL.format(campaign_id=713231614)
+        return page, slot, draft_clicks
+
+    def test_updates_headline_on_draft_campaign_saving_as_draft(self):
+        page, slot, draft_clicks = self._draft_page_with_headline_slot(
+            saved_text_after_save="Новый заголовок"
+        )
+
+        result = browser_masters.update_master(
+            page, 713231614, headlines={0: "Новый заголовок"}
+        )
+
+        self.assertEqual(slot.inner_text(), "Новый заголовок")
+        self.assertEqual(len(draft_clicks), 1)
+        self.assertEqual(
+            result, {"CampaignId": 713231614, "Headlines": {0: "Новый заголовок"}}
+        )
+
+    def test_error_message_on_draft_mismatch_names_the_draft_button_not_save(self):
+        # The mismatch error text must reflect the button THIS run actually
+        # clicked, not a hard-coded "Сохранить кампанию" that was never on
+        # the page.
+        slot = _FakeContentEditableHandle(text="Старый заголовок")
+        slot.type = lambda value, delay=None: None  # write silently rejected
+        selector = (
+            f"[data-testid="
+            f'"{browser_masters._HEADLINES_TESTID_TEMPLATE.format(index=0)}"]'
+        )
+
+        def _on_draft_click():
+            page.url = browser_masters.WIZARD_OVERVIEW_URL.format(campaign_id=713231614)
+
+        page = FakePage(
+            locators={
+                browser_masters._DRAFT_SAVE_DRAFT_BUTTON_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle(on_click=_on_draft_click)]
+                ),
+                selector: _FakeLocator([slot]),
+            }
+        )
+        page.url = browser_masters.WIZARD_EDIT_URL.format(campaign_id=713231614)
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(
+                page, 713231614, headlines={0: "Новый заголовок"}
+            )
+
+        self.assertIn(
+            f"'{browser_masters._SAVE_DRAFT_BUTTON_TEXT}'", str(ctx.exception)
+        )
+        self.assertNotIn(browser_masters._SAVE_BUTTON_TEXT, str(ctx.exception))
+
+
 class TestUpdateMaster(unittest.TestCase):
     """``update_master`` (issue #631, Этап A) — partial updates, one whole-form save.
 
@@ -2378,12 +2562,51 @@ class TestUpdateMaster(unittest.TestCase):
         weekly_budget_state=None,
         directs_helps_state=None,
         name_state=None,
+        headlines_state=None,
+        texts_state=None,
     ):
         save_clicks = []
         save_handle = _FakeTextLocatorHandle(
             visible=True, on_click=lambda: save_clicks.append(True)
         )
         locators = dict(extra_locators or {})
+        headline_handles = {}
+        text_handles = {}
+
+        def _add_repeating_slot_locators(state, testid_template, slot_count, out):
+            # ``state`` maps 0-based index -> starting text, pre-populated
+            # by the test with whatever the fake edit page starts showing
+            # (a real slot is either filled or empty; ``_set_repeating_value``
+            # refuses to write to an empty one, mirroring the live page).
+            #
+            # FakePage reuses the SAME handle object across both goto()
+            # calls inside one update_master() run (save, then the
+            # post-save reload), just like the real page keeps rendering
+            # the same slot — so a plain _FakeContentEditableHandle's own
+            # mutable ``_text`` already carries the mutation
+            # ``_set_repeating_value`` made into ``_verify_saved``'s re-read.
+            # ``out`` hands the handles back to the caller so a test can
+            # assert on ``handle.inner_text()`` directly.
+            for index in range(slot_count):
+                selector = f'[data-testid="{testid_template.format(index=index)}"]'
+                handle = _FakeContentEditableHandle(text=state.get(index, ""))
+                locators[selector] = _FakeLocator([handle])
+                out[index] = handle
+
+        if headlines_state is not None:
+            _add_repeating_slot_locators(
+                headlines_state,
+                browser_masters._HEADLINES_TESTID_TEMPLATE,
+                browser_masters._HEADLINES_SLOT_COUNT,
+                headline_handles,
+            )
+        if texts_state is not None:
+            _add_repeating_slot_locators(
+                texts_state,
+                browser_masters._TEXTS_TESTID_TEMPLATE,
+                browser_masters._TEXTS_SLOT_COUNT,
+                text_handles,
+            )
 
         if weekly_budget_state is not None:
             budget_handle = _FakeLocatorHandle(
@@ -2432,6 +2655,11 @@ class TestUpdateMaster(unittest.TestCase):
             locators=locators,
             role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
         )
+        # Attached rather than returned as extra tuple elements, so the
+        # many existing ``page, save_clicks = ...`` two-value call sites
+        # above don't all need updating for this one new capability.
+        page.headline_handles = headline_handles
+        page.text_handles = text_handles
         return page, save_clicks
 
     def test_updates_only_weekly_budget(self):
@@ -2658,6 +2886,99 @@ class TestUpdateMaster(unittest.TestCase):
             browser_masters.update_master(page, 42, promotion_goal="max-clicks")
         self.assertIn("did not save as requested", str(ctx.exception))
 
+    def test_updates_only_one_headline_slot(self):
+        headlines_state = {0: "Старый заголовок", 1: "Другой заголовок"}
+        page, save_clicks = self._page_with_save_button(headlines_state=headlines_state)
+
+        result = browser_masters.update_master(
+            page, 42, headlines={0: "Новый заголовок"}
+        )
+
+        self.assertEqual(page.headline_handles[0].inner_text(), "Новый заголовок")
+        # Slot 1 must be left exactly as it was.
+        self.assertEqual(page.headline_handles[1].inner_text(), "Другой заголовок")
+        self.assertEqual(len(save_clicks), 1)
+        self.assertEqual(
+            result, {"CampaignId": 42, "Headlines": {0: "Новый заголовок"}}
+        )
+
+    def test_updates_headline_and_text_together_with_weekly_budget(self):
+        budget_state = {}
+        headlines_state = {0: "Старый заголовок"}
+        texts_state = {0: "Старый текст"}
+        page, save_clicks = self._page_with_save_button(
+            weekly_budget_state=budget_state,
+            headlines_state=headlines_state,
+            texts_state=texts_state,
+        )
+
+        result = browser_masters.update_master(
+            page,
+            42,
+            weekly_budget=60000,
+            headlines={0: "Новый заголовок"},
+            texts={0: "Новый текст"},
+        )
+
+        self.assertEqual(budget_state["value"], "60000")
+        self.assertEqual(page.headline_handles[0].inner_text(), "Новый заголовок")
+        self.assertEqual(page.text_handles[0].inner_text(), "Новый текст")
+        self.assertEqual(len(save_clicks), 1)
+        self.assertEqual(
+            result,
+            {
+                "CampaignId": 42,
+                "WeeklyBudget": 60000,
+                "Headlines": {0: "Новый заголовок"},
+                "Texts": {0: "Новый текст"},
+            },
+        )
+
+    def test_raises_when_saved_headline_does_not_match_requested(self):
+        # The setter's write "succeeds", but the post-save reload shows the
+        # OLD value still in the slot (mirrors the budget/goal equivalents
+        # above) — must be a hard error, not a false success.
+        headlines_state = {0: "Старый заголовок"}
+        save_clicks = []
+        save_handle = _FakeTextLocatorHandle(
+            visible=True, on_click=lambda: save_clicks.append(True)
+        )
+        slot = _FakeContentEditableHandle(text=headlines_state[0])
+        # Detach the write from the shared state entirely, unlike the
+        # normal helper wiring, to simulate Yandex silently rejecting it.
+        slot.type = lambda value, delay=None: None
+        selector = (
+            f"[data-testid="
+            f'"{browser_masters._HEADLINES_TESTID_TEMPLATE.format(index=0)}"]'
+        )
+        page = FakePage(
+            locators={selector: _FakeLocator([slot])},
+            role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
+        )
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(page, 42, headlines={0: "Новый заголовок"})
+
+        self.assertEqual(len(save_clicks), 1)  # save WAS clicked
+        self.assertIn("did not save as requested", str(ctx.exception))
+
+    def test_does_not_click_save_when_headline_slot_is_empty(self):
+        headlines_state = {0: ""}  # empty slot -> _set_repeating_value refuses
+        page, save_clicks = self._page_with_save_button(headlines_state=headlines_state)
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters.update_master(page, 42, headlines={0: "Новый заголовок"})
+
+        self.assertEqual(save_clicks, [])
+
+    def test_raises_value_error_when_only_empty_headlines_dict_provided(self):
+        # An empty dict is falsy — same "nothing to update" guard as every
+        # other field, not treated as "update with zero slots".
+        page = FakePage()
+
+        with self.assertRaises(ValueError):
+            browser_masters.update_master(page, 42, headlines={})
+
 
 class TestMastersUpdateCommand(unittest.TestCase):
     """CLI wiring for `masters update` (issue #631, Этап A)."""
@@ -2772,6 +3093,163 @@ class TestMastersUpdateCommand(unittest.TestCase):
         with patch("direct_cli.browser.masters.update_master") as mock_update:
             self.runner.invoke(cli, ["masters", "update", "42"])
         mock_update.assert_not_called()
+
+    def test_documents_headline_and_text_flags(self):
+        result = self.runner.invoke(cli, ["masters", "update", "--help"])
+        self.assertIn("--headline", result.output)
+        self.assertIn("--text", result.output)
+
+    def test_passes_headline_slot_as_zero_based_index(self):
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42}
+            result = self.runner.invoke(
+                cli, ["masters", "update", "42", "--headline", "2=Новый заголовок"]
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        # User-facing slot 2 (1-based) -> browser layer's 0-based index 1.
+        self.assertEqual(
+            mock_update.call_args.kwargs["headlines"], {1: "Новый заголовок"}
+        )
+
+    def test_passes_multiple_headline_and_text_slots(self):
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42}
+            result = self.runner.invoke(
+                cli,
+                [
+                    "masters",
+                    "update",
+                    "42",
+                    "--headline",
+                    "1=Заголовок один",
+                    "--headline",
+                    "3=Заголовок три",
+                    "--text",
+                    "2=Текст два",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(
+            mock_update.call_args.kwargs["headlines"],
+            {0: "Заголовок один", 2: "Заголовок три"},
+        )
+        self.assertEqual(mock_update.call_args.kwargs["texts"], {1: "Текст два"})
+
+    def test_headline_value_containing_equals_sign_splits_on_first_only(self):
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42}
+            result = self.runner.invoke(
+                cli,
+                ["masters", "update", "42", "--headline", "1=x=y=z"],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(mock_update.call_args.kwargs["headlines"], {0: "x=y=z"})
+
+    def test_rejects_headline_without_equals_sign(self):
+        result = self.runner.invoke(
+            cli, ["masters", "update", "42", "--headline", "no equals here"]
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn('"N=text"', result.output)
+
+    def test_rejects_non_numeric_slot_number(self):
+        result = self.runner.invoke(
+            cli, ["masters", "update", "42", "--headline", "abc=Текст"]
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("integer", result.output)
+
+    def test_rejects_slot_number_below_one(self):
+        result = self.runner.invoke(
+            cli, ["masters", "update", "42", "--headline", "0=Текст"]
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("1 or greater", result.output)
+
+    def test_rejects_duplicate_slot_number(self):
+        result = self.runner.invoke(
+            cli,
+            [
+                "masters",
+                "update",
+                "42",
+                "--headline",
+                "1=Первый",
+                "--headline",
+                "1=Второй",
+            ],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("more than once", result.output)
+
+    def test_format_errors_do_not_open_a_browser_session(self):
+        with patch("direct_cli.commands.masters._with_session") as mock_with_session:
+            result = self.runner.invoke(
+                cli, ["masters", "update", "42", "--headline", "bogus"]
+            )
+        self.assertNotEqual(result.exit_code, 0)
+        mock_with_session.assert_not_called()
+
+    def test_headline_flag_alone_satisfies_the_at_least_one_field_guard(self):
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42}
+            result = self.runner.invoke(
+                cli, ["masters", "update", "42", "--headline", "1=Текст"]
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+
+    def test_documents_launch_flag(self):
+        result = self.runner.invoke(cli, ["masters", "update", "--help"])
+        self.assertIn("--launch", result.output)
+
+    def test_launch_flag_defaults_to_false(self):
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42}
+            result = self.runner.invoke(
+                cli, ["masters", "update", "42", "--weekly-budget", "1000"]
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertFalse(mock_update.call_args.kwargs["launch"])
+
+    def test_passes_launch_flag(self):
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42}
+            result = self.runner.invoke(
+                cli,
+                ["masters", "update", "42", "--weekly-budget", "1000", "--launch"],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertTrue(mock_update.call_args.kwargs["launch"])
 
 
 class TestMastersLoginCommand(unittest.TestCase):
@@ -3478,6 +3956,128 @@ class TestReadRepeatingValues(unittest.TestCase):
         values = browser_masters._read_repeating_values(page, "fake{index}.textarea", 2)
 
         self.assertEqual(values, ["ok", ""])
+
+
+class TestSetRepeatingValue(unittest.TestCase):
+    """``_set_repeating_value`` (issue #665, Этап B) — point replacement of
+    ONE existing headline/text slot on the edit page.
+
+    Unlike ``_add_repeating_values`` (the create-page setter, which clears
+    and rewrites every slot unconditionally), this only ever touches the
+    one requested slot — the rest of the fakes' slots must stay untouched
+    across every scenario, mirroring the module's own docstring contract.
+    """
+
+    def test_replaces_a_filled_slot(self):
+        events = []
+        field = _FakeContentEditableHandle(
+            text="Старый заголовок",
+            on_press=lambda key: events.append(("press", key)),
+            on_fill=lambda v: events.append(("type", v)),
+        )
+        page = FakePage(
+            locators={'[data-testid="fake0.textarea"]': _FakeLocator([field])}
+        )
+
+        browser_masters._set_repeating_value(
+            page, "fake{index}.textarea", 5, 0, "Новый заголовок"
+        )
+
+        self.assertEqual(field.inner_text(), "Новый заголовок")
+        # Clear must happen before typing, same convention as
+        # _add_repeating_values.
+        self.assertEqual(
+            events,
+            [
+                ("press", "ControlOrMeta+a"),
+                ("press", "Backspace"),
+                ("type", "Новый заголовок"),
+            ],
+        )
+
+    def test_other_slots_are_never_touched(self):
+        untouched = _FakeContentEditableHandle(text="Не трогать")
+        target = _FakeContentEditableHandle(text="Старый текст")
+        page = FakePage(
+            locators={
+                '[data-testid="fake0.textarea"]': _FakeLocator([untouched]),
+                '[data-testid="fake1.textarea"]': _FakeLocator([target]),
+            }
+        )
+
+        browser_masters._set_repeating_value(
+            page, "fake{index}.textarea", 2, 1, "Новый текст"
+        )
+
+        self.assertEqual(untouched.inner_text(), "Не трогать")
+        self.assertEqual(target.inner_text(), "Новый текст")
+
+    def test_raises_when_slot_is_empty(self):
+        """Writing to an empty slot would add a new variant, not replace one
+        — refused rather than silently treated as "add" (issue #665)."""
+        field = _FakeContentEditableHandle(text="")
+        page = FakePage(
+            locators={'[data-testid="fake0.textarea"]': _FakeLocator([field])}
+        )
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._set_repeating_value(
+                page, "fake{index}.textarea", 5, 0, "Новый заголовок"
+            )
+
+        self.assertIn("empty", str(ctx.exception).lower())
+        # Nothing should have been typed into the empty slot.
+        self.assertEqual(field.inner_text(), "")
+
+    def test_raises_when_index_out_of_range(self):
+        page = FakePage(locators={})
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._set_repeating_value(
+                page, "fake{index}.textarea", 3, 5, "x"
+            )
+
+        self.assertIn("out of range", str(ctx.exception).lower())
+
+    def test_raises_when_field_missing(self):
+        page = FakePage(locators={})
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters._set_repeating_value(
+                page, "fake{index}.textarea", 1, 0, "x"
+            )
+
+    def test_aborts_when_slot_cannot_be_cleared(self):
+        """Same ``supports_modifier=False`` (Playwright <1.44) guard as
+        ``_add_repeating_values`` — must fail loudly, not splice text."""
+        field = _FakeContentEditableHandle(
+            text="Старый заголовок", supports_modifier=False
+        )
+        page = FakePage(
+            locators={'[data-testid="fake0.textarea"]': _FakeLocator([field])}
+        )
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._set_repeating_value(
+                page, "fake{index}.textarea", 5, 0, "Новый заголовок"
+            )
+
+        self.assertEqual(field.inner_text(), "Старый заголовок")
+        self.assertIn("clear", str(ctx.exception).lower())
+
+    def test_click_failure_raises_browser_session_error(self):
+        field = _FakeContentEditableHandle(text="Старый заголовок")
+        field.click = lambda timeout=None: (_ for _ in ()).throw(
+            PlaywrightError("element detached")
+        )
+        page = FakePage(
+            locators={'[data-testid="fake0.textarea"]': _FakeLocator([field])}
+        )
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters._set_repeating_value(
+                page, "fake{index}.textarea", 5, 0, "Новый заголовок"
+            )
 
 
 class TestSetRegion(unittest.TestCase):

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -3205,6 +3205,51 @@ class TestMastersUpdateCommand(unittest.TestCase):
         self.assertNotEqual(result.exit_code, 0)
         mock_with_session.assert_not_called()
 
+    def test_rejects_an_out_of_range_headline_slot(self):
+        """``--headline "6=x"`` names a slot the edit page does not have.
+
+        The edit page renders a FIXED 5 headline / 3 text slots, so an
+        oversized slot number is a purely invalid CLI argument — it must be
+        refused here, as a UsageError, not carried into a browser session
+        only for ``_set_repeating_value`` to reject it as a
+        BrowserSessionError after a Chromium launch and possible auth prompt.
+        """
+        result = self.runner.invoke(
+            cli, ["masters", "update", "42", "--headline", "6=x"]
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("1-5", result.output)
+
+    def test_rejects_an_out_of_range_text_slot(self):
+        result = self.runner.invoke(cli, ["masters", "update", "42", "--text", "4=x"])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("1-3", result.output)
+
+    def test_accepts_the_last_valid_slot_of_each_field(self):
+        """The upper bound is inclusive — 5 headlines and 3 texts are valid."""
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42}
+            result = self.runner.invoke(
+                cli,
+                ["masters", "update", "42", "--headline", "5=a", "--text", "3=b"],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(mock_update.call_args.kwargs["headlines"], {4: "a"})
+        self.assertEqual(mock_update.call_args.kwargs["texts"], {2: "b"})
+
+    def test_out_of_range_slot_does_not_open_a_browser_session(self):
+        with patch("direct_cli.commands.masters._with_session") as mock_with_session:
+            result = self.runner.invoke(
+                cli, ["masters", "update", "42", "--headline", "6=x"]
+            )
+        self.assertNotEqual(result.exit_code, 0)
+        mock_with_session.assert_not_called()
+
     def test_rejects_an_empty_headline_replacement(self):
         """``--headline "1="`` would DELETE variant 1, not replace it.
 

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -3205,6 +3205,36 @@ class TestMastersUpdateCommand(unittest.TestCase):
         self.assertNotEqual(result.exit_code, 0)
         mock_with_session.assert_not_called()
 
+    def test_rejects_an_empty_headline_replacement(self):
+        """``--headline "1="`` would DELETE variant 1, not replace it.
+
+        Deleting a variant is explicitly out of scope for Этап B (issue
+        #665), and the failure mode is silent: the slot gets cleared, the
+        empty string typed, the form saved, and the post-save check compares
+        the re-read slot against the requested value — both empty, so it
+        matches and the delete is reported as a successful update.
+        """
+        result = self.runner.invoke(
+            cli, ["masters", "update", "42", "--headline", "1="]
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("empty", result.output.lower())
+
+    def test_rejects_a_whitespace_only_text_replacement(self):
+        result = self.runner.invoke(cli, ["masters", "update", "42", "--text", "2=   "])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("empty", result.output.lower())
+
+    def test_empty_replacement_does_not_open_a_browser_session(self):
+        """The refusal must land before any live page is touched — an
+        already-open edit page is a live, no-rollback mutation surface."""
+        with patch("direct_cli.commands.masters._with_session") as mock_with_session:
+            result = self.runner.invoke(
+                cli, ["masters", "update", "42", "--headline", "1="]
+            )
+        self.assertNotEqual(result.exit_code, 0)
+        mock_with_session.assert_not_called()
+
     def test_headline_flag_alone_satisfies_the_at_least_one_field_guard(self):
         with (
             patch("direct_cli.browser.masters.update_master") as mock_update,
@@ -4078,6 +4108,46 @@ class TestSetRepeatingValue(unittest.TestCase):
             browser_masters._set_repeating_value(
                 page, "fake{index}.textarea", 5, 0, "Новый заголовок"
             )
+
+    def test_refuses_to_blank_a_slot_with_an_empty_value(self):
+        """An empty replacement would DELETE a live ad variant.
+
+        Deleting a variant is explicitly out of scope for Этап B (issue #665
+        lists it under "Явно вне объёма"), and the damage is silent: the slot
+        is cleared, the empty string is typed, the form is saved, and
+        ``_verify_repeating_value_mismatches`` then compares the re-read slot
+        against the REQUESTED value — ``"" == ""`` matches, so the delete is
+        reported as a successful update. On an active campaign that is a live
+        ad mutation with no rollback (and with ``--launch`` on a DRAFT, it is
+        published immediately). Guarded here as well as at the CLI boundary
+        so the browser layer is safe for any caller, not just the CLI.
+        """
+        field = _FakeContentEditableHandle(text="Старый заголовок")
+        page = FakePage(
+            locators={'[data-testid="fake0.textarea"]': _FakeLocator([field])}
+        )
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._set_repeating_value(page, "fake{index}.textarea", 5, 0, "")
+
+        # The existing variant must survive untouched — not cleared-then-failed.
+        self.assertEqual(field.inner_text(), "Старый заголовок")
+        self.assertIn("empty", str(ctx.exception).lower())
+
+    def test_refuses_to_blank_a_slot_with_a_whitespace_only_value(self):
+        """Whitespace-only is the same delete wearing a disguise."""
+        field = _FakeContentEditableHandle(text="Старый заголовок")
+        page = FakePage(
+            locators={'[data-testid="fake0.textarea"]': _FakeLocator([field])}
+        )
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._set_repeating_value(
+                page, "fake{index}.textarea", 5, 0, "   "
+            )
+
+        self.assertEqual(field.inner_text(), "Старый заголовок")
+        self.assertIn("empty", str(ctx.exception).lower())
 
 
 class TestSetRegion(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Implements `direct masters update --headline "N=text"` / `--text "N=text"` — point-replacement of one existing headline/ad-text variant slot at a time (N is the 1-based slot, 1-5 for headlines, 1-3 for ad text). Closes the Этап B gap tracked under the #648 umbrella (issue #665, originally #631).
- **Deliberate departure from this CLI's dominant list-field convention**: everywhere else `update` replaces the WHOLE array in one call (e.g. `campaigns update --negative-keywords`, built on `_array_of_string_option`). Мастер кампаний has no API at all, variant sets can be large, and forcing every variant to be re-typed to fix one typo would defeat the point of a partial update. See `_set_repeating_value`'s docstring, and the CHANGELOG/README sections, for the full rationale — documented as a conscious choice, not an oversight; a future refactor may want to unify this with the rest of the CLI, but that's explicitly out of scope here.
- Reuses `_clear_text_field`/`_read_repeating_values` from the create-page implementation (#653) as-is. Does **not** reuse `_add_repeating_values` — that function's contract (clear and rewrite every slot) is the opposite of a point replacement.
- Writing to a currently-empty slot is refused (`UsageError`) — this only edits variants that already exist, it does not add new ones. Deleting a variant and editing variant weights are out of scope, tracked as follow-ups.
- Live-recon (read-only) confirmed the edit page's slots (`CampaignTitles{N}.textarea`/`CampaignTexts{N}.textarea`, 5/3 slots) are identical in shape/count to the create page's — see `tests/fixtures/masters_wizard_edit_stage_b.html`.

## Also fixes: `masters update` on DRAFT campaigns (issue #668)

Found while live-verifying this PR — the two DRAFT campaigns available in the account (leftover clones from #659/#663) couldn't be used to test `update`, because DRAFT edit pages have no "Сохранить кампанию" button at all, only `CampaignFormControls.saveDraft.button`/`.save.button` (the latter labelled "Запустить кампанию" — publishes the campaign).

- `update_master` now detects DRAFT (via presence of the `saveDraft.button` testid) and clicks it by default, keeping DRAFT status. New `--launch` flag publishes instead.
- Live-recon also found the draft-save click redirects away from `/edit/` to the campaign's overview page, and not instantly (~5s observed) — the original immediate post-click reload raced this redirect, producing a false "did not save as requested" error even though the edit had actually saved server-side. Fixed by polling `page.url` until it leaves `/edit/` before re-verifying, mirroring the pattern `copy_master` already uses for its own post-click redirect.

## Test plan

- [x] `pytest tests/test_masters.py -q` — 240/240 pass (including 8 new DRAFT-support tests, 7 `_set_repeating_value` tests, and 14 new `update`/CLI tests).
- [x] `pytest -q` — full offline suite green (2819 passed; the 62 errors are the pre-existing, unrelated VCR/aiohttp environment issue noted in prior masters PRs).
- [x] `black`/`flake8` clean on all touched files.
- [x] **Live-verified end to end** against DRAFT campaign 713231614: replaced headline slot 1 via `direct masters update 713231614 --headline "1=..."`, confirmed saved via reload, reverted to the original text the same way. Confirmed via `masters list --status all` that the campaign remained DRAFT throughout (never published).

Closes #665
Closes #668