### PR TITLE
docs(masters): fix stale not-live-verified note in _apply_image_operations

### DIFF
--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -3802,16 +3802,17 @@ def _apply_image_operations(
     legitimate outcomes (unlike headlines/texts, images have no "at least
     one" invariant — see ``_IMAGES_MAX_COUNT``'s module-level comment).
 
-    **Not live-verified (flag for live smoke before relying on this in
-    production):** whether Yandex's "Добавить в кампанию" button stays
-    clickable when the modal's selection is reduced to zero mid-session
-    (the ``delete``-everything / ``set``-with-nothing-kept case) — this
-    matters most for ``masters adimages delete --all`` and ``masters
-    adimages set`` replacing every image. Also not verified: uploading via
-    a single ``set_input_files([path1, path2, ...])`` call with multiple
-    paths — real Playwright accepts a list, but PR #672's recon never
-    exercised it, so this uploads strictly one path per call, sequentially,
-    to stay on already-confirmed ground.
+    Confirmed live 2026-08-03 on DRAFT campaign 713234191: Yandex's
+    "Добавить в кампанию" button stays clickable when the modal's selection
+    is reduced to zero mid-session (the ``delete``-everything /
+    ``set``-with-nothing-kept case) — this was the primitive's one
+    previously-unverified risk, exercised via ``masters adimages delete
+    --all`` and ``masters adimages set --allow-empty``.
+
+    **Not live-verified:** uploading via a single ``set_input_files([path1,
+    path2, ...])`` call with multiple paths — real Playwright accepts a
+    list, but PR #672's recon never exercised it, so this uploads strictly
+    one path per call, sequentially, to stay on already-confirmed ground.
 
     Removals are located by the target's thumb URL, captured from the
     modal's panel BEFORE any removal in this call runs — exactly the


### PR DESCRIPTION
## Summary
- `_apply_image_operations`'s docstring listed the zero-selection case (`delete --all` / `set --allow-empty`) under "Not live-verified", but commit 6046684 already confirmed live on 2026-08-03 (DRAFT campaign 713234191) that Yandex's "Добавить в кампанию" button stays clickable when the modal's selection is reduced to zero.
- Reworded the paragraph to state the live confirmation (date + campaign ID, matching the module's existing convention), keeping only the genuinely open caveat about multi-path `set_input_files([path1, path2, ...])`, which PR #672's recon never exercised.
- No logic changes — docstring only.

Closes #679

## Test plan
- [x] Docstring-only change; no behavior affected
- [x] Reviewed against commit 6046684 (PR #677) to confirm wording accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NoyiMJDZX7HhUWfg3WJTbW