### PR TITLE
fix(masters): make _poll_until's deadline clock injectable

### DIFF
--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -3581,6 +3581,7 @@ def _poll_until(
     timeout_ms: int,
     *,
     tick_ms: int = 250,
+    clock: "Callable[[], float]" = time.monotonic,
 ) -> bool:
     """Poll ``predicate`` until it is true or ``timeout_ms`` elapses.
 
@@ -3591,9 +3592,19 @@ def _poll_until(
     ``PlaywrightError`` from the predicate is suppressed and treated as
     "not yet" — a locator query racing a mid-render DOM is the normal case
     these loops exist to absorb.
+
+    ``clock`` defaults to ``time.monotonic`` (unchanged production
+    behaviour) but can be swapped for a fake clock in tests (issue #715):
+    the previous hard-coded ``time.monotonic()`` measured real wall-clock
+    time, so a test mocking ``page.wait_for_timeout`` as a no-op tick
+    counter got a tick count purely determined by how many iterations the
+    host CPU spun through before real time elapsed — non-deterministic
+    under a loaded CI runner. A fake clock that only advances inside
+    ``wait_for_timeout`` makes the deadline (and therefore the tick count)
+    deterministic instead.
     """
-    deadline = time.monotonic() + timeout_ms / 1000
-    while time.monotonic() < deadline:
+    deadline = clock() + timeout_ms / 1000
+    while clock() < deadline:
         with contextlib.suppress(PlaywrightError):
             if predicate():
                 return True
@@ -3721,6 +3732,7 @@ def _poll_until_terminal(
     timeout_ms: int,
     *,
     tick_ms: int = 250,
+    clock: "Callable[[], float]" = time.monotonic,
 ) -> "Optional[str]":
     """Like ``_poll_until``, but for a predicate returning a terminal-state
     string (truthy, non-``None``) instead of a bare bool.
@@ -3730,9 +3742,12 @@ def _poll_until_terminal(
     true/false — see ``_edit_form_terminal_state``. ``PlaywrightError`` is
     suppressed the same way ``_poll_until`` does, for the same reason (a
     locator query racing a mid-render DOM is expected, not a failure).
+
+    ``clock`` defaults to ``time.monotonic`` — see ``_poll_until``'s
+    docstring (issue #715) for why this is injectable.
     """
-    deadline = time.monotonic() + timeout_ms / 1000
-    while time.monotonic() < deadline:
+    deadline = clock() + timeout_ms / 1000
+    while clock() < deadline:
         with contextlib.suppress(PlaywrightError):
             state = predicate()
             if state is not None:

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -1603,6 +1603,56 @@ class TestWithSessionRetry(unittest.TestCase):
         self.assertEqual(result, "ok:fresh-page")
 
 
+class TestPollUntil(unittest.TestCase):
+    """Issue #715: ``_poll_until``'s ``while time.monotonic() < deadline``
+    loop measures real wall-clock time, so on a CPU-loaded CI runner (many
+    Python-level iterations execute per real millisecond) the loop can run
+    an unbounded number of ticks before ``time.monotonic()`` finally reports
+    the deadline has passed — the tick count is not a function of the
+    predicate/timeout alone, it also depends on how fast the host CPU
+    happens to be at that moment. Injecting a ``clock`` callable (defaulting
+    to ``time.monotonic``, so production behaviour is unchanged) lets a test
+    supply a fake clock that only advances when ``page.wait_for_timeout`` is
+    actually called, making the tick count fully deterministic regardless of
+    real CPU speed.
+    """
+
+    def test_tick_count_is_deterministic_under_a_fake_clock_that_only_advances_on_wait(
+        self,
+    ):
+        # Simulates a CPU-loaded runner: the predicate loop can spin many
+        # times per real millisecond, but the deadline must still be judged
+        # in terms of ticks (fake-clock advancement), not raw loop
+        # iterations. A fake clock that starts at 0 and only advances by
+        # ``tick_ms`` inside ``wait_for_timeout`` proves the loop runs
+        # exactly ``timeout_ms // tick_ms`` ticks before giving up, no
+        # matter how many times the predicate itself is polled between
+        # ticks.
+        fake_time = {"now": 0.0}
+
+        class _FakeClockPage(FakePage):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.tick_count = 0
+
+            def wait_for_timeout(self, timeout):
+                self.tick_count += 1
+                fake_time["now"] += timeout / 1000
+
+        page = _FakeClockPage(locators={})
+        result = browser_masters._poll_until(
+            page,
+            lambda: False,
+            1_000,
+            tick_ms=250,
+            clock=lambda: fake_time["now"],
+        )
+        self.assertFalse(result)
+        # 1000ms / 250ms == 4 ticks, deterministically -- not a real
+        # wall-clock race against however fast the host CPU spins the loop.
+        self.assertEqual(page.tick_count, 4)
+
+
 class TestFetchMastersList(unittest.TestCase):
     """`list` reads the grid's GridCampaigns JSON call, not its DOM (#639):
     the grid is a virtualized SPA and never renders a


### PR DESCRIPTION
## Summary

- `_poll_until`/`_poll_until_terminal` (`direct_cli/browser/masters.py`) measured their deadline against real `time.monotonic()`, so `tests/test_masters.py::TestFetchMaster::test_stable_partial_tile_set_returns_without_waiting_out_the_timeout` and `test_zero_tiles_returns_without_waiting_out_the_timeout` — which mock `page.wait_for_timeout` as a no-op tick counter and assert `tick_count < 40` — were deterministically flaky on a CPU-loaded xdist CI runner (observed: `9582628 not less than 40`, `10347381 not less than 40`, on a doc-only PR #712 that never touched `masters.py`).
- Added `clock: Callable[[], float] = time.monotonic` to both functions — production behaviour is unchanged (same default clock), but tests can now inject a fake clock that only advances inside `wait_for_timeout`, making the deadline (and tick count) deterministic regardless of real elapsed wall-clock time or host CPU speed.
- Rewrote the two flaky tests to drive the injected fake clock (via a `_poll_until` wrapper, since `fetch_master` calls `_poll_until` internally) instead of asserting on a raw `wait_for_timeout` call count against real time.
- Added `TestPollUntil` — a direct unit test of `_poll_until`'s new `clock` parameter.

Closes #715

## Test plan

- [x] Red: `TestPollUntil`'s new test fails with `TypeError: _poll_until() got an unexpected keyword argument 'clock'` before the fix.
- [x] Green: same test passes after adding the `clock` parameter.
- [x] `tests/test_masters.py` full module: 448 passed.
- [x] Manual mutation check: reverting `_poll_until`'s body to hard-coded `time.monotonic()` (mutmut not installed) makes `TestPollUntil` fail with `1586572 != 4`, confirming the test actually exercises the injected clock rather than passing vacuously.
- [x] `black --check` / `flake8` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151UUT7udvZH88pm38VNuL6