### PR TITLE
fix(session): wait for a DOM marker instead of domcontentloaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,36 @@
   in ~15-25s across repeated runs (previously could exhaust the 30s
   `expect_response` timeout).
 
+**Fixed — `direct playwright login`/`doctor` navigation could time out on
+`wait_until="domcontentloaded"` (#686):**
+
+- The three navigations in `direct_cli/browser/session.py`
+  (`login_persistent_session`'s Passport tab and poll probe,
+  `capture_storage_state`'s grid verification) occasionally timed out on
+  `domcontentloaded` during Passport's own slow initial paint — the same
+  long-poll-connections issue #634 already worked around for
+  `networkidle`, one navigation-event tier down.
+- All three now use `wait_until="commit"` (returns as soon as the
+  navigation is committed, before the target SPA's own JS runs) followed by
+  a new `_wait_for_marker` poll for a concrete DOM marker —
+  `[data-testid="auth-logo"]` for Passport, `[data-testid="Sidebar"]` for
+  the authenticated Direct/grid shell (confirmed live 2026-08-03). Only
+  once the marker is present does the caller trust `page.content()` for its
+  captcha/auth checks.
+- `login_persistent_session`'s polling loop (re-navigates to the grid every
+  tick while the user is still logging in by hand) accepts either marker,
+  capped at the poll interval rather than the full marker timeout — an
+  unfinished login redirects the grid URL right back to Passport, and
+  waiting on the grid's marker alone would burn the full timeout every
+  tick until the user finishes.
+- The marker poll now fails closed: if neither marker ever appears (a
+  blank/unrendered shell, matching none of the captcha/login-page markers
+  either), `login_persistent_session`'s initial Passport navigation and
+  `capture_storage_state`'s grid verification raise instead of trusting an
+  unrendered page's `page.content()`, and the login-completion poll loop
+  treats an unrendered tick as "not authenticated yet" rather than a
+  successful, verified login (cycle-review on #692).
+
 **Added — `direct masters adimages delete/set` (#648):**
 
 - Completes the `masters adimages` subgroup, so a campaign's image set can

--- a/direct_cli/browser/session.py
+++ b/direct_cli/browser/session.py
@@ -458,7 +458,18 @@ def login_persistent_session(
     ) as context:
         page = context.new_page()
         page.goto(_PASSPORT_LOGIN_URL, wait_until="commit")
-        _wait_for_marker(page, _PASSPORT_PAGE_MARKERS)
+        if not _wait_for_marker(page, _PASSPORT_PAGE_MARKERS):
+            # Fail closed: a timed-out marker means the page never rendered
+            # far enough to trust `page.content()` — an in-progress/blank
+            # shell may contain neither the login-page nor captcha markers
+            # `assert_authenticated`/`assert_not_captcha` scan for, which
+            # would otherwise let an unrendered page sail through as if it
+            # were a real one (issue #692 cycle-review).
+            raise BrowserSessionError(
+                f"Timed out waiting for {_PASSPORT_LOGIN_URL} to render. "
+                "This can happen on a slow connection — retry `direct "
+                "masters login`."
+            )
 
         # Poll on a second page, never on `page`: the human is typing into
         # that one, and navigating it to the grid once a second would wipe a
@@ -478,11 +489,21 @@ def login_persistent_session(
                 # interval, not `_PAGE_MARKER_TIMEOUT_MS`, so a slow-to-paint
                 # page degrades to "try again next tick" rather than
                 # stalling this loop's own cadence.
-                _wait_for_marker(
+                marker_found = _wait_for_marker(
                     probe,
                     _DIRECT_OR_PASSPORT_PAGE_MARKERS,
                     timeout_ms=_LOGIN_POLL_INTERVAL_MS,
                 )
+                if not marker_found:
+                    # Neither page rendered far enough this tick to trust
+                    # `probe.content()` — a blank/in-progress shell can
+                    # contain neither the login-page nor captcha markers, so
+                    # treat this exactly like "not authenticated yet" rather
+                    # than risking `assert_authenticated` passing an
+                    # unrendered page (issue #692 cycle-review). This is the
+                    # expected outcome on a slow tick, not an error.
+                    elapsed_ms += _LOGIN_POLL_INTERVAL_MS
+                    continue
                 html = probe.content()
                 assert_not_captcha(html)
                 try:
@@ -586,7 +607,15 @@ def capture_storage_state(
             # the grid, and `assert_authenticated` below is what turns that
             # into the specific `BrowserAuthError` (see `_wait_for_marker`'s
             # docstring for why a single marker would be wrong here).
-            _wait_for_marker(page, _DIRECT_OR_PASSPORT_PAGE_MARKERS)
+            if not _wait_for_marker(page, _DIRECT_OR_PASSPORT_PAGE_MARKERS):
+                # Fail closed: an unrendered page can contain neither the
+                # login-page nor captcha markers the checks below scan for,
+                # which would otherwise let it pass as if it were a
+                # verified, authenticated grid (issue #692 cycle-review).
+                raise BrowserAuthError(
+                    f"Timed out waiting for {GRID_URL} to render while "
+                    "verifying the session. Retry `direct playwright login`."
+                )
             html = page.content()
             assert_not_captcha(html)
             assert_authenticated(html)

--- a/direct_cli/browser/session.py
+++ b/direct_cli/browser/session.py
@@ -39,6 +39,7 @@ instead of a transparent cookie copy.
 import contextlib
 import os
 import platform
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Generator, Optional, Tuple
 
@@ -46,6 +47,11 @@ from .._captcha import find_captcha_marker, find_marker
 
 if TYPE_CHECKING:
     from playwright.sync_api import Browser, Page
+
+try:
+    from playwright.sync_api import Error as PlaywrightError
+except ImportError:  # pragma: no cover - exercised only when playwright is absent
+    PlaywrightError = Exception  # type: ignore[assignment,misc]
 
 _BROWSER_INSTALL_HINT = (
     'pip install "direct-cli[browser]" && playwright install chromium'
@@ -127,6 +133,89 @@ _LOGIN_PAGE_MARKERS = (
     "passport.yandex.ru/pwl-yandex",
     "Войдите с Яндекс ID",
 )
+
+# DOM markers this module polls for after ``wait_until="commit"`` navigations
+# — see ``_wait_for_marker``'s docstring for why ``commit`` replaced
+# ``domcontentloaded`` here (issue #686). Both are the outer shell of their
+# respective page, present regardless of which specific sub-state (account
+# picker, password form, 2FA prompt; populated grid vs. empty one) is
+# showing, so waiting on them cannot itself race the thing a caller actually
+# wants to inspect next (``page.content()`` for the auth/captcha checks, or —
+# for the Passport case — the human's own typing into the form).
+#
+# ``auth-logo`` confirmed live 2026-08-03 against a real
+# ``passport.yandex.ru/pwl-yandex/auth/list`` response (Yandex's own account
+# picker) — the Passport page shell's logo, present on every Passport screen
+# (login form, account list, 2FA) since it's part of the shared layout, not
+# any single step's own markup.
+_PASSPORT_PAGE_MARKERS = ('[data-testid="auth-logo"]',)
+
+# ``Sidebar`` confirmed live 2026-08-03 against a real, authenticated
+# ``https://direct.yandex.ru/dna/grid/campaigns/`` response — Direct's own
+# left navigation shell, present on every authenticated Direct page
+# regardless of the grid's own virtualized content (issue #639: the grid
+# never renders a stable content marker of its own, only its
+# ``GridCampaigns`` data call does — see ``direct_cli/browser/masters.py``'s
+# ``_capture_grid_campaigns_request``). Waiting on the general Direct shell
+# is sufficient here: both call sites only need ``page.content()`` to be
+# real markup for the captcha/auth checks, not the grid's own data.
+_DIRECT_PAGE_MARKERS = ('[data-testid="Sidebar"]',)
+
+# Union of both marker sets — for a navigation that can legitimately land on
+# either page (see ``_wait_for_marker``'s "Accepts multiple selectors"
+# paragraph).
+_DIRECT_OR_PASSPORT_PAGE_MARKERS = _DIRECT_PAGE_MARKERS + _PASSPORT_PAGE_MARKERS
+
+# Both markers render fast (page-shell chrome, not the data-heavy content
+# behind it) — comfortably inside the same budget the module's other
+# navigation timeouts use.
+_PAGE_MARKER_TIMEOUT_MS = 30_000
+_PAGE_MARKER_POLL_MS = 250
+
+
+def _wait_for_marker(
+    page: "Page",
+    selectors: "Tuple[str, ...]",
+    timeout_ms: int = _PAGE_MARKER_TIMEOUT_MS,
+) -> bool:
+    """Poll until any of ``selectors`` appears in ``page``'s DOM, or on timeout.
+
+    Used after ``wait_until="commit"`` navigations to Yandex Passport and the
+    Direct campaigns grid. ``commit`` only waits for the network response to
+    begin — it returns as soon as the browser has committed to the
+    navigation, before any of the SPA's own JS has run. ``domcontentloaded``
+    would normally be the next step up, but both Passport and the grid keep
+    long-poll connections open (see ``BrowserAuthError``'s docstring and
+    ``_capture_grid_campaigns_request`` in ``masters.py``), so
+    ``domcontentloaded`` — which Playwright fires once the HTML parser
+    finishes, external long-poll requests notwithstanding — is not the
+    problem; the problem observed live (issue #686) was ``goto`` itself
+    occasionally timing out on ``domcontentloaded`` during Passport's own
+    slow initial paint. Polling for a concrete DOM marker instead means every
+    caller observes an actually-rendered page, on a budget independent of
+    whichever network event Playwright happens to fire first.
+
+    Accepts multiple selectors (matched as "any of") rather than one,
+    because a single ``goto`` can legitimately land on either page: the
+    ``login_persistent_session`` polling loop re-navigates to the grid every
+    tick, but an unfinished login redirects that same URL back to Passport —
+    waiting on the grid's marker alone would burn ``timeout_ms`` every tick
+    until the user finishes logging in.
+
+    Returns ``True`` once a marker is found, ``False`` on timeout — mirrors
+    ``direct_cli/browser/masters.py``'s ``_poll_until`` so a timeout is a
+    normal, non-raising outcome the caller decides how to handle (a
+    ``BrowserAuthError``/``BrowserCaptchaError`` from the content-based
+    checks that follow it is almost always the more specific error the user
+    should see, rather than a generic "marker never appeared").
+    """
+    deadline = time.monotonic() + timeout_ms / 1000
+    while time.monotonic() < deadline:
+        with contextlib.suppress(PlaywrightError):
+            if any(page.locator(selector).first.count() > 0 for selector in selectors):
+                return True
+        page.wait_for_timeout(_PAGE_MARKER_POLL_MS)
+    return False
 
 
 def default_chrome_profile_dir() -> Optional[Path]:
@@ -368,7 +457,8 @@ def login_persistent_session(
         sync_playwright, resolved_dir, headless=headless
     ) as context:
         page = context.new_page()
-        page.goto(_PASSPORT_LOGIN_URL, wait_until="domcontentloaded")
+        page.goto(_PASSPORT_LOGIN_URL, wait_until="commit")
+        _wait_for_marker(page, _PASSPORT_PAGE_MARKERS)
 
         # Poll on a second page, never on `page`: the human is typing into
         # that one, and navigating it to the grid once a second would wipe a
@@ -379,7 +469,20 @@ def login_persistent_session(
         try:
             elapsed_ms = 0
             while elapsed_ms < timeout_ms:
-                probe.goto(GRID_URL, wait_until="domcontentloaded")
+                probe.goto(GRID_URL, wait_until="commit")
+                # Either marker is a valid landing spot here: an unfinished
+                # login redirects the grid URL right back to Passport, so
+                # waiting on the grid's own marker alone would burn the full
+                # timeout every tick until the user finishes logging in (see
+                # `_wait_for_marker`'s docstring). Capped at the poll
+                # interval, not `_PAGE_MARKER_TIMEOUT_MS`, so a slow-to-paint
+                # page degrades to "try again next tick" rather than
+                # stalling this loop's own cadence.
+                _wait_for_marker(
+                    probe,
+                    _DIRECT_OR_PASSPORT_PAGE_MARKERS,
+                    timeout_ms=_LOGIN_POLL_INTERVAL_MS,
+                )
                 html = probe.content()
                 assert_not_captcha(html)
                 try:
@@ -477,7 +580,13 @@ def capture_storage_state(
             from .masters import GRID_URL
 
             page = context.new_page()
-            page.goto(GRID_URL, wait_until="domcontentloaded")
+            page.goto(GRID_URL, wait_until="commit")
+            # Either marker is a valid landing spot: a bad/expired cookie
+            # jar redirects the grid URL to Passport instead of rendering
+            # the grid, and `assert_authenticated` below is what turns that
+            # into the specific `BrowserAuthError` (see `_wait_for_marker`'s
+            # docstring for why a single marker would be wrong here).
+            _wait_for_marker(page, _DIRECT_OR_PASSPORT_PAGE_MARKERS)
             html = page.content()
             assert_not_captcha(html)
             assert_authenticated(html)
@@ -543,10 +652,20 @@ def assert_authenticated(html: str) -> None:
     Injected cookies can decrypt successfully yet represent an expired or
     wrong-account session — before #634 this surfaced only as a
     ``Page.goto`` timeout, because Yandex's login page holds long-poll
-    connections and ``wait_until="networkidle"`` never settles on it. Callers
-    should use ``wait_until="domcontentloaded"`` and call this immediately
+    connections and ``wait_until="networkidle"`` never settles on it.
+    ``wait_until="domcontentloaded"`` fixed that, but issue #686 found it
+    still occasionally timed out on Passport's own slow initial paint, so
+    every ``goto`` this module makes to Passport or the Direct grid now uses
+    ``wait_until="commit"`` (returns as soon as the navigation is committed,
+    before any of the target SPA's own JS runs) followed by
+    :func:`_wait_for_marker` polling for a concrete DOM marker
+    (``_PASSPORT_PAGE_MARKERS``/``_DIRECT_PAGE_MARKERS``) — only once that
+    marker is present is the page actually rendered enough for
+    ``page.content()`` to reflect the real page (login page or Direct page)
+    rather than an in-progress shell. Callers should follow this same
+    ``commit`` + marker-poll pattern and call this function immediately
     after, so an auth failure is reported explicitly instead of as an opaque
-    30-second timeout.
+    timeout.
 
     Uses the same ``find_marker`` scan primitive as
     :func:`assert_not_captcha` (``direct_cli._captcha``), just against a

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -1011,6 +1011,61 @@ class TestPersistentSession(unittest.TestCase):
         self.assertEqual(login_page.goto_wait_until, "commit")
         self.assertEqual(authed_page.goto_wait_until, "commit")
 
+    def test_login_fails_closed_when_passport_marker_never_appears(self):
+        """Issue #692 cycle-review: `_wait_for_marker`'s `False` return must
+        not be discarded. A blank/unrendered Passport page matches neither
+        `_PASSPORT_PAGE_MARKERS` nor `_LOGIN_PAGE_MARKERS` — trusting
+        `page.content()` regardless would let an unrendered page slip past
+        `assert_authenticated` undetected, instead of failing loudly."""
+        pytest.importorskip("playwright")
+        from direct_cli.browser import session as session_module
+
+        blank_page = FakePage(locators={}, html="<html></html>")
+        persistent_ctx = _FakePersistentContext(pages=[blank_page])
+        fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
+        fake_playwright = _FakePlaywright(fake_chromium)
+
+        with (
+            patch("playwright.sync_api.sync_playwright", return_value=fake_playwright),
+            patch.object(session_module, "_PAGE_MARKER_TIMEOUT_MS", 10),
+        ):
+            with self.assertRaises(session_module.BrowserSessionError) as ctx:
+                session_module.login_persistent_session(
+                    profile_dir=self.profile_dir, timeout_ms=5_000
+                )
+        self.assertIn("Timed out", str(ctx.exception))
+        self.assertFalse(
+            session_module.PROFILE_POINTER_PATH.exists(),
+            "an unrendered login must not be recorded as a usable profile",
+        )
+
+    def test_login_poll_treats_unrendered_tick_as_not_yet_authenticated(self):
+        """Issue #692 cycle-review: a tick where neither the grid nor
+        Passport marker appears must be treated like "not authenticated
+        yet" (same as an explicit `BrowserAuthError`), not like a
+        successful, verified login — a blank grid response matches neither
+        `_LOGIN_PAGE_MARKERS` nor a captcha marker, so `assert_authenticated`
+        alone would silently accept it."""
+        pytest.importorskip("playwright")
+        from direct_cli.browser import session as session_module
+        from direct_cli.browser.session import BrowserAuthError
+
+        login_page = _passport_page()
+        blank_probe = FakePage(locators={}, html="<html></html>")
+        persistent_ctx = _FakePersistentContext(pages=[login_page, blank_probe])
+        fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
+        fake_playwright = _FakePlaywright(fake_chromium)
+
+        with patch("playwright.sync_api.sync_playwright", return_value=fake_playwright):
+            with self.assertRaises(BrowserAuthError):
+                session_module.login_persistent_session(
+                    profile_dir=self.profile_dir,
+                    timeout_ms=1_000,
+                )
+
+        # The unfinished login must never be recorded as a usable profile.
+        self.assertFalse(session_module.PROFILE_POINTER_PATH.exists())
+
 
 class _FakeVerifyContext(_FakeContext):
     """A ``_FakeContext`` whose ``new_page()`` returns one pre-built page and
@@ -1098,6 +1153,40 @@ class TestCaptureStorageState(unittest.TestCase):
                 session_module.capture_storage_state()
 
         self.assertEqual(page.goto_wait_until, "commit")
+
+    def test_verify_fails_closed_when_grid_marker_never_appears(self):
+        """Issue #692 cycle-review: `_wait_for_marker`'s `False` return must
+        not be discarded here either — a blank/unrendered grid response
+        matches neither `_LOGIN_PAGE_MARKERS` nor a captcha marker, so
+        trusting `page.content()` regardless would let
+        ``capture_storage_state(verify=True)`` return unverified cookies as
+        if the session had been confirmed."""
+        pytest.importorskip("playwright")
+        from direct_cli.browser import session as session_module
+        from direct_cli.browser.session import BrowserAuthError
+
+        blank_page = FakePage(locators={}, html="<html></html>")
+        fake_browser = _FakeBrowser()
+        fake_context = _FakeVerifyContext(blank_page, storage_state={"cookies": []})
+        fake_browser.new_context = lambda **kwargs: fake_context
+        fake_chromium = _FakeChromium(fake_browser)
+        fake_playwright = _FakePlaywright(fake_chromium)
+
+        with (
+            patch("playwright.sync_api.sync_playwright", return_value=fake_playwright),
+            self._patch_decrypt(),
+            patch.object(
+                session_module,
+                "default_chrome_profile_dir",
+                return_value=Path("/fake/chrome/profile"),
+            ),
+            patch.object(Path, "exists", return_value=True),
+            patch.object(session_module, "_PAGE_MARKER_TIMEOUT_MS", 10),
+        ):
+            with self.assertRaises(BrowserAuthError) as ctx:
+                session_module.capture_storage_state()
+
+        self.assertIn("Timed out", str(ctx.exception))
 
 
 class TestOpenSessionTiers(unittest.TestCase):

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -446,6 +446,38 @@ class FakePage:
         pass
 
 
+def _passport_page(html="<body>Войдите с Яндекс ID</body>", **kwargs):
+    """A ``FakePage`` that also carries the Passport DOM marker.
+
+    ``session.py``'s ``login_persistent_session``/``capture_storage_state``
+    poll for ``_PASSPORT_PAGE_MARKERS``/``_DIRECT_PAGE_MARKERS`` via
+    ``_wait_for_marker`` after every ``wait_until="commit"`` navigation
+    (issue #686) — a bare ``FakePage(locators={}, html=...)`` matches neither
+    marker, so ``_wait_for_marker`` would poll for real wall-clock seconds
+    until timeout. This factory (and ``_direct_page`` below) keeps the fake's
+    ``locators`` in sync with whichever page state its ``html`` models.
+    """
+    from direct_cli.browser import session as session_module
+
+    locators = dict(kwargs.pop("locators", {}) or {})
+    for selector in session_module._PASSPORT_PAGE_MARKERS:
+        locators.setdefault(selector, _FakeLocator([_FakeLocatorHandle()]))
+    return FakePage(locators=locators, html=html, **kwargs)
+
+
+def _direct_page(html="<body>Кампания остановлена</body>", **kwargs):
+    """A ``FakePage`` that also carries the Direct (grid) DOM marker.
+
+    See ``_passport_page``'s docstring — same rationale, opposite page.
+    """
+    from direct_cli.browser import session as session_module
+
+    locators = dict(kwargs.pop("locators", {}) or {})
+    for selector in session_module._DIRECT_PAGE_MARKERS:
+        locators.setdefault(selector, _FakeLocator([_FakeLocatorHandle()]))
+    return FakePage(locators=locators, html=html, **kwargs)
+
+
 class TestMastersRegistered(unittest.TestCase):
     """The group and its subcommands must be wired into the root CLI."""
 
@@ -780,8 +812,8 @@ class TestPersistentSession(unittest.TestCase):
         from direct_cli.browser import session as session_module
         from direct_cli.browser.session import BrowserAuthError
 
-        login_page = FakePage(locators={}, html="<body>Войдите с Яндекс ID</body>")
-        probe_page = FakePage(locators={}, html="<body>Войдите с Яндекс ID</body>")
+        login_page = _passport_page()
+        probe_page = _passport_page()
         persistent_ctx = _FakePersistentContext(pages=[login_page, probe_page])
         fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
         fake_playwright = _FakePlaywright(fake_chromium)
@@ -885,8 +917,8 @@ class TestPersistentSession(unittest.TestCase):
 
         # Page 1 is the visible Passport tab; page 2 is the poll probe whose
         # HTML decides whether login has completed.
-        login_page = FakePage(locators={}, html="<body>Войдите с Яндекс ID</body>")
-        authed_page = FakePage(locators={}, html="<body>Кампания остановлена</body>")
+        login_page = _passport_page()
+        authed_page = _direct_page()
         persistent_ctx = _FakePersistentContext(pages=[login_page, authed_page])
         fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
         fake_playwright = _FakePlaywright(fake_chromium)
@@ -904,8 +936,8 @@ class TestPersistentSession(unittest.TestCase):
         from direct_cli.browser import session as session_module
         from direct_cli.browser.session import BrowserAuthError
 
-        login_page = FakePage(locators={}, html="<body>Войдите с Яндекс ID</body>")
-        probe_page = FakePage(locators={}, html="<body>Войдите с Яндекс ID</body>")
+        login_page = _passport_page()
+        probe_page = _passport_page()
         persistent_ctx = _FakePersistentContext(pages=[login_page, probe_page])
         fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
         fake_playwright = _FakePlaywright(fake_chromium)
@@ -932,8 +964,8 @@ class TestPersistentSession(unittest.TestCase):
         from direct_cli.browser import session as session_module
         from direct_cli.browser.session import BrowserAuthError
 
-        login_page = FakePage(locators={}, html="<body>Войдите с Яндекс ID</body>")
-        probe_page = FakePage(locators={}, html="<body>Войдите с Яндекс ID</body>")
+        login_page = _passport_page()
+        probe_page = _passport_page()
         persistent_ctx = _FakePersistentContext(pages=[login_page, probe_page])
         fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
         fake_playwright = _FakePlaywright(fake_chromium)
@@ -952,6 +984,120 @@ class TestPersistentSession(unittest.TestCase):
             [session_module._PASSPORT_LOGIN_URL],
             "poll loop navigated the user's login page away from Passport",
         )
+
+    def test_login_navigations_use_commit_not_domcontentloaded(self):
+        """Issue #686: both `goto` calls in the login flow (the visible
+        Passport tab and the poll probe) must use `wait_until="commit"`, not
+        `domcontentloaded` — Passport occasionally timed out on
+        `domcontentloaded` during its own slow initial paint. `commit`
+        returns as soon as the navigation is committed, and
+        `_wait_for_marker` polling for a concrete DOM marker afterwards is
+        what actually confirms the page rendered (see `_wait_for_marker`'s
+        docstring)."""
+        pytest.importorskip("playwright")
+        from direct_cli.browser import session as session_module
+
+        login_page = _passport_page()
+        authed_page = _direct_page()
+        persistent_ctx = _FakePersistentContext(pages=[login_page, authed_page])
+        fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
+        fake_playwright = _FakePlaywright(fake_chromium)
+
+        with patch("playwright.sync_api.sync_playwright", return_value=fake_playwright):
+            session_module.login_persistent_session(
+                profile_dir=self.profile_dir, timeout_ms=5_000
+            )
+
+        self.assertEqual(login_page.goto_wait_until, "commit")
+        self.assertEqual(authed_page.goto_wait_until, "commit")
+
+
+class _FakeVerifyContext(_FakeContext):
+    """A ``_FakeContext`` whose ``new_page()`` returns one pre-built page and
+    which fakes ``storage_state()`` — needed by ``capture_storage_state``,
+    which neither ``_FakeContext`` nor ``_FakePersistentContext`` support.
+    """
+
+    def __init__(self, page, storage_state=None):
+        super().__init__()
+        self._page = page
+        self._storage_state = storage_state if storage_state is not None else {}
+
+    def new_page(self):
+        return self._page
+
+    def storage_state(self):
+        return self._storage_state
+
+
+class TestCaptureStorageState(unittest.TestCase):
+    """``capture_storage_state`` (``direct playwright login``'s verify path)
+    — issue #686: the grid ``goto`` must use ``wait_until="commit"`` +
+    ``_wait_for_marker`` instead of ``domcontentloaded``.
+    """
+
+    def _patch_decrypt(self):
+        return patch(
+            "direct_cli.browser._chrome_crypto.load_yandex_cookies",
+            return_value=[{"name": "Session_id", "value": "x", "domain": ".yandex.ru"}],
+        )
+
+    def test_verify_navigation_uses_commit_and_succeeds_against_the_grid(self):
+        pytest.importorskip("playwright")
+        from direct_cli.browser import session as session_module
+
+        page = _direct_page()
+        fake_browser = _FakeBrowser()
+        fake_context = _FakeVerifyContext(page, storage_state={"cookies": []})
+        fake_browser.new_context = lambda **kwargs: fake_context
+        fake_chromium = _FakeChromium(fake_browser)
+        fake_playwright = _FakePlaywright(fake_chromium)
+
+        with (
+            patch("playwright.sync_api.sync_playwright", return_value=fake_playwright),
+            self._patch_decrypt(),
+            patch.object(
+                session_module,
+                "default_chrome_profile_dir",
+                return_value=Path("/fake/chrome/profile"),
+            ),
+            patch.object(Path, "exists", return_value=True),
+        ):
+            storage_state, _source_meta = session_module.capture_storage_state()
+
+        self.assertEqual(page.goto_wait_until, "commit")
+        self.assertEqual(storage_state, {"cookies": []})
+
+    def test_verify_raises_auth_error_when_grid_redirects_to_passport(self):
+        """A bad/expired cookie jar redirects the grid URL to Passport
+        instead of rendering the grid — `_wait_for_marker` must accept
+        either page's marker (see its docstring) so `assert_authenticated`
+        gets a real, rendered page to inspect, not an in-progress shell."""
+        pytest.importorskip("playwright")
+        from direct_cli.browser import session as session_module
+        from direct_cli.browser.session import BrowserAuthError
+
+        page = _passport_page()
+        fake_browser = _FakeBrowser()
+        fake_context = _FakeVerifyContext(page)
+        fake_browser.new_context = lambda **kwargs: fake_context
+        fake_chromium = _FakeChromium(fake_browser)
+        fake_playwright = _FakePlaywright(fake_chromium)
+
+        with (
+            patch("playwright.sync_api.sync_playwright", return_value=fake_playwright),
+            self._patch_decrypt(),
+            patch.object(
+                session_module,
+                "default_chrome_profile_dir",
+                return_value=Path("/fake/chrome/profile"),
+            ),
+            patch.object(Path, "exists", return_value=True),
+        ):
+            with self.assertRaises(BrowserAuthError):
+                session_module.capture_storage_state()
+
+        self.assertEqual(page.goto_wait_until, "commit")
 
 
 class TestOpenSessionTiers(unittest.TestCase):


### PR DESCRIPTION
## Summary

- `login_persistent_session` (Passport tab + poll probe) and `capture_storage_state` (grid verification) in `direct_cli/browser/session.py` occasionally timed out on `wait_until="domcontentloaded"` during Passport's own slow initial paint — the same long-poll-connections issue #634 already worked around for `networkidle`, one navigation-event tier down (see #671 for the full diagnosis).
- All three `page.goto` calls now use `wait_until="commit"` followed by a new `_wait_for_marker` poll for a concrete DOM marker, confirmed live 2026-08-03: `[data-testid="auth-logo"]` for Passport, `[data-testid="Sidebar"]` for the authenticated Direct/grid shell. Only once the marker is present does the caller trust `page.content()` for its captcha/auth checks.
- `login_persistent_session`'s polling loop (re-navigates to the grid every tick while the user logs in by hand) accepts either marker, capped at the poll interval rather than the full marker timeout — an unfinished login redirects the grid URL right back to Passport, and waiting on the grid's marker alone would burn the full timeout every tick.
- Updated `assert_authenticated`'s docstring (previously prescribed `domcontentloaded` as the pattern for future callers) to describe the new `commit` + marker-poll pattern.

## Test plan

- [x] `pytest tests/test_masters.py tests/test_playwright_session.py -q` — 362 passed (existing `TestPersistentSession` tests updated to supply the new DOM markers via `_passport_page()`/`_direct_page()` factories; two new tests added: `test_login_navigations_use_commit_not_domcontentloaded`, and a new `TestCaptureStorageState` class covering the grid-verify success and auth-redirect paths)
- [x] `black --check` / `flake8` clean
- [x] Live: `direct playwright doctor` — fully green
- [x] Live: `direct playwright login` — succeeds without timeout (`verified=yes`)

Closes #686

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G9hqvLoRpA46jyGCjG6SJE