### PR TITLE
fix(masters): confirm region picker renders on step 2 (#705)

### DIFF
--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -2699,13 +2699,16 @@ def _wait_for_step2(page: "Page") -> None:
     Polls for ``CampaignTitles0.textarea`` (issue #690 re-recon,
     2026-08-04) rather than the "Регион показов" heading this used before:
     live testing found the region picker section (``RegionsTreeEditor`` /
-    "Регион показов") no longer renders on this page at all — its
-    ``data-testid``s and heading text are both completely absent from a
-    fully-loaded step 2 in the account tested. Headlines slot 0 is used
-    instead for the same reason ``_EDIT_FORM_READY_TESTID`` picked it on the
-    edit page: it is the one field guaranteed present and stably
-    identified by ``data-testid`` on every step 2 render (see
-    ``_HEADLINES_SLOT_COUNT``'s docstring).
+    "Регион показов") had not yet rendered at the point that snapshot was
+    taken. Headlines slot 0 is used instead for the same reason
+    ``_EDIT_FORM_READY_TESTID`` picked it on the edit page: it is the one
+    field guaranteed present and stably identified by ``data-testid`` on
+    every step 2 render (see ``_HEADLINES_SLOT_COUNT``'s docstring).
+
+    Issue #705 re-recon, same day: confirmed the region picker section DOES
+    render on this same account shortly after this function returns — it was
+    a render-timing snapshot, not a removed field (see ``_set_region``'s
+    docstring and the fixture's 2026-08-04 region re-recon notes).
     """
     headlines_ready = page.locator(f'[data-testid="{_EDIT_FORM_READY_TESTID}"]')
     if _poll_until(
@@ -3977,6 +3980,17 @@ def _set_region(page: "Page", regions: List[str]) -> None:
     times, and each retry is idempotent by construction — see that
     constant's comment for why an unconditional re-click + re-type would
     make attempts 2..N guaranteed no-ops.
+
+    Issue #705 re-recon, 2026-08-04: live re-testing on the account where
+    #690/#703 found this section apparently missing confirms it renders
+    reliably, and all the testids above are unchanged — the launcher now
+    sits one level deeper (``GroupRegionsHyperlocalInput.Tree`` >
+    ``RegionsTreeEditor`` > ``RegionsTreeEditor.RegionsTreeTagGroup`` >
+    ``RegionsTreeTagGroup``), but every selector this function uses is a
+    bare ``data-testid`` match, not a DOM-depth-sensitive path, so the
+    extra nesting needed no code change. This function's existing
+    retry/actionability-wait already tolerates the section's few-hundred-ms
+    render lag after ``_wait_for_step2`` returns.
     """
     for region in regions:
         # XPath, not a plain data-testid selector: the tree auto-expands
@@ -4356,11 +4370,16 @@ def create_master(
         page, _HEADLINES_TESTID_TEMPLATE, _HEADLINES_SLOT_COUNT, headlines
     )
     _add_repeating_values(page, _TEXTS_TESTID_TEMPLATE, _TEXTS_SLOT_COUNT, texts)
-    # Known-broken on accounts matching the one re-recon'd for #690/#703: the
-    # region picker _set_region needs (RegionsTreeTagGroup.launcher) was
-    # confirmed absent from a fully-loaded step 2 there — see issue #705.
-    # #690 scoped step 1 only, so this is not fixed here; _set_region raises
-    # its own clear BrowserSessionError when the launcher can't be found.
+    # Issue #705 re-recon, 2026-08-04: on the account where #690/#703's
+    # re-recon found the "Регион показов" section (and its heading/testids)
+    # completely absent from a fully-loaded step 2, that turned out to be a
+    # snapshot taken mid-render, not a permanently removed field — live
+    # re-testing confirms the section (RegionsTreeEditor/RegionsTreeTagGroup,
+    # nested one level deeper under GroupRegionsHyperlocalInput.Tree) renders
+    # reliably shortly after _wait_for_step2 returns, and _set_region's
+    # existing launcher-click already tolerates that short race (Playwright's
+    # default actionability wait covers the ~0.4s gap observed live). No
+    # markup change was needed.
     _set_region(page, regions)
     if weekly_budget is not None:
         _set_weekly_budget_on_create(page, weekly_budget)

--- a/tests/fixtures/masters_wizard_create.html
+++ b/tests/fixtures/masters_wizard_create.html
@@ -182,6 +182,53 @@ this campaign type is NOT resolved by this pass — _set_region/_read_region_tag
 were not touched and are out of scope for issue #690, which is step 1 only.
 
 =====================================================================
+RE-RECON, 2026-08-04 (issue #705): region picker DOES render — was a
+render-timing snapshot, not a removed field
+=====================================================================
+
+Follow-up live re-recon (same ksamatadirect account, headless Playwright via
+a saved `direct playwright login` session, read-only — step 1 filled with
+https://ksamata.ru/, step 2 reached via _wait_for_step2, NO launch/save
+click) found the "Регион показов" section renders normally shortly after
+_wait_for_step2 returns:
+
+- The heading text "Регион показов" IS present (label text observed:
+  "Страны, области, города" directly on the FormField, "Регион показов" as
+  the outer section heading per the full-page screenshot).
+- All of _set_region/_read_region_tags's existing data-testid selectors are
+  UNCHANGED and confirmed working end-to-end (opened the tree via
+  RegionsTreeTagGroup.launcher, typed into RegionsTreeTagGroup.editor,
+  selected "Москва" via RegionsTreeNode.Checkbox.label exact match, read it
+  back from RegionsTreeTagGroup.tags-wrapper) — ran _set_region(page,
+  ["Москва"]) directly with no code changes and it succeeded on the first
+  attempt across 3 repeated runs.
+- Structural nesting changed one level: the launcher/tree now sits inside a
+  NEW wrapper, GroupRegionsHyperlocalInput.Tree (sibling of
+  GroupRegionsHyperlocalInput.link, "Указать регион на карте" — an
+  alternate map-based entry point, not explored) > RegionsTreeEditor >
+  RegionsTreeEditor.RegionsTreeTagGroup > RegionsTreeTagGroup. None of
+  _set_region's selectors are DOM-depth-sensitive (all are bare
+  data-testid attribute matches), so this extra nesting required no code
+  change.
+- The section takes a small but nonzero moment to render after
+  _wait_for_step2 (which now polls CampaignTitles0.textarea, per the #690
+  re-recon above) returns — observed ~0.4s in one direct measurement,
+  launcher count() was 0 immediately after _wait_for_step2 and appeared
+  within that window. _set_region's launcher.click() already tolerates
+  this via Playwright's default actionability wait (up to 30s), and in
+  create_master's real call sequence the two _add_repeating_values calls
+  for headlines/texts run first and consume more than enough time for the
+  section to be fully rendered by the time _set_region is reached.
+
+Conclusion: issue #705's original symptom (RegionsTreeTagGroup.launcher
+confirmed absent from a "fully-loaded" step 2) was captured on a page that
+had not actually finished rendering everything yet — likely because that
+recon pass's step 2 wait was based on the pre-#703 "Регион показов" heading
+marker itself, which cannot detect its own section's absence versus a
+timing gap. No code change to _set_region/_read_region_tags was needed;
+the section is confirmed reliably present and functional as-is.
+
+=====================================================================
 Step 2: full field inventory ("Конверсии и трафик" type)
 =====================================================================
 


### PR DESCRIPTION
## Summary

Live re-recon (issue #705) against the ksamatadirect account, headless Playwright via a saved `direct playwright login` session, read-only (no launch/save click), found `_set_region`/`_read_region_tags` already work correctly against the current step 2 markup — no code change needed.

- All existing selectors (`RegionsTreeTagGroup.launcher`/`.editor`/`.tags-wrapper`, `RegionsTreeNode.Checkbox.label`/`.input`) are unchanged. The section is nested one level deeper under a new `GroupRegionsHyperlocalInput.Tree` wrapper, but every selector `_set_region` uses is a bare `data-testid` match, not DOM-depth-sensitive, so that extra nesting needed no code change.
- #705's original symptom — `RegionsTreeTagGroup.launcher` confirmed absent from a "fully-loaded" step 2 — turned out to be a render-timing snapshot, not a removed field: the region section renders shortly (~0.4s observed) after `_wait_for_step2` returns. `_set_region`'s `launcher.click()` already tolerates that gap via Playwright's default actionability wait.
- Confirmed live with 3 repeated direct calls to `_set_region(page, ["Москва"])` immediately after `_wait_for_step2` (no extra delay, no headline/text fill first) — all succeeded on the first attempt, `_read_region_tags` correctly read back `['Москва']` each time.

Updates docstrings/comments in `direct_cli/browser/masters.py` that called the region picker "known-broken" (from #705's filing, based on the #690/#703 recon snapshot), and records the re-recon findings + updated nesting structure in `tests/fixtures/masters_wizard_create.html`.

## Test plan

- [x] `pytest tests/test_masters.py` — 399 passed
- [x] `black --check` / `flake8` clean on changed files (pre-existing unrelated findings elsewhere in the repo, not touched by this PR)
- [x] Live re-recon via `direct playwright login` + a headless Playwright script against the real `ksamatadirect` account: reached step 2, called `_set_region`/`_read_region_tags` directly 3x, all succeeded — no campaign actually launched or drafted

Closes #705