### PR TITLE
fix(masters): re-recon step 1's Combobox markup and fix _fill_landing_url

### DIFF
--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -2268,17 +2268,22 @@ def _fill_landing_url(page: "Page", url: str) -> None:
     # separately keeps this a plain data-testid lookup like every other
     # locator in this module.
     #
-    # Scoped to the bare-domain-root case ONLY (``urlsplit(url).path == "/"``)
-    # — confirmed live is exactly "https://host/" vs. the stored
-    # "https://host". Generalizing this to any URL ending in "/" would also
-    # strip a PATH's trailing slash (e.g. "/sale/" -> "/sale"), which is not
-    # confirmed to be the same destination and was never observed live —
-    # matching on that alone risked selecting an unintended suggestion and
-    # launching the campaign against a different landing page (Codex review,
-    # PR #703 round 1).
+    # Scoped to the bare-domain-root case ONLY — confirmed live is exactly
+    # "https://host/" vs. the stored "https://host", i.e. path == "/" AND no
+    # query/fragment. Generalizing this to any URL ending in "/" would also
+    # strip a PATH's trailing slash (e.g. "/sale/" -> "/sale") or a QUERY
+    # VALUE's trailing slash (e.g. "/?next=/" -> "/?next="), neither of
+    # which is confirmed to be the same destination and neither was
+    # observed live — matching on that alone risked selecting an unintended
+    # suggestion and launching the campaign against a different landing
+    # page (Codex review, PR #703 rounds 1 and 2).
+    split_url = urlsplit(url)
     url_candidates = (
         [url, url.rstrip("/")]
-        if url.endswith("/") and urlsplit(url).path == "/"
+        if url.endswith("/")
+        and split_url.path == "/"
+        and not split_url.query
+        and not split_url.fragment
         else [url]
     )
     option_locators = [

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -346,7 +346,36 @@ _CREATE_URL_INPUT_TESTID = '[data-testid="CampaignFormUrl.Textinput"]'
 # Step 1's "Далее" button — confirmed live (issue #650 re-recon) it now also
 # carries a stable data-testid, and only renders/becomes clickable after the
 # URL field has text (unlike the old always-present button this replaced).
+# Issue #690 re-recon (2026-08-04): this button ONLY renders when the typed
+# URL has NO match in the account's suggestion history (see
+# _CREATE_URL_LISTBOX_TESTID below) — when a match exists, Yandex shows a
+# suggestions dropdown instead and this button never appears at all (count()
+# stays 0 the whole time), so _fill_landing_url must not treat its absence
+# as an error on its own.
 _CREATE_NEXT_BUTTON_TESTID = '[data-testid="CampaignFormUrl.button"]'
+
+# Issue #690 re-recon (2026-08-04, live against ksamatadirect account):
+# typing ANY URL — matched in the account's suggestion history or not —
+# renders a Combobox suggestions popup (a `role="listbox"` whose options
+# each carry a `data-testid` of `CampaignFormUrl.listBox.<raw suggestion
+# url>`, confirmed live), showing unrelated history when there's no real
+# match. _CREATE_NEXT_BUTTON_TESTID is absent from the DOM only while a
+# suggestion EXACTLY matching the typed URL exists — see _fill_landing_url,
+# which locates that one option directly by its full data-testid rather
+# than matching the popup as a whole, so an unrelated suggestion already
+# showing is never clicked by mistake.
+
+# How long to wait for either the suggestions popup or the "Далее" button to
+# appear after typing — confirmed live the popup can take ~1-3s to render
+# (it does its own debounced lookup against the account's history).
+_CREATE_URL_RESPONSE_TIMEOUT_MS = 8_000
+
+# Per-keystroke delay and retry budget for _type_landing_url (issue #690
+# re-recon, 2026-08-04) — see its docstring for why a retry-with-verify loop
+# is needed at all. 80ms is a human-typing-like rate; every live retry
+# observed succeeded within 2 attempts, so 5 leaves generous headroom.
+_TYPE_URL_DELAY_MS = 80
+_TYPE_URL_MAX_ATTEMPTS = 5
 
 # Confirmed live: this exact string appears under the URL field when the
 # "Далее" click rejects the value as not a well-formed URL. Pure
@@ -2130,43 +2159,155 @@ def set_master_images(
     }
 
 
+def _type_landing_url(field: Any, url: str) -> None:
+    """Type ``url`` into step 1's contenteditable field, verifying it landed.
+
+    Issue #690 re-recon (2026-08-04): typing this field via
+    ``field.type(url)`` intermittently drops characters from the MIDDLE of
+    the string — confirmed live via ``textContent`` reads immediately after
+    typing (e.g. typing produced ``"https://.ru/novaya-..."`` with
+    ``"ksamata"`` simply missing), not just a trailing/leading truncation.
+    This reproduces at both the Playwright default (no per-key delay) and a
+    150ms delay, just less often at the latter — it is the widget's own
+    debounced-suggestion lookup racing a keystroke burst, not something a
+    fixed delay alone reliably avoids. ``field.fill()`` does not help either
+    despite succeeding without error: it sets the DOM text directly without
+    the real ``input`` events this Combobox listens for, so neither the
+    suggestions popup nor the "Далее" button ever appears afterwards
+    (confirmed live: polled 10s with zero reaction from the widget).
+
+    The only reliable approach found live is retry-with-verify: type with a
+    human-like delay, read ``textContent`` back, and retry (clearing first,
+    since ``.type()`` APPENDS to a contenteditable — see
+    ``_clear_text_field``) if it doesn't match. Every attempt observed live
+    needed at most 2 tries; ``_TYPE_URL_MAX_ATTEMPTS`` leaves generous
+    headroom above that.
+    """
+    actual: Optional[str] = None
+    for attempt in range(_TYPE_URL_MAX_ATTEMPTS):
+        if attempt:
+            _clear_text_field(field)
+        try:
+            field.type(url, delay=_TYPE_URL_DELAY_MS)
+        except PlaywrightError as exc:
+            raise BrowserSessionError(
+                "Could not type into the landing-page URL field on the "
+                "Мастер кампаний create page — Yandex may have changed the "
+                "page's markup. Re-run with --headful to inspect the page."
+            ) from exc
+        try:
+            actual = field.text_content()
+        except PlaywrightError:
+            actual = None
+        if actual == url:
+            return
+
+    raise BrowserSessionError(
+        f"Typed {url!r} into the landing-page URL field on the Мастер "
+        f"кампаний create page {_TYPE_URL_MAX_ATTEMPTS} times, but the "
+        f"field still shows {actual!r} — Yandex's Combobox widget appears "
+        "to be dropping keystrokes. Re-run with --headful to inspect the "
+        "page."
+    )
+
+
 def _fill_landing_url(page: "Page", url: str) -> None:
-    """Fill step 1's URL field and click "Далее" to advance to step 2.
+    """Fill step 1's URL field and advance to step 2.
 
     Field located by ``_CREATE_URL_INPUT_TESTID`` (issue #650 re-recon,
     2026-08-02) — Yandex replaced the plain ``<input placeholder="...">``
     with a Combobox whose text control is a ``contenteditable`` ``<div
     role="textbox">`` that ``get_by_placeholder()`` (matches only
     ``<input>``/``<textarea>``) can no longer find, even though the
-    placeholder text itself is unchanged. ``.fill()`` does not work on a
-    contenteditable div, so this types the URL via keyboard events instead
-    (also what triggers the "Далее" button to render — see below).
+    placeholder text itself is unchanged. See ``_type_landing_url`` for why
+    typing itself needs a retry-with-verify loop.
 
-    Confirmed live: unlike the old always-present button this replaced, the
-    "Далее" button now only renders once the field has text — this waits
-    for it via Playwright's own actionability check (``click()`` auto-waits
-    for the element to appear and become visible) rather than an immediate
-    ``count()``. It is clickable even when the field holds a malformed
-    value — it does not disable on format, so a click is always needed to
-    trigger the (purely client-side) validation. If Yandex rejects the
-    format, this raises :class:`BrowserSessionError` immediately instead of
-    waiting the full step-2 timeout for a page that will never render (see
-    ``_CREATE_INVALID_URL_TEXT``).
+    **Two distinct continuations, not one "Далее" click** (issue #690
+    re-recon): typing a URL Yandex recognises from the account's own
+    history (previously used landing pages, e.g. a bare match of a
+    previously created campaign's URL) renders a suggestions Combobox popup
+    (confirmed live: a ``role="listbox"`` containing one ``role="option"``
+    per suggestion, each carrying a ``data-testid`` of
+    ``CampaignFormUrl.listBox.<raw suggestion url>``) INSTEAD of enabling
+    ``_CREATE_NEXT_BUTTON_TESTID`` — the button's own data-testid is
+    completely absent from the DOM the whole time this popup is open.
+    Selecting the matching option is enough to advance: Yandex re-validates
+    the URL server-side and the SPA moves on to step 2 on its own within
+    ~10s, with no "Далее" click at all (confirmed live: the button
+    reappears disabled, then becomes enabled-but-invisible, without ever
+    being clicked, exactly when step 2's own markup takes over the DOM).
+    Confirmed live: Yandex stores the suggestion WITHOUT a trailing slash
+    even when the campaign's actual URL has one (``.../ksamata.ru`` for a
+    site whose real landing is ``.../ksamata.ru/``) — the testid is matched
+    against both the exact ``url`` and its trailing-slash-stripped form so
+    a same-site match isn't missed over that alone.
+
+    A URL with NO exact suggestion match still renders this popup — showing
+    the account's unrelated suggestion history instead (confirmed live) —
+    but with ``_CREATE_NEXT_BUTTON_TESTID`` also present and already
+    enabled; this is matched by exact ``data-testid``, not accessible-name
+    text, precisely so an unrelated suggestion is never clicked by mistake.
     """
     field = page.locator(_CREATE_URL_INPUT_TESTID).first
     try:
         field.click()
-        field.type(url)
     except PlaywrightError as exc:
         raise BrowserSessionError(
-            "Could not find or fill the landing-page URL field on the "
+            "Could not find or click the landing-page URL field on the "
             "Мастер кампаний create page — Yandex may have changed the "
             "page's markup. Re-run with --headful to inspect the page."
         ) from exc
 
-    next_button = page.locator(_CREATE_NEXT_BUTTON_TESTID).first
+    _type_landing_url(field, url)
+
+    next_button = page.locator(_CREATE_NEXT_BUTTON_TESTID)
+    # Two candidate testids, not one combined CSS selector: confirmed live
+    # Yandex stores the suggestion without a trailing slash even when the
+    # real URL has one (see docstring), and querying each candidate
+    # separately keeps this a plain data-testid lookup like every other
+    # locator in this module.
+    url_candidates = [url, url.rstrip("/")] if url.endswith("/") else [url]
+    option_locators = [
+        page.locator(f'[data-testid="CampaignFormUrl.listBox.{candidate}"]')
+        for candidate in url_candidates
+    ]
+
+    def _matching_option():
+        for locator in option_locators:
+            if locator.count():
+                return locator
+        return None
+
+    def _suggestion_or_button_ready() -> bool:
+        return _matching_option() is not None or bool(next_button.count())
+
+    if not _poll_until(
+        page, _suggestion_or_button_ready, _CREATE_URL_RESPONSE_TIMEOUT_MS
+    ):
+        raise BrowserSessionError(
+            "Neither a matching suggestion nor the 'Далее' button appeared "
+            "after typing the landing-page URL on the Мастер кампаний "
+            "create page within "
+            f"{_CREATE_URL_RESPONSE_TIMEOUT_MS / 1000:.0f}s — Yandex may "
+            "have changed the page's markup. Re-run with --headful to "
+            "inspect the page."
+        )
+
+    matching_option = _matching_option()
+    if matching_option is not None:
+        try:
+            matching_option.first.click()
+        except PlaywrightError as exc:
+            raise BrowserSessionError(
+                f"Could not click the matching suggestion for {url!r} on "
+                "the Мастер кампаний create page — Yandex may have changed "
+                "the page's markup. Re-run with --headful to inspect the "
+                "page."
+            ) from exc
+        return
+
     try:
-        next_button.click()
+        next_button.first.click()
     except PlaywrightError as exc:
         raise BrowserSessionError(
             "Could not find or click the 'Далее' button on the Мастер "
@@ -2229,39 +2370,46 @@ def _wait_for_create_step1(page: "Page") -> None:
 def _wait_for_step2(page: "Page") -> None:
     """Block until step 2's long form has rendered.
 
-    Confirmed live this can take 10-15s+ after clicking "Далее" — Yandex
-    scans the landing page's content server-side to pre-fill headlines,
-    texts, and images before rendering the rest of the form. Polls for the
-    "Регион показов" heading (the one field guaranteed to be present and
-    genuinely empty — see module docstring) rather than a fixed sleep.
+    Confirmed live this can take 10-15s+ after advancing from step 1 —
+    Yandex scans the landing page's content server-side to pre-fill
+    headlines, texts, and images before rendering the rest of the form.
+
+    Polls for ``CampaignTitles0.textarea`` (issue #690 re-recon,
+    2026-08-04) rather than the "Регион показов" heading this used before:
+    live testing found the region picker section (``RegionsTreeEditor`` /
+    "Регион показов") no longer renders on this page at all — its
+    ``data-testid``s and heading text are both completely absent from a
+    fully-loaded step 2 in the account tested. Headlines slot 0 is used
+    instead for the same reason ``_EDIT_FORM_READY_TESTID`` picked it on the
+    edit page: it is the one field guaranteed present and stably
+    identified by ``data-testid`` on every step 2 render (see
+    ``_HEADLINES_SLOT_COUNT``'s docstring).
     """
-    region_heading = page.get_by_text("Регион показов", exact=False)
-    deadline = time.monotonic() + _CREATE_STEP2_TIMEOUT_MS / 1000
-    while time.monotonic() < deadline:
-        with contextlib.suppress(PlaywrightError):
-            if region_heading.count():
-                return
-        page.wait_for_timeout(250)
+    headlines_ready = page.locator(f'[data-testid="{_EDIT_FORM_READY_TESTID}"]')
+    if _poll_until(
+        page, lambda: bool(headlines_ready.count()), _CREATE_STEP2_TIMEOUT_MS
+    ):
+        return
 
     # Which step the page is actually stuck on changes the diagnosis
     # entirely, and re-running --headful just to find out is expensive on a
     # page with no sandbox — so report it in the error itself. Step 1's URL
     # field is gone from the DOM once step 2 renders, so its presence means
-    # "Далее" never advanced the form.
+    # the form never advanced.
     still_on_step1 = False
     with contextlib.suppress(PlaywrightError):
         still_on_step1 = bool(page.locator(_CREATE_URL_INPUT_TESTID).count())
     where = (
-        "The page is still showing step 1 (the URL field), so 'Далее' never "
-        "advanced the form — Yandex may still be scanning the landing page."
+        "The page is still showing step 1 (the URL field), so it never "
+        "advanced — Yandex may still be scanning the landing page."
         if still_on_step1
         else "The page has left step 1, so step 2 rendered but without the "
-        "expected 'Регион показов' section — its markup may have changed."
+        "expected first headline slot — its markup may have changed."
     )
 
     raise BrowserSessionError(
         "Timed out waiting for the Мастер кампаний create form's step 2 "
-        f"(the 'Регион показов' section) to render within "
+        f"(the first headline slot) to render within "
         f"{_CREATE_STEP2_TIMEOUT_MS / 1000:.0f}s. {where} Re-run with "
         "--headful to inspect the page."
     )

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -202,6 +202,7 @@ import contextlib
 import json
 import re
 import time
+from urllib.parse import urlsplit
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -2266,7 +2267,20 @@ def _fill_landing_url(page: "Page", url: str) -> None:
     # real URL has one (see docstring), and querying each candidate
     # separately keeps this a plain data-testid lookup like every other
     # locator in this module.
-    url_candidates = [url, url.rstrip("/")] if url.endswith("/") else [url]
+    #
+    # Scoped to the bare-domain-root case ONLY (``urlsplit(url).path == "/"``)
+    # — confirmed live is exactly "https://host/" vs. the stored
+    # "https://host". Generalizing this to any URL ending in "/" would also
+    # strip a PATH's trailing slash (e.g. "/sale/" -> "/sale"), which is not
+    # confirmed to be the same destination and was never observed live —
+    # matching on that alone risked selecting an unintended suggestion and
+    # launching the campaign against a different landing page (Codex review,
+    # PR #703 round 1).
+    url_candidates = (
+        [url, url.rstrip("/")]
+        if url.endswith("/") and urlsplit(url).path == "/"
+        else [url]
+    )
     option_locators = [
         page.locator(f'[data-testid="CampaignFormUrl.listBox.{candidate}"]')
         for candidate in url_candidates
@@ -4034,6 +4048,11 @@ def create_master(
         page, _HEADLINES_TESTID_TEMPLATE, _HEADLINES_SLOT_COUNT, headlines
     )
     _add_repeating_values(page, _TEXTS_TESTID_TEMPLATE, _TEXTS_SLOT_COUNT, texts)
+    # Known-broken on accounts matching the one re-recon'd for #690/#703: the
+    # region picker _set_region needs (RegionsTreeTagGroup.launcher) was
+    # confirmed absent from a fully-loaded step 2 there — see issue #705.
+    # #690 scoped step 1 only, so this is not fixed here; _set_region raises
+    # its own clear BrowserSessionError when the launcher can't be found.
     _set_region(page, regions)
     if weekly_budget is not None:
         _set_weekly_budget_on_create(page, weekly_budget)

--- a/tests/fixtures/masters_wizard_create.html
+++ b/tests/fixtures/masters_wizard_create.html
@@ -118,6 +118,70 @@ from (it lists arbitrary past URLs, not a canonical "sites for this account"
 API).
 
 =====================================================================
+RE-RECON, 2026-08-04 (issue #690): step 1 markup migrated to a Combobox
+=====================================================================
+
+The plain <input placeholder="..."> above no longer exists (broke #650's
+_fill_landing_url, which relied on it having a stable "Далее" button that
+was always present once the field had text). Live re-recon against the same
+ksamatadirect account found:
+
+- The field is now a Combobox: a contenteditable <div role="textbox"
+  data-testid="CampaignFormUrl.Textinput">. Typing into it is unreliable at
+  Playwright's default (no per-key delay) AND even at a 150ms delay — the
+  widget intermittently drops characters from the MIDDLE of the typed
+  string (confirmed via textContent reads immediately after typing, e.g.
+  "https://ksamata.ru/novaya-..." losing "ksamata" entirely). The fix
+  (_type_landing_url) types with an 80ms delay, reads textContent back, and
+  retries (clearing first) up to 5 times if it doesn't match — every live
+  retry needed at most 2 attempts. Locator.fill() does NOT work as a
+  substitute despite succeeding without error: it sets the DOM text
+  directly without the real input events the widget listens for, so
+  neither the suggestions popup nor "Далее" ever reacts afterwards.
+
+- ANY typed URL — matched in the account's suggestion history or not —
+  renders a suggestions Combobox popup after ~1-3s (role="listbox",
+  data-testid="CampaignFormUrl.listBox", containing role="option" children
+  each carrying data-testid="CampaignFormUrl.listBox.<raw suggestion url>").
+  A URL with NO real match still shows this popup — full of unrelated
+  history — but ALSO renders "Далее" (data-testid="CampaignFormUrl.button")
+  already enabled next to it.
+
+- A URL that DOES match an item in the account's history (exactly, or
+  after stripping the typed URL's trailing slash — Yandex stores
+  suggestions without one even when the real campaign URL has one) has NO
+  "Далее" button in the DOM at all while the popup is open — only the
+  matching listBox option. Clicking that option is enough to advance:
+  Yandex re-validates the URL server-side, and after ~8-11s (same "scanning
+  the landing page" delay as clicking "Далее" always took) the SPA moves on
+  to step 2 on its own, with NO "Далее" click ever happening. (The button
+  reappears briefly, disabled, then becomes enabled-but-invisible without
+  ever being clicked, exactly as step 2's markup takes over the DOM — this
+  is what caused #690's original symptom: the button's count() flipping
+  looked like a markup change broke the click entirely, when actually
+  clicking it was never the right action for this path.)
+
+- A URL with NO history match: "Далее" is real and clickable and DOES need
+  a click — confirmed against a fresh, unused ksamata.ru subpage.
+
+=====================================================================
+RE-RECON, 2026-08-04 (issue #690): step 2's region picker section is gone
+=====================================================================
+
+Live re-recon (same account, same recon pass as above) found the fully-
+rendered step 2 form no longer contains ANY trace of the "Регион показов"
+section documented in item 12 below — no heading text, no
+RegionsTreeEditor/RegionsTreeTagGroup data-testids at all. This was used as
+_wait_for_step2's readiness marker before this recon and is no longer
+reliable. The fix switches that marker to the first headline slot
+(data-testid="CampaignTitles0.textarea"), which IS still present and
+stably identified (same marker _wait_for_edit_form already uses on the
+edit page). Whether the region picker moved elsewhere in the form, is
+gated behind a not-yet-expanded section, or is genuinely no longer part of
+this campaign type is NOT resolved by this pass — _set_region/_read_region_tags
+were not touched and are out of scope for issue #690, which is step 1 only.
+
+=====================================================================
 Step 2: full field inventory ("Конверсии и трафик" type)
 =====================================================================
 

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -140,6 +140,14 @@ class _FakeLocatorHandle:
         # needs to record what was entered.
         self.fill(value)
 
+    def text_content(self):
+        # Supports _type_landing_url's retry-with-verify loop (issue #690):
+        # it reads this back after every type() to confirm the widget didn't
+        # drop characters, same underlying state fill()/type() write to.
+        if self._raises:
+            raise PlaywrightError("element detached")
+        return self._text
+
     def check(self):
         if self._raises:
             raise PlaywrightError("element detached")
@@ -2202,7 +2210,7 @@ class TestCopyMaster(unittest.TestCase):
         self,
         menu_trigger=None,
         clone_item=None,
-        region_heading=True,
+        step2_ready=True,
         terminal_button_text=None,
         redirect_on_click=True,
     ):
@@ -2215,14 +2223,12 @@ class TestCopyMaster(unittest.TestCase):
             locators[browser_masters._CLONE_MENU_ITEM_SELECTOR] = _FakeLocator(
                 [clone_item]
             )
-
-        text_buttons = {}
-        if region_heading:
-            text_buttons["Регион показов"] = _FakeGetByTextLocator(
-                [_FakeTextLocatorHandle()]
+        if step2_ready:
+            locators[f'[data-testid="{browser_masters._EDIT_FORM_READY_TESTID}"]'] = (
+                _FakeLocator([_FakeLocatorHandle()])
             )
 
-        page = FakePage(locators=locators, text_buttons=text_buttons)
+        page = FakePage(locators=locators)
 
         if terminal_button_text is not None:
 
@@ -4546,27 +4552,55 @@ class TestBrowserSessionErrors(unittest.TestCase):
 
 
 class TestFillLandingUrl(unittest.TestCase):
-    """``_fill_landing_url`` (issue #632, re-recon issue #650) — step 1's URL
-    field + "Далее".
+    """``_fill_landing_url`` (issue #632, re-recon issues #650/#690) — step
+    1's URL field, then either a matching suggestion or "Далее".
 
-    Both the URL field and the "Далее" button are located via
-    ``page.locator(...)`` on their ``data-testid`` (issue #650 re-recon,
-    2026-08-02) — Yandex replaced the plain ``<input placeholder="...">``
-    with a Combobox whose text control is a ``contenteditable`` ``<div
-    role="textbox">`` that ``get_by_placeholder()``/``get_by_role()`` can no
-    longer find the same way.
+    The URL field and the "Далее" button are located via ``page.locator(...)``
+    on their ``data-testid`` (issue #650 re-recon, 2026-08-02) — Yandex
+    replaced the plain ``<input placeholder="...">`` with a Combobox whose
+    text control is a ``contenteditable`` ``<div role="textbox">`` that
+    ``get_by_placeholder()``/``get_by_role()`` can no longer find the same
+    way.
+
+    Issue #690 re-recon (2026-08-04, live): typing a URL Yandex recognises
+    from the account's own suggestion history renders a
+    ``CampaignFormUrl.listBox.<url>`` option INSTEAD of enabling the "Далее"
+    button (whose ``data-testid`` is then absent from the DOM entirely) —
+    clicking that option is enough to advance, no "Далее" click needed. A
+    URL with no such match only ever gets the button.
     """
 
-    def _page(self, url_state=None, next_clicks=None, error_visible=False):
+    def _page(
+        self,
+        url_state=None,
+        next_clicks=None,
+        error_visible=False,
+        matching_option=None,
+        option_clicks=None,
+        field_handle=None,
+    ):
         url_state = url_state if url_state is not None else {}
         next_clicks = next_clicks if next_clicks is not None else []
-        field = _FakeLocatorHandle(on_fill=lambda v: url_state.__setitem__("url", v))
+        option_clicks = option_clicks if option_clicks is not None else []
+        field = field_handle or _FakeContentEditableHandle(
+            on_fill=lambda v: url_state.__setitem__("url", v)
+        )
         next_button = _FakeLocatorHandle(on_click=lambda: next_clicks.append(True))
+        locators = {
+            browser_masters._CREATE_URL_INPUT_TESTID: _FakeLocator([field]),
+            browser_masters._CREATE_NEXT_BUTTON_TESTID: _FakeLocator(
+                [] if matching_option else [next_button]
+            ),
+        }
+        if matching_option:
+            option_handle = _FakeLocatorHandle(
+                on_click=lambda: option_clicks.append(True)
+            )
+            locators[f'[data-testid="CampaignFormUrl.listBox.{matching_option}"]'] = (
+                _FakeLocator([option_handle])
+            )
         return FakePage(
-            locators={
-                browser_masters._CREATE_URL_INPUT_TESTID: _FakeLocator([field]),
-                browser_masters._CREATE_NEXT_BUTTON_TESTID: _FakeLocator([next_button]),
-            },
+            locators=locators,
             text_buttons={
                 browser_masters._CREATE_INVALID_URL_TEXT: _FakeGetByTextLocator(
                     [_FakeTextLocatorHandle()] if error_visible else []
@@ -4574,7 +4608,7 @@ class TestFillLandingUrl(unittest.TestCase):
             },
         )
 
-    def test_fills_field_and_clicks_next(self):
+    def test_fills_field_and_clicks_next_when_no_suggestion_matches(self):
         url_state = {}
         next_clicks = []
         page = self._page(url_state=url_state, next_clicks=next_clicks)
@@ -4584,22 +4618,58 @@ class TestFillLandingUrl(unittest.TestCase):
         self.assertEqual(url_state["url"], "https://ksamata.ru/")
         self.assertEqual(len(next_clicks), 1)
 
+    def test_clicks_matching_suggestion_instead_of_next_button(self):
+        """Issue #690: a history match renders a listBox option and the
+        "Далее" button's own data-testid is absent — clicking the option is
+        the only way to advance, and "Далее" must never be clicked."""
+        url_state = {}
+        next_clicks = []
+        option_clicks = []
+        page = self._page(
+            url_state=url_state,
+            next_clicks=next_clicks,
+            matching_option="https://ksamata.ru",
+            option_clicks=option_clicks,
+        )
+
+        browser_masters._fill_landing_url(page, "https://ksamata.ru/")
+
+        self.assertEqual(len(option_clicks), 1)
+        self.assertEqual(len(next_clicks), 0)
+
+    def test_clicks_matching_suggestion_ignoring_trailing_slash(self):
+        """Confirmed live: Yandex stores the suggestion WITHOUT the trailing
+        slash the campaign's real URL has — the typed URL (with slash) must
+        still match it."""
+        option_clicks = []
+        page = self._page(
+            matching_option="https://ksamata.ru",  # no trailing slash
+            option_clicks=option_clicks,
+        )
+
+        browser_masters._fill_landing_url(page, "https://ksamata.ru/")
+
+        self.assertEqual(len(option_clicks), 1)
+
     def test_raises_when_url_field_missing(self):
         page = FakePage(locators={})
 
         with self.assertRaises(BrowserSessionError):
             browser_masters._fill_landing_url(page, "https://ksamata.ru/")
 
-    def test_raises_when_next_button_missing(self):
+    def test_raises_when_neither_suggestion_nor_button_appears(self):
         page = FakePage(
             locators={
                 browser_masters._CREATE_URL_INPUT_TESTID: _FakeLocator(
-                    [_FakeLocatorHandle()]
+                    [_FakeContentEditableHandle()]
                 ),
             },
         )
 
-        with self.assertRaises(BrowserSessionError):
+        with (
+            patch.object(browser_masters, "_CREATE_URL_RESPONSE_TIMEOUT_MS", 1),
+            self.assertRaises(BrowserSessionError),
+        ):
             browser_masters._fill_landing_url(page, "https://ksamata.ru/")
 
     def test_raises_on_invalid_url_format_error(self):
@@ -4609,21 +4679,67 @@ class TestFillLandingUrl(unittest.TestCase):
             browser_masters._fill_landing_url(page, "not-a-valid-url")
         self.assertIn("malformed", str(ctx.exception))
 
+    def test_retries_typing_when_widget_drops_characters(self):
+        """Issue #690: the real Combobox intermittently drops characters
+        from the typed URL — this asserts _fill_landing_url actually
+        notices via a text_content() mismatch and retries rather than
+        silently proceeding with a mangled value."""
+        field = _FakeContentEditableHandle(supports_modifier=True)
+        # First type() call is deliberately mangled (drops "ksamata"); the
+        # SECOND call (after _clear_text_field) types correctly - modelled
+        # by overriding .type() to mangle only the first invocation.
+        original_type = field.type
+        call_count = {"n": 0}
+
+        def _flaky_type(value, delay=None):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                original_type(value.replace("ksamata", ""), delay=delay)
+            else:
+                original_type(value, delay=delay)
+
+        field.type = _flaky_type
+        page = self._page(field_handle=field)
+
+        browser_masters._fill_landing_url(page, "https://ksamata.ru/")
+
+        self.assertEqual(call_count["n"], 2)
+        self.assertEqual(field.text_content(), "https://ksamata.ru/")
+
+    def test_raises_when_widget_never_stops_dropping_characters(self):
+        field = _FakeContentEditableHandle()
+        original_type = field.type
+        field.type = lambda value, delay=None: original_type("garbled", delay=delay)
+        page = self._page(field_handle=field)
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._fill_landing_url(page, "https://ksamata.ru/")
+        self.assertIn("dropping keystrokes", str(ctx.exception))
+
 
 class TestWaitForStep2(unittest.TestCase):
-    """``_wait_for_step2`` (issue #632) — polls for the "Регион показов" heading."""
+    """``_wait_for_step2`` (issue #632, re-recon #690) — polls for the first
+    headline slot (``CampaignTitles0.textarea``), not the "Регион показов"
+    heading this used before: issue #690 re-recon (2026-08-04) found the
+    region picker no longer renders at all on a fully-loaded step 2 in the
+    account tested — its data-testids and heading text were both completely
+    absent.
+    """
 
-    def test_returns_once_heading_present(self):
+    def _step2_ready_selector(self):
+        return f'[data-testid="{browser_masters._EDIT_FORM_READY_TESTID}"]'
+
+    def test_returns_once_first_headline_slot_present(self):
         page = FakePage(
-            text_buttons={
-                "Регион показов": _FakeGetByTextLocator([_FakeTextLocatorHandle()])
+            locators={
+                self._step2_ready_selector(): _FakeLocator([_FakeLocatorHandle()])
             }
         )
 
         browser_masters._wait_for_step2(page)  # must not raise
 
-    def test_raises_when_heading_never_appears(self):
-        page = FakePage(text_buttons={})
+    def test_raises_when_marker_never_appears(self):
+        page = FakePage(locators={})
 
         with (
             patch.object(browser_masters, "_CREATE_STEP2_TIMEOUT_MS", 10),
@@ -4635,9 +4751,8 @@ class TestWaitForStep2(unittest.TestCase):
         # Issue #653: which step the page is stuck on changes the diagnosis
         # entirely, and re-running --headful just to find out is expensive on
         # a page with no sandbox — so the error must say it. Step 1's URL
-        # field still being in the DOM means "Далее" never advanced the form.
+        # field still being in the DOM means the form never advanced.
         page = FakePage(
-            text_buttons={},
             locators={
                 browser_masters._CREATE_URL_INPUT_TESTID: _FakeLocator(
                     [_FakeLocatorHandle()]
@@ -4654,8 +4769,9 @@ class TestWaitForStep2(unittest.TestCase):
 
     def test_timeout_message_says_the_page_left_step_1(self):
         # The other branch: step 1's URL field is gone, so step 2 rendered but
-        # without the expected section — that points at a markup change.
-        page = FakePage(text_buttons={}, locators={})
+        # without the expected first headline slot — that points at a markup
+        # change.
+        page = FakePage(locators={})
 
         with (
             patch.object(browser_masters, "_CREATE_STEP2_TIMEOUT_MS", 10),
@@ -6806,7 +6922,7 @@ class TestCreateMaster(unittest.TestCase):
         launch_clicks = []
         draft_clicks = []
 
-        url_field = _FakeLocatorHandle(
+        url_field = _FakeContentEditableHandle(
             on_fill=lambda v: url_state.__setitem__("url", v)
         )
         headline_last = {"value": ""}
@@ -6922,7 +7038,6 @@ class TestCreateMaster(unittest.TestCase):
             ],
             text_buttons={
                 browser_masters._CREATE_INVALID_URL_TEXT: _FakeGetByTextLocator([]),
-                "Регион показов": _FakeGetByTextLocator([_FakeTextLocatorHandle()]),
             },
         )
         return page, {

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -4675,6 +4675,21 @@ class TestFillLandingUrl(unittest.TestCase):
 
         self.assertEqual(len(next_clicks), 1)
 
+    def test_does_not_match_suggestion_by_stripping_a_query_trailing_slash(self):
+        """Same risk as the path case, but for a query value ending in "/":
+        ``urlsplit(url).path`` alone is "/" here even though the URL is NOT
+        a bare domain root — the query must also be empty before stripping
+        (Codex review, PR #703 round 2)."""
+        next_clicks = []
+        page = self._page(
+            next_clicks=next_clicks,
+            unrelated_option="https://site.ru/?next=",  # no trailing slash
+        )
+
+        browser_masters._fill_landing_url(page, "https://site.ru/?next=/")
+
+        self.assertEqual(len(next_clicks), 1)
+
     def test_raises_when_url_field_missing(self):
         page = FakePage(locators={})
 

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -4578,6 +4578,7 @@ class TestFillLandingUrl(unittest.TestCase):
         matching_option=None,
         option_clicks=None,
         field_handle=None,
+        unrelated_option=None,
     ):
         url_state = url_state if url_state is not None else {}
         next_clicks = next_clicks if next_clicks is not None else []
@@ -4598,6 +4599,13 @@ class TestFillLandingUrl(unittest.TestCase):
             )
             locators[f'[data-testid="CampaignFormUrl.listBox.{matching_option}"]'] = (
                 _FakeLocator([option_handle])
+            )
+        if unrelated_option:
+            # Confirmed live: a URL with no EXACT suggestion match still
+            # renders the popup (unrelated history) while "Далее" is also
+            # present and enabled — see _fill_landing_url's docstring.
+            locators[f'[data-testid="CampaignFormUrl.listBox.{unrelated_option}"]'] = (
+                _FakeLocator([_FakeLocatorHandle()])
             )
         return FakePage(
             locators=locators,
@@ -4650,6 +4658,22 @@ class TestFillLandingUrl(unittest.TestCase):
         browser_masters._fill_landing_url(page, "https://ksamata.ru/")
 
         self.assertEqual(len(option_clicks), 1)
+
+    def test_does_not_match_suggestion_by_stripping_a_path_trailing_slash(self):
+        """A suggestion for a DIFFERENT path (``/sale`` without the slash)
+        must never be treated as a match for ``/sale/`` — only the bare
+        domain-root case (confirmed live) drops the trailing slash. Matching
+        on path/query would risk launching against an unintended destination
+        (Codex review, PR #703 round 1)."""
+        next_clicks = []
+        page = self._page(
+            next_clicks=next_clicks,
+            unrelated_option="https://site.ru/sale",  # no trailing slash
+        )
+
+        browser_masters._fill_landing_url(page, "https://site.ru/sale/")
+
+        self.assertEqual(len(next_clicks), 1)
 
     def test_raises_when_url_field_missing(self):
         page = FakePage(locators={})


### PR DESCRIPTION
## Summary

Live re-recon (issue #690) against the ksamatadirect account found Yandex replaced step 1's URL field's old always-present "Далее" button flow with a Combobox suggestions popup, breaking `_fill_landing_url`. Full findings recorded in `tests/fixtures/masters_wizard_create.html`.

- **Typing is unreliable**: `Locator.type()` intermittently drops characters from the *middle* of the URL — reproduces even with a 150ms per-key delay. `_type_landing_url` now types with an 80ms delay, reads `textContent` back, and retries (clearing first via the existing `_clear_text_field`) up to 5 times until it matches. `Locator.fill()` does not work as a substitute: it sets the DOM text without dispatching the real input events the widget listens for, so neither the popup nor "Далее" ever react.
- **Two distinct continuations**: a URL matching the account's suggestion history renders a `CampaignFormUrl.listBox.<url>` option and no "Далее" button at all (its data-testid is absent from the DOM) — clicking the matching option (tolerant of Yandex stripping a trailing slash) is enough; Yandex auto-advances to step 2 within ~10s with no button click. A URL with no history match still shows the popup (unrelated history) but also renders an already-enabled "Далее" that needs a real click.
- **`_wait_for_step2`'s marker moved**: "Регион показов" no longer renders anywhere on this account's fully-loaded step 2 (confirmed live — no heading text, no `RegionsTreeEditor`/`RegionsTreeTagGroup` testids). Switched to the first headline slot (`CampaignTitles0.textarea`), the same marker `_wait_for_edit_form` already uses on the edit page. The region picker itself (`_set_region`/`_read_region_tags`) was intentionally left untouched — out of scope for this issue, which is step 1 only.

## Test plan

- [x] `pytest tests/test_masters.py` — 366 passed
- [x] `pytest` (full offline suite) — 2945 passed, 8 skipped, 62 pre-existing `vcr`/`aiohttp` environment errors unrelated to this change (reproduced on a clean checkout before any edits)
- [x] `black --check` / `flake8` clean
- [x] Live re-recon via `direct playwright login` + a headless Playwright script against the real `ksamatadirect` account: both the matching-suggestion path and the fresh-URL path advance to step 2 reliably (repeated runs, no campaign actually launched/drafted)

Closes #690