### PR TITLE
feat(masters): add `direct masters adimages delete/set`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 ## Unreleased
 
+**Added — `direct masters adimages delete/set` (#648):**
+
+- Completes the `masters adimages` subgroup, so a campaign's image set can
+  be managed end-to-end rather than only read (`get`) or appended to
+  (`add`):
+  - `adimages delete <ID>` removes images addressed by `--position`
+    (1-based, as shown by `adimages get`), `--content-id`, or `--all`.
+    `--all` on an already-empty set is an idempotent no-op; naming a
+    position or content ID that doesn't exist is always an error. `--all`
+    cannot be combined with `--position`/`--content-id` — the combination
+    is ambiguous and risks silent data loss, so it is a `UsageError`
+    rather than a silent "ignore the narrower ones".
+  - `adimages set <ID> --image-file PATH` replaces the WHOLE set inside
+    one modal session (every current image removed, every given file
+    uploaded), so a 5→5 replacement never transiently exceeds the cap.
+    With no files it requires `--allow-empty`, guarding against an
+    accidentally-empty shell glob wiping the set — the empty end state
+    stays reachable, just deliberately (or via `delete --all`).
+- **Leaving a campaign with zero images is a valid end state.** This is
+  what `_verify_image_set_mismatches`'s absolute end-state check (added
+  with `adimages get`) exists for: `delete --all` genuinely asserts the
+  saved set is now empty rather than inferring it from a count delta.
+- Both accept `--launch` (same draft-publishing semantics as `masters
+  update`) and are classified DANGEROUS: they can remove every image in a
+  campaign and are not idempotent.
+- **Confirmed live 2026-08-03** on DRAFT campaign 713234191:
+  `delete --position`, `delete --all`, `set` (full replacement) and
+  `set --allow-empty` all round-tripped correctly across a fresh reload.
+  This also settles the one previously-unverified risk — Yandex's Save
+  control stays clickable when the modal's selection is reduced to zero.
+
 **Added — `direct masters adimages add` (#648):**
 
 - `adimages add <ID> --image-file PATH` (repeatable) appends local

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ direct masters update 72349978 --headline "2=Новый заголовок" --te
 direct masters update 72349978 --image "2=/path/to/banner.png"
 direct masters adimages get 72349978
 direct masters adimages add 72349978 --image-file /path/to/a.png --image-file /path/to/b.png
+direct masters adimages delete 72349978 --position 2
+direct masters adimages delete 72349978 --all
+direct masters adimages set 72349978 --image-file /path/to/a.png --image-file /path/to/b.png
 direct masters add https://example.com/ --headline "Заголовок 1" --headline "Заголовок 2" --text "Текст объявления" --region Москва --weekly-budget 50000 --draft
 direct masters add https://example.com/ --headline "Заголовок 1" --text "Текст объявления" --region-id 213 --weekly-budget 50000 --draft
 direct masters copy 72349978
@@ -109,19 +112,27 @@ adimages` below. Because both the removal and the upload happen inside the
 same open modal, any failure before Save leaves the campaign's saved image
 set untouched.
 
-`masters adimages get/add` mirrors `direct adimages get/add`'s vocabulary
-(the API-side ad-image group) for a campaign's whole image set. Unlike
-`--image`, an empty image set is a completely normal state here — a
-campaign can start with zero images and `adimages add` works from there,
-exactly like ad images on a text ad via the API. `adimages get` is
-read-only and never saves. `adimages add --image-file PATH` (repeatable)
-appends files, refusing if the campaign's current count plus the new files
-would exceed Yandex's cap of 5; it accepts `--launch` (same
-draft-publishing semantics as `masters update`) and, like `--image`, is
-NOT idempotent — a retried call after a partial failure may upload
-duplicates. Every removal and upload happens inside one open modal with a
-single Save at the end, so any earlier failure leaves the saved set
-untouched.
+`masters adimages get/add/delete/set` is the full CRUD counterpart to
+`--image`, mirroring `direct adimages get/add/delete`'s vocabulary (the
+API-side ad-image group) for a campaign's whole image set. Unlike `--image`,
+an empty image set is a completely normal state on both ends here — a
+campaign can start with zero images (`adimages add` works from an empty
+set), and every image can be deleted (`adimages delete --all`), exactly like
+ad images on a text ad via the API. `adimages get` is read-only and never
+saves. `adimages add --image-file PATH` (repeatable) appends files, refusing
+if the campaign's current count plus the new files would exceed Yandex's cap
+of 5. `adimages delete` removes images addressed by `--position` (1-based,
+as shown by `adimages get`), `--content-id`, or `--all`; `--all` on an
+already-empty set is an idempotent no-op, but naming a specific position or
+content ID that doesn't exist is always an error. `adimages set --image-file
+PATH` (repeatable) replaces the ENTIRE set — every current image is removed
+and every given file uploaded inside one modal session; with no
+`--image-file` at all it would delete every image, so it requires an
+explicit `--allow-empty` to confirm (or use `adimages delete --all`
+instead). All three mutating subcommands accept `--launch` (same
+draft-publishing semantics as `masters update`) and, like `--image`, are
+NOT idempotent for `add`/`set` — a retried call after a partial failure may
+upload duplicates.
 
 Later fields (sitelinks, audience, Metrika counters/goals, budget adaptation,
 video) aren't implemented yet.
@@ -1219,6 +1230,9 @@ direct masters update 72349978 --headline "2=Новый заголовок" --te
 direct masters update 72349978 --image "2=/path/to/banner.png"
 direct masters adimages get 72349978
 direct masters adimages add 72349978 --image-file /path/to/a.png --image-file /path/to/b.png
+direct masters adimages delete 72349978 --position 2
+direct masters adimages delete 72349978 --all
+direct masters adimages set 72349978 --image-file /path/to/a.png --image-file /path/to/b.png
 direct masters add https://example.com/ --headline "Заголовок 1" --headline "Заголовок 2" --text "Текст объявления" --region Москва --weekly-budget 50000 --draft
 direct masters add https://example.com/ --headline "Заголовок 1" --text "Текст объявления" --region-id 213 --weekly-budget 50000 --draft
 direct masters copy 72349978
@@ -1287,20 +1301,28 @@ direct masters copy 72349978 --launch
 происходят внутри одной открытой модалки, любая ошибка до Save оставляет
 сохранённый набор изображений кампании нетронутым.
 
-`masters adimages get/add` повторяет словарь `direct adimages get/add`
-(API-группа изображений объявлений) для всего набора изображений кампании.
-В отличие от `--image`, пустой набор изображений здесь — совершенно
-нормальное состояние: кампания может начинаться без единого изображения, и
-`adimages add` работает и с пустым набором, точно как изображения
-объявлений через API. `adimages get` — только чтение, никогда не
-сохраняет. `adimages add --image-file PATH` (можно повторять) добавляет
-файлы, отказывая, если текущее число изображений плюс новые превысит лимит
-Яндекса в 5 штук; принимает `--launch` (та же семантика публикации
-черновика, что и у `masters update`) и, как и `--image`, НЕ идемпотентна —
-повторный вызов после частичного сбоя может загрузить дубликаты. Все
-удаления и загрузки происходят внутри одной открытой модалки с единственным
-Save в конце, поэтому любая более ранняя ошибка оставляет сохранённый набор
-нетронутым.
+`masters adimages get/add/delete/set` — полноценный CRUD-аналог `--image`
+для всего набора изображений кампании, повторяющий словарь `direct adimages
+get/add/delete` (API-группа изображений объявлений). В отличие от `--image`,
+пустой набор изображений здесь — совершенно нормальное состояние с обеих
+сторон: кампания может начинаться без единого изображения (`adimages add`
+работает и с пустым набором), и все изображения можно удалить (`adimages
+delete --all`), точно как изображения объявлений через API. `adimages get`
+— только чтение, никогда не сохраняет. `adimages add --image-file PATH`
+(можно повторять) добавляет файлы, отказывая, если текущее число изображений
+плюс новые превысит лимит Яндекса в 5 штук. `adimages delete` удаляет
+изображения по `--position` (1-based, как показывает `adimages get`),
+`--content-id` или `--all`; `--all` на уже пустом наборе — идемпотентный
+no-op, а вот конкретная позиция или content ID, которых не существует, —
+всегда ошибка. `adimages set --image-file PATH` (можно повторять) заменяет
+ВЕСЬ набор целиком — все текущие изображения удаляются, а все переданные
+файлы загружаются внутри одной модалки; без единого `--image-file` команда
+удалила бы все изображения, поэтому требуется явный `--allow-empty` для
+подтверждения (или используйте `adimages delete --all`). Все три
+мутирующие подкоманды принимают `--launch` (та же семантика публикации
+черновика, что и у `masters update`) и, как и `--image`, НЕ идемпотентны для
+`add`/`set` — повторный вызов после частичного сбоя может загрузить
+дубликаты.
 
 Остальные поля (быстрые ссылки, аудитория, счётчики Метрики/цели, адаптация
 бюджета, видео) тоже пока не реализованы.

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -1929,6 +1929,130 @@ def add_master_images(
     }
 
 
+def delete_master_images(
+    page: "Page",
+    campaign_id: int,
+    *,
+    positions: Optional[Sequence[int]] = None,
+    content_ids: Optional[Sequence[str]] = None,
+    all_images: bool = False,
+    launch: bool = False,
+) -> Dict[str, Any]:
+    """Delete images from the campaign's image set, addressed by 0-based
+    ``positions``, explicit ``content_ids``, or ``all_images=True`` for
+    every image currently in the set.
+
+    ``all_images=True`` against an already-empty set is an idempotent
+    no-op success (mirrors ``suspend``/``resume``'s "idempotent if already
+    X" convention) — no modal is opened, nothing is saved. Naming a
+    specific position or content ID that does not exist is always an
+    error, empty set or not.
+    """
+    if not positions and not content_ids and not all_images:
+        raise ValueError(
+            "delete_master_images requires positions, content_ids, or "
+            "all_images=True."
+        )
+
+    before_ids = _open_images_editor(page, campaign_id)
+
+    if all_images:
+        if not before_ids:
+            return {"CampaignId": campaign_id, "Deleted": 0, "Count": 0}
+        targets: List[str] = list(before_ids)
+    else:
+        targets = []
+        for position in positions or ():
+            if position >= len(before_ids):
+                raise BrowserSessionError(
+                    f"Image position {position + 1} is out of range — "
+                    f"this campaign currently has {len(before_ids)} "
+                    f"image(s) (positions 1-{len(before_ids)})."
+                )
+            cid = before_ids[position]
+            if cid not in targets:
+                targets.append(cid)
+        for content_id in content_ids or ():
+            if content_id not in before_ids:
+                raise BrowserSessionError(
+                    f"Content ID {content_id!r} is not present in "
+                    f"campaign {campaign_id}'s current image set."
+                )
+            if content_id not in targets:
+                targets.append(content_id)
+
+    _apply_image_operations(
+        page,
+        remove_content_ids=targets,
+        upload_paths=(),
+    )
+
+    final_ids = _save_and_verify_images(
+        page,
+        campaign_id,
+        expected_kept_ids=[cid for cid in before_ids if cid not in targets],
+        removed_ids=set(targets),
+        expected_added_count=0,
+        launch=launch,
+        not_idempotent_noun="image deletions",
+    )
+
+    return {
+        "CampaignId": campaign_id,
+        "Deleted": len(targets),
+        "Count": len(final_ids),
+    }
+
+
+def set_master_images(
+    page: "Page",
+    campaign_id: int,
+    *,
+    paths: Sequence[str],
+    launch: bool = False,
+) -> Dict[str, Any]:
+    """Replace the campaign's ENTIRE image set with ``paths`` — every
+    current image is removed, then every file in ``paths`` is uploaded, in
+    one modal session. ``paths=()`` empties the set entirely.
+
+    Removals and uploads happen inside the SAME ``_apply_image_operations``
+    call, so a full at-cap replacement (e.g. 5 images out, 5 images in)
+    never transiently exceeds Yandex's cap — the removals are applied to
+    the modal's live selection before any upload begins.
+    """
+    if len(paths) > _IMAGES_MAX_COUNT:
+        raise BrowserSessionError(
+            f"Cannot set {len(paths)} images — Yandex's cap is "
+            f"{_IMAGES_MAX_COUNT} images per campaign."
+        )
+
+    before_ids = _open_images_editor(page, campaign_id)
+
+    if not before_ids and not paths:
+        return {"CampaignId": campaign_id, "Count": 0}
+
+    _apply_image_operations(
+        page,
+        remove_content_ids=before_ids,
+        upload_paths=paths,
+    )
+
+    final_ids = _save_and_verify_images(
+        page,
+        campaign_id,
+        expected_kept_ids=[],
+        removed_ids=set(before_ids),
+        expected_added_count=len(paths),
+        launch=launch,
+        not_idempotent_noun="image replacements",
+    )
+
+    return {
+        "CampaignId": campaign_id,
+        "Count": len(final_ids),
+    }
+
+
 def _fill_landing_url(page: "Page", url: str) -> None:
     """Fill step 1's URL field and click "Далее" to advance to step 2.
 
@@ -2691,11 +2815,16 @@ def _apply_image_operations(
     legitimate outcomes (unlike headlines/texts, images have no "at least
     one" invariant — see ``_IMAGES_MAX_COUNT``'s module-level comment).
 
-    **Not live-verified:** uploading via a single
-    ``set_input_files([path1, path2, ...])`` call with multiple paths —
-    real Playwright accepts a list, but PR #672's recon never exercised
-    it, so this uploads strictly one path per call, sequentially, to stay
-    on already-confirmed ground.
+    **Not live-verified (flag for live smoke before relying on this in
+    production):** whether Yandex's "Добавить в кампанию" button stays
+    clickable when the modal's selection is reduced to zero mid-session
+    (the ``delete``-everything / ``set``-with-nothing-kept case) — this
+    matters most for ``masters adimages delete --all`` and ``masters
+    adimages set`` replacing every image. Also not verified: uploading via
+    a single ``set_input_files([path1, path2, ...])`` call with multiple
+    paths — real Playwright accepts a list, but PR #672's recon never
+    exercised it, so this uploads strictly one path per call, sequentially,
+    to stay on already-confirmed ground.
 
     Removals are located by the target's thumb URL, captured from the
     modal's panel BEFORE any removal in this call runs — exactly the
@@ -2844,8 +2973,8 @@ def _verify_image_mismatches(
     ``update_master``/``_verify_saved`` call it with the before/replaced
     vocabulary, and because the empty-``replaced_ids`` early return is
     specific to ``--image`` (nothing requested ⇒ nothing to verify),
-    whereas the general version must still assert an empty end state when
-    every image is removed.
+    whereas the general version must still assert an empty end state for
+    ``adimages delete --all``.
     """
     if not replaced_ids:
         return []
@@ -2887,8 +3016,8 @@ def _verify_image_set_mismatches(
 
     Unlike ``_verify_image_mismatches``, this does NOT early-return when
     ``removed_ids`` is empty — ``expected_kept_ids=[]`` with
-    ``expected_added_count=0`` (removing every image) must still assert
-    the saved set is actually empty.
+    ``expected_added_count=0`` (the ``delete --all`` / ``set`` with no
+    files case) must still assert the saved set is actually empty.
     """
     # ``_verify_saved_images`` re-navigates before calling this, so the
     # section is once again mid-render — reading straight away would
@@ -2932,7 +3061,7 @@ def _save_and_verify_images(
     set matches the expected end state; return the fresh content ID list.
 
     The whole post-``_apply_image_operations`` tail shared by
-    the image-set mutations built on ``_apply_image_operations``:
+    ``add_master_images``/``delete_master_images``/``set_master_images``:
     resolve the draft-aware button label, click it, verify, and translate a
     mid-verification session expiry into a "do NOT retry" error (these
     commands are not idempotent, so ``_with_session``'s auto-retry must not
@@ -2978,7 +3107,8 @@ def _verify_saved_images(
     """Reload the edit page, confirm the saved image set matches the
     expected end state, and return the fresh content ID list on success.
 
-    Shared post-save verification for the image-set mutations — mirrors
+    Shared post-save verification for ``add_master_images``/
+    ``delete_master_images``/``set_master_images`` — mirrors
     ``_verify_saved``'s re-navigate-and-re-read discipline (never trust the
     save click alone; Yandex's client-side validation can silently reject
     a value) but scoped to just the image set, via

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -14,10 +14,11 @@ Read-only: ``list`` and ``get``. Mutations: ``suspend``/``resume`` (issue
 #630) and ``add`` (issue #632, create — NOT idempotent, no sandbox/rollback,
 see ``add``'s own docstring). ``update`` (issue #631) edits a campaign's
 settings, including point-replacement of individual images via
-``--image``. ``adimages get``/``add`` (issue #648) read a campaign's whole
-image set and append to it — mirrors the API-side ``direct adimages
-get``/``add`` vocabulary, treats an empty image set as legitimate (unlike
-``update --image``), and ``add`` is likewise NOT idempotent.
+``--image``. ``adimages get/add/delete/set`` (issue #648) is the full CRUD
+counterpart for a campaign's whole image set — mirrors the API-side
+``direct adimages get/add/delete`` vocabulary, treats an empty image set as
+legitimate on both ends (unlike ``update --image``), and is likewise NOT
+idempotent for ``add``/``delete``/``set``.
 
 No ``--login``/agency support (issue #639): this group only ever reads the
 logged-in user's own account, so it needs no Yandex Direct credentials at
@@ -678,15 +679,17 @@ def adimages():
     docstring), so unlike ``direct adimages get/add/delete`` (API-backed ad
     images, ``direct_cli/commands/adimages.py``) every subcommand here drives
     a real browser session against the campaign's edit page. The vocabulary
-    is deliberately the same. There is no ``--dry-run``: there is no
-    request payload to preview for a browser-driven mutation, matching
-    ``masters update``'s existing precedent.
+    is deliberately the same — ``get``/``add``/``delete``, plus ``set`` for a
+    whole-set replacement the API-side group has no equivalent for — but
+    there is no ``--dry-run``: there is no request payload to preview for a
+    browser-driven mutation, matching ``masters update``'s existing
+    precedent.
 
     Unlike ``masters update --image`` (point-replacement of one existing
     image only, refuses on an empty set), these commands treat an empty
-    image set as a completely normal state — a campaign can legitimately
-    have zero images and ``add`` works from there, exactly like ad images
-    on a text ad via the API.
+    image set as a completely normal state on both ends — a campaign can
+    start with zero images, and every image can be deleted, exactly like ad
+    images on a text ad via the API.
     """
 
 
@@ -768,6 +771,184 @@ def adimages_add(
         profile_dir,
         chrome_profile,
         lambda page: add_master_images(
+            page, campaign_id, paths=list(image_files), launch=launch
+        ),
+    )
+
+    format_output(result, output_format, output)
+
+
+@adimages.command("delete")
+@click.argument("campaign_id", type=int)
+@click.option(
+    "--position",
+    "positions",
+    multiple=True,
+    type=int,
+    help=(
+        "1-based position of an image to delete, as shown by `masters "
+        "adimages get` — repeat for multiple. Mutually exclusive with --all."
+    ),
+)
+@click.option(
+    "--content-id",
+    "content_ids",
+    multiple=True,
+    help=(
+        "Yandex content ID of an image to delete, as shown by `masters "
+        "adimages get` — repeat for multiple. The positional analogue of "
+        "the API group's `adimages delete --hash`. Mutually exclusive "
+        "with --all."
+    ),
+)
+@click.option(
+    "--all",
+    "all_images",
+    is_flag=True,
+    default=False,
+    help=(
+        "Delete EVERY image in the campaign. Leaving a campaign with zero "
+        "images is a valid state. Mutually exclusive with --position/"
+        "--content-id. Idempotent if the campaign already has no images."
+    ),
+)
+@click.option(
+    "--launch",
+    is_flag=True,
+    default=False,
+    help=(
+        "If CAMPAIGN_ID is currently a DRAFT, publish it while saving "
+        "(default: keep it a DRAFT). Has no effect on a non-DRAFT campaign."
+    ),
+)
+@_masters_browser_options
+@click.pass_context
+@handle_api_errors
+def adimages_delete(
+    ctx,
+    campaign_id,
+    positions,
+    content_ids,
+    all_images,
+    launch,
+    headful,
+    profile_dir,
+    chrome_profile,
+    output_format,
+    output,
+):
+    """Delete one or more images from a Мастер кампаний campaign"""
+    from ..browser.masters import _IMAGES_MAX_COUNT, delete_master_images
+
+    if not positions and not content_ids and not all_images:
+        raise click.UsageError(
+            "Provide at least one of --position, --content-id, or --all."
+        )
+    if all_images and (positions or content_ids):
+        raise click.UsageError(
+            "--all cannot be combined with --position/--content-id — "
+            "pass --all on its own to delete every image, or list "
+            "specific --position/--content-id values without --all."
+        )
+    if len(set(positions)) != len(positions):
+        raise click.UsageError(
+            "--position was specified more than once for the same slot."
+        )
+    for position in positions:
+        if position < 1 or position > _IMAGES_MAX_COUNT:
+            raise click.UsageError(
+                f"--position {position} is out of range — expected "
+                f"1-{_IMAGES_MAX_COUNT}."
+            )
+
+    result = _with_session(
+        ctx,
+        headful,
+        profile_dir,
+        chrome_profile,
+        lambda page: delete_master_images(
+            page,
+            campaign_id,
+            positions=[p - 1 for p in positions] or None,
+            content_ids=list(content_ids) or None,
+            all_images=all_images,
+            launch=launch,
+        ),
+    )
+
+    format_output(result, output_format, output)
+
+
+@adimages.command("set")
+@click.argument("campaign_id", type=int)
+@click.option(
+    "--image-file",
+    "image_files",
+    multiple=True,
+    help="Local PNG/JPEG/GIF file — repeat for multiple. Replaces the WHOLE image set.",
+)
+@click.option(
+    "--allow-empty",
+    is_flag=True,
+    default=False,
+    help=(
+        "Permit `set` with no --image-file, i.e. delete every image. "
+        "Without this flag, `set` with no files is refused as a likely "
+        "mistake (e.g. an empty shell glob)."
+    ),
+)
+@click.option(
+    "--launch",
+    is_flag=True,
+    default=False,
+    help=(
+        "If CAMPAIGN_ID is currently a DRAFT, publish it while saving "
+        "(default: keep it a DRAFT). Has no effect on a non-DRAFT campaign."
+    ),
+)
+@_masters_browser_options
+@click.pass_context
+@handle_api_errors
+def adimages_set(
+    ctx,
+    campaign_id,
+    image_files,
+    allow_empty,
+    launch,
+    headful,
+    profile_dir,
+    chrome_profile,
+    output_format,
+    output,
+):
+    """Replace a Мастер кампаний campaign's ENTIRE image set
+
+    Every current image is removed and every ``--image-file`` is uploaded,
+    inside one modal session. With no ``--image-file`` this deletes every
+    image — pass ``--allow-empty`` to confirm, or use ``masters adimages
+    delete --all`` instead.
+    """
+    from ..browser.masters import _IMAGES_MAX_COUNT, set_master_images
+
+    if not image_files and not allow_empty:
+        raise click.UsageError(
+            "'set' with no --image-file would delete every image. Pass "
+            "--allow-empty to confirm, or use 'masters adimages delete "
+            "--all'."
+        )
+    if len(image_files) > _IMAGES_MAX_COUNT:
+        raise click.UsageError(
+            f"--image-file was passed {len(image_files)} times — Yandex's "
+            f"cap is {_IMAGES_MAX_COUNT} images per campaign."
+        )
+    _validate_image_files(image_files)
+
+    result = _with_session(
+        ctx,
+        headful,
+        profile_dir,
+        chrome_profile,
+        lambda page: set_master_images(
             page, campaign_id, paths=list(image_files), launch=launch
         ),
     )

--- a/direct_cli/smoke_matrix.py
+++ b/direct_cli/smoke_matrix.py
@@ -200,13 +200,16 @@ SMOKE_MATRIX = {
         # above -- there is no way to isolate a live form save from
         # production. Manual-only, per scripts/test_dangerous_commands.sh.
         "masters.update",
-        # Browser-driven image upload against Мастер кампаний (masters
-        # adimages add). Same no-sandbox-equivalent rationale as
-        # masters.update above — there is no way to isolate a live modal
-        # save from production. Uploads real files, and is NOT idempotent
-        # (a retried add appends again). Manual-only, per
+        # Browser-driven image-set mutations against Мастер кампаний (masters
+        # adimages). Same no-sandbox-equivalent rationale as masters.update
+        # above — there is no way to isolate a live modal save from
+        # production. add/set upload real files; delete/set can remove every
+        # image in the campaign. Not idempotent (a retried add/delete would
+        # touch a set that already changed). Manual-only, per
         # scripts/test_dangerous_commands.sh.
         "masters.adimages.add",
+        "masters.adimages.delete",
+        "masters.adimages.set",
         # Creates a brand-new Мастер кампаний (issue #632) — no API surface,
         # no sandbox, and NOT idempotent (a second run creates a second
         # campaign, not an update). Riskiest command in this whole group:

--- a/scripts/test_dangerous_commands.sh
+++ b/scripts/test_dangerous_commands.sh
@@ -34,6 +34,10 @@ non-critical campaign, confirming before/after state in the web UI):
     --promotion-goal, --directs-helps/--no-directs-helps)
   - direct masters adimages add <campaign_id> --image-file ...
     (uploads real files -- NOT idempotent)
+  - direct masters adimages delete <campaign_id> --position ... / --content-id ... / --all
+    (can remove every image in the campaign -- NOT idempotent)
+  - direct masters adimages set <campaign_id> --image-file ...
+    (replaces the ENTIRE image set -- NOT idempotent)
   - direct masters archive <campaign_id>
     (irreversible -- there is no `masters unarchive`)
   - direct masters add <url> --headline ... --text ... --region ...

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -50,6 +50,8 @@ DRY_RUN_EXCEPTIONS = {
     "masters.add",
     "masters.copy",
     "masters.adimages.add",
+    "masters.adimages.delete",
+    "masters.adimages.set",
 }
 
 FORBIDDEN_HELP_TEXT = (

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -3622,6 +3622,19 @@ class TestMastersAdimagesCommand(unittest.TestCase):
         self.assertIn("--image-file", result.output)
         self.assertIn("--launch", result.output)
 
+    def test_delete_help_documents_addressing_flags(self):
+        result = self.runner.invoke(cli, ["masters", "adimages", "delete", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("--position", result.output)
+        self.assertIn("--content-id", result.output)
+        self.assertIn("--all", result.output)
+
+    def test_set_help_documents_allow_empty(self):
+        result = self.runner.invoke(cli, ["masters", "adimages", "set", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("--image-file", result.output)
+        self.assertIn("--allow-empty", result.output)
+
     def test_get_calls_fetch_master_images(self):
         with (
             patch("direct_cli.browser.masters.fetch_master_images") as mock_fetch,
@@ -3708,6 +3721,123 @@ class TestMastersAdimagesCommand(unittest.TestCase):
         self.assertEqual(args[1], 42)
         self.assertEqual(kwargs["paths"], [f.name])
         self.assertTrue(kwargs["launch"])
+
+    def test_delete_rejects_when_no_addressing_flag_given(self):
+        result = self.runner.invoke(cli, ["masters", "adimages", "delete", "42"])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("at least one", result.output.lower())
+
+    def test_delete_rejects_all_combined_with_position(self):
+        result = self.runner.invoke(
+            cli, ["masters", "adimages", "delete", "42", "--all", "--position", "1"]
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("cannot be combined", result.output.lower())
+
+    def test_delete_rejects_position_zero(self):
+        result = self.runner.invoke(
+            cli, ["masters", "adimages", "delete", "42", "--position", "0"]
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("out of range", result.output.lower())
+
+    def test_delete_rejects_duplicate_positions(self):
+        result = self.runner.invoke(
+            cli,
+            [
+                "masters",
+                "adimages",
+                "delete",
+                "42",
+                "--position",
+                "1",
+                "--position",
+                "1",
+            ],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("more than once", result.output.lower())
+
+    def test_delete_calls_delete_master_images_with_zero_based_positions(self):
+        with (
+            patch("direct_cli.browser.masters.delete_master_images") as mock_delete,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_delete.return_value = {"CampaignId": 42, "Deleted": 1, "Count": 1}
+            result = self.runner.invoke(
+                cli,
+                ["masters", "adimages", "delete", "42", "--position", "2"],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        kwargs = mock_delete.call_args.kwargs
+        self.assertEqual(kwargs["positions"], [1])
+        self.assertIsNone(kwargs["content_ids"])
+        self.assertFalse(kwargs["all_images"])
+
+    def test_delete_calls_delete_master_images_with_all(self):
+        with (
+            patch("direct_cli.browser.masters.delete_master_images") as mock_delete,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_delete.return_value = {"CampaignId": 42, "Deleted": 3, "Count": 0}
+            result = self.runner.invoke(
+                cli, ["masters", "adimages", "delete", "42", "--all"]
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        kwargs = mock_delete.call_args.kwargs
+        self.assertTrue(kwargs["all_images"])
+
+    def test_set_rejects_no_files_without_allow_empty(self):
+        result = self.runner.invoke(cli, ["masters", "adimages", "set", "42"])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("allow-empty", result.output.lower())
+        self.assertIn("delete --all", result.output)
+
+    def test_set_with_allow_empty_calls_set_master_images_with_no_paths(self):
+        with (
+            patch("direct_cli.browser.masters.set_master_images") as mock_set,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_set.return_value = {"CampaignId": 42, "Count": 0}
+            result = self.runner.invoke(
+                cli, ["masters", "adimages", "set", "42", "--allow-empty"]
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(mock_set.call_args.kwargs["paths"], [])
+
+    def test_set_calls_set_master_images_with_paths(self):
+        import tempfile
+
+        with (
+            tempfile.NamedTemporaryFile(suffix=".png") as f,
+            patch("direct_cli.browser.masters.set_master_images") as mock_set,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_set.return_value = {"CampaignId": 42, "Count": 1}
+            result = self.runner.invoke(
+                cli, ["masters", "adimages", "set", "42", "--image-file", f.name]
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(mock_set.call_args.kwargs["paths"], [f.name])
+
+    def test_set_rejects_more_files_than_the_cap(self):
+        with patch("direct_cli.commands.masters._with_session") as mock_with_session:
+            args = ["masters", "adimages", "set", "42"]
+            for i in range(6):
+                args += ["--image-file", f"/tmp/{i}.png"]
+            result = self.runner.invoke(cli, args)
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("cap", result.output.lower())
+        mock_with_session.assert_not_called()
 
 
 class TestMastersLoginCommand(unittest.TestCase):
@@ -4610,7 +4740,7 @@ class _FakeImagesPage(FakePage):
         self._upload_ids = list(upload_ids or [])
         self._upload_call = 0
         # Every path passed to set_input_files(), in call order — lets
-        # ``masters adimages add`` tests assert upload sequencing
+        # ``masters adimages set``/``add`` tests assert upload sequencing
         # (e.g. "removed everything, then uploaded in the order given").
         self.upload_paths = []
 
@@ -5086,8 +5216,8 @@ class TestVerifyImageSetMismatches(unittest.TestCase):
         self.assertEqual(mismatches, [])
 
     def test_asserts_the_set_is_now_empty(self):
-        """Removing every image — the old ``_verify_image_mismatches``
-        couldn't express this at all."""
+        """The ``delete --all`` / ``set`` with no files case — the old
+        ``_verify_image_mismatches`` couldn't express this at all."""
         page = _FakeImagesPage([])
 
         mismatches = browser_masters._verify_image_set_mismatches(
@@ -5261,6 +5391,133 @@ class TestAddMasterImages(unittest.TestCase):
                 browser_masters.add_master_images(page, 42, paths=["/tmp/a.png"])
 
         self.assertIn("not idempotent", str(ctx.exception).lower())
+
+
+class TestDeleteMasterImages(unittest.TestCase):
+    """``delete_master_images`` — by position, by content ID, or ``--all``."""
+
+    def _page_with_save(self, ids, **kwargs):
+        save_clicks = []
+        save_handle = _FakeTextLocatorHandle(
+            visible=True, on_click=lambda: save_clicks.append(True)
+        )
+        page = _FakeImagesPage(
+            ids,
+            role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
+            **kwargs,
+        )
+        return page, save_clicks
+
+    def test_deletes_by_position(self):
+        page, save_clicks = self._page_with_save(["a", "b", "c"])
+
+        result = browser_masters.delete_master_images(page, 42, positions=[1])
+
+        self.assertEqual(page.ids, ["a", "c"])
+        self.assertEqual(len(save_clicks), 1)
+        self.assertEqual(result, {"CampaignId": 42, "Deleted": 1, "Count": 2})
+
+    def test_deletes_by_content_id(self):
+        page, save_clicks = self._page_with_save(["a", "b", "c"])
+
+        result = browser_masters.delete_master_images(page, 42, content_ids=["b"])
+
+        self.assertEqual(page.ids, ["a", "c"])
+        self.assertEqual(result, {"CampaignId": 42, "Deleted": 1, "Count": 2})
+
+    def test_deletes_all(self):
+        page, save_clicks = self._page_with_save(["a", "b", "c"])
+
+        result = browser_masters.delete_master_images(page, 42, all_images=True)
+
+        self.assertEqual(page.ids, [])
+        self.assertEqual(len(save_clicks), 1)
+        self.assertEqual(result, {"CampaignId": 42, "Deleted": 3, "Count": 0})
+
+    def test_all_on_an_already_empty_set_is_an_idempotent_no_op(self):
+        page, save_clicks = self._page_with_save([])
+
+        result = browser_masters.delete_master_images(page, 42, all_images=True)
+
+        self.assertEqual(result, {"CampaignId": 42, "Deleted": 0, "Count": 0})
+        self.assertEqual(save_clicks, [])
+        self.assertFalse(page.modal_open)
+
+    def test_out_of_range_position_raises(self):
+        page, save_clicks = self._page_with_save(["a", "b"])
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.delete_master_images(page, 42, positions=[5])
+
+        self.assertIn("out of range", str(ctx.exception).lower())
+        self.assertEqual(save_clicks, [])
+
+    def test_unknown_content_id_raises(self):
+        page, save_clicks = self._page_with_save(["a", "b"])
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.delete_master_images(page, 42, content_ids=["ghost"])
+
+        self.assertIn("not present", str(ctx.exception).lower())
+        self.assertEqual(save_clicks, [])
+
+
+class TestSetMasterImages(unittest.TestCase):
+    """``set_master_images`` — whole-set replacement in one modal."""
+
+    def _page_with_save(self, ids, **kwargs):
+        save_clicks = []
+        save_handle = _FakeTextLocatorHandle(
+            visible=True, on_click=lambda: save_clicks.append(True)
+        )
+        page = _FakeImagesPage(
+            ids,
+            role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
+            **kwargs,
+        )
+        return page, save_clicks
+
+    def test_full_replacement_in_one_modal(self):
+        page, save_clicks = self._page_with_save(["a", "b", "c"], upload_ids=["x", "y"])
+
+        result = browser_masters.set_master_images(
+            page, 42, paths=["/tmp/x.png", "/tmp/y.png"]
+        )
+
+        self.assertEqual(page.ids, ["x", "y"])
+        self.assertEqual(len(save_clicks), 1)
+        self.assertEqual(result, {"CampaignId": 42, "Count": 2})
+
+    def test_empty_paths_empties_the_set(self):
+        page, save_clicks = self._page_with_save(["a", "b"])
+
+        result = browser_masters.set_master_images(page, 42, paths=[])
+
+        self.assertEqual(page.ids, [])
+        self.assertEqual(len(save_clicks), 1)
+        self.assertEqual(result, {"CampaignId": 42, "Count": 0})
+
+    def test_already_empty_with_no_paths_is_a_no_op(self):
+        page, save_clicks = self._page_with_save([])
+
+        result = browser_masters.set_master_images(page, 42, paths=[])
+
+        self.assertEqual(result, {"CampaignId": 42, "Count": 0})
+        self.assertEqual(save_clicks, [])
+        self.assertFalse(page.modal_open)
+
+    def test_exceeding_the_cap_raises(self):
+        page, save_clicks = self._page_with_save([])
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.set_master_images(
+                page,
+                42,
+                paths=[f"/tmp/{i}.png" for i in range(6)],
+            )
+
+        self.assertIn("cap", str(ctx.exception).lower())
+        self.assertEqual(save_clicks, [])
 
 
 class TestVerifyImageMismatches(unittest.TestCase):


### PR DESCRIPTION
> Стек: базируется на #676 (`pr/masters-adimages-add`). Ретаргетить на `main` после мержа стека.

Завершает подгруппу `masters adimages`: с уже имеющимися `get` (чтение) и `add` (дозапись) эти две команды закрывают удаление и замену всего набора, так что изображениями кампании можно управлять от начала до конца, а не только точечно заменять через `masters update --image`.

```
direct masters adimages delete 72349978 --position 2
direct masters adimages delete 72349978 --all
direct masters adimages set 72349978 --image-file a.png
```

`delete` адресует изображения по `--position` (1-based, как показывает `adimages get`), по `--content-id` или через `--all`. `--all` на уже пустом наборе — идемпотентный no-op: модалка не открывается и ничего не сохраняется, — тогда как указание несуществующей позиции или content ID всегда ошибка. `--all` нельзя комбинировать с `--position`/`--content-id`: комбинация неоднозначна и рискует молчаливой потерей данных, поэтому это `UsageError`, а не тихое «проигнорируем более узкие».

`set` заменяет весь набор внутри ОДНОГО вызова `_apply_image_operations` (удалить всё, затем загрузить всё), так что замена 5→5 никогда не превышает лимит Яндекса транзиентно, как это сделала бы двухфазная связка delete-then-add. Без единого `--image-file` команда опустошила бы набор, поэтому она требует явного `--allow-empty` — защита от случайно пустого шелл-глоба, а не ограничение: пустое конечное состояние остаётся достижимым, просто осознанно, а `delete --all` говорит то же самое прямее.

Кампания с нулём изображений — валидное конечное состояние, и именно ради этого существует абсолютная проверка конечного состояния в `_verify_image_set_mismatches`: `delete --all` действительно утверждает, что сохранённый набор теперь пуст, а не выводит это из дельты счётчиков, как приходилось старому верификатору «удалено == добавлено».

**Живая проверка** 2026-08-03 на DRAFT-кампании 713234191: `delete --position`, `delete --all`, `set` (полная замена) и `set --allow-empty` — все прошли round-trip через свежую перезагрузку. Это закрывает единственный ранее непроверенный риск, отмеченный при написании примитива: контрол «Сохранить» у Яндекса остаётся кликабельным, когда выбор в модалке сведён к нулю.

Refs #648

🤖 Generated with [Claude Code](https://claude.com/claude-code)