### PR TITLE
fix(masters): handle DRAFT campaigns in get/archive/suspend/resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@
   to the normal dashboard extractors (caught in review; the module's other
   presence checks, e.g. `_is_draft_edit_page`, already use `.count()` for
   exactly this reason).
+- That same `.count() == 0` snapshot, taken immediately after
+  `goto(..., wait_until="domcontentloaded")`, raced the SPA's own hydration
+  — the same class of bug issue #685 already fixed for the create page's
+  step 1 field. `_is_draft_overview_page` now polls (up to 15s) for EITHER
+  `CampaignHeader.Status` (DRAFT) or the non-DRAFT dashboard's own status
+  body text (`_read_status_text`'s markers) to actually render before
+  classifying the page, instead of concluding "not DRAFT" from a page that
+  simply hadn't finished rendering yet (caught in review).
 
 **Fixed — images-section "ghost" render pass caused false "no images" reads (#687):**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@
   (checked live, both the overview page and the grid row's own menu).
 - Live-verified against campaign 713231614 (the draft copy left over from
   #659's recon) — see `tests/fixtures/masters_wizard_draft_overview.html`.
+- `_is_draft_overview_page` checks `.count() == 0` before calling
+  `inner_text()` on the `CampaignHeader.Status` locator — a non-DRAFT
+  overview page has no such node at all, and calling `inner_text()` directly
+  would make Playwright auto-wait its full actionability timeout (default
+  30s) on every `masters get`/`suspend`/`resume` call before falling through
+  to the normal dashboard extractors (caught in review; the module's other
+  presence checks, e.g. `_is_draft_edit_page`, already use `.count()` for
+  exactly this reason).
 
 **Fixed — images-section "ghost" render pass caused false "no images" reads (#687):**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## Unreleased
 
+**Fixed — `masters get`/`archive`/`suspend`/`resume` on `DRAFT` campaigns (#660):**
+
+- A `DRAFT` Мастер кампаний's overview page (`WIZARD_OVERVIEW_URL` itself, no
+  `/edit/`) renders the editable wizard form, not the stats-dashboard
+  overview every other status renders — no `CampaignHeader.MenuTrigger`, no
+  status text, no stat tiles. This previously made `masters get` degrade to
+  `{"CampaignId": ..., "LandingUrl": ...}` (with unhelpful "Could not read
+  campaign name"/"Could not determine status" warnings) and made `masters
+  archive`/`suspend`/`resume` crash with `BrowserSessionError` on a missing
+  selector.
+- `fetch_master` (`direct_cli/browser/masters.py`) now detects a `DRAFT`
+  overview page via `CampaignHeader.Status` reading "Черновик"
+  (`_is_draft_overview_page`) and reads `Name`/`Status`/`WeeklyBudget` from
+  the form's header and budget input instead of the dashboard extractors —
+  no `LandingUrl`/`Stats` (the form has neither).
+- `archive_master`/`suspend_master`/`resume_master` now refuse a `DRAFT`
+  campaign with a clear `BrowserSessionError` explaining there is no
+  archive/suspend/resume action available for a draft (launch it first via
+  `masters update --launch`), instead of crashing on a missing selector.
+  No delete action exists for a Мастер кампаний draft anywhere in the UI
+  (checked live, both the overview page and the grid row's own menu).
+- Live-verified against campaign 713231614 (the draft copy left over from
+  #659's recon) — see `tests/fixtures/masters_wizard_draft_overview.html`.
+
 **Fixed — images-section "ghost" render pass caused false "no images" reads (#687):**
 
 - `_wait_for_images_editor` (`direct_cli/browser/masters.py`) previously

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@
   body text (`_read_status_text`'s markers) to actually render before
   classifying the page, instead of concluding "not DRAFT" from a page that
   simply hadn't finished rendering yet (caught in review).
+- The status-node poll above still only checked node *presence*
+  (`.count() > 0`), not its text — a framework can mount
+  `CampaignHeader.Status` before filling in its content, which would read
+  as "rendered" while the node is still empty and misclassify a real DRAFT
+  campaign as non-DRAFT. `_is_draft_overview_page` now polls for the node's
+  actual (trimmed) text, not just its presence (caught in review).
 
 **Fixed — images-section "ghost" render pass caused false "no images" reads (#687):**
 

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -189,13 +189,34 @@ campaign's ID (confirmed live, ~7s after the click) — the primary ID source
 (confirmed to agree during recon) before reporting success, following the
 module's "never trust the click alone" convention.
 
-**Not fixed here (see issue #660):** a freshly created ``DRAFT`` campaign's
-overview page turned out, live, to be the editable wizard form itself (no
-"⋮" menu, no ``CampaignHeader.MenuTrigger``) rather than the
-stats-dashboard overview every other status renders — so ``masters get``/
-``archive``/``suspend``/``resume`` (untested against ``DRAFT`` until this
-recon) cannot yet read or act on a campaign in that state. ``copy_master``
-itself does not depend on any of those working.
+**DRAFT overview page** (issue #660, live-confirmed 2026-08-04 against
+campaign 713231614 — see ``tests/fixtures/masters_wizard_draft_overview.html``).
+A freshly created ``DRAFT`` campaign's overview page (``WIZARD_OVERVIEW_URL``
+itself, no ``/edit/``) turns out to BE the editable wizard form — no "⋮"
+menu, no ``CampaignHeader.MenuTrigger``, no "Кампания остановлена"/"активна"
+status text, no stat tiles — rather than the stats-dashboard overview every
+other status renders. It reuses the SAME header testids the edit page's
+DRAFT path already relies on for its terminal save/launch buttons
+(``CampaignFormControls.saveDraft.button``/``CampaignFormControls.save.button``,
+see "DRAFT support" above), plus ``CampaignHeader.TitleName``,
+``CampaignHeader.Status`` (reads "Черновик"), and
+``BudgetWithSuggest.PriceTextInput`` for the weekly budget field.
+``fetch_master`` detects this via ``_is_draft_overview_page`` (keyed off
+``CampaignHeader.Status`` reading "Черновик", mirroring
+``_is_draft_edit_page``'s "detection and the click it gates can never
+disagree" rationale) and reads name/status/weekly budget from the form
+instead of the dashboard extractors — no ``LandingUrl``/``Stats`` (the form
+has no rendered landing-URL link with the confirmed ``utm_source=`` marker,
+and obviously no stats yet). No delete action exists for a Мастер кампаний
+draft anywhere in the UI (checked live: neither this page nor the grid row's
+own menu has one) — so ``archive_master``/``suspend_master``/
+``resume_master`` all refuse with a clear ``BrowserSessionError`` on a
+``DRAFT`` campaign instead of clicking blind at selectors that don't exist
+on this page (``archive_master`` already reads the campaign's grid row
+before navigating, so this is a plain status check added there;
+``suspend``/``resume`` check ``_is_draft_overview_page`` right after
+navigating, before ``_read_status_text`` would otherwise report "unrecognised
+status text"). ``copy_master`` itself does not depend on any of these working.
 """
 
 import contextlib
@@ -306,6 +327,19 @@ _CLONE_MENU_ITEM_SELECTOR = '[data-testid="CampaignHeader.Menu.clone"]'
 # How long to wait, after clicking Архивировать, for the grid API to report
 # the campaign as ARCHIVED before giving up (see archive_master).
 _ARCHIVE_VERIFY_TIMEOUT_MS = 10_000
+
+# DRAFT overview page support (issue #660, live-confirmed 2026-08-04 against
+# campaign 713231614 — see the module docstring's "DRAFT overview page" note).
+# A DRAFT campaign's overview page (WIZARD_OVERVIEW_URL itself, no "/edit/")
+# renders the editable wizard form, not the stats dashboard: no
+# CampaignHeader.MenuTrigger, no status text ("Кампания остановлена"/
+# "активна"), no stat tiles. It reuses the SAME header/terminal-button testids
+# as the edit page's DRAFT path (_DRAFT_SAVE_DRAFT_BUTTON_TESTID/
+# _DRAFT_LAUNCH_BUTTON_TESTID above), plus its own header ones below.
+_CAMPAIGN_HEADER_TITLE_NAME_SELECTOR = '[data-testid="CampaignHeader.TitleName"]'
+_CAMPAIGN_HEADER_STATUS_SELECTOR = '[data-testid="CampaignHeader.Status"]'
+_BUDGET_INPUT_SELECTOR = '[data-testid="BudgetWithSuggest.PriceTextInput"]'
+_DRAFT_STATUS_TEXT = "Черновик"
 
 # How long to wait, after clicking the clone form's terminal button, for
 # Yandex to redirect page.url to the new campaign's overview URL (confirmed
@@ -807,11 +841,20 @@ def fetch_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
 
     No ``ulogin`` on the URL (see module docstring) — confirmed live that
     Yandex itself redirects to the correct ``?ulogin=<chief login>``.
+
+    A DRAFT campaign renders a different page at this same URL (issue #660,
+    see module docstring's "DRAFT overview page" note) — no status text, no
+    stat tiles, the header uses different testids. ``_fetch_draft_master``
+    handles that case; every other status keeps using the stats-dashboard
+    extractors below.
     """
     url = WIZARD_OVERVIEW_URL.format(campaign_id=campaign_id)
     page.goto(url, wait_until="domcontentloaded")
     assert_not_captcha(page.content())
     assert_authenticated(page.content())
+
+    if _is_draft_overview_page(page):
+        return _fetch_draft_master(page, campaign_id)
 
     result: Dict[str, Any] = {"CampaignId": campaign_id}
 
@@ -819,6 +862,51 @@ def fetch_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
     _extract_status(page, result)
     _extract_landing_url(page, result)
     _extract_stat_tiles(page, result)
+
+    return result
+
+
+def _is_draft_overview_page(page: "Page") -> bool:
+    """True if the overview page currently open is a DRAFT campaign's.
+
+    Detected by ``CampaignHeader.Status`` reading "Черновик" — the same
+    testid the non-DRAFT dashboard doesn't have at all (its status instead
+    lives in plain body text, see ``_read_status_text``), so this check and
+    the DRAFT-specific extractors it gates can never disagree about what
+    "DRAFT" means (mirrors ``_is_draft_edit_page``'s own rationale).
+    """
+    try:
+        handle = page.locator(_CAMPAIGN_HEADER_STATUS_SELECTOR).first
+        return handle.inner_text().strip() == _DRAFT_STATUS_TEXT
+    except PlaywrightError:
+        return False
+
+
+def _fetch_draft_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
+    """Read name/status/weekly budget from a DRAFT campaign's overview page.
+
+    No stat tiles, no landing-URL link with the confirmed ``utm_source=``
+    marker the non-DRAFT extractor keys off (the form's landing-URL field is
+    a plain input, not a rendered link) — DRAFT results simply omit
+    ``LandingUrl``/``Stats`` rather than guessing at a different selector.
+    """
+    result: Dict[str, Any] = {"CampaignId": campaign_id, "Status": "DRAFT"}
+
+    try:
+        result["Name"] = (
+            page.locator(_CAMPAIGN_HEADER_TITLE_NAME_SELECTOR)
+            .first.inner_text()
+            .strip()
+        )
+    except PlaywrightError:
+        print_warning(f"Could not read campaign name for {campaign_id}.")
+
+    try:
+        result["WeeklyBudget"] = (
+            page.locator(_BUDGET_INPUT_SELECTOR).first.input_value().strip()
+        )
+    except PlaywrightError:
+        print_warning(f"Could not read weekly budget for {campaign_id}.")
 
     return result
 
@@ -958,11 +1046,23 @@ def _suspend_or_resume(
     matching action button and re-reads the status to confirm the mutation
     actually took effect — a click that doesn't visibly change the status is
     reported as a hard error, not a silent success.
+
+    A DRAFT campaign's overview page has no ACTIVE/SUSPENDED status and no
+    action button to click (issue #660, see module docstring's "DRAFT
+    overview page" note) — refuses with a clear error instead of clicking
+    blind or misreporting a made-up status.
     """
     url = WIZARD_OVERVIEW_URL.format(campaign_id=campaign_id)
     page.goto(url, wait_until="domcontentloaded")
     assert_not_captcha(page.content())
     assert_authenticated(page.content())
+
+    if _is_draft_overview_page(page):
+        raise BrowserSessionError(
+            f"Campaign {campaign_id} is a DRAFT — it has no ACTIVE/SUSPENDED "
+            "state to suspend/resume. Launch it first (masters update "
+            '--launch, or the wizard\'s "Запустить кампанию" button).'
+        )
 
     current_status = _read_status_text(page)
     if current_status is None:
@@ -1060,6 +1160,13 @@ def archive_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
     if existing["Status"] == "ARCHIVED":
         print_warning(f"Campaign {campaign_id} is already archived; not clicking.")
         return existing
+    if existing["Status"] == "DRAFT":
+        raise BrowserSessionError(
+            f"Campaign {campaign_id} is a DRAFT — its overview page has no "
+            '"⋮" menu to archive from (issue #660), and no delete action '
+            "exists for a Мастер кампаний draft anywhere in the UI. Launch "
+            "it first (masters update --launch) if you want to archive it."
+        )
 
     url = WIZARD_OVERVIEW_URL.format(campaign_id=campaign_id)
     page.goto(url, wait_until="domcontentloaded")

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -888,28 +888,31 @@ def _is_draft_overview_page(page: "Page") -> bool:
     necessarily rendered either shape (the same race issue #685 hit for the
     create page's step 1 field — see ``_wait_for_create_step1``), so this
     polls, up to ``_DRAFT_OVERVIEW_DETECT_TIMEOUT_MS``, until EITHER
-    ``CampaignHeader.Status`` (DRAFT) OR one of the non-DRAFT dashboard's own
-    status-text markers (``_read_status_text``'s "Кампания остановлена"/
-    "активна"/"включена") has actually appeared, before deciding — a bare
-    ``.count()`` snapshot right after ``goto`` could read "0" simply because
-    neither shape has rendered yet.
+    ``CampaignHeader.Status`` reads its final text (DRAFT) OR one of the
+    non-DRAFT dashboard's own status-text markers (``_read_status_text``'s
+    "Кампания остановлена"/"активна"/"включена") has appeared, before
+    deciding. Checking the status node's mere *presence* would not be
+    enough — a framework can mount an element before filling in its text,
+    so this reads the node's actual (trimmed) text on every poll tick,
+    not just whether it exists yet.
     """
 
+    def _read_draft_status_text() -> str:
+        try:
+            return (
+                page.locator(_CAMPAIGN_HEADER_STATUS_SELECTOR)
+                .first.inner_text()
+                .strip()
+            )
+        except PlaywrightError:
+            return ""
+
     def _either_rendered() -> bool:
-        return (
-            page.locator(_CAMPAIGN_HEADER_STATUS_SELECTOR).first.count() > 0
-            or _read_status_text(page) is not None
-        )
+        return bool(_read_draft_status_text()) or _read_status_text(page) is not None
 
     _poll_until(page, _either_rendered, _DRAFT_OVERVIEW_DETECT_TIMEOUT_MS)
 
-    try:
-        status_locator = page.locator(_CAMPAIGN_HEADER_STATUS_SELECTOR).first
-        if status_locator.count() == 0:
-            return False
-        return status_locator.inner_text().strip() == _DRAFT_STATUS_TEXT
-    except PlaywrightError:
-        return False
+    return _read_draft_status_text() == _DRAFT_STATUS_TEXT
 
 
 def _fetch_draft_master(page: "Page", campaign_id: int) -> Dict[str, Any]:

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -874,9 +874,17 @@ def _is_draft_overview_page(page: "Page") -> bool:
     lives in plain body text, see ``_read_status_text``), so this check and
     the DRAFT-specific extractors it gates can never disagree about what
     "DRAFT" means (mirrors ``_is_draft_edit_page``'s own rationale).
+
+    Uses ``.count()`` to check presence before ``inner_text()`` — like every
+    other presence check in this module (e.g. ``_is_draft_edit_page``) — so a
+    non-DRAFT page (which has no ``CampaignHeader.Status`` node at all) is
+    recognised immediately instead of Playwright auto-waiting its full
+    actionability timeout for a selector that will never appear.
     """
     try:
         handle = page.locator(_CAMPAIGN_HEADER_STATUS_SELECTOR).first
+        if handle.count() == 0:
+            return False
         return handle.inner_text().strip() == _DRAFT_STATUS_TEXT
     except PlaywrightError:
         return False

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -341,6 +341,15 @@ _CAMPAIGN_HEADER_STATUS_SELECTOR = '[data-testid="CampaignHeader.Status"]'
 _BUDGET_INPUT_SELECTOR = '[data-testid="BudgetWithSuggest.PriceTextInput"]'
 _DRAFT_STATUS_TEXT = "Черновик"
 
+# How long to wait, right after navigating to the overview page, for EITHER
+# CampaignHeader.Status (DRAFT) or the non-DRAFT dashboard's own status body
+# text (see _read_status_text) to hydrate before classifying the page.
+# wait_until="domcontentloaded" returns before the SPA's client-side render
+# has necessarily produced either — the same race that #685 already fixed
+# for the create page's step 1 field (_wait_for_create_step1) via
+# _poll_until rather than a bare .count() snapshot.
+_DRAFT_OVERVIEW_DETECT_TIMEOUT_MS = 15_000
+
 # How long to wait, after clicking the clone form's terminal button, for
 # Yandex to redirect page.url to the new campaign's overview URL (confirmed
 # live ~7s, issue #659) before giving up on copy_master.
@@ -875,17 +884,30 @@ def _is_draft_overview_page(page: "Page") -> bool:
     the DRAFT-specific extractors it gates can never disagree about what
     "DRAFT" means (mirrors ``_is_draft_edit_page``'s own rationale).
 
-    Uses ``.count()`` to check presence before ``inner_text()`` — like every
-    other presence check in this module (e.g. ``_is_draft_edit_page``) — so a
-    non-DRAFT page (which has no ``CampaignHeader.Status`` node at all) is
-    recognised immediately instead of Playwright auto-waiting its full
-    actionability timeout for a selector that will never appear.
+    ``goto(..., wait_until="domcontentloaded")`` returns before the SPA has
+    necessarily rendered either shape (the same race issue #685 hit for the
+    create page's step 1 field — see ``_wait_for_create_step1``), so this
+    polls, up to ``_DRAFT_OVERVIEW_DETECT_TIMEOUT_MS``, until EITHER
+    ``CampaignHeader.Status`` (DRAFT) OR one of the non-DRAFT dashboard's own
+    status-text markers (``_read_status_text``'s "Кампания остановлена"/
+    "активна"/"включена") has actually appeared, before deciding — a bare
+    ``.count()`` snapshot right after ``goto`` could read "0" simply because
+    neither shape has rendered yet.
     """
+
+    def _either_rendered() -> bool:
+        return (
+            page.locator(_CAMPAIGN_HEADER_STATUS_SELECTOR).first.count() > 0
+            or _read_status_text(page) is not None
+        )
+
+    _poll_until(page, _either_rendered, _DRAFT_OVERVIEW_DETECT_TIMEOUT_MS)
+
     try:
-        handle = page.locator(_CAMPAIGN_HEADER_STATUS_SELECTOR).first
-        if handle.count() == 0:
+        status_locator = page.locator(_CAMPAIGN_HEADER_STATUS_SELECTOR).first
+        if status_locator.count() == 0:
             return False
-        return handle.inner_text().strip() == _DRAFT_STATUS_TEXT
+        return status_locator.inner_text().strip() == _DRAFT_STATUS_TEXT
     except PlaywrightError:
         return False
 

--- a/tests/fixtures/masters_wizard_draft_overview.html
+++ b/tests/fixtures/masters_wizard_draft_overview.html
@@ -1,0 +1,111 @@
+<!--
+Fixture: text-content/DOM snapshot of the Yandex Direct "Мастер кампаний" (Campaign
+Wizard) DRAFT overview page, captured 2026-08-04 via Chrome DevTools / claude-in-chrome
+against a live account (PII scrubbed: account name kept as it is already visible in the
+product UI and carries no secret value).
+
+Source URL:
+  https://direct.yandex.ru/wizard/campaigns/713231614/?ulogin=ksamatadirect
+  (same WIZARD_OVERVIEW_URL every other status renders a stats dashboard at — NOT the
+  /edit/ URL. Campaign 713231614 is the draft copy left over from issue #659's live recon
+  of `masters copy`, status DRAFT confirmed via `masters list --status all`.)
+
+## Key finding (issue #660)
+
+A DRAFT campaign's overview page is NOT the stats-dashboard overview every other status
+(ACTIVE/SUSPENDED/ARCHIVED) renders — it IS the editable wizard form itself, the same
+form `masters update`'s DRAFT edit-page path (issue #668) already knows how to save. This
+confirms the gap `masters copy`'s live recon first reported:
+
+  - No `[data-testid="CampaignHeader.MenuTrigger"]` anywhere on the page — confirmed via
+    `document.querySelectorAll('[data-testid]')`, filtered for the string "MenuTrigger":
+    zero matches. `archive_master`'s "⋮" menu click has nothing to click.
+  - No "Кампания остановлена"/"Кампания активна" body text anywhere — `_read_status_text`
+    (suspend_master/resume_master's current-status check) returns None on this page, which
+    is exactly the "refusing to click blind" BrowserSessionError path, but with a
+    misleading message ("unrecognised status text") since the real reason is "this
+    campaign has no such status at all, being a draft".
+  - No stat tiles (`button` nodes with a two-line numeric-value/label body) — the page has
+    dozens of buttons (image pickers, sitelink editors, region tree nodes, ...) but none
+    match the Показы/Клики/Конверсии/... shape `_extract_stat_tiles` looks for.
+
+## Confirmed data-testid attributes (header + terminal buttons)
+
+Via `document.querySelectorAll('[data-testid]')` on the live page:
+
+  CampaignHeader                              -- header container (name + status + meta line)
+  CampaignHeader.Title                        -- name row (name text + edit-pencil button)
+  CampaignHeader.Title.Content
+  CampaignHeader.TitleName                    -- campaign name text node itself
+  CampaignHeader.EditName.Button              -- pencil icon that opens the rename modal
+                                                  (same ModalEditTitle.CampaignName flow as
+                                                  issue #663's non-DRAFT `name` support)
+  CampaignHeader.Status                       -- status badge text node, reads "Черновик"
+  BudgetWithSuggest                           -- weekly-budget form field container
+  BudgetWithSuggest.PriceTextInput            -- the actual <input>, .value = "80 000"
+                                                  (space-grouped digits, currency symbol
+                                                  rendered as a separate sibling "₽" label,
+                                                  NOT part of the input's value)
+  CampaignFormControls.save.button            -- "Запустить кампанию" (publish + launch)
+  CampaignFormControls.saveDraft.button       -- "Сохранить как черновик" (stays DRAFT)
+                                                  same testids `_click_draft_terminal_button`
+                                                  already uses on the /edit/ page (issue
+                                                  #668) -- confirms this overview URL and
+                                                  the edit URL render the SAME form for a
+                                                  DRAFT campaign, just reached differently.
+
+`document.querySelector('[data-testid="CampaignHeader"]').innerText`:
+
+  Конверсии и трафик
+  Мастер ИЖ-1 Сосуды и вены (холодный)
+  Черновик
+  №713231614
+  ・Создана 02.08.2026
+  ・
+  lp.ksamata.ru
+
+Accessibility-tree read (read_page, filter=all, depth=6) confirms the same structure a
+human/screen-reader sees, matching the plain-form shape used by the rest of the wizard
+create/edit flow (`masters_wizard_create.html`, `masters_wizard_edit_stage_a.html`):
+
+  heading "Мастер ИЖ-1 Сосуды и вены (холодный)"
+   generic "Мастер ИЖ-1 Сосуды и вены (холодный)"
+   button [ref=EditName.Button, pencil icon]
+  generic "Черновик"
+  generic "・Создана 02.08.2026"
+   link "№713231614"
+  ... (full form: landing URL field, headline/text variants, images, sitelinks,
+      schedule, audience, promotion goal, Metrika counters, target actions,
+      weekly budget input showing "80 000", adaptive-budget field, "Директ
+      помогает" toggle) ...
+  button "Запустить кампанию"
+  button "Сохранить как черновик"
+
+## No delete action anywhere
+
+Checked live, both on this overview page and on the campaigns grid row for the same
+campaign (`/dna/grid/campaigns/`): neither exposes a "Удалить"/delete action for a DRAFT
+Мастер кампаний. The grid row's own context menu for a DRAFT row offers only
+Перейти/Редактировать/Статистика (no Архивировать either — archiving from the grid
+appears to require a non-DRAFT status too, though this wasn't the focus of this recon).
+This matches issue #633's earlier finding that Мастер кампаний has no delete at all, only
+archive — and archive itself is unavailable to a DRAFT. A DRAFT campaign therefore has no
+CLI-reachable lifecycle action besides `masters update --launch` (publish it, after which
+the normal ACTIVE-status archive/suspend/resume paths apply) or leaving it as an inert
+draft indefinitely.
+
+## Parser implication
+
+`fetch_master` detects a DRAFT overview page via `CampaignHeader.Status` reading exactly
+"Черновик" (`_is_draft_overview_page`) and, when true, reads Name/Status/WeeklyBudget from
+the form's header + budget input instead of the dashboard extractors — no LandingUrl (the
+form's URL field is a plain input, not the confirmed-live `a[href*='utm_source=']` link
+the non-DRAFT extractor keys off) and no Stats (nothing has run yet). `archive_master`
+already reads the campaign's grid row (`Status` field, already exposing "DRAFT" — see
+`_PRIMARY_STATUS_TO_CLI_STATUS`/`STATUS_FILTERS` in the module) before ever navigating to
+the overview page, so it refuses on `existing["Status"] == "DRAFT"` without an extra
+navigation. `suspend_master`/`resume_master` don't have a pre-navigation grid read (they
+only need the overview page's own status text), so they call
+`_is_draft_overview_page` right after `goto()`, before `_read_status_text` would otherwise
+misreport "unrecognised status text" as the failure reason.
+-->

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -1794,6 +1794,90 @@ class TestFetchMaster(unittest.TestCase):
         self.assertGreaterEqual(warn.call_count, 3)  # name, status, landing, stats
 
 
+class TestFetchMasterDraft(unittest.TestCase):
+    """DRAFT overview-page parsing (issue #660): name/status/weekly budget only.
+
+    See tests/fixtures/masters_wizard_draft_overview.html for the live recon
+    this is modeled on — a DRAFT campaign's overview page IS the editable
+    wizard form (no status text, no stat tiles, no MenuTrigger), reusing the
+    edit page's own CampaignFormControls testids plus its own header ones.
+    """
+
+    def _draft_page(
+        self, title="Мастер ИЖ-1 Сосуды и вены (холодный)", budget="80 000"
+    ):
+        return FakePage(
+            locators={
+                browser_masters._CAMPAIGN_HEADER_STATUS_SELECTOR: _FakeLocator(
+                    [_FakeLocatorHandle(text=browser_masters._DRAFT_STATUS_TEXT)]
+                ),
+                browser_masters._CAMPAIGN_HEADER_TITLE_NAME_SELECTOR: _FakeLocator(
+                    [_FakeLocatorHandle(text=title)]
+                ),
+                browser_masters._BUDGET_INPUT_SELECTOR: _FakeLocator(
+                    [_FakeLocatorHandle(text=budget)]
+                ),
+            },
+        )
+
+    def test_parses_draft_overview(self):
+        page = self._draft_page()
+
+        result = browser_masters.fetch_master(page, 713231614)
+
+        self.assertEqual(
+            result,
+            {
+                "CampaignId": 713231614,
+                "Status": "DRAFT",
+                "Name": "Мастер ИЖ-1 Сосуды и вены (холодный)",
+                "WeeklyBudget": "80 000",
+            },
+        )
+
+    def test_draft_result_has_no_landing_url_or_stats(self):
+        result = browser_masters.fetch_master(self._draft_page(), 1)
+
+        self.assertNotIn("LandingUrl", result)
+        self.assertNotIn("Stats", result)
+
+    def test_draft_partial_result_on_missing_name_and_budget(self):
+        page = FakePage(
+            locators={
+                browser_masters._CAMPAIGN_HEADER_STATUS_SELECTOR: _FakeLocator(
+                    [_FakeLocatorHandle(text=browser_masters._DRAFT_STATUS_TEXT)]
+                ),
+            },
+        )
+
+        with patch("direct_cli.browser.masters.print_warning") as warn:
+            result = browser_masters.fetch_master(page, 1)
+
+        self.assertEqual(result, {"CampaignId": 1, "Status": "DRAFT"})
+        self.assertEqual(warn.call_count, 2)  # name, budget
+
+    def test_non_draft_page_unaffected(self):
+        # A page whose CampaignHeader.Status reads something other than
+        # "Черновик" must fall through to the normal dashboard extractors,
+        # not be misdetected as a draft.
+        page = FakePage(
+            locators={
+                browser_masters._CAMPAIGN_HEADER_STATUS_SELECTOR: _FakeLocator(
+                    [_FakeLocatorHandle(text="Активна")]
+                ),
+                "h1, [role=heading]": _FakeLocator(
+                    [_FakeLocatorHandle(text="Обычная")]
+                ),
+            },
+            body_text="Кампания активна",
+        )
+
+        result = browser_masters.fetch_master(page, 1)
+
+        self.assertEqual(result["Status"], "ACTIVE")
+        self.assertNotIn("WeeklyBudget", result)
+
+
 class TestSuspendResumeMaster(unittest.TestCase):
     """suspend_master/resume_master (issue #630): click + verify, idempotent.
 
@@ -1904,6 +1988,37 @@ class TestSuspendResumeMaster(unittest.TestCase):
 
         with self.assertRaises(BrowserSessionError):
             browser_masters.suspend_master(page, 42)
+
+    def _draft_page(self):
+        return FakePage(
+            locators={
+                browser_masters._CAMPAIGN_HEADER_STATUS_SELECTOR: _FakeLocator(
+                    [_FakeLocatorHandle(text=browser_masters._DRAFT_STATUS_TEXT)]
+                ),
+            },
+        )
+
+    def test_suspend_raises_clear_error_on_draft(self):
+        # issue #660: a DRAFT campaign has no ACTIVE/SUSPENDED status or
+        # action button at all — must refuse with a DRAFT-specific message,
+        # not "unrecognised status text" (_read_status_text would return
+        # None on this page, which is a different, misleading failure mode).
+        page = self._draft_page()
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.suspend_master(page, 713231614)
+        self.assertIn("DRAFT", str(ctx.exception))
+        self.assertEqual(
+            page.navigated_to,
+            [browser_masters.WIZARD_OVERVIEW_URL.format(campaign_id=713231614)],
+        )
+
+    def test_resume_raises_clear_error_on_draft(self):
+        page = self._draft_page()
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.resume_master(page, 713231614)
+        self.assertIn("DRAFT", str(ctx.exception))
 
 
 class TestMastersSuspendResumeCommand(unittest.TestCase):
@@ -2072,6 +2187,23 @@ class TestArchiveMaster(unittest.TestCase):
                 browser_masters.archive_master(page, 42)
 
         self.assertIn("did not report it as ARCHIVED", str(ctx.exception))
+
+    def test_raises_clear_error_on_draft_without_navigating(self):
+        # issue #660: the grid already reports DRAFT before any navigation
+        # happens, and a DRAFT overview page has no "⋮" menu to click at all
+        # — refuse immediately with a clear message instead of navigating
+        # and hitting "Could not open the campaign menu".
+        page = self._page_with_menu()
+
+        with patch(
+            "direct_cli.browser.masters.fetch_masters_list",
+            return_value=[self._row("DRAFT")],
+        ):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters.archive_master(page, 42)
+
+        self.assertIn("DRAFT", str(ctx.exception))
+        self.assertEqual(page.navigated_to, [])
 
 
 class TestMastersArchiveCommand(unittest.TestCase):

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -1877,6 +1877,30 @@ class TestFetchMasterDraft(unittest.TestCase):
         self.assertEqual(result["Status"], "ACTIVE")
         self.assertNotIn("WeeklyBudget", result)
 
+    def test_absent_status_node_detected_via_count_not_inner_text(self):
+        # Regression: a non-DRAFT overview page has NO CampaignHeader.Status
+        # node at all (its status lives in plain body text instead, see
+        # _read_status_text) — _is_draft_overview_page must recognise that
+        # via .count() == 0 and return False immediately, the same way
+        # _is_draft_edit_page does, rather than calling inner_text() on the
+        # locator's raising `.first` handle. Real Playwright's inner_text()
+        # auto-waits its full actionability timeout (default 30s) for a
+        # selector that will never appear before raising — calling it here
+        # would silently stall every non-DRAFT masters get/suspend/resume.
+        page = FakePage(
+            locators={
+                "h1, [role=heading]": _FakeLocator(
+                    [_FakeLocatorHandle(text="Обычная")]
+                ),
+            },
+            body_text="Кампания активна",
+        )
+
+        self.assertFalse(browser_masters._is_draft_overview_page(page))
+
+        result = browser_masters.fetch_master(page, 1)
+        self.assertEqual(result["Status"], "ACTIVE")
+
 
 class TestSuspendResumeMaster(unittest.TestCase):
     """suspend_master/resume_master (issue #630): click + verify, idempotent.

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -1954,6 +1954,32 @@ class TestFetchMasterDraft(unittest.TestCase):
         self.assertFalse(browser_masters._is_draft_overview_page(page))
         self.assertEqual(ticks["count"], 1)
 
+    def test_draft_status_node_mounted_but_empty_is_not_settled(self):
+        # Regression (Codex, cycle-review round 3 of PR #700): a framework
+        # can mount CampaignHeader.Status before filling in its text — node
+        # PRESENCE alone must not be read as "hydration done", or a real
+        # DRAFT campaign whose status text arrives late gets misclassified
+        # as non-DRAFT. Models the node existing (count() > 0) from the
+        # start but its inner_text() staying "" until one polling tick later.
+        ticks = {"count": 0}
+
+        class _EmptyThenFilledStatusPage(FakePage):
+            def locator(self, selector):
+                if selector == browser_masters._CAMPAIGN_HEADER_STATUS_SELECTOR:
+                    text = (
+                        "" if ticks["count"] < 1 else browser_masters._DRAFT_STATUS_TEXT
+                    )
+                    return _FakeLocator([_FakeLocatorHandle(text=text)])
+                return super().locator(selector)
+
+            def wait_for_timeout(self, timeout):
+                ticks["count"] += 1
+
+        page = _EmptyThenFilledStatusPage()
+
+        self.assertTrue(browser_masters._is_draft_overview_page(page))
+        self.assertEqual(ticks["count"], 1)
+
 
 class TestSuspendResumeMaster(unittest.TestCase):
     """suspend_master/resume_master (issue #630): click + verify, idempotent.

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -1901,6 +1901,59 @@ class TestFetchMasterDraft(unittest.TestCase):
         result = browser_masters.fetch_master(page, 1)
         self.assertEqual(result["Status"], "ACTIVE")
 
+    def test_draft_detected_after_delayed_hydration(self):
+        # Regression: goto(..., wait_until="domcontentloaded") returns before
+        # the SPA has necessarily rendered CampaignHeader.Status yet (the
+        # same race issue #685 fixed for the create page's step 1 field via
+        # _poll_until) — _is_draft_overview_page must not give up on the
+        # first, pre-hydration snapshot. Models the status node appearing
+        # only after one wait_for_timeout tick.
+        ticks = {"count": 0}
+
+        class _DelayedStatusPage(FakePage):
+            def locator(self, selector):
+                if (
+                    selector == browser_masters._CAMPAIGN_HEADER_STATUS_SELECTOR
+                    and ticks["count"] < 1
+                ):
+                    return _FakeLocator([])
+                return super().locator(selector)
+
+            def wait_for_timeout(self, timeout):
+                ticks["count"] += 1
+
+        page = _DelayedStatusPage(
+            locators={
+                browser_masters._CAMPAIGN_HEADER_STATUS_SELECTOR: _FakeLocator(
+                    [_FakeLocatorHandle(text=browser_masters._DRAFT_STATUS_TEXT)]
+                ),
+            },
+        )
+
+        self.assertTrue(browser_masters._is_draft_overview_page(page))
+        self.assertEqual(ticks["count"], 1)
+
+    def test_non_draft_detected_after_delayed_hydration(self):
+        # Same race, non-DRAFT side: the status BODY TEXT (not a testid, see
+        # _read_status_text) also only settles after the SPA hydrates —
+        # the poll must wait for it instead of concluding "no DRAFT marker
+        # yet" means DRAFT is ruled out for good.
+        ticks = {"count": 0}
+
+        class _DelayedBodyPage(FakePage):
+            def inner_text(self, selector=None):
+                if selector == "body" and ticks["count"] < 1:
+                    return ""
+                return "Кампания активна"
+
+            def wait_for_timeout(self, timeout):
+                ticks["count"] += 1
+
+        page = _DelayedBodyPage()
+
+        self.assertFalse(browser_masters._is_draft_overview_page(page))
+        self.assertEqual(ticks["count"], 1)
+
 
 class TestSuspendResumeMaster(unittest.TestCase):
     """suspend_master/resume_master (issue #630): click + verify, idempotent.


### PR DESCRIPTION
## Summary

- Live recon (against campaign 713231614, the draft copy left over from #659's recon) confirmed: a `DRAFT` Мастер кампаний's overview page (`WIZARD_OVERVIEW_URL` itself, no `/edit/`) renders the editable wizard form, not the stats dashboard every other status renders — no `CampaignHeader.MenuTrigger`, no "Кампания остановлена"/"активна" status text, no stat tiles. New fixture: `tests/fixtures/masters_wizard_draft_overview.html`.
- `fetch_master` now detects a DRAFT overview page via `CampaignHeader.Status` reading "Черновик" and reads `Name`/`Status`/`WeeklyBudget` from the form's header + budget input instead of degrading to a near-empty result with confusing warnings.
- `archive_master`/`suspend_master`/`resume_master` now refuse a `DRAFT` campaign with a clear `BrowserSessionError` (suggesting `masters update --launch` first) instead of crashing on a missing selector. No delete action exists for a Мастер кампаний draft anywhere in the UI (checked live, both the overview page and the grid row's own menu) — confirmed and documented in the fixture.

Closes #660

## Test plan

- [x] `pytest tests/test_masters.py -q` — 360 passed
- [x] `black`/`flake8` clean on changed files
- [x] Live-verified against real DRAFT campaign 713231614:
  - `direct masters get 713231614` → `{"CampaignId": 713231614, "Status": "DRAFT", "Name": "...", "WeeklyBudget": "80 000"}`
  - `direct masters archive 713231614` → clear DRAFT-specific error, no navigation
  - `direct masters suspend/resume 713231614` → clear DRAFT-specific error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GJJrAffUriEUtAGcrt9JC