### PR TITLE
fix(masters): replace domcontentloaded with commit + explicit form wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,27 @@
   treats an unrendered tick as "not authenticated yet" rather than a
   successful, verified login (cycle-review on #692).
 
+**Fixed — `wait_until="domcontentloaded"` timeout on `masters` wizard-edit
+navigation (#684):**
+
+- All four `WIZARD_EDIT_URL` navigation sites (`_verify_saved`,
+  `update_master`, `_open_images_editor`, `_verify_saved_images`) switched
+  from `page.goto(url, wait_until="domcontentloaded")` to
+  `wait_until="commit"` — `domcontentloaded` was observed to time out under
+  real network conditions on this SPA (Yandex holds long-poll connections
+  that can make even that early a lifecycle event hang), while `commit`
+  only waits on the response itself and never hangs on page-internal
+  behaviour.
+- `commit` guarantees nothing about the DOM, so every site now polls a new
+  `_wait_for_edit_form` helper for the edit form's first headline slot
+  (`CampaignTitles0.textarea` — guaranteed present on any rendered edit
+  page, DRAFT or not, since headlines are not optional) before touching
+  the page, mirroring `_wait_for_images_editor`'s existing "wait for real
+  content, not just the navigation call" discipline.
+- `fetch_master_images`'s existing `_wait_for_images_editor` call is
+  unaffected — confirmed this fix composes cleanly with it (the form-ready
+  wait happens first, then the images-specific stub wait, as before).
+
 **Added — `direct masters adimages delete/set` (#648):**
 
 - Completes the `masters adimages` subgroup, so a campaign's image set can

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,14 @@ navigation (#684):**
 - `fetch_master_images`'s existing `_wait_for_images_editor` call is
   unaffected — confirmed this fix composes cleanly with it (the form-ready
   wait happens first, then the images-specific stub wait, as before).
+- Cycle-review follow-up: `_wait_for_edit_form`'s poll loop now re-checks
+  `assert_not_captcha`/`assert_authenticated` on every tick, not just once
+  right after `goto(..., wait_until="commit")`. A captcha gate or expired
+  session that the SPA's own JS renders in *after* that initial commit
+  response was previously invisible to the one-shot checks and only
+  surfaced as a generic timeout — losing the specific `BrowserCaptchaError`/
+  `BrowserAuthError` that `_verify_saved_images`'s post-save caller relies
+  on to know not to retry a non-idempotent image mutation.
 
 **Added — `direct masters adimages delete/set` (#648):**
 

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -383,6 +383,19 @@ _TEXTS_SLOT_COUNT = 3
 _HEADLINES_TESTID_TEMPLATE = "CampaignTitles{index}.textarea"
 _TEXTS_TESTID_TEMPLATE = "CampaignTexts{index}.textarea"
 
+# Edit-page-ready marker (issue #684). ``goto(..., wait_until="commit")``
+# returns as soon as the response headers are received — before ANY of the
+# SPA's own JS has run — so every call site that immediately reads/writes a
+# form field needs an explicit wait for real content first, same reasoning
+# as ``_IMAGES_EDITOR_TIMEOUT_MS`` below. The first headline slot
+# (``CampaignTitles0.textarea``) is the marker: headlines are not optional
+# like images (see ``_HEADLINES_SLOT_COUNT``'s module-level comment), so
+# slot 0 is guaranteed present on every rendered edit page, DRAFT or not
+# (the DRAFT edit page still renders headlines/texts — see module docstring's
+# "DRAFT support" note).
+_EDIT_FORM_READY_TESTID = _HEADLINES_TESTID_TEMPLATE.format(index=0)
+_EDIT_FORM_READY_TIMEOUT_MS = 30_000
+
 # Images (issue #670, Этап D). Confirmed live 2026-08-02 against DRAFT clone
 # 713234191 that images are a COMPLETELY different shape from headlines/texts
 # above: there is no fixed slot count in the DOM at all — the edit page
@@ -1579,9 +1592,10 @@ def _verify_saved(
     take effect and this raises rather than reporting false success.
     """
     url = WIZARD_EDIT_URL.format(campaign_id=campaign_id)
-    page.goto(url, wait_until="domcontentloaded")
+    page.goto(url, wait_until="commit")
     assert_not_captcha(page.content())
     assert_authenticated(page.content())
+    _wait_for_edit_form(page, campaign_id)
 
     checks = [
         ("weekly_budget", weekly_budget, _read_weekly_budget),
@@ -1724,9 +1738,10 @@ def update_master(
         )
 
     url = WIZARD_EDIT_URL.format(campaign_id=campaign_id)
-    page.goto(url, wait_until="domcontentloaded")
+    page.goto(url, wait_until="commit")
     assert_not_captcha(page.content())
     assert_authenticated(page.content())
+    _wait_for_edit_form(page, campaign_id)
 
     if name is not None:
         _set_campaign_name(page, name)
@@ -1848,10 +1863,11 @@ def _open_images_editor(page: "Page", campaign_id: int) -> List[str]:
     """
     page.goto(
         WIZARD_EDIT_URL.format(campaign_id=campaign_id),
-        wait_until="domcontentloaded",
+        wait_until="commit",
     )
     assert_not_captcha(page.content())
     assert_authenticated(page.content())
+    _wait_for_edit_form(page, campaign_id)
 
     _wait_for_images_editor(page)
     return _read_image_content_ids(page)
@@ -2517,6 +2533,42 @@ def _read_testid_suffixes(
     return suffixes
 
 
+def _wait_for_edit_form(page: "Page", campaign_id: int) -> None:
+    """Block until the edit page's form has actually rendered.
+
+    Issue #684: every ``WIZARD_EDIT_URL`` navigation in this module now uses
+    ``wait_until="commit"`` (fires as soon as the response starts arriving,
+    before any redirect/parse/JS has happened) instead of the previous
+    ``wait_until="domcontentloaded"`` — ``domcontentloaded`` on this SPA was
+    observed to time out under real network conditions (the page's own
+    long-poll connections can make even that early a lifecycle event hang;
+    see the module's "The edit page is an SPA" comment on
+    ``_IMAGES_EDITOR_TIMEOUT_MS`` for the same long-poll reasoning).
+    ``commit`` never hangs on page-internal behaviour — it only waits on the
+    network response itself — but it also guarantees nothing about the DOM,
+    so every call site must wait for a real content marker afterwards
+    instead of trusting the navigation call alone.
+
+    Polls for ``_EDIT_FORM_READY_TESTID`` (the first headline slot) rather
+    than a fixed sleep, same convention as ``_wait_for_step2``/
+    ``_wait_for_images_editor``.
+    """
+    if _poll_until(
+        page,
+        lambda: page.locator(f'[data-testid="{_EDIT_FORM_READY_TESTID}"]').count() > 0,
+        _EDIT_FORM_READY_TIMEOUT_MS,
+    ):
+        return
+
+    raise BrowserSessionError(
+        f"The edit page for campaign {campaign_id} did not finish rendering "
+        f"within {_EDIT_FORM_READY_TIMEOUT_MS / 1000:.0f}s (the "
+        f"'{_EDIT_FORM_READY_TESTID}' field never appeared). Yandex may have "
+        "changed the page's markup, the campaign may not exist, or the page "
+        "may still be loading. Re-run with --headful to inspect the page."
+    )
+
+
 def _wait_for_images_editor(page: "Page") -> None:
     """Block until the edit page's "Изображения" section has rendered ITS
     ACTUAL CONTENT, not just its outer container.
@@ -3176,9 +3228,10 @@ def _verify_saved_images(
     ``_verify_image_set_mismatches``.
     """
     url = WIZARD_EDIT_URL.format(campaign_id=campaign_id)
-    page.goto(url, wait_until="domcontentloaded")
+    page.goto(url, wait_until="commit")
     assert_not_captcha(page.content())
     assert_authenticated(page.content())
+    _wait_for_edit_form(page, campaign_id)
 
     mismatches = _verify_image_set_mismatches(
         page,

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -2551,11 +2551,20 @@ def _wait_for_edit_form(page: "Page", campaign_id: int) -> None:
 
     Polls for ``_EDIT_FORM_READY_TESTID`` (the first headline slot) rather
     than a fixed sleep, same convention as ``_wait_for_step2``/
-    ``_wait_for_images_editor``.
+    ``_wait_for_images_editor``. Also re-checks ``assert_not_captcha``/
+    ``assert_authenticated`` on every tick (cycle-review #689 finding):
+    the one-shot checks each call site runs right after ``goto(...,
+    wait_until="commit")`` only see whatever the response committed with —
+    a captcha gate or an expired-session redirect that the SPA's own JS
+    renders in *after* that point would be invisible to those checks and
+    would otherwise surface here as a generic timeout instead of the
+    specific ``BrowserCaptchaError``/``BrowserAuthError`` callers rely on
+    to know not to retry a non-idempotent operation (e.g.
+    ``_verify_saved_images``).
     """
     if _poll_until(
         page,
-        lambda: page.locator(f'[data-testid="{_EDIT_FORM_READY_TESTID}"]').count() > 0,
+        lambda: _edit_form_ready_or_raise(page),
         _EDIT_FORM_READY_TIMEOUT_MS,
     ):
         return
@@ -2567,6 +2576,22 @@ def _wait_for_edit_form(page: "Page", campaign_id: int) -> None:
         "changed the page's markup, the campaign may not exist, or the page "
         "may still be loading. Re-run with --headful to inspect the page."
     )
+
+
+def _edit_form_ready_or_raise(page: "Page") -> bool:
+    """Predicate for ``_wait_for_edit_form``'s poll loop.
+
+    Checked on every tick rather than once before the loop starts, so a
+    captcha/login page that renders in after the initial ``commit``
+    response is caught with its specific error instead of being missed and
+    only surfacing later as ``_wait_for_edit_form``'s generic timeout.
+    ``assert_not_captcha``/``assert_authenticated`` raise on a match, which
+    ``_poll_until`` lets propagate (it only suppresses ``PlaywrightError``).
+    """
+    html = page.content()
+    assert_not_captcha(html)
+    assert_authenticated(html)
+    return page.locator(f'[data-testid="{_EDIT_FORM_READY_TESTID}"]').count() > 0
 
 
 def _wait_for_images_editor(page: "Page") -> None:

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -214,8 +214,10 @@ from typing import (
     Tuple,
 )
 
+from .._captcha import find_captcha_marker, find_marker
 from ..output import print_warning
 from .session import (
+    _LOGIN_PAGE_MARKERS,
     BrowserAuthError,
     BrowserSessionError,
     assert_authenticated,
@@ -2551,23 +2553,38 @@ def _wait_for_edit_form(page: "Page", campaign_id: int) -> None:
 
     Polls for ``_EDIT_FORM_READY_TESTID`` (the first headline slot) rather
     than a fixed sleep, same convention as ``_wait_for_step2``/
-    ``_wait_for_images_editor``. Also re-checks ``assert_not_captcha``/
-    ``assert_authenticated`` on every tick (cycle-review #689 finding):
-    the one-shot checks each call site runs right after ``goto(...,
-    wait_until="commit")`` only see whatever the response committed with —
-    a captcha gate or an expired-session redirect that the SPA's own JS
-    renders in *after* that point would be invisible to those checks and
-    would otherwise surface here as a generic timeout instead of the
-    specific ``BrowserCaptchaError``/``BrowserAuthError`` callers rely on
-    to know not to retry a non-idempotent operation (e.g.
-    ``_verify_saved_images``).
+    ``_wait_for_images_editor``. Also re-checks for a captcha/login page on
+    every tick (cycle-review #689 finding): the one-shot
+    ``assert_not_captcha``/``assert_authenticated`` checks each call site
+    runs right after ``goto(..., wait_until="commit")`` only see whatever
+    the response committed with — a captcha gate or an expired-session
+    redirect that the SPA's own JS renders in *after* that point would be
+    invisible to those checks and would otherwise surface here as a
+    generic timeout instead of the specific ``BrowserCaptchaError``/
+    ``BrowserAuthError`` callers rely on to know not to retry a
+    non-idempotent operation (e.g. ``_verify_saved_images``).
+
+    The captcha/auth check happens OUTSIDE ``_poll_until``'s predicate
+    (via ``_edit_form_terminal_state``, which returns a marker instead of
+    raising) rather than inside it: ``_poll_until`` suppresses
+    ``PlaywrightError``, which is aliased to the broad ``Exception`` when
+    Playwright isn't installed (the offline-unit-test import fallback
+    above) — in that environment a raise from inside the predicate would
+    be silently swallowed as "not yet" instead of propagating, and this
+    function would misreport a real captcha/auth failure as its own
+    generic render-timeout.
     """
-    if _poll_until(
+    state = _poll_until_terminal(
         page,
-        lambda: _edit_form_ready_or_raise(page),
+        lambda: _edit_form_terminal_state(page),
         _EDIT_FORM_READY_TIMEOUT_MS,
-    ):
+    )
+    if state == "ready":
         return
+    if state == "captcha":
+        assert_not_captcha(page.content())  # re-raises BrowserCaptchaError
+    if state == "auth":
+        assert_authenticated(page.content())  # re-raises BrowserAuthError
 
     raise BrowserSessionError(
         f"The edit page for campaign {campaign_id} did not finish rendering "
@@ -2578,20 +2595,50 @@ def _wait_for_edit_form(page: "Page", campaign_id: int) -> None:
     )
 
 
-def _edit_form_ready_or_raise(page: "Page") -> bool:
+def _edit_form_terminal_state(page: "Page") -> "Optional[str]":
     """Predicate for ``_wait_for_edit_form``'s poll loop.
 
-    Checked on every tick rather than once before the loop starts, so a
-    captcha/login page that renders in after the initial ``commit``
-    response is caught with its specific error instead of being missed and
-    only surfacing later as ``_wait_for_edit_form``'s generic timeout.
-    ``assert_not_captcha``/``assert_authenticated`` raise on a match, which
-    ``_poll_until`` lets propagate (it only suppresses ``PlaywrightError``).
+    Returns ``"ready"`` once the form marker is present, ``"captcha"``/
+    ``"auth"`` if a captcha or login page appears instead, or ``None`` to
+    keep polling. Deliberately returns rather than raises — see
+    ``_wait_for_edit_form``'s docstring for why the caller re-runs
+    ``assert_not_captcha``/``assert_authenticated`` itself, outside the
+    poll loop, to actually raise.
     """
     html = page.content()
-    assert_not_captcha(html)
-    assert_authenticated(html)
-    return page.locator(f'[data-testid="{_EDIT_FORM_READY_TESTID}"]').count() > 0
+    if find_captcha_marker(html) is not None:
+        return "captcha"
+    if find_marker(html, _LOGIN_PAGE_MARKERS) is not None:
+        return "auth"
+    if page.locator(f'[data-testid="{_EDIT_FORM_READY_TESTID}"]').count() > 0:
+        return "ready"
+    return None
+
+
+def _poll_until_terminal(
+    page: "Page",
+    predicate: "Callable[[], Optional[str]]",
+    timeout_ms: int,
+    *,
+    tick_ms: int = 250,
+) -> "Optional[str]":
+    """Like ``_poll_until``, but for a predicate returning a terminal-state
+    string (truthy, non-``None``) instead of a bare bool.
+
+    Used where the poll loop must distinguish several ready-to-stop states
+    (e.g. "form rendered" vs. "captcha appeared") rather than a single
+    true/false — see ``_edit_form_terminal_state``. ``PlaywrightError`` is
+    suppressed the same way ``_poll_until`` does, for the same reason (a
+    locator query racing a mid-render DOM is expected, not a failure).
+    """
+    deadline = time.monotonic() + timeout_ms / 1000
+    while time.monotonic() < deadline:
+        with contextlib.suppress(PlaywrightError):
+            state = predicate()
+            if state is not None:
+                return state
+        page.wait_for_timeout(tick_ms)
+    return None
 
 
 def _wait_for_images_editor(page: "Page") -> None:

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -2898,6 +2898,19 @@ class TestUpdateMaster(unittest.TestCase):
                 [header_handle]
             )
 
+        # Issue #684: every WIZARD_EDIT_URL goto() now polls
+        # _wait_for_edit_form for the first headline slot before trusting
+        # the page. headlines_state already adds a real handle for slot 0
+        # when a test cares about headline content; otherwise stand in with
+        # a bare present handle, mirroring _FakeImagesPage's treatment of
+        # _IMAGES_EDITOR_SELECTOR as "always present once the page renders".
+        edit_form_ready_selector = (
+            f'[data-testid="{browser_masters._EDIT_FORM_READY_TESTID}"]'
+        )
+        locators.setdefault(
+            edit_form_ready_selector, _FakeLocator([_FakeLocatorHandle()])
+        )
+
         page = FakePage(
             locators=locators,
             role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
@@ -3001,6 +3014,9 @@ class TestUpdateMaster(unittest.TestCase):
         accept_handle = _FakeLocatorHandle()
         header_handle = _FakeLocatorHandle()
         header_handle.inner_text = lambda: name_state["value"]
+        edit_form_ready_selector = (
+            f'[data-testid="{browser_masters._EDIT_FORM_READY_TESTID}"]'
+        )
         page = FakePage(
             locators={
                 browser_masters._EDIT_NAME_BUTTON_SELECTOR: _FakeLocator(
@@ -3013,6 +3029,7 @@ class TestUpdateMaster(unittest.TestCase):
                     [accept_handle]
                 ),
                 browser_masters._NAME_HEADER_SELECTOR: _FakeLocator([header_handle]),
+                edit_form_ready_selector: _FakeLocator([_FakeLocatorHandle()]),
             },
             role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
         )
@@ -3069,11 +3086,15 @@ class TestUpdateMaster(unittest.TestCase):
             on_fill=lambda v: None,  # the fill "succeeds" but doesn't persist
             get_value=lambda: budget_state["value"],
         )
+        edit_form_ready_selector = (
+            f'[data-testid="{browser_masters._EDIT_FORM_READY_TESTID}"]'
+        )
         page = FakePage(
             locators={
                 browser_masters._WEEKLY_BUDGET_INPUT_XPATH: _FakeLocator(
                     [budget_handle]
-                )
+                ),
+                edit_form_ready_selector: _FakeLocator([_FakeLocatorHandle()]),
             },
             role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
         )
@@ -3091,11 +3112,15 @@ class TestUpdateMaster(unittest.TestCase):
             on_check=lambda v: None,
             get_checked=lambda: checkbox_state["checked"],
         )
+        edit_form_ready_selector = (
+            f'[data-testid="{browser_masters._EDIT_FORM_READY_TESTID}"]'
+        )
         page = FakePage(
             locators={
                 browser_masters._DIRECT_HELPS_CHECKBOX_XPATH: _FakeLocator(
                     [checkbox_handle]
-                )
+                ),
+                edit_form_ready_selector: _FakeLocator([_FakeLocatorHandle()]),
             },
             role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
         )
@@ -3119,9 +3144,13 @@ class TestUpdateMaster(unittest.TestCase):
         trigger = _FakeLocatorHandle(text="Цель продвижения")
         trigger.inner_text = lambda: next(trigger_texts)
         save_handle = _FakeTextLocatorHandle(visible=True)
+        edit_form_ready_selector = (
+            f'[data-testid="{browser_masters._EDIT_FORM_READY_TESTID}"]'
+        )
         page = FakePage(
             locators={
-                browser_masters._PROMOTION_GOAL_BUTTON_XPATH: _FakeLocator([trigger])
+                browser_masters._PROMOTION_GOAL_BUTTON_XPATH: _FakeLocator([trigger]),
+                edit_form_ready_selector: _FakeLocator([_FakeLocatorHandle()]),
             },
             role_elements=[
                 ("option", "Максимум переходов", _FakeTextLocatorHandle(visible=True)),
@@ -4987,6 +5016,15 @@ class _FakeImagesPage(FakePage):
         self.upload_paths = []
 
     def locator(self, selector):
+        edit_form_ready_selector = (
+            f'[data-testid="{browser_masters._EDIT_FORM_READY_TESTID}"]'
+        )
+        if selector == edit_form_ready_selector:
+            # Issue #684: _wait_for_edit_form's marker — headlines always
+            # render on the edit page regardless of the images fake's own
+            # state, same "present as soon as the page has rendered"
+            # treatment as _IMAGES_EDITOR_SELECTOR just below.
+            return _FakeLocator([_FakeLocatorHandle()])
         if selector == browser_masters._IMAGES_EDITOR_SELECTOR:
             # The images section itself — present as soon as the (fake) page
             # has rendered, which is what `_wait_for_images_editor` polls for
@@ -5197,6 +5235,144 @@ class TestWaitForImagesEditor(unittest.TestCase):
 
         self.assertIn("did not finish rendering", str(ctx.exception))
         self.assertIn("loading placeholders", str(ctx.exception))
+
+
+class TestWaitForEditForm(unittest.TestCase):
+    """``_wait_for_edit_form`` (issue #684) — regression guard for the
+    ``domcontentloaded`` navigation timeout.
+
+    Every ``WIZARD_EDIT_URL`` ``goto()`` now uses ``wait_until="commit"``
+    (never hangs on the SPA's own long-poll connections) instead of
+    ``domcontentloaded``, which was observed to time out. ``commit``
+    guarantees nothing about the DOM, so every call site polls this
+    function for the first headline slot before trusting the page.
+    """
+
+    def _edit_form_ready_selector(self):
+        return f'[data-testid="{browser_masters._EDIT_FORM_READY_TESTID}"]'
+
+    def test_returns_once_the_first_headline_slot_is_present(self):
+        page = FakePage(
+            locators={
+                self._edit_form_ready_selector(): _FakeLocator([_FakeLocatorHandle()])
+            }
+        )
+
+        browser_masters._wait_for_edit_form(page, 42)  # must not raise
+
+    def test_raises_if_the_marker_never_appears(self):
+        page = FakePage(locators={})
+        with patch.object(browser_masters, "_EDIT_FORM_READY_TIMEOUT_MS", 1):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters._wait_for_edit_form(page, 42)
+
+        self.assertIn("did not finish rendering", str(ctx.exception))
+        self.assertIn("42", str(ctx.exception))
+        self.assertIn(browser_masters._EDIT_FORM_READY_TESTID, str(ctx.exception))
+
+    def test_polls_rather_than_failing_on_the_first_absence(self):
+        """Mirrors ``_wait_for_images_editor``'s stub-window test: the
+        marker appearing on a LATER poll (not the first) must still be
+        accepted, not just an immediately-present one."""
+
+        class _AppearsAfterTicksPage(FakePage):
+            def __init__(self, *args, absent_ticks=2, **kwargs):
+                super().__init__(*args, **kwargs)
+                self._absent_ticks_remaining = absent_ticks
+
+            def locator(self, selector):
+                if (
+                    selector
+                    == (
+                        f'[data-testid="' f'{browser_masters._EDIT_FORM_READY_TESTID}"]'
+                    )
+                    and self._absent_ticks_remaining > 0
+                ):
+                    self._absent_ticks_remaining -= 1
+                    return _FakeLocator([])
+                return super().locator(selector)
+
+        page = _AppearsAfterTicksPage(
+            locators={
+                self._edit_form_ready_selector(): _FakeLocator([_FakeLocatorHandle()])
+            },
+            absent_ticks=2,
+        )
+
+        browser_masters._wait_for_edit_form(page, 42)  # must not raise
+
+        self.assertEqual(page._absent_ticks_remaining, 0)
+
+
+class TestWizardEditNavigationUsesCommit(unittest.TestCase):
+    """Issue #684: all four ``WIZARD_EDIT_URL`` navigation sites must use
+    ``wait_until="commit"`` (never hangs on the SPA's long-poll
+    connections) and wait for ``_wait_for_edit_form`` before touching the
+    page — regression guard against reintroducing
+    ``wait_until="domcontentloaded"``, which was observed to time out.
+    """
+
+    def test_verify_saved_uses_commit_and_waits_for_the_form(self):
+        page, save_clicks = TestUpdateMaster()._page_with_save_button(
+            weekly_budget_state={"value": "80000"}
+        )
+
+        browser_masters.update_master(page, 42, weekly_budget=80000)
+
+        self.assertEqual(page.goto_wait_until, "commit")
+
+    def test_update_master_uses_commit_for_the_initial_navigation(self):
+        navigated_wait_untils = []
+
+        class _RecordingPage(FakePage):
+            def goto(self, url, wait_until=None):
+                navigated_wait_untils.append(wait_until)
+                super().goto(url, wait_until=wait_until)
+
+        edit_form_ready_selector = (
+            f'[data-testid="{browser_masters._EDIT_FORM_READY_TESTID}"]'
+        )
+        budget_state = {"value": "80000"}
+        budget_handle = _FakeLocatorHandle(
+            on_fill=lambda v: budget_state.__setitem__("value", v),
+            get_value=lambda: budget_state["value"],
+        )
+        save_handle = _FakeTextLocatorHandle(visible=True)
+        page = _RecordingPage(
+            locators={
+                browser_masters._WEEKLY_BUDGET_INPUT_XPATH: _FakeLocator(
+                    [budget_handle]
+                ),
+                edit_form_ready_selector: _FakeLocator([_FakeLocatorHandle()]),
+            },
+            role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
+        )
+
+        browser_masters.update_master(page, 42, weekly_budget=95000)
+
+        # Both the initial edit and _verify_saved's post-save reload.
+        self.assertEqual(navigated_wait_untils, ["commit", "commit"])
+
+    def test_open_images_editor_uses_commit(self):
+        page = _FakeImagesPage(["a"])
+
+        browser_masters._open_images_editor(page, 42)
+
+        self.assertEqual(page.goto_wait_until, "commit")
+
+    def test_verify_saved_images_uses_commit(self):
+        page = _FakeImagesPage(["a"])
+
+        browser_masters._verify_saved_images(
+            page,
+            42,
+            expected_kept_ids=["a"],
+            removed_ids=set(),
+            expected_added_count=0,
+            clicked_button_label="Сохранить кампанию",
+        )
+
+        self.assertEqual(page.goto_wait_until, "commit")
 
 
 class TestSetImage(unittest.TestCase):

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -5351,6 +5351,41 @@ class TestWaitForEditForm(unittest.TestCase):
         with self.assertRaises(BrowserAuthError):
             browser_masters._wait_for_edit_form(page, 42)
 
+    def test_raises_browser_captcha_error_even_when_playwright_error_is_broad_exception(
+        self,
+    ):
+        """Regression guard for the CI failure this fix caused before this
+        commit: ``PlaywrightError`` falls back to the broad ``Exception``
+        (module top, ``ImportError`` branch) when Playwright isn't
+        installed — the case for this repo's offline unit-test CI job.
+        ``_poll_until``/``_poll_until_terminal`` suppress ``PlaywrightError``
+        inside their loop, so if the captcha/auth check were allowed to
+        *raise* from inside the polled predicate (as an earlier version of
+        this fix did), that broad alias would silently swallow
+        ``BrowserCaptchaError``/``BrowserAuthError`` too in this
+        environment, and the poll would run out the clock and report a
+        generic ``BrowserSessionError`` instead — exactly what broke CI.
+        This test patches ``PlaywrightError`` to ``Exception`` directly
+        (rather than relying on a real Playwright-absent environment) so
+        the regression is caught locally too, not just in CI."""
+
+        class _CaptchaAppearsAfterTicksPage(FakePage):
+            def __init__(self, *args, clean_ticks=2, **kwargs):
+                super().__init__(*args, **kwargs)
+                self._clean_ticks_remaining = clean_ticks
+
+            def content(self):
+                if self._clean_ticks_remaining > 0:
+                    self._clean_ticks_remaining -= 1
+                    return "<html></html>"
+                return "<html>showCaptcha marker here</html>"
+
+        page = _CaptchaAppearsAfterTicksPage(locators={}, clean_ticks=2)
+
+        with patch.object(browser_masters, "PlaywrightError", Exception):
+            with self.assertRaises(BrowserCaptchaError):
+                browser_masters._wait_for_edit_form(page, 42)
+
 
 class TestWizardEditNavigationUsesCommit(unittest.TestCase):
     """Issue #684: all four ``WIZARD_EDIT_URL`` navigation sites must use

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -3381,14 +3381,17 @@ class TestUpdateMaster(unittest.TestCase):
         )
 
         original_assert_authenticated = browser_masters.assert_authenticated
-        calls = []
 
         def _assert_authenticated(content):
-            calls.append(True)
-            # First call happens before any mutation (module convention);
-            # only the post-save reload inside _verify_saved (second call)
-            # hits the invalidated session.
-            if len(calls) >= 2:
+            # The terminal save click is irreversible and NOT idempotent for
+            # images (see this test's own docstring) — only an auth failure
+            # AFTER that click (i.e. during _verify_saved's post-save
+            # reload) is the dangerous case this test guards. Gating on
+            # page_save_clicks rather than a raw call count keeps this
+            # correct regardless of how many assert_authenticated calls
+            # precede the save (e.g. _wait_for_edit_form's own poll-loop
+            # check, added in cycle-review round 1 of PR #689).
+            if page_save_clicks:
                 raise BrowserAuthError("stale session, detected mid-body")
             return original_assert_authenticated(content)
 
@@ -5282,16 +5285,16 @@ class TestWaitForEditForm(unittest.TestCase):
 
             def locator(self, selector):
                 if (
-                    selector
-                    == (
-                        f'[data-testid="' f'{browser_masters._EDIT_FORM_READY_TESTID}"]'
-                    )
+                    selector == self._edit_form_ready_selector_str
                     and self._absent_ticks_remaining > 0
                 ):
                     self._absent_ticks_remaining -= 1
                     return _FakeLocator([])
                 return super().locator(selector)
 
+        _AppearsAfterTicksPage._edit_form_ready_selector_str = (
+            f'[data-testid="{browser_masters._EDIT_FORM_READY_TESTID}"]'
+        )
         page = _AppearsAfterTicksPage(
             locators={
                 self._edit_form_ready_selector(): _FakeLocator([_FakeLocatorHandle()])
@@ -5302,6 +5305,51 @@ class TestWaitForEditForm(unittest.TestCase):
         browser_masters._wait_for_edit_form(page, 42)  # must not raise
 
         self.assertEqual(page._absent_ticks_remaining, 0)
+
+    def test_raises_browser_captcha_error_if_captcha_appears_mid_poll(self):
+        """Issue #684 cycle-review: ``wait_until="commit"`` returns before
+        the SPA's own JS has redirected to a captcha/login page, so a
+        SmartCaptcha gate served AFTER the initial commit response must
+        still be caught by ``_wait_for_edit_form``'s poll loop — not just
+        missed by the one-shot ``assert_not_captcha``/``assert_authenticated``
+        checks that ran immediately after ``goto()``, before this function
+        was even called."""
+
+        class _CaptchaAppearsAfterTicksPage(FakePage):
+            def __init__(self, *args, clean_ticks=2, **kwargs):
+                super().__init__(*args, **kwargs)
+                self._clean_ticks_remaining = clean_ticks
+
+            def content(self):
+                if self._clean_ticks_remaining > 0:
+                    self._clean_ticks_remaining -= 1
+                    return "<html></html>"
+                return "<html>showCaptcha marker here</html>"
+
+        page = _CaptchaAppearsAfterTicksPage(locators={}, clean_ticks=2)
+
+        with self.assertRaises(BrowserCaptchaError):
+            browser_masters._wait_for_edit_form(page, 42)
+
+    def test_raises_browser_auth_error_if_login_page_appears_mid_poll(self):
+        """Same race as the captcha case above, but for an expired/wrong
+        session redirecting to Yandex Passport instead."""
+
+        class _LoginAppearsAfterTicksPage(FakePage):
+            def __init__(self, *args, clean_ticks=2, **kwargs):
+                super().__init__(*args, **kwargs)
+                self._clean_ticks_remaining = clean_ticks
+
+            def content(self):
+                if self._clean_ticks_remaining > 0:
+                    self._clean_ticks_remaining -= 1
+                    return "<html></html>"
+                return "<html>Войдите с Яндекс ID</html>"
+
+        page = _LoginAppearsAfterTicksPage(locators={}, clean_ticks=2)
+
+        with self.assertRaises(BrowserAuthError):
+            browser_masters._wait_for_edit_form(page, 42)
 
 
 class TestWizardEditNavigationUsesCommit(unittest.TestCase):


### PR DESCRIPTION
## Summary

- All four `WIZARD_EDIT_URL` navigation sites (`_verify_saved`, `update_master`, `_open_images_editor`, `_verify_saved_images`) switch from `page.goto(url, wait_until="domcontentloaded")` to `wait_until="commit"` — `domcontentloaded` was observed to time out under real network conditions (the page's own long-poll connections can make even that early lifecycle event hang).
- `commit` guarantees nothing about the DOM, so a new `_wait_for_edit_form` helper polls for the edit form's first headline slot (`CampaignTitles0.textarea` — guaranteed present on any rendered edit page, DRAFT or not) before any call site touches the page, mirroring `_wait_for_images_editor`'s existing "wait for real content, not just the navigation call" discipline.
- `fetch_master_images`'s pre-existing `_wait_for_images_editor` call composes cleanly on top (form-ready wait first, then the images-specific stub wait, unchanged).

## Live verification (2026-08-03, DRAFT campaign 713234191)

- Two consecutive `masters update --weekly-budget` runs round-tripped correctly, exercising both `update_master`'s initial navigation and `_verify_saved`'s post-save re-navigation (would have raised `BrowserSessionError` on any mismatch — neither did).
- `masters adimages get` confirmed `_open_images_editor` (the third navigation site) still works correctly after the switch.

## Test plan

- [x] `pytest tests/test_masters.py -q` — 364 passed (includes new `TestWaitForEditForm` + `TestWizardEditNavigationUsesCommit` regression coverage)
- [x] `black --check` / `flake8` clean on touched Python files
- [x] Live verification as above

Closes #684