### PR TITLE
feat(masters): add `direct masters adimages get`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## Unreleased
 
+**Added — `direct masters adimages get` (#648):**
+
+- New `direct masters adimages` subgroup, the browser-driven counterpart to
+  the API-side `direct adimages` group (Мастер кампаний has no API surface
+  at all). `adimages get <CAMPAIGN_ID>` reports the campaign's whole image
+  set — `Position` (1-based), `ContentId`, and `ThumbUrl` per image, plus
+  `Count` and `MaxCount`.
+- **An empty image set is a successful result (`Count: 0`), not an error**,
+  unlike `masters update --image` which refuses outright when a campaign
+  has no images. Images are optional on a Мастер кампаний campaign, exactly
+  like ad images on a text ad via the API — there is no "at least one"
+  invariant of the kind headlines and texts have.
+- Read-only: the thumbnail URL is not exposed on the edit page itself, so
+  this opens the image manager modal to read it and then abandons the modal
+  WITHOUT ever clicking Save — nothing commits to the campaign. A campaign
+  with no images skips the modal entirely, there being nothing to read.
+- `_verify_image_mismatches` now delegates to a new
+  `_verify_image_set_mismatches`, which checks an ABSOLUTE expected end
+  state (every removed ID gone, every kept ID present, total size as
+  expected) rather than assuming "removed count == added count". A point
+  replacement is that general check with the two counts pinned equal, so
+  the existing behaviour is unchanged.
+- `masters adimages get` is the CLI's first three-level command; it is
+  classified SAFE in the smoke matrix.
+
 **Fixed — `_wait_for_images_editor` returned during a loading-stub state,
 under-reporting a campaign's real image count (#648):**
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ direct masters update 72349978 --promotion-goal max-clicks --no-directs-helps
 direct masters update 72349978 --name "Мастер ИЖ Источник Жизни (тёплый)"
 direct masters update 72349978 --headline "2=Новый заголовок" --text "1=Новый текст"
 direct masters update 72349978 --image "2=/path/to/banner.png"
+direct masters adimages get 72349978
 direct masters add https://example.com/ --headline "Заголовок 1" --headline "Заголовок 2" --text "Текст объявления" --region Москва --weekly-budget 50000 --draft
 direct masters add https://example.com/ --headline "Заголовок 1" --text "Текст объявления" --region-id 213 --weekly-budget 50000 --draft
 direct masters copy 72349978
@@ -104,6 +105,14 @@ accept are rejected before any browser opens. Adding an image beyond the
 current set and deleting one without replacement are out of scope. Because
 both the removal and the upload happen inside the same open modal, any
 failure before Save leaves the campaign's saved image set untouched.
+
+`masters adimages get` reads a campaign's whole image set — position,
+content ID and thumbnail URL for each image — mirroring the vocabulary of
+`direct adimages get` (the API-side ad-image group). It is read-only and
+never saves. Unlike `--image`, an empty image set is a completely normal,
+successful result here (`Count: 0`), not an error: images are optional on
+a Мастер кампаний campaign, exactly like ad images on a text ad via the
+API.
 
 Later fields (sitelinks, audience, Metrika counters/goals, budget adaptation,
 video) aren't implemented yet.
@@ -1199,6 +1208,7 @@ direct masters update 72349978 --promotion-goal max-clicks --no-directs-helps
 direct masters update 72349978 --name "Мастер ИЖ Источник Жизни (тёплый)"
 direct masters update 72349978 --headline "2=Новый заголовок" --text "1=Новый текст"
 direct masters update 72349978 --image "2=/path/to/banner.png"
+direct masters adimages get 72349978
 direct masters add https://example.com/ --headline "Заголовок 1" --headline "Заголовок 2" --text "Текст объявления" --region Москва --weekly-budget 50000 --draft
 direct masters add https://example.com/ --headline "Заголовок 1" --text "Текст объявления" --region-id 213 --weekly-budget 50000 --draft
 direct masters copy 72349978
@@ -1265,6 +1275,14 @@ direct masters copy 72349978 --launch
 объёма. Поскольку и удаление, и загрузка происходят внутри одной открытой
 модалки, любая ошибка до Save оставляет сохранённый набор изображений
 кампании нетронутым.
+
+`masters adimages get` читает весь набор изображений кампании — позицию,
+content ID и URL миниатюры для каждого — повторяя словарь `direct adimages
+get` (группа изображений объявлений на стороне API). Команда только
+читает и никогда ничего не сохраняет. В отличие от `--image`, пустой набор
+изображений здесь — совершенно нормальный успешный результат (`Count: 0`),
+а не ошибка: изображения у Мастера кампаний необязательны, ровно как
+изображения у текстового объявления через API.
 
 Остальные поля (быстрые ссылки, аудитория, счётчики Метрики/цели, адаптация
 бюджета, видео) тоже пока не реализованы.

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -202,7 +202,16 @@ import contextlib
 import json
 import re
 import time
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+)
 
 from ..output import print_warning
 from .session import (
@@ -377,7 +386,6 @@ _TEXTS_TESTID_TEMPLATE = "CampaignTexts{index}.textarea"
 # always ``len(_read_image_content_ids(page))``, read fresh from the page.
 _IMAGES_MAX_COUNT = 5
 _IMAGES_EDITOR_SELECTOR = '[data-testid="ImageSuggestionsEditor"]'
-_IMAGES_CONTENT_TESTID_PREFIX = "ImageSuggestionsEditor.CampaignContents.ContentImage."
 # Loading skeleton the section renders BEFORE the real content resolves —
 # confirmed live 2026-08-03 against campaigns 713234191/713234204 (both with
 # 4 real images): ``ImageSuggestionsEditor`` itself appears first with four
@@ -391,6 +399,7 @@ _IMAGES_CONTENT_TESTID_PREFIX = "ImageSuggestionsEditor.CampaignContents.Content
 # rendered" failure mode ``_wait_for_images_editor``'s own docstring already
 # describes but did not fully guard against. See ``_wait_for_images_editor``.
 _IMAGES_STUB_TESTID_PREFIX = "ImageSuggestionsEditor.CampaignContents.Stub"
+_IMAGES_CONTENT_TESTID_PREFIX = "ImageSuggestionsEditor.CampaignContents.ContentImage."
 _IMAGES_OPEN_MODAL_SELECTOR = '[data-testid="ImageSuggestionsEditor.Open"]'
 _IMAGES_MODAL_SELECTOR = '[data-testid="ImageSuggestionsEditorModal"]'
 _IMAGES_MODAL_FILE_INPUT_SELECTOR = (
@@ -1803,6 +1812,70 @@ def update_master(
     return result
 
 
+def _open_images_editor(page: "Page", campaign_id: int) -> List[str]:
+    """Navigate to the campaign's edit page and return its current image
+    content IDs, once the "Изображения" section has actually rendered.
+
+    The shared opening move of every ``masters adimages`` entry point:
+    ``goto`` + captcha/auth assertions + ``_wait_for_images_editor``. That
+    settle is what makes the returned list trustworthy — read any earlier
+    and a campaign that simply has not finished rendering is
+    indistinguishable from one that genuinely has no images (see
+    ``_wait_for_images_editor``).
+    """
+    page.goto(
+        WIZARD_EDIT_URL.format(campaign_id=campaign_id),
+        wait_until="domcontentloaded",
+    )
+    assert_not_captcha(page.content())
+    assert_authenticated(page.content())
+
+    _wait_for_images_editor(page)
+    return _read_image_content_ids(page)
+
+
+def fetch_master_images(page: "Page", campaign_id: int) -> Dict[str, Any]:
+    """Read a campaign's current image set — content IDs, 1-based
+    positions, and thumb URLs.
+
+    Read-only: opens the image manager modal to also read
+    ``_read_modal_selected_thumb_urls`` (the thumb URL is not exposed on
+    the edit page itself), then abandons it WITHOUT ever clicking Save —
+    safe, because nothing commits to the saved image set before Save (the
+    same invariant ``_set_image``'s docstring establishes). A campaign
+    with no images skips the modal entirely, there being nothing to read.
+
+    An empty image set is a legitimate, successful result (``Count: 0``),
+    not an error — unlike headlines/texts, images have no "at least one"
+    invariant (see ``_IMAGES_MAX_COUNT``'s module-level comment).
+    """
+    content_ids = _open_images_editor(page, campaign_id)
+
+    thumb_urls: Dict[str, Optional[str]] = {cid: None for cid in content_ids}
+    if content_ids:
+        _open_images_modal(page)
+        modal_ids = _read_image_content_ids(page)
+        panel_urls = _read_modal_selected_thumb_urls(page)
+        if len(modal_ids) == len(panel_urls):
+            thumb_urls.update(dict(zip(modal_ids, panel_urls)))
+
+    images = [
+        {
+            "Position": index + 1,
+            "ContentId": content_id,
+            "ThumbUrl": thumb_urls.get(content_id),
+        }
+        for index, content_id in enumerate(content_ids)
+    ]
+
+    return {
+        "CampaignId": campaign_id,
+        "Images": images,
+        "Count": len(content_ids),
+        "MaxCount": _IMAGES_MAX_COUNT,
+    }
+
+
 def _fill_landing_url(page: "Page", url: str) -> None:
     """Fill step 1's URL field and click "Далее" to advance to step 2.
 
@@ -2207,7 +2280,8 @@ def _read_testid_suffixes(
 
 
 def _wait_for_images_editor(page: "Page") -> None:
-    """Block until the edit page's "Изображения" section has rendered.
+    """Block until the edit page's "Изображения" section has rendered ITS
+    ACTUAL CONTENT, not just its outer container.
 
     The edit page is a client-rendered SPA — ``goto(...,
     wait_until="domcontentloaded")`` (what every entry point in this module
@@ -2232,10 +2306,12 @@ def _wait_for_images_editor(page: "Page") -> None:
     Returning as soon as the outer container exists (the original
     ``_IMAGES_EDITOR_SELECTOR``-only check) reproduces the exact bug this
     function's docstring already describes, just one render stage later:
-    a campaign that demonstrably has 4 images reads back as having none,
-    and ``--image`` then refuses to replace anything. This function now
-    also polls until no ``_IMAGES_STUB_TESTID_PREFIX`` element remains, so
-    a caller never observes the mid-render stub state.
+    ``masters adimages get`` on one of the campaigns above reported
+    ``Count: 0`` for a campaign that demonstrably has 4 images, and a
+    subsequent ``adimages add`` then uploaded into what it believed was an
+    empty set and timed out, because the true starting panel size was wrong.
+    This function now also polls until no ``_IMAGES_STUB_TESTID_PREFIX``
+    element remains, so a caller never observes the mid-render stub state.
 
     Absence of the section (or persistence of the stub state) after the
     timeout is reported as a hard error rather than silently treated as
@@ -2551,31 +2627,80 @@ def _verify_image_mismatches(
     touch is still there, and (c) the set size is unchanged (removed count
     == added count). A rejected/failed upload would leave a replaced ID
     still present, which (a) catches.
+
+    Thin wrapper over ``_verify_image_set_mismatches``: a point replacement
+    is that general absolute-end-state check with ``expected_added_count``
+    pinned to ``len(replaced_ids)``. Kept as its own function because
+    ``update_master``/``_verify_saved`` call it with the before/replaced
+    vocabulary, and because the empty-``replaced_ids`` early return is
+    specific to ``--image`` (nothing requested ⇒ nothing to verify),
+    whereas the general version must still assert an empty end state for
+    ``adimages delete --all``.
     """
     if not replaced_ids:
         return []
 
-    # ``_verify_saved`` re-navigates before calling this, so the section is
-    # once again mid-render — reading straight away would report every image
+    # A point replacement is the special case of the general absolute
+    # end-state check where exactly as many images are added back as were
+    # removed, so this delegates rather than repeating the three checks.
+    # ``_verify_image_set_mismatches`` performs the ``_wait_for_images_editor``
+    # settle its own callers need for the same post-reload reason.
+    return _verify_image_set_mismatches(
+        page,
+        expected_kept_ids=[cid for cid in before_ids if cid not in replaced_ids],
+        removed_ids=replaced_ids,
+        expected_added_count=len(replaced_ids),
+    )
+
+
+def _verify_image_set_mismatches(
+    page: "Page",
+    *,
+    expected_kept_ids: List[str],
+    removed_ids: Set[str],
+    expected_added_count: int,
+) -> List[str]:
+    """Re-read the campaign's saved image set and confirm it matches an
+    ABSOLUTE expected end state: every ``removed_ids`` gone, every
+    ``expected_kept_ids`` still present, and the total size equal to
+    ``len(expected_kept_ids) + expected_added_count``.
+
+    Sibling of ``_verify_image_mismatches`` (left untouched — ``update_master``
+    /``_verify_saved`` and ``TestVerifyImageMismatches`` depend on its exact
+    signature), generalizing that function's hardcoded "removed count ==
+    added count" assumption for callers where the two counts routinely
+    differ (e.g. deleting 3 and adding 0, or deleting all N and adding M
+    — the bulk image mutations that build on this). Uploaded images get a
+    Yandex-assigned
+    content ID that is not known ahead of time, so newly added images are
+    verified by COUNT only, never by identity — a real limitation of this
+    browser surface, not an oversight.
+
+    Unlike ``_verify_image_mismatches``, this does NOT early-return when
+    ``removed_ids`` is empty — ``expected_kept_ids=[]`` with
+    ``expected_added_count=0`` (removing every image) must still assert
+    the saved set is actually empty.
+    """
+    # Callers re-navigate before calling this, so the section is once
+    # again mid-render — reading straight away would report every image
     # as missing (see ``_wait_for_images_editor``).
     _wait_for_images_editor(page)
     actual_ids = set(_read_image_content_ids(page))
-    kept_ids = [cid for cid in before_ids if cid not in replaced_ids]
 
     mismatches = []
-    still_present = sorted(replaced_ids & actual_ids)
+    still_present = sorted(removed_ids & actual_ids)
     if still_present:
         mismatches.append(
-            "image(s) that should have been replaced are still present: "
+            "image(s) that should have been removed are still present: "
             + ", ".join(still_present)
         )
-    missing_kept = sorted(cid for cid in kept_ids if cid not in actual_ids)
+    missing_kept = sorted(cid for cid in expected_kept_ids if cid not in actual_ids)
     if missing_kept:
         mismatches.append(
             "image(s) that should have been left untouched are now "
             "missing: " + ", ".join(missing_kept)
         )
-    expected_size = len(kept_ids) + len(replaced_ids)
+    expected_size = len(expected_kept_ids) + expected_added_count
     if len(actual_ids) != expected_size:
         mismatches.append(
             f"image set now has {len(actual_ids)} image(s), expected "

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -12,7 +12,11 @@ wrapper around.
 
 Read-only: ``list`` and ``get``. Mutations: ``suspend``/``resume`` (issue
 #630) and ``add`` (issue #632, create — NOT idempotent, no sandbox/rollback,
-see ``add``'s own docstring).
+see ``add``'s own docstring). ``update`` (issue #631) edits a campaign's
+settings, including point-replacement of individual images via
+``--image``. ``adimages get`` (issue #648) reads a campaign's whole image
+set, mirroring the API-side ``direct adimages get`` vocabulary and
+treating an empty set as legitimate (unlike ``update --image``).
 
 No ``--login``/agency support (issue #639): this group only ever reads the
 logged-in user's own account, so it needs no Yandex Direct credentials at
@@ -644,6 +648,49 @@ def _validate_image_paths(parsed_images: "dict[int, str]") -> None:
                 f"--image path {raw_path!r} (slot {slot}) has an unsupported "
                 f"extension {path.suffix!r} — Yandex accepts PNG, JPEG, or GIF."
             )
+
+
+@masters.group("adimages")
+def adimages():
+    """Manage a Мастер кампаний campaign's image set (browser-driven, no API)
+
+    Мастер кампаний has no Yandex Direct API surface (see this module's own
+    docstring), so unlike ``direct adimages get/add/delete`` (API-backed ad
+    images, ``direct_cli/commands/adimages.py``) every subcommand here drives
+    a real browser session against the campaign's edit page. The vocabulary
+    is deliberately the same.
+
+    Unlike ``masters update --image`` (point-replacement of one existing
+    image only, refuses on an empty set), this group treats an empty image
+    set as a completely normal state — a campaign can legitimately have
+    zero images, exactly like ad images on a text ad via the API.
+    """
+
+
+@adimages.command("get")
+@click.argument("campaign_id", type=int)
+@_masters_browser_options
+@click.pass_context
+@handle_api_errors
+def adimages_get(
+    ctx, campaign_id, headful, profile_dir, chrome_profile, output_format, output
+):
+    """Get a Мастер кампаний campaign's current image set
+
+    An empty set is a valid, successful result (``Count: 0``), not an
+    error — see the ``adimages`` group's docstring.
+    """
+    from ..browser.masters import fetch_master_images
+
+    result = _with_session(
+        ctx,
+        headful,
+        profile_dir,
+        chrome_profile,
+        lambda page: fetch_master_images(page, campaign_id),
+    )
+
+    format_output(result, output_format, output)
 
 
 @masters.command()

--- a/direct_cli/smoke_matrix.py
+++ b/direct_cli/smoke_matrix.py
@@ -50,6 +50,11 @@ SMOKE_MATRIX = {
         "keywordsresearch.deduplicate",
         "keywordsresearch.has-search-volume",
         "leads.get",
+        "masters.adimages.get",
+        # Read-only: opens the image manager modal to read thumb URLs but
+        # never clicks Save (see fetch_master_images's docstring) — nothing
+        # commits to the campaign, so this is safe to exercise like any
+        # other *.get.
         "masters.get",
         "masters.list",
         "negativekeywordsharedsets.get",

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -3600,6 +3600,36 @@ class TestMastersUpdateCommand(unittest.TestCase):
                 self.assertEqual(mock_update.call_args.kwargs["images"], {1: f.name})
 
 
+class TestMastersAdimagesCommand(unittest.TestCase):
+    """CLI wiring for `masters adimages get/add/delete/set`."""
+
+    def setUp(self):
+        self.runner = CliRunner()
+
+    def test_group_registered(self):
+        result = self.runner.invoke(cli, ["masters", "adimages", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        for leaf in ("get", "add", "delete", "set"):
+            self.assertIn(leaf, result.output)
+
+    def test_get_help_registered(self):
+        result = self.runner.invoke(cli, ["masters", "adimages", "get", "--help"])
+        self.assertEqual(result.exit_code, 0)
+
+    def test_get_calls_fetch_master_images(self):
+        with (
+            patch("direct_cli.browser.masters.fetch_master_images") as mock_fetch,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_fetch.return_value = {"CampaignId": 42, "Images": [], "Count": 0}
+            result = self.runner.invoke(cli, ["masters", "adimages", "get", "42"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        mock_fetch.assert_called_once()
+        self.assertEqual(mock_fetch.call_args.args[1], 42)
+
+
 class TestMastersLoginCommand(unittest.TestCase):
     """CLI wiring for `masters login` (issue #635)."""
 
@@ -4499,6 +4529,9 @@ class _FakeImagesPage(FakePage):
         # without depending on upload ordering internals.
         self._upload_ids = list(upload_ids or [])
         self._upload_call = 0
+        # Every path passed to set_input_files(), in call order — lets
+        # upload tests assert sequencing.
+        self.upload_paths = []
 
     def locator(self, selector):
         if selector == browser_masters._IMAGES_EDITOR_SELECTOR:
@@ -4574,6 +4607,7 @@ class _FakeImagesPage(FakePage):
         return f"{browser_masters._IMAGES_MODAL_SELECTED_PREFIX}{content_id}"
 
     def _upload(self, path):
+        self.upload_paths.append(path)
         if self._upload_call < len(self._upload_ids):
             new_id = self._upload_ids[self._upload_call]
         else:
@@ -4657,9 +4691,10 @@ class TestWaitForImagesEditor(unittest.TestCase):
         loading placeholders, and NEITHER ``ContentImage.*`` nor ``.Open``
         exist yet — only ~3s later do the stubs get replaced by the real
         content. Waiting on ``_IMAGES_EDITOR_SELECTOR`` alone (the original
-        implementation) returned during this stub window, so a campaign
-        that demonstrably had 4 images read back as having none and
-        ``masters update --image`` refused to replace anything.
+        implementation) returned during this stub window, so
+        ``masters adimages get`` reported ``Count: 0`` for a campaign that
+        demonstrably had 4 images, and a subsequent ``adimages add`` then
+        uploaded into what it believed was an empty set and timed out.
         """
 
         class _StubThenContentPage(_FakeImagesPage):
@@ -4817,6 +4852,148 @@ class TestSetImage(unittest.TestCase):
 
         self.assertIn("still shown", str(ctx.exception).lower())
         self.assertEqual(page.save_clicks, [])
+
+
+class TestVerifyImageSetMismatches(unittest.TestCase):
+    """``_verify_image_set_mismatches`` — absolute end-state verification
+    generalizing ``_verify_image_mismatches``'s hardcoded "removed count ==
+    added count" assumption, so ``masters adimages add/delete/set`` can each
+    state their own expected end size.
+    """
+
+    def test_no_mismatches_when_end_state_matches(self):
+        page = _FakeImagesPage(["a", "c", "new"])  # "b" removed, "new" added
+
+        mismatches = browser_masters._verify_image_set_mismatches(
+            page,
+            expected_kept_ids=["a", "c"],
+            removed_ids={"b"},
+            expected_added_count=1,
+        )
+
+        self.assertEqual(mismatches, [])
+
+    def test_asserts_the_set_is_now_empty(self):
+        """The ``delete --all`` / ``set`` with no files case — the old
+        ``_verify_image_mismatches`` couldn't express this at all."""
+        page = _FakeImagesPage([])
+
+        mismatches = browser_masters._verify_image_set_mismatches(
+            page,
+            expected_kept_ids=[],
+            removed_ids={"a", "b", "c"},
+            expected_added_count=0,
+        )
+
+        self.assertEqual(mismatches, [])
+
+    def test_flags_a_leftover_image_when_set_should_be_empty(self):
+        page = _FakeImagesPage(["leftover"])
+
+        mismatches = browser_masters._verify_image_set_mismatches(
+            page,
+            expected_kept_ids=[],
+            removed_ids={"a"},
+            expected_added_count=0,
+        )
+
+        self.assertTrue(any("expected 0" in m for m in mismatches))
+
+    def test_flags_a_removed_id_still_present(self):
+        page = _FakeImagesPage(["a", "b"])
+
+        mismatches = browser_masters._verify_image_set_mismatches(
+            page, expected_kept_ids=[], removed_ids={"a", "b"}, expected_added_count=0
+        )
+
+        self.assertTrue(any("still present" in m for m in mismatches))
+
+    def test_flags_a_kept_id_that_went_missing(self):
+        page = _FakeImagesPage(["a"])
+
+        mismatches = browser_masters._verify_image_set_mismatches(
+            page,
+            expected_kept_ids=["a", "b"],
+            removed_ids=set(),
+            expected_added_count=0,
+        )
+
+        self.assertTrue(any("missing" in m for m in mismatches))
+
+    def test_flags_wrong_end_size_with_both_numbers(self):
+        page = _FakeImagesPage(["a", "b", "c"])
+
+        mismatches = browser_masters._verify_image_set_mismatches(
+            page, expected_kept_ids=["a"], removed_ids=set(), expected_added_count=1
+        )
+
+        self.assertTrue(any("has 3 image(s), expected 2" in m for m in mismatches))
+
+
+class TestFetchMasterImages(unittest.TestCase):
+    """``fetch_master_images`` — read-only, never saves."""
+
+    def test_returns_positions_content_ids_and_thumb_urls(self):
+        page = _FakeImagesPage(["a", "b", "c"])
+
+        result = browser_masters.fetch_master_images(page, 42)
+
+        self.assertEqual(result["CampaignId"], 42)
+        self.assertEqual(result["Count"], 3)
+        self.assertEqual(result["MaxCount"], browser_masters._IMAGES_MAX_COUNT)
+        self.assertEqual(
+            result["Images"],
+            [
+                {"Position": 1, "ContentId": "a", "ThumbUrl": "a"},
+                {"Position": 2, "ContentId": "b", "ThumbUrl": "b"},
+                {"Position": 3, "ContentId": "c", "ThumbUrl": "c"},
+            ],
+        )
+        self.assertEqual(page.save_clicks, [])
+
+    def test_empty_set_is_a_successful_result_not_an_error(self):
+        page = _FakeImagesPage([])
+
+        result = browser_masters.fetch_master_images(page, 42)
+
+        self.assertEqual(result["Count"], 0)
+        self.assertEqual(result["Images"], [])
+        self.assertEqual(page.save_clicks, [])
+
+    def test_never_clicks_save(self):
+        """The modal opens to read thumb URLs, but is abandoned rather than
+        Saved — nothing commits to the saved image set (see
+        ``fetch_master_images``'s docstring: same abandon-safe invariant
+        ``_set_image`` relies on)."""
+        page = _FakeImagesPage(["a", "b"])
+
+        browser_masters.fetch_master_images(page, 42)
+
+        self.assertEqual(page.save_clicks, [])
+
+    def test_empty_set_never_opens_the_modal(self):
+        """Nothing to read a thumb URL for, so the modal stays shut."""
+        page = _FakeImagesPage([])
+
+        result = browser_masters.fetch_master_images(page, 42)
+
+        self.assertEqual(result["Count"], 0)
+        self.assertFalse(page.modal_open)
+
+    def test_unrendered_editor_raises_rather_than_reporting_no_images(self):
+        class _NoEditorPage(_FakeImagesPage):
+            def locator(self, selector):
+                if selector == browser_masters._IMAGES_EDITOR_SELECTOR:
+                    return _FakeLocator([])
+                return super().locator(selector)
+
+        page = _NoEditorPage([])
+        with patch.object(browser_masters, "_IMAGES_EDITOR_TIMEOUT_MS", 1):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters.fetch_master_images(page, 42)
+
+        self.assertIn("did not finish rendering", str(ctx.exception))
+        self.assertNotIn("no images", str(ctx.exception).lower())
 
 
 class TestVerifyImageMismatches(unittest.TestCase):


### PR DESCRIPTION
> Стек: базируется на #674 (`pr/recurse-command-tree-walkers`). Ретаргетить на родителя/`main` по мере мержа стека.

У Мастера кампаний нет API-поверхности в Яндекс Директе, поэтому `masters update --image` (#672) — сейчас единственный способ тронуть изображения кампании, и он умеет только ЗАМЕНИТЬ одно существующее, отказываясь на пустом наборе. Посмотреть, какие изображения у кампании есть, нельзя вообще никак.

Добавляет читающую половину браузерного аналога API-группы `direct adimages`, намеренно переиспользуя её словарь:

```
direct masters adimages get 72349978
```

Показывает `Position` (1-based), `ContentId` и `ThumbUrl` по каждому изображению, плюс `Count` и `MaxCount`. ПУСТОЙ набор — успешный результат (`Count: 0`), а не ошибка: изображения на кампании МК опциональны, ровно как ad images у текстового объявления через API — инварианта «хотя бы одно», как у заголовков и текстов, здесь нет.

Read-only. URL миниатюры на самой странице редактирования не выставлен, поэтому команда открывает модалку менеджера изображений, чтобы его прочитать, и покидает модалку, ни разу не нажав «Сохранить» — ничего не коммитится (тот же abandon-safe инвариант, на который уже опирается `_set_image`). Кампания без изображений модалку не открывает вовсе.

Заодно обобщён верификатор: `_verify_image_mismatches` теперь делегирует новому `_verify_image_set_mismatches`, который проверяет АБСОЛЮТНОЕ ожидаемое конечное состояние вместо допущения «удалено == добавлено». Точечная замена — та же проверка с двумя счётчиками, приравненными друг к другу, поэтому существующее поведение не меняется (`TestVerifyImageMismatches` проходит без правок). Обобщение — то, что позволит будущему вызывающему «удали все изображения» проверить, что набор действительно пуст, чего старая форма выразить не могла.

`masters adimages get` — первая трёхуровневая команда CLI; обходчики сделаны рекурсивными в предыдущем PR, поэтому здесь добавляется только SAFE-запись в матрицу.

Refs #648

🤖 Generated with [Claude Code](https://claude.com/claude-code)