### PR TITLE
fix(masters): wrap entire expect_response with-block in try/except

### DIFF
--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -670,6 +670,14 @@ def _capture_grid_campaigns_request(page: "Page") -> Dict[str, Any]:
             assert_not_captcha(page.content())
             assert_authenticated(page.content())
         response = response_info.value
+    except BrowserSessionError:
+        # assert_not_captcha/assert_authenticated raise BrowserCaptchaError/
+        # BrowserAuthError (both BrowserSessionError subclasses) -- these
+        # must propagate as-is, not be relabelled as the generic timeout
+        # error below. Without this PlaywrightError falls back to bare
+        # Exception when the playwright package isn't installed (see the
+        # import fallback above), which would otherwise swallow them too.
+        raise
     except PlaywrightError as exc:
         # Playwright's EventContextManager.__exit__ resolves
         # response_info.value itself when the `with` block exits without

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -658,19 +658,26 @@ def _capture_grid_campaigns_request(page: "Page") -> Dict[str, Any]:
     so their marker text is present in the initial document body Yandex
     sends, before any client-side JS runs.
     """
-    with page.expect_response(
-        _is_grid_campaigns_request, timeout=_GRID_CAPTURE_TIMEOUT_MS
-    ) as response_info:
-        # commit, not domcontentloaded/networkidle: see docstring. No
-        # ulogin here (see module docstring): passing our own login as the
-        # managed-client param produces "Доступ ограничен" + HTTP 401.
-        page.goto(GRID_URL, wait_until="commit")
-        assert_not_captcha(page.content())
-        assert_authenticated(page.content())
-
     try:
+        with page.expect_response(
+            _is_grid_campaigns_request, timeout=_GRID_CAPTURE_TIMEOUT_MS
+        ) as response_info:
+            # commit, not domcontentloaded/networkidle: see docstring. No
+            # ulogin here (see module docstring): passing our own login as
+            # the managed-client param produces "Доступ ограничен" + HTTP
+            # 401.
+            page.goto(GRID_URL, wait_until="commit")
+            assert_not_captcha(page.content())
+            assert_authenticated(page.content())
         response = response_info.value
     except PlaywrightError as exc:
+        # Playwright's EventContextManager.__exit__ resolves
+        # response_info.value itself when the `with` block exits without
+        # raising — so a expect_response timeout surfaces as the `with`
+        # block's own exit, not as an exception from reading
+        # response_info.value afterwards (issue #694). The whole block
+        # (goto/assert_* included) must be inside this try, or the timeout
+        # escapes uncaught.
         raise BrowserSessionError(
             "Could not observe the campaigns grid's data request "
             f"(operationName={_GRID_CAMPAIGNS_OPERATION}) within "

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -322,6 +322,29 @@ class _FakeExpectResponse:
         return False
 
 
+class _FakeExpectResponseExitRaises(_FakeExpectResponse):
+    """Faithfully mimics real Playwright's ``EventContextManager.__exit__``.
+
+    Real Playwright resolves ``response_info.value`` itself inside
+    ``__exit__`` when the wrapped ``with`` block exits without raising — so
+    a ``expect_response`` timeout surfaces as an exception from the `with`
+    block's own exit, NOT from a later, separate access to
+    ``response_info.value`` (see issue #694). ``_FakeExpectResponse``/
+    ``_FakeResponseInfo`` above resolve lazily on ``.value`` access instead,
+    which cannot reproduce that ordering bug — this subclass raises in
+    ``__exit__`` itself when no matching response was ever observed, to
+    exercise the real failure mode.
+    """
+
+    def __exit__(self, *exc_info):
+        if exc_info[0] is not None:
+            return False
+        candidate = self._page._grid_response
+        if candidate is None or not self._predicate(candidate):
+            raise PlaywrightError("Timeout waiting for response")
+        return False
+
+
 class _FakeTextLocatorHandle:
     """One matched element for ``get_by_text`` — supports ``is_visible``/``click``.
 
@@ -411,6 +434,8 @@ class FakePage:
         self.closed = True
 
     def expect_response(self, predicate, timeout=None):
+        if getattr(self, "_expect_response_exit_raises", False):
+            return _FakeExpectResponseExitRaises(self, predicate)
         return _FakeExpectResponse(self, predicate)
 
     def eval_on_selector_all(self, selector, expression):
@@ -1662,6 +1687,21 @@ class TestFetchMastersList(unittest.TestCase):
         # The grid fired no matching response at all (e.g. Yandex renamed the
         # operation) -> a clear BrowserSessionError, not a silent empty list.
         page = FakePage(grid_response=None)
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters.fetch_masters_list(page, status="all")
+
+    def test_expect_response_timeout_from_with_exit_raises_browser_session_error(
+        self,
+    ):
+        # #694: real Playwright's EventContextManager.__exit__ resolves
+        # response_info.value itself and raises the TimeoutError there when
+        # the `with` block exits cleanly but no matching response ever
+        # arrived -- so the timeout must be caught by wrapping the whole
+        # `with page.expect_response(...): goto(...); ...` block, not just a
+        # later, separate read of response_info.value after the block.
+        page = FakePage(grid_response=None)
+        page._expect_response_exit_raises = True
 
         with self.assertRaises(BrowserSessionError):
             browser_masters.fetch_masters_list(page, status="all")

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -4468,6 +4468,26 @@ class TestAuthDetection(unittest.TestCase):
         with self.assertRaises(BrowserAuthError):
             browser_masters.fetch_master(page, 1)
 
+    def test_fetch_masters_list_login_page_not_masked_without_playwright(self):
+        # CI's "quality" job runs the offline suite without the playwright
+        # package installed, so PlaywrightError falls back to bare Exception
+        # (see the import fallback in direct_cli/browser/masters.py). Once
+        # _capture_grid_campaigns_request's whole `with page.expect_response`
+        # block (goto/assert_* included) moved inside one try/except
+        # PlaywrightError (issue #694 fix), that broad except-Exception
+        # fallback started swallowing assert_authenticated's BrowserAuthError
+        # too, relabelling it as the generic "could not observe the grid's
+        # data request" timeout error instead of letting it propagate --
+        # confirmed live on CI (PR #698). Simulate the no-playwright fallback
+        # here directly so this regression is caught locally too, regardless
+        # of whether playwright happens to be installed in the dev env.
+        page = FakePage(locators={}, html="<body>Войдите с Яндекс ID</body>")
+        from direct_cli.browser.session import BrowserAuthError
+
+        with patch.object(browser_masters, "PlaywrightError", Exception):
+            with self.assertRaises(BrowserAuthError):
+                browser_masters.fetch_masters_list(page)
+
     def test_fetch_masters_list_waits_for_commit_not_networkidle(self):
         # #634: networkidle never settles on Yandex's login page (it holds
         # long-poll connections), which is what turned an auth failure into


### PR DESCRIPTION
## Summary

`_capture_grid_campaigns_request` wrapped `page.expect_response(...)` in a `with` block, then read `response_info.value` in a separate `try/except PlaywrightError` placed AFTER the block. Real Playwright's `EventContextManager.__exit__` resolves `response_info.value` itself and raises there if the wrapped code (here, `goto`/`assert_not_captcha`/`assert_authenticated`) didn't already raise — so a `GridCampaigns` observation timeout surfaced as an uncaught `playwright.sync_api.TimeoutError` escaping the `with` block's own exit, never reaching the `try/except` that follows it. That handler was dead code for the timeout scenario.

Practical effect: instead of the intended `BrowserSessionError("Could not observe the campaigns grid's data request...")`, callers got a raw Playwright traceback. Downstream, `_with_session`'s retry logic (which only matches `BrowserAuthError`/`BrowserSessionError`) never triggered either, since the escaping exception didn't match those types.

## Fix

Move the entire `with page.expect_response(...) as response_info: goto(...); assert_*(...)` block, plus the `response_info.value` read, inside one `try/except PlaywrightError` — so the timeout is caught regardless of whether it surfaces from the `with` block's exit or from `.value` access.

Grepped the rest of `direct_cli/browser/masters.py` for `expect_response` — `_capture_grid_campaigns_request` is the only call site using this pattern; no other instances to fix.

## Tests

Added `test_expect_response_timeout_from_with_exit_raises_browser_session_error` in `tests/test_masters.py`, backed by a new `_FakeExpectResponseExitRaises` test double that faithfully reproduces real Playwright's `__exit__`-raises-on-timeout ordering (the existing `_FakeExpectResponse`/`_FakeResponseInfo` fakes resolve lazily on `.value` access, which can't reproduce this bug). Verified the new test fails against the pre-fix code (raw `playwright._impl._errors.Error` escapes) and passes with the fix.

- `pytest tests/test_masters.py` — 354 passed
- `black --check` / `flake8` — clean
- Confirmed pre-existing, unrelated `test_read_cassettes.py` errors are present identically on `main` (not introduced by this change)

Closes #694