### PR TITLE
fix(masters): root-cause the images-section ghost render pass (#687)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+**Fixed — images-section "ghost" render pass caused false "no images" reads (#687):**
+
+- `_wait_for_images_editor` (`direct_cli/browser/masters.py`) previously
+  trusted "editor present, no `StubN`" as a settled state. Live diagnosis
+  found a third, earlier render stage — before any `StubN` placeholder
+  round begins, `ImageSuggestionsEditor` briefly mounts with zero `StubN`
+  AND zero `ContentImage` elements (observed live: under 1s to ~14.5s) —
+  indistinguishable from a genuine empty-set settle by DOM shape alone.
+  Confirmed 100% reproducible across 3 consecutive live runs: the
+  pre-fix guard returned within ~4s reading `[]` for a campaign with 5
+  real images, the exact "no images" false negative #687 describes.
+- Fixed by only trusting "no `StubN`" once a real `StubN` round has been
+  observed and cleared, OR `ContentImage` elements are already present,
+  OR the "nothing yet" reading holds continuously for
+  `_IMAGES_GHOST_GRACE_S` (20s) — covering a genuinely empty image set.
+  `_IMAGES_EDITOR_TIMEOUT_MS` bumped 30s → 60s to accommodate the
+  worst observed combined ghost+real timeline (43.6s, 11 repeat runs).
+- Confirmed live 2026-08-03: `masters adimages get` on two campaigns with
+  5 images each now correctly reads all images (previously reproducibly
+  empty).
+
 **Fixed — grid navigation `domcontentloaded` timeout (#682):**
 
 - `_capture_grid_campaigns_request` (`direct_cli/browser/masters.py`) — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@
 - Confirmed live 2026-08-03: `masters adimages get` on two campaigns with
   5 images each now correctly reads all images (previously reproducibly
   empty).
+- Re-verified live 2026-08-03 in combination with PR #689's `commit` +
+  `_wait_for_edit_form` navigation changes (raised as a possible gap by
+  issue #695): direct instrumentation and 8 subsequent `masters adimages
+  get` runs across both campaigns all correctly read 5 images each
+  (12.3s-28.1s elapsed); no occurrence of a stuck/never-hydrating section
+  was observed.
 
 **Fixed — grid navigation `domcontentloaded` timeout (#682):**
 

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -2751,6 +2751,18 @@ def _wait_for_images_editor(page: "Page") -> None:
     images" prematurely — re-verify against one if hydration issues
     resurface on empty-image campaigns specifically.
 
+    **Timing caveat re: issue #695:** the live verification above ran
+    before PR #689 (issue #684) landed ``wait_until="commit"`` +
+    ``_wait_for_edit_form`` on the other three ``WIZARD_EDIT_URL``
+    navigation sites — this function's own fix and its live evidence
+    predate that change, so they do not by themselves confirm this
+    section still hydrates correctly in combination with #689's
+    navigation changes on current ``main``. If #695's original symptom
+    (section stuck at ``children == 0`` for 20+ seconds — a real timeout,
+    not this function's ghost-pass false-negative) still reproduces after
+    #689, re-run the live diagnosis; it is a distinct, not yet
+    live-verified-together, code path.
+
     Absence of the section (or persistence of the stub state, or a settle
     declared before any ``StubN`` round was ever observed) after the timeout
     is reported as a hard error rather than silently treated as "no images",

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -2751,17 +2751,22 @@ def _wait_for_images_editor(page: "Page") -> None:
     images" prematurely — re-verify against one if hydration issues
     resurface on empty-image campaigns specifically.
 
-    **Timing caveat re: issue #695:** the live verification above ran
-    before PR #689 (issue #684) landed ``wait_until="commit"`` +
-    ``_wait_for_edit_form`` on the other three ``WIZARD_EDIT_URL``
-    navigation sites — this function's own fix and its live evidence
-    predate that change, so they do not by themselves confirm this
-    section still hydrates correctly in combination with #689's
-    navigation changes on current ``main``. If #695's original symptom
-    (section stuck at ``children == 0`` for 20+ seconds — a real timeout,
-    not this function's ghost-pass false-negative) still reproduces after
-    #689, re-run the live diagnosis; it is a distinct, not yet
-    live-verified-together, code path.
+    **Re-verified live 2026-08-03 in combination with PR #689 (issue #695):**
+    the live verification above originally ran before PR #689 landed
+    ``wait_until="commit"`` + ``_wait_for_edit_form`` on the other three
+    ``WIZARD_EDIT_URL`` navigation sites. After rebasing this fix onto
+    #689, direct instrumentation of both campaigns (post-``_wait_for_edit_form``,
+    reading the same ``editor``/``stub``/``content`` counts this function
+    itself checks) confirmed the same three-stage render — ghost pass
+    (≤2.3s here), a real ``StubN`` round, then content — settling within
+    ~3-6s, well inside the ``_IMAGES_GHOST_GRACE_S``/timeout budget. 8
+    subsequent ``masters adimages get`` runs across both campaigns (via
+    this fixed code, not the pre-#687 guard) all correctly read 5 images
+    each, elapsed 12.3s-28.1s. No occurrence of #695's original symptom
+    (section stuck at ``children == 0`` for 20+ seconds with no stub round
+    ever appearing) was observed in this combined verification — #695's
+    concern was a reasonable one to raise pending confirmation, but did
+    not reproduce here.
 
     Absence of the section (or persistence of the stub state, or a settle
     declared before any ``StubN`` round was ever observed) after the timeout

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -453,7 +453,20 @@ _IMAGE_UPLOAD_TIMEOUT_MS = 60_000
 # 2026-08-02 to make `--image` fail with a false "no images" on campaigns
 # that demonstrably had four. Hence an explicit wait for the section itself
 # before any read that a decision depends on (see `_wait_for_images_editor`).
-_IMAGES_EDITOR_TIMEOUT_MS = 30_000
+# Bumped 30s -> 60s for issue #687's "ghost" render pass (see
+# `_wait_for_images_editor`): that pass alone was observed lasting up to
+# ~14.5s live before the real stub round even begins, and one full
+# ghost+real timeline was clocked at 43.6s live (11 repeat runs, both
+# campaigns) — so the original 30s budget, and even a first attempt at 45s,
+# left too little margin.
+_IMAGES_EDITOR_TIMEOUT_MS = 60_000
+# How long a "no StubN observed yet, no ContentImage yet" reading must hold
+# continuously before `_wait_for_images_editor` trusts it as a genuinely
+# empty/already-settled campaign rather than issue #687's ghost render pass
+# (see that function's docstring). The ghost pass was observed live lasting
+# up to ~14.5s, so this must clear that with margin; a truly empty campaign
+# pays this as fixed latency once per edit-page visit.
+_IMAGES_GHOST_GRACE_S = 20.0
 
 # Region picker (issue #653 re-recon, 2026-08-02): Yandex replaced the old
 # text-combobox-with-suggestions flow with a tree/tag-group widget
@@ -2675,17 +2688,118 @@ def _wait_for_images_editor(page: "Page") -> None:
     This function now also polls until no ``_IMAGES_STUB_TESTID_PREFIX``
     element remains, so a caller never observes the mid-render stub state.
 
-    Absence of the section (or persistence of the stub state) after the
-    timeout is reported as a hard error rather than silently treated as
-    "no images", for the same reason.
+    **Third render stage, root-caused live 2026-08-03 for issue #687 (both
+    campaigns above, 6 independent repeat runs, both with 5 real images by
+    the time of this investigation):** BEFORE the ``StubN`` round described
+    above even begins, ``ImageSuggestionsEditor`` briefly mounts a first
+    time with ``.Open`` present but ZERO ``StubN`` and ZERO ``ContentImage``
+    elements — a stale/ghost render, most likely the section's own
+    "collapsed" resting state re-appearing for one paint before the real
+    data fetch kicks off, not a genuine settle. This ghost pass never shows
+    a single ``StubN`` element; the real pass always does. Observed
+    live 2026-08-03: the ghost pass alone can last from under a second up to
+    ~14.5s, and the check that existed before this fix — "editor present AND
+    zero ``StubN``" — is trivially true throughout it, so it is
+    indistinguishable from a real settle by DOM shape alone. This is exactly
+    the false-negative-to-false-positive drift #673 already fixed one render
+    stage earlier (empty container -> unsettled stub round), one stage
+    earlier still: ``masters adimages get``/``update --image`` calling
+    ``_wait_for_images_editor`` at that instant would read ``[]`` for a
+    campaign confirmed live to have 5 images, reproducing #687's exact
+    "no images" false negative. Confirmed by direct instrumentation of this
+    function, unmodified, before the fix below: it returned within ~4s with
+    ``_read_image_content_ids`` reading ``[]`` on a campaign with 5 images,
+    100% reproducible across 3 consecutive live runs.
+
+    The fix cannot be a fixed debounce window — the ghost pass's observed
+    duration (under 1s to ~14.5s) makes any fixed wait either too short
+    (still catches the ghost) or too close to the whole timeout budget (too
+    slow). Instead "no ``StubN``" is only trusted once ANY of:
+
+    (a) at least one real ``StubN`` element has actually been observed
+        first — the ghost pass never produces one;
+    (b) ``ContentImage`` elements are already present — confirmed live:
+        their count is always 0 throughout the ghost pass, so their
+        presence is never a false positive, and this also covers a
+        campaign whose images were already loaded with no stub round at
+        all (e.g. a fast-enough fetch, or a repeat read on an
+        already-hydrated page — the shape every other test in this class
+        exercises);
+    (c) the "editor present, no ``StubN``, no ``ContentImage``" reading
+        holds continuously for ``_IMAGES_GHOST_GRACE_S`` — the ghost pass
+        and a genuinely empty image set are otherwise indistinguishable by
+        DOM shape at a single instant (images are legitimately optional —
+        see ``_IMAGES_MAX_COUNT``'s module comment), so a truly empty
+        campaign is only trusted once that reading has outlasted the
+        ghost pass's worst observed duration, at the cost of paying that
+        wait once per edit-page visit.
+
+    Verified live 2026-08-03: 11/11 repeat runs across both non-empty
+    campaigns (after correcting an initial false-negative batch that turned
+    out to be testing a stale editable install pointing at a different
+    checkout — see the worktree caveat below) settle on the correct, stable
+    image count via (a)/(b), with a worst observed combined ghost+real
+    timeline of 43.6s (see ``_IMAGES_EDITOR_TIMEOUT_MS``'s bump to
+    accommodate it with margin). Path (c) has no live test campaign with a
+    genuinely empty image set available at investigation time (every DRAFT
+    campaign on the verification account already had images) — its
+    correctness rests on the offline fixture in
+    ``tests/test_masters.py::TestWaitForImagesEditor`` and the invariant
+    that the ghost pass never lasted longer than ~14.5s across every run
+    observed. If a live campaign with zero images later shows a ghost pass
+    longer than ``_IMAGES_GHOST_GRACE_S``, this path would misreport "no
+    images" prematurely — re-verify against one if hydration issues
+    resurface on empty-image campaigns specifically.
+
+    Absence of the section (or persistence of the stub state, or a settle
+    declared before any ``StubN`` round was ever observed) after the timeout
+    is reported as a hard error rather than silently treated as "no images",
+    for the same reason.
     """
 
+    stubs_ever_seen = False
+    empty_since: Optional[float] = None
+
     def _content_settled() -> bool:
+        nonlocal stubs_ever_seen, empty_since
         if page.locator(_IMAGES_EDITOR_SELECTOR).first.count() == 0:
+            empty_since = None
             return False
-        return (
-            page.locator(f'[data-testid^="{_IMAGES_STUB_TESTID_PREFIX}"]').count() == 0
-        )
+        stub_count = page.locator(
+            f'[data-testid^="{_IMAGES_STUB_TESTID_PREFIX}"]'
+        ).count()
+        if stub_count > 0:
+            stubs_ever_seen = True
+            empty_since = None
+            return False
+        if stubs_ever_seen:
+            # A real StubN round has already been observed and cleared —
+            # this "no StubN" reading is trustworthy regardless of content
+            # count (zero is the legitimate "campaign has no images" state).
+            return True
+        content_count = page.locator(
+            f'[data-testid^="{_IMAGES_CONTENT_TESTID_PREFIX}"]'
+        ).count()
+        if content_count > 0:
+            # Confirmed live: content count is always 0 throughout the ghost
+            # pass (see the docstring note above), so its presence here is
+            # never a false positive — this is a campaign whose images were
+            # already loaded server-side with no stub round at all.
+            return True
+        # No StubN round has ever been seen AND there is no content yet —
+        # this is EITHER the ghost pass (transient, confirmed live to last
+        # up to ~14.5s) OR a campaign that genuinely has zero images and
+        # settled straight into that state with no stub round to observe.
+        # These are indistinguishable by DOM shape alone at a single instant,
+        # so require this exact state (no editor mutation observed) to hold
+        # continuously for `_IMAGES_GHOST_GRACE_S` before trusting it — long
+        # enough to outlast the ghost pass, short enough not to matter for a
+        # page that is genuinely already settled.
+        now = time.monotonic()
+        if empty_since is None:
+            empty_since = now
+            return False
+        return (now - empty_since) >= _IMAGES_GHOST_GRACE_S
 
     if _poll_until(page, _content_settled, _IMAGES_EDITOR_TIMEOUT_MS):
         return

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -38,6 +38,23 @@ from direct_cli.cli import cli
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
+# `_IMAGES_GHOST_GRACE_S` (issue #687) makes `_wait_for_images_editor` hold a
+# "no StubN, no ContentImage yet" reading for real wall-clock seconds before
+# trusting it as a genuinely empty image set, to survive a live ghost render
+# pass no fake page here ever produces. Every test in this module drives fake
+# Page/Locator objects with no real timing behaviour at all, so patched to 0
+# for the whole module — otherwise every empty-image-set test (there are
+# many, across several classes) would pay the real production grace period.
+_images_ghost_grace_patch = patch.object(browser_masters, "_IMAGES_GHOST_GRACE_S", 0.0)
+
+
+def setUpModule():
+    _images_ghost_grace_patch.start()
+
+
+def tearDownModule():
+    _images_ghost_grace_patch.stop()
+
 
 def _load_grid_campaigns_fixture():
     with open(FIXTURES_DIR / "masters_grid_campaigns.json", encoding="utf-8") as f:
@@ -5138,6 +5155,11 @@ class TestWaitForImagesEditor(unittest.TestCase):
     """
 
     def test_returns_once_the_section_is_present(self):
+        """The base fixture renders content immediately with no ``StubN``
+        tick at all — the "campaign has no images" shape the ghost-pass gate
+        (issue #687) must NOT mistake for the ghost pass, since here
+        ``ContentImage`` elements are present from tick one, unlike the
+        ghost pass which never has any."""
         page = _FakeImagesPage(["a"])
 
         browser_masters._wait_for_images_editor(page)  # must not raise
@@ -5238,6 +5260,109 @@ class TestWaitForImagesEditor(unittest.TestCase):
 
         self.assertIn("did not finish rendering", str(ctx.exception))
         self.assertIn("loading placeholders", str(ctx.exception))
+
+    def test_does_not_settle_on_the_ghost_pass_before_stubs_appear(self):
+        """Issue #687, root-caused live 2026-08-03: BEFORE the ``StubN``
+        round even begins, ``ImageSuggestionsEditor`` briefly mounts with
+        ZERO ``StubN`` and ZERO ``ContentImage`` elements — a ghost render
+        that looks identical, by DOM shape alone, to a genuine settle
+        (``editor`` present, no ``StubN``). The pre-#687 guard (editor
+        present AND no ``StubN``) returned during this ghost pass on 3/3
+        live repeats, reading ``[]`` for a campaign confirmed to have 5
+        images. The fix requires having actually observed at least one
+        ``StubN`` tick before trusting "no ``StubN``" as a settle."""
+
+        class _GhostThenStubThenContentPage(_FakeImagesPage):
+            def __init__(self, *args, ghost_ticks=3, stub_ticks=2, **kwargs):
+                super().__init__(*args, **kwargs)
+                self._ghost_ticks_remaining = ghost_ticks
+                self._stub_ticks_remaining = stub_ticks
+
+            def locator(self, selector):
+                stub_prefix = (
+                    f'[data-testid^="{browser_masters._IMAGES_STUB_TESTID_PREFIX}"]'
+                )
+                if selector == stub_prefix:
+                    if self._ghost_ticks_remaining > 0:
+                        self._ghost_ticks_remaining -= 1
+                        return _FakeLocator([])
+                    if self._stub_ticks_remaining > 0:
+                        self._stub_ticks_remaining -= 1
+                        return _FakeLocator([_FakeLocatorHandle() for _ in range(4)])
+                    return _FakeLocator([])
+                content_prefix = (
+                    f'[data-testid^="{browser_masters._IMAGES_CONTENT_TESTID_PREFIX}"]'
+                )
+                if selector == content_prefix and (
+                    self._ghost_ticks_remaining > 0 or self._stub_ticks_remaining > 0
+                ):
+                    return _FakeLocator([])
+                return super().locator(selector)
+
+        page = _GhostThenStubThenContentPage(
+            ["a", "b", "c", "d"], ghost_ticks=3, stub_ticks=2
+        )
+
+        # The module-wide grace-period patch (see setUpModule) would let the
+        # ghost pass settle instantly on its own; force it back up so this
+        # test exercises the StubN-gate path specifically, not the grace
+        # period's separate fallback (covered by its own tests below).
+        with patch.object(browser_masters, "_IMAGES_GHOST_GRACE_S", 9999.0):
+            browser_masters._wait_for_images_editor(page)  # must not raise
+
+        # Settling must have consumed BOTH the ghost pass and the real stub
+        # round, not returned during the ghost pass's "no StubN" window.
+        self.assertEqual(page._ghost_ticks_remaining, 0)
+        self.assertEqual(page._stub_ticks_remaining, 0)
+        self.assertEqual(
+            browser_masters._read_image_content_ids(page), ["a", "b", "c", "d"]
+        )
+
+    def test_raises_if_stuck_in_the_ghost_pass_forever(self):
+        """A page stuck showing the ghost pass (no StubN ever observed) must
+        be a hard error, not a false "settle" on the pre-#687 guard's logic
+        nor a false "no images"."""
+
+        class _StuckGhostPage(_FakeImagesPage):
+            def locator(self, selector):
+                stub_prefix = (
+                    f'[data-testid^="{browser_masters._IMAGES_STUB_TESTID_PREFIX}"]'
+                )
+                if selector == stub_prefix:
+                    return _FakeLocator([])
+                content_prefix = (
+                    f'[data-testid^="{browser_masters._IMAGES_CONTENT_TESTID_PREFIX}"]'
+                )
+                if selector == content_prefix:
+                    return _FakeLocator([])
+                return super().locator(selector)
+
+        page = _StuckGhostPage(["a", "b", "c", "d"])
+        with (
+            patch.object(browser_masters, "_IMAGES_GHOST_GRACE_S", 9999.0),
+            patch.object(browser_masters, "_IMAGES_EDITOR_TIMEOUT_MS", 1),
+        ):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters._wait_for_images_editor(page)
+
+        self.assertIn("did not finish rendering", str(ctx.exception))
+
+    def test_settles_a_genuinely_empty_set_after_the_grace_period_with_no_stub_round(
+        self,
+    ):
+        """A campaign with zero images can settle into "editor present, no
+        StubN, no ContentImage" straight away with no stub round at all —
+        the module-wide grace-period patch (see setUpModule) makes this
+        instant for every OTHER test in this file, so this test explicitly
+        restores a real, non-zero grace period to prove the fallback itself
+        works, not just that patching it to 0 short-circuits it."""
+
+        page = _FakeImagesPage([])  # base fixture: no stubs, no content, ever
+
+        with patch.object(browser_masters, "_IMAGES_GHOST_GRACE_S", 0.05):
+            browser_masters._wait_for_images_editor(page)  # must not raise
+
+        self.assertEqual(browser_masters._read_image_content_ids(page), [])
 
 
 class TestWaitForEditForm(unittest.TestCase):


### PR DESCRIPTION
## Summary

Live investigation for #687 (why React doesn't hydrate `ImageSuggestionsEditor.CampaignContents` in Playwright) found the section actually goes through **three** render stages, not the two `_wait_for_images_editor` (#673) already handled:

1. **Ghost pass** (new, root-caused here): before any `StubN` placeholder appears, the section briefly mounts with zero `StubN` AND zero `ContentImage` elements — indistinguishable from a genuine settle by the pre-#687 guard's "editor present, no StubN" check.
2. `StubN` placeholder round (#673).
3. Real `ContentImage` content.

Confirmed by direct instrumentation of the unmodified `_wait_for_images_editor`: it returned within ~4s reading `[]` for campaign 713234204 (confirmed live to have 5 images), 100% reproducible across 3 consecutive runs. `masters adimages get`/`update --image` would silently report "no images" on a campaign that demonstrably has some — the exact bug #687 describes.

## Fix

The ghost pass's observed live duration (under 1s to ~14.5s) rules out a fixed debounce window. `_wait_for_images_editor` now trusts a "no StubN" reading only when:
- (a) a real `StubN` round has actually been observed and cleared, or
- (b) `ContentImage` elements are already present (confirmed live: always 0 during the ghost pass, so never a false positive — also covers a campaign whose images load with no stub round at all), or
- (c) the "nothing yet" reading holds continuously for `_IMAGES_GHOST_GRACE_S` (20s) — covering a genuinely empty image set, otherwise indistinguishable from the ghost pass by DOM shape at a single instant.

`_IMAGES_EDITOR_TIMEOUT_MS` bumped 30s → 60s: one live ghost+real timeline was clocked at 43.6s across 11 repeat runs.

**Open caveat, documented in the docstring:** every DRAFT campaign on the verification account already had images, so path (c) — the genuinely-empty-set grace period — could not be confirmed against a live campaign. It's covered by an offline fixture test only. If hydration issues resurface specifically on empty-image campaigns, re-verify against a live one.

**Known residual risk (raised in cycle-review, tracked as `UNVERIFIED`):** path (c)'s 20s grace period is still time-based, not a positive hydration-completion signal — if a ghost pass ever exceeds 20s live (worst observed so far: 14.5s), a mutating command (`adimages set`/`delete`) could act on a falsely-empty `before_ids`. Post-save verification (`_verify_image_set_mismatches`) would catch the resulting size mismatch and raise an explicit error before silently reporting success, but the browser-side mutation would already have been applied. This is a pre-existing class of race (this PR narrows the reproducible window from ~100% at ~4s to requiring >20s), not a new regression — no live campaign with a ghost pass long enough to trigger it has been observed.

## Live verification

**2026-08-03 (original, pre-#689 rebase):**
- `masters adimages get 713234191` / `713234204` now correctly read all 5 images each (previously reproducibly empty via direct instrumentation).
- 11 repeat runs across both campaigns settled correctly with the fix, worst-case combined ghost+real timeline 43.6s.

**2026-08-03 (re-verified after rebasing onto PR #689's `commit` + `_wait_for_edit_form` navigation changes, in response to issue #695's question about whether the images section still hydrates after that change):**
- Direct instrumentation of both campaigns (`editor`/`stub`/`content` counts, same signals `_wait_for_images_editor` itself checks), run immediately after `_wait_for_edit_form` passes: ghost pass ≤2.3s, real `StubN` round, then content — full settle within ~3-6s on both campaigns, comfortably inside the timeout/grace-period budget.
- 8 subsequent `masters adimages get` runs across both campaigns via the fixed code path all correctly read 5 images each, elapsed 12.3s-28.1s.
- No occurrence of issue #695's original symptom (section stuck at `children == 0` for 20+ seconds, no stub round ever appearing) was observed in this combined verification. Left this result as a comment on #695 (not closing it — that's the issue author's call), recommending it stay open as a distinct follow-up rather than being treated as a duplicate of #687, since the two describe different code paths (this PR's false-negative-too-early-settle vs. #695's true-timeout concern) that had not been live-verified together before this rebase.

## Test plan

- [x] `pytest tests/test_masters.py -q` — 356 passed (after rebase onto main; 2 new regression tests for the ghost pass, 1 new test for the empty-set grace-period fallback; existing empty-image-set tests patched via module-wide `setUpModule` to zero the grace period so they stay fast)
- [x] `black`/`flake8` clean
- [x] Broad offline suite (`pytest -n0`) — 2935 passed, 8 skipped, 62 pre-existing cassette-fixture errors confirmed present on a clean `origin/main` checkout too (unrelated to this PR)
- [x] Live: `masters adimages get` on both campaigns, correct image counts, both before and after rebasing onto PR #689

Closes #687

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158rFW1LWSXsKMFKphhBi3M
