### PR TITLE
fix(masters): verify DRAFT->MODERATION transition in update_master --launch

### DIFF
--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -2817,8 +2817,26 @@ def update_master(
         # --launch previously reported "Launched": True purely off the
         # click/redirect, with no check that the campaign didn't silently
         # stay DRAFT.
-        _goto_overview_page(page, campaign_id)
-        _verify_launched_to_moderation(page, campaign_id)
+        #
+        # This trip is just as irreversible/non-idempotent as the click
+        # itself (see the guard above _verify_saved): if the session is
+        # invalidated in this window, letting BrowserAuthError propagate
+        # bare would make _with_session retry the ENTIRE update_master call
+        # under a fresh session, re-mutating any --image replacements a
+        # second time (found via adversarial review, cycle-review round 1
+        # of PR #727).
+        try:
+            _goto_overview_page(page, campaign_id)
+            _verify_launched_to_moderation(page, campaign_id)
+        except BrowserAuthError as exc:
+            raise BrowserSessionError(
+                f"Clicked '{_LAUNCH_BUTTON_TEXT}' for campaign {campaign_id}, "
+                "but the session was invalidated while confirming it reached "
+                "moderation — the requested changes were likely already "
+                f"applied and launched; check campaign {campaign_id} "
+                "manually rather than retrying (image replacements are not "
+                "idempotent)."
+            ) from exc
         result["Launched"] = True
     return result
 

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -1565,6 +1565,53 @@ def archive_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
     return updated
 
 
+def _verify_launched_to_moderation(page: "Page", campaign_id: int) -> str:
+    """Poll the overview page's status text until it reports MODERATION.
+
+    Shared by ``launch_master`` and ``update_master --launch`` (issue #721):
+    both click a DRAFT edit page's launch button and then need the SAME
+    proof the publish actually happened — Yandex does not flip a DRAFT
+    straight to ACTIVE, clicking "Запустить кампанию" sends it to moderation
+    first (confirmed live, issue #668's recon of the same button). Reads the
+    overview page's own status text (``_read_status_text``, "Кампания
+    на\xa0модерации"), NOT the campaigns grid (``fetch_masters_list``) — the
+    grid's ``primaryStatus`` was observed to lag the real DRAFT->MODERATION
+    transition by 45+ seconds in the issue #704 recon, while the overview
+    page already reflected it immediately after the click's own redirect.
+
+    Callers must already be on (or have just navigated to) the campaign's
+    overview page — this function only polls ``_read_status_text``, it does
+    not navigate itself, so callers with different pre-poll navigation needs
+    (``launch_master`` re-navigates via ``_goto_overview_page`` after its
+    click; ``update_master`` is already there after ``_click_save``'s own
+    redirect-wait) stay in control of that step.
+
+    Raises :class:`BrowserSessionError` if the status never becomes
+    MODERATION within ``_LAUNCH_VERIFY_TIMEOUT_MS`` — a click that doesn't
+    visibly change the status is a hard error, not a silent success, per
+    this module's dominant convention (see ``_suspend_or_resume``).
+    """
+    deadline = time.monotonic() + _LAUNCH_VERIFY_TIMEOUT_MS / 1000
+    new_status = None
+    while time.monotonic() < deadline:
+        new_status = _read_status_text(page)
+        if new_status == "MODERATION":
+            break
+        page.wait_for_timeout(250)
+
+    if new_status != "MODERATION":
+        raise BrowserSessionError(
+            f"Clicked '{_LAUNCH_BUTTON_TEXT}' for campaign {campaign_id}, but "
+            "its overview page did not report MODERATION within "
+            f"{_LAUNCH_VERIFY_TIMEOUT_MS / 1000:.0f}s (still "
+            f"{new_status!r}). The click may not have hit the right "
+            "element, or Yandex is slow to apply it — verify manually "
+            "before retrying."
+        )
+
+    return new_status
+
+
 def launch_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
     """Publish a DRAFT Мастер кампаний via the edit page's launch button (issue #704).
 
@@ -1587,7 +1634,9 @@ def launch_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
     click's own redirect. The grid is still used for the BEFORE check
     (there is no cheaper way to confirm a campaign is currently DRAFT
     without first knowing which page to open), but never for the AFTER
-    check.
+    check — that half is ``_verify_launched_to_moderation`` (issue #721),
+    shared with ``update_master --launch`` so both entry points that publish
+    a DRAFT prove it the same way.
 
     Reuses ``_click_draft_terminal_button(page, campaign_id, launch=True)``
     from #668 — the same DRAFT edit-page save-as-draft/launch pair
@@ -1635,23 +1684,7 @@ def launch_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
     # status text at all, because the SPA hadn't painted anything yet).
     _goto_overview_page(page, campaign_id)
 
-    deadline = time.monotonic() + _LAUNCH_VERIFY_TIMEOUT_MS / 1000
-    new_status = None
-    while time.monotonic() < deadline:
-        new_status = _read_status_text(page)
-        if new_status == "MODERATION":
-            break
-        page.wait_for_timeout(250)
-
-    if new_status != "MODERATION":
-        raise BrowserSessionError(
-            f"Clicked 'Запустить кампанию' for campaign {campaign_id}, but "
-            "its overview page did not report MODERATION within "
-            f"{_LAUNCH_VERIFY_TIMEOUT_MS / 1000:.0f}s (still "
-            f"{new_status!r}). The click may not have hit the right "
-            "element, or Yandex is slow to apply it — verify manually "
-            "before retrying."
-        )
+    new_status = _verify_launched_to_moderation(page, campaign_id)
 
     return {"CampaignId": campaign_id, "Status": new_status}
 
@@ -2771,6 +2804,21 @@ def update_master(
     if images:
         result["Images"] = images
     if was_draft and launch:
+        # Issue #721: the DRAFT edit page's launch click redirects away from
+        # /edit/ (already awaited by _click_draft_terminal_button inside
+        # _click_save above), but that redirect is not proof Yandex actually
+        # sent the campaign to moderation — it can land on the overview page
+        # mid-transition, same race launch_master's own recon hit (see
+        # module docstring). _verify_saved above already re-navigated the
+        # page back to WIZARD_EDIT_URL to check the touched fields, so this
+        # needs its own trip to the overview page (mirroring launch_master's
+        # own _goto_overview_page call) before _verify_launched_to_moderation
+        # can read its status text — closing the gap where update_master
+        # --launch previously reported "Launched": True purely off the
+        # click/redirect, with no check that the campaign didn't silently
+        # stay DRAFT.
+        _goto_overview_page(page, campaign_id)
+        _verify_launched_to_moderation(page, campaign_id)
         result["Launched"] = True
     return result
 

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -3800,8 +3800,53 @@ class TestUpdateMasterDraftSupport(unittest.TestCase):
         )
 
     def test_launch_true_on_draft_campaign_adds_launched_key(self):
-        # Issue #704: update --launch still needs to report it actually
-        # published the DRAFT, not just that the field was saved.
+        # Issue #704/#721: update --launch still needs to report it actually
+        # published the DRAFT, not just that the field was saved — the
+        # overview page's status text must explicitly read MODERATION (see
+        # TestLaunchMaster._draft_edit_page's own on_click convention).
+        slot = _FakeContentEditableHandle(text="Старый заголовок")
+        selector = (
+            f"[data-testid="
+            f'"{browser_masters._HEADLINES_TESTID_TEMPLATE.format(index=0)}"]'
+        )
+        state = {"status_text": "Черновик"}
+
+        def _on_launch_click():
+            state["status_text"] = "Кампания на\xa0модерации"
+            page.url = browser_masters.WIZARD_OVERVIEW_URL.format(campaign_id=713231614)
+
+        page = FakePage(
+            locators={
+                browser_masters._DRAFT_SAVE_DRAFT_BUTTON_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                ),
+                browser_masters._DRAFT_LAUNCH_BUTTON_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle(on_click=_on_launch_click)]
+                ),
+                selector: _FakeLocator([slot]),
+            }
+        )
+        page.url = browser_masters.WIZARD_EDIT_URL.format(campaign_id=713231614)
+        page.inner_text = lambda selector=None: state["status_text"]
+
+        result = browser_masters.update_master(
+            page, 713231614, headlines={0: "Новый заголовок"}, launch=True
+        )
+
+        self.assertEqual(
+            result,
+            {
+                "CampaignId": 713231614,
+                "Headlines": {0: "Новый заголовок"},
+                "Launched": True,
+            },
+        )
+
+    def test_launch_true_raises_when_status_stays_draft(self):
+        # Regression (issue #721): fields saved and the click redirected away
+        # from /edit/, but the overview page's status text never actually
+        # became MODERATION — must not report "Launched": True on the
+        # redirect alone.
         slot = _FakeContentEditableHandle(text="Старый заголовок")
         selector = (
             f"[data-testid="
@@ -3823,19 +3868,15 @@ class TestUpdateMasterDraftSupport(unittest.TestCase):
             }
         )
         page.url = browser_masters.WIZARD_EDIT_URL.format(campaign_id=713231614)
+        page.inner_text = lambda selector=None: "Черновик"
 
-        result = browser_masters.update_master(
-            page, 713231614, headlines={0: "Новый заголовок"}, launch=True
-        )
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(
+                page, 713231614, headlines={0: "Новый заголовок"}, launch=True
+            )
 
-        self.assertEqual(
-            result,
-            {
-                "CampaignId": 713231614,
-                "Headlines": {0: "Новый заголовок"},
-                "Launched": True,
-            },
-        )
+        self.assertIn("did not report MODERATION", str(ctx.exception))
+        self.assertEqual(slot.inner_text(), "Новый заголовок")
 
     def test_error_message_on_draft_mismatch_names_the_draft_button_not_save(self):
         # The mismatch error text must reflect the button THIS run actually

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -3928,6 +3928,70 @@ class TestUpdateMasterDraftSupport(unittest.TestCase):
         self.assertIn("did not report MODERATION", str(ctx.exception))
         self.assertEqual(slot.inner_text(), "Новый заголовок")
 
+    def test_auth_error_during_post_launch_moderation_check_is_not_retried(self):
+        # Found via adversarial review (Codex) in cycle-review round 1 of
+        # PR #727. Mirrors
+        # test_auth_error_during_post_save_image_verification_is_not_retried's
+        # pattern: the launch click has ALREADY happened (irreversible), and
+        # if --image was also passed, any image replacement is NOT
+        # idempotent either. If the session is invalidated while
+        # _goto_overview_page/_verify_launched_to_moderation confirm
+        # MODERATION, letting BrowserAuthError propagate bare would make
+        # _with_session retry the ENTIRE update_master call under a fresh
+        # session, re-mutating already-applied changes.
+        slot = _FakeContentEditableHandle(text="Старый заголовок")
+        selector = (
+            f"[data-testid="
+            f'"{browser_masters._HEADLINES_TESTID_TEMPLATE.format(index=0)}"]'
+        )
+        state = {"status_text": "Черновик"}
+        launch_clicks = []
+
+        def _on_launch_click():
+            launch_clicks.append(True)
+            state["status_text"] = "Кампания на\xa0модерации"
+            page.url = browser_masters.WIZARD_OVERVIEW_URL.format(campaign_id=713231614)
+
+        page = FakePage(
+            locators={
+                browser_masters._DRAFT_SAVE_DRAFT_BUTTON_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                ),
+                browser_masters._DRAFT_LAUNCH_BUTTON_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle(on_click=_on_launch_click)]
+                ),
+                selector: _FakeLocator([slot]),
+            }
+        )
+        page.url = browser_masters.WIZARD_EDIT_URL.format(campaign_id=713231614)
+        page.inner_text = lambda selector=None: state["status_text"]
+
+        original_assert_authenticated = browser_masters.assert_authenticated
+        calls_after_click = {"n": 0}
+
+        def _assert_authenticated(content):
+            if launch_clicks:
+                calls_after_click["n"] += 1
+                # Let the FIRST post-click call (inside the existing
+                # _verify_saved guard) succeed; fail on the SECOND (inside
+                # _goto_overview_page, called from the launch-moderation
+                # check added by issue #721).
+                if calls_after_click["n"] >= 2:
+                    raise BrowserAuthError("stale session, detected mid-body")
+            return original_assert_authenticated(content)
+
+        with patch.object(
+            browser_masters,
+            "assert_authenticated",
+            side_effect=_assert_authenticated,
+        ):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters.update_master(
+                    page, 713231614, headlines={0: "Новый заголовок"}, launch=True
+                )
+
+        self.assertNotIsInstance(ctx.exception, BrowserAuthError)
+
     def test_error_message_on_draft_mismatch_names_the_draft_button_not_save(self):
         # The mismatch error text must reflect the button THIS run actually
         # clicked, not a hard-coded "Сохранить кампанию" that was never on


### PR DESCRIPTION
## Summary
- `update_master --launch` previously reported `Launched: True` purely off the DRAFT edit page's click/redirect, without confirming the campaign actually reached moderation
- Extracted the polling loop into a shared `_verify_launched_to_moderation(page, campaign_id)` helper, reused by both `launch_master` and `update_master` (mirrors the guard `launch_master` already had via #704)

Closes #721

## Test plan
- [x] `pytest tests/test_masters.py` — extended coverage for the new shared helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USAEHXk4pbnUZbuHgdF4DZ