### PR TITLE
fix(dictionaries): honor --locale for get-geo-regions (#658)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,26 @@
 - Part of #681/#648 (Этап C, target actions/CPA sub-item), split out as
   #707.
 
+**Fixed — `dictionaries get-geo-regions` ignored `--locale`, always returned English names (#658):**
+
+- `GeoRegionName`/`ParentGeoRegionNames` always came back in English regardless
+  of `--locale ru`/`en`, unlike the Direct web UI (including the Мастер
+  кампаний region widget), which shows Russian names by default.
+- The v5 API adapter already supports an `Accept-Language` header
+  (`language` client param, same mechanism `reports get --language` uses) —
+  `dictionaries get-geo-regions` (`direct_cli/commands/dictionaries.py`) just
+  never set it. It now builds its client with
+  `language=resolve_locale(ctx)`, so the resolved `--locale` (CLI flag >
+  `YANDEX_DIRECT_CLI_LOCALE` env var > `ru` default) reaches the API as
+  `Accept-Language`.
+- Live-verified against the production API: `--locale ru` now returns
+  "Москва"/"Москва и область"/"Россия" for region IDs 213/1/225; `--locale en`
+  still returns "Moscow"/"Moscow and Moscow Oblast"/"Russia"; the no-flag
+  default now also returns Russian names, matching the CLI's documented `ru`
+  default (previously always English regardless of default).
+- `dictionaries get` (the generic multi-dictionary command) is unaffected —
+  only `get-geo-regions` builds its own client with the resolved locale.
+
 **Fixed — `masters get`/`archive`/`suspend`/`resume` on `DRAFT` campaigns (#660):**
 
 - A `DRAFT` Мастер кампаний's overview page (`WIZARD_OVERVIEW_URL` itself, no

--- a/direct_cli/commands/dictionaries.py
+++ b/direct_cli/commands/dictionaries.py
@@ -5,6 +5,7 @@ Dictionaries commands
 import click
 
 from ..api import client_from_ctx, create_client
+from ..i18n import resolve_locale
 from ..output import format_output, handle_api_errors
 from ..utils import parse_csv_strings, parse_ids, reference_output_options
 
@@ -60,7 +61,12 @@ def get(ctx, names, output_format, output):
 @handle_api_errors
 def get_geo_regions(ctx, name, region_ids, exact_names, fields, output_format, output):
     """Get GeoRegions dictionary entries"""
-    client = client_from_ctx(ctx, create_client)
+    client = create_client(
+        token=ctx.obj.get("token"),
+        login=ctx.obj.get("login"),
+        sandbox=ctx.obj.get("sandbox"),
+        language=resolve_locale(ctx),
+    )
 
     params = {"FieldNames": parse_csv_strings(fields)}
     selection_criteria = {}

--- a/tests/test_low_coverage_payloads.py
+++ b/tests/test_low_coverage_payloads.py
@@ -244,6 +244,63 @@ def test_b2b_dictionaries_get_drops_empty_names():
     assert body["params"]["DictionaryNames"] == ["Currencies", "GeoRegions"]
 
 
+def test_dictionaries_get_geo_regions_passes_locale_as_language():
+    """#658: --locale must reach getGeoRegions as Accept-Language."""
+    service = Mock()
+    service.post.return_value = FakeResponse()
+    client = Mock()
+    client.dictionaries.return_value = service
+
+    with patch("direct_cli.cli.get_active_profile", return_value=None):
+        with patch(
+            "direct_cli.commands.dictionaries.create_client", return_value=client
+        ) as mock_create_client:
+            result = CliRunner().invoke(
+                cli,
+                [
+                    "--locale",
+                    "ru",
+                    "dictionaries",
+                    "get-geo-regions",
+                    "--region-ids",
+                    "213",
+                    "--fields",
+                    "GeoRegionId,GeoRegionName",
+                ],
+            )
+
+    assert result.exit_code == 0, result.output
+    assert mock_create_client.call_args.kwargs["language"] == "ru"
+
+
+def test_dictionaries_get_geo_regions_defaults_locale_to_ru():
+    """No --locale still resolves to the CLI's ru default, not None."""
+    service = Mock()
+    service.post.return_value = FakeResponse()
+    client = Mock()
+    client.dictionaries.return_value = service
+
+    with patch("direct_cli.cli.get_active_profile", return_value=None):
+        with patch(
+            "direct_cli.commands.dictionaries.create_client", return_value=client
+        ) as mock_create_client:
+            result = CliRunner().invoke(
+                cli,
+                [
+                    "dictionaries",
+                    "get-geo-regions",
+                    "--region-ids",
+                    "213",
+                    "--fields",
+                    "GeoRegionId,GeoRegionName",
+                ],
+                env={"YANDEX_DIRECT_CLI_LOCALE": ""},
+            )
+
+    assert result.exit_code == 0, result.output
+    assert mock_create_client.call_args.kwargs["language"] == "ru"
+
+
 def test_strategies_add_typed_fields_payload():
     body = _dry_run(
         "strategies",


### PR DESCRIPTION
## Summary
- `dictionaries get-geo-regions` ignored `--locale` and always returned `GeoRegionName`/`ParentGeoRegionNames` in English, unlike the Direct web UI which shows Russian names.
- The v5 API adapter already supports `Accept-Language` via the client's `language` param (same mechanism `reports get --language` uses) — `get-geo-regions` just never set it.
- Now builds its own client with `language=resolve_locale(ctx)`, so the resolved `--locale` (CLI flag > `YANDEX_DIRECT_CLI_LOCALE` env var > `ru` default) reaches the API as `Accept-Language`.
- `dictionaries get` (generic multi-dictionary command) is unaffected.

## Live verification
Ran against production (read-only) for region IDs 213/1/225:
- `--locale ru` → "Москва" / "Москва и область" / "Россия"
- `--locale en` → "Moscow" / "Moscow and Moscow Oblast" / "Russia"
- no `--locale` flag → "Москва" (now correctly matches the CLI's documented `ru` default; previously always English)

## Test plan
- [x] `pytest tests/test_low_coverage_payloads.py -k "dictionaries or geo_regions"` — 4 passed, including 2 new tests asserting `Accept-Language`/`language` is resolved from `--locale`
- [x] `pytest` full offline suite — no new failures (2 pre-existing failures in `test_masters.py` and 62 pre-existing errors in cassette/integration-write tests unrelated to this change, confirmed via `git stash`)
- [x] `black`/`flake8` clean on changed files
- [x] Live read-only API call confirms the fix

Closes #658

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFwC1jkU4tJTqMsqtCBTBm