### PR TITLE
fix(masters): retry goal_price/target_action_price reads against hydration race

### DIFF
--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -2265,25 +2265,33 @@ def _read_until_matches(
     expected: Any,
     *,
     timeout_ms: int = _VERIFY_FIELD_READ_TIMEOUT_MS,
+    matches: "Optional[Callable[[Any, Any], bool]]" = None,
 ) -> Any:
-    """Retry ``reader(page)`` until it returns ``expected`` or ``timeout_ms`` elapses.
+    """Retry ``reader(page)`` until it matches ``expected`` or ``timeout_ms`` elapses.
 
     ``_wait_for_edit_form`` only guarantees the first headline slot has
     rendered — a one-shot call to ``_read_weekly_budget``/
     ``_read_directs_helps``/``_read_promotion_goal_label``/
-    ``_read_campaign_name`` right after it can catch that field still
-    showing its pre-reload value while the rest of the form is still
-    hydrating (issue #706, same race ``_read_goal_price`` was hardened
-    against in issue #696). Returns the LAST value read — on a genuine
-    mismatch (Yandex actually rejected the save) that is the settled,
-    correct-but-wrong value, so ``_verify_saved`` still reports it
-    accurately once the retries are exhausted.
+    ``_read_campaign_name``/``_read_goal_price``/``_read_target_actions``
+    right after it can catch that field still showing its pre-reload value
+    while the rest of the form is still hydrating (issue #706/#716, same
+    race ``_read_goal_price`` was first hardened against in issue #696).
+    Returns the LAST value read — on a genuine mismatch (Yandex actually
+    rejected the save) that is the settled, correct-but-wrong value, so
+    ``_verify_saved`` still reports it accurately once the retries are
+    exhausted.
+
+    ``matches`` defaults to ``==`` but accepts a predicate for callers whose
+    "did it match" comparison isn't plain equality (e.g. ``_goal_price_matches``'s
+    comma/dot normalization, or ``target_action_prices``' per-goal lookup into
+    the list ``_read_target_actions`` returns).
     """
+    is_match = matches or (lambda actual, exp: actual == exp)
     last: Any = None
     deadline = time.monotonic() + timeout_ms / 1000
     while True:
         last = reader(page)
-        if last == expected or time.monotonic() >= deadline:
+        if is_match(last, expected) or time.monotonic() >= deadline:
             return last
         page.wait_for_timeout(250)
 
@@ -2344,7 +2352,12 @@ def _verify_saved(
             )
 
     if goal_price is not None:
-        actual_goal_price = _read_goal_price(page)
+        actual_goal_price = _read_until_matches(
+            page,
+            _read_goal_price,
+            goal_price,
+            matches=lambda actual, expected: _goal_price_matches(expected, actual),
+        )
         if not _goal_price_matches(goal_price, actual_goal_price):
             mismatches.append(
                 f"goal_price: expected {goal_price!r}, page now shows "
@@ -2352,9 +2365,24 @@ def _verify_saved(
             )
 
     if target_action_prices:
-        actual_target_actions = {
-            row["GoalId"]: row["Price"] for row in _read_target_actions(page)
-        }
+
+        def _read_target_action_prices(p: "Page") -> Dict[int, Optional[float]]:
+            return {row["GoalId"]: row["Price"] for row in _read_target_actions(p)}
+
+        def _target_action_prices_match(
+            actual: Dict[int, Optional[float]], expected: Dict[int, float]
+        ) -> bool:
+            return all(
+                _target_action_price_matches(price, actual.get(goal_id))
+                for goal_id, price in expected.items()
+            )
+
+        actual_target_actions = _read_until_matches(
+            page,
+            _read_target_action_prices,
+            target_action_prices,
+            matches=_target_action_prices_match,
+        )
         for goal_id, expected_price in target_action_prices.items():
             actual_price = actual_target_actions.get(goal_id)
             if not _target_action_price_matches(expected_price, actual_price):

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -3899,6 +3899,105 @@ class TestUpdateMaster(unittest.TestCase):
 
         self.assertEqual(result, {"CampaignId": 42, "WeeklyBudget": 95000})
 
+    def test_verify_saved_survives_delayed_goal_price_hydration(self):
+        # Issue #716: goal_price's one-shot _read_goal_price() call in
+        # _verify_saved wasn't wrapped in _read_until_matches (unlike the
+        # four fields #706 hardened) — same hydration race, different
+        # field. Models the target-price input still showing the PRE-save
+        # figure for one tick after reload, settling to the actually-saved
+        # value only afterwards.
+        ticks = {"count": 0}
+        price_state = {"value": "500"}
+
+        def _get_price_value():
+            if ticks["count"] < 1:
+                return "999"  # stale pre-save snapshot
+            return price_state["value"]
+
+        price_handle = _FakeLocatorHandle(
+            on_fill=lambda v: price_state.__setitem__("value", v),
+            get_value=_get_price_value,
+        )
+        save_handle = _FakeTextLocatorHandle(visible=True)
+        edit_form_ready_selector = (
+            f'[data-testid="{browser_masters._EDIT_FORM_READY_TESTID}"]'
+        )
+
+        class _DelayedPricePage(FakePage):
+            def wait_for_timeout(self, timeout):
+                ticks["count"] += 1
+
+        page = _DelayedPricePage(
+            locators={
+                browser_masters._GOAL_PRICE_INPUT_TESTID: _FakeLocator([price_handle]),
+                edit_form_ready_selector: _FakeLocator([_FakeLocatorHandle()]),
+            },
+            role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
+        )
+
+        result = browser_masters.update_master(page, 42, goal_price=500)
+
+        self.assertEqual(result, {"CampaignId": 42, "GoalPrice": 500})
+
+    def test_verify_saved_survives_delayed_target_action_price_hydration(self):
+        # Issue #716: target_action_prices' one-shot _read_target_actions()
+        # call in _verify_saved wasn't wrapped in _read_until_matches either
+        # — the "Целевые действия" table sits even lower on the edit page
+        # (per _set_target_action_price's own docstring) so it is at least
+        # as exposed to this hydration race as weekly_budget/goal_price.
+        ticks = {"count": 0}
+        price_state = {"value": "200"}
+
+        def _get_price_value():
+            if ticks["count"] < 1:
+                return "150"  # stale pre-save snapshot
+            return price_state["value"]
+
+        price_handle = _FakeLocatorHandle(
+            on_fill=lambda v: price_state.__setitem__("value", v),
+            get_value=_get_price_value,
+        )
+        row_testid = browser_masters._TARGET_ACTION_ROW_TESTID_TEMPLATE.format(
+            category=browser_masters._TARGET_ACTIONS_CATEGORY, goal_id=159614149
+        )
+        price_testid = browser_masters._TARGET_ACTION_PRICE_TESTID_TEMPLATE.format(
+            category=browser_masters._TARGET_ACTIONS_CATEGORY, goal_id=159614149
+        )
+        row_prefix_selector = (
+            f'[data-testid^="TargetActions.'
+            f'{browser_masters._TARGET_ACTIONS_CATEGORY}."]'
+        )
+        save_handle = _FakeTextLocatorHandle(visible=True)
+        edit_form_ready_selector = (
+            f'[data-testid="{browser_masters._EDIT_FORM_READY_TESTID}"]'
+        )
+
+        class _DelayedTargetActionPage(FakePage):
+            def wait_for_timeout(self, timeout):
+                ticks["count"] += 1
+
+        page = _DelayedTargetActionPage(
+            locators={
+                browser_masters._TARGET_ACTIONS_SECTION_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                ),
+                row_prefix_selector: _FakeLocator(
+                    [_FakeLocatorHandle(attrs={"data-testid": row_testid})]
+                ),
+                f'[data-testid="{price_testid}"]': _FakeLocator([price_handle]),
+                edit_form_ready_selector: _FakeLocator([_FakeLocatorHandle()]),
+            },
+            role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
+        )
+
+        result = browser_masters.update_master(
+            page, 42, target_action_prices={159614149: 200}
+        )
+
+        self.assertEqual(
+            result, {"CampaignId": 42, "TargetActionPrices": {159614149: 200}}
+        )
+
     def test_updates_only_target_action_price(self):
         prices_state = {159614149: "150"}
         page, save_clicks = self._page_with_save_button(


### PR DESCRIPTION
## Summary

Issue #706/#710 (`552be97`) wrapped four `_verify_saved` field reads (`weekly_budget`, `directs_helps`, `promotion_goal`, `name`) in `_read_until_matches` to survive the edit page's hydration race, but left `goal_price` and `target_action_prices` as one-shot reads — the same race, unpatched on two more fields.

Confirmed live on prod 2026-08-04 (campaign 713234191, goal 159614149): `masters update --target-action-price` reported `expected 100.0, page now shows 150.0` and exited 1, while `masters targetactions get` immediately after showed the price had actually saved as 100.0. Same result on a second campaign (713234221). A false failure like this poisons exit-code-driven batch runs — a batch of 21 real successes can report 18 "errors."

**Fix:** `_read_until_matches` now accepts an optional `matches` predicate (defaults to `==`) so callers whose comparison isn't plain equality can still retry against the settled value:
- `goal_price` retries via `_goal_price_matches` (comma/dot decimal normalization).
- `target_action_prices` retries by re-reading the whole `_read_target_actions()` list each tick and checking every requested goal via `_target_action_price_matches`.

**Regression tests** (mirroring `test_verify_saved_survives_delayed_weekly_budget_hydration`'s style): a fake reader returns the stale pre-save value on the first tick and the actually-saved value after — fails on pre-fix code, passes with this fix. Added for both `goal_price` and `target_action_prices`.

Closes #716

## Test plan

- [x] Two new regression tests fail against pre-fix code, pass after the fix
- [x] `pytest tests/test_masters.py -q` — 449 passed
- [x] `pytest tests/test_masters.py tests/test_cli.py tests/test_comprehensive.py -q` — 519 passed, 30 subtests passed
- [x] `black`/`flake8` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DhSQk7ke69FCdqbg9pJhWi