### PR TITLE
refactor: recurse the command-tree walkers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## Unreleased
 
+**Fixed — `_wait_for_images_editor` returned during a loading-stub state,
+under-reporting a campaign's real image count (#648):**
+
+- The edit page's "Изображения" section renders in TWO stages — first
+  `ImageSuggestionsEditor` itself appears with four
+  `ImageSuggestionsEditor.CampaignContents.StubN` loading placeholders and
+  NEITHER `ContentImage.*` nor `.Open` present yet, then roughly 3s later
+  the stubs are replaced by the real content. `_wait_for_images_editor`
+  previously returned as soon as the outer container existed — i.e.
+  during the stub window — so `_read_image_content_ids` read `[]` for a
+  campaign that demonstrably had 4 real images, and `masters update
+  --image` then refused to replace anything with "campaign has no images".
+- **Confirmed live 2026-08-03, campaigns 713234191 and 713234204** (both
+  with 4 real images each): the images section read back as empty before
+  this fix and as 4 images after it. The two campaigns and their symptom
+  exactly mirror the four-DRAFT regression `_wait_for_images_editor` was
+  originally written to guard against (2026-08-02) — the guard just
+  didn't cover this second render stage.
+- `_wait_for_images_editor` now also polls until no
+  `ImageSuggestionsEditor.CampaignContents.StubN` element remains, so
+  every caller observes only the settled state, never the transient one.
+  The timeout error message now says "did not finish rendering... may
+  still be showing loading placeholders" instead of "did not render", to
+  describe the stub case accurately.
+
 **Added — `direct masters update --image` (#670, Этап D):**
 
 - New repeatable `--image "N=/path/to/file.png"` flag on `direct masters

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -378,6 +378,19 @@ _TEXTS_TESTID_TEMPLATE = "CampaignTexts{index}.textarea"
 _IMAGES_MAX_COUNT = 5
 _IMAGES_EDITOR_SELECTOR = '[data-testid="ImageSuggestionsEditor"]'
 _IMAGES_CONTENT_TESTID_PREFIX = "ImageSuggestionsEditor.CampaignContents.ContentImage."
+# Loading skeleton the section renders BEFORE the real content resolves —
+# confirmed live 2026-08-03 against campaigns 713234191/713234204 (both with
+# 4 real images): ``ImageSuggestionsEditor`` itself appears first with four
+# ``ImageSuggestionsEditor.CampaignContents.StubN`` placeholders (N=0-3) and
+# NEITHER ``ContentImage.*`` NOR ``.Open`` present yet; the stubs are
+# replaced by the real content ~3s later. Waiting only for
+# ``_IMAGES_EDITOR_SELECTOR`` (what this constant guarded before) is
+# insufficient — it returns during the stub window, so
+# ``_read_image_content_ids`` reads ``[]`` for a campaign that demonstrably
+# has 4 images, exactly the "empty list indistinguishable from not-yet-
+# rendered" failure mode ``_wait_for_images_editor``'s own docstring already
+# describes but did not fully guard against. See ``_wait_for_images_editor``.
+_IMAGES_STUB_TESTID_PREFIX = "ImageSuggestionsEditor.CampaignContents.Stub"
 _IMAGES_OPEN_MODAL_SELECTOR = '[data-testid="ImageSuggestionsEditor.Open"]'
 _IMAGES_MODAL_SELECTOR = '[data-testid="ImageSuggestionsEditorModal"]'
 _IMAGES_MODAL_FILE_INPUT_SELECTOR = (
@@ -2210,22 +2223,42 @@ def _wait_for_images_editor(page: "Page") -> None:
     images by ``masters update --image`` while the very same edit pages
     demonstrably rendered four ``ContentImage`` elements each.
 
-    Absence of the section after the timeout is reported as a hard error
-    rather than silently treated as "no images", for the same reason.
+    **Two-stage render, confirmed live 2026-08-03 (campaigns 713234191 and
+    713234204, both with 4 real images):** ``ImageSuggestionsEditor`` itself
+    (the selector this function used to wait on exclusively) appears FIRST
+    with four ``ImageSuggestionsEditor.CampaignContents.StubN`` loading
+    placeholders and NEITHER ``ContentImage.*`` nor ``.Open`` present yet —
+    then, roughly 3s later, the stubs are replaced by the real content.
+    Returning as soon as the outer container exists (the original
+    ``_IMAGES_EDITOR_SELECTOR``-only check) reproduces the exact bug this
+    function's docstring already describes, just one render stage later:
+    a campaign that demonstrably has 4 images reads back as having none,
+    and ``--image`` then refuses to replace anything. This function now
+    also polls until no ``_IMAGES_STUB_TESTID_PREFIX`` element remains, so
+    a caller never observes the mid-render stub state.
+
+    Absence of the section (or persistence of the stub state) after the
+    timeout is reported as a hard error rather than silently treated as
+    "no images", for the same reason.
     """
-    if _poll_until(
-        page,
-        lambda: page.locator(_IMAGES_EDITOR_SELECTOR).first.count() > 0,
-        _IMAGES_EDITOR_TIMEOUT_MS,
-    ):
+
+    def _content_settled() -> bool:
+        if page.locator(_IMAGES_EDITOR_SELECTOR).first.count() == 0:
+            return False
+        return (
+            page.locator(f'[data-testid^="{_IMAGES_STUB_TESTID_PREFIX}"]').count() == 0
+        )
+
+    if _poll_until(page, _content_settled, _IMAGES_EDITOR_TIMEOUT_MS):
         return
 
     raise BrowserSessionError(
-        "The edit page's 'Изображения' section did not render within "
-        f"{_IMAGES_EDITOR_TIMEOUT_MS / 1000:.0f}s, so this command cannot "
-        "tell whether the campaign has images or not. Yandex may have "
-        "changed the page's markup, or the page may still be loading. "
-        "Re-run with --headful to inspect the page."
+        "The edit page's 'Изображения' section did not finish rendering "
+        f"within {_IMAGES_EDITOR_TIMEOUT_MS / 1000:.0f}s (it may still be "
+        "showing loading placeholders), so this command cannot tell "
+        "whether the campaign has images or not. Yandex may have changed "
+        "the page's markup, or the page may still be loading. Re-run with "
+        "--headful to inspect the page."
     )
 
 

--- a/direct_cli/smoke_matrix.py
+++ b/direct_cli/smoke_matrix.py
@@ -266,14 +266,27 @@ def commands_for_category(category: str) -> list[str]:
     return list(SMOKE_MATRIX[category])
 
 
+def _walk_leaf_command_keys(prefix: str, group) -> Iterable[str]:
+    """Yield dotted command keys for every LEAF command under ``group``,
+    recursing into any subcommand that is itself a group. A two-level-only
+    walk would either treat a nested group as one opaque leaf or (worse)
+    silently drop its own subcommands from smoke classification entirely.
+    """
+    for name, command in group.commands.items():
+        key = f"{prefix}.{name}"
+        if hasattr(command, "commands"):
+            yield from _walk_leaf_command_keys(key, command)
+        else:
+            yield key
+
+
 def _registered_cli_commands() -> set[str]:
     from direct_cli.cli import cli
 
     registered = set()
     for group_name, group in cli.commands.items():
         if hasattr(group, "commands"):
-            for command_name in group.commands:
-                registered.add(command_key(group_name, command_name))
+            registered.update(_walk_leaf_command_keys(group_name, group))
         else:
             registered.add(group_name)
     return registered

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -67,10 +67,22 @@ def _option_names(command):
     }
 
 
+def _walk_leaf_commands(group_path, group):
+    """Yield (group_path, leaf_name, command) recursing into any subcommand
+    that is itself a group. A flat one-level walk would either yield a
+    nested group itself as an opaque "command" (never checking its own
+    leaves) or miss them outright.
+    """
+    for name, command in sorted(getattr(group, "commands", {}).items()):
+        if hasattr(command, "commands"):
+            yield from _walk_leaf_commands(f"{group_path}.{name}", command)
+        else:
+            yield group_path, name, command
+
+
 def _subcommands():
     for group_name, group in sorted(cli.commands.items()):
-        for command_name, command in sorted(getattr(group, "commands", {}).items()):
-            yield group_name, command_name, command
+        yield from _walk_leaf_commands(group_name, group)
 
 
 def _readme_direct_example_lines():
@@ -138,8 +150,9 @@ def test_help_output_does_not_advertise_raw_payload_inputs():
     offenders = []
 
     for group_name, command_name, _command in _subcommands():
-        result = runner.invoke(cli, [group_name, command_name, "--help"])
-        assert result.exit_code == 0, f"direct {group_name} {command_name} --help"
+        argv = group_name.split(".") + [command_name, "--help"]
+        result = runner.invoke(cli, argv)
+        assert result.exit_code == 0, f"direct {' '.join(argv)}"
         for forbidden in FORBIDDEN_HELP_TEXT:
             if forbidden in result.output:
                 offenders.append(f"{group_name}.{command_name}: {forbidden}")
@@ -192,16 +205,21 @@ def test_readme_bash_blocks_do_not_use_deprecated_direct_cli_executable():
 
 def test_smoke_matrix_entries_are_registered_canonical_commands():
     registered = set()
-    for group_name, group in cli.commands.items():
-        for command_name in getattr(group, "commands", {}):
-            registered.add(f"{group_name}.{command_name}")
+    for group_path, command_name, _command in _subcommands():
+        registered.add(f"{group_path}.{command_name}")
 
     offenders = []
     for commands in SMOKE_MATRIX.values():
         for command in commands:
             if "." in command:
-                group_name, command_name = command.split(".", 1)
-                if not GROUP_NAME_RE.fullmatch(group_name):
+                # The leaf name is always the LAST segment: a nested group
+                # makes the group path itself dotted (``a.b.leaf``), so
+                # splitting on the FIRST dot would mis-parse it.
+                group_name, command_name = command.rsplit(".", 1)
+                if not all(
+                    GROUP_NAME_RE.fullmatch(segment)
+                    for segment in group_name.split(".")
+                ):
                     offenders.append(f"{command}: noncanonical group")
                 if not COMMAND_NAME_RE.fullmatch(command_name):
                     offenders.append(f"{command}: noncanonical command")

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -4628,7 +4628,7 @@ class TestWaitForImagesEditor(unittest.TestCase):
             with self.assertRaises(BrowserSessionError) as ctx:
                 browser_masters._wait_for_images_editor(page)
 
-        self.assertIn("did not render", str(ctx.exception))
+        self.assertIn("did not finish rendering", str(ctx.exception))
 
     def test_set_image_does_not_claim_no_images_before_the_section_renders(self):
         """The end-to-end shape of the live bug: `_set_image` must not
@@ -4647,8 +4647,68 @@ class TestWaitForImagesEditor(unittest.TestCase):
                     page, 0, "/tmp/fake.png", target_content_id="a"
                 )
 
-        self.assertIn("did not render", str(ctx.exception))
+        self.assertIn("did not finish rendering", str(ctx.exception))
         self.assertNotIn("no images", str(ctx.exception).lower())
+
+    def test_waits_out_the_loading_stub_state_before_returning(self):
+        """Live-confirmed 2026-08-03 regression (campaigns 713234191 and
+        713234204, both with 4 real images): ``ImageSuggestionsEditor``
+        itself renders FIRST with four ``...CampaignContents.StubN``
+        loading placeholders, and NEITHER ``ContentImage.*`` nor ``.Open``
+        exist yet — only ~3s later do the stubs get replaced by the real
+        content. Waiting on ``_IMAGES_EDITOR_SELECTOR`` alone (the original
+        implementation) returned during this stub window, so a campaign
+        that demonstrably had 4 images read back as having none and
+        ``masters update --image`` refused to replace anything.
+        """
+
+        class _StubThenContentPage(_FakeImagesPage):
+            def __init__(self, *args, stub_ticks=2, **kwargs):
+                super().__init__(*args, **kwargs)
+                self._stub_ticks_remaining = stub_ticks
+
+            def locator(self, selector):
+                stub_prefix = (
+                    f'[data-testid^="{browser_masters._IMAGES_STUB_TESTID_PREFIX}"]'
+                )
+                if selector == stub_prefix:
+                    if self._stub_ticks_remaining > 0:
+                        self._stub_ticks_remaining -= 1
+                        return _FakeLocator([_FakeLocatorHandle() for _ in range(4)])
+                    return _FakeLocator([])
+                return super().locator(selector)
+
+        page = _StubThenContentPage(["a", "b", "c", "d"], stub_ticks=2)
+
+        browser_masters._wait_for_images_editor(page)  # must not raise
+
+        # Confirms the wait actually consumed the stub ticks rather than
+        # returning on the very first (still-stubbed) poll.
+        self.assertEqual(page._stub_ticks_remaining, 0)
+        self.assertEqual(
+            browser_masters._read_image_content_ids(page), ["a", "b", "c", "d"]
+        )
+
+    def test_raises_if_stubs_never_clear(self):
+        """A section stuck showing loading placeholders forever must be a
+        hard error, not silently treated as an empty (or populated) set."""
+
+        class _StuckStubPage(_FakeImagesPage):
+            def locator(self, selector):
+                stub_prefix = (
+                    f'[data-testid^="{browser_masters._IMAGES_STUB_TESTID_PREFIX}"]'
+                )
+                if selector == stub_prefix:
+                    return _FakeLocator([_FakeLocatorHandle() for _ in range(4)])
+                return super().locator(selector)
+
+        page = _StuckStubPage(["a", "b", "c", "d"])
+        with patch.object(browser_masters, "_IMAGES_EDITOR_TIMEOUT_MS", 1):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters._wait_for_images_editor(page)
+
+        self.assertIn("did not finish rendering", str(ctx.exception))
+        self.assertIn("loading placeholders", str(ctx.exception))
 
 
 class TestSetImage(unittest.TestCase):

--- a/tests/test_smoke_matrix.py
+++ b/tests/test_smoke_matrix.py
@@ -35,12 +35,27 @@ def _load_sandbox_runner_module():
     return module
 
 
+def _walk_leaf_command_keys(prefix: str, group):
+    """Recurse into any subcommand that is itself a group.
+
+    Deliberately a local re-implementation rather than an import of
+    ``direct_cli.smoke_matrix._walk_leaf_command_keys``: these tests are an
+    independent oracle for the smoke summary's counts, and importing the
+    implementation they check would make them tautological.
+    """
+    for name, command in group.commands.items():
+        key = f"{prefix}.{name}"
+        if hasattr(command, "commands"):
+            yield from _walk_leaf_command_keys(key, command)
+        else:
+            yield key
+
+
 def _registered_cli_commands() -> set[str]:
     registered = set()
     for group_name, group in cli.commands.items():
         if hasattr(group, "commands"):
-            for command_name in group.commands:
-                registered.add(command_key(group_name, command_name))
+            registered.update(_walk_leaf_command_keys(group_name, group))
         else:
             registered.add(group_name)
     return registered
@@ -75,13 +90,14 @@ def test_smoke_matrix_counts_are_self_consistent():
     # smoke_matrix.smoke_summary.
     expected_cli_groups = len(cli.commands)
 
-    # Subcommands registered everywhere — counts ``group.subcommand`` for
-    # groups with ``.commands`` plus bare top-level commands. Matches
-    # ``_registered_cli_commands()`` in smoke_matrix.
+    # Subcommands registered everywhere — counts LEAF commands (recursing
+    # into any nested group) for groups with ``.commands`` plus bare
+    # top-level commands. Matches ``_registered_cli_commands()`` in
+    # smoke_matrix.
     expected_cli_subcommands = 0
     for group in cli.commands.values():
         if hasattr(group, "commands"):
-            expected_cli_subcommands += len(group.commands)
+            expected_cli_subcommands += len(list(_walk_leaf_command_keys("", group)))
         else:
             expected_cli_subcommands += 1
 
@@ -91,7 +107,9 @@ def test_smoke_matrix_counts_are_self_consistent():
         if group_name in ("auth", "playwright"):
             continue
         if hasattr(group, "commands"):
-            expected_api_cli_subcommands += len(group.commands)
+            expected_api_cli_subcommands += len(
+                list(_walk_leaf_command_keys("", group))
+            )
         else:
             expected_api_cli_subcommands += 1
 


### PR DESCRIPTION
> Стек: базируется на #673 (`pr/masters-loading-stubs`). Ретаргетить на `main` после мержа родителя.

Три места обходят дерево команд Click ровно на два уровня и считают каждую подкоманду листом: `smoke_matrix._registered_cli_commands`, `test_cli_contract._subcommands` и независимый оракул счётчиков в `test_smoke_matrix`. Группа, вложенная в группу, трактовалась бы как один непрозрачный лист — её собственные подкоманды молча выпадали бы и из smoke-классификации (дыра в безопасности: DANGEROUS-команды классифицируются именно этим обходом), и из контрактных проверок CLI.

Все три обхода сделаны рекурсивными; заодно починены два потребителя, предполагавших, что путь группы не содержит точек: вызов `--help` теперь разбивает путь на сегменты argv, а проверка канонического имени использует `rsplit` (лист — всегда ПОСЛЕДНИЙ сегмент) и валидирует каждый сегмент пути по отдельности.

Чистый no-op на текущем дереве: вложенных групп сегодня нет, поэтому набор зарегистрированных команд побайтово идентичен до и после (165 команд, `validate_matrix()` чистый). Это подготовка, вынесенная отдельно, чтобы поведенческое изменение, вводящее первую вложенную группу, ревьюилось само по себе.

`test_smoke_matrix` намеренно сохраняет локальную реализацию вместо импорта из `smoke_matrix`: это независимый оракул для счётчиков сводки, и импорт тестируемой реализации сделал бы проверку тавтологичной.

Refs #648

🤖 Generated with [Claude Code](https://claude.com/claude-code)