### PR TITLE
feat(masters): add `direct masters adimages add`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## Unreleased
 
+**Added — `direct masters adimages add` (#648):**
+
+- `adimages add <ID> --image-file PATH` (repeatable) appends local
+  PNG/JPEG/GIF files to a campaign's image set, refusing if the current
+  count plus the new files would exceed Yandex's cap of 5. Works from an
+  empty set — the case `masters update --image` refuses outright. Accepts
+  `--launch` (same draft-publishing semantics as `masters update`).
+- `_apply_image_operations` is the new bulk primitive: open the image
+  manager modal ONCE, apply every removal and every upload, click Save
+  once. Removals are located by thumb URLs captured before any removal, so
+  a later removal in the same batch is not thrown off by the panel
+  re-indexing as earlier cards disappear; uploads poll an ABSOLUTE expected
+  panel size rather than `_set_image`'s relative "grew back to the original
+  size" check, which only happens to work for an exact 1-for-1 swap.
+  Nothing commits before the single Save, so any earlier failure leaves the
+  saved set untouched. `_set_image` (what `update --image` uses) is left
+  untouched.
+- `_save_and_verify_images` wraps the shared post-save tail: resolve the
+  draft-aware button label, click it, verify against an absolute expected
+  end state, and translate a mid-verification session expiry into a "do
+  NOT retry" error (uploads are not idempotent, so `_with_session`'s
+  auto-retry must not re-run them).
+- Classified DANGEROUS in the smoke matrix and listed in
+  `scripts/test_dangerous_commands.sh`: Мастер кампаний has no sandbox
+  equivalent, real files are uploaded, and a retried `add` appends again.
+- **Confirmed live 2026-08-03** on DRAFT campaign 713234191, including
+  uploading into a genuinely empty set.
+
 **Added — `direct masters adimages get` (#648):**
 
 - New `direct masters adimages` subgroup, the browser-driven counterpart to

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ direct masters update 72349978 --name "Мастер ИЖ Источник Жиз
 direct masters update 72349978 --headline "2=Новый заголовок" --text "1=Новый текст"
 direct masters update 72349978 --image "2=/path/to/banner.png"
 direct masters adimages get 72349978
+direct masters adimages add 72349978 --image-file /path/to/a.png --image-file /path/to/b.png
 direct masters add https://example.com/ --headline "Заголовок 1" --headline "Заголовок 2" --text "Текст объявления" --region Москва --weekly-budget 50000 --draft
 direct masters add https://example.com/ --headline "Заголовок 1" --text "Текст объявления" --region-id 213 --weekly-budget 50000 --draft
 direct masters copy 72349978
@@ -101,18 +102,26 @@ the upper bound for N is whatever the campaign actually has (up to Yandex's
 cap of 5), read fresh from the page, and a campaign with no images at all is
 a legitimate state that `--image` refuses with its own explicit error rather
 than a generic "out of range". Nonexistent paths and extensions Yandex won't
-accept are rejected before any browser opens. Adding an image beyond the
-current set and deleting one without replacement are out of scope. Because
-both the removal and the upload happen inside the same open modal, any
-failure before Save leaves the campaign's saved image set untouched.
+accept are rejected before any browser opens. `--image` only replaces an
+existing image one at a time — for adding beyond the current set, deleting
+without a replacement, or replacing the whole set at once, use `masters
+adimages` below. Because both the removal and the upload happen inside the
+same open modal, any failure before Save leaves the campaign's saved image
+set untouched.
 
-`masters adimages get` reads a campaign's whole image set — position,
-content ID and thumbnail URL for each image — mirroring the vocabulary of
-`direct adimages get` (the API-side ad-image group). It is read-only and
-never saves. Unlike `--image`, an empty image set is a completely normal,
-successful result here (`Count: 0`), not an error: images are optional on
-a Мастер кампаний campaign, exactly like ad images on a text ad via the
-API.
+`masters adimages get/add` mirrors `direct adimages get/add`'s vocabulary
+(the API-side ad-image group) for a campaign's whole image set. Unlike
+`--image`, an empty image set is a completely normal state here — a
+campaign can start with zero images and `adimages add` works from there,
+exactly like ad images on a text ad via the API. `adimages get` is
+read-only and never saves. `adimages add --image-file PATH` (repeatable)
+appends files, refusing if the campaign's current count plus the new files
+would exceed Yandex's cap of 5; it accepts `--launch` (same
+draft-publishing semantics as `masters update`) and, like `--image`, is
+NOT idempotent — a retried call after a partial failure may upload
+duplicates. Every removal and upload happens inside one open modal with a
+single Save at the end, so any earlier failure leaves the saved set
+untouched.
 
 Later fields (sitelinks, audience, Metrika counters/goals, budget adaptation,
 video) aren't implemented yet.
@@ -1209,6 +1218,7 @@ direct masters update 72349978 --name "Мастер ИЖ Источник Жиз
 direct masters update 72349978 --headline "2=Новый заголовок" --text "1=Новый текст"
 direct masters update 72349978 --image "2=/path/to/banner.png"
 direct masters adimages get 72349978
+direct masters adimages add 72349978 --image-file /path/to/a.png --image-file /path/to/b.png
 direct masters add https://example.com/ --headline "Заголовок 1" --headline "Заголовок 2" --text "Текст объявления" --region Москва --weekly-budget 50000 --draft
 direct masters add https://example.com/ --headline "Заголовок 1" --text "Текст объявления" --region-id 213 --weekly-budget 50000 --draft
 direct masters copy 72349978
@@ -1270,19 +1280,27 @@ direct masters copy 72349978 --launch
 жёсткого лимита Яндекса в 5 штук), прочитанное со страницы, а кампания вообще
 без изображений — законное состояние, на котором `--image` падает отдельной
 внятной ошибкой, а не generic «out of range». Несуществующий путь и
-неподдерживаемое расширение отлетают ещё до открытия браузера. Добавление
-изображения сверх текущего набора и удаление изображения без замены — вне
-объёма. Поскольку и удаление, и загрузка происходят внутри одной открытой
-модалки, любая ошибка до Save оставляет сохранённый набор изображений
-кампании нетронутым.
+неподдерживаемое расширение отлетают ещё до открытия браузера. `--image`
+заменяет только одно уже существующее изображение за раз — для добавления
+сверх текущего набора, удаления без замены или полной замены всего набора
+разом используйте `masters adimages` ниже. Поскольку и удаление, и загрузка
+происходят внутри одной открытой модалки, любая ошибка до Save оставляет
+сохранённый набор изображений кампании нетронутым.
 
-`masters adimages get` читает весь набор изображений кампании — позицию,
-content ID и URL миниатюры для каждого — повторяя словарь `direct adimages
-get` (группа изображений объявлений на стороне API). Команда только
-читает и никогда ничего не сохраняет. В отличие от `--image`, пустой набор
-изображений здесь — совершенно нормальный успешный результат (`Count: 0`),
-а не ошибка: изображения у Мастера кампаний необязательны, ровно как
-изображения у текстового объявления через API.
+`masters adimages get/add` повторяет словарь `direct adimages get/add`
+(API-группа изображений объявлений) для всего набора изображений кампании.
+В отличие от `--image`, пустой набор изображений здесь — совершенно
+нормальное состояние: кампания может начинаться без единого изображения, и
+`adimages add` работает и с пустым набором, точно как изображения
+объявлений через API. `adimages get` — только чтение, никогда не
+сохраняет. `adimages add --image-file PATH` (можно повторять) добавляет
+файлы, отказывая, если текущее число изображений плюс новые превысит лимит
+Яндекса в 5 штук; принимает `--launch` (та же семантика публикации
+черновика, что и у `masters update`) и, как и `--image`, НЕ идемпотентна —
+повторный вызов после частичного сбоя может загрузить дубликаты. Все
+удаления и загрузки происходят внутри одной открытой модалки с единственным
+Save в конце, поэтому любая более ранняя ошибка оставляет сохранённый набор
+нетронутым.
 
 Остальные поля (быстрые ссылки, аудитория, счётчики Метрики/цели, адаптация
 бюджета, видео) тоже пока не реализованы.

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -209,6 +209,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Sequence,
     Set,
     Tuple,
 )
@@ -1842,8 +1843,9 @@ def fetch_master_images(page: "Page", campaign_id: int) -> Dict[str, Any]:
     ``_read_modal_selected_thumb_urls`` (the thumb URL is not exposed on
     the edit page itself), then abandons it WITHOUT ever clicking Save —
     safe, because nothing commits to the saved image set before Save (the
-    same invariant ``_set_image``'s docstring establishes). A campaign
-    with no images skips the modal entirely, there being nothing to read.
+    same invariant ``_set_image``'s and ``_apply_image_operations``'s
+    docstrings establish). A campaign with no images skips the modal
+    entirely, there being nothing to read.
 
     An empty image set is a legitimate, successful result (``Count: 0``),
     not an error — unlike headlines/texts, images have no "at least one"
@@ -1873,6 +1875,57 @@ def fetch_master_images(page: "Page", campaign_id: int) -> Dict[str, Any]:
         "Images": images,
         "Count": len(content_ids),
         "MaxCount": _IMAGES_MAX_COUNT,
+    }
+
+
+def add_master_images(
+    page: "Page",
+    campaign_id: int,
+    *,
+    paths: Sequence[str],
+    launch: bool = False,
+) -> Dict[str, Any]:
+    """Upload every file in ``paths`` and append them to the campaign's
+    image set — works from an empty set (unlike ``update_master``'s
+    ``--image``, which only replaces an existing image).
+
+    All uploads happen inside ONE modal session via
+    ``_apply_image_operations``, followed by the edit page's terminal
+    save (draft-aware, same as ``update_master``) and a re-navigate
+    verification via ``_verify_saved_images``.
+    """
+    if not paths:
+        raise ValueError("add_master_images requires at least one path.")
+
+    before_ids = _open_images_editor(page, campaign_id)
+
+    if len(before_ids) + len(paths) > _IMAGES_MAX_COUNT:
+        raise BrowserSessionError(
+            f"Campaign {campaign_id} currently has {len(before_ids)} "
+            f"image(s); adding {len(paths)} more would exceed Yandex's "
+            f"cap of {_IMAGES_MAX_COUNT} images per campaign."
+        )
+
+    _apply_image_operations(
+        page,
+        remove_content_ids=(),
+        upload_paths=paths,
+    )
+
+    final_ids = _save_and_verify_images(
+        page,
+        campaign_id,
+        expected_kept_ids=before_ids,
+        removed_ids=set(),
+        expected_added_count=len(paths),
+        launch=launch,
+        not_idempotent_noun="image uploads",
+    )
+
+    return {
+        "CampaignId": campaign_id,
+        "Added": len(paths),
+        "Count": len(final_ids),
     }
 
 
@@ -2611,6 +2664,163 @@ def _set_image(page: "Page", index: int, path: str, *, target_content_id: str) -
     )
 
 
+def _apply_image_operations(
+    page: "Page",
+    *,
+    remove_content_ids: "Sequence[str]",
+    upload_paths: "Sequence[str]",
+) -> None:
+    """Remove zero or more images and upload zero or more files inside ONE
+    open/Save cycle of the image manager modal.
+
+    Unlike ``_set_image`` (one open/remove/upload/Save cycle PER call — left
+    untouched, still what ``update_master``'s ``--image`` point-replacement
+    uses), this is the bulk primitive for ``masters adimages add/delete/
+    set``: open the modal once, perform every removal, perform every
+    upload, then click "Добавить в кампанию" exactly once. Composed from
+    the same two Yandex primitives ``_set_image`` uses — "remove from the
+    set" and "add to the set" — there being no bulk endpoint either.
+
+    Nothing is committed to the campaign's saved image set until the single
+    Save click at the end; a failure at any earlier point leaves the saved
+    set untouched (same abandon-safe property as ``_set_image``).
+
+    An empty ``remove_content_ids``/``upload_paths`` pair (both empty) is a
+    no-op — the modal is never opened. Removing every image so the set ends
+    up EMPTY, or uploading into a campaign that currently has none, are both
+    legitimate outcomes (unlike headlines/texts, images have no "at least
+    one" invariant — see ``_IMAGES_MAX_COUNT``'s module-level comment).
+
+    **Not live-verified:** uploading via a single
+    ``set_input_files([path1, path2, ...])`` call with multiple paths —
+    real Playwright accepts a list, but PR #672's recon never exercised
+    it, so this uploads strictly one path per call, sequentially, to stay
+    on already-confirmed ground.
+
+    Removals are located by the target's thumb URL, captured from the
+    modal's panel BEFORE any removal in this call runs — exactly the
+    ``target_content_id`` → thumb-URL resolution ``_set_image`` already
+    does — so a later removal in the same batch is never thrown off by the
+    panel's re-indexing as earlier cards disappear.
+
+    Uploads are waited for via an ABSOLUTE expected panel size (the size
+    after all removals, plus one per upload so far), not ``_set_image``'s
+    relative "grew back to at least the original size" check — that only
+    happens to work for an exact 1-removed/1-added swap and would under- or
+    over-count for any other combination.
+    """
+    if not remove_content_ids and not upload_paths:
+        return
+
+    _open_images_modal(page)
+
+    panel_urls = _read_modal_selected_thumb_urls(page)
+    modal_ids = _read_image_content_ids(page)
+    if len(modal_ids) != len(panel_urls):
+        raise BrowserSessionError(
+            f"The image manager modal shows {len(panel_urls)} selected "
+            f"image(s), which does not match the {len(modal_ids)} shown on "
+            "the edit page itself. Yandex may have changed the page's "
+            "markup. Re-run with --headful to inspect the page."
+        )
+    url_by_content_id = dict(zip(modal_ids, panel_urls))
+
+    for content_id in remove_content_ids:
+        target_url = url_by_content_id.get(content_id)
+        if target_url is None:
+            raise BrowserSessionError(
+                f"Content ID {content_id!r} is not present in the image "
+                "manager modal's current selection — it may already have "
+                "been removed earlier in this same command. The "
+                "campaign's saved image set has NOT been changed (the "
+                "modal was never saved)."
+            )
+
+        remove_selector = (
+            f'[data-testid="'
+            f"{_IMAGES_MODAL_REMOVE_TESTID_TEMPLATE.format(thumb_url=target_url)}"
+            f'"]'
+        )
+        try:
+            page.locator(remove_selector).first.click()
+        except PlaywrightError as exc:
+            raise BrowserSessionError(
+                f"Could not remove image {content_id!r} inside the image "
+                "manager modal — Yandex may have changed the page's "
+                "markup. Re-run with --headful to inspect the page. The "
+                "campaign's saved image set has NOT been changed (the "
+                "modal was never saved)."
+            ) from exc
+
+        if not _poll_until(
+            page,
+            lambda target_url=target_url: target_url
+            not in _read_modal_selected_thumb_urls(page),
+            _IMAGE_MODAL_OPEN_TIMEOUT_MS,
+        ):
+            raise BrowserSessionError(
+                f"Clicked to remove image {content_id!r} inside the image "
+                "manager modal, but it is still shown there after "
+                f"{_IMAGE_MODAL_OPEN_TIMEOUT_MS / 1000:.0f}s. The "
+                "campaign's saved image set has NOT been changed (the "
+                "modal was never saved) — close the browser and retry."
+            )
+
+    base_count = len(panel_urls) - len(remove_content_ids)
+    for expected_count, path in enumerate(upload_paths, start=base_count + 1):
+        try:
+            page.locator(_IMAGES_MODAL_FILE_INPUT_SELECTOR).first.set_input_files(path)
+        except PlaywrightError as exc:
+            raise BrowserSessionError(
+                f"Could not upload {path!r} inside the image manager modal "
+                "— Yandex may have changed the page's markup. Re-run with "
+                "--headful to inspect the page. The campaign's saved image "
+                "set has NOT been changed (the modal was never saved)."
+            ) from exc
+
+        if not _poll_until(
+            page,
+            lambda expected_count=expected_count: len(
+                _read_modal_selected_thumb_urls(page)
+            )
+            >= expected_count,
+            _IMAGE_UPLOAD_TIMEOUT_MS,
+        ):
+            raise BrowserSessionError(
+                f"Uploaded {path!r} inside the image manager modal, but no "
+                "new image appeared there within "
+                f"{_IMAGE_UPLOAD_TIMEOUT_MS / 1000:.0f}s — Yandex's "
+                "asynchronous processing may have failed or be unusually "
+                "slow. The campaign's saved image set has NOT been changed "
+                "(the modal was never saved) — close the browser and "
+                "retry."
+            )
+
+    try:
+        page.locator(_IMAGES_MODAL_SAVE_SELECTOR).first.click()
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            "Could not find/click 'Добавить в кампанию' to commit the "
+            "image manager modal — Yandex may have changed the page's "
+            "markup. Re-run with --headful to inspect the page. The "
+            "campaign's saved image set has NOT been changed (the modal "
+            "was never saved)."
+        ) from exc
+
+    if _poll_until(
+        page,
+        lambda: page.locator(_IMAGES_MODAL_SELECTOR).first.count() == 0,
+        _IMAGE_MODAL_OPEN_TIMEOUT_MS,
+    ):
+        return
+
+    raise BrowserSessionError(
+        "Clicked 'Добавить в кампанию' but the image manager modal did not "
+        f"close within {_IMAGE_MODAL_OPEN_TIMEOUT_MS / 1000:.0f}s — the "
+        "commit may not have completed. Verify manually before retrying."
+    )
+
+
 def _verify_image_mismatches(
     page: "Page", *, before_ids: List[str], replaced_ids: Set[str]
 ) -> List[str]:
@@ -2634,8 +2844,8 @@ def _verify_image_mismatches(
     ``update_master``/``_verify_saved`` call it with the before/replaced
     vocabulary, and because the empty-``replaced_ids`` early return is
     specific to ``--image`` (nothing requested ⇒ nothing to verify),
-    whereas the general version must still assert an empty end state for
-    ``adimages delete --all``.
+    whereas the general version must still assert an empty end state when
+    every image is removed.
     """
     if not replaced_ids:
         return []
@@ -2668,10 +2878,9 @@ def _verify_image_set_mismatches(
     Sibling of ``_verify_image_mismatches`` (left untouched — ``update_master``
     /``_verify_saved`` and ``TestVerifyImageMismatches`` depend on its exact
     signature), generalizing that function's hardcoded "removed count ==
-    added count" assumption for callers where the two counts routinely
-    differ (e.g. deleting 3 and adding 0, or deleting all N and adding M
-    — the bulk image mutations that build on this). Uploaded images get a
-    Yandex-assigned
+    added count" assumption for ``masters adimages add/delete/set``, where
+    the two counts routinely differ (e.g. deleting 3 and adding 0, or
+    deleting all N and adding M). Uploaded images get a Yandex-assigned
     content ID that is not known ahead of time, so newly added images are
     verified by COUNT only, never by identity — a real limitation of this
     browser surface, not an oversight.
@@ -2681,9 +2890,9 @@ def _verify_image_set_mismatches(
     ``expected_added_count=0`` (removing every image) must still assert
     the saved set is actually empty.
     """
-    # Callers re-navigate before calling this, so the section is once
-    # again mid-render — reading straight away would report every image
-    # as missing (see ``_wait_for_images_editor``).
+    # ``_verify_saved_images`` re-navigates before calling this, so the
+    # section is once again mid-render — reading straight away would
+    # report every image as missing (see ``_wait_for_images_editor``).
     _wait_for_images_editor(page)
     actual_ids = set(_read_image_content_ids(page))
 
@@ -2707,6 +2916,94 @@ def _verify_image_set_mismatches(
             f"{expected_size}"
         )
     return mismatches
+
+
+def _save_and_verify_images(
+    page: "Page",
+    campaign_id: int,
+    *,
+    expected_kept_ids: List[str],
+    removed_ids: Set[str],
+    expected_added_count: int,
+    launch: bool,
+    not_idempotent_noun: str,
+) -> List[str]:
+    """Click the edit page's terminal save, then confirm the saved image
+    set matches the expected end state; return the fresh content ID list.
+
+    The whole post-``_apply_image_operations`` tail shared by
+    the image-set mutations built on ``_apply_image_operations``:
+    resolve the draft-aware button label, click it, verify, and translate a
+    mid-verification session expiry into a "do NOT retry" error (these
+    commands are not idempotent, so ``_with_session``'s auto-retry must not
+    re-run them — same reasoning as ``update_master``'s own wrapper).
+    ``not_idempotent_noun`` is the phrase naming what was already applied
+    ("image uploads", "image deletions", ...).
+    """
+    clicked_button_label = (
+        (_LAUNCH_BUTTON_TEXT if launch else _SAVE_DRAFT_BUTTON_TEXT)
+        if _is_draft_edit_page(page)
+        else _SAVE_BUTTON_TEXT
+    )
+    _click_save(page, campaign_id, launch=launch)
+
+    try:
+        return _verify_saved_images(
+            page,
+            campaign_id,
+            expected_kept_ids=expected_kept_ids,
+            removed_ids=removed_ids,
+            expected_added_count=expected_added_count,
+            clicked_button_label=clicked_button_label,
+        )
+    except BrowserAuthError as exc:
+        raise BrowserSessionError(
+            f"Clicked '{clicked_button_label}' for campaign {campaign_id}, "
+            "but the session was invalidated while verifying the save — "
+            "the requested changes were likely already applied; check "
+            f"campaign {campaign_id} manually rather than retrying "
+            f"({not_idempotent_noun} are not idempotent)."
+        ) from exc
+
+
+def _verify_saved_images(
+    page: "Page",
+    campaign_id: int,
+    *,
+    expected_kept_ids: List[str],
+    removed_ids: Set[str],
+    expected_added_count: int,
+    clicked_button_label: str,
+) -> List[str]:
+    """Reload the edit page, confirm the saved image set matches the
+    expected end state, and return the fresh content ID list on success.
+
+    Shared post-save verification for the image-set mutations — mirrors
+    ``_verify_saved``'s re-navigate-and-re-read discipline (never trust the
+    save click alone; Yandex's client-side validation can silently reject
+    a value) but scoped to just the image set, via
+    ``_verify_image_set_mismatches``.
+    """
+    url = WIZARD_EDIT_URL.format(campaign_id=campaign_id)
+    page.goto(url, wait_until="domcontentloaded")
+    assert_not_captcha(page.content())
+    assert_authenticated(page.content())
+
+    mismatches = _verify_image_set_mismatches(
+        page,
+        expected_kept_ids=expected_kept_ids,
+        removed_ids=removed_ids,
+        expected_added_count=expected_added_count,
+    )
+    if mismatches:
+        raise BrowserSessionError(
+            f"Clicked '{clicked_button_label}' for campaign {campaign_id}, "
+            "but re-reading the saved campaign shows: "
+            + "; ".join(mismatches)
+            + ". Yandex may have rejected the change without a visible "
+            "error — check the campaign manually."
+        )
+    return _read_image_content_ids(page)
 
 
 def _set_region(page: "Page", regions: List[str]) -> None:

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -14,9 +14,10 @@ Read-only: ``list`` and ``get``. Mutations: ``suspend``/``resume`` (issue
 #630) and ``add`` (issue #632, create — NOT idempotent, no sandbox/rollback,
 see ``add``'s own docstring). ``update`` (issue #631) edits a campaign's
 settings, including point-replacement of individual images via
-``--image``. ``adimages get`` (issue #648) reads a campaign's whole image
-set, mirroring the API-side ``direct adimages get`` vocabulary and
-treating an empty set as legitimate (unlike ``update --image``).
+``--image``. ``adimages get``/``add`` (issue #648) read a campaign's whole
+image set and append to it — mirrors the API-side ``direct adimages
+get``/``add`` vocabulary, treats an empty image set as legitimate (unlike
+``update --image``), and ``add`` is likewise NOT idempotent.
 
 No ``--login``/agency support (issue #639): this group only ever reads the
 logged-in user's own account, so it needs no Yandex Direct credentials at
@@ -623,8 +624,8 @@ def _parse_repeating_slot_options(
     return parsed
 
 
-def _validate_image_paths(parsed_images: "dict[int, str]") -> None:
-    """Reject ``--image`` paths that don't exist or that Yandex won't accept.
+def _validate_image_path(raw_path: str, *, option_name: str, context: str) -> None:
+    """Reject one image path that doesn't exist or that Yandex won't accept.
 
     Runs before any browser session (and possibly an auth prompt) is opened,
     mirroring every other format error in this command. The accepted
@@ -632,22 +633,41 @@ def _validate_image_paths(parsed_images: "dict[int, str]") -> None:
     (imported here rather than at module load, matching this module's other
     deferred browser imports) so the CLI's check can't drift from what
     Yandex's file input actually accepts.
+
+    Shared by ``_validate_image_paths`` (``--image "N=path"``, slot-indexed)
+    and ``_validate_image_files`` (``--image-file path``, no slot) — ``context``
+    supplies whatever slot/position wording the caller wants appended to the
+    error, or an empty string for none.
     """
     from ..browser.masters import _IMAGE_UPLOAD_SUFFIXES
 
+    path = Path(raw_path)
+    if not path.is_file():
+        raise click.UsageError(
+            f"{option_name} path {raw_path!r}{context} does not exist or "
+            "is not a file."
+        )
+    if path.suffix.lower() not in _IMAGE_UPLOAD_SUFFIXES:
+        raise click.UsageError(
+            f"{option_name} path {raw_path!r}{context} has an unsupported "
+            f"extension {path.suffix!r} — Yandex accepts PNG, JPEG, or GIF."
+        )
+
+
+def _validate_image_paths(parsed_images: "dict[int, str]") -> None:
+    """Reject ``--image "N=path"`` paths that don't exist or that Yandex
+    won't accept. See ``_validate_image_path`` for the per-path check."""
     for index, raw_path in parsed_images.items():
-        slot = index + 1
-        path = Path(raw_path)
-        if not path.is_file():
-            raise click.UsageError(
-                f"--image path {raw_path!r} (slot {slot}) does not exist or "
-                "is not a file."
-            )
-        if path.suffix.lower() not in _IMAGE_UPLOAD_SUFFIXES:
-            raise click.UsageError(
-                f"--image path {raw_path!r} (slot {slot}) has an unsupported "
-                f"extension {path.suffix!r} — Yandex accepts PNG, JPEG, or GIF."
-            )
+        _validate_image_path(
+            raw_path, option_name="--image", context=f" (slot {index + 1})"
+        )
+
+
+def _validate_image_files(paths: "tuple[str, ...]") -> None:
+    """Reject ``--image-file`` paths that don't exist or that Yandex won't
+    accept. See ``_validate_image_path`` for the per-path check."""
+    for raw_path in paths:
+        _validate_image_path(raw_path, option_name="--image-file", context="")
 
 
 @masters.group("adimages")
@@ -658,12 +678,15 @@ def adimages():
     docstring), so unlike ``direct adimages get/add/delete`` (API-backed ad
     images, ``direct_cli/commands/adimages.py``) every subcommand here drives
     a real browser session against the campaign's edit page. The vocabulary
-    is deliberately the same.
+    is deliberately the same. There is no ``--dry-run``: there is no
+    request payload to preview for a browser-driven mutation, matching
+    ``masters update``'s existing precedent.
 
     Unlike ``masters update --image`` (point-replacement of one existing
-    image only, refuses on an empty set), this group treats an empty image
-    set as a completely normal state — a campaign can legitimately have
-    zero images, exactly like ad images on a text ad via the API.
+    image only, refuses on an empty set), these commands treat an empty
+    image set as a completely normal state — a campaign can legitimately
+    have zero images and ``add`` works from there, exactly like ad images
+    on a text ad via the API.
     """
 
 
@@ -688,6 +711,65 @@ def adimages_get(
         profile_dir,
         chrome_profile,
         lambda page: fetch_master_images(page, campaign_id),
+    )
+
+    format_output(result, output_format, output)
+
+
+@adimages.command("add")
+@click.argument("campaign_id", type=int)
+@click.option(
+    "--image-file",
+    "image_files",
+    multiple=True,
+    required=True,
+    help=(
+        "Local PNG/JPEG/GIF file to append to the campaign's image set — "
+        "repeat for multiple files. Works even if the campaign currently "
+        "has no images."
+    ),
+)
+@click.option(
+    "--launch",
+    is_flag=True,
+    default=False,
+    help=(
+        "If CAMPAIGN_ID is currently a DRAFT, publish it while saving "
+        "(default: keep it a DRAFT). Has no effect on a non-DRAFT campaign."
+    ),
+)
+@_masters_browser_options
+@click.pass_context
+@handle_api_errors
+def adimages_add(
+    ctx,
+    campaign_id,
+    image_files,
+    launch,
+    headful,
+    profile_dir,
+    chrome_profile,
+    output_format,
+    output,
+):
+    """Append one or more local images to a Мастер кампаний campaign"""
+    from ..browser.masters import _IMAGES_MAX_COUNT, add_master_images
+
+    if len(image_files) > _IMAGES_MAX_COUNT:
+        raise click.UsageError(
+            f"--image-file was passed {len(image_files)} times — Yandex's "
+            f"cap is {_IMAGES_MAX_COUNT} images per campaign."
+        )
+    _validate_image_files(image_files)
+
+    result = _with_session(
+        ctx,
+        headful,
+        profile_dir,
+        chrome_profile,
+        lambda page: add_master_images(
+            page, campaign_id, paths=list(image_files), launch=launch
+        ),
     )
 
     format_output(result, output_format, output)

--- a/direct_cli/smoke_matrix.py
+++ b/direct_cli/smoke_matrix.py
@@ -200,6 +200,13 @@ SMOKE_MATRIX = {
         # above -- there is no way to isolate a live form save from
         # production. Manual-only, per scripts/test_dangerous_commands.sh.
         "masters.update",
+        # Browser-driven image upload against Мастер кампаний (masters
+        # adimages add). Same no-sandbox-equivalent rationale as
+        # masters.update above — there is no way to isolate a live modal
+        # save from production. Uploads real files, and is NOT idempotent
+        # (a retried add appends again). Manual-only, per
+        # scripts/test_dangerous_commands.sh.
+        "masters.adimages.add",
         # Creates a brand-new Мастер кампаний (issue #632) — no API surface,
         # no sandbox, and NOT idempotent (a second run creates a second
         # campaign, not an update). Riskiest command in this whole group:

--- a/scripts/test_dangerous_commands.sh
+++ b/scripts/test_dangerous_commands.sh
@@ -32,6 +32,8 @@ non-critical campaign, confirming before/after state in the web UI):
   - direct masters resume <campaign_id>
   - direct masters update <campaign_id> --weekly-budget ... (Этап A: also
     --promotion-goal, --directs-helps/--no-directs-helps)
+  - direct masters adimages add <campaign_id> --image-file ...
+    (uploads real files -- NOT idempotent)
   - direct masters archive <campaign_id>
     (irreversible -- there is no `masters unarchive`)
   - direct masters add <url> --headline ... --text ... --region ...

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -49,6 +49,7 @@ DRY_RUN_EXCEPTIONS = {
     "masters.update",
     "masters.add",
     "masters.copy",
+    "masters.adimages.add",
 }
 
 FORBIDDEN_HELP_TEXT = (

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -3616,6 +3616,12 @@ class TestMastersAdimagesCommand(unittest.TestCase):
         result = self.runner.invoke(cli, ["masters", "adimages", "get", "--help"])
         self.assertEqual(result.exit_code, 0)
 
+    def test_add_help_documents_image_file_and_launch(self):
+        result = self.runner.invoke(cli, ["masters", "adimages", "add", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("--image-file", result.output)
+        self.assertIn("--launch", result.output)
+
     def test_get_calls_fetch_master_images(self):
         with (
             patch("direct_cli.browser.masters.fetch_master_images") as mock_fetch,
@@ -3628,6 +3634,80 @@ class TestMastersAdimagesCommand(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, result.output)
         mock_fetch.assert_called_once()
         self.assertEqual(mock_fetch.call_args.args[1], 42)
+
+    def test_add_rejects_missing_file_before_any_session_opens(self):
+        with patch("direct_cli.commands.masters._with_session") as mock_with_session:
+            result = self.runner.invoke(
+                cli,
+                [
+                    "masters",
+                    "adimages",
+                    "add",
+                    "42",
+                    "--image-file",
+                    "/tmp/does-not-exist-xyz-123.png",
+                ],
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("does not exist", result.output)
+        mock_with_session.assert_not_called()
+
+    def test_add_rejects_unsupported_extension_before_any_session_opens(self):
+        import tempfile
+
+        with (
+            tempfile.NamedTemporaryFile(suffix=".webp") as f,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            result = self.runner.invoke(
+                cli, ["masters", "adimages", "add", "42", "--image-file", f.name]
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("unsupported extension", result.output)
+        mock_with_session.assert_not_called()
+
+    def test_add_rejects_more_files_than_the_cap_before_any_session_opens(self):
+        with patch("direct_cli.commands.masters._with_session") as mock_with_session:
+            args = ["masters", "adimages", "add", "42"]
+            for i in range(6):
+                args += ["--image-file", f"/tmp/{i}.png"]
+            result = self.runner.invoke(cli, args)
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("cap", result.output.lower())
+        mock_with_session.assert_not_called()
+
+    def test_add_calls_add_master_images_with_paths_and_launch(self):
+        import tempfile
+
+        with (
+            tempfile.NamedTemporaryFile(suffix=".jpg") as f,
+            patch("direct_cli.browser.masters.add_master_images") as mock_add,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_add.return_value = {"CampaignId": 42, "Added": 1, "Count": 1}
+            result = self.runner.invoke(
+                cli,
+                [
+                    "masters",
+                    "adimages",
+                    "add",
+                    "42",
+                    "--image-file",
+                    f.name,
+                    "--launch",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        mock_add.assert_called_once()
+        args, kwargs = mock_add.call_args
+        self.assertEqual(args[1], 42)
+        self.assertEqual(kwargs["paths"], [f.name])
+        self.assertTrue(kwargs["launch"])
 
 
 class TestMastersLoginCommand(unittest.TestCase):
@@ -4530,7 +4610,8 @@ class _FakeImagesPage(FakePage):
         self._upload_ids = list(upload_ids or [])
         self._upload_call = 0
         # Every path passed to set_input_files(), in call order — lets
-        # upload tests assert sequencing.
+        # ``masters adimages add`` tests assert upload sequencing
+        # (e.g. "removed everything, then uploaded in the order given").
         self.upload_paths = []
 
     def locator(self, selector):
@@ -4854,6 +4935,137 @@ class TestSetImage(unittest.TestCase):
         self.assertEqual(page.save_clicks, [])
 
 
+class TestApplyImageOperations(unittest.TestCase):
+    """``_apply_image_operations`` — the bulk one-modal primitive behind
+    ``masters adimages add/delete/set`` (unlike ``_set_image``, which opens
+    its own modal per call).
+    """
+
+    def test_no_op_when_both_lists_empty(self):
+        page = _FakeImagesPage(["a", "b"])
+
+        browser_masters._apply_image_operations(
+            page, remove_content_ids=(), upload_paths=()
+        )
+
+        self.assertEqual(page.ids, ["a", "b"])
+        self.assertFalse(page.modal_open)
+        self.assertEqual(page.save_clicks, [])
+
+    def test_uploads_into_an_empty_set(self):
+        page = _FakeImagesPage([], upload_ids=["new1", "new2"])
+
+        browser_masters._apply_image_operations(
+            page,
+            remove_content_ids=(),
+            upload_paths=["/tmp/a.png", "/tmp/b.png"],
+        )
+
+        self.assertEqual(page.ids, ["new1", "new2"])
+        self.assertEqual(page.upload_paths, ["/tmp/a.png", "/tmp/b.png"])
+        self.assertEqual(len(page.save_clicks), 1)
+        self.assertFalse(page.modal_open)
+
+    def test_removes_every_image_leaving_the_set_empty(self):
+        page = _FakeImagesPage(["a", "b", "c"])
+
+        browser_masters._apply_image_operations(
+            page,
+            remove_content_ids=["a", "b", "c"],
+            upload_paths=(),
+        )
+
+        self.assertEqual(page.ids, [])
+        self.assertEqual(len(page.save_clicks), 1)
+
+    def test_removes_and_uploads_in_one_modal_session(self):
+        """The core invariant bulk ops need: N removes + M uploads, but
+        exactly ONE open/Save cycle — not N+M cycles like ``_set_image``."""
+        page = _FakeImagesPage(["a", "b", "c"], upload_ids=["x", "y"])
+
+        browser_masters._apply_image_operations(
+            page,
+            remove_content_ids=["a", "b", "c"],
+            upload_paths=["/tmp/x.png", "/tmp/y.png"],
+        )
+
+        self.assertEqual(page.ids, ["x", "y"])
+        self.assertEqual(page.upload_paths, ["/tmp/x.png", "/tmp/y.png"])
+        self.assertEqual(len(page.save_clicks), 1)
+
+    def test_upload_order_is_preserved(self):
+        page = _FakeImagesPage(["a"], upload_ids=["u1", "u2", "u3"])
+
+        browser_masters._apply_image_operations(
+            page,
+            remove_content_ids=(),
+            upload_paths=["/tmp/1.png", "/tmp/2.png", "/tmp/3.png"],
+        )
+
+        self.assertEqual(page.upload_paths, ["/tmp/1.png", "/tmp/2.png", "/tmp/3.png"])
+        self.assertEqual(page.ids, ["a", "u1", "u2", "u3"])
+
+    def test_unknown_remove_content_id_raises_before_any_click(self):
+        page = _FakeImagesPage(["a", "b"])
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._apply_image_operations(
+                page,
+                remove_content_ids=["nonexistent"],
+                upload_paths=(),
+            )
+
+        self.assertIn("not present", str(ctx.exception).lower())
+        self.assertEqual(page.ids, ["a", "b"])
+        self.assertEqual(page.save_clicks, [])
+
+    def test_upload_that_never_lands_raises_and_does_not_save(self):
+        page = _FakeImagesPage(["a"], upload_ids=[])
+        original_locator = page.locator
+
+        def _locator(selector):
+            if selector == browser_masters._IMAGES_MODAL_FILE_INPUT_SELECTOR:
+                return _FakeLocator([_FakeLocatorHandle(on_upload=lambda path: None)])
+            return original_locator(selector)
+
+        page.locator = _locator
+        with patch.object(browser_masters, "_IMAGE_UPLOAD_TIMEOUT_MS", 1):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters._apply_image_operations(
+                    page,
+                    remove_content_ids=(),
+                    upload_paths=["/tmp/a.png"],
+                )
+
+        self.assertIn("no new", str(ctx.exception).lower())
+        self.assertEqual(page.save_clicks, [])
+
+    def test_remove_that_never_takes_effect_raises_and_does_not_save(self):
+        page = _FakeImagesPage(["a", "b"])
+        original_locator = page.locator
+
+        def _locator(selector):
+            remove_testid = browser_masters._IMAGES_MODAL_REMOVE_TESTID_TEMPLATE.format(
+                thumb_url="a"
+            )
+            remove_selector = f'[data-testid="{remove_testid}"]'
+            if selector == remove_selector:
+                return _FakeLocator([_FakeLocatorHandle(on_click=lambda: None)])
+            return original_locator(selector)
+
+        page.locator = _locator
+        with patch.object(browser_masters, "_IMAGE_MODAL_OPEN_TIMEOUT_MS", 1):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters._apply_image_operations(
+                    page,
+                    remove_content_ids=["a"],
+                    upload_paths=(),
+                )
+
+        self.assertIn("still shown", str(ctx.exception).lower())
+        self.assertEqual(page.save_clicks, [])
+
+
 class TestVerifyImageSetMismatches(unittest.TestCase):
     """``_verify_image_set_mismatches`` — absolute end-state verification
     generalizing ``_verify_image_mismatches``'s hardcoded "removed count ==
@@ -4874,8 +5086,8 @@ class TestVerifyImageSetMismatches(unittest.TestCase):
         self.assertEqual(mismatches, [])
 
     def test_asserts_the_set_is_now_empty(self):
-        """The ``delete --all`` / ``set`` with no files case — the old
-        ``_verify_image_mismatches`` couldn't express this at all."""
+        """Removing every image — the old ``_verify_image_mismatches``
+        couldn't express this at all."""
         page = _FakeImagesPage([])
 
         mismatches = browser_masters._verify_image_set_mismatches(
@@ -4964,7 +5176,7 @@ class TestFetchMasterImages(unittest.TestCase):
         """The modal opens to read thumb URLs, but is abandoned rather than
         Saved — nothing commits to the saved image set (see
         ``fetch_master_images``'s docstring: same abandon-safe invariant
-        ``_set_image`` relies on)."""
+        ``_set_image``/``_apply_image_operations`` rely on)."""
         page = _FakeImagesPage(["a", "b"])
 
         browser_masters.fetch_master_images(page, 42)
@@ -4994,6 +5206,61 @@ class TestFetchMasterImages(unittest.TestCase):
 
         self.assertIn("did not finish rendering", str(ctx.exception))
         self.assertNotIn("no images", str(ctx.exception).lower())
+
+
+class TestAddMasterImages(unittest.TestCase):
+    """``add_master_images`` — append into an existing or empty set."""
+
+    def _page_with_save(self, ids, **kwargs):
+        save_clicks = []
+        save_handle = _FakeTextLocatorHandle(
+            visible=True, on_click=lambda: save_clicks.append(True)
+        )
+        page = _FakeImagesPage(
+            ids,
+            role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
+            **kwargs,
+        )
+        return page, save_clicks
+
+    def test_appends_into_an_empty_set(self):
+        page, save_clicks = self._page_with_save([], upload_ids=["new1"])
+
+        result = browser_masters.add_master_images(page, 42, paths=["/tmp/a.png"])
+
+        self.assertEqual(page.ids, ["new1"])
+        self.assertEqual(len(save_clicks), 1)
+        self.assertEqual(result, {"CampaignId": 42, "Added": 1, "Count": 1})
+
+    def test_appends_onto_an_existing_set(self):
+        page, save_clicks = self._page_with_save(["a", "b"], upload_ids=["new1"])
+
+        result = browser_masters.add_master_images(page, 42, paths=["/tmp/a.png"])
+
+        self.assertEqual(page.ids, ["a", "b", "new1"])
+        self.assertEqual(result, {"CampaignId": 42, "Added": 1, "Count": 3})
+
+    def test_exceeding_the_cap_raises_and_never_opens_the_modal(self):
+        page, save_clicks = self._page_with_save(["a", "b", "c", "d", "e"])
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.add_master_images(page, 42, paths=["/tmp/a.png"])
+
+        self.assertIn("cap", str(ctx.exception).lower())
+        self.assertFalse(page.modal_open)
+        self.assertEqual(save_clicks, [])
+
+    def test_auth_error_during_verification_is_re_raised_non_idempotent(self):
+        page, _save_clicks = self._page_with_save([], upload_ids=["new1"])
+        with patch.object(
+            browser_masters,
+            "_verify_saved_images",
+            side_effect=BrowserAuthError("stale session"),
+        ):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters.add_master_images(page, 42, paths=["/tmp/a.png"])
+
+        self.assertIn("not idempotent", str(ctx.exception).lower())
 
 
 class TestVerifyImageMismatches(unittest.TestCase):


### PR DESCRIPTION
> Стек: базируется на #675 (`pr/masters-adimages-get`). Ретаргетить по мере мержа стека.

`masters update --image "N=path"` (#672) умеет только ЗАМЕНИТЬ уже существующее изображение и отказывается работать, когда у кампании их нет. Добавить изображение сверх текущего набора или поставить первое на кампанию с нулём — невозможно.

Добавляет дописывающую половину мутирующей стороны:

```
direct masters adimages add 72349978 --image-file a.png --image-file b.png
```

Отказывается, если текущее количество плюс новые файлы превысят лимит Яндекса в 5. Работает от пустого набора — изображения на кампании МК опциональны, ровно как ad images у текстового объявления через API. Принимает `--launch` (та же семантика публикации черновика, что у `masters update`).

`_apply_image_operations` — новый bulk-примитив, на котором это построено: открыть модалку менеджера изображений ОДИН раз, применить все удаления и все загрузки, нажать «Сохранить» один раз. Он принимает и список удалений, и список загрузок, хотя `add` всегда передаёт только загрузки — путь удаления и делает его примитивом, а не хелпером формы `add`, и покрыт собственными тестами здесь же. Удаления адресуются по thumb URL, снятым ДО первого удаления, чтобы более позднее удаление в том же батче не сбилось из-за переиндексации панели по мере исчезновения ранних карточек. Загрузки опрашивают АБСОЛЮТНЫЙ ожидаемый размер панели, а не относительную проверку `_set_image` «вырос обратно до исходного размера», которая работает лишь для точного обмена 1-в-1. До единственного «Сохранить» ничего не коммитится, поэтому любой более ранний сбой оставляет сохранённый набор нетронутым. `_set_image` — то, что использует `update --image` — не тронут.

`_save_and_verify_images` оборачивает общий послесохраняющий хвост: label кнопки с учётом черновика, клик, проверка против абсолютного ожидаемого конечного состояния (через `_verify_image_set_mismatches` из предыдущего PR) и трансляция истёкшей посреди верификации сессии в ошибку «НЕ повторять» — загрузки не идемпотентны, поэтому авторетрай `_with_session` не должен их переигрывать.

Классифицировано DANGEROUS: песочницы для Мастера кампаний не существует, загружаются реальные файлы, а повторённый `add` допишет ещё раз.

**Живая проверка** 2026-08-03 на DRAFT-кампании 713234191, включая загрузку в заведомо пустой набор.

Refs #648

🤖 Generated with [Claude Code](https://claude.com/claude-code)