### PR TITLE
fix(masters): replace stat-tile stabilization guess with real DOM marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,24 @@
 - `dictionaries get` (the generic multi-dictionary command) is unaffected —
   only `get-geo-regions` builds its own client with the resolved locale.
 
+**Fixed — `masters get`'s stat-tile extraction used a tick-stabilization guess instead of a real render marker (#708):**
+
+- `_extract_stat_tiles` (`direct_cli/browser/masters.py`) previously scanned
+  every button on the overview page for a 2-line "value\nlabel" shape and
+  waited for that found set to stay unchanged for several consecutive poll
+  ticks before trusting it as final (issue #697's stopgap) — a heuristic
+  that structurally could not distinguish "this campaign genuinely has
+  fewer than 5 tiles" from "the tiles just haven't started rendering yet".
+- Live recon (12 runs across 9 distinct ACTIVE campaigns in one account)
+  found a real DOM marker: each tile carries a stable
+  `data-testid="ChartSummary.<key>"` (`shows`/`clicks`/`conversions`/`cpa`/
+  `cost`), and all five render atomically in a single React commit — the
+  first poll tick that observes any `ChartSummary.*` node always already
+  has all five. `_extract_stat_tiles` now waits for that marker directly
+  (mirroring `_OVERVIEW_TITLE_SELECTOR`'s convention) and reads the fixed
+  testid set, instead of guessing with a tick count. No behavior change for
+  the CLI's `Stats` output shape.
+
 **Fixed — `masters get`/`archive`/`suspend`/`resume` on `DRAFT` campaigns (#660):**
 
 - A `DRAFT` Мастер кампаний's overview page (`WIZARD_OVERVIEW_URL` itself, no

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -294,15 +294,33 @@ STATUS_FILTERS = {
 # (fetch_master's status-text parser already produces "SUSPENDED"/"ACTIVE").
 _PRIMARY_STATUS_TO_CLI_STATUS = {"STOPPED": "SUSPENDED"}
 
-# Fixed order of the overview page's stat tiles, confirmed live (see fixture).
-_STAT_TILE_LABELS = {
-    "Показа": "impressions",
-    "Показов": "impressions",
-    "Кликов": "clicks",
-    "Конверсии": "conversions",
-    "Конверсий": "conversions",
-    "За конверсию": "cost_per_conversion",
-    "Расход": "cost",
+# Stat-tiles section render marker (issue #708, live recon 2026-08-04 against
+# 12 live ACTIVE campaigns in one account — see _extract_stat_tiles). Each
+# tile carries a stable ``data-testid`` of ``ChartSummary.<key>`` (confirmed
+# live: shows/clicks/conversions/cpa/cost — see _STAT_TILE_TESTID_KEYS)
+# inside the same ``ChartSummary`` chart-container the overview
+# page always renders. Unlike the previous text-based button scan, this
+# needs no label/whitespace normalisation and no consecutive-stable-tick
+# heuristic: live recon (12/12 runs, 9 distinct campaigns, 50ms poll
+# granularity) found the DOM has NO partial state at all — the section
+# renders zero ``ChartSummary.*`` nodes, then all five atomically in the
+# same React commit (first-observed-with-any-tile-present == first-observed-
+# with-all-five-present in every run). Network capture of the same loads
+# confirmed why: the tiles are driven by a single
+# ``GET /wizard/web-api/aggregate?...`` XHR whose response arrives ~1-2ms
+# before the DOM update, not a piecemeal per-tile render — so unlike
+# _wait_for_images_editor's stub/ghost render passes, there is no
+# loading-skeleton state to distinguish from "genuinely fewer tiles" here,
+# because live data never showed fewer than 5. This resolves #708's
+# open question for the confirmed-live shape: wait for the marker, don't
+# guess with a tick count.
+_STAT_TILE_TESTID_PREFIX = "ChartSummary."
+_STAT_TILE_TESTID_KEYS = {
+    "shows": "impressions",
+    "clicks": "clicks",
+    "conversions": "conversions",
+    "cpa": "cost_per_conversion",
+    "cost": "cost",
 }
 
 # Overview-page action button text for resume/suspend (see module docstring:
@@ -331,36 +349,22 @@ _OVERVIEW_TITLE_SELECTOR = '[data-testid="CampaignHeader.Title"]'
 # tree paints anything at all.
 _OVERVIEW_LOAD_TIMEOUT_MS = 30_000
 
-# How long _extract_stat_tiles retries after the title has rendered but
-# before the stat tiles themselves have (issue #683). Confirmed live
-# (campaign 72349978, headless): the title (`_OVERVIEW_TITLE_SELECTOR`) is
-# present well before the stat tile buttons finish rendering — a single
-# post-title read intermittently found 0 of them despite the campaign
-# genuinely having 5. As slow as _OVERVIEW_LOAD_TIMEOUT_MS itself: live
-# headless recon measured the tiles finishing their OWN render up to ~15s
-# after the title, not the sub-second gap a headful/extension browser
-# showed — these are two independent SPA render passes, not one paint.
+# How long _extract_stat_tiles waits for _STAT_TILE_TESTID_PREFIX's marker
+# after the title has rendered but before the stat tiles themselves have
+# (issue #683). Confirmed live (campaign 72349978, headless): the title
+# (`_OVERVIEW_TITLE_SELECTOR`) is present well before the stat tiles finish
+# rendering — a single post-title read intermittently found 0 of them
+# despite the campaign genuinely having 5. As slow as
+# _OVERVIEW_LOAD_TIMEOUT_MS itself: live headless recon measured the tiles
+# finishing their OWN render up to ~15s after the title, not the sub-second
+# gap a headful/extension browser showed — these are two independent SPA
+# render passes, not one paint. #708's follow-up recon found the real
+# marker (see _STAT_TILE_TESTID_PREFIX) so this timeout now gates a single
+# explicit wait instead of a tick-stabilization heuristic, but the same
+# generous budget still applies since the underlying render latency is
+# unchanged.
 _STAT_TILES_TIMEOUT_MS = 30_000
 
-# How many CONSECUTIVE poll ticks the found stat-tile key set must stay
-# unchanged before _extract_stat_tiles treats it as final (cycle-review
-# #697 finding, Codex): a single unchanged tick is indistinguishable from
-# "the page just hasn't started rendering tiles yet" -- at _poll_until's
-# default 250ms tick, one quiet tick is only 250ms of evidence against a
-# render this file itself documents as taking up to ~15s. 8 consecutive
-# ticks (~2s of continuous silence at the default tick rate) is comfortably
-# below that real-world render time while still returning well short of
-# the full timeout for a campaign that genuinely never renders more tiles.
-#
-# KNOWN ACCEPTED TRADE-OFF (tracked in #708): no finite tick count can
-# fully close the race between "campaign genuinely has fewer tiles" and
-# "tiles just haven't rendered yet" without a real DOM settled/loading
-# marker for the stat-tiles section, which does not exist in this code
-# (unlike _OVERVIEW_TITLE_SELECTOR for the header, #683, or
-# _wait_for_images_editor's section marker, #670). This value fixes the
-# confirmed-live #683 scenario and narrows the window versus a 1-tick
-# check; it does not eliminate it. See #708 for finding a real marker.
-_STAT_TILES_STABLE_TICKS = 8
 
 # How long to wait, after launch_master's click already redirected away from
 # /edit/, for the overview page's own status text to report MODERATION
@@ -1279,72 +1283,38 @@ def _extract_landing_url(page: "Page", result: Dict[str, Any]) -> None:
 
 
 def _extract_stat_tiles(page: "Page", result: Dict[str, Any]) -> None:
-    # Stat tiles render near the top of the page, well before the dozens of
-    # nav/tab/edit buttons further down — stop as soon as every known label
-    # is found instead of walking every button on the page.
-    #
-    # Confirmed live 2026-08-03 (issue #683, campaign 72349978): the tiles
-    # render AFTER _OVERVIEW_TITLE_SELECTOR (which _goto_overview_page
-    # already waited for) — a single read right after that wait
-    # intermittently found 0 tiles for a campaign that demonstrably has 5.
-    # Retries for a short bounded window rather than reading once, mirroring
-    # _wait_for_images_editor's "outer container present, content not yet
-    # settled" guard (#670) applied to this page's own two-stage render.
-    #
-    # Stops as soon as the found set STABILIZES for _STAT_TILES_STABLE_TICKS
-    # consecutive ticks (unchanged from tick to tick), not only when every
-    # known key is found (cycle-review #697 finding): a campaign that
-    # genuinely has fewer than 5 tiles -- DRAFT with no stats dashboard, or
-    # Yandex simply not rendering a metric -- would otherwise always burn
-    # the full _STAT_TILES_TIMEOUT_MS waiting for keys that will never
-    # appear. Live-measured: a single-tile fixture took the full 30s under
-    # the old all-keys-required condition.
-    #
-    # Requires SEVERAL consecutive stable ticks, not just one (cycle-review
-    # #697 re-review finding, Codex): a single unchanged tick is only
-    # ~250ms of evidence -- indistinguishable from "the page hasn't started
-    # rendering tiles yet" on a render this file itself documents as taking
-    # up to ~15s. A reproduction confirmed a naive one-tick check returns
-    # an empty/partial result after the very first poll, before the real
-    # tiles have had any chance to render at all.
-    wanted_keys = set(_STAT_TILE_LABELS.values())
+    # Confirmed live 2026-08-04 (issue #708, 12 runs across 9 distinct ACTIVE
+    # campaigns): the stat tiles carry a stable ``data-testid`` of
+    # ``ChartSummary.<key>`` (see _STAT_TILE_TESTID_KEYS) and render
+    # atomically — the first poll tick that observes ANY ChartSummary.* node
+    # always already has all five. There is therefore a real settled marker
+    # here (unlike the previous text-based button scan this replaced, which
+    # needed a consecutive-stable-tick heuristic to guess when rendering had
+    # finished — see #683/#697 history in git blame): wait for the marker's
+    # first appearance, then read the fixed testid set directly, no scanning
+    # every button on the page and no label/whitespace matching required.
+    _poll_until(
+        page,
+        lambda: page.locator(f'[data-testid^="{_STAT_TILE_TESTID_PREFIX}"]').count()
+        > 0,
+        _STAT_TILES_TIMEOUT_MS,
+    )
+
     stats: Dict[str, str] = {}
-    previous_keys: Optional[frozenset] = None
-    stable_ticks = 0
-
-    def _scan() -> bool:
-        nonlocal previous_keys, stable_ticks
-        buttons = page.locator("button")
-        count = buttons.count()
+    try:
+        tiles = page.locator(f'[data-testid^="{_STAT_TILE_TESTID_PREFIX}"]')
+        count = tiles.count()
         for i in range(count):
-            if stats.keys() >= wanted_keys:
-                break
-            try:
-                text = buttons.nth(i).inner_text().strip()
-            except PlaywrightError:
+            testid = tiles.nth(i).get_attribute("data-testid") or ""
+            suffix = testid[len(_STAT_TILE_TESTID_PREFIX) :]
+            key = _STAT_TILE_TESTID_KEYS.get(suffix)
+            if not key:
                 continue
-            lines = [line.strip() for line in text.splitlines() if line.strip()]
-            if len(lines) != 2:
-                continue
-            value, label = lines
-            # Confirmed live 2026-08-03 (campaign 72349978): "За конверсию"
-            # renders with a non-breaking space (U+00A0) between the words,
-            # not a plain one — normalise before the lookup so
-            # _STAT_TILE_LABELS' plain-space keys still match.
-            key = _STAT_TILE_LABELS.get(label.replace("\xa0", " "))
-            if key and key not in stats:
+            value = tiles.nth(i).inner_text().strip()
+            if value:
                 stats[key] = value
-        if stats.keys() >= wanted_keys:
-            return True
-        current_keys = frozenset(stats.keys())
-        if current_keys == previous_keys:
-            stable_ticks += 1
-        else:
-            stable_ticks = 0
-        previous_keys = current_keys
-        return stable_ticks >= _STAT_TILES_STABLE_TICKS
-
-    _poll_until(page, _scan, _STAT_TILES_TIMEOUT_MS)
+    except PlaywrightError:
+        pass
 
     if stats:
         result["Stats"] = stats

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -1804,6 +1804,10 @@ class TestFetchMastersList(unittest.TestCase):
 class TestFetchMaster(unittest.TestCase):
     """Overview-page parsing: title, status, landing URL, stat tiles."""
 
+    _STAT_TILES_SELECTOR = (
+        f'[data-testid^="{browser_masters._STAT_TILE_TESTID_PREFIX}"]'
+    )
+
     def _page_for(self, title="Мастер Тест", status_text="Кампания остановлена"):
         return FakePage(
             locators={
@@ -1822,16 +1826,28 @@ class TestFetchMaster(unittest.TestCase):
                         )
                     ]
                 ),
-                "button": _FakeLocator(
+                self._STAT_TILES_SELECTOR: _FakeLocator(
                     [
-                        _FakeLocatorHandle(text="281 722\nПоказа"),
-                        _FakeLocatorHandle(text="2 529\nКликов"),
-                        _FakeLocatorHandle(text="83\nКонверсии"),
-                        _FakeLocatorHandle(text="272,45 ₽\nЗа конверсию"),
-                        _FakeLocatorHandle(text="22 613,58 ₽\nРасход"),
                         _FakeLocatorHandle(
-                            text="Возобновить кампанию"
-                        ),  # noise: ignored
+                            text="281 722",
+                            attrs={"data-testid": "ChartSummary.shows"},
+                        ),
+                        _FakeLocatorHandle(
+                            text="2 529",
+                            attrs={"data-testid": "ChartSummary.clicks"},
+                        ),
+                        _FakeLocatorHandle(
+                            text="83",
+                            attrs={"data-testid": "ChartSummary.conversions"},
+                        ),
+                        _FakeLocatorHandle(
+                            text="272,45 ₽",
+                            attrs={"data-testid": "ChartSummary.cpa"},
+                        ),
+                        _FakeLocatorHandle(
+                            text="22 613,58 ₽",
+                            attrs={"data-testid": "ChartSummary.cost"},
+                        ),
                     ]
                 ),
             },
@@ -1866,158 +1882,82 @@ class TestFetchMaster(unittest.TestCase):
         result = browser_masters.fetch_master(page, 1)
         self.assertEqual(result["Status"], "ACTIVE")
 
-    def test_stat_label_with_non_breaking_space_still_matches(self):
-        # Confirmed live 2026-08-03 (issue #683, campaign 72349978): "За
-        # конверсию" renders with U+00A0 between the words, not a plain
-        # space — _STAT_TILE_LABELS' plain-space key must still match.
+    def test_unknown_testid_suffix_is_ignored(self):
+        # Live recon (issue #708) confirmed exactly 5 stable suffixes
+        # (shows/clicks/conversions/cpa/cost) -- an extra tile Yandex might
+        # add later must not raise, only be skipped by the key lookup.
         page = FakePage(
             locators={
-                "button": _FakeLocator(
-                    [_FakeLocatorHandle(text="191,07 ₽\nЗа\xa0конверсию")]
+                self._STAT_TILES_SELECTOR: _FakeLocator(
+                    [
+                        _FakeLocatorHandle(
+                            text="1",
+                            attrs={"data-testid": "ChartSummary.somethingNew"},
+                        ),
+                        _FakeLocatorHandle(
+                            text="281 722",
+                            attrs={"data-testid": "ChartSummary.shows"},
+                        ),
+                    ]
                 ),
             },
         )
         result = browser_masters.fetch_master(page, 1)
-        self.assertEqual(result["Stats"], {"cost_per_conversion": "191,07 ₽"})
-
-    def test_stable_partial_tile_set_returns_without_waiting_out_the_timeout(self):
-        # cycle-review #697 finding (Codex): the old completion condition
-        # required every one of the 5 known keys before _poll_until could
-        # return true, so a campaign that genuinely has fewer tiles (fewer
-        # metrics enabled, or Yandex not rendering one) always burned the
-        # full _STAT_TILES_TIMEOUT_MS. A stable (unchanged-between-ticks)
-        # partial set must now return as soon as it stabilizes, not after
-        # the full timeout.
-        #
-        # Asserted via _poll_until's own tick count (page.wait_for_timeout
-        # call count), not wall-clock elapsed time (cycle-review #697 CI
-        # finding): _poll_until's `while time.monotonic() < deadline` loop
-        # measures real wall-clock time, which is NOT deterministic under a
-        # loaded CI runner (observed: a xdist-parallel CI run took a real
-        # 15s here despite an artificially large timeout and only needing a
-        # few ticks to stabilize -- 60x slower than the ~0.07s this test
-        # takes locally). Tick count is deterministic regardless of how
-        # slowly wall-clock time actually elapses between ticks.
-        # _poll_until's deadline check (`while time.monotonic() < deadline`)
-        # relies on real wall-clock time elapsing -- a `wait_for_timeout`
-        # override that only counts calls without actually advancing the
-        # clock (the original form of this fixture) makes the loop spin as
-        # fast as the CPU allows, burning the FULL real _STAT_TILES_TIMEOUT_MS
-        # in wall-clock terms regardless of how few "ticks" the logic itself
-        # needed -- on a fast/CI runner this racks up millions of iterations
-        # before the deadline elapses (observed live on GitHub Actions: PR
-        # #711's rebase CI run failed with "4588300 not less than 40",
-        # confirming this was never actually fixed by asserting tick count
-        # alone). Patching time.monotonic to advance in lockstep with each
-        # wait_for_timeout call makes the deadline check trip after exactly
-        # the intended number of ticks, independent of real elapsed time.
-        #
-        # body_text must contain a recognised (non-DRAFT) status marker --
-        # see the sibling zero-tiles test's comment for why an unrecognised
-        # (here: empty/default) body_text would otherwise let
-        # _is_draft_overview_page burn its own full 60-tick budget before
-        # _extract_stat_tiles (what this test actually exercises) ever runs.
-        clock = {"now": 0.0}
-        with patch.object(browser_masters.time, "monotonic", lambda: clock["now"]):
-
-            class _TickCountingPage(FakePage):
-                def __init__(self, *args, **kwargs):
-                    super().__init__(*args, **kwargs)
-                    self.tick_count = 0
-
-                def wait_for_timeout(self, timeout):
-                    self.tick_count += 1
-                    clock["now"] += timeout / 1000
-
-            page = _TickCountingPage(
-                locators={
-                    "button": _FakeLocator(
-                        [_FakeLocatorHandle(text="191,07 ₽\nЗа конверсию")]
-                    ),
-                },
-                body_text="Кампания активна",
-            )
-            with patch.object(browser_masters, "_STAT_TILES_TIMEOUT_MS", 10_000):
-                result = browser_masters.fetch_master(page, 1)
-        self.assertEqual(result["Stats"], {"cost_per_conversion": "191,07 ₽"})
-        # Must stop once the set stabilizes, not burn through the full
-        # 10_000ms / 250ms = 40-tick timeout budget.
-        self.assertLess(page.tick_count, 40)
+        self.assertEqual(result["Stats"], {"impressions": "281 722"})
 
     def test_zero_tiles_returns_without_waiting_out_the_timeout(self):
-        # Same fix, empty-set edge case (cycle-review #697): the old
-        # condition never matched an empty `stats` dict against
-        # `wanted_keys`, so a page with no recognisable stat tiles at all
-        # also burned the full timeout. See the sibling test above for why
-        # this asserts tick count rather than wall-clock elapsed time, and
-        # why time.monotonic is patched to advance with each tick.
+        # A page with no ChartSummary.* nodes at all (e.g. Yandex changed
+        # the markup) must not raise -- the marker-wait predicate
+        # (`count() > 0`) is simply never satisfied, _poll_until returns
+        # False once the timeout elapses, and _extract_stat_tiles degrades
+        # to a warning instead of populating "Stats". A short timeout keeps
+        # this test fast in real wall-clock time (FakePage.wait_for_timeout
+        # is a no-op, so _poll_until's real `time.monotonic()` deadline is
+        # what actually bounds the loop here).
         #
-        # body_text must contain a recognised (non-DRAFT) status marker --
-        # issue #660's _is_draft_overview_page (fetch_master's very first
-        # call after _goto_overview_page) polls up to
-        # _DRAFT_OVERVIEW_DETECT_TIMEOUT_MS (15s / 60 ticks at the default
-        # rate) for EITHER a DRAFT marker OR _read_status_text to recognise
-        # something -- an unrecognisable body_text like the plain
-        # "something Yandex changed" used elsewhere in this file silently
-        # burns that ENTIRE budget before _extract_stat_tiles (what this
-        # test actually exercises) ever runs, inflating tick_count by 60 on
-        # top of the stat-tile poll's own ticks.
-        clock = {"now": 0.0}
-        with patch.object(browser_masters.time, "monotonic", lambda: clock["now"]):
-
-            class _TickCountingPage(FakePage):
-                def __init__(self, *args, **kwargs):
-                    super().__init__(*args, **kwargs)
-                    self.tick_count = 0
-
-                def wait_for_timeout(self, timeout):
-                    self.tick_count += 1
-                    clock["now"] += timeout / 1000
-
-            page = _TickCountingPage(locators={}, body_text="Кампания активна")
-            with patch.object(browser_masters, "_STAT_TILES_TIMEOUT_MS", 10_000):
-                with patch("direct_cli.browser.masters.print_warning"):
-                    result = browser_masters.fetch_master(page, 1)
+        # body_text carries a recognisable status marker so
+        # _is_draft_overview_page's own _poll_until (which runs first, to
+        # decide DRAFT vs. non-DRAFT) resolves immediately instead of
+        # burning its own real-time _DRAFT_OVERVIEW_DETECT_TIMEOUT_MS budget
+        # before _extract_stat_tiles ever gets a chance to run.
+        page = FakePage(locators={}, body_text="Кампания активна")
+        with patch.object(browser_masters, "_STAT_TILES_TIMEOUT_MS", 200):
+            with patch("direct_cli.browser.masters.print_warning") as warn:
+                result = browser_masters.fetch_master(page, 1)
         self.assertNotIn("Stats", result)
-        self.assertLess(page.tick_count, 40)
+        warn.assert_any_call("Could not read overview stat tiles for campaign 1.")
 
-    def test_delayed_tile_render_is_not_mistaken_for_a_stable_empty_set(self):
-        # cycle-review #697 re-review finding (Codex): the first version of
-        # the stabilization fix treated a SINGLE unchanged tick as proof the
-        # tile set was final -- but on a page that genuinely has tiles which
-        # just haven't rendered yet (the ~15s two-stage-render delay this
-        # module's own comments document), the very first couple of ticks
-        # are ALSO an unchanged (empty) set, purely because nothing has
-        # rendered yet. A naive one-tick check returned an empty Stats dict
-        # after only ~250ms on a page whose tile genuinely appears a few
-        # ticks later. _STAT_TILES_STABLE_TICKS now requires several
-        # consecutive stable ticks, giving a slow-but-real render room to
-        # actually happen before its result is trusted as final.
+    def test_delayed_tile_render_is_waited_for(self):
+        # Live recon (issue #708): the marker (any ChartSummary.* node) can
+        # take several seconds to appear after the title has rendered, but
+        # once it does, all five tiles are present in that same DOM read --
+        # no partial/stabilizing state to account for. Models the marker
+        # appearing on the 2nd locator() call, not the 1st.
         class _DelayedTilePage(FakePage):
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
                 self.tile_scan_count = 0
 
             def locator(self, selector):
-                if selector == "button":
+                if selector == TestFetchMaster._STAT_TILES_SELECTOR:
                     self.tile_scan_count += 1
-                    # Renders on the 2nd scan -- a single-stable-tick check
-                    # would already have declared the empty 1st scan final
-                    # before this tile had a chance to appear.
                     if self.tile_scan_count <= 1:
                         return _FakeLocator([])
-                    return _FakeLocator([_FakeLocatorHandle(text="281 722\nПоказа")])
+                    return _FakeLocator(
+                        [
+                            _FakeLocatorHandle(
+                                text="281 722",
+                                attrs={"data-testid": "ChartSummary.shows"},
+                            )
+                        ]
+                    )
                 return super().locator(selector)
 
         page = _DelayedTilePage(locators={})
         result = browser_masters.fetch_master(page, 1)
 
         self.assertEqual(result["Stats"], {"impressions": "281 722"})
-        # Confirms the stabilization window is actually being exercised,
-        # not short-circuited by the "all wanted keys found" fast path.
-        self.assertGreaterEqual(
-            page.tile_scan_count, 1 + browser_masters._STAT_TILES_STABLE_TICKS
-        )
+        self.assertGreaterEqual(page.tile_scan_count, 2)
 
     def test_partial_result_on_unrecognised_sections(self):
         # A page whose title element IS present (so _goto_overview_page is


### PR DESCRIPTION
## Summary

- Issue #708 (a follow-up from PR #697's Codex adversarial review): `_extract_stat_tiles` previously scanned every button on the overview page for a "value\nlabel" shape and waited for the found key set to stay unchanged for several consecutive poll ticks before trusting it as final. That heuristic could not structurally distinguish "this campaign genuinely has fewer than 5 tiles" from "the tiles just haven't started rendering yet".
- Live recon (12 runs across 9 distinct ACTIVE campaigns in one account, headless, 50ms poll granularity) found a real DOM settled marker: each tile carries a stable `data-testid="ChartSummary.<key>"` (`shows`/`clicks`/`conversions`/`cpa`/`cost` — matching `_STAT_TILE_LABELS`' five values 1:1), and all five render atomically in a single React commit. In every run, the first poll tick that observed ANY `ChartSummary.*` node already had all five present — no partial/skeleton state exists for this section, unlike the images editor's stub/ghost render passes (#670).
- Network capture of the same loads explains why: the tiles are driven by a single `GET /wizard/web-api/aggregate?...` XHR whose response arrives ~1-2ms before the DOM update, not a piecemeal per-tile render.
- Replaced the tick-stabilization scan with an explicit wait for the marker (`_STAT_TILE_TESTID_PREFIX`, mirroring `_OVERVIEW_TITLE_SELECTOR`'s own convention from #683) and a direct read of the fixed testid set via `_STAT_TILE_TESTID_KEYS` — no more scanning every button on the page, no more non-breaking-space label normalisation (the testid-keyed value is already clean).
- No change to the CLI's `Stats` output shape/keys.

## Live verification

- `direct masters get <id>` (via an in-process `CliRunner` invocation of this worktree's code — see note below) against 3 distinct ACTIVE campaigns: all 5 stat tiles read correctly every time, including `cost_per_conversion`.
- Recon note: `direct`'s installed binary resolves `direct_cli` via a global editable install pointed at a different checkout, not this worktree — live checks against the `direct` binary directly were validating stale code. Verified this via `direct_cli.browser.masters.__file__` and cross-checked with a `click.testing.CliRunner` invocation running against this worktree's `sys.path`, which is what the summary above reflects.

## Tests

- `pytest tests/test_masters.py` — 446 passed. Rewrote the stat-tiles test block (`TestFetchMaster`) for the new marker-based extraction: fixture pages now register `data-testid`-tagged handles instead of button text; replaced the removed stabilization/non-breaking-space tests with `test_unknown_testid_suffix_is_ignored`, `test_zero_tiles_returns_without_waiting_out_the_timeout`, and `test_delayed_tile_render_is_waited_for`.
- `black --check` / `flake8` clean on both changed files.

Closes #708