### PR TITLE
fix(masters): --launch on adimages delete/set must not no-op on empty images

### DIFF
--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -1983,10 +1983,13 @@ def delete_master_images(
     every image currently in the set.
 
     ``all_images=True`` against an already-empty set is an idempotent
-    no-op success (mirrors ``suspend``/``resume``'s "idempotent if already
-    X" convention) — no modal is opened, nothing is saved. Naming a
-    specific position or content ID that does not exist is always an
-    error, empty set or not.
+    no-op success when ``launch=False`` (mirrors ``suspend``/``resume``'s
+    "idempotent if already X" convention) — no modal is opened, nothing is
+    saved. With ``launch=True``, the no-op still applies to the images (the
+    modal is never opened), but the DRAFT-publish click still happens —
+    ``--launch`` is a second, independent request that an empty image set
+    must not swallow (issue #678). Naming a specific position or content ID
+    that does not exist is always an error, empty set or not.
     """
     if not positions and not content_ids and not all_images:
         raise ValueError(
@@ -1997,7 +2000,7 @@ def delete_master_images(
     before_ids = _open_images_editor(page, campaign_id)
 
     if all_images:
-        if not before_ids:
+        if not before_ids and not launch:
             return {"CampaignId": campaign_id, "Deleted": 0, "Count": 0}
         targets: List[str] = list(before_ids)
     else:
@@ -2059,6 +2062,12 @@ def set_master_images(
     call, so a full at-cap replacement (e.g. 5 images out, 5 images in)
     never transiently exceeds Yandex's cap — the removals are applied to
     the modal's live selection before any upload begins.
+
+    An already-empty set with ``paths=()`` is a no-op for the images (the
+    modal is never opened) when ``launch=False``. With ``launch=True`` the
+    DRAFT-publish click still happens — ``--launch`` is a second,
+    independent request that an empty image set must not swallow (issue
+    #678).
     """
     if len(paths) > _IMAGES_MAX_COUNT:
         raise BrowserSessionError(
@@ -2068,7 +2077,7 @@ def set_master_images(
 
     before_ids = _open_images_editor(page, campaign_id)
 
-    if not before_ids and not paths:
+    if not before_ids and not paths and not launch:
         return {"CampaignId": campaign_id, "Count": 0}
 
     _apply_image_operations(

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -5962,6 +5962,60 @@ class TestDeleteMasterImages(unittest.TestCase):
         self.assertIn("not present", str(ctx.exception).lower())
         self.assertEqual(save_clicks, [])
 
+    def test_all_with_launch_still_publishes_an_already_empty_draft(self):
+        """Issue #678: ``--launch`` is a second, independent request ("publish
+        the draft while saving") that an images no-op must not swallow — the
+        help text's only stated exception is a non-DRAFT campaign, not an
+        empty image set.
+        """
+        clicks = []
+
+        def _on_launch_click():
+            clicks.append("launch")
+            page.url = browser_masters.WIZARD_OVERVIEW_URL.format(campaign_id=42)
+
+        page = _FakeImagesPage(
+            [],
+            locators={
+                browser_masters._DRAFT_SAVE_DRAFT_BUTTON_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle(on_click=lambda: clicks.append("draft"))]
+                ),
+                browser_masters._DRAFT_LAUNCH_BUTTON_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle(on_click=_on_launch_click)]
+                ),
+            },
+        )
+
+        result = browser_masters.delete_master_images(
+            page, 42, all_images=True, launch=True
+        )
+
+        self.assertEqual(clicks, ["launch"])
+        self.assertEqual(result, {"CampaignId": 42, "Deleted": 0, "Count": 0})
+        self.assertFalse(page.modal_open)
+
+    def test_all_on_an_already_empty_set_without_launch_is_still_a_no_op(self):
+        """Guard: without ``--launch``, an empty ``--all`` must remain a true
+        no-op — nothing clicked, least of all a publish button."""
+        clicks = []
+        page = _FakeImagesPage(
+            [],
+            locators={
+                browser_masters._DRAFT_SAVE_DRAFT_BUTTON_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle(on_click=lambda: clicks.append("draft"))]
+                ),
+                browser_masters._DRAFT_LAUNCH_BUTTON_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle(on_click=lambda: clicks.append("launch"))]
+                ),
+            },
+        )
+
+        result = browser_masters.delete_master_images(page, 42, all_images=True)
+
+        self.assertEqual(clicks, [])
+        self.assertEqual(result, {"CampaignId": 42, "Deleted": 0, "Count": 0})
+        self.assertFalse(page.modal_open)
+
 
 class TestSetMasterImages(unittest.TestCase):
     """``set_master_images`` — whole-set replacement in one modal."""
@@ -6019,6 +6073,55 @@ class TestSetMasterImages(unittest.TestCase):
 
         self.assertIn("cap", str(ctx.exception).lower())
         self.assertEqual(save_clicks, [])
+
+    def test_empty_with_launch_still_publishes_an_already_empty_draft(self):
+        """Issue #678, symmetric case: ``set --allow-empty --launch`` on an
+        already-empty DRAFT must still publish it."""
+        clicks = []
+
+        def _on_launch_click():
+            clicks.append("launch")
+            page.url = browser_masters.WIZARD_OVERVIEW_URL.format(campaign_id=42)
+
+        page = _FakeImagesPage(
+            [],
+            locators={
+                browser_masters._DRAFT_SAVE_DRAFT_BUTTON_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle(on_click=lambda: clicks.append("draft"))]
+                ),
+                browser_masters._DRAFT_LAUNCH_BUTTON_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle(on_click=_on_launch_click)]
+                ),
+            },
+        )
+
+        result = browser_masters.set_master_images(page, 42, paths=[], launch=True)
+
+        self.assertEqual(clicks, ["launch"])
+        self.assertEqual(result, {"CampaignId": 42, "Count": 0})
+        self.assertFalse(page.modal_open)
+
+    def test_already_empty_with_no_paths_without_launch_is_still_a_no_op(self):
+        """Guard: without ``--launch``, empty-in/empty-out remains a true
+        no-op — nothing clicked, least of all a publish button."""
+        clicks = []
+        page = _FakeImagesPage(
+            [],
+            locators={
+                browser_masters._DRAFT_SAVE_DRAFT_BUTTON_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle(on_click=lambda: clicks.append("draft"))]
+                ),
+                browser_masters._DRAFT_LAUNCH_BUTTON_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle(on_click=lambda: clicks.append("launch"))]
+                ),
+            },
+        )
+
+        result = browser_masters.set_master_images(page, 42, paths=[])
+
+        self.assertEqual(clicks, [])
+        self.assertEqual(result, {"CampaignId": 42, "Count": 0})
+        self.assertFalse(page.modal_open)
 
 
 class TestVerifyImageMismatches(unittest.TestCase):


### PR DESCRIPTION
## Summary
- `delete_master_images` (`all_images` branch) and `set_master_images` returned early on an already-empty image set, bypassing `_save_and_verify_images` entirely — so `masters adimages delete --all --launch` / `masters adimages set --allow-empty --launch` silently left a DRAFT campaign unpublished.
- `--launch` is a second, independent request ("publish the draft while saving"). Its documented exception is a non-DRAFT campaign, not an empty image set — a no-op on images must not swallow it.
- Fix: guard the early-return with `and not launch`. A true no-op (no `--launch`) stays untouched; `--launch` now always reaches `_save_and_verify_images`, which resolves the DRAFT-aware terminal button (`_LAUNCH_BUTTON_TEXT` vs `_SAVE_DRAFT_BUTTON_TEXT`) and clicks it, without ever opening the images modal (nothing to remove/add).

## Test plan
- [x] Red: `test_all_with_launch_still_publishes_an_already_empty_draft` (delete) and its `set_master_images` counterpart failed pre-fix with `clicks == []` (launch button never clicked) — reproducing the issue's provided red test.
- [x] Green: both tests pass post-fix; full `tests/test_masters.py` (357 tests) passes.
- [x] Symmetric guard tests added: without `--launch`, an empty set stays a genuine no-op (nothing clicked, modal never opened).
- [x] Mutation check (mutmut not installed in this env): manually reverted each `and not launch` guard and confirmed the corresponding red test fails again (regression caught).
- [x] `flake8` / `black --check` clean on changed files.
- [x] Full offline suite: 2936 passed, 8 skipped, 62 pre-existing errors (unrelated `vcr`/`aiohttp` env incompatibility in `test_read_cassettes.py`/live-write cassette tests — confirmed present on `main` too, unaffected by this change).

Closes #678

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gVYyAwYeAmBNJzt6kbTia