### PR TITLE
fix(masters): retry _verify_saved field reads against hydration race

### DIFF
--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -717,6 +717,17 @@ _GOAL_PRICE_INPUT_TESTID = '[data-testid="CampaignTargetSelect.PriceInput"]'
 # succeed server-side.
 _GOAL_PRICE_WAIT_TIMEOUT_MS = 5_000
 
+# How long _verify_saved's _read_until_matches retries a field reader before
+# trusting its value (issue #706 live testing): _wait_for_edit_form only
+# polls the first HEADLINE slot, near the top of the page — the weekly-
+# budget input, "Директ помогает" checkbox, "Цель продвижения" dropdown, and
+# name header all sit elsewhere on the same form and can still be hydrating
+# (still showing the PRE-reload value) once that wait returns, the same race
+# _GOAL_PRICE_WAIT_TIMEOUT_MS was added for. A one-shot read of any of them
+# right after _wait_for_edit_form can misreport a save that DID succeed
+# server-side as a mismatch.
+_VERIFY_FIELD_READ_TIMEOUT_MS = 5_000
+
 _EDIT_NAME_BUTTON_SELECTOR = '[data-testid="CampaignHeader.EditName.Button"]'
 _NAME_HEADER_SELECTOR = '[data-testid="CampaignHeader.TitleName"]'
 _NAME_MODAL_INPUT_SELECTOR = '[data-testid="ModalEditTitle.CampaignName"]'
@@ -1902,6 +1913,35 @@ def _verify_repeating_value_mismatches(
     return mismatches
 
 
+def _read_until_matches(
+    page: "Page",
+    reader: "Callable[[Page], Any]",
+    expected: Any,
+    *,
+    timeout_ms: int = _VERIFY_FIELD_READ_TIMEOUT_MS,
+) -> Any:
+    """Retry ``reader(page)`` until it returns ``expected`` or ``timeout_ms`` elapses.
+
+    ``_wait_for_edit_form`` only guarantees the first headline slot has
+    rendered — a one-shot call to ``_read_weekly_budget``/
+    ``_read_directs_helps``/``_read_promotion_goal_label``/
+    ``_read_campaign_name`` right after it can catch that field still
+    showing its pre-reload value while the rest of the form is still
+    hydrating (issue #706, same race ``_read_goal_price`` was hardened
+    against in issue #696). Returns the LAST value read — on a genuine
+    mismatch (Yandex actually rejected the save) that is the settled,
+    correct-but-wrong value, so ``_verify_saved`` still reports it
+    accurately once the retries are exhausted.
+    """
+    last: Any = None
+    deadline = time.monotonic() + timeout_ms / 1000
+    while True:
+        last = reader(page)
+        if last == expected or time.monotonic() >= deadline:
+            return last
+        page.wait_for_timeout(250)
+
+
 def _verify_saved(
     page: "Page",
     campaign_id: int,
@@ -1950,7 +1990,7 @@ def _verify_saved(
     for label, expected, reader in checks:
         if expected is None:
             continue
-        actual = reader(page)
+        actual = _read_until_matches(page, reader, expected)
         if actual != expected:
             mismatches.append(
                 f"{label}: expected {expected!r}, page now shows {actual!r}"

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -3436,6 +3436,53 @@ class TestUpdateMaster(unittest.TestCase):
             browser_masters.update_master(page, 42, goal_price=500)
         self.assertIn("did not save as requested", str(ctx.exception))
 
+    def test_verify_saved_survives_delayed_weekly_budget_hydration(self):
+        # Issue #706: _wait_for_edit_form's poll only waits for the FIRST
+        # HEADLINE slot (_EDIT_FORM_READY_TESTID) to appear — a different,
+        # earlier-in-the-DOM section than the weekly-budget input further
+        # down the page. _read_weekly_budget reads input_value() exactly
+        # once, right after that wait returns, with no poll/retry of its
+        # own (unlike _read_goal_price, which was already hardened for this
+        # in issue #696 via wait_for(state="visible")). Models the budget
+        # input's value still showing the PRE-save figure for one tick after
+        # the reload, settling to the actually-saved value only afterwards
+        # — the same class of hydration race #700 fixed for
+        # _is_draft_overview_page, just on a different field.
+        ticks = {"count": 0}
+        budget_state = {"value": "95000"}
+
+        def _get_budget_value():
+            if ticks["count"] < 1:
+                return "80000"  # stale pre-save snapshot
+            return budget_state["value"]
+
+        budget_handle = _FakeLocatorHandle(
+            on_fill=lambda v: budget_state.__setitem__("value", v),
+            get_value=_get_budget_value,
+        )
+        save_handle = _FakeTextLocatorHandle(visible=True)
+        edit_form_ready_selector = (
+            f'[data-testid="{browser_masters._EDIT_FORM_READY_TESTID}"]'
+        )
+
+        class _DelayedBudgetPage(FakePage):
+            def wait_for_timeout(self, timeout):
+                ticks["count"] += 1
+
+        page = _DelayedBudgetPage(
+            locators={
+                browser_masters._WEEKLY_BUDGET_INPUT_XPATH: _FakeLocator(
+                    [budget_handle]
+                ),
+                edit_form_ready_selector: _FakeLocator([_FakeLocatorHandle()]),
+            },
+            role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
+        )
+
+        result = browser_masters.update_master(page, 42, weekly_budget=95000)
+
+        self.assertEqual(result, {"CampaignId": 42, "WeeklyBudget": 95000})
+
     def test_updates_multiple_fields_in_one_call(self):
         budget_state = {}
         checkbox_state = {"checked": False}
@@ -3624,8 +3671,21 @@ class TestUpdateMaster(unittest.TestCase):
                 "Цель продвижения\nМаксимум целевых действий",
             ]
         )
+        # _read_until_matches (issue #706) retries the reader until it
+        # settles or times out — the fake models a real page's stable value
+        # by repeating the LAST scripted line once the iterator is
+        # exhausted, instead of raising StopIteration on a second read.
+        import contextlib
+
+        last_text = {"value": None}
+
+        def _next_trigger_text():
+            with contextlib.suppress(StopIteration):
+                last_text["value"] = next(trigger_texts)
+            return last_text["value"]
+
         trigger = _FakeLocatorHandle(text="Цель продвижения")
-        trigger.inner_text = lambda: next(trigger_texts)
+        trigger.inner_text = _next_trigger_text
         save_handle = _FakeTextLocatorHandle(visible=True)
         edit_form_ready_selector = (
             f'[data-testid="{browser_masters._EDIT_FORM_READY_TESTID}"]'


### PR DESCRIPTION
## Summary

Issue #706 asked for an audit of `direct_cli/browser/masters.py`/`session.py` for the same hydration-race class fixed in PR #700's `_is_draft_overview_page`: a snapshot read (`.count()`/`.inner_text()`/`.input_value()`) taken right after `page.goto(..., wait_until="domcontentloaded"/"commit")`, without polling for the specific node's actual settled text/value.

**Audit result (every `_is_*_page`/`_read_*`/`_wait_for_*` helper checked):**

- `session.py` — already fully hardened (issue #692's `_wait_for_marker`).
- `_is_draft_overview_page`, `_is_draft_edit_page` — presence-only checks of structural markers (button either exists or doesn't); correct as-is, same rationale as their own docstrings.
- `_wait_for_create_step1`/`_wait_for_step2`/`_wait_for_images_editor`/`_wait_for_edit_form` — existence-barriers, correct pattern already used throughout.
- `_read_repeating_values`, `_read_image_content_ids`, `_read_modal_selected_thumb_urls`, `_read_testid_suffixes` — read structural lists/attributes in the SAME DOM section their barrier already polls; safe.
- `_read_goal_price` — already hardened in issue #696 via `wait_for(state="visible")`.
- **Found:** `_read_weekly_budget`, `_read_directs_helps`, `_read_promotion_goal_label`, `_read_campaign_name` — called from `_verify_saved` immediately after `_wait_for_edit_form`, which only polls the FIRST HEADLINE slot (`_EDIT_FORM_READY_TESTID`), a different, earlier-rendering section of the form than these four fields. Each did a **one-shot** `.input_value()`/`.is_checked()`/`.inner_text()` read with no retry — exactly the bug class #700 fixed, just on different fields. The module's own comment near `_GOAL_PRICE_WAIT_TIMEOUT_MS` already flagged this risk for the goal-price field but the fix wasn't applied to its three siblings.

**Fix:** added `_read_until_matches(page, reader, expected, timeout_ms=_VERIFY_FIELD_READ_TIMEOUT_MS)` — retries a reader against its expected value (same `_poll_until` tick cadence) before `_verify_saved` treats a mismatch as a real save failure. A genuine mismatch (Yandex actually rejected the value) still surfaces correctly once retries are exhausted, since the last read value is returned either way.

**Reproduced offline** (`test_verify_saved_survives_delayed_weekly_budget_hydration`, same style as #700/#685's slow-render regression tests): models the weekly-budget input's `input_value()` returning the stale pre-save figure for one tick, settling to the actually-saved value after — fails on `main`, passes with this fix.

`_read_region_tags` was also examined but is dead code (never called) — left untouched, out of scope.

## Test plan

- [x] New regression test fails against pre-fix code, passes after the fix
- [x] `pytest tests/test_masters.py -q` — 400 passed
- [x] `pytest -q` (full offline suite) — passed
- [x] `black`/`flake8` clean on changed files

Closes #706

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLfhwtDVhET3jiwpjBUi1d