### PR TITLE
fix(masters): domcontentloaded → commit + explicit step1 wait in create_master

### DIFF
--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -356,6 +356,15 @@ _CREATE_INVALID_URL_TEXT = "Некорректный формат ссылки"
 # content to pre-fill headlines/texts/images), well within this budget.
 _CREATE_STEP2_TIMEOUT_MS = 30_000
 
+# How long to wait for step 1's URL field to render after ``goto`` (issue
+# #685). Same SPA shape as the edit page (``_wait_for_images_editor``'s
+# docstring): the create page hydrates client-side, so
+# ``wait_until="commit"`` — which only waits for the response headers, not
+# even the initial HTML parse ``domcontentloaded`` gives you — returns while
+# step 1's own field is still absent from the DOM. 15s is generous for a
+# static first step (no server-side scan happens until "Далее" is clicked).
+_CREATE_STEP1_TIMEOUT_MS = 15_000
+
 # Step 2 field locators for headlines/texts (issue #653 re-recon,
 # 2026-08-02): Yandex replaced the single "current variant input + Enter"
 # flow with a FIXED set of pre-rendered slots, each its own contenteditable
@@ -2110,6 +2119,45 @@ def _fill_landing_url(page: "Page", url: str) -> None:
         )
 
 
+def _wait_for_create_step1(page: "Page") -> None:
+    """Block until the create page's step 1 URL field has rendered.
+
+    ``goto(WIZARD_CREATE_URL, wait_until="commit")`` returns as soon as the
+    response headers arrive — before Playwright has even parsed the initial
+    HTML, let alone run the client-side JS that renders step 1's field (see
+    ``_CREATE_STEP1_TIMEOUT_MS``). Without this wait, ``_fill_landing_url``'s
+    ``page.locator(_CREATE_URL_INPUT_TESTID).first.click()`` races the page's
+    hydration: Playwright's own actionability auto-wait usually absorbs this,
+    but on a slow render it can exceed ``.click()``'s default timeout and
+    surface as an opaque ``PlaywrightError`` that ``_fill_landing_url``
+    reports as "Yandex may have changed the page's markup" — a misdiagnosis
+    of a load-timing issue as a markup change (issue #685).
+    """
+    if _poll_until(
+        page,
+        lambda: page.locator(_CREATE_URL_INPUT_TESTID).count() > 0,
+        _CREATE_STEP1_TIMEOUT_MS,
+    ):
+        return
+
+    # ``commit`` returns before the page has any real content, so the
+    # captcha/auth checks callers run immediately after ``goto`` may have
+    # passed vacuously against near-empty HTML. Re-run them against
+    # whatever rendered during the poll above so a captcha/login page that
+    # only appeared partway through is reported specifically, instead of as
+    # this function's generic step-1 timeout.
+    assert_not_captcha(page.content())
+    assert_authenticated(page.content())
+
+    raise BrowserSessionError(
+        "Timed out waiting for the Мастер кампаний create page's step 1 "
+        f"(the landing-page URL field) to render within "
+        f"{_CREATE_STEP1_TIMEOUT_MS / 1000:.0f}s. Yandex may have changed "
+        "the page's markup, or the page may still be loading. Re-run with "
+        "--headful to inspect the page."
+    )
+
+
 def _wait_for_step2(page: "Page") -> None:
     """Block until step 2's long form has rendered.
 
@@ -3526,9 +3574,17 @@ def create_master(
     if not regions:
         raise ValueError("create_master requires at least one region.")
 
-    page.goto(WIZARD_CREATE_URL, wait_until="domcontentloaded")
+    # ``wait_until="commit"``, not ``domcontentloaded`` (issue #685):
+    # confirmed live the create page can take long enough to hydrate that
+    # even ``domcontentloaded`` — which additionally waits for the initial
+    # HTML parse — occasionally times out before Playwright's navigation
+    # settles. "commit" only waits for the response to start arriving, so
+    # the actual page-ready check is the explicit
+    # ``_wait_for_create_step1`` below, not the navigation wait itself.
+    page.goto(WIZARD_CREATE_URL, wait_until="commit")
     assert_not_captcha(page.content())
     assert_authenticated(page.content())
+    _wait_for_create_step1(page)
 
     _fill_landing_url(page, url)
     _wait_for_step2(page)

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -6174,6 +6174,7 @@ class TestCreateMaster(unittest.TestCase):
             },
         )
         self.assertEqual(page.navigated_to, [browser_masters.WIZARD_CREATE_URL])
+        self.assertEqual(page.goto_wait_until, "commit")
 
     def test_saves_as_draft_when_launch_false(self):
         page, state = self._full_page()
@@ -6257,6 +6258,28 @@ class TestCreateMaster(unittest.TestCase):
                 texts=["t"],
                 regions=["Москва"],
             )
+
+    def test_step1_timeout_raises_when_url_field_never_renders(self):
+        """issue #685: ``goto`` now uses ``wait_until="commit"``, which
+        returns before the page has any real content — the create page's
+        step 1 field must be waited on explicitly, and a page that never
+        renders it must fail with a specific ``BrowserSessionError``, not an
+        opaque markup-changed error from ``_fill_landing_url`` racing an
+        unrendered field.
+        """
+        page, _ = self._full_page()
+        del page._locators[browser_masters._CREATE_URL_INPUT_TESTID]
+
+        with patch.object(browser_masters, "_CREATE_STEP1_TIMEOUT_MS", 10):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters.create_master(
+                    page,
+                    "https://ksamata.ru/",
+                    headlines=["h"],
+                    texts=["t"],
+                    regions=["Москва"],
+                )
+        self.assertIn("step 1", str(ctx.exception))
 
     def test_raises_before_launch_when_a_headline_slot_did_not_actually_clear(
         self,


### PR DESCRIPTION
## Summary

- `create_master` navigated to `WIZARD_CREATE_URL` with
  `wait_until="domcontentloaded"`, which can time out before the create
  page finishes rendering (confirmed by the issue's own recon).
- Switches to `wait_until="commit"` (only waits for the response to start
  arriving, not even the initial HTML parse) paired with a new
  `_wait_for_create_step1` that explicitly polls for step 1's URL field
  (`_CREATE_URL_INPUT_TESTID`) before proceeding — the same
  "commit/domcontentloaded goto + explicit marker wait" pattern already
  used elsewhere in this module (`_wait_for_step2`,
  `_wait_for_images_editor`).
- On timeout, re-runs `assert_not_captcha`/`assert_authenticated` against
  whatever rendered during the poll, so a captcha/login page that only
  appeared partway through the poll is still reported specifically —
  `wait_until="commit"` can return before those checks have any real
  content to inspect.

## Live verification

Ran `direct masters add <url> --headline ... --text ... --region Москва
--draft` against the real account.

- ✅ **In scope for this fix**: navigation with `wait_until="commit"` +
  `_wait_for_create_step1` works correctly live — the URL field
  (`CampaignFormUrl.Textinput`) renders and is found immediately, no
  timeout.
- ⚠️ **Pre-existing, unrelated markup drift found**: after typing into the
  URL field, `CampaignFormUrl.button` ("Далее") no longer exists anywhere
  in the DOM — confirmed via a full `data-testid` dump and a screenshot.
  Yandex appears to have replaced the field with a Combobox
  (autocomplete/suggestions popup), so the old "type URL, click adjacent
  button" flow is stale independent of this issue's `wait_until` fix.
  Filed as #690 for follow-up; `create_master` cannot currently complete
  end-to-end until that's fixed, but that failure is unrelated to (and
  postdates) the `domcontentloaded` timeout this PR addresses.

## Tests

- Added `test_step1_timeout_raises_when_url_field_never_renders` —
  patches `_CREATE_STEP1_TIMEOUT_MS` down and asserts a specific
  `BrowserSessionError` when the URL field never renders.
- Added an assertion in `test_launches_by_default` that `goto` is now
  called with `wait_until="commit"`.
- `pytest tests/test_masters.py` — 337 passed.
- `black`/`flake8` clean.

Closes #685

🤖 Generated with [Claude Code](https://claude.com/claude-code)