### PR TITLE
feat(masters): add --goal-price to masters update

### DIFF
--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -1395,9 +1395,8 @@ def _set_promotion_goal(page: "Page", goal: str) -> None:
     option = page.locator(f'[data-testid="{option_testid}"]').first
     clicked = False
     try:
-        if option.is_visible():
-            option.click()
-            clicked = True
+        option.click()
+        clicked = True
     except PlaywrightError:
         clicked = False
 

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -330,6 +330,16 @@ PROMOTION_GOAL_CHOICES = {
     "max-clicks": "Максимум переходов",
 }
 
+# Yandex's own internal enum values for each PROMOTION_GOAL_CHOICES key,
+# confirmed live 2026-08-04 (issue #696 recon) via each option row's
+# data-testid (``CampaignTargetSelect.TargetSelect.ListBox.<value>``). These
+# ALSO gate whether ``CampaignTargetSelect.PriceInput`` (the --goal-price
+# field) exists at all — see ``_set_goal_price``.
+PROMOTION_GOAL_INTERNAL_VALUES = {
+    "max-conversions": "INVOLVED_CONVERSION",
+    "max-clicks": "DIRECT_CLICK",
+}
+
 # create_master (issue #632) — confirmed live, see
 # tests/fixtures/masters_wizard_create.html.
 WIZARD_CREATE_URL = "https://direct.yandex.ru/wizard/campaigns/new/"
@@ -582,6 +592,44 @@ _PROMOTION_GOAL_BUTTON_XPATH = (
     "xpath=//*[self::h1 or self::h2 or self::h3][normalize-space(text())="
     "'Цель продвижения']/following::button[1]"
 )
+
+# "Цель продвижения" dropdown option rows, by data-testid (issue #696
+# recon, 2026-08-04 re-investigation): Yandex now renders each option's
+# accessible name as the label PLUS a description sentence and, for some
+# rows, a "Рекомендуем" badge (e.g. "Максимум целевых действийЕсли хотите
+# получать больше звонков и сообщений от клиентовРекомендуем") — this broke
+# the previous get_by_role("option", name=label, exact=True) match, which
+# requires the WHOLE accessible name to equal the bare label. The
+# data-testid suffix (PROMOTION_GOAL_INTERNAL_VALUES) is stable and
+# unambiguous regardless of the surrounding description text.
+_PROMOTION_GOAL_OPTION_TESTID_TEMPLATE = (
+    "CampaignTargetSelect.TargetSelect.ListBox.{value}"
+)
+
+# --goal-price (issue #696 recon, 2026-08-04, campaigns 713234191/713234204):
+# a single ``CampaignTargetSelect.PriceInput`` <input type="text"> exists in
+# the "Цель продвижения" block ONLY when promotion_goal is "max-clicks"
+# (DIRECT_CLICK) — confirmed live it does NOT exist at all for
+# "max-conversions" (INVOLVED_CONVERSION), whose price is instead set
+# per-goal in the separate "Целевые действия" table
+# (``TargetActions.<id>.PriceInput``, out of scope here). Even under
+# max-clicks, the field only renders while the "Цена перехода" strategy
+# selector is on its default AVG_PRICE value ("Средняя за неделю") — it
+# disappears entirely under the OPTIMUM ("Без ограничений") strategy, which
+# has no fixed/target price at all. This module never touches the strategy
+# selector itself, so --goal-price only works against a campaign whose
+# current strategy is (or defaults to) AVG_PRICE.
+_GOAL_PRICE_INPUT_TESTID = '[data-testid="CampaignTargetSelect.PriceInput"]'
+
+# How long _read_goal_price waits for the field to render before concluding
+# it genuinely does not exist for the campaign's current goal (issue #696
+# live testing): the "Цель продвижения" section can still be hydrating
+# when _wait_for_edit_form returns (that wait only polls the first
+# headline slot, near the top of the page) — an immediate is_visible()
+# check raced this and read "not there yet" as "field doesn't exist",
+# producing a false negative in _verify_saved right after a save that DID
+# succeed server-side.
+_GOAL_PRICE_WAIT_TIMEOUT_MS = 5_000
 
 _EDIT_NAME_BUTTON_SELECTOR = '[data-testid="CampaignHeader.EditName.Button"]'
 _NAME_HEADER_SELECTOR = '[data-testid="CampaignHeader.TitleName"]'
@@ -1299,12 +1347,22 @@ def _set_promotion_goal(page: "Page", goal: str) -> None:
     продвижения" dropdown.
 
     Opens the dropdown (click the trigger button), clicks the option row
-    whose text matches the target Russian label, then verifies the trigger
-    button's own text now reflects the new selection — mirrors
-    ``_suspend_or_resume``'s "never trust the click alone" convention.
+    matching ``goal``'s ``PROMOTION_GOAL_INTERNAL_VALUES`` data-testid, then
+    verifies the trigger button's own text now reflects the new selection —
+    mirrors ``_suspend_or_resume``'s "never trust the click alone"
+    convention.
+
+    Matched by data-testid, not accessible-name text (issue #696
+    re-investigation, 2026-08-04): Yandex now appends a description sentence
+    and, for some rows, a "Рекомендуем" badge to each option's accessible
+    name, so the previous ``get_by_role("option", name=label, exact=True)``
+    — which required the WHOLE accessible name to equal the bare label — no
+    longer matches anything and this failed on every live call. The
+    data-testid suffix is stable regardless of that surrounding text.
     """
     label = PROMOTION_GOAL_CHOICES.get(goal)
-    if label is None:
+    internal_value = PROMOTION_GOAL_INTERNAL_VALUES.get(goal)
+    if label is None or internal_value is None:
         raise ValueError(
             f"Unknown promotion goal {goal!r}; expected one of "
             f"{sorted(PROMOTION_GOAL_CHOICES)}."
@@ -1320,26 +1378,15 @@ def _set_promotion_goal(page: "Page", goal: str) -> None:
             "markup. Re-run with --headful to inspect the page."
         ) from exc
 
-    # get_by_role scopes to actual clickable option rows (not any container
-    # whose text happens to contain the label as a substring) — see the
-    # cycle-review finding this fixed: the previous get_by_text(exact=False)
-    # could match an ancestor wrapper instead of the option itself.
-    option = page.get_by_role("option", name=label, exact=True)
+    option_testid = _PROMOTION_GOAL_OPTION_TESTID_TEMPLATE.format(value=internal_value)
+    option = page.locator(f'[data-testid="{option_testid}"]').first
     clicked = False
     try:
-        count = option.count()
-    except PlaywrightError:
-        count = 0
-    for i in range(count):
-        handle = option.nth(i)
-        try:
-            if not handle.is_visible():
-                continue
-            handle.click()
+        if option.is_visible():
+            option.click()
             clicked = True
-            break
-        except PlaywrightError:
-            continue
+    except PlaywrightError:
+        clicked = False
 
     if not clicked:
         raise BrowserSessionError(
@@ -1359,6 +1406,56 @@ def _set_promotion_goal(page: "Page", goal: str) -> None:
             "click may not have hit the right element — verify manually "
             "before retrying."
         )
+
+
+def _set_goal_price(page: "Page", goal_price: float) -> None:
+    """Fill the "Цель продвижения" block's target-price input.
+
+    Only exists (see ``_GOAL_PRICE_INPUT_TESTID``) when the campaign's
+    promotion goal is currently "max-clicks" — callers must call
+    ``_set_promotion_goal(page, "max-clicks")`` first (or already have that
+    goal saved) before this. Raises ``BrowserSessionError`` naming that
+    requirement if the field is absent, rather than silently no-op'ing.
+
+    Uses ``click()`` (not a one-shot ``is_visible()`` snapshot) to locate
+    the field before filling — live testing (issue #696) found this
+    section of the edit page can still be hydrating when
+    ``_wait_for_edit_form`` returns (that wait only polls the first
+    headline slot, near the top of the page), so an immediate
+    ``is_visible()`` check can read "not there yet" as "field doesn't
+    exist for this goal" and raise a false negative. ``click()``'s
+    built-in actionability auto-wait (mirrors ``_set_weekly_budget``'s
+    identical pattern for the same lower-page-position field) gives the
+    section time to render before concluding the field is genuinely
+    absent.
+    """
+    field = page.locator(_GOAL_PRICE_INPUT_TESTID).first
+    try:
+        field.click()
+        field.fill(_format_goal_price(goal_price))
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            "Could not find or fill the target-price input for 'Цель "
+            "продвижения' on the campaign edit page. This field only "
+            "exists when the promotion goal is 'max-clicks' — pass "
+            "--promotion-goal max-clicks together with --goal-price, or "
+            "set it on the campaign first. It also requires the 'Цена "
+            "перехода' strategy to be 'Средняя за неделю' (the default) "
+            "rather than 'Без ограничений'. If the field should exist, "
+            "Yandex may have changed the page's markup — re-run with "
+            "--headful to inspect the page."
+        ) from exc
+
+
+def _format_goal_price(goal_price: float) -> str:
+    """Render ``goal_price`` the way ``--weekly-budget``-style numeric CLI
+    fields are rendered: an integer value with no trailing ``.0`` (the
+    field's own input mask accepts a plain integer or decimal string —
+    confirmed live it displays a comma, not a dot, as the decimal
+    separator, but ``fill()`` accepts either)."""
+    if isinstance(goal_price, float) and goal_price.is_integer():
+        return str(int(goal_price))
+    return str(goal_price)
 
 
 def _click_draft_terminal_button(
@@ -1527,6 +1624,47 @@ def _read_promotion_goal_label(page: "Page") -> Optional[str]:
     return lines[-1] if lines else None
 
 
+def _read_goal_price(page: "Page") -> Optional[str]:
+    """Read the "Цель продвижения" block's target-price input value.
+
+    Returns ``None`` both when the field can't be found/read AND when it
+    legitimately does not exist for the campaign's current promotion goal
+    (see ``_GOAL_PRICE_INPUT_TESTID``) — either way, the caller treats
+    ``None`` as "verification inconclusive", never as a specific price.
+
+    Uses ``wait_for(state="visible")`` (see ``_GOAL_PRICE_WAIT_TIMEOUT_MS``)
+    rather than a one-shot ``is_visible()`` snapshot, for the same reason
+    ``_set_goal_price`` switched to ``click()``: this section of the edit
+    page can still be hydrating right after ``_wait_for_edit_form``
+    returns, and an immediate check can misread "not rendered yet" as
+    "field doesn't exist for this goal".
+    """
+    field = page.locator(_GOAL_PRICE_INPUT_TESTID).first
+    try:
+        field.wait_for(state="visible", timeout=_GOAL_PRICE_WAIT_TIMEOUT_MS)
+        return field.input_value()
+    except PlaywrightError:
+        return None
+
+
+def _goal_price_matches(expected: float, actual: Optional[str]) -> bool:
+    """Compare a requested ``--goal-price`` against the page's re-read value.
+
+    The field's own input mask renders a comma as the decimal separator
+    (confirmed live) and may pad/trim trailing zeros, so this compares
+    parsed numeric values rather than raw strings — mirrors
+    ``_read_weekly_budget``'s digit-only normalization for the same class
+    of "Yandex's own formatting differs from what we typed" mismatch.
+    """
+    if actual is None:
+        return False
+    normalized = actual.strip().replace(",", ".").replace("\xa0", "")
+    try:
+        return float(normalized) == float(expected)
+    except ValueError:
+        return False
+
+
 def _read_campaign_name(page: "Page") -> Optional[str]:
     """Read the edit page header's current campaign name.
 
@@ -1579,6 +1717,7 @@ def _verify_saved(
     texts: Optional[Dict[int, str]] = None,
     images_before_ids: Optional[List[str]] = None,
     images_replaced_ids: Optional[Set[str]] = None,
+    goal_price: Optional[float] = None,
     clicked_button_label: str = _SAVE_BUTTON_TEXT,
 ) -> None:
     """Reload the edit page and confirm every requested field actually saved.
@@ -1618,6 +1757,14 @@ def _verify_saved(
         if actual != expected:
             mismatches.append(
                 f"{label}: expected {expected!r}, page now shows {actual!r}"
+            )
+
+    if goal_price is not None:
+        actual_goal_price = _read_goal_price(page)
+        if not _goal_price_matches(goal_price, actual_goal_price):
+            mismatches.append(
+                f"goal_price: expected {goal_price!r}, page now shows "
+                f"{actual_goal_price!r}"
             )
 
     mismatches.extend(
@@ -1662,6 +1809,7 @@ def update_master(
     *,
     weekly_budget: Optional[int] = None,
     promotion_goal: Optional[str] = None,
+    goal_price: Optional[float] = None,
     directs_helps: Optional[bool] = None,
     name: Optional[str] = None,
     headlines: Optional[Dict[int, str]] = None,
@@ -1723,10 +1871,21 @@ def update_master(
     asks to publish it, mirroring ``create_master``/``copy_master``'s own
     draft-preserving defaults. Has no effect on a non-DRAFT campaign, which
     always uses the single "Сохранить кампанию" button regardless.
+
+    ``goal_price`` (issue #696) sets the "Цель продвижения" block's target
+    price. Confirmed live this field ONLY exists on the page when the
+    campaign's promotion goal is (or is being set to) "max-clicks" — under
+    "max-conversions" the price is instead per-goal in a separate table,
+    out of scope here. Passing ``goal_price`` does not implicitly change
+    ``promotion_goal``; if the campaign's CURRENT goal is not "max-clicks"
+    and ``promotion_goal="max-clicks"`` isn't also passed in this same
+    call, ``_set_goal_price`` raises ``BrowserSessionError`` naming the
+    field as not found, since it genuinely is not on the page yet.
     """
     if (
         weekly_budget is None
         and promotion_goal is None
+        and goal_price is None
         and directs_helps is None
         and name is None
         and not headlines
@@ -1735,8 +1894,8 @@ def update_master(
     ):
         raise ValueError(
             "update_master requires at least one field to update "
-            "(weekly_budget, promotion_goal, directs_helps, name, "
-            "headlines, texts, images)."
+            "(weekly_budget, promotion_goal, goal_price, directs_helps, "
+            "name, headlines, texts, images)."
         )
 
     url = WIZARD_EDIT_URL.format(campaign_id=campaign_id)
@@ -1751,6 +1910,8 @@ def update_master(
         _set_weekly_budget(page, weekly_budget)
     if promotion_goal is not None:
         _set_promotion_goal(page, promotion_goal)
+    if goal_price is not None:
+        _set_goal_price(page, goal_price)
     if directs_helps is not None:
         _set_directs_helps(page, directs_helps)
     for index, value in (headlines or {}).items():
@@ -1823,6 +1984,7 @@ def update_master(
             texts=texts,
             images_before_ids=images_before_ids,
             images_replaced_ids=images_replaced_ids,
+            goal_price=goal_price,
             clicked_button_label=clicked_button_label,
         )
     except BrowserAuthError as exc:
@@ -1839,6 +2001,8 @@ def update_master(
         result["WeeklyBudget"] = weekly_budget
     if promotion_goal is not None:
         result["PromotionGoal"] = promotion_goal
+    if goal_price is not None:
+        result["GoalPrice"] = goal_price
     if directs_helps is not None:
         result["DirectsHelps"] = directs_helps
     if name is not None:

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -969,6 +969,19 @@ def adimages_set(
     help="Promotion goal (Цель продвижения)",
 )
 @click.option(
+    "--goal-price",
+    type=float,
+    help=(
+        "Target price for the promotion goal (Цена целевого действия / "
+        "Цена перехода), in account currency. Only exists on the page "
+        "when the campaign's promotion goal is (or is being set to via "
+        "--promotion-goal in this same call) 'max-clicks' — under "
+        "'max-conversions' the price is set per-goal in a separate table "
+        "not covered by this flag, and this fails with an error naming "
+        "that requirement."
+    ),
+)
+@click.option(
     "--directs-helps/--no-directs-helps",
     "directs_helps",
     default=None,
@@ -1039,6 +1052,7 @@ def update(
     campaign_id,
     weekly_budget,
     promotion_goal,
+    goal_price,
     directs_helps,
     name,
     headlines,
@@ -1053,13 +1067,22 @@ def update(
 ):
     """Update settings of one Мастер кампаний (Этап A/B/D fields, plus name)
 
-    Covers weekly budget, promotion goal, the "Директ помогает"
-    auto-recommendations toggle, the campaign name, per-slot headline/
-    ad-text variant replacement, and per-position image replacement. The
-    edit page has a single whole-form save (no per-section save) — see
-    ``direct_cli/browser/masters.py`` module docstring — so only the fields
-    passed here are changed; every other on-page field keeps its current
-    value.
+    Covers weekly budget, promotion goal (plus its target price), the
+    "Директ помогает" auto-recommendations toggle, the campaign name,
+    per-slot headline/ad-text variant replacement, and per-position image
+    replacement. The edit page has a single whole-form save (no per-section
+    save) — see ``direct_cli/browser/masters.py`` module docstring — so
+    only the fields passed here are changed; every other on-page field
+    keeps its current value.
+
+    ``--goal-price`` (issue #696) sets the "Цель продвижения" block's
+    target price — but that field only exists on the page when the
+    campaign's promotion goal is 'max-clicks': under 'max-conversions' the
+    price is per-goal in a separate table this CLI does not cover. Passing
+    ``--goal-price`` together with ``--promotion-goal max-conversions`` is
+    therefore refused up front, and passing ``--goal-price`` alone (no
+    ``--promotion-goal``) fails against a campaign whose CURRENT goal isn't
+    already 'max-clicks' — the field genuinely is not on the page yet.
 
     ``--headline``/``--text``/``--image`` each replace ONE existing
     slot/position at a time rather than the whole list — unlike this CLI's
@@ -1086,6 +1109,7 @@ def update(
     if (
         weekly_budget is None
         and promotion_goal is None
+        and goal_price is None
         and directs_helps is None
         and name is None
         and not headlines
@@ -1094,8 +1118,17 @@ def update(
     ):
         raise click.UsageError(
             "Provide at least one of --weekly-budget, --promotion-goal, "
-            "--directs-helps/--no-directs-helps, --name, --headline, "
-            "--text, --image."
+            "--goal-price, --directs-helps/--no-directs-helps, --name, "
+            "--headline, --text, --image."
+        )
+
+    if goal_price is not None and promotion_goal == "max-conversions":
+        raise click.UsageError(
+            "--goal-price has no effect under --promotion-goal "
+            "max-conversions — that goal's price is set per-target-action "
+            "in the 'Целевые действия' table, which this CLI does not "
+            "cover yet. --goal-price only applies to --promotion-goal "
+            "max-clicks."
         )
 
     # Slot counts come from the browser layer's own constants (imported here
@@ -1135,6 +1168,7 @@ def update(
             campaign_id,
             weekly_budget=weekly_budget,
             promotion_goal=promotion_goal,
+            goal_price=goal_price,
             directs_helps=directs_helps,
             name=name,
             headlines=parsed_headlines,

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -103,6 +103,15 @@ class _FakeLocatorHandle:
             raise PlaywrightError("element detached")
         return self._visible
 
+    def wait_for(self, state="visible", timeout=None):
+        # Models Locator.wait_for(state="visible") — used by _read_goal_price
+        # instead of a one-shot is_visible() snapshot (issue #696). Raises
+        # the same PlaywrightError a real timeout would when the element is
+        # absent/detached/not visible, so a test can model "field never
+        # rendered" without a separate polling loop.
+        if self._raises or not self._visible:
+            raise PlaywrightError("Timeout waiting for element state")
+
     def click(self, timeout=None):
         if self._raises:
             raise PlaywrightError("element detached")
@@ -2443,13 +2452,14 @@ class TestSetDirectsHelps(unittest.TestCase):
 class TestSetPromotionGoal(unittest.TestCase):
     """``_set_promotion_goal`` (issue #631, Этап A) — open dropdown, click, verify.
 
-    Options are modeled via ``role_elements`` (role="option"), not
-    ``text_buttons`` — ``_set_promotion_goal`` uses
-    ``get_by_role("option", name=label, exact=True)`` (cycle-review fix: the
-    previous ``get_by_text(exact=False)`` risked matching an ancestor
-    container instead of the option row itself). Using ``role_elements``
-    here means these tests actually exercise the same exact-name matching
-    the real code performs, instead of matching by an opaque dict key.
+    Options are modeled via ``locators`` keyed by the option row's
+    data-testid selector, NOT ``role_elements`` (issue #696
+    re-investigation, 2026-08-04): Yandex now appends a description
+    sentence and, for some rows, a "Рекомендуем" badge to each option's
+    accessible name, which broke the previous
+    ``get_by_role("option", name=label, exact=True)`` match entirely on
+    live pages. ``_set_promotion_goal`` now matches by the option's stable
+    data-testid (``PROMOTION_GOAL_INTERNAL_VALUES``) instead.
 
     The trigger's ``inner_text()`` is modeled as TWO lines (static section
     label, then the current selection) — confirmed live 2026-08-01 (see
@@ -2461,7 +2471,14 @@ class TestSetPromotionGoal(unittest.TestCase):
 
     _TRIGGER_LABEL = "Цель продвижения"
 
-    def _page_for_goal_selection(self, target_label, selected_line_after_click):
+    def _option_testid(self, goal):
+        return browser_masters._PROMOTION_GOAL_OPTION_TESTID_TEMPLATE.format(
+            value=browser_masters.PROMOTION_GOAL_INTERNAL_VALUES[goal]
+        )
+
+    def _page_for_goal_selection(
+        self, goal, selected_line_after_click, *, visible=True
+    ):
         state = {"selected_line": "Максимум целевых действий"}
 
         def _select():
@@ -2472,54 +2489,23 @@ class TestSetPromotionGoal(unittest.TestCase):
         # option — two lines, matching the live-confirmed shape.
         trigger.inner_text = lambda: f"{self._TRIGGER_LABEL}\n{state['selected_line']}"
 
+        option = _FakeLocatorHandle(visible=visible, on_click=_select)
+        option_selector = f'[data-testid="{self._option_testid(goal)}"]'
+
         return FakePage(
             locators={
-                browser_masters._PROMOTION_GOAL_BUTTON_XPATH: _FakeLocator([trigger])
+                browser_masters._PROMOTION_GOAL_BUTTON_XPATH: _FakeLocator([trigger]),
+                option_selector: _FakeLocator([option]),
             },
-            role_elements=[
-                (
-                    "option",
-                    target_label,
-                    _FakeTextLocatorHandle(visible=True, on_click=_select),
-                )
-            ],
         )
 
     def test_selects_option_and_verifies(self):
-        page = self._page_for_goal_selection("Максимум переходов", "Максимум переходов")
+        page = self._page_for_goal_selection("max-clicks", "Максимум переходов")
 
         browser_masters._set_promotion_goal(page, "max-clicks")
 
         trigger = page.locator(browser_masters._PROMOTION_GOAL_BUTTON_XPATH).first
         self.assertEqual(trigger.inner_text(), "Цель продвижения\nМаксимум переходов")
-
-    def test_does_not_match_option_whose_name_only_contains_label_as_substring(self):
-        # A decoy element whose accessible name merely CONTAINS the target
-        # label (e.g. an ancestor wrapper with extra description text) must
-        # NOT be treated as a match — get_by_role(..., exact=True) requires
-        # an exact accessible-name equality, not a substring.
-        state = {"trigger_text": "Цель продвижения"}
-        trigger = _FakeLocatorHandle(text="Цель продвижения")
-        trigger.inner_text = lambda: state["trigger_text"]
-        decoy_clicked = []
-        page = FakePage(
-            locators={
-                browser_masters._PROMOTION_GOAL_BUTTON_XPATH: _FakeLocator([trigger])
-            },
-            role_elements=[
-                (
-                    "option",
-                    "Максимум переходов — если хотите получать больше кликов",
-                    _FakeTextLocatorHandle(
-                        visible=True, on_click=lambda: decoy_clicked.append(True)
-                    ),
-                )
-            ],
-        )
-
-        with self.assertRaises(BrowserSessionError):
-            browser_masters._set_promotion_goal(page, "max-clicks")
-        self.assertEqual(decoy_clicked, [])
 
     def test_raises_on_unknown_goal_key(self):
         page = FakePage()
@@ -2539,7 +2525,14 @@ class TestSetPromotionGoal(unittest.TestCase):
             locators={
                 browser_masters._PROMOTION_GOAL_BUTTON_XPATH: _FakeLocator([trigger])
             },
-            role_elements=[],
+        )
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters._set_promotion_goal(page, "max-clicks")
+
+    def test_raises_when_option_not_visible(self):
+        page = self._page_for_goal_selection(
+            "max-clicks", "Максимум переходов", visible=False
         )
 
         with self.assertRaises(BrowserSessionError):
@@ -2548,13 +2541,108 @@ class TestSetPromotionGoal(unittest.TestCase):
     def test_raises_when_click_does_not_change_trigger_text(self):
         # Option is clicked but the trigger's selected line never changes.
         page = self._page_for_goal_selection(
-            "Максимум переходов",
+            "max-clicks",
             "Максимум целевых действий",  # unchanged
         )
 
         with self.assertRaises(BrowserSessionError) as ctx:
             browser_masters._set_promotion_goal(page, "max-clicks")
         self.assertIn("does not show it", str(ctx.exception))
+
+
+class TestSetGoalPrice(unittest.TestCase):
+    """``_set_goal_price``/``_read_goal_price`` (issue #696).
+
+    ``CampaignTargetSelect.PriceInput`` only exists on the page when the
+    campaign's promotion goal is 'max-clicks' (confirmed live, see module
+    docstring above ``_GOAL_PRICE_INPUT_TESTID``) — so the field-missing
+    case (goal is 'max-conversions', or the strategy isn't AVG_PRICE) is
+    modeled the same way as every other optional-field helper in this
+    module: an empty/invisible ``_FakeLocator``, not a special code path.
+    """
+
+    def _page_with_price_field(self, *, visible=True, initial_value=""):
+        state = {"value": initial_value}
+        field = _FakeLocatorHandle(visible=visible)
+        field.fill = lambda value: state.__setitem__("value", value)
+        field.input_value = lambda: state["value"]
+        page = FakePage(
+            locators={browser_masters._GOAL_PRICE_INPUT_TESTID: _FakeLocator([field])},
+        )
+        return page, state
+
+    def test_fills_price_field(self):
+        page, state = self._page_with_price_field()
+
+        browser_masters._set_goal_price(page, 500)
+
+        self.assertEqual(state["value"], "500")
+
+    def test_fills_non_integer_price_as_is(self):
+        page, state = self._page_with_price_field()
+
+        browser_masters._set_goal_price(page, 12.5)
+
+        self.assertEqual(state["value"], "12.5")
+
+    def test_raises_when_field_not_present(self):
+        page = FakePage(locators={})
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._set_goal_price(page, 500)
+        self.assertIn("max-clicks", str(ctx.exception))
+
+    def test_raises_when_field_click_fails(self):
+        # click() (not a one-shot is_visible() snapshot) is what locates
+        # the field before filling — see _set_goal_price's docstring for
+        # why (the section can still be hydrating when this runs). Modeled
+        # via raises=True, the same "element not found/detached" fake
+        # every other click()-based helper in this module uses.
+        field = _FakeLocatorHandle(raises=True)
+        page = FakePage(
+            locators={browser_masters._GOAL_PRICE_INPUT_TESTID: _FakeLocator([field])},
+        )
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters._set_goal_price(page, 500)
+
+    def test_reads_current_value(self):
+        page, _ = self._page_with_price_field(initial_value="500")
+
+        self.assertEqual(browser_masters._read_goal_price(page), "500")
+
+    def test_read_returns_none_when_field_not_visible(self):
+        page, _ = self._page_with_price_field(visible=False, initial_value="500")
+
+        self.assertIsNone(browser_masters._read_goal_price(page))
+
+    def test_read_returns_none_when_field_missing(self):
+        page = FakePage(locators={})
+
+        self.assertIsNone(browser_masters._read_goal_price(page))
+
+
+class TestGoalPriceMatches(unittest.TestCase):
+    """``_goal_price_matches`` — numeric comparison tolerant of Yandex's
+    own comma-decimal / whitespace formatting on read-back."""
+
+    def test_matches_identical_string(self):
+        self.assertTrue(browser_masters._goal_price_matches(500, "500"))
+
+    def test_matches_comma_decimal(self):
+        self.assertTrue(browser_masters._goal_price_matches(12.5, "12,5"))
+
+    def test_matches_with_nbsp_thousands_separator(self):
+        self.assertTrue(browser_masters._goal_price_matches(1500, "1\xa0500"))
+
+    def test_does_not_match_different_value(self):
+        self.assertFalse(browser_masters._goal_price_matches(500, "600"))
+
+    def test_does_not_match_none(self):
+        self.assertFalse(browser_masters._goal_price_matches(500, None))
+
+    def test_does_not_match_unparseable_value(self):
+        self.assertFalse(browser_masters._goal_price_matches(500, "not-a-number"))
 
 
 class TestClickSave(unittest.TestCase):
@@ -2811,6 +2899,7 @@ class TestUpdateMaster(unittest.TestCase):
         name_state=None,
         headlines_state=None,
         texts_state=None,
+        goal_price_state=None,
     ):
         save_clicks = []
         save_handle = _FakeTextLocatorHandle(
@@ -2898,6 +2987,15 @@ class TestUpdateMaster(unittest.TestCase):
                 [header_handle]
             )
 
+        if goal_price_state is not None:
+            price_handle = _FakeLocatorHandle(
+                on_fill=lambda v: goal_price_state.__setitem__("value", v),
+                get_value=lambda: goal_price_state.get("value", ""),
+            )
+            locators[browser_masters._GOAL_PRICE_INPUT_TESTID] = _FakeLocator(
+                [price_handle]
+            )
+
         # Issue #684: every WIZARD_EDIT_URL goto() now polls
         # _wait_for_edit_form for the first headline slot before trusting
         # the page. headlines_state already adds a real handle for slot 0
@@ -2952,6 +3050,42 @@ class TestUpdateMaster(unittest.TestCase):
         self.assertTrue(checkbox_state["checked"])
         self.assertEqual(len(save_clicks), 1)
         self.assertEqual(result, {"CampaignId": 42, "DirectsHelps": True})
+
+    def test_updates_only_goal_price(self):
+        price_state = {}
+        page, save_clicks = self._page_with_save_button(goal_price_state=price_state)
+
+        result = browser_masters.update_master(page, 42, goal_price=500)
+
+        self.assertEqual(price_state["value"], "500")
+        self.assertEqual(len(save_clicks), 1)
+        self.assertEqual(result, {"CampaignId": 42, "GoalPrice": 500})
+
+    def test_raises_when_saved_goal_price_does_not_match_requested(self):
+        # The field fills fine, but the post-save reload shows a DIFFERENT
+        # value than what was requested (Yandex rejected it client-side) —
+        # _verify_saved must catch this the same way it catches every
+        # other silently-rejected field.
+        price_state = {"value": "999"}
+        price_handle = _FakeLocatorHandle(
+            on_fill=lambda v: None,  # fill() is a no-op — value never changes
+            get_value=lambda: price_state["value"],
+        )
+        save_handle = _FakeTextLocatorHandle(visible=True)
+        edit_form_ready_selector = (
+            f'[data-testid="{browser_masters._EDIT_FORM_READY_TESTID}"]'
+        )
+        page = FakePage(
+            locators={
+                browser_masters._GOAL_PRICE_INPUT_TESTID: _FakeLocator([price_handle]),
+                edit_form_ready_selector: _FakeLocator([_FakeLocatorHandle()]),
+            },
+            role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
+        )
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(page, 42, goal_price=500)
+        self.assertIn("did not save as requested", str(ctx.exception))
 
     def test_updates_multiple_fields_in_one_call(self):
         budget_state = {}
@@ -3147,13 +3281,17 @@ class TestUpdateMaster(unittest.TestCase):
         edit_form_ready_selector = (
             f'[data-testid="{browser_masters._EDIT_FORM_READY_TESTID}"]'
         )
+        option_testid = browser_masters._PROMOTION_GOAL_OPTION_TESTID_TEMPLATE.format(
+            value=browser_masters.PROMOTION_GOAL_INTERNAL_VALUES["max-clicks"]
+        )
+        option_selector = f'[data-testid="{option_testid}"]'
         page = FakePage(
             locators={
                 browser_masters._PROMOTION_GOAL_BUTTON_XPATH: _FakeLocator([trigger]),
                 edit_form_ready_selector: _FakeLocator([_FakeLocatorHandle()]),
+                option_selector: _FakeLocator([_FakeLocatorHandle(visible=True)]),
             },
             role_elements=[
-                ("option", "Максимум переходов", _FakeTextLocatorHandle(visible=True)),
                 ("button", browser_masters._SAVE_BUTTON_TEXT, save_handle),
             ],
         )
@@ -3488,6 +3626,81 @@ class TestMastersUpdateCommand(unittest.TestCase):
             cli, ["masters", "update", "42", "--promotion-goal", "bogus"]
         )
         self.assertNotEqual(result.exit_code, 0)
+
+    def test_passes_goal_price(self):
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42}
+            result = self.runner.invoke(
+                cli,
+                [
+                    "masters",
+                    "update",
+                    "42",
+                    "--promotion-goal",
+                    "max-clicks",
+                    "--goal-price",
+                    "500",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(mock_update.call_args.kwargs["goal_price"], 500.0)
+        self.assertEqual(mock_update.call_args.kwargs["promotion_goal"], "max-clicks")
+
+    def test_goal_price_alone_is_a_valid_field(self):
+        # --goal-price on its own (no --promotion-goal) is accepted by the
+        # CLI's "at least one field" guard — whether it actually works
+        # depends on the campaign's CURRENT saved goal already being
+        # 'max-clicks', which update_master (not this guard) determines.
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42}
+            result = self.runner.invoke(
+                cli, ["masters", "update", "42", "--goal-price", "300"]
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(mock_update.call_args.kwargs["goal_price"], 300.0)
+        self.assertIsNone(mock_update.call_args.kwargs["promotion_goal"])
+
+    def test_rejects_goal_price_with_max_conversions(self):
+        result = self.runner.invoke(
+            cli,
+            [
+                "masters",
+                "update",
+                "42",
+                "--promotion-goal",
+                "max-conversions",
+                "--goal-price",
+                "500",
+            ],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("max-conversions", result.output)
+
+    def test_does_not_call_update_master_when_goal_price_rejected(self):
+        with patch("direct_cli.browser.masters.update_master") as mock_update:
+            self.runner.invoke(
+                cli,
+                [
+                    "masters",
+                    "update",
+                    "42",
+                    "--promotion-goal",
+                    "max-conversions",
+                    "--goal-price",
+                    "500",
+                ],
+            )
+        mock_update.assert_not_called()
 
     def test_passes_directs_helps_flag(self):
         with (

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -132,6 +132,15 @@ class _FakeLocatorHandle:
     def click(self, timeout=None):
         if self._raises:
             raise PlaywrightError("element detached")
+        if not self._visible:
+            # Real Playwright's click() carries an actionability auto-wait
+            # and times out (raising) against an element that never becomes
+            # visible — models that terminal case. A handle whose
+            # is_visible() flips True after some number of calls (see
+            # test_does_not_raise_when_option_is_still_hydrating) still
+            # succeeds here, since that test never calls click() while
+            # _visible is False.
+            raise PlaywrightError("Timeout waiting for element to be visible")
         if self._on_click is not None:
             self._on_click()
 
@@ -2554,6 +2563,48 @@ class TestSetPromotionGoal(unittest.TestCase):
 
         with self.assertRaises(BrowserSessionError):
             browser_masters._set_promotion_goal(page, "max-clicks")
+
+    def test_does_not_raise_when_option_is_still_hydrating(self):
+        # Regression test (issue #696 cycle-review finding): the option row
+        # can still be hydrating/animating in immediately after
+        # trigger.click() opens the dropdown — is_visible() reports False on
+        # the very first check even though the element becomes visible and
+        # clickable moments later, exactly the class of race _set_goal_price/
+        # _read_goal_price were fixed for elsewhere in this same module. A
+        # one-shot is_visible() gate (with no actionability wait) treats this
+        # transient state as "option not found" and raises — even though
+        # click() itself would have waited for and hit the element fine.
+        state = {"selected_line": "Максимум целевых действий", "visible_checks": 0}
+
+        def _select():
+            state["selected_line"] = "Максимум переходов"
+
+        trigger = _FakeLocatorHandle(text=self._TRIGGER_LABEL)
+        trigger.inner_text = lambda: f"{self._TRIGGER_LABEL}\n{state['selected_line']}"
+
+        option = _FakeLocatorHandle(visible=True, on_click=_select)
+
+        def _is_visible_after_hydration():
+            # False on the first check (still hydrating), True from then on —
+            # models the option becoming visible moments after the dropdown
+            # opens. click() (unlike a one-shot is_visible() gate) would wait
+            # for and hit this element without issue.
+            state["visible_checks"] += 1
+            return state["visible_checks"] > 1
+
+        option.is_visible = _is_visible_after_hydration
+        option_selector = f'[data-testid="{self._option_testid("max-clicks")}"]'
+
+        page = FakePage(
+            locators={
+                browser_masters._PROMOTION_GOAL_BUTTON_XPATH: _FakeLocator([trigger]),
+                option_selector: _FakeLocator([option]),
+            },
+        )
+
+        browser_masters._set_promotion_goal(page, "max-clicks")
+
+        self.assertEqual(state["selected_line"], "Максимум переходов")
 
     def test_raises_when_click_does_not_change_trigger_text(self):
         # Option is clicked but the trigger's selected line never changes.


### PR DESCRIPTION
## Summary

- Adds `--goal-price` to `direct masters update`, setting the "Цель продвижения" block's target price (`CampaignTargetSelect.PriceInput`).
- Live recon (required by the issue) found this field only exists on the page when the campaign's promotion goal is **`max-clicks`** and its strategy selector is on the default `AVG_PRICE` ("Средняя за неделю") value. Under **`max-conversions`** the price is instead set per-goal in a separate "Целевые действия" table — out of scope here. `--goal-price` combined with `--promotion-goal max-conversions` is rejected up front by the CLI with a clear error; `--goal-price` alone (no `--promotion-goal`) works if the campaign's *current* saved goal is already `max-clicks`, and fails with a descriptive error otherwise.
- Post-save verification (`_verify_saved`) re-reads the field after reload and compares numerically, tolerant of Yandex's comma-decimal/nbsp-thousands formatting on read-back.
- **Fixes a live regression found during the same recon**: Yandex now appends a description sentence and a "Рекомендуем" badge to each "Цель продвижения" dropdown option's accessible name (e.g. `"Максимум целевых действийЕсли хотите получать больше звонков и сообщений от клиентовРекомендуем"`), which broke the existing `_set_promotion_goal`'s `get_by_role(..., exact=True)` match on **every** live call — any `masters update --promotion-goal ...` was failing. Switched to matching by the option's stable `data-testid` instead.
- Also fixed a timing race found during live verification: the "Цель продвижения" section can still be hydrating when `_wait_for_edit_form` returns (that wait only polls the first headline slot near the top of the page). `_set_goal_price` now uses `click()`'s built-in actionability auto-wait (mirrors `_set_weekly_budget`'s identical pattern) instead of a one-shot `is_visible()` check, and `_read_goal_price` uses `wait_for(state="visible", timeout=5000)` instead of a one-shot check — both were producing false negatives against a save that actually succeeded server-side.

## Live verification

Against draft campaigns 713234191/713234204/713234212 (client project, reverted after each test):

- `masters update --promotion-goal max-clicks --goal-price 500` → saved and read back correctly.
- `masters update --goal-price 777` (no `--promotion-goal`, campaign already on `max-clicks`) → saved and read back correctly.
- `masters update --promotion-goal max-conversions --goal-price 500` → rejected by the CLI before any browser mutation.
- Confirmed live that `max-conversions` has no single target-price field at all (price lives in the per-goal "Целевые действия" table instead).

All test campaigns were left in their original state (`max-conversions`) after verification; each required adding one target-action entry to satisfy Yandex's own form validation on re-save (documented in commit history / conversation, disclosed to the account owner).

## Test plan

- [x] `pytest tests/test_masters.py -q` — 379 passed
- [x] `black --check` / `flake8` on changed files — clean
- [x] Live `direct masters update --promotion-goal max-clicks --goal-price <N>` on draft campaigns, read back via re-navigation to the edit page
- [x] Live confirmation `--goal-price` + `--promotion-goal max-conversions` is rejected before any API/browser mutation

Closes #696

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6gq7afSCCZM6Vawmz22iQ