### PR TITLE
fix(masters): wait out the images-section loading stubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## Unreleased
 
+**Fixed — `_wait_for_images_editor` returned during a loading-stub state,
+under-reporting a campaign's real image count (#648):**
+
+- The edit page's "Изображения" section renders in TWO stages — first
+  `ImageSuggestionsEditor` itself appears with four
+  `ImageSuggestionsEditor.CampaignContents.StubN` loading placeholders and
+  NEITHER `ContentImage.*` nor `.Open` present yet, then roughly 3s later
+  the stubs are replaced by the real content. `_wait_for_images_editor`
+  previously returned as soon as the outer container existed — i.e.
+  during the stub window — so `_read_image_content_ids` read `[]` for a
+  campaign that demonstrably had 4 real images, and `masters update
+  --image` then refused to replace anything with "campaign has no images".
+- **Confirmed live 2026-08-03, campaigns 713234191 and 713234204** (both
+  with 4 real images each): the images section read back as empty before
+  this fix and as 4 images after it. The two campaigns and their symptom
+  exactly mirror the four-DRAFT regression `_wait_for_images_editor` was
+  originally written to guard against (2026-08-02) — the guard just
+  didn't cover this second render stage.
+- `_wait_for_images_editor` now also polls until no
+  `ImageSuggestionsEditor.CampaignContents.StubN` element remains, so
+  every caller observes only the settled state, never the transient one.
+  The timeout error message now says "did not finish rendering... may
+  still be showing loading placeholders" instead of "did not render", to
+  describe the stub case accurately.
+
 **Added — `direct masters update --image` (#670, Этап D):**
 
 - New repeatable `--image "N=/path/to/file.png"` flag on `direct masters

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -378,6 +378,19 @@ _TEXTS_TESTID_TEMPLATE = "CampaignTexts{index}.textarea"
 _IMAGES_MAX_COUNT = 5
 _IMAGES_EDITOR_SELECTOR = '[data-testid="ImageSuggestionsEditor"]'
 _IMAGES_CONTENT_TESTID_PREFIX = "ImageSuggestionsEditor.CampaignContents.ContentImage."
+# Loading skeleton the section renders BEFORE the real content resolves —
+# confirmed live 2026-08-03 against campaigns 713234191/713234204 (both with
+# 4 real images): ``ImageSuggestionsEditor`` itself appears first with four
+# ``ImageSuggestionsEditor.CampaignContents.StubN`` placeholders (N=0-3) and
+# NEITHER ``ContentImage.*`` NOR ``.Open`` present yet; the stubs are
+# replaced by the real content ~3s later. Waiting only for
+# ``_IMAGES_EDITOR_SELECTOR`` (what this constant guarded before) is
+# insufficient — it returns during the stub window, so
+# ``_read_image_content_ids`` reads ``[]`` for a campaign that demonstrably
+# has 4 images, exactly the "empty list indistinguishable from not-yet-
+# rendered" failure mode ``_wait_for_images_editor``'s own docstring already
+# describes but did not fully guard against. See ``_wait_for_images_editor``.
+_IMAGES_STUB_TESTID_PREFIX = "ImageSuggestionsEditor.CampaignContents.Stub"
 _IMAGES_OPEN_MODAL_SELECTOR = '[data-testid="ImageSuggestionsEditor.Open"]'
 _IMAGES_MODAL_SELECTOR = '[data-testid="ImageSuggestionsEditorModal"]'
 _IMAGES_MODAL_FILE_INPUT_SELECTOR = (
@@ -2210,22 +2223,42 @@ def _wait_for_images_editor(page: "Page") -> None:
     images by ``masters update --image`` while the very same edit pages
     demonstrably rendered four ``ContentImage`` elements each.
 
-    Absence of the section after the timeout is reported as a hard error
-    rather than silently treated as "no images", for the same reason.
+    **Two-stage render, confirmed live 2026-08-03 (campaigns 713234191 and
+    713234204, both with 4 real images):** ``ImageSuggestionsEditor`` itself
+    (the selector this function used to wait on exclusively) appears FIRST
+    with four ``ImageSuggestionsEditor.CampaignContents.StubN`` loading
+    placeholders and NEITHER ``ContentImage.*`` nor ``.Open`` present yet —
+    then, roughly 3s later, the stubs are replaced by the real content.
+    Returning as soon as the outer container exists (the original
+    ``_IMAGES_EDITOR_SELECTOR``-only check) reproduces the exact bug this
+    function's docstring already describes, just one render stage later:
+    a campaign that demonstrably has 4 images reads back as having none,
+    and ``--image`` then refuses to replace anything. This function now
+    also polls until no ``_IMAGES_STUB_TESTID_PREFIX`` element remains, so
+    a caller never observes the mid-render stub state.
+
+    Absence of the section (or persistence of the stub state) after the
+    timeout is reported as a hard error rather than silently treated as
+    "no images", for the same reason.
     """
-    if _poll_until(
-        page,
-        lambda: page.locator(_IMAGES_EDITOR_SELECTOR).first.count() > 0,
-        _IMAGES_EDITOR_TIMEOUT_MS,
-    ):
+
+    def _content_settled() -> bool:
+        if page.locator(_IMAGES_EDITOR_SELECTOR).first.count() == 0:
+            return False
+        return (
+            page.locator(f'[data-testid^="{_IMAGES_STUB_TESTID_PREFIX}"]').count() == 0
+        )
+
+    if _poll_until(page, _content_settled, _IMAGES_EDITOR_TIMEOUT_MS):
         return
 
     raise BrowserSessionError(
-        "The edit page's 'Изображения' section did not render within "
-        f"{_IMAGES_EDITOR_TIMEOUT_MS / 1000:.0f}s, so this command cannot "
-        "tell whether the campaign has images or not. Yandex may have "
-        "changed the page's markup, or the page may still be loading. "
-        "Re-run with --headful to inspect the page."
+        "The edit page's 'Изображения' section did not finish rendering "
+        f"within {_IMAGES_EDITOR_TIMEOUT_MS / 1000:.0f}s (it may still be "
+        "showing loading placeholders), so this command cannot tell "
+        "whether the campaign has images or not. Yandex may have changed "
+        "the page's markup, or the page may still be loading. Re-run with "
+        "--headful to inspect the page."
     )
 
 

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -4628,7 +4628,7 @@ class TestWaitForImagesEditor(unittest.TestCase):
             with self.assertRaises(BrowserSessionError) as ctx:
                 browser_masters._wait_for_images_editor(page)
 
-        self.assertIn("did not render", str(ctx.exception))
+        self.assertIn("did not finish rendering", str(ctx.exception))
 
     def test_set_image_does_not_claim_no_images_before_the_section_renders(self):
         """The end-to-end shape of the live bug: `_set_image` must not
@@ -4647,8 +4647,68 @@ class TestWaitForImagesEditor(unittest.TestCase):
                     page, 0, "/tmp/fake.png", target_content_id="a"
                 )
 
-        self.assertIn("did not render", str(ctx.exception))
+        self.assertIn("did not finish rendering", str(ctx.exception))
         self.assertNotIn("no images", str(ctx.exception).lower())
+
+    def test_waits_out_the_loading_stub_state_before_returning(self):
+        """Live-confirmed 2026-08-03 regression (campaigns 713234191 and
+        713234204, both with 4 real images): ``ImageSuggestionsEditor``
+        itself renders FIRST with four ``...CampaignContents.StubN``
+        loading placeholders, and NEITHER ``ContentImage.*`` nor ``.Open``
+        exist yet — only ~3s later do the stubs get replaced by the real
+        content. Waiting on ``_IMAGES_EDITOR_SELECTOR`` alone (the original
+        implementation) returned during this stub window, so a campaign
+        that demonstrably had 4 images read back as having none and
+        ``masters update --image`` refused to replace anything.
+        """
+
+        class _StubThenContentPage(_FakeImagesPage):
+            def __init__(self, *args, stub_ticks=2, **kwargs):
+                super().__init__(*args, **kwargs)
+                self._stub_ticks_remaining = stub_ticks
+
+            def locator(self, selector):
+                stub_prefix = (
+                    f'[data-testid^="{browser_masters._IMAGES_STUB_TESTID_PREFIX}"]'
+                )
+                if selector == stub_prefix:
+                    if self._stub_ticks_remaining > 0:
+                        self._stub_ticks_remaining -= 1
+                        return _FakeLocator([_FakeLocatorHandle() for _ in range(4)])
+                    return _FakeLocator([])
+                return super().locator(selector)
+
+        page = _StubThenContentPage(["a", "b", "c", "d"], stub_ticks=2)
+
+        browser_masters._wait_for_images_editor(page)  # must not raise
+
+        # Confirms the wait actually consumed the stub ticks rather than
+        # returning on the very first (still-stubbed) poll.
+        self.assertEqual(page._stub_ticks_remaining, 0)
+        self.assertEqual(
+            browser_masters._read_image_content_ids(page), ["a", "b", "c", "d"]
+        )
+
+    def test_raises_if_stubs_never_clear(self):
+        """A section stuck showing loading placeholders forever must be a
+        hard error, not silently treated as an empty (or populated) set."""
+
+        class _StuckStubPage(_FakeImagesPage):
+            def locator(self, selector):
+                stub_prefix = (
+                    f'[data-testid^="{browser_masters._IMAGES_STUB_TESTID_PREFIX}"]'
+                )
+                if selector == stub_prefix:
+                    return _FakeLocator([_FakeLocatorHandle() for _ in range(4)])
+                return super().locator(selector)
+
+        page = _StuckStubPage(["a", "b", "c", "d"])
+        with patch.object(browser_masters, "_IMAGES_EDITOR_TIMEOUT_MS", 1):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters._wait_for_images_editor(page)
+
+        self.assertIn("did not finish rendering", str(ctx.exception))
+        self.assertIn("loading placeholders", str(ctx.exception))
 
 
 class TestSetImage(unittest.TestCase):


### PR DESCRIPTION
Секция «Изображения» на странице редактирования рендерится в два этапа: сначала появляется `ImageSuggestionsEditor` с четырьмя плейсхолдерами `…CampaignContents.StubN` (ни `ContentImage.*`, ни `.Open` ещё нет), и только ~3s спустя заглушки заменяются реальным содержимым.

`_wait_for_images_editor` возвращался, как только существовал внешний контейнер — то есть внутри окна заглушек. `_read_image_content_ids` читал `[]` для кампании, у которой заведомо было 4 изображения, и `masters update --image` отказывался что-либо заменять с ложным «campaign has no images».

Это тот же режим отказа, который уже описан в докстринге самой функции (регрессия four-DRAFT от 2026-08-02), на одну стадию рендера позже: исходный guard закрывал только «секции нет», но не «секция есть, но всё ещё показывает скелетоны».

Теперь ожидание дополнительно опрашивает страницу, пока не исчезнет последний `StubN`, так что любой вызывающий видит только устоявшееся состояние. Сообщение таймаута отличает случай заглушек.

**Живая проверка** 2026-08-03 на кампаниях 713234191 и 713234204 (по 4 реальных изображения): до фикса читалось пусто, после — 4.

Refs #648

🤖 Generated with [Claude Code](https://claude.com/claude-code)