### PR TITLE
feat(masters): add `masters update --image` — Этап D point-replacement (#670)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,76 @@
 
 ## Unreleased
 
+**Added — `direct masters update --image` (#670, Этап D):**
+
+- New repeatable `--image "N=/path/to/file.png"` flag on `direct masters
+  update <CAMPAIGN_ID>` replaces the image currently at position N of the
+  campaign's image set with a local PNG/JPEG/GIF file, driven through the
+  edit page's image manager modal (`ImageSuggestionsEditorModal`).
+- **Known limitation — the image set is reordered.** Yandex has no "replace
+  this slot" primitive for images at all, only "remove from the set" and
+  "add to the set", so the point replacement is composed from the two.
+  Confirmed live 2026-08-02 (campaign 713234191, Save never clicked, no
+  campaign mutated): a newly uploaded image is always appended to the END
+  of the set, never inserted at the freed position — replacing position 2
+  of `[A, B, C, D]` yields `[A, C, D, NEW]`, not `[A, NEW, C, D]`. The
+  flag therefore means "replace the image currently at position N" (which
+  one to drop), not "put the new image at position N". This has no effect
+  on ad delivery — Yandex rotates images by performance regardless of their
+  order — but the CLI help, README and this entry say so rather than
+  implying a true positional swap.
+- **No fixed slot count, unlike headlines/texts.** The edit page renders
+  exactly as many `ContentImage` elements as the campaign has images, keyed
+  by a Yandex content ID rather than an index, so the real upper bound for
+  N is read fresh from the page. `_IMAGES_MAX_COUNT = 5` (Yandex's hard cap
+  on set size) bounds CLI parsing only — `--image "5=..."` on a campaign
+  with four images is refused by the browser layer as out of range, not
+  silently appended as a fifth.
+- **An empty image set is a legitimate state** (there is no "at least one"
+  invariant as there is for headlines/texts), and it gets its own explicit
+  error rather than a generic out-of-range one — this command only replaces
+  images that already exist, it does not add the first one.
+- The edit page is an SPA: `goto(..., wait_until="domcontentloaded")`
+  returns before the images section exists, and reading too early yields an
+  empty list indistinguishable from "this campaign genuinely has no
+  images". Live-confirmed to produce a false "no images" failure on four
+  consecutive campaigns that demonstrably had four images each. Hence
+  `_wait_for_images_editor`, which reports a timeout as a hard error
+  instead of silently treating it as an empty set.
+- Nonexistent paths and extensions Yandex won't accept are rejected as a
+  `UsageError` before any browser session opens, with the accepted suffixes
+  imported from the browser layer's own `_IMAGE_UPLOAD_SUFFIXES` (mirroring
+  the page's `accept="image/png,image/jpeg,image/jpg,image/gif"`, confirmed
+  live) so the two can't drift.
+- Post-save verification is **set-membership**, not positional, matching
+  the append-to-end behaviour above; identity is read from the content ID
+  in the `data-testid`, not from the thumbnail's visual availability (a
+  broken preview does not mean a missing image — observed live).
+- Because both the removal and the upload happen inside the same open
+  modal, any failure before `Save` leaves the campaign's saved image set
+  untouched — every error message says so explicitly.
+- Adding an image beyond the current set, deleting one without replacement,
+  picking from the modal's `USER`/`WEB_SITE`/`AI_GENERATED`/`NEURO_STOCK`
+  libraries, and video are all out of scope (video is a separate follow-up:
+  it uses a different control and a different processing pipeline).
+- Each image is replaced through its own open/remove/upload/Save modal
+  cycle, so replacing N images costs N cycles. Batching them into a single
+  modal session looks possible (`set_input_files` accepts a list) but is
+  not live-verified, so it is deliberately left for a follow-up.
+
+**Changed — shared scaffolding in `direct_cli/browser/masters.py` (#670):**
+
+- New `_poll_until` replaces five hand-rolled `deadline` /
+  `wait_for_timeout(250)` loops and the two sentinel flags (`removed`,
+  `uploaded`) that only existed because those loops were inline. It also
+  makes `PlaywrightError` suppression uniform — previously only one of the
+  five loops suppressed it.
+- New `_read_testid_suffixes` collapses `_read_image_content_ids` and
+  `_read_modal_selected_thumb_urls`, which were the same prefix-scraping
+  body twice.
+- New `_validate_image_paths` lifts the extension/existence check out of
+  the Click callback body.
+
 **Added — `direct masters update --headline`/`--text` (#665, Этап B):**
 
 - New `--headline "N=text"` / `--text "N=text"` flags on `direct masters

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ direct masters update 72349978 --weekly-budget 95000
 direct masters update 72349978 --promotion-goal max-clicks --no-directs-helps
 direct masters update 72349978 --name "Мастер ИЖ Источник Жизни (тёплый)"
 direct masters update 72349978 --headline "2=Новый заголовок" --text "1=Новый текст"
+direct masters update 72349978 --image "2=/path/to/banner.png"
 direct masters add https://example.com/ --headline "Заголовок 1" --headline "Заголовок 2" --text "Текст объявления" --region Москва --weekly-budget 50000 --draft
 direct masters add https://example.com/ --headline "Заголовок 1" --text "Текст объявления" --region-id 213 --weekly-budget 50000 --draft
 direct masters copy 72349978
@@ -54,14 +55,16 @@ It always reads the logged-in browser session's own account — there is no
 
 `masters update` edits a single Мастер кампаний's settings page. It currently
 covers the simplest scalar fields (Этап A of a larger, staged rollout — see
-`direct_cli/browser/masters.py` module docstring), the campaign name, and
-point-replacement of individual headline/ad-text variants (Этап B):
+`direct_cli/browser/masters.py` module docstring), the campaign name,
+point-replacement of individual headline/ad-text variants (Этап B), and
+point-replacement of individual images (Этап D):
 `--weekly-budget` (integer), `--promotion-goal`
 (`max-conversions`/`max-clicks`), `--directs-helps`/`--no-directs-helps`
-(auto-apply recommendations), `--name` (Название кампании), and
+(auto-apply recommendations), `--name` (Название кампании),
 `--headline`/`--text` (repeatable `"N=text"`, N is the 1-based variant slot
-shown on the edit page — 1-5 for headlines, 1-3 for ad text). At least one
-flag is required. The settings page is a single form with one save button —
+shown on the edit page — 1-5 for headlines, 1-3 for ad text), and `--image`
+(repeatable `"N=/path/to/file.png"`, N is the 1-based position in the
+campaign's *current* image set). At least one flag is required. The settings page is a single form with one save button —
 passing only some flags leaves every other field at its current value; it
 does not send a partial payload to a separate per-field endpoint. Unlike the
 other fields, `--name` is edited through a separate header modal, not a plain
@@ -79,9 +82,31 @@ Writing to a slot that is currently empty is refused (`UsageError`) — this
 only edits variants that already exist, it does not add new ones. An empty or
 whitespace-only replacement (`--headline "1="`) is refused for the mirror-image
 reason: blanking a slot would delete a live ad variant, not replace it.
-Deleting a variant and editing variant weights aren't implemented yet. Later fields
-(sitelinks, audience, Metrika counters/goals, budget adaptation, images/
-video) aren't implemented yet either.
+Deleting a variant and editing variant weights aren't implemented yet.
+
+`--image "N=/path/to/file.png"` replaces the image currently at position N of
+the campaign's image set with a local PNG/JPEG/GIF file, through the edit
+page's image manager modal. **Known limitation — the set is reordered.**
+Yandex has no "replace this slot" primitive for images at all, only "remove
+from the set" and "add to the set", so a point replacement is composed from
+the two — and a newly uploaded image is always appended to the END of the set
+(confirmed live), never inserted at the freed position. Replacing position 2
+of `[A, B, C, D]` therefore yields `[A, C, D, NEW]`, not `[A, NEW, C, D]`.
+The flag's semantics are "replace the image that is currently at position N"
+(which one to drop), not "put the new image at position N". This has no
+effect on ad delivery — Yandex rotates images by performance regardless of
+their order in the set. Unlike headlines/texts there is no fixed slot count:
+the upper bound for N is whatever the campaign actually has (up to Yandex's
+cap of 5), read fresh from the page, and a campaign with no images at all is
+a legitimate state that `--image` refuses with its own explicit error rather
+than a generic "out of range". Nonexistent paths and extensions Yandex won't
+accept are rejected before any browser opens. Adding an image beyond the
+current set and deleting one without replacement are out of scope. Because
+both the removal and the upload happen inside the same open modal, any
+failure before Save leaves the campaign's saved image set untouched.
+
+Later fields (sitelinks, audience, Metrika counters/goals, budget adaptation,
+video) aren't implemented yet.
 
 A DRAFT campaign's edit page has no "Сохранить кампанию" button at all —
 `masters update` on a DRAFT saves it via "Сохранить как черновик" by
@@ -1173,6 +1198,7 @@ direct masters update 72349978 --weekly-budget 95000
 direct masters update 72349978 --promotion-goal max-clicks --no-directs-helps
 direct masters update 72349978 --name "Мастер ИЖ Источник Жизни (тёплый)"
 direct masters update 72349978 --headline "2=Новый заголовок" --text "1=Новый текст"
+direct masters update 72349978 --image "2=/path/to/banner.png"
 direct masters add https://example.com/ --headline "Заголовок 1" --headline "Заголовок 2" --text "Текст объявления" --region Москва --weekly-budget 50000 --draft
 direct masters add https://example.com/ --headline "Заголовок 1" --text "Текст объявления" --region-id 213 --weekly-budget 50000 --draft
 direct masters copy 72349978
@@ -1187,14 +1213,17 @@ direct masters copy 72349978 --launch
 
 `masters update` редактирует настройки одного «Мастера кампаний». Пока
 поддерживаются простые скалярные поля (Этап A поэтапного плана — см.
-докстринг модуля `direct_cli/browser/masters.py`), название кампании и
-точечная замена отдельных вариантов заголовков/текстов (Этап B):
+докстринг модуля `direct_cli/browser/masters.py`), название кампании,
+точечная замена отдельных вариантов заголовков/текстов (Этап B) и точечная
+замена отдельных изображений (Этап D):
 `--weekly-budget` (недельный бюджет, целое число), `--promotion-goal`
 (`max-conversions`/`max-clicks` — цель продвижения),
 `--directs-helps`/`--no-directs-helps` (автоприменение рекомендаций «Директ
-помогает»), `--name` (Название кампании) и `--headline`/`--text`
+помогает»), `--name` (Название кампании), `--headline`/`--text`
 (повторяемые, формат `"N=текст"`, N — номер слота варианта на странице
-редактирования, 1-based: 1-5 для заголовков, 1-3 для текстов). Нужно указать
+редактирования, 1-based: 1-5 для заголовков, 1-3 для текстов) и `--image`
+(повторяемый, формат `"N=/путь/к/файлу.png"`, N — 1-based позиция в
+*текущем* наборе изображений кампании). Нужно указать
 хотя бы один флаг. Страница настроек — единая форма с одной кнопкой
 сохранения: если указать не все флаги, остальные поля останутся с текущим
 значением — это не частичный запрос к отдельному API-эндпоинту на каждое
@@ -1212,9 +1241,33 @@ direct masters copy 72349978 --launch
 `direct_cli/browser/masters.py::_set_repeating_value`. Запись в пустой слот
 запрещена (`UsageError`) — команда только редактирует уже существующие
 варианты, а не добавляет новые; удаление варианта и редактирование весов
-вариантов пока не реализованы. Остальные поля (быстрые ссылки, аудитория,
-счётчики Метрики/цели, адаптация бюджета, изображения/видео) тоже пока не
-реализованы.
+вариантов пока не реализованы.
+
+`--image "N=/путь/к/файлу.png"` заменяет изображение, которое сейчас стоит на
+позиции N набора кампании, локальным файлом PNG/JPEG/GIF — через модалку
+менеджера изображений на странице редактирования. **Известное ограничение —
+набор переупорядочивается.** У Яндекса вообще нет примитива «заменить
+изображение в позиции», есть только «удалить из набора» и «добавить в набор»,
+поэтому точечная замена собирается из этих двух операций — а загруженное
+изображение всегда встаёт в КОНЕЦ набора (подтверждено живьём), а не на
+освободившуюся позицию. Замена позиции 2 в наборе `[A, B, C, D]` даёт
+`[A, C, D, NEW]`, а не `[A, NEW, C, D]`. Семантика флага — «заменить
+изображение, которое сейчас на позиции N» (какое именно убрать), а не
+«поставить новое на позицию N». На показы это не влияет: Яндекс всё равно
+ротирует изображения по эффективности независимо от их порядка в наборе.
+В отличие от заголовков и текстов, фиксированного числа слотов здесь нет:
+верхняя граница N — это фактическое число изображений у кампании (в пределах
+жёсткого лимита Яндекса в 5 штук), прочитанное со страницы, а кампания вообще
+без изображений — законное состояние, на котором `--image` падает отдельной
+внятной ошибкой, а не generic «out of range». Несуществующий путь и
+неподдерживаемое расширение отлетают ещё до открытия браузера. Добавление
+изображения сверх текущего набора и удаление изображения без замены — вне
+объёма. Поскольку и удаление, и загрузка происходят внутри одной открытой
+модалки, любая ошибка до Save оставляет сохранённый набор изображений
+кампании нетронутым.
+
+Остальные поля (быстрые ссылки, аудитория, счётчики Метрики/цели, адаптация
+бюджета, видео) тоже пока не реализованы.
 
 У черновика («DRAFT») страница редактирования вообще не имеет кнопки
 «Сохранить кампанию» — `masters update` на черновике по умолчанию сохраняет

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -1739,19 +1739,38 @@ def update_master(
 
     _click_save(page, campaign_id, launch=launch)
 
-    _verify_saved(
-        page,
-        campaign_id,
-        weekly_budget=weekly_budget,
-        promotion_goal=promotion_goal,
-        directs_helps=directs_helps,
-        name=name,
-        headlines=headlines,
-        texts=texts,
-        images_before_ids=images_before_ids,
-        images_replaced_ids=images_replaced_ids,
-        clicked_button_label=clicked_button_label,
-    )
+    # The terminal-button click above already happened — irreversible, and
+    # for images NOT idempotent (a retry would re-snapshot the
+    # already-mutated set and replace DIFFERENT images than the ones the
+    # caller named; see _set_image's docstring). If the saved session is
+    # invalidated in exactly this window, _verify_saved's own
+    # assert_authenticated raises BrowserAuthError; letting that propagate
+    # as-is would make _with_session (direct_cli/commands/masters.py) retry
+    # this ENTIRE update_master call under a fresh session. Re-raise as a
+    # plain BrowserSessionError so that retry does not trigger — mirrors
+    # copy_master's identical guard around its own post-click verification.
+    try:
+        _verify_saved(
+            page,
+            campaign_id,
+            weekly_budget=weekly_budget,
+            promotion_goal=promotion_goal,
+            directs_helps=directs_helps,
+            name=name,
+            headlines=headlines,
+            texts=texts,
+            images_before_ids=images_before_ids,
+            images_replaced_ids=images_replaced_ids,
+            clicked_button_label=clicked_button_label,
+        )
+    except BrowserAuthError as exc:
+        raise BrowserSessionError(
+            f"Clicked '{clicked_button_label}' for campaign {campaign_id}, "
+            "but the session was invalidated while verifying the save — "
+            "the requested changes were likely already applied; check "
+            f"campaign {campaign_id} manually rather than retrying "
+            "(image replacements are not idempotent)."
+        ) from exc
 
     result: Dict[str, Any] = {"CampaignId": campaign_id}
     if weekly_budget is not None:

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -202,7 +202,7 @@ import contextlib
 import json
 import re
 import time
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple
 
 from ..output import print_warning
 from .session import (
@@ -363,6 +363,50 @@ _HEADLINES_SLOT_COUNT = 5
 _TEXTS_SLOT_COUNT = 3
 _HEADLINES_TESTID_TEMPLATE = "CampaignTitles{index}.textarea"
 _TEXTS_TESTID_TEMPLATE = "CampaignTexts{index}.textarea"
+
+# Images (issue #670, Этап D). Confirmed live 2026-08-02 against DRAFT clone
+# 713234191 that images are a COMPLETELY different shape from headlines/texts
+# above: there is no fixed slot count in the DOM at all — the edit page
+# renders exactly as many ``ContentImage``/``CloseButton`` pairs as the
+# campaign actually has images (observed: 4), keyed by a Yandex-assigned
+# content ID, not a 0-based slot index. "Можно добавить до 5 штук" is an
+# upper bound on the SET, not a slot count — unlike headlines/texts, an
+# images set may legitimately be EMPTY (zero images is a valid state; there
+# is no "at least one" invariant here). ``_IMAGES_MAX_COUNT`` therefore
+# bounds the CLI's slot-number parsing only; the real per-campaign ceiling is
+# always ``len(_read_image_content_ids(page))``, read fresh from the page.
+_IMAGES_MAX_COUNT = 5
+_IMAGES_EDITOR_SELECTOR = '[data-testid="ImageSuggestionsEditor"]'
+_IMAGES_CONTENT_TESTID_PREFIX = "ImageSuggestionsEditor.CampaignContents.ContentImage."
+_IMAGES_OPEN_MODAL_SELECTOR = '[data-testid="ImageSuggestionsEditor.Open"]'
+_IMAGES_MODAL_SELECTOR = '[data-testid="ImageSuggestionsEditorModal"]'
+_IMAGES_MODAL_FILE_INPUT_SELECTOR = (
+    '[data-testid="ImageSuggestionsEditorModal.UploadZone.filePicker"]'
+)
+_IMAGES_MODAL_SELECTED_PREFIX = (
+    "ImageSuggestionsEditorModal.SelectedImagesContainer.SelectedImage."
+)
+_IMAGES_MODAL_REMOVE_TESTID_TEMPLATE = (
+    "ImageSuggestionsEditorModal.SelectedImagesContainer.SelectedImage."
+    "{thumb_url}.CloseButton"
+)
+_IMAGES_MODAL_SAVE_SELECTOR = '[data-testid="ImageSuggestionsEditorModal.Save"]'
+# ``accept=`` on Yandex's own file input (the selector above) is
+# ``image/png,image/jpeg,image/jpg,image/gif`` — confirmed live 2026-08-02.
+# Lives here, next to the input it describes, so the CLI's fail-fast check
+# can't drift from what the page actually accepts (same reasoning as
+# ``_IMAGES_MAX_COUNT``).
+_IMAGE_UPLOAD_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".gif"})
+_IMAGE_MODAL_OPEN_TIMEOUT_MS = 10_000
+_IMAGE_UPLOAD_TIMEOUT_MS = 60_000
+# The edit page is an SPA: ``goto(..., wait_until="domcontentloaded")``
+# returns long before the images section exists in the DOM. Reading the set
+# too early yields an empty list, which is INDISTINGUISHABLE from the
+# legitimate "this campaign genuinely has no images" state — live-confirmed
+# 2026-08-02 to make `--image` fail with a false "no images" on campaigns
+# that demonstrably had four. Hence an explicit wait for the section itself
+# before any read that a decision depends on (see `_wait_for_images_editor`).
+_IMAGES_EDITOR_TIMEOUT_MS = 30_000
 
 # Region picker (issue #653 re-recon, 2026-08-02): Yandex replaced the old
 # text-combobox-with-suggestions flow with a tree/tag-group widget
@@ -1473,6 +1517,8 @@ def _verify_saved(
     name: Optional[str] = None,
     headlines: Optional[Dict[int, str]] = None,
     texts: Optional[Dict[int, str]] = None,
+    images_before_ids: Optional[List[str]] = None,
+    images_replaced_ids: Optional[Set[str]] = None,
     clicked_button_label: str = _SAVE_BUTTON_TEXT,
 ) -> None:
     """Reload the edit page and confirm every requested field actually saved.
@@ -1531,6 +1577,13 @@ def _verify_saved(
             requested=texts,
         )
     )
+    mismatches.extend(
+        _verify_image_mismatches(
+            page,
+            before_ids=images_before_ids or [],
+            replaced_ids=images_replaced_ids or set(),
+        )
+    )
 
     if mismatches:
         raise BrowserSessionError(
@@ -1552,9 +1605,10 @@ def update_master(
     name: Optional[str] = None,
     headlines: Optional[Dict[int, str]] = None,
     texts: Optional[Dict[int, str]] = None,
+    images: Optional[Dict[int, str]] = None,
     launch: bool = False,
 ) -> Dict[str, Any]:
-    """Update one or more Этап A/B fields (plus the campaign name) and save.
+    """Update one or more Этап A/B/D fields (plus the campaign name) and save.
 
     Only fields passed as non-``None`` are touched — see module docstring for
     why this is safe despite the page having a single whole-form save (fields
@@ -1584,9 +1638,22 @@ def update_master(
     ``copy_master`` this function needs no extra guard against
     ``_with_session``'s whole-operation retry on ``BrowserAuthError``.
 
-    Later Этап (C/D) fields — sitelinks, audience, Metrika counters/goals,
-    budget adaptation, media — are out of scope for this function; see
-    issue #648.
+    ``images`` (issue #670, Этап D) maps a 0-based POSITION (not a content
+    ID — content IDs are Yandex-assigned and unknown to callers ahead of
+    time) to a local file path, and replaces the image currently at that
+    position. Unlike ``headlines``/``texts``, this is NOT a literal
+    positional swap — Yandex has no "replace in place" primitive for
+    images, so this composes remove+add inside the image manager modal, and
+    the newly uploaded image always lands at the END of the set (confirmed
+    live — see ``_set_image``'s docstring). The set may legitimately be
+    EMPTY (images are optional, unlike headlines/texts); writing to an
+    empty set, or to a position beyond the campaign's actual image count,
+    raises ``BrowserSessionError``.
+
+    Later Этап C fields — sitelinks, audience, Metrika counters/goals,
+    budget adaptation — plus video (a separate follow-up issue, different
+    upload control/pipeline) are out of scope for this function; see issue
+    #648.
 
     ``launch`` (issue #668) matters only when ``campaign_id`` is currently a
     DRAFT: that edit page has no "Сохранить кампанию" button at all, only a
@@ -1603,11 +1670,12 @@ def update_master(
         and name is None
         and not headlines
         and not texts
+        and not images
     ):
         raise ValueError(
             "update_master requires at least one field to update "
             "(weekly_budget, promotion_goal, directs_helps, name, "
-            "headlines, texts)."
+            "headlines, texts, images)."
         )
 
     url = WIZARD_EDIT_URL.format(campaign_id=campaign_id)
@@ -1632,6 +1700,22 @@ def update_master(
             page, _TEXTS_TESTID_TEMPLATE, _TEXTS_SLOT_COUNT, index, value
         )
 
+    # Snapshotted BEFORE any image mutation — ``_verify_saved`` needs to know
+    # which content IDs were replaced (to confirm they're gone) and which
+    # were left alone (to confirm they're still there); by the time
+    # ``_set_image`` runs, the requested index no longer maps onto the same
+    # content ID it did when the caller specified it. The wait matters here
+    # too: an unrendered section would snapshot an empty "before" set and
+    # silently verify nothing afterwards.
+    if images:
+        _wait_for_images_editor(page)
+    images_before_ids = _read_image_content_ids(page) if images else []
+    images_replaced_ids: Set[str] = set()
+    for index, path in (images or {}).items():
+        if index < len(images_before_ids):
+            images_replaced_ids.add(images_before_ids[index])
+        _set_image(page, index, path)
+
     # Determined BEFORE clicking, while the page still reflects what's about
     # to be clicked — after the click, _verify_saved's own reload leaves no
     # way to tell which button this run actually used.
@@ -1653,6 +1737,8 @@ def update_master(
         name=name,
         headlines=headlines,
         texts=texts,
+        images_before_ids=images_before_ids,
+        images_replaced_ids=images_replaced_ids,
         clicked_button_label=clicked_button_label,
     )
 
@@ -1669,6 +1755,8 @@ def update_master(
         result["Headlines"] = headlines
     if texts:
         result["Texts"] = texts
+    if images:
+        result["Images"] = images
     return result
 
 
@@ -2013,6 +2101,394 @@ def _set_repeating_value(
             f"at {selector!r} — Yandex may have changed the page's markup. "
             "Re-run with --headful to inspect the page."
         ) from exc
+
+
+def _poll_until(
+    page: "Page",
+    predicate: "Callable[[], bool]",
+    timeout_ms: int,
+    *,
+    tick_ms: int = 250,
+) -> bool:
+    """Poll ``predicate`` until it is true or ``timeout_ms`` elapses.
+
+    Returns ``True`` if the predicate became true, ``False`` on timeout, so
+    each caller keeps its own (deliberately site-specific) ``BrowserSessionError``
+    message rather than sharing a generic one.
+
+    ``PlaywrightError`` from the predicate is suppressed and treated as
+    "not yet" — a locator query racing a mid-render DOM is the normal case
+    these loops exist to absorb.
+    """
+    deadline = time.monotonic() + timeout_ms / 1000
+    while time.monotonic() < deadline:
+        with contextlib.suppress(PlaywrightError):
+            if predicate():
+                return True
+        page.wait_for_timeout(tick_ms)
+    return False
+
+
+def _read_testid_suffixes(
+    page: "Page", prefix: str, *, skip_suffixes: "tuple[str, ...]" = ()
+) -> List[str]:
+    """Read every ``data-testid`` starting with ``prefix``, in DOM order,
+    with ``prefix`` stripped off.
+
+    Shared by the two image readers below — both scrape a testid prefix off
+    ``page`` directly (matching every other reader in this module, which
+    always locates by a single full ``data-testid`` selector rather than a
+    scoped container + chained sub-locator).
+
+    A locator failure yields ``[]`` rather than raising: for images an empty
+    result is a legitimate state, and callers that need to distinguish it
+    from "not rendered yet" wait for the section first
+    (``_wait_for_images_editor``).
+    """
+    try:
+        elements = page.locator(f'[data-testid^="{prefix}"]')
+        count = elements.count()
+    except PlaywrightError:
+        return []
+
+    suffixes = []
+    for i in range(count):
+        testid = elements.nth(i).get_attribute("data-testid")
+        if not testid:
+            continue
+        suffix = testid[len(prefix) :]
+        if skip_suffixes and suffix.endswith(skip_suffixes):
+            continue
+        suffixes.append(suffix)
+    return suffixes
+
+
+def _wait_for_images_editor(page: "Page") -> None:
+    """Block until the edit page's "Изображения" section has rendered.
+
+    The edit page is a client-rendered SPA — ``goto(...,
+    wait_until="domcontentloaded")`` (what every entry point in this module
+    uses, deliberately: Yandex holds long-poll connections, so
+    ``networkidle`` never settles) returns while this section is still
+    absent from the DOM.
+
+    Without this wait, ``_read_image_content_ids`` returns ``[]`` for a
+    campaign that simply has not rendered yet, and an empty list is
+    INDISTINGUISHABLE from the legitimate "this campaign has no images"
+    state (images are optional — unlike headlines/texts). Live-confirmed
+    2026-08-02: four consecutive DRAFT campaigns were reported as having no
+    images by ``masters update --image`` while the very same edit pages
+    demonstrably rendered four ``ContentImage`` elements each.
+
+    Absence of the section after the timeout is reported as a hard error
+    rather than silently treated as "no images", for the same reason.
+    """
+    if _poll_until(
+        page,
+        lambda: page.locator(_IMAGES_EDITOR_SELECTOR).first.count() > 0,
+        _IMAGES_EDITOR_TIMEOUT_MS,
+    ):
+        return
+
+    raise BrowserSessionError(
+        "The edit page's 'Изображения' section did not render within "
+        f"{_IMAGES_EDITOR_TIMEOUT_MS / 1000:.0f}s, so this command cannot "
+        "tell whether the campaign has images or not. Yandex may have "
+        "changed the page's markup, or the page may still be loading. "
+        "Re-run with --headful to inspect the page."
+    )
+
+
+def _read_image_content_ids(page: "Page") -> List[str]:
+    """Read the campaign's current image set as an ordered list of Yandex
+    content IDs.
+
+    Unlike ``_read_repeating_values`` (headlines/texts), there is no fixed
+    slot count to iterate — the edit page renders exactly as many
+    ``ImageSuggestionsEditor.CampaignContents.ContentImage.<contentId>``
+    elements as the campaign actually has images, in DOM order (confirmed
+    live 2026-08-02, campaign 713234191, stable across reloads). An EMPTY
+    list is a valid, normal result — images are optional, unlike headlines/
+    texts which always have at least one variant.
+
+    A broken/unloaded thumbnail does not affect this: the ``ContentImage``
+    element (and its ``data-testid``) is present in the DOM regardless of
+    whether the underlying thumb URL actually rendered — confirmed live,
+    2 of 4 images had a broken-image icon while still being fully valid,
+    counted images. So content ID, never the thumb URL's load state, is the
+    only thing this reads.
+
+    Selects directly off ``page`` by the ``ContentImage`` testid prefix
+    (matching every other reader in this module — ``_read_repeating_values``
+    etc. — which always locates by a single full ``data-testid`` selector,
+    never a scoped container + chained sub-locator).
+    """
+    return _read_testid_suffixes(page, _IMAGES_CONTENT_TESTID_PREFIX)
+
+
+def _open_images_modal(page: "Page") -> None:
+    """Click "Выбрать другие изображения" and wait for the image manager
+    modal to actually render.
+
+    Confirmed live 2026-08-02: the modal (``ImageSuggestionsEditorModal``) is
+    not in the DOM at all until this button is clicked — a fresh element,
+    not merely hidden — so this must poll for its appearance rather than
+    assume the click was synchronous.
+    """
+    open_button = page.locator(_IMAGES_OPEN_MODAL_SELECTOR).first
+    try:
+        open_button.click()
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            "Could not find/click the 'Выбрать другие изображения' button — "
+            "Yandex may have changed the page's markup. Re-run with "
+            "--headful to inspect the page."
+        ) from exc
+
+    if _poll_until(
+        page,
+        lambda: page.locator(_IMAGES_MODAL_SELECTOR).first.count() > 0,
+        _IMAGE_MODAL_OPEN_TIMEOUT_MS,
+    ):
+        return
+
+    raise BrowserSessionError(
+        "Clicked 'Выбрать другие изображения' but the image manager modal "
+        f"did not appear within {_IMAGE_MODAL_OPEN_TIMEOUT_MS / 1000:.0f}s "
+        "— Yandex may have changed the page's markup. Re-run with "
+        "--headful to inspect the page."
+    )
+
+
+def _read_modal_selected_thumb_urls(page: "Page") -> List[str]:
+    """Read the image manager modal's right-hand "Выбранные изображения"
+    panel as an ordered list of thumb URLs.
+
+    Confirmed live 2026-08-02: this panel's DOM order matches the edit
+    page's own image order exactly (same 4 thumb URLs, same sequence) — so
+    the Nth entry here corresponds to the Nth ``ContentImage`` on the page,
+    letting slot index N map onto this panel positionally without ever
+    needing to correlate a content ID with a thumb URL.
+
+    Selects directly off ``page``, same reasoning as
+    ``_read_image_content_ids``.
+
+    Each card renders THREE testids sharing the same thumb-URL prefix (the
+    card itself, ``.Content``, ``.CloseButton`` — confirmed live) — only the
+    bare thumb URL (no further ``.`` suffix) identifies one distinct image;
+    the sub-elements would otherwise be double-counted, hence the skip list.
+    """
+    return _read_testid_suffixes(
+        page,
+        _IMAGES_MODAL_SELECTED_PREFIX,
+        skip_suffixes=(".Content", ".CloseButton"),
+    )
+
+
+def _set_image(page: "Page", index: int, path: str) -> None:
+    """Replace the image currently at position ``index`` (0-based) of the
+    campaign's image set with the file at ``path``.
+
+    Issue #670 (Этап D, part of the #648 umbrella). Unlike headlines/texts'
+    ``_set_repeating_value``, Yandex has no "replace this slot" primitive at
+    all for images — only "remove from the set" and "add to the set", both
+    inside the ``ImageSuggestionsEditorModal`` opened via ``_open_images_modal``.
+    This function composes the two into one synthetic point-replacement:
+
+    1. Read the current set; refuse if empty (images are optional — unlike
+       headlines/texts, a campaign can legitimately have zero) or if
+       ``index`` is out of the set's ACTUAL bounds (there are no fixed
+       slots to size against, unlike ``_set_repeating_value``'s
+       ``slot_count``).
+    2. Open the modal.
+    3. Remove the card at ``index`` from the modal's right-hand panel
+       (confirmed live: this panel's order matches the page's image order
+       positionally — see ``_read_modal_selected_thumb_urls``).
+    4. Upload the new file via the modal's hidden file input.
+    5. Poll for the new card to appear in the panel — Yandex processes the
+       upload asynchronously before it shows up there (confirmed live: not
+       instant).
+    6. Click "Добавить в кампанию" (Save) to commit the whole modal
+       operation back onto the edit page in one shot.
+
+    **Confirmed live 2026-08-02, campaign 713234191 (real DOM mutation,
+    Save never clicked, page abandoned afterwards — no campaign mutation):
+    a newly uploaded image is always appended to the END of the set, never
+    inserted at the freed position.** So this is NOT a literal positional
+    replacement — replacing position 2 of ``[A, B, C, D]`` yields
+    ``[A, C, D, NEW]``, not ``[A, NEW, C, D]``. The set's order carries no
+    product meaning (Yandex rotates/biases images by performance regardless
+    of position), so this is a cosmetic limitation, not a functional one —
+    but callers (the CLI help text, README, CHANGELOG) MUST say so rather
+    than imply a true positional swap.
+
+    Because both the removal and the upload happen inside the same open
+    modal, a failure at any point before ``Save`` leaves the campaign's
+    actual saved image set untouched — the modal can simply be abandoned
+    (``Cancel`` or navigating away), unlike a mid-way failure that had
+    already committed a change to the live page.
+    """
+    # Must precede the read: an empty result is only meaningful once the
+    # section has actually rendered (see _wait_for_images_editor).
+    _wait_for_images_editor(page)
+    current_ids = _read_image_content_ids(page)
+
+    if not current_ids:
+        raise BrowserSessionError(
+            "This campaign has no images — there is nothing to replace. "
+            "Adding a brand-new image (to an empty set) is not supported "
+            "by this command."
+        )
+
+    if index >= len(current_ids):
+        raise BrowserSessionError(
+            f"Image position {index + 1} is out of range — this campaign "
+            f"currently has {len(current_ids)} image(s) "
+            f"(positions 1-{len(current_ids)})."
+        )
+
+    _open_images_modal(page)
+
+    before_urls = _read_modal_selected_thumb_urls(page)
+    if index >= len(before_urls):
+        raise BrowserSessionError(
+            f"Image position {index + 1} is out of range inside the image "
+            f"manager modal — it shows {len(before_urls)} selected image(s), "
+            f"which does not match "
+            f"the {len(current_ids)} shown on the edit page itself. Yandex "
+            "may have changed the page's markup. Re-run with --headful to "
+            "inspect the page."
+        )
+    target_url = before_urls[index]
+
+    remove_selector = (
+        f'[data-testid="'
+        f"{_IMAGES_MODAL_REMOVE_TESTID_TEMPLATE.format(thumb_url=target_url)}"
+        f'"]'
+    )
+    try:
+        page.locator(remove_selector).first.click()
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            f"Could not remove the image at position {index + 1} inside "
+            "the image manager modal — Yandex may have changed the page's "
+            "markup. Re-run with --headful to inspect the page. The "
+            "campaign's saved image set has NOT been changed (the modal "
+            "was never saved)."
+        ) from exc
+
+    if not _poll_until(
+        page,
+        lambda: target_url not in _read_modal_selected_thumb_urls(page),
+        _IMAGE_MODAL_OPEN_TIMEOUT_MS,
+    ):
+        raise BrowserSessionError(
+            f"Clicked to remove the image at position {index + 1} inside "
+            "the image manager modal, but it is still shown there after "
+            f"{_IMAGE_MODAL_OPEN_TIMEOUT_MS / 1000:.0f}s. The campaign's "
+            "saved image set has NOT been changed (the modal was never "
+            "saved) — close the browser and retry."
+        )
+
+    try:
+        page.locator(_IMAGES_MODAL_FILE_INPUT_SELECTOR).first.set_input_files(path)
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            f"Could not upload {path!r} inside the image manager modal — "
+            "Yandex may have changed the page's markup. Re-run with "
+            "--headful to inspect the page. The campaign's saved image set "
+            "has NOT been changed (the modal was never saved)."
+        ) from exc
+
+    # One image was just removed, so the post-removal panel holds
+    # ``len(before_urls) - 1``; the upload has landed once the panel grows
+    # back to at least its original size.
+    if not _poll_until(
+        page,
+        lambda: len(_read_modal_selected_thumb_urls(page)) >= len(before_urls),
+        _IMAGE_UPLOAD_TIMEOUT_MS,
+    ):
+        raise BrowserSessionError(
+            f"Uploaded {path!r} inside the image manager modal, but no new "
+            f"image appeared there within {_IMAGE_UPLOAD_TIMEOUT_MS / 1000:.0f}s "
+            "— Yandex's asynchronous processing may have failed or be "
+            "unusually slow. The campaign's saved image set has NOT been "
+            "changed (the modal was never saved) — close the browser and "
+            "retry."
+        )
+
+    try:
+        page.locator(_IMAGES_MODAL_SAVE_SELECTOR).first.click()
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            "Could not find/click 'Добавить в кампанию' to commit the "
+            "image manager modal — Yandex may have changed the page's "
+            "markup. Re-run with --headful to inspect the page. The "
+            "campaign's saved image set has NOT been changed (the modal "
+            "was never saved)."
+        ) from exc
+
+    if _poll_until(
+        page,
+        lambda: page.locator(_IMAGES_MODAL_SELECTOR).first.count() == 0,
+        _IMAGE_MODAL_OPEN_TIMEOUT_MS,
+    ):
+        return
+
+    raise BrowserSessionError(
+        "Clicked 'Добавить в кампанию' but the image manager modal did not "
+        f"close within {_IMAGE_MODAL_OPEN_TIMEOUT_MS / 1000:.0f}s — the "
+        "commit may not have completed. Verify manually before retrying."
+    )
+
+
+def _verify_image_mismatches(
+    page: "Page", *, before_ids: List[str], replaced_ids: Set[str]
+) -> List[str]:
+    """Re-read the campaign's saved image set and confirm every replaced
+    image is actually gone and every untouched image is still present.
+
+    Unlike ``_verify_repeating_value_mismatches``, this is NOT a positional
+    comparison — a newly uploaded image always lands at the end of the set
+    (see ``_set_image``'s docstring), so "position N now shows something
+    different" is not a meaningful check. What IS meaningful, and what
+    Yandex's silent-validation-rejection failure mode (module docstring)
+    would actually break, is: (a) every content ID this call meant to
+    replace is gone from the saved set, (b) every content ID it did NOT
+    touch is still there, and (c) the set size is unchanged (removed count
+    == added count). A rejected/failed upload would leave a replaced ID
+    still present, which (a) catches.
+    """
+    if not replaced_ids:
+        return []
+
+    # ``_verify_saved`` re-navigates before calling this, so the section is
+    # once again mid-render — reading straight away would report every image
+    # as missing (see ``_wait_for_images_editor``).
+    _wait_for_images_editor(page)
+    actual_ids = set(_read_image_content_ids(page))
+    kept_ids = [cid for cid in before_ids if cid not in replaced_ids]
+
+    mismatches = []
+    still_present = sorted(replaced_ids & actual_ids)
+    if still_present:
+        mismatches.append(
+            "image(s) that should have been replaced are still present: "
+            + ", ".join(still_present)
+        )
+    missing_kept = sorted(cid for cid in kept_ids if cid not in actual_ids)
+    if missing_kept:
+        mismatches.append(
+            "image(s) that should have been left untouched are now "
+            "missing: " + ", ".join(missing_kept)
+        )
+    expected_size = len(kept_ids) + len(replaced_ids)
+    if len(actual_ids) != expected_size:
+        mismatches.append(
+            f"image set now has {len(actual_ids)} image(s), expected "
+            f"{expected_size}"
+        )
+    return mismatches
 
 
 def _set_region(page: "Page", regions: List[str]) -> None:

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -1702,19 +1702,30 @@ def update_master(
 
     # Snapshotted BEFORE any image mutation — ``_verify_saved`` needs to know
     # which content IDs were replaced (to confirm they're gone) and which
-    # were left alone (to confirm they're still there); by the time
-    # ``_set_image`` runs, the requested index no longer maps onto the same
-    # content ID it did when the caller specified it. The wait matters here
-    # too: an unrendered section would snapshot an empty "before" set and
-    # silently verify nothing afterwards.
+    # were left alone (to confirm they're still there). This snapshot is
+    # ALSO what each ``_set_image`` call is resolved against (by content ID,
+    # never by re-deriving a live position): a naive per-position loop would
+    # resolve later ``--image`` flags against the set as ``_set_image`` left
+    # it after an earlier replacement — which always appends to the end
+    # (see ``_set_image``'s docstring) — silently removing a DIFFERENT image
+    # than the one the caller named. Found independently by two reviewers in
+    # cycle-review round 1 of PR #670/#672. The wait matters here too: an
+    # unrendered section would snapshot an empty "before" set and silently
+    # verify nothing afterwards.
     if images:
         _wait_for_images_editor(page)
     images_before_ids = _read_image_content_ids(page) if images else []
     images_replaced_ids: Set[str] = set()
     for index, path in (images or {}).items():
-        if index < len(images_before_ids):
-            images_replaced_ids.add(images_before_ids[index])
-        _set_image(page, index, path)
+        if index >= len(images_before_ids):
+            raise BrowserSessionError(
+                f"Image position {index + 1} is out of range — this "
+                f"campaign currently has {len(images_before_ids)} image(s) "
+                f"(positions 1-{len(images_before_ids)})."
+            )
+        target_content_id = images_before_ids[index]
+        images_replaced_ids.add(target_content_id)
+        _set_image(page, index, path, target_content_id=target_content_id)
 
     # Determined BEFORE clicking, while the page still reflects what's about
     # to be clicked — after the click, _verify_saved's own reload leaves no
@@ -2285,9 +2296,11 @@ def _read_modal_selected_thumb_urls(page: "Page") -> List[str]:
     )
 
 
-def _set_image(page: "Page", index: int, path: str) -> None:
-    """Replace the image currently at position ``index`` (0-based) of the
-    campaign's image set with the file at ``path``.
+def _set_image(page: "Page", index: int, path: str, *, target_content_id: str) -> None:
+    """Replace the image identified by ``target_content_id`` — the image
+    originally at position ``index`` (0-based) when the caller snapshotted
+    the set, before any of this call's siblings ran — with the file at
+    ``path``.
 
     Issue #670 (Этап D, part of the #648 umbrella). Unlike headlines/texts'
     ``_set_repeating_value``, Yandex has no "replace this slot" primitive at
@@ -2295,15 +2308,20 @@ def _set_image(page: "Page", index: int, path: str) -> None:
     inside the ``ImageSuggestionsEditorModal`` opened via ``_open_images_modal``.
     This function composes the two into one synthetic point-replacement:
 
-    1. Read the current set; refuse if empty (images are optional — unlike
-       headlines/texts, a campaign can legitimately have zero) or if
-       ``index`` is out of the set's ACTUAL bounds (there are no fixed
-       slots to size against, unlike ``_set_repeating_value``'s
-       ``slot_count``).
+    1. Locate ``target_content_id`` in the current set; refuse if the set is
+       empty (images are optional — unlike headlines/texts, a campaign can
+       legitimately have zero) or if that content ID is no longer present
+       (it must always be found on the FIRST replacement in a batch; a
+       later one going missing means an earlier replacement in the same
+       call already removed it — a caller bug, not a live-page race, so
+       this raises rather than silently no-op'ing).
     2. Open the modal.
-    3. Remove the card at ``index`` from the modal's right-hand panel
+    3. Remove that image's card from the modal's right-hand panel
        (confirmed live: this panel's order matches the page's image order
-       positionally — see ``_read_modal_selected_thumb_urls``).
+       positionally — see ``_read_modal_selected_thumb_urls`` — but this
+       function locates by content ID, not by re-deriving a position, so it
+       is immune to any prior reordering within the same ``update_master``
+       call).
     4. Upload the new file via the modal's hidden file input.
     5. Poll for the new card to appear in the panel — Yandex processes the
        upload asynchronously before it shows up there (confirmed live: not
@@ -2321,6 +2339,19 @@ def _set_image(page: "Page", index: int, path: str) -> None:
     of position), so this is a cosmetic limitation, not a functional one —
     but callers (the CLI help text, README, CHANGELOG) MUST say so rather
     than imply a true positional swap.
+
+    **``index`` is used only for user-facing error messages — never to
+    locate the image to remove.** A previous version resolved ``index``
+    against the LIVE, already-reordered set on each call; since a
+    replacement always appends to the end, a second ``--image`` in the same
+    ``update_master`` call would silently resolve against a set that had
+    already shifted because of the first, removing a DIFFERENT image than
+    the one the caller named — found independently by two reviewers in
+    cycle-review round 1 of PR #670/#672, and reproduced via
+    ``tests/test_masters.py::test_update_master_replaces_multiple_images_by_original_position``.
+    ``target_content_id`` is resolved once, by the caller
+    (``update_master``), against the set as it stood before any
+    replacement in the batch ran, closing that gap.
 
     Because both the removal and the upload happen inside the same open
     modal, a failure at any point before ``Save`` leaves the campaign's
@@ -2347,19 +2378,29 @@ def _set_image(page: "Page", index: int, path: str) -> None:
             f"(positions 1-{len(current_ids)})."
         )
 
+    if target_content_id not in current_ids:
+        raise BrowserSessionError(
+            f"Image position {index + 1} (content ID {target_content_id}) "
+            "is no longer present in the campaign's image set — an earlier "
+            "--image replacement in this same command already removed it. "
+            "Re-run with the remaining --image flags only, after checking "
+            "the campaign's current image set."
+        )
+
     _open_images_modal(page)
 
     before_urls = _read_modal_selected_thumb_urls(page)
-    if index >= len(before_urls):
+    modal_ids = _read_image_content_ids(page)
+    if target_content_id not in modal_ids or len(modal_ids) != len(before_urls):
         raise BrowserSessionError(
-            f"Image position {index + 1} is out of range inside the image "
-            f"manager modal — it shows {len(before_urls)} selected image(s), "
-            f"which does not match "
-            f"the {len(current_ids)} shown on the edit page itself. Yandex "
-            "may have changed the page's markup. Re-run with --headful to "
-            "inspect the page."
+            f"Image position {index + 1} (content ID {target_content_id}) "
+            f"could not be matched inside the image manager modal — it "
+            f"shows {len(before_urls)} selected image(s), which does not "
+            f"match the {len(current_ids)} shown on the edit page itself. "
+            "Yandex may have changed the page's markup. Re-run with "
+            "--headful to inspect the page."
         )
-    target_url = before_urls[index]
+    target_url = before_urls[modal_ids.index(target_content_id)]
 
     remove_selector = (
         f'[data-testid="'

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -538,32 +538,55 @@ def suspend(
 
 
 def _parse_repeating_slot_options(
-    option_name: str, values: "tuple[str, ...]", slot_count: int
+    option_name: str,
+    values: "tuple[str, ...]",
+    slot_count: int,
+    *,
+    value_label: str = "text",
+    value_example: str = "New headline",
+    empty_hint: str = (
+        "which would DELETE that ad variant rather than replace it. "
+        "Removing a variant is not supported — pass the replacement text, "
+        "or edit the campaign with --headful."
+    ),
 ) -> "dict[int, str]":
-    """Parse repeated ``"N=text"`` CLI values into a 0-based slot index map.
+    """Parse repeated ``"N=<value_label>"`` CLI values into a 0-based slot
+    index map.
 
     N is the 1-based slot number shown to the user (matches how a person
     would count "headline 1, headline 2, ..." reading the edit page); the
-    browser layer (``update_master``/``_set_repeating_value``) works in
-    0-based indices like the rest of ``masters.py``'s slot machinery, so the
-    conversion happens here, at the CLI boundary. All format errors are
-    raised as ``click.UsageError`` before any browser session is opened,
-    rather than surfacing mid-session as a ``BrowserSessionError``.
+    browser layer (``update_master``/``_set_repeating_value``/``_set_image``)
+    works in 0-based indices like the rest of ``masters.py``'s slot
+    machinery, so the conversion happens here, at the CLI boundary. All
+    format errors are raised as ``click.UsageError`` before any browser
+    session is opened, rather than surfacing mid-session as a
+    ``BrowserSessionError``.
 
-    ``slot_count`` is the number of slots the page actually renders for this
-    field (5 headlines / 3 texts), taken from the browser layer's own
-    constants so the two can't drift apart. The upper bound is enforced here
-    as well as in ``_set_repeating_value``: an oversized slot number is a
-    purely invalid CLI argument, and letting it through would launch a
-    browser (and possibly an auth prompt) only to fail with a
-    ``BrowserSessionError`` — contradicting this helper's fail-fast contract.
+    ``slot_count`` is the upper bound this field can ever have — for
+    headlines/texts that's the page's fixed slot count (5/3, from the
+    browser layer's own constants so the two can't drift apart); for images
+    (issue #670, Этап D) there are no fixed slots at all, so this is
+    ``_IMAGES_MAX_COUNT`` (Yandex's hard cap on the set size) — the actual,
+    possibly-empty, per-campaign ceiling is only known once the browser
+    layer reads the live page, and is enforced there
+    (``_set_image``/``_read_image_content_ids``). Rejecting an
+    obviously-oversized slot number here is still worth doing eagerly: it is
+    a purely invalid CLI argument, and letting it through would launch a
+    browser (and possibly an auth prompt) only to fail downstream —
+    contradicting this helper's fail-fast contract.
+
+    ``value_label``/``value_example``/``empty_hint``
+    parameterize the two messages that are specific to what "N=..." holds
+    (headline/ad-text copy vs. an image file path) — added for ``--image``
+    (issue #670). Defaults keep the original Этап B (``--headline``/
+    ``--text``) wording byte-for-byte; only ``--image`` passes overrides.
     """
     parsed: "dict[int, str]" = {}
     for raw in values:
         if "=" not in raw:
             raise click.UsageError(
-                f'{option_name} value {raw!r} must be in the form "N=text" '
-                '(e.g. "2=New headline").'
+                f"{option_name} value {raw!r} must be in the form "
+                f'"N={value_label}" (e.g. "2={value_example}").'
             )
         index_part, text = raw.split("=", 1)
         try:
@@ -580,7 +603,7 @@ def _parse_repeating_slot_options(
         if slot_number > slot_count:
             raise click.UsageError(
                 f"{option_name} slot number {slot_number} is out of range — "
-                f"this field has {slot_count} slots (1-{slot_count})."
+                f"this field has slots (1-{slot_count})."
             )
         index = slot_number - 1
         if index in parsed:
@@ -590,12 +613,37 @@ def _parse_repeating_slot_options(
         if not text.strip():
             raise click.UsageError(
                 f"{option_name} slot {slot_number} was given an empty "
-                "replacement, which would DELETE that ad variant rather than "
-                "replace it. Removing a variant is not supported — pass the "
-                "replacement text, or edit the campaign with --headful."
+                f"replacement, {empty_hint}"
             )
         parsed[index] = text
     return parsed
+
+
+def _validate_image_paths(parsed_images: "dict[int, str]") -> None:
+    """Reject ``--image`` paths that don't exist or that Yandex won't accept.
+
+    Runs before any browser session (and possibly an auth prompt) is opened,
+    mirroring every other format error in this command. The accepted
+    extensions come from the browser layer's own ``_IMAGE_UPLOAD_SUFFIXES``
+    (imported here rather than at module load, matching this module's other
+    deferred browser imports) so the CLI's check can't drift from what
+    Yandex's file input actually accepts.
+    """
+    from ..browser.masters import _IMAGE_UPLOAD_SUFFIXES
+
+    for index, raw_path in parsed_images.items():
+        slot = index + 1
+        path = Path(raw_path)
+        if not path.is_file():
+            raise click.UsageError(
+                f"--image path {raw_path!r} (slot {slot}) does not exist or "
+                "is not a file."
+            )
+        if path.suffix.lower() not in _IMAGE_UPLOAD_SUFFIXES:
+            raise click.UsageError(
+                f"--image path {raw_path!r} (slot {slot}) has an unsupported "
+                f"extension {path.suffix!r} — Yandex accepts PNG, JPEG, or GIF."
+            )
 
 
 @masters.command()
@@ -645,6 +693,26 @@ def _parse_repeating_slot_options(
     ),
 )
 @click.option(
+    "--image",
+    "images",
+    multiple=True,
+    help=(
+        'Replace an EXISTING image: "N=path" where N is the 1-based '
+        "position of the image currently shown on the edit page (position "
+        "count is whatever the campaign actually has — up to 5, and may be "
+        "0 if the campaign has no images at all, in which case this "
+        "refuses). Repeat for multiple positions. path must be a local "
+        "PNG/JPEG/GIF file. Writing to a position beyond the campaign's "
+        "current image count is refused — this only replaces images that "
+        "already exist, it does not add new ones. NOTE: Yandex has no "
+        "in-place image replacement — the image at position N is removed "
+        "and the new one is appended to the END of the set, so the set's "
+        "order changes (this has no effect on ad delivery: Yandex rotates "
+        "images by performance regardless of position). Other images are "
+        "left untouched."
+    ),
+)
+@click.option(
     "--launch",
     is_flag=True,
     default=False,
@@ -665,6 +733,7 @@ def update(
     name,
     headlines,
     texts,
+    images,
     launch,
     headful,
     profile_dir,
@@ -672,24 +741,30 @@ def update(
     output_format,
     output,
 ):
-    """Update settings of one Мастер кампаний (Этап A/B fields, plus name)
+    """Update settings of one Мастер кампаний (Этап A/B/D fields, plus name)
 
     Covers weekly budget, promotion goal, the "Директ помогает"
-    auto-recommendations toggle, the campaign name, and per-slot headline/
-    ad-text variant replacement. The edit page has a single whole-form save
-    (no per-section save) — see ``direct_cli/browser/masters.py`` module
-    docstring — so only the fields passed here are changed; every other
-    on-page field keeps its current value.
+    auto-recommendations toggle, the campaign name, per-slot headline/
+    ad-text variant replacement, and per-position image replacement. The
+    edit page has a single whole-form save (no per-section save) — see
+    ``direct_cli/browser/masters.py`` module docstring — so only the fields
+    passed here are changed; every other on-page field keeps its current
+    value.
 
-    ``--headline``/``--text`` replace ONE variant slot at a time rather than
-    the whole variant list — unlike this CLI's usual list-field convention
-    (e.g. ``campaigns update --negative-keywords``, which replaces the
-    entire array). This is deliberate: Мастер кампаний has no API, variant
-    sets can be large, and forcing every variant to be re-typed to fix one
-    typo defeats the point of a partial update — see
+    ``--headline``/``--text``/``--image`` each replace ONE existing
+    slot/position at a time rather than the whole list — unlike this CLI's
+    usual list-field convention (e.g. ``campaigns update
+    --negative-keywords``, which replaces the entire array). This is
+    deliberate: Мастер кампаний has no API, variant sets can be large, and
+    forcing every variant to be re-typed to fix one typo defeats the point
+    of a partial update — see
     ``direct_cli/browser/masters.py::_set_repeating_value`` for the full
-    rationale. Later fields (sitelinks, audience, Metrika counters/goals,
-    budget adaptation, media) are tracked separately, see issue #648.
+    rationale. ``--image`` additionally has NO in-place replacement at all
+    on Yandex's side — see its own help text and
+    ``direct_cli/browser/masters.py::_set_image`` for why the image set's
+    order changes as a result. Later fields (sitelinks, audience, Metrika
+    counters/goals, budget adaptation) and video (a separate follow-up
+    issue) are tracked separately, see issue #648.
 
     A DRAFT campaign's edit page has no "Сохранить кампанию" button at all —
     only a save-as-draft/launch pair (issue #668). ``update`` saves it as a
@@ -705,21 +780,40 @@ def update(
         and name is None
         and not headlines
         and not texts
+        and not images
     ):
         raise click.UsageError(
             "Provide at least one of --weekly-budget, --promotion-goal, "
-            "--directs-helps/--no-directs-helps, --name, --headline, --text."
+            "--directs-helps/--no-directs-helps, --name, --headline, "
+            "--text, --image."
         )
 
     # Slot counts come from the browser layer's own constants (imported here
     # rather than at module load, matching this module's other deferred
     # browser imports) so the CLI's bound can't drift from the page's.
-    from ..browser.masters import _HEADLINES_SLOT_COUNT, _TEXTS_SLOT_COUNT
+    from ..browser.masters import (
+        _HEADLINES_SLOT_COUNT,
+        _IMAGES_MAX_COUNT,
+        _TEXTS_SLOT_COUNT,
+    )
 
     parsed_headlines = _parse_repeating_slot_options(
         "--headline", headlines, _HEADLINES_SLOT_COUNT
     )
     parsed_texts = _parse_repeating_slot_options("--text", texts, _TEXTS_SLOT_COUNT)
+    parsed_images = _parse_repeating_slot_options(
+        "--image",
+        images,
+        _IMAGES_MAX_COUNT,
+        value_label="path",
+        value_example="/path/to/image.jpg",
+        empty_hint=(
+            "which is not a valid image path. Removing an image without a "
+            "replacement is not supported — pass a replacement file, or "
+            "edit the campaign with --headful."
+        ),
+    )
+    _validate_image_paths(parsed_images)
 
     result = _with_session(
         ctx,
@@ -735,6 +829,7 @@ def update(
             name=name,
             headlines=parsed_headlines,
             texts=parsed_texts,
+            images=parsed_images,
             launch=launch,
         ),
     )

--- a/tests/fixtures/masters_wizard_edit_stage_d.html
+++ b/tests/fixtures/masters_wizard_edit_stage_d.html
@@ -1,0 +1,119 @@
+<!--
+Fixture: DOM findings for editing images on the Yandex Direct "Мастер кампаний"
+(Campaign Wizard) edit page, Этап D — images only (issue #670, part of the
+#648 umbrella) — captured 2026-08-02 via claude-in-chrome against DRAFT clone
+713234191 ("Мастер ИД Исцеляющий Детокс (холодный) клфразы сентябрь 2022 JS
+28.06 ии — 2", status: DRAFT).
+
+Two phases:
+
+Phase 1 — read-only: page/modal markup read via
+`document.querySelectorAll('[data-testid]')` and targeted DOM reads. No field
+was clicked/typed into, no save button was pressed.
+
+Phase 2 — a real DOM mutation, but NOT a campaign mutation: two probe PNGs
+were uploaded into the image manager modal's hidden file input (via a
+synthetic `File`/`DataTransfer`, since this recon has no real file picker to
+drive) to answer the one question read-only inspection could not: where does
+a newly uploaded image land in the set? `ImageSuggestionsEditorModal.Save`
+("Добавить в кампанию") was NEVER clicked, and the modal was abandoned by
+navigating away rather than using its own Cancel/Save controls. Re-opening the
+edit page afterwards confirmed the campaign's saved image set was unchanged —
+still the same 4 original content IDs, in the same order.
+
+Source URL:
+  https://direct.yandex.ru/wizard/campaigns/{id}/edit/?ulogin={login}
+
+KEY FINDING #1 — the issue's original "5 fixed slots" hypothesis (modeled on
+`_HEADLINES_SLOT_COUNT`/`_TEXTS_SLOT_COUNT`) is WRONG. The page renders
+exactly as many image cards as the campaign actually has (4, here), not a
+fixed 5 — "Можно добавить до 5 штук" is an upper bound on the SET, not a slot
+count. There are no empty slots in the DOM to discriminate against, unlike
+headlines/texts. Confirmed testids (edit page):
+
+  ImageSuggestionsEditor
+  ImageSuggestionsEditor.HeaderHelp.HelpButton
+  ImageSuggestionsEditor.CampaignContents
+  ImageSuggestionsEditor.CampaignContents.ContentImage.<contentId>
+  ImageSuggestionsEditor.CampaignContents.CloseButton.<contentId>
+  ImageSuggestionsEditor.Open                    <- "Выбрать другие изображения"
+
+Four `ContentImage`/`CloseButton` pairs observed, keyed by a Yandex-assigned
+numeric content ID (NOT a 0-based slot index the way `CampaignTitlesN` is):
+
+  3271043491215551029
+  3271047625691389195
+  3271068856356873853
+  3271089191340751814
+
+Order is stable across reloads — this is what `_read_image_content_ids`
+relies on for positional mapping. Two of the four cards rendered with a
+broken-image icon (thumbnail failed to load) while still being fully valid,
+counted images — confirming content ID, never thumbnail load state, is the
+correct signal to read.
+
+KEY FINDING #2 — there is no `<input type="file">` anywhere on the edit page
+itself (0 matches for `input[type=file]`). It only appears once the "Выбрать
+другие изображения" button opens a modal:
+
+  ImageSuggestionsEditorModal
+  ImageSuggestionsEditorModal.CloseButton
+  ImageSuggestionsEditorModal.ImageSourcePanel
+  ImageSuggestionsEditorModal.ImageSourcePanel.UPLOAD
+  ImageSuggestionsEditorModal.ImageSourcePanel.USER
+  ImageSuggestionsEditorModal.ImageSourcePanel.USER.Counter
+  ImageSuggestionsEditorModal.ImageSourcePanel.WEB_SITE
+  ImageSuggestionsEditorModal.ImageSourcePanel.AI_GENERATED
+  ImageSuggestionsEditorModal.ImageSourcePanel.NEURO_STOCK
+  ImageSuggestionsEditorModal.UploadZone
+  ImageSuggestionsEditorModal.UploadZone.openFilePicker   <- "Загрузить изображения"
+  ImageSuggestionsEditorModal.UploadZone.filePicker        <- hidden <input type="file">,
+                                                               accept="image/png,image/jpeg,image/jpg,image/gif",
+                                                               multiple
+  ImageSuggestionsEditorModal.SelectedImagesContainer
+  ImageSuggestionsEditorModal.SelectedImagesContainer.SelectedImage.<thumbUrl>
+  ImageSuggestionsEditorModal.SelectedImagesContainer.SelectedImage.<thumbUrl>.Content
+  ImageSuggestionsEditorModal.SelectedImagesContainer.SelectedImage.<thumbUrl>.CloseButton
+  ImageSuggestionsEditorModal.Save                         <- "Добавить в кампанию"
+  ImageSuggestionsEditorModal.Cancel                        <- "Отмена"
+
+KEY FINDING #3 — Yandex has NO "replace this image in place" primitive at
+all; only "remove from the set" (either the page's own CloseButton, or the
+modal's right-hand "Выбранные изображения" panel — the latter shows the
+whole set with its own crosses, confirmed via the "4 из 5" counter text) and
+"add to the set" (modal upload). This module composes remove+upload+save
+inside ONE modal session into a synthetic point-replacement
+(`_set_image`) — doing both inside the modal, rather than removing on the
+page first, means a failure before Save leaves the campaign's saved set
+completely untouched.
+
+Confirmed live: the modal's "Выбранные изображения" panel renders cards in
+the SAME order as the page's own image cards (same 4 thumb URLs, same
+sequence) — so position N maps onto the panel positionally, with no need to
+correlate a content ID with a thumb URL.
+
+KEY FINDING #4 (Phase 2, the one read-only inspection could not answer) — a
+newly uploaded image is always appended to the END of the set, never
+inserted at the freed position. Uploading two probe PNGs (after having
+already probed the modal's markup once) landed both at the tail of the
+panel — the original 4 images stayed in their original order at positions
+1-4. This means `--image "N=path"` is NOT a literal positional swap:
+replacing position 2 of [A, B, C, D] yields [A, C, D, NEW], not
+[A, NEW, C, D]. Since Yandex rotates/biases images by performance regardless
+of position (same "Изображения чередуются, эффективные показываются чаще"
+copy as the create page), this has no product-visible effect on ad
+delivery — but it must be documented, not silently implied to be a true
+positional replacement (`--image`'s CLI help text, README, CHANGELOG).
+
+Also observed in Phase 2: the panel does not block exceeding the 5-image cap
+client-side (6 cards were briefly shown after both probe uploads, and the "N
+из 5" counter text disappeared) — so the CLI enforces the cap itself, rather
+than trusting the modal's own UI to reject an oversized set before Save.
+
+Confirmed no campaign mutation: after both phases, re-opening
+`/wizard/campaigns/713234191/edit/?ulogin=ksamatadirect` showed the same 4
+original content IDs, same order, `ImageSuggestionsEditorModal` absent from
+the DOM (i.e. no modal state carried over) — the two probe uploads existed
+only inside the modal's own component state and were discarded when the
+modal was abandoned without `Save`.
+-->

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -3014,6 +3014,46 @@ class TestUpdateMaster(unittest.TestCase):
         self.assertEqual(len(page_save_clicks), 1)
         self.assertEqual(result, {"CampaignId": 42, "Images": {1: "/tmp/fake.png"}})
 
+    def test_update_master_replaces_multiple_images_by_original_position(self):
+        """Two ``--image`` flags in one call must resolve BOTH positions
+        against the ORIGINAL (pre-mutation) set, not the live, already
+        reordered one.
+
+        Found independently by both reviewers in cycle-review round 1 of
+        PR #672: ``_set_image`` re-reads the live page on every call, and
+        the image manager appends replacements to the END of the set
+        (confirmed live), so a naive per-position loop resolves the second
+        ``--image`` against a set that has already shifted because of the
+        first. Replacing positions 1 and 2 of ``[a, b, c, d]`` must remove
+        exactly ``a`` and ``b`` — never a third, untouched image like
+        ``c`` — regardless of set reordering in between.
+        """
+        page_save_clicks = []
+        save_handle = _FakeTextLocatorHandle(
+            visible=True, on_click=lambda: page_save_clicks.append(True)
+        )
+        page = _FakeImagesPage(
+            ["a", "b", "c", "d"],
+            upload_ids=["new1", "new2"],
+            role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
+        )
+
+        result = browser_masters.update_master(
+            page, 42, images={0: "/tmp/one.png", 1: "/tmp/two.png"}
+        )
+
+        self.assertEqual(set(page.ids), {"c", "d", "new1", "new2"})
+        self.assertNotIn("a", page.ids)
+        self.assertNotIn("b", page.ids)
+        self.assertEqual(len(page_save_clicks), 1)
+        self.assertEqual(
+            result,
+            {
+                "CampaignId": 42,
+                "Images": {0: "/tmp/one.png", 1: "/tmp/two.png"},
+            },
+        )
+
     def test_update_master_raises_when_saved_image_set_does_not_match(self):
         """Mirrors the headline "silently rejected" test — the page-level
         save WAS clicked, but the post-reload re-read still shows the image
@@ -4542,7 +4582,9 @@ class TestWaitForImagesEditor(unittest.TestCase):
         page = _NoEditorPage([])
         with patch.object(browser_masters, "_IMAGES_EDITOR_TIMEOUT_MS", 1):
             with self.assertRaises(BrowserSessionError) as ctx:
-                browser_masters._set_image(page, 0, "/tmp/fake.png")
+                browser_masters._set_image(
+                    page, 0, "/tmp/fake.png", target_content_id="a"
+                )
 
         self.assertIn("did not render", str(ctx.exception))
         self.assertNotIn("no images", str(ctx.exception).lower())
@@ -4556,7 +4598,7 @@ class TestSetImage(unittest.TestCase):
     def test_replaces_the_requested_position_only(self):
         page = _FakeImagesPage(["a", "b", "c"], upload_ids=["new"])
 
-        browser_masters._set_image(page, 1, "/tmp/fake.png")
+        browser_masters._set_image(page, 1, "/tmp/fake.png", target_content_id="b")
 
         # Confirmed-live behaviour: the new image lands at the END of the
         # set, not back at position 1 — see _set_image's own docstring.
@@ -4568,7 +4610,7 @@ class TestSetImage(unittest.TestCase):
         page = _FakeImagesPage([])
 
         with self.assertRaises(BrowserSessionError) as ctx:
-            browser_masters._set_image(page, 0, "/tmp/fake.png")
+            browser_masters._set_image(page, 0, "/tmp/fake.png", target_content_id="a")
 
         self.assertIn("no images", str(ctx.exception).lower())
         self.assertEqual(page.save_clicks, [])
@@ -4577,9 +4619,29 @@ class TestSetImage(unittest.TestCase):
         page = _FakeImagesPage(["a", "b"])
 
         with self.assertRaises(BrowserSessionError) as ctx:
-            browser_masters._set_image(page, 5, "/tmp/fake.png")
+            browser_masters._set_image(
+                page, 5, "/tmp/fake.png", target_content_id="nonexistent"
+            )
 
         self.assertIn("out of range", str(ctx.exception).lower())
+        self.assertEqual(page.ids, ["a", "b"])
+        self.assertEqual(page.save_clicks, [])
+
+    def test_raises_when_target_content_id_already_gone(self):
+        """Models the caller-contract violation this signature exists to
+        prevent: a second ``_set_image`` in the same batch naming a content
+        ID an earlier call in the SAME batch already removed. A live page
+        race is not the scenario here — ``update_master`` always resolves
+        ``target_content_id`` from its own pre-batch snapshot, so this can
+        only happen if a caller passes a stale/already-consumed ID."""
+        page = _FakeImagesPage(["a", "b"])
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._set_image(
+                page, 0, "/tmp/fake.png", target_content_id="already-removed"
+            )
+
+        self.assertIn("no longer present", str(ctx.exception).lower())
         self.assertEqual(page.ids, ["a", "b"])
         self.assertEqual(page.save_clicks, [])
 
@@ -4600,7 +4662,9 @@ class TestSetImage(unittest.TestCase):
         # failure, and never hardcodes it (a `finally:` assignment would).
         with patch.object(browser_masters, "_IMAGE_UPLOAD_TIMEOUT_MS", 1):
             with self.assertRaises(BrowserSessionError) as ctx:
-                browser_masters._set_image(page, 0, "/tmp/fake.png")
+                browser_masters._set_image(
+                    page, 0, "/tmp/fake.png", target_content_id="a"
+                )
 
         self.assertIn("no new", str(ctx.exception).lower())
         self.assertEqual(page.save_clicks, [])
@@ -4626,7 +4690,9 @@ class TestSetImage(unittest.TestCase):
         page.locator = _locator
         with patch.object(browser_masters, "_IMAGE_MODAL_OPEN_TIMEOUT_MS", 1):
             with self.assertRaises(BrowserSessionError) as ctx:
-                browser_masters._set_image(page, 0, "/tmp/fake.png")
+                browser_masters._set_image(
+                    page, 0, "/tmp/fake.png", target_content_id="a"
+                )
 
         self.assertIn("still shown", str(ctx.exception).lower())
         self.assertEqual(page.save_clicks, [])

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -3084,6 +3084,67 @@ class TestUpdateMaster(unittest.TestCase):
         self.assertEqual(len(page_save_clicks), 1)
         self.assertIn("did not save as requested", str(ctx.exception))
 
+    def test_auth_error_during_post_save_image_verification_is_not_retried(self):
+        """Mirrors ``copy_master``'s
+        ``test_auth_error_during_post_click_verification_is_not_retried``.
+
+        By the time ``_verify_saved`` reloads the edit page, every requested
+        image replacement has ALREADY been committed via its own modal Save
+        — irreversible from here, and NOT idempotent for images the way
+        ``_set_repeating_value`` is for headlines/texts (replacement always
+        appends to the end of the set — see ``_set_image``'s docstring), so
+        a positional re-application on retry would replace DIFFERENT images
+        than the ones the caller named. If the saved session is invalidated
+        in exactly this window, ``_verify_saved``'s own
+        ``assert_authenticated`` raises ``BrowserAuthError`` — letting that
+        propagate as-is would make ``_with_session``
+        (``direct_cli/commands/masters.py``) retry this ENTIRE
+        ``update_master`` call under a fresh session, re-snapshotting the
+        now-already-mutated image set and removing further, untouched
+        images. This must surface as a plain ``BrowserSessionError`` (not
+        ``BrowserAuthError``), so ``_with_session``'s retry-on-auth-error
+        does not fire — found via adversarial review (Codex) in
+        cycle-review round 2 of PR #672.
+        """
+        page_save_clicks = []
+        save_handle = _FakeTextLocatorHandle(
+            visible=True, on_click=lambda: page_save_clicks.append(True)
+        )
+        page = _FakeImagesPage(
+            ["a", "b", "c", "d"],
+            upload_ids=["new1", "new2"],
+            role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
+        )
+
+        original_assert_authenticated = browser_masters.assert_authenticated
+        calls = []
+
+        def _assert_authenticated(content):
+            calls.append(True)
+            # First call happens before any mutation (module convention);
+            # only the post-save reload inside _verify_saved (second call)
+            # hits the invalidated session.
+            if len(calls) >= 2:
+                raise BrowserAuthError("stale session, detected mid-body")
+            return original_assert_authenticated(content)
+
+        with patch.object(
+            browser_masters,
+            "assert_authenticated",
+            side_effect=_assert_authenticated,
+        ):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters.update_master(
+                    page, 42, images={0: "/tmp/one.png", 1: "/tmp/two.png"}
+                )
+
+        self.assertNotIsInstance(ctx.exception, BrowserAuthError)
+        self.assertEqual(len(page_save_clicks), 1)
+        # The images WERE already replaced (irreversibly) before the auth
+        # error surfaced -- the error message must say so rather than
+        # implying nothing happened.
+        self.assertIn("42", str(ctx.exception))
+
 
 class TestMastersUpdateCommand(unittest.TestCase):
     """CLI wiring for `masters update` (issue #631, Этап A)."""

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -73,6 +73,7 @@ class _FakeLocatorHandle:
         on_press=None,
         get_value=None,
         get_checked=None,
+        on_upload=None,
     ):
         self._text = text
         self._attrs = attrs or {}
@@ -84,6 +85,7 @@ class _FakeLocatorHandle:
         self._on_press = on_press
         self._get_value = get_value
         self._get_checked = get_checked
+        self._on_upload = on_upload
 
     def inner_text(self):
         if self._raises:
@@ -157,6 +159,16 @@ class _FakeLocatorHandle:
         # 1 otherwise. `_set_region` uses exactly this to decide whether the
         # region popup is already open before clicking the launcher again.
         return 0 if self._raises else 1
+
+    def set_input_files(self, path):
+        # Models Playwright's Locator.set_input_files() on the image manager
+        # modal's hidden <input type="file"> (issue #670, Этап D) — a fake
+        # test supplies ``on_upload`` to mutate whatever shared state models
+        # "a new image now appears in the modal's selected panel".
+        if self._raises:
+            raise PlaywrightError("element detached")
+        if self._on_upload is not None:
+            self._on_upload(path)
 
 
 class _FakeContentEditableHandle(_FakeLocatorHandle):
@@ -2979,6 +2991,59 @@ class TestUpdateMaster(unittest.TestCase):
         with self.assertRaises(ValueError):
             browser_masters.update_master(page, 42, headlines={})
 
+    def test_raises_value_error_when_only_empty_images_dict_provided(self):
+        page = FakePage()
+
+        with self.assertRaises(ValueError):
+            browser_masters.update_master(page, 42, images={})
+
+    def test_update_master_replaces_an_image(self):
+        page_save_clicks = []
+        save_handle = _FakeTextLocatorHandle(
+            visible=True, on_click=lambda: page_save_clicks.append(True)
+        )
+        page = _FakeImagesPage(
+            ["a", "b", "c"],
+            upload_ids=["new"],
+            role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
+        )
+
+        result = browser_masters.update_master(page, 42, images={1: "/tmp/fake.png"})
+
+        self.assertEqual(page.ids, ["a", "c", "new"])
+        self.assertEqual(len(page_save_clicks), 1)
+        self.assertEqual(result, {"CampaignId": 42, "Images": {1: "/tmp/fake.png"}})
+
+    def test_update_master_raises_when_saved_image_set_does_not_match(self):
+        """Mirrors the headline "silently rejected" test — the page-level
+        save WAS clicked, but the post-reload re-read still shows the image
+        that was supposed to be gone."""
+        page_save_clicks = []
+        save_handle = _FakeTextLocatorHandle(
+            visible=True, on_click=lambda: page_save_clicks.append(True)
+        )
+        page = _FakeImagesPage(
+            ["a", "b", "c"],
+            upload_ids=["new"],
+            role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
+        )
+        # Sabotage AFTER _set_image runs but BEFORE _verify_saved's reload —
+        # models Yandex accepting the modal's own Save but the page-level
+        # terminal save silently not persisting the change.
+        original_click = save_handle._on_click
+
+        def _click():
+            original_click()
+            page.ids = ["a", "b", "c"]  # revert, as if nothing was saved
+
+        save_handle._on_click = _click
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(page, 42, images={1: "/tmp/fake.png"})
+
+        self.assertEqual(len(page_save_clicks), 1)
+        self.assertIn("did not save as requested", str(ctx.exception))
+
 
 class TestMastersUpdateCommand(unittest.TestCase):
     """CLI wiring for `masters update` (issue #631, Этап A)."""
@@ -3325,6 +3390,113 @@ class TestMastersUpdateCommand(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertTrue(mock_update.call_args.kwargs["launch"])
+
+    def test_documents_image_flag(self):
+        result = self.runner.invoke(cli, ["masters", "update", "--help"])
+        self.assertIn("--image", result.output)
+
+    def test_image_uses_path_not_text_in_format_error(self):
+        """--image must show its OWN vocabulary ("N=path"), not Этап B's
+        "N=text" — regression guard for the shared parser's parameterization
+        (issue #670): the two option's defaults must never bleed into each
+        other."""
+        result = self.runner.invoke(
+            cli, ["masters", "update", "42", "--image", "no equals here"]
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn('"N=path"', result.output)
+        self.assertNotIn('"N=text"', result.output)
+
+    def test_headline_format_error_still_says_text_after_image_added(self):
+        """The Этап B regression anchor itself, byte-for-byte — proves
+        adding --image's overrides did not change --headline's defaults."""
+        result = self.runner.invoke(
+            cli, ["masters", "update", "42", "--headline", "no equals here"]
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn('"N=text"', result.output)
+
+    def test_rejects_a_nonexistent_image_path(self):
+        result = self.runner.invoke(
+            cli, ["masters", "update", "42", "--image", "1=/no/such/file.png"]
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("does not exist", result.output.lower())
+
+    def test_rejects_an_unsupported_image_extension(self):
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".txt") as f:
+            result = self.runner.invoke(
+                cli, ["masters", "update", "42", "--image", f"1={f.name}"]
+            )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("unsupported extension", result.output.lower())
+
+    def test_rejects_an_out_of_range_image_slot(self):
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".png") as f:
+            result = self.runner.invoke(
+                cli, ["masters", "update", "42", "--image", f"6={f.name}"]
+            )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("1-5", result.output)
+
+    def test_rejects_an_empty_image_replacement(self):
+        result = self.runner.invoke(cli, ["masters", "update", "42", "--image", "1="])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("empty", result.output.lower())
+        self.assertNotIn("ad variant", result.output.lower())
+
+    def test_image_format_errors_do_not_open_a_browser_session(self):
+        with patch("direct_cli.commands.masters._with_session") as mock_with_session:
+            result = self.runner.invoke(
+                cli, ["masters", "update", "42", "--image", "bogus"]
+            )
+        self.assertNotEqual(result.exit_code, 0)
+        mock_with_session.assert_not_called()
+
+    def test_nonexistent_image_path_does_not_open_a_browser_session(self):
+        with patch("direct_cli.commands.masters._with_session") as mock_with_session:
+            result = self.runner.invoke(
+                cli, ["masters", "update", "42", "--image", "1=/no/such/file.png"]
+            )
+        self.assertNotEqual(result.exit_code, 0)
+        mock_with_session.assert_not_called()
+
+    def test_image_flag_alone_satisfies_the_at_least_one_field_guard(self):
+        import tempfile
+
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42}
+            with tempfile.NamedTemporaryFile(suffix=".png") as f:
+                result = self.runner.invoke(
+                    cli, ["masters", "update", "42", "--image", f"1={f.name}"]
+                )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+
+    def test_calls_update_master_with_parsed_images(self):
+        import tempfile
+
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42}
+            with tempfile.NamedTemporaryFile(suffix=".jpg") as f:
+                result = self.runner.invoke(
+                    cli, ["masters", "update", "42", "--image", f"2={f.name}"]
+                )
+
+                self.assertEqual(result.exit_code, 0, result.output)
+                self.assertEqual(mock_update.call_args.kwargs["images"], {1: f.name})
 
 
 class TestMastersLoginCommand(unittest.TestCase):
@@ -4193,6 +4365,315 @@ class TestSetRepeatingValue(unittest.TestCase):
 
         self.assertEqual(field.inner_text(), "Старый заголовок")
         self.assertIn("empty", str(ctx.exception).lower())
+
+
+class _FakeImagesPage(FakePage):
+    """Models the image set + image manager modal (issue #670, Этап D).
+
+    Unlike headlines/texts, there is no fixed slot count — the page and the
+    modal's "Выбранные изображения" panel each render a variable-length list
+    of cards. This fake keeps ONE shared ``ids`` list (content IDs, standing
+    in 1:1 for thumb URLs too, since ``_set_image`` never needs to tell them
+    apart — see ``_read_modal_selected_thumb_urls``'s docstring) that both
+    ``_read_image_content_ids`` (via the page-level ``ContentImage.*``
+    locator) and ``_read_modal_selected_thumb_urls``/the remove buttons (via
+    the modal-level ``SelectedImage.*`` locators) read/mutate — mirroring
+    how ``_page_with_save_button``'s ``budget_state``/``headline_handles``
+    share mutable state between the "edit" and "post-save reload" phases of
+    one ``update_master`` call.
+
+    ``open_images_modal`` toggles whether ``ImageSuggestionsEditorModal`` is
+    present at all — real Playwright only renders it after the "Выбрать
+    другие изображения" click (confirmed live), and ``_open_images_modal``'s
+    polling loop depends on that transition being observable.
+    """
+
+    def __init__(self, ids, *, save_clicks=None, upload_ids=None, **kwargs):
+        super().__init__(**kwargs)
+        self.ids = list(ids)
+        self.modal_open = False
+        self.save_clicks = save_clicks if save_clicks is not None else []
+        # Content IDs assigned to successive set_input_files() uploads, one
+        # per call, in order — mirrors a test wanting deterministic new IDs
+        # without depending on upload ordering internals.
+        self._upload_ids = list(upload_ids or [])
+        self._upload_call = 0
+
+    def locator(self, selector):
+        if selector == browser_masters._IMAGES_EDITOR_SELECTOR:
+            # The images section itself — present as soon as the (fake) page
+            # has rendered, which is what `_wait_for_images_editor` polls for
+            # before trusting an empty read as "this campaign has no images".
+            return _FakeLocator([_FakeLocatorHandle()])
+        if not self.modal_open and selector == browser_masters._IMAGES_MODAL_SELECTOR:
+            return _FakeLocator([])
+        if self.modal_open and selector == browser_masters._IMAGES_MODAL_SELECTOR:
+            return _FakeLocator([_FakeLocatorHandle()])
+        if selector == browser_masters._IMAGES_OPEN_MODAL_SELECTOR:
+            return _FakeLocator(
+                [_FakeLocatorHandle(on_click=lambda: setattr(self, "modal_open", True))]
+            )
+        if selector == browser_masters._IMAGES_MODAL_FILE_INPUT_SELECTOR:
+            return _FakeLocator([_FakeLocatorHandle(on_upload=self._upload)])
+        if selector == browser_masters._IMAGES_MODAL_SAVE_SELECTOR:
+            return _FakeLocator(
+                [
+                    _FakeLocatorHandle(
+                        on_click=lambda: (
+                            self.save_clicks.append(True),
+                            setattr(self, "modal_open", False),
+                        )
+                    )
+                ]
+            )
+        selector_prefix = (
+            f'[data-testid^="{browser_masters._IMAGES_CONTENT_TESTID_PREFIX}"]'
+        )
+        if selector == selector_prefix:
+            return _FakeLocator(
+                [
+                    _FakeLocatorHandle(attrs={"data-testid": self._content_testid(cid)})
+                    for cid in self.ids
+                ]
+            )
+        modal_prefix = (
+            f'[data-testid^="{browser_masters._IMAGES_MODAL_SELECTED_PREFIX}"]'
+        )
+        if selector == modal_prefix:
+            return _FakeLocator(
+                [
+                    _FakeLocatorHandle(
+                        attrs={"data-testid": self._selected_testid(cid)}
+                    )
+                    for cid in self.ids
+                ]
+            )
+        for cid in self.ids:
+            remove_testid = browser_masters._IMAGES_MODAL_REMOVE_TESTID_TEMPLATE.format(
+                thumb_url=cid
+            )
+            remove_selector = f'[data-testid="{remove_testid}"]'
+            if selector == remove_selector:
+                bound_cid = cid
+                return _FakeLocator(
+                    [
+                        _FakeLocatorHandle(
+                            on_click=lambda bound_cid=bound_cid: self.ids.remove(
+                                bound_cid
+                            )
+                        )
+                    ]
+                )
+        return super().locator(selector)
+
+    def _content_testid(self, content_id):
+        return f"{browser_masters._IMAGES_CONTENT_TESTID_PREFIX}{content_id}"
+
+    def _selected_testid(self, content_id):
+        return f"{browser_masters._IMAGES_MODAL_SELECTED_PREFIX}{content_id}"
+
+    def _upload(self, path):
+        if self._upload_call < len(self._upload_ids):
+            new_id = self._upload_ids[self._upload_call]
+        else:
+            new_id = f"uploaded-{self._upload_call}"
+        self._upload_call += 1
+        self.ids.append(new_id)
+
+
+class TestReadImageContentIds(unittest.TestCase):
+    """``_read_image_content_ids`` (issue #670, Этап D)."""
+
+    def test_reads_ids_in_dom_order(self):
+        page = _FakeImagesPage(["a", "b", "c"])
+
+        self.assertEqual(browser_masters._read_image_content_ids(page), ["a", "b", "c"])
+
+    def test_empty_set_is_not_an_error(self):
+        """Unlike headlines/texts, zero images is a legitimate campaign state."""
+        page = _FakeImagesPage([])
+
+        self.assertEqual(browser_masters._read_image_content_ids(page), [])
+
+
+class TestWaitForImagesEditor(unittest.TestCase):
+    """``_wait_for_images_editor`` (issue #670) — regression guard for a bug
+    found during live verification.
+
+    The edit page is an SPA: ``goto(wait_until="domcontentloaded")`` returns
+    while the images section is still absent, so reading the set straight
+    away yields ``[]`` — indistinguishable from "this campaign genuinely has
+    no images". Live-confirmed: four consecutive DRAFT campaigns were
+    rejected with "no images" by ``masters update --image`` while their edit
+    pages demonstrably rendered four images each.
+    """
+
+    def test_returns_once_the_section_is_present(self):
+        page = _FakeImagesPage(["a"])
+
+        browser_masters._wait_for_images_editor(page)  # must not raise
+
+    def test_raises_rather_than_reporting_no_images(self):
+        """A section that never renders is a hard error, NOT an empty set."""
+
+        class _NoEditorPage(_FakeImagesPage):
+            def locator(self, selector):
+                if selector == browser_masters._IMAGES_EDITOR_SELECTOR:
+                    return _FakeLocator([])
+                return super().locator(selector)
+
+        page = _NoEditorPage([])
+        with patch.object(browser_masters, "_IMAGES_EDITOR_TIMEOUT_MS", 1):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters._wait_for_images_editor(page)
+
+        self.assertIn("did not render", str(ctx.exception))
+
+    def test_set_image_does_not_claim_no_images_before_the_section_renders(self):
+        """The end-to-end shape of the live bug: `_set_image` must not
+        report "no images" for a page whose section has not rendered yet."""
+
+        class _NoEditorPage(_FakeImagesPage):
+            def locator(self, selector):
+                if selector == browser_masters._IMAGES_EDITOR_SELECTOR:
+                    return _FakeLocator([])
+                return super().locator(selector)
+
+        page = _NoEditorPage([])
+        with patch.object(browser_masters, "_IMAGES_EDITOR_TIMEOUT_MS", 1):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters._set_image(page, 0, "/tmp/fake.png")
+
+        self.assertIn("did not render", str(ctx.exception))
+        self.assertNotIn("no images", str(ctx.exception).lower())
+
+
+class TestSetImage(unittest.TestCase):
+    """``_set_image`` (issue #670, Этап D) — synthetic point-replacement
+    composed from the image manager modal's remove+upload+save.
+    """
+
+    def test_replaces_the_requested_position_only(self):
+        page = _FakeImagesPage(["a", "b", "c"], upload_ids=["new"])
+
+        browser_masters._set_image(page, 1, "/tmp/fake.png")
+
+        # Confirmed-live behaviour: the new image lands at the END of the
+        # set, not back at position 1 — see _set_image's own docstring.
+        self.assertEqual(page.ids, ["a", "c", "new"])
+        self.assertEqual(len(page.save_clicks), 1)
+        self.assertFalse(page.modal_open)
+
+    def test_raises_when_image_set_is_empty(self):
+        page = _FakeImagesPage([])
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._set_image(page, 0, "/tmp/fake.png")
+
+        self.assertIn("no images", str(ctx.exception).lower())
+        self.assertEqual(page.save_clicks, [])
+
+    def test_raises_when_position_out_of_range(self):
+        page = _FakeImagesPage(["a", "b"])
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._set_image(page, 5, "/tmp/fake.png")
+
+        self.assertIn("out of range", str(ctx.exception).lower())
+        self.assertEqual(page.ids, ["a", "b"])
+        self.assertEqual(page.save_clicks, [])
+
+    def test_does_not_save_when_upload_never_appears(self):
+        """A stalled/failed async upload must not be committed via Save."""
+        page = _FakeImagesPage(["a", "b"], upload_ids=[])
+        # Sabotage the upload: the file input exists but never actually adds
+        # a new card to the selected panel.
+        original_locator = page.locator
+
+        def _locator(selector):
+            if selector == browser_masters._IMAGES_MODAL_FILE_INPUT_SELECTOR:
+                return _FakeLocator([_FakeLocatorHandle(on_upload=lambda path: None)])
+            return original_locator(selector)
+
+        page.locator = _locator
+        # Keep the test fast — patch.object restores the real value even on
+        # failure, and never hardcodes it (a `finally:` assignment would).
+        with patch.object(browser_masters, "_IMAGE_UPLOAD_TIMEOUT_MS", 1):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters._set_image(page, 0, "/tmp/fake.png")
+
+        self.assertIn("no new", str(ctx.exception).lower())
+        self.assertEqual(page.save_clicks, [])
+        # The removed image must NOT still be missing from the caller's
+        # perspective of "nothing was saved" — the campaign's actually-saved
+        # set is untouched because Save was never clicked, even though the
+        # modal's own in-progress state lost it.
+
+    def test_removed_image_not_still_present_raises(self):
+        """Models Yandex's own remove click silently failing."""
+        page = _FakeImagesPage(["a", "b"])
+        original_locator = page.locator
+
+        def _locator(selector):
+            remove_testid = browser_masters._IMAGES_MODAL_REMOVE_TESTID_TEMPLATE.format(
+                thumb_url="a"
+            )
+            remove_selector = f'[data-testid="{remove_testid}"]'
+            if selector == remove_selector:
+                return _FakeLocator([_FakeLocatorHandle(on_click=lambda: None)])
+            return original_locator(selector)
+
+        page.locator = _locator
+        with patch.object(browser_masters, "_IMAGE_MODAL_OPEN_TIMEOUT_MS", 1):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters._set_image(page, 0, "/tmp/fake.png")
+
+        self.assertIn("still shown", str(ctx.exception).lower())
+        self.assertEqual(page.save_clicks, [])
+
+
+class TestVerifyImageMismatches(unittest.TestCase):
+    """``_verify_image_mismatches`` (issue #670, Этап D) — set-membership
+    verification, NOT positional (see ``_set_image``'s docstring for why).
+    """
+
+    def test_no_mismatches_when_replaced_gone_and_kept_present(self):
+        page = _FakeImagesPage(["a", "c", "new"])  # "b" was replaced by "new"
+
+        mismatches = browser_masters._verify_image_mismatches(
+            page, before_ids=["a", "b", "c"], replaced_ids={"b"}
+        )
+
+        self.assertEqual(mismatches, [])
+
+    def test_flags_a_replaced_id_still_present(self):
+        """Yandex silently rejected the replacement — "b" never left."""
+        page = _FakeImagesPage(["a", "b", "c"])
+
+        mismatches = browser_masters._verify_image_mismatches(
+            page, before_ids=["a", "b", "c"], replaced_ids={"b"}
+        )
+
+        self.assertTrue(any("still present" in m for m in mismatches))
+
+    def test_flags_a_kept_id_that_went_missing(self):
+        """Something clobbered an image the caller never asked to touch."""
+        page = _FakeImagesPage(["a", "new"])  # "c" vanished unexpectedly
+
+        mismatches = browser_masters._verify_image_mismatches(
+            page, before_ids=["a", "b", "c"], replaced_ids={"b"}
+        )
+
+        self.assertTrue(any("missing" in m for m in mismatches))
+
+    def test_no_requested_replacements_is_a_no_op(self):
+        page = _FakeImagesPage(["a", "b", "c"])
+
+        mismatches = browser_masters._verify_image_mismatches(
+            page, before_ids=[], replaced_ids=set()
+        )
+
+        self.assertEqual(mismatches, [])
 
 
 class TestSetRegion(unittest.TestCase):


### PR DESCRIPTION
Replaces the image at a given position of a Мастер кампаний campaign's image set with a local file, via the edit page's image manager modal.

Closes #670

## Why images aren't like headlines/texts

Yandex has **no "replace this slot" primitive for images at all** — only "remove from the set" and "add to the set", both inside `ImageSuggestionsEditorModal`. `_set_image` composes the two into one synthetic point-replacement (open modal → remove card at position → upload → poll for the new card → Save).

**Confirmed live 2026-08-02** (campaign 713234191, real DOM mutation, Save never clicked, page abandoned — no campaign was mutated): a newly uploaded image is **always appended to the END** of the set, never inserted at the freed position. Replacing position 2 of `[A, B, C, D]` yields `[A, C, D, NEW]`, not `[A, NEW, C, D]`. The set's order carries no product meaning (Yandex rotates/biases images by performance regardless of position), so this is a cosmetic limitation — but the CLI help, README and CHANGELOG say so rather than implying a true positional swap.

Images are structurally different in three more ways, all of which the code accounts for:
- there is **no fixed slot count** in the DOM — the page renders exactly as many `ContentImage` elements as the campaign has images, keyed by a Yandex content ID, not an index. `_IMAGES_MAX_COUNT` bounds CLI parsing only; the real ceiling is read fresh from the page.
- an **empty set is legitimate** (unlike headlines/texts, there's no "at least one" invariant).
- the edit page is an **SPA**: `goto(..., wait_until="domcontentloaded")` returns before the images section exists. Reading too early yields `[]`, which is indistinguishable from "this campaign genuinely has no images" — live-confirmed to make `--image` fail with a false "no images" on four consecutive campaigns that demonstrably had four images each. Hence `_wait_for_images_editor`, which reports a timeout as a hard error rather than silently treating it as "no images".

Post-save verification is **set-membership**, not positional, matching the append-to-end behaviour above.

Because both the removal and the upload happen inside the same open modal, any failure before `Save` leaves the campaign's saved image set untouched — every error message says so explicitly.

## Shared scaffolding folded in

The feature earned four cleanups rather than adding its own copies:

- **`_poll_until`** replaces five hand-rolled `deadline`/`wait_for_timeout(250)` loops and the two sentinel flags (`removed`, `uploaded`) that only existed because the loops were inline. It also makes `PlaywrightError` suppression uniform — previously only one of the five suppressed it.
- **`_read_testid_suffixes`** collapses `_read_image_content_ids` and `_read_modal_selected_thumb_urls`, which were the same prefix-scraping body twice.
- **`_IMAGE_UPLOAD_SUFFIXES`** lives in the browser layer next to the file input it describes (`accept=image/png,image/jpeg,image/jpg,image/gif`, confirmed live), imported by the CLI — same reasoning as `_IMAGES_MAX_COUNT`, so the fail-fast check can't drift from what the page accepts.
- **`_validate_image_paths`** lifts the extension/existence check out of the Click callback body.

Tests patch timeout constants with `patch.object` rather than assigning module globals with a hardcoded restore value, keeping the offline tier process-parallel-safe.

## Testing

- `pytest tests/test_masters.py` — 278 passed
- `pytest` (full offline tier) — 2857 passed, 8 skipped
- `black` / `flake8` clean

The 62 errors in the live-write tier are pre-existing and identical on a pristine baseline (verified via `git stash`) — they need credentials this run didn't have.

## Known limitation

Each image is replaced through its own open/remove/upload/Save modal cycle, so replacing N images costs N cycles. Batching them into a single modal session looks possible (`set_input_files` accepts a list) but that claim is **not live-verified**, so it's deliberately left for a follow-up with proper recon rather than guessed at here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtBiHRofaYua9pmistY6oz