### PR TITLE
fix(masters): use commit not domcontentloaded for grid navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+**Fixed — grid navigation `domcontentloaded` timeout (#682):**
+
+- `_capture_grid_campaigns_request` (`direct_cli/browser/masters.py`) — the
+  single navigation point for the campaigns grid, used by `masters list`,
+  `get`, `archive`, and `update` — navigated with
+  `wait_until="domcontentloaded"`. Live diagnosis in #671 found the grid is
+  a virtualized SPA whose `document.readyState` never advances past
+  `"interactive"`, so `domcontentloaded` could wait out its full 30s
+  timeout even though the grid's own `GridCampaigns` data request had
+  already fired.
+- Switched to `wait_until="commit"`, which only waits for the response
+  headers and the start of the document body — safe here because the
+  actual wait for grid data is `page.expect_response(...)`, not the
+  `goto` call itself. `assert_not_captcha`/`assert_authenticated` still
+  see valid HTML at `commit` time: both are server-rendered gate pages
+  (not part of the grid SPA), so their marker text is present in the
+  initial document body before any client-side JS runs.
+- Confirmed live 2026-08-03: `direct masters list --status all` completes
+  in ~15-25s across repeated runs (previously could exhaust the 30s
+  `expect_response` timeout).
+
 **Added — `direct masters adimages delete/set` (#648):**
 
 - Completes the `masters adimages` subgroup, so a campaign's image set can

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -620,14 +620,27 @@ def _capture_grid_campaigns_request(page: "Page") -> Dict[str, Any]:
     settles and burns its full timeout even though ``GridCampaigns`` fired
     seconds earlier — ``expect_response`` blocks on the actual event instead
     of sampling on an interval, and needs no listener cleanup.
+
+    Uses ``wait_until="commit"``, not ``"domcontentloaded"`` (#682): live
+    diagnosis in #671 found the grid is a virtualized SPA whose
+    ``document.readyState`` never advances past ``"interactive"``, so
+    ``domcontentloaded`` itself was timing out after 30s waiting for an
+    event that never fires. ``commit`` only waits for the network response
+    headers and the start of the document body — earlier than
+    ``domcontentloaded`` — which is safe here because the actual wait for
+    grid data is ``expect_response`` above, not the ``goto`` call. The
+    captcha/login-page checks below still see valid HTML at ``commit``
+    time: both are server-rendered gate pages (not part of the grid SPA),
+    so their marker text is present in the initial document body Yandex
+    sends, before any client-side JS runs.
     """
     with page.expect_response(
         _is_grid_campaigns_request, timeout=_GRID_CAPTURE_TIMEOUT_MS
     ) as response_info:
-        # domcontentloaded, not networkidle: see docstring. No ulogin here
-        # (see module docstring): passing our own login as the
+        # commit, not domcontentloaded/networkidle: see docstring. No
+        # ulogin here (see module docstring): passing our own login as the
         # managed-client param produces "Доступ ограничен" + HTTP 401.
-        page.goto(GRID_URL, wait_until="domcontentloaded")
+        page.goto(GRID_URL, wait_until="commit")
         assert_not_captcha(page.content())
         assert_authenticated(page.content())
 

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -4161,19 +4161,26 @@ class TestAuthDetection(unittest.TestCase):
         with self.assertRaises(BrowserAuthError):
             browser_masters.fetch_master(page, 1)
 
-    def test_fetch_masters_list_waits_for_domcontentloaded_not_networkidle(self):
+    def test_fetch_masters_list_waits_for_commit_not_networkidle(self):
         # #634: networkidle never settles on Yandex's login page (it holds
         # long-poll connections), which is what turned an auth failure into
-        # an opaque 30s timeout instead of a clear error. Guard against a
-        # silent regression back to networkidle. (No captured grid response
-        # here -> raises BrowserSessionError right after the goto assertion,
-        # which is all this test needs to observe.)
+        # an opaque 30s timeout instead of a clear error. #682: the grid's
+        # own document.readyState never advances past "interactive" either,
+        # so domcontentloaded itself was timing out — commit is the
+        # earliest wait_until that still lets expect_response observe the
+        # navigation. Guard against a silent regression back to
+        # networkidle/domcontentloaded. (No captured grid response here ->
+        # raises BrowserSessionError right after the goto assertion, which
+        # is all this test needs to observe.)
         page = FakePage(locators={})
         with self.assertRaises(BrowserSessionError):
             browser_masters.fetch_masters_list(page)
-        self.assertEqual(page.goto_wait_until, "domcontentloaded")
+        self.assertEqual(page.goto_wait_until, "commit")
 
     def test_fetch_master_waits_for_domcontentloaded_not_networkidle(self):
+        # fetch_master navigates to the wizard overview page, not the grid
+        # (_capture_grid_campaigns_request) — out of scope for #682, which
+        # only touches the grid's own goto.
         page = FakePage(locators={})
         browser_masters.fetch_master(page, 1)
         self.assertEqual(page.goto_wait_until, "domcontentloaded")


### PR DESCRIPTION
## Summary
- `_capture_grid_campaigns_request` navigated the campaigns grid with `wait_until="domcontentloaded"`. Live diagnosis in #671 found the grid is a virtualized SPA whose `document.readyState` never advances past `"interactive"`, so `domcontentloaded` could wait out its full 30s timeout even though the grid's own `GridCampaigns` data request had already fired.
- Switched to `wait_until="commit"`, which only waits for response headers and the start of the document body — safe because the actual wait for grid data is `page.expect_response(...)`, not the `goto` call itself.
- `assert_not_captcha`/`assert_authenticated` still see valid HTML at `commit` time: both are server-rendered gate pages (not part of the grid SPA), so their marker text is present in the initial document body before any client-side JS runs.
- `fetch_master` (wizard overview page, a separate navigation target) is unchanged — out of scope per the issue.

Closes #682

## Test plan
- [x] `pytest tests/test_masters.py` — 336 passed
- [x] Full offline suite (`pytest`) — 2915 passed, unrelated pre-existing `test_read_cassettes.py` errors confirmed present on unpatched `main` too
- [x] `black --check` / `flake8` clean
- [x] Live: `direct masters list --status all` — multiple runs, completes in ~15-25s, no 30s timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UgcWjSh37ubLwnALi7zLmZ