### PR TITLE
fix(masters): replace domcontentloaded race with commit+poll for wizard overview

### DIFF
--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -293,10 +293,40 @@ _SUSPEND_BUTTON_TEXTS = ("Остановить кампанию", "Приост�
 # actually change before giving up and reporting a possible false success.
 _STATUS_CHANGE_TIMEOUT_MS = 10_000
 
+# Overview page's header title, confirmed live (issue #683) as the earliest
+# stable marker of a rendered wizard overview page — present on BOTH a
+# DRAFT campaign's page (which has no "⋮" menu at all, see _MENU_TRIGGER_
+# SELECTOR below and issue #660) and every other status. Unlike the plain
+# `h1, [role=heading]` CSS selector `_extract_title` uses (which matches
+# nothing here — the real element is an `<h2 data-testid="CampaignHeader.
+# Title">` with no explicit `role` attribute), this selector is exact.
+_OVERVIEW_TITLE_SELECTOR = '[data-testid="CampaignHeader.Title"]'
+
+# How long to wait for `_OVERVIEW_TITLE_SELECTOR` to render after navigating
+# to WIZARD_OVERVIEW_URL (issue #683). Confirmed live: the overview page can
+# take several seconds after `wait_until="commit"` returns before its React
+# tree paints anything at all.
+_OVERVIEW_LOAD_TIMEOUT_MS = 30_000
+
+# How long _extract_stat_tiles retries after the title has rendered but
+# before the stat tiles themselves have (issue #683). Confirmed live
+# (campaign 72349978, headless): the title (`_OVERVIEW_TITLE_SELECTOR`) is
+# present well before the stat tile buttons finish rendering — a single
+# post-title read intermittently found 0 of them despite the campaign
+# genuinely having 5. As slow as _OVERVIEW_LOAD_TIMEOUT_MS itself: live
+# headless recon measured the tiles finishing their OWN render up to ~15s
+# after the title, not the sub-second gap a headful/extension browser
+# showed — these are two independent SPA render passes, not one paint.
+_STAT_TILES_TIMEOUT_MS = 30_000
+
 # Overview page's "⋮" menu, confirmed live (issue #633) — see module
 # docstring. Unlike _RESUME_BUTTON_TEXTS/_SUSPEND_BUTTON_TEXTS these are
 # selectors, not text-matched candidates: both testids were read directly off
-# a live account's DOM, not guessed.
+# a live account's DOM, not guessed. NOT present on a DRAFT campaign's
+# overview page (issue #660) — callers that need it (archive_master,
+# copy_master) still only wait for _OVERVIEW_TITLE_SELECTOR via
+# _goto_overview_page; DRAFT support for the menu-based actions remains the
+# tracked #660 gap, not something this fixes.
 _MENU_TRIGGER_SELECTOR = '[data-testid="CampaignHeader.MenuTrigger"]'
 _ARCHIVE_MENU_ITEM_SELECTOR = '[data-testid="CampaignHeader.Menu.archive"]'
 # Confirmed live (issue #659) alongside the archive item above — same menu,
@@ -785,6 +815,58 @@ def fetch_masters_list(
     return masters
 
 
+def _goto_overview_page(page: "Page", campaign_id: int) -> None:
+    """Navigate to a campaign's wizard overview page and block until it has
+    actually rendered (issue #683).
+
+    Every entry point that reads/mutates the overview page previously used
+    ``page.goto(url, wait_until="domcontentloaded")`` and immediately trusted
+    the page to be ready — but the overview page is a client-rendered SPA,
+    same as the edit page ``_wait_for_images_editor`` guards against (#670):
+    ``domcontentloaded`` fires while the header/menu/stats are all still
+    absent from the DOM. Live-confirmed 2026-08-03 against campaign
+    72349978: ``fetch_master`` intermittently failed to read the campaign
+    name (``h1, [role=heading]`` — a selector that, separately, never
+    matches this page's real ``<h2 data-testid="CampaignHeader.Title">``
+    element at all) while status/landing-URL/stats all read back fine, a
+    classic race between the read and the still-in-flight render.
+
+    ``wait_until="commit"`` (fires as soon as the navigation's response
+    headers arrive, before ANY DOM work) replaces ``domcontentloaded`` here
+    so this function's own poll loop is what actually waits for content,
+    rather than layering an unreliable implicit wait under an also-unreliable
+    explicit one. It polls for ``_OVERVIEW_TITLE_SELECTOR`` — confirmed live
+    to render on both a DRAFT campaign's overview page (which has no "⋮"
+    menu at all, see ``_MENU_TRIGGER_SELECTOR`` and issue #660) and every
+    other status, making it the earliest common marker every caller here can
+    rely on regardless of campaign status.
+
+    ``assert_not_captcha``/``assert_authenticated`` run on every poll tick
+    (not just once after the wait) so a captcha gate or an expired session
+    is reported immediately via its own specific error, instead of only
+    surfacing after burning the full ``_OVERVIEW_LOAD_TIMEOUT_MS`` waiting
+    for a title that a login/captcha page will never render.
+    """
+    url = WIZARD_OVERVIEW_URL.format(campaign_id=campaign_id)
+    page.goto(url, wait_until="commit")
+
+    def _rendered() -> bool:
+        assert_not_captcha(page.content())
+        assert_authenticated(page.content())
+        return page.locator(_OVERVIEW_TITLE_SELECTOR).first.count() > 0
+
+    if _poll_until(page, _rendered, _OVERVIEW_LOAD_TIMEOUT_MS):
+        return
+
+    raise BrowserSessionError(
+        f"The wizard overview page for campaign {campaign_id} did not "
+        f"render within {_OVERVIEW_LOAD_TIMEOUT_MS / 1000:.0f}s (no "
+        f"{_OVERVIEW_TITLE_SELECTOR!r} appeared) — Yandex may have changed "
+        "the page's markup, or the page may still be loading. Re-run with "
+        "--headful to inspect the page."
+    )
+
+
 def fetch_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
     """Fetch overview details for one Мастер кампаний by navigating its wizard page.
 
@@ -795,10 +877,7 @@ def fetch_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
     No ``ulogin`` on the URL (see module docstring) — confirmed live that
     Yandex itself redirects to the correct ``?ulogin=<chief login>``.
     """
-    url = WIZARD_OVERVIEW_URL.format(campaign_id=campaign_id)
-    page.goto(url, wait_until="domcontentloaded")
-    assert_not_captcha(page.content())
-    assert_authenticated(page.content())
+    _goto_overview_page(page, campaign_id)
 
     result: Dict[str, Any] = {"CampaignId": campaign_id}
 
@@ -811,7 +890,13 @@ def fetch_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
 
 
 def _extract_title(page: "Page", result: Dict[str, Any]) -> None:
-    heading = page.locator("h1, [role=heading]").first
+    # Confirmed live 2026-08-03 (issue #683 investigation, campaign
+    # 72349978): the overview page's real title element is
+    # `<h2 data-testid="CampaignHeader.Title">` — no `role` attribute, so
+    # the previous `h1, [role=heading]` CSS selector never matched it at
+    # all. _goto_overview_page already waits for this exact selector
+    # (_OVERVIEW_TITLE_SELECTOR) before this function ever runs.
+    heading = page.locator(_OVERVIEW_TITLE_SELECTOR).first
     try:
         result["Name"] = heading.inner_text().strip()
     except PlaywrightError:
@@ -852,24 +937,42 @@ def _extract_stat_tiles(page: "Page", result: Dict[str, Any]) -> None:
     # Stat tiles render near the top of the page, well before the dozens of
     # nav/tab/edit buttons further down — stop as soon as every known label
     # is found instead of walking every button on the page.
+    #
+    # Confirmed live 2026-08-03 (issue #683, campaign 72349978): the tiles
+    # render AFTER _OVERVIEW_TITLE_SELECTOR (which _goto_overview_page
+    # already waited for) — a single read right after that wait
+    # intermittently found 0 tiles for a campaign that demonstrably has 5.
+    # Retries for a short bounded window rather than reading once, mirroring
+    # _wait_for_images_editor's "outer container present, content not yet
+    # settled" guard (#670) applied to this page's own two-stage render.
     wanted_keys = set(_STAT_TILE_LABELS.values())
     stats: Dict[str, str] = {}
-    buttons = page.locator("button")
-    count = buttons.count()
-    for i in range(count):
-        if stats.keys() >= wanted_keys:
-            break
-        try:
-            text = buttons.nth(i).inner_text().strip()
-        except PlaywrightError:
-            continue
-        lines = [line.strip() for line in text.splitlines() if line.strip()]
-        if len(lines) != 2:
-            continue
-        value, label = lines
-        key = _STAT_TILE_LABELS.get(label)
-        if key and key not in stats:
-            stats[key] = value
+
+    def _scan() -> bool:
+        stats.clear()
+        buttons = page.locator("button")
+        count = buttons.count()
+        for i in range(count):
+            if stats.keys() >= wanted_keys:
+                break
+            try:
+                text = buttons.nth(i).inner_text().strip()
+            except PlaywrightError:
+                continue
+            lines = [line.strip() for line in text.splitlines() if line.strip()]
+            if len(lines) != 2:
+                continue
+            value, label = lines
+            # Confirmed live 2026-08-03 (campaign 72349978): "За конверсию"
+            # renders with a non-breaking space (U+00A0) between the words,
+            # not a plain one — normalise before the lookup so
+            # _STAT_TILE_LABELS' plain-space keys still match.
+            key = _STAT_TILE_LABELS.get(label.replace("\xa0", " "))
+            if key and key not in stats:
+                stats[key] = value
+        return bool(stats)
+
+    _poll_until(page, _scan, _STAT_TILES_TIMEOUT_MS)
 
     if stats:
         result["Stats"] = stats
@@ -946,10 +1049,7 @@ def _suspend_or_resume(
     actually took effect — a click that doesn't visibly change the status is
     reported as a hard error, not a silent success.
     """
-    url = WIZARD_OVERVIEW_URL.format(campaign_id=campaign_id)
-    page.goto(url, wait_until="domcontentloaded")
-    assert_not_captcha(page.content())
-    assert_authenticated(page.content())
+    _goto_overview_page(page, campaign_id)
 
     current_status = _read_status_text(page)
     if current_status is None:
@@ -1048,10 +1148,7 @@ def archive_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
         print_warning(f"Campaign {campaign_id} is already archived; not clicking.")
         return existing
 
-    url = WIZARD_OVERVIEW_URL.format(campaign_id=campaign_id)
-    page.goto(url, wait_until="domcontentloaded")
-    assert_not_captcha(page.content())
-    assert_authenticated(page.content())
+    _goto_overview_page(page, campaign_id)
 
     menu_trigger = page.locator(_MENU_TRIGGER_SELECTOR).first
     try:
@@ -1118,10 +1215,7 @@ def copy_master(
             "grid — check the ID, or it may already be gone."
         )
 
-    url = WIZARD_OVERVIEW_URL.format(campaign_id=campaign_id)
-    page.goto(url, wait_until="domcontentloaded")
-    assert_not_captcha(page.content())
-    assert_authenticated(page.content())
+    _goto_overview_page(page, campaign_id)
 
     menu_trigger = page.locator(_MENU_TRIGGER_SELECTOR).first
     try:

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -853,8 +853,8 @@ def _goto_overview_page(page: "Page", campaign_id: int) -> None:
     on ``_poll_until``'s first tick actually running promptly.
 
     The captcha/auth check happens OUTSIDE ``_poll_until``'s predicate (via
-    ``_overview_terminal_state``, which returns a marker instead of
-    raising), same pattern as ``_wait_for_edit_form``/
+    ``_terminal_state``, which returns a marker instead of raising), same
+    pattern as ``_wait_for_edit_form``/
     ``_edit_form_terminal_state`` (issue #689): ``_poll_until`` suppresses
     ``PlaywrightError``, which is aliased to the broad ``Exception`` when
     Playwright isn't installed (the offline-unit-test import fallback

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -320,6 +320,17 @@ _OVERVIEW_LOAD_TIMEOUT_MS = 30_000
 # showed — these are two independent SPA render passes, not one paint.
 _STAT_TILES_TIMEOUT_MS = 30_000
 
+# How many CONSECUTIVE poll ticks the found stat-tile key set must stay
+# unchanged before _extract_stat_tiles treats it as final (cycle-review
+# #697 finding, Codex): a single unchanged tick is indistinguishable from
+# "the page just hasn't started rendering tiles yet" -- at _poll_until's
+# default 250ms tick, one quiet tick is only 250ms of evidence against a
+# render this file itself documents as taking up to ~15s. 8 consecutive
+# ticks (~2s of continuous silence at the default tick rate) is comfortably
+# below that real-world render time while still returning well short of
+# the full timeout for a campaign that genuinely never renders more tiles.
+_STAT_TILES_STABLE_TICKS = 8
+
 # Overview page's "⋮" menu, confirmed live (issue #633) — see module
 # docstring. Unlike _RESUME_BUTTON_TEXTS/_SUSPEND_BUTTON_TEXTS these are
 # selectors, not text-matched candidates: both testids were read directly off
@@ -979,20 +990,29 @@ def _extract_stat_tiles(page: "Page", result: Dict[str, Any]) -> None:
     # _wait_for_images_editor's "outer container present, content not yet
     # settled" guard (#670) applied to this page's own two-stage render.
     #
-    # Stops as soon as the found set STABILIZES across a tick (unchanged
-    # from the previous scan), not only when every known key is found
-    # (cycle-review #697 finding): a campaign that genuinely has fewer than
-    # 5 tiles -- DRAFT with no stats dashboard, or Yandex simply not
-    # rendering a metric -- would otherwise always burn the full
-    # _STAT_TILES_TIMEOUT_MS waiting for keys that will never appear.
-    # Live-measured: a single-tile fixture took the full 30s under the old
-    # all-keys-required condition.
+    # Stops as soon as the found set STABILIZES for _STAT_TILES_STABLE_TICKS
+    # consecutive ticks (unchanged from tick to tick), not only when every
+    # known key is found (cycle-review #697 finding): a campaign that
+    # genuinely has fewer than 5 tiles -- DRAFT with no stats dashboard, or
+    # Yandex simply not rendering a metric -- would otherwise always burn
+    # the full _STAT_TILES_TIMEOUT_MS waiting for keys that will never
+    # appear. Live-measured: a single-tile fixture took the full 30s under
+    # the old all-keys-required condition.
+    #
+    # Requires SEVERAL consecutive stable ticks, not just one (cycle-review
+    # #697 re-review finding, Codex): a single unchanged tick is only
+    # ~250ms of evidence -- indistinguishable from "the page hasn't started
+    # rendering tiles yet" on a render this file itself documents as taking
+    # up to ~15s. A reproduction confirmed a naive one-tick check returns
+    # an empty/partial result after the very first poll, before the real
+    # tiles have had any chance to render at all.
     wanted_keys = set(_STAT_TILE_LABELS.values())
     stats: Dict[str, str] = {}
     previous_keys: Optional[frozenset] = None
+    stable_ticks = 0
 
     def _scan() -> bool:
-        nonlocal previous_keys
+        nonlocal previous_keys, stable_ticks
         buttons = page.locator("button")
         count = buttons.count()
         for i in range(count):
@@ -1016,9 +1036,12 @@ def _extract_stat_tiles(page: "Page", result: Dict[str, Any]) -> None:
         if stats.keys() >= wanted_keys:
             return True
         current_keys = frozenset(stats.keys())
-        stabilized = current_keys == previous_keys
+        if current_keys == previous_keys:
+            stable_ticks += 1
+        else:
+            stable_ticks = 0
         previous_keys = current_keys
-        return stabilized
+        return stable_ticks >= _STAT_TILES_STABLE_TICKS
 
     _poll_until(page, _scan, _STAT_TILES_TIMEOUT_MS)
 

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -851,8 +851,9 @@ def _goto_overview_page(page: "Page", campaign_id: int) -> None:
     page.goto(url, wait_until="commit")
 
     def _rendered() -> bool:
-        assert_not_captcha(page.content())
-        assert_authenticated(page.content())
+        html = page.content()
+        assert_not_captcha(html)
+        assert_authenticated(html)
         return page.locator(_OVERVIEW_TITLE_SELECTOR).first.count() > 0
 
     if _poll_until(page, _rendered, _OVERVIEW_LOAD_TIMEOUT_MS):
@@ -949,7 +950,6 @@ def _extract_stat_tiles(page: "Page", result: Dict[str, Any]) -> None:
     stats: Dict[str, str] = {}
 
     def _scan() -> bool:
-        stats.clear()
         buttons = page.locator("button")
         count = buttons.count()
         for i in range(count):
@@ -970,7 +970,7 @@ def _extract_stat_tiles(page: "Page", result: Dict[str, Any]) -> None:
             key = _STAT_TILE_LABELS.get(label.replace("\xa0", " "))
             if key and key not in stats:
                 stats[key] = value
-        return bool(stats)
+        return stats.keys() >= wanted_keys
 
     _poll_until(page, _scan, _STAT_TILES_TIMEOUT_MS)
 

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -841,14 +841,22 @@ def _goto_overview_page(page: "Page", campaign_id: int) -> None:
     other status, making it the earliest common marker every caller here can
     rely on regardless of campaign status.
 
-    ``assert_not_captcha``/``assert_authenticated`` run on every poll tick
-    (not just once after the wait) so a captcha gate or an expired session
-    is reported immediately via its own specific error, instead of only
-    surfacing after burning the full ``_OVERVIEW_LOAD_TIMEOUT_MS`` waiting
-    for a title that a login/captcha page will never render.
+    ``assert_not_captcha``/``assert_authenticated`` run once immediately
+    after navigation AND on every poll tick, so a captcha gate or an
+    expired session is reported via its own specific error right away,
+    instead of only surfacing after burning the full
+    ``_OVERVIEW_LOAD_TIMEOUT_MS`` waiting for a title that a login/captcha
+    page will never render. The extra upfront check does not change
+    behavior on the happy path -- it only matters when the gate is already
+    present at commit time, which is exactly the case that must not depend
+    on ``_poll_until``'s first tick actually running promptly.
     """
     url = WIZARD_OVERVIEW_URL.format(campaign_id=campaign_id)
     page.goto(url, wait_until="commit")
+
+    initial_html = page.content()
+    assert_not_captcha(initial_html)
+    assert_authenticated(initial_html)
 
     def _rendered() -> bool:
         html = page.content()

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -219,6 +219,7 @@ from ..output import print_warning
 from .session import (
     _LOGIN_PAGE_MARKERS,
     BrowserAuthError,
+    BrowserCaptchaError,
     BrowserSessionError,
     assert_authenticated,
     assert_not_captcha,
@@ -850,6 +851,17 @@ def _goto_overview_page(page: "Page", campaign_id: int) -> None:
     behavior on the happy path -- it only matters when the gate is already
     present at commit time, which is exactly the case that must not depend
     on ``_poll_until``'s first tick actually running promptly.
+
+    The captcha/auth check happens OUTSIDE ``_poll_until``'s predicate (via
+    ``_overview_terminal_state``, which returns a marker instead of
+    raising), same pattern as ``_wait_for_edit_form``/
+    ``_edit_form_terminal_state`` (issue #689): ``_poll_until`` suppresses
+    ``PlaywrightError``, which is aliased to the broad ``Exception`` when
+    Playwright isn't installed (the offline-unit-test import fallback
+    above) — in that environment a raise from inside the predicate would
+    be silently swallowed as "not yet" instead of propagating, and this
+    function would misreport a real captcha/auth failure as its own
+    generic render-timeout (cycle-review #697 finding).
     """
     url = WIZARD_OVERVIEW_URL.format(campaign_id=campaign_id)
     page.goto(url, wait_until="commit")
@@ -858,14 +870,26 @@ def _goto_overview_page(page: "Page", campaign_id: int) -> None:
     assert_not_captcha(initial_html)
     assert_authenticated(initial_html)
 
-    def _rendered() -> bool:
+    def _terminal_state() -> "Optional[str]":
         html = page.content()
-        assert_not_captcha(html)
-        assert_authenticated(html)
-        return page.locator(_OVERVIEW_TITLE_SELECTOR).first.count() > 0
+        try:
+            assert_not_captcha(html)
+            assert_authenticated(html)
+        except BrowserCaptchaError:
+            return "captcha"
+        except BrowserAuthError:
+            return "auth"
+        if page.locator(_OVERVIEW_TITLE_SELECTOR).first.count() > 0:
+            return "ready"
+        return None
 
-    if _poll_until(page, _rendered, _OVERVIEW_LOAD_TIMEOUT_MS):
+    state = _poll_until_terminal(page, _terminal_state, _OVERVIEW_LOAD_TIMEOUT_MS)
+    if state == "ready":
         return
+    if state == "captcha":
+        assert_not_captcha(page.content())  # re-raises BrowserCaptchaError
+    if state == "auth":
+        assert_authenticated(page.content())  # re-raises BrowserAuthError
 
     raise BrowserSessionError(
         f"The wizard overview page for campaign {campaign_id} did not "
@@ -954,10 +978,21 @@ def _extract_stat_tiles(page: "Page", result: Dict[str, Any]) -> None:
     # Retries for a short bounded window rather than reading once, mirroring
     # _wait_for_images_editor's "outer container present, content not yet
     # settled" guard (#670) applied to this page's own two-stage render.
+    #
+    # Stops as soon as the found set STABILIZES across a tick (unchanged
+    # from the previous scan), not only when every known key is found
+    # (cycle-review #697 finding): a campaign that genuinely has fewer than
+    # 5 tiles -- DRAFT with no stats dashboard, or Yandex simply not
+    # rendering a metric -- would otherwise always burn the full
+    # _STAT_TILES_TIMEOUT_MS waiting for keys that will never appear.
+    # Live-measured: a single-tile fixture took the full 30s under the old
+    # all-keys-required condition.
     wanted_keys = set(_STAT_TILE_LABELS.values())
     stats: Dict[str, str] = {}
+    previous_keys: Optional[frozenset] = None
 
     def _scan() -> bool:
+        nonlocal previous_keys
         buttons = page.locator("button")
         count = buttons.count()
         for i in range(count):
@@ -978,7 +1013,12 @@ def _extract_stat_tiles(page: "Page", result: Dict[str, Any]) -> None:
             key = _STAT_TILE_LABELS.get(label.replace("\xa0", " "))
             if key and key not in stats:
                 stats[key] = value
-        return stats.keys() >= wanted_keys
+        if stats.keys() >= wanted_keys:
+            return True
+        current_keys = frozenset(stats.keys())
+        stabilized = current_keys == previous_keys
+        previous_keys = current_keys
+        return stabilized
 
     _poll_until(page, _scan, _STAT_TILES_TIMEOUT_MS)
 

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -329,6 +329,15 @@ _STAT_TILES_TIMEOUT_MS = 30_000
 # ticks (~2s of continuous silence at the default tick rate) is comfortably
 # below that real-world render time while still returning well short of
 # the full timeout for a campaign that genuinely never renders more tiles.
+#
+# KNOWN ACCEPTED TRADE-OFF (tracked in #708): no finite tick count can
+# fully close the race between "campaign genuinely has fewer tiles" and
+# "tiles just haven't rendered yet" without a real DOM settled/loading
+# marker for the stat-tiles section, which does not exist in this code
+# (unlike _OVERVIEW_TITLE_SELECTOR for the header, #683, or
+# _wait_for_images_editor's section marker, #670). This value fixes the
+# confirmed-live #683 scenario and narrows the window versus a 1-tick
+# check; it does not eliminate it. See #708 for finding a real marker.
 _STAT_TILES_STABLE_TICKS = 8
 
 # Overview page's "⋮" menu, confirmed live (issue #633) — see module

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -19,6 +19,7 @@ additions below for how that replay is faked.
 """
 
 import json
+import time
 import unittest
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -1789,6 +1790,43 @@ class TestFetchMaster(unittest.TestCase):
         )
         result = browser_masters.fetch_master(page, 1)
         self.assertEqual(result["Stats"], {"cost_per_conversion": "191,07 ₽"})
+
+    def test_stable_partial_tile_set_returns_without_waiting_out_the_timeout(self):
+        # cycle-review #697 finding (Codex): the old completion condition
+        # required every one of the 5 known keys before _poll_until could
+        # return true, so a campaign that genuinely has fewer tiles (fewer
+        # metrics enabled, or Yandex not rendering one) always burned the
+        # full _STAT_TILES_TIMEOUT_MS. A stable (unchanged-between-ticks)
+        # partial set must now return as soon as it stabilizes, not after
+        # the full timeout -- proven here via an artificially large timeout
+        # that the fix must NOT actually wait out.
+        page = FakePage(
+            locators={
+                "button": _FakeLocator(
+                    [_FakeLocatorHandle(text="191,07 ₽\nЗа конверсию")]
+                ),
+            },
+        )
+        start = time.monotonic()
+        with patch.object(browser_masters, "_STAT_TILES_TIMEOUT_MS", 10_000):
+            result = browser_masters.fetch_master(page, 1)
+        elapsed = time.monotonic() - start
+        self.assertEqual(result["Stats"], {"cost_per_conversion": "191,07 ₽"})
+        self.assertLess(elapsed, 2.0)
+
+    def test_zero_tiles_returns_without_waiting_out_the_timeout(self):
+        # Same fix, empty-set edge case (cycle-review #697): the old
+        # condition never matched an empty `stats` dict against
+        # `wanted_keys`, so a page with no recognisable stat tiles at all
+        # also burned the full timeout.
+        page = FakePage(locators={}, body_text="something Yandex changed")
+        start = time.monotonic()
+        with patch.object(browser_masters, "_STAT_TILES_TIMEOUT_MS", 10_000):
+            with patch("direct_cli.browser.masters.print_warning"):
+                result = browser_masters.fetch_master(page, 1)
+        elapsed = time.monotonic() - start
+        self.assertNotIn("Stats", result)
+        self.assertLess(elapsed, 2.0)
 
     def test_partial_result_on_unrecognised_sections(self):
         # A page whose title element IS present (so _goto_overview_page is
@@ -4617,6 +4655,56 @@ class TestGotoOverviewPage(unittest.TestCase):
 
         with self.assertRaises(BrowserAuthError):
             browser_masters._goto_overview_page(page, 1)
+
+    def test_captcha_appearing_mid_poll_raises_not_swallowed_as_timeout(self):
+        # cycle-review #697 finding (claude/review): a captcha gate that
+        # appears AFTER the upfront check (e.g. the session expires while
+        # waiting) must still surface as BrowserCaptchaError, not be
+        # swallowed as "not yet ready" and reported as a generic render
+        # timeout. Mirrors _wait_for_edit_form's own
+        # _edit_form_terminal_state pattern (#689): the captcha/auth check
+        # must live outside _poll_until's suppressed predicate.
+        #
+        # PlaywrightError is patched to the real playwright.sync_api.Error
+        # here to exercise the exact runtime configuration where the bug
+        # bites: with playwright installed, BrowserCaptchaError/
+        # BrowserAuthError are NOT subclasses of PlaywrightError, so
+        # contextlib.suppress(PlaywrightError) can't hide them regardless
+        # of where the check lives -- the swallow only happens when
+        # PlaywrightError is aliased to the bare Exception (the
+        # no-playwright offline fallback, masters.py's own import
+        # try/except), which every raise is a subclass of.
+        html_sequence = iter(
+            ["<html></html>", "<script>smartCaptcha.render()</script>"]
+        )
+
+        class _CaptchaAfterFirstTickPage(FakePage):
+            def content(self):
+                return next(html_sequence, "<script>smartCaptcha.render()</script>")
+
+        page = _CaptchaAfterFirstTickPage(locators={})
+        del page._locators[browser_masters._OVERVIEW_TITLE_SELECTOR]
+
+        with patch.object(browser_masters, "PlaywrightError", Exception):
+            with self.assertRaises(BrowserCaptchaError):
+                browser_masters._goto_overview_page(page, 1)
+
+    def test_auth_failure_appearing_mid_poll_raises_not_swallowed_as_timeout(self):
+        # Same fix, auth-error variant (cycle-review #697 finding). See the
+        # sibling captcha test above for why PlaywrightError is patched to
+        # the bare Exception.
+        html_sequence = iter(["<html></html>", "<body>Войдите с Яндекс ID</body>"])
+
+        class _AuthFailureAfterFirstTickPage(FakePage):
+            def content(self):
+                return next(html_sequence, "<body>Войдите с Яндекс ID</body>")
+
+        page = _AuthFailureAfterFirstTickPage(locators={})
+        del page._locators[browser_masters._OVERVIEW_TITLE_SELECTOR]
+
+        with patch.object(browser_masters, "PlaywrightError", Exception):
+            with self.assertRaises(BrowserAuthError):
+                browser_masters._goto_overview_page(page, 1)
 
 
 class TestBrowserSessionErrors(unittest.TestCase):

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -19,7 +19,6 @@ additions below for how that replay is faked.
 """
 
 import json
-import time
 import unittest
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -1798,35 +1797,59 @@ class TestFetchMaster(unittest.TestCase):
         # metrics enabled, or Yandex not rendering one) always burned the
         # full _STAT_TILES_TIMEOUT_MS. A stable (unchanged-between-ticks)
         # partial set must now return as soon as it stabilizes, not after
-        # the full timeout -- proven here via an artificially large timeout
-        # that the fix must NOT actually wait out.
-        page = FakePage(
+        # the full timeout.
+        #
+        # Asserted via _poll_until's own tick count (page.wait_for_timeout
+        # call count), not wall-clock elapsed time (cycle-review #697 CI
+        # finding): _poll_until's `while time.monotonic() < deadline` loop
+        # measures real wall-clock time, which is NOT deterministic under a
+        # loaded CI runner (observed: a xdist-parallel CI run took a real
+        # 15s here despite an artificially large timeout and only needing a
+        # few ticks to stabilize -- 60x slower than the ~0.07s this test
+        # takes locally). Tick count is deterministic regardless of how
+        # slowly wall-clock time actually elapses between ticks.
+        class _TickCountingPage(FakePage):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.tick_count = 0
+
+            def wait_for_timeout(self, timeout):
+                self.tick_count += 1
+
+        page = _TickCountingPage(
             locators={
                 "button": _FakeLocator(
                     [_FakeLocatorHandle(text="191,07 ₽\nЗа конверсию")]
                 ),
             },
         )
-        start = time.monotonic()
         with patch.object(browser_masters, "_STAT_TILES_TIMEOUT_MS", 10_000):
             result = browser_masters.fetch_master(page, 1)
-        elapsed = time.monotonic() - start
         self.assertEqual(result["Stats"], {"cost_per_conversion": "191,07 ₽"})
-        self.assertLess(elapsed, 2.0)
+        # Must stop once the set stabilizes, not burn through the full
+        # 10_000ms / 250ms = 40-tick timeout budget.
+        self.assertLess(page.tick_count, 40)
 
     def test_zero_tiles_returns_without_waiting_out_the_timeout(self):
         # Same fix, empty-set edge case (cycle-review #697): the old
         # condition never matched an empty `stats` dict against
         # `wanted_keys`, so a page with no recognisable stat tiles at all
-        # also burned the full timeout.
-        page = FakePage(locators={}, body_text="something Yandex changed")
-        start = time.monotonic()
+        # also burned the full timeout. See the sibling test above for why
+        # this asserts tick count rather than wall-clock elapsed time.
+        class _TickCountingPage(FakePage):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.tick_count = 0
+
+            def wait_for_timeout(self, timeout):
+                self.tick_count += 1
+
+        page = _TickCountingPage(locators={}, body_text="something Yandex changed")
         with patch.object(browser_masters, "_STAT_TILES_TIMEOUT_MS", 10_000):
             with patch("direct_cli.browser.masters.print_warning"):
                 result = browser_masters.fetch_master(page, 1)
-        elapsed = time.monotonic() - start
         self.assertNotIn("Stats", result)
-        self.assertLess(elapsed, 2.0)
+        self.assertLess(page.tick_count, 40)
 
     def test_delayed_tile_render_is_not_mistaken_for_a_stable_empty_set(self):
         # cycle-review #697 re-review finding (Codex): the first version of

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -374,6 +374,16 @@ class FakePage:
         role_elements=None,
     ):
         self._locators = locators or {}
+        # Every overview-page test implicitly exercises _goto_overview_page
+        # (issue #683), which polls for this exact testid before returning
+        # control to the caller — default it present so existing tests that
+        # don't care about the wait mechanics aren't all forced to register
+        # it explicitly. A test that DOES care (e.g. the DRAFT-shaped
+        # "marker never appears" timeout case) removes it from `locators`.
+        self._locators.setdefault(
+            browser_masters._OVERVIEW_TITLE_SELECTOR,
+            _FakeLocator([_FakeLocatorHandle()]),
+        )
         self._body_text = body_text
         self._html = html
         self.navigated_to = []
@@ -1707,7 +1717,9 @@ class TestFetchMaster(unittest.TestCase):
     def _page_for(self, title="Мастер Тест", status_text="Кампания остановлена"):
         return FakePage(
             locators={
-                "h1, [role=heading]": _FakeLocator([_FakeLocatorHandle(text=title)]),
+                browser_masters._OVERVIEW_TITLE_SELECTOR: _FakeLocator(
+                    [_FakeLocatorHandle(text=title)]
+                ),
                 "a[href*='utm_source=']": _FakeLocator(
                     [
                         _FakeLocatorHandle(
@@ -1764,11 +1776,38 @@ class TestFetchMaster(unittest.TestCase):
         result = browser_masters.fetch_master(page, 1)
         self.assertEqual(result["Status"], "ACTIVE")
 
+    def test_stat_label_with_non_breaking_space_still_matches(self):
+        # Confirmed live 2026-08-03 (issue #683, campaign 72349978): "За
+        # конверсию" renders with U+00A0 between the words, not a plain
+        # space — _STAT_TILE_LABELS' plain-space key must still match.
+        page = FakePage(
+            locators={
+                "button": _FakeLocator(
+                    [_FakeLocatorHandle(text="191,07 ₽\nЗа\xa0конверсию")]
+                ),
+            },
+        )
+        result = browser_masters.fetch_master(page, 1)
+        self.assertEqual(result["Stats"], {"cost_per_conversion": "191,07 ₽"})
+
     def test_partial_result_on_unrecognised_sections(self):
-        # A page with none of the expected sections must not raise — every
-        # extractor degrades to omitting its field plus a warning, per the
-        # module's "best-effort" contract (see fetch_master docstring).
+        # A page whose title element IS present (so _goto_overview_page is
+        # satisfied the overview page is ready — see TestGotoOverviewPage
+        # for the "never renders at all" case) but whose text can't be read,
+        # and whose other sections weren't recognised, must not raise —
+        # every extractor degrades to omitting its field plus a warning, per
+        # the module's "best-effort" contract (see fetch_master docstring).
+        class _PresentButUnreadableTitle(_FakeLocatorHandle):
+            def count(self):
+                return 1  # matched -> _goto_overview_page's wait is satisfied
+
+            def inner_text(self):
+                raise PlaywrightError("element detached")
+
         page = FakePage(locators={}, body_text="something Yandex changed the markup to")
+        page._locators[browser_masters._OVERVIEW_TITLE_SELECTOR] = _FakeLocator(
+            [_PresentButUnreadableTitle()]
+        )
 
         with patch("direct_cli.browser.masters.print_warning") as warn:
             result = browser_masters.fetch_master(page, 999)
@@ -4444,13 +4483,140 @@ class TestAuthDetection(unittest.TestCase):
             browser_masters.fetch_masters_list(page)
         self.assertEqual(page.goto_wait_until, "commit")
 
-    def test_fetch_master_waits_for_domcontentloaded_not_networkidle(self):
-        # fetch_master navigates to the wizard overview page, not the grid
+    def test_fetch_master_uses_commit_not_domcontentloaded(self):
+        # #683: domcontentloaded raced the overview page's client-rendered
+        # header (live-confirmed intermittent "Could not read campaign name"
+        # against campaign 72349978) -- _goto_overview_page now uses
+        # wait_until="commit" and polls for the header marker itself instead
+        # of trusting an implicit DOM-ready signal. fetch_master navigates to
+        # the wizard overview page, not the grid
         # (_capture_grid_campaigns_request) — out of scope for #682, which
         # only touches the grid's own goto.
         page = FakePage(locators={})
         browser_masters.fetch_master(page, 1)
-        self.assertEqual(page.goto_wait_until, "domcontentloaded")
+        self.assertEqual(page.goto_wait_until, "commit")
+
+
+class TestGotoOverviewPage(unittest.TestCase):
+    """_goto_overview_page (issue #683): the shared wait every wizard
+    overview entry point (get/suspend/resume/archive/copy) now goes through.
+
+    domcontentloaded raced the overview page's client-rendered header --
+    live-confirmed intermittent "Could not read campaign name" against
+    campaign 72349978 while status/landing-URL/stats all read back fine.
+    wait_until="commit" plus an explicit poll for
+    _OVERVIEW_TITLE_SELECTOR (the "<h2 data-testid=CampaignHeader.Title>"
+    element, confirmed live present on BOTH DRAFT and non-DRAFT overview
+    pages, unlike _MENU_TRIGGER_SELECTOR which #660 found absent on DRAFT)
+    replaces it.
+    """
+
+    def test_every_overview_entry_point_uses_commit(self):
+        # fetch_master (get), _suspend_or_resume (suspend/resume),
+        # archive_master, and copy_master all navigate through
+        # _goto_overview_page -- each must request wait_until="commit", not
+        # domcontentloaded (#683).
+        page = FakePage(locators={})
+        browser_masters.fetch_master(page, 1)
+        self.assertEqual(page.goto_wait_until, "commit")
+
+        page = FakePage(body_text="Кампания активна")
+        browser_masters.resume_master(page, 1)
+        self.assertEqual(page.goto_wait_until, "commit")
+
+        page = FakePage(
+            locators={
+                browser_masters._MENU_TRIGGER_SELECTOR: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                ),
+                browser_masters._ARCHIVE_MENU_ITEM_SELECTOR: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                ),
+            },
+        )
+        with patch(
+            "direct_cli.browser.masters.fetch_masters_list",
+            side_effect=[
+                [
+                    {
+                        "CampaignId": 1,
+                        "Name": "x",
+                        "Status": "STOPPED",
+                        "Type": "TEXT",
+                        "StartDate": "2025-01-01",
+                    }
+                ],
+                [
+                    {
+                        "CampaignId": 1,
+                        "Name": "x",
+                        "Status": "ARCHIVED",
+                        "Type": "TEXT",
+                        "StartDate": "2025-01-01",
+                    }
+                ],
+            ],
+        ):
+            browser_masters.archive_master(page, 1)
+        self.assertEqual(page.goto_wait_until, "commit")
+
+    def test_waits_for_title_marker_before_returning(self):
+        # A page whose header hasn't rendered yet on the first poll tick
+        # must not be treated as ready -- mirrors _wait_for_images_editor's
+        # own "stub state" guard (#670).
+        remaining = {"ticks": 2}
+        title_selector = browser_masters._OVERVIEW_TITLE_SELECTOR
+
+        class _SlowHeaderPage(FakePage):
+            def locator(self, selector):
+                if selector == title_selector:
+                    if remaining["ticks"] > 0:
+                        remaining["ticks"] -= 1
+                        return _FakeLocator([])
+                    return _FakeLocator([_FakeLocatorHandle()])
+                return super().locator(selector)
+
+        page = _SlowHeaderPage(locators={})
+
+        browser_masters.fetch_master(page, 1)  # must not raise
+
+        self.assertEqual(remaining["ticks"], 0)
+
+    def test_raises_when_title_marker_never_appears(self):
+        # A DRAFT campaign's overview page has no _MENU_TRIGGER_SELECTOR
+        # (issue #660, not fixed here) -- archive_master/copy_master still
+        # fail on it, but as a clear bounded timeout, not an indefinite
+        # hang. Simulated here via a header that never renders at all.
+        page = FakePage(locators={})
+        del page._locators[browser_masters._OVERVIEW_TITLE_SELECTOR]
+
+        with patch.object(browser_masters, "_OVERVIEW_LOAD_TIMEOUT_MS", 1):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters._goto_overview_page(page, 999)
+
+        self.assertIn("did not render within", str(ctx.exception))
+        self.assertIn("999", str(ctx.exception))
+
+    def test_reports_captcha_immediately_without_waiting_out_the_timeout(self):
+        # A captcha gate is reported via its own specific error as soon as
+        # it's detected, rather than only after burning the full
+        # _OVERVIEW_LOAD_TIMEOUT_MS waiting for a header a captcha page will
+        # never render.
+        page = FakePage(
+            locators={},
+            html="<script>smartCaptcha.render()</script>",
+        )
+        del page._locators[browser_masters._OVERVIEW_TITLE_SELECTOR]
+
+        with self.assertRaises(BrowserCaptchaError):
+            browser_masters._goto_overview_page(page, 1)
+
+    def test_reports_auth_failure_immediately_without_waiting_out_the_timeout(self):
+        page = FakePage(locators={}, html="<body>Войдите с Яндекс ID</body>")
+        del page._locators[browser_masters._OVERVIEW_TITLE_SELECTOR]
+
+        with self.assertRaises(BrowserAuthError):
+            browser_masters._goto_overview_page(page, 1)
 
 
 class TestBrowserSessionErrors(unittest.TestCase):

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -1828,6 +1828,44 @@ class TestFetchMaster(unittest.TestCase):
         self.assertNotIn("Stats", result)
         self.assertLess(elapsed, 2.0)
 
+    def test_delayed_tile_render_is_not_mistaken_for_a_stable_empty_set(self):
+        # cycle-review #697 re-review finding (Codex): the first version of
+        # the stabilization fix treated a SINGLE unchanged tick as proof the
+        # tile set was final -- but on a page that genuinely has tiles which
+        # just haven't rendered yet (the ~15s two-stage-render delay this
+        # module's own comments document), the very first couple of ticks
+        # are ALSO an unchanged (empty) set, purely because nothing has
+        # rendered yet. A naive one-tick check returned an empty Stats dict
+        # after only ~250ms on a page whose tile genuinely appears a few
+        # ticks later. _STAT_TILES_STABLE_TICKS now requires several
+        # consecutive stable ticks, giving a slow-but-real render room to
+        # actually happen before its result is trusted as final.
+        class _DelayedTilePage(FakePage):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.tile_scan_count = 0
+
+            def locator(self, selector):
+                if selector == "button":
+                    self.tile_scan_count += 1
+                    # Renders on the 2nd scan -- a single-stable-tick check
+                    # would already have declared the empty 1st scan final
+                    # before this tile had a chance to appear.
+                    if self.tile_scan_count <= 1:
+                        return _FakeLocator([])
+                    return _FakeLocator([_FakeLocatorHandle(text="281 722\nПоказа")])
+                return super().locator(selector)
+
+        page = _DelayedTilePage(locators={})
+        result = browser_masters.fetch_master(page, 1)
+
+        self.assertEqual(result["Stats"], {"impressions": "281 722"})
+        # Confirms the stabilization window is actually being exercised,
+        # not short-circuited by the "all wanted keys found" fast path.
+        self.assertGreaterEqual(
+            page.tile_scan_count, 1 + browser_masters._STAT_TILES_STABLE_TICKS
+        )
+
     def test_partial_result_on_unrecognised_sections(self):
         # A page whose title element IS present (so _goto_overview_page is
         # satisfied the overview page is ready — see TestGotoOverviewPage


### PR DESCRIPTION
## Summary

- `page.goto(url, wait_until="domcontentloaded")` at the 4 wizard-overview navigation sites (`fetch_master`/`get`, `_suspend_or_resume`/`suspend`/`resume`, `archive_master`/`archive`, `copy_master`/`copy`) raced a client-rendered SPA — the DOM event fires before React has painted anything, causing intermittent multi-second stalls and wrong/missing extracted fields.
- Replaced with `wait_until="commit"` (fires as soon as response headers arrive) plus a new `_goto_overview_page(page, campaign_id)` helper that explicitly polls for the overview page's title (`[data-testid="CampaignHeader.Title"]`) via the existing `_poll_until` mechanism, up to `_OVERVIEW_LOAD_TIMEOUT_MS` (30s). Captcha/auth checks now run on every poll tick instead of once, so those failures surface immediately instead of only after burning the full timeout.
- `CampaignHeader.Title` was chosen over the issue's suggested `CampaignHeader.MenuTrigger` because live testing confirmed the latter is absent on DRAFT campaigns (issue #660) — the title selector works across every status, so `_goto_overview_page` itself never spuriously times out on DRAFT.

## Additional fixes found during live investigation (explicit sign-off given during the session)

- `_extract_title` used a dead CSS selector `h1, [role=heading]` that never matched the real overview title element (`<h2 data-testid="CampaignHeader.Title">`, no `role` attribute) — campaign name was **silently unreadable on every single call**. Fixed to use the same `CampaignHeader.Title` selector `_goto_overview_page` already waits for.
- `_extract_stat_tiles` compared rendered stat labels against `_STAT_TILE_LABELS` without normalising the non-breaking space (U+00A0) Yandex actually renders in "За⍽конверсию" — `cost_per_conversion` silently never matched its dict key. Fixed with `.replace("\xa0", " ")` before lookup.
- `_extract_stat_tiles`'s tile scan is now wrapped in its own poll loop (`_STAT_TILES_TIMEOUT_MS`, 30s): live headless recon showed the stat tiles render as an **independent, later SPA pass** — up to ~15-20s after the title itself — so a single post-title read intermittently found 0 of 5 tiles even though the title had already rendered.

## Efficiency cleanup (from an internal /simplify pass, no behavior change)

- `_goto_overview_page`'s poll predicate fetched `page.content()` twice per tick; now fetched once and reused.
- `_extract_stat_tiles`'s scan cleared and rebuilt `stats` from scratch on every poll tick; now accumulates across ticks and stops as soon as all wanted keys are found.

## Live verification

- `direct masters get 72349978` (ACTIVE campaign): went from an intermittent ~41-48s stall with a wrong/missing name to a reliable run with all fields (name, status, stats) correctly populated.
- `direct masters update 713234064 --launch` (DRAFT → published): confirmed the fixed navigation path also works correctly on the edit-page flow, not just overview `get`.
- `direct masters get 713234064` post-launch (now MODERATION status): title and stats render correctly (Stats now shows all 5 keys including `cost_per_conversion`); status text is correctly left unrecognised since MODERATION has no ACTIVE/SUSPENDED-style status text to match — expected, not a regression.

## Known follow-up (unchanged, out of scope)

DRAFT/MODERATION campaigns still can't be suspended/resumed (no matching status text) or archived (no `CampaignHeader.MenuTrigger`) — that gap is tracked separately in #660 and is unaffected by this fix.

## Tests

- `pytest tests/test_masters.py` — 342 passed, including new `TestGotoOverviewPage` (commit-not-domcontentloaded at all 4 sites, delayed-title-render doesn't return early, timeout raises `BrowserSessionError`, captcha/auth detected immediately not after timeout) and a `\xa0`-label regression test.
- `black --check` / `flake8` clean on both changed files.

Closes #683