### PR TITLE
docs(agents): allow N-level command paths in CLI contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,16 +15,18 @@ The current CLI convention is defined as follows.
 The canonical command shape is:
 
 ```bash
-direct <group> <command> [flags]
+direct <group> [<group> ...] <command> [flags]
 ```
+
+A command is a path of one or more group segments followed by a leaf command name. Most commands use a single group segment; nested groups are allowed and already shipped (`direct masters adimages get|add|delete|set`). Every group segment in the path is validated with the same `group` rule below; the leaf is validated with the `command` rule.
 
 Naming rules:
 
-- `group`:
+- `group` (each segment in the path):
   - lowercase ASCII only
   - no underscores
   - multiword groups are concatenated
-  - examples: `dynamicads`, `smartadtargets`, `negativekeywordsharedsets`
+  - examples: `dynamicads`, `smartadtargets`, `negativekeywordsharedsets`, `masters adimages`
 
 - `command`:
   - lowercase only
@@ -110,6 +112,7 @@ direct keywordsresearch has-search-volume --keywords "buy laptop,buy desktop"
 direct smartadtargets update --id 456 --priority HIGH
 direct dynamicads set-bids --id 789 --bid 12.5
 direct dictionaries get-geo-regions --region-ids 225 --fields GeoRegionId,GeoRegionName
+direct masters adimages get 123
 ```
 
 Invalid examples:


### PR DESCRIPTION
## Summary
- AGENTS.md described the canonical CLI shape as exactly `direct <group> <command>`, which is stale: PR #674 made three command-tree walkers recursive specifically to support nested groups, and PR #675-#677 shipped `masters adimages get|add|delete|set` as a real three-level leaf.
- The stale wording already produced a false P1 from a review bot on PR #675, citing AGENTS.md L15-19 as evidence that the new nested group broke the contract (triaged and rejected there, but the underlying wording remained misleading for future reviewers).
- Reworded the contract to describe a path of one or more group segments plus a leaf command name, each segment validated by the same `group`/`command` rules (`tests/test_cli_contract.py`'s `GROUP_NAME_RE`/`COMMAND_NAME_RE` only ever validated segment names, never tree depth), and added `direct masters adimages get 123` as a documented example of the existing pattern.

## Test plan
- [x] `pytest tests/test_cli_contract.py tests/test_smoke_matrix.py -q` — 29 passed
- [x] `python -m direct_cli.cli masters adimages get --help` — confirmed the example command's real signature (positional `CAMPAIGN_ID`, no `--wizard-id` flag)

Closes #680

🤖 Generated with [Claude Code](https://claude.com/claude-code)