### PR TITLE
fix(masters): verify region identity by RegionId, not just label text (#657)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+**Fixed — `masters add --region-id` verified only by label text, not RegionId identity (#657):**
+
+- `--region-id` resolved to Yandex's canonical `GeoRegionName` (#652) and
+  handed that bare name to the browser's `_set_region`, which selects the
+  tree/tag-group widget's checkbox by exact label-text match. GeoRegions
+  names are not globally unique, so a text-only match could in principle
+  click a same-named decoy checkbox belonging to a different RegionId than
+  the one requested — `_resolve_region_ids`'s own ambiguity guard already
+  refused known-ambiguous names up front, but gave no protection against a
+  markup/DOM surprise landing on the wrong same-named node at click time.
+- `_resolve_region_ids` now returns `(name, region_id)` pairs instead of
+  bare names, threaded through `masters add`/`create_master` into
+  `_set_region`. When a `region_id` is known, `_set_region` additionally
+  reads the checked checkbox's own `id` attribute (confirmed live it is
+  always `id="region-node-<RegionId>"`) and refuses — unchecking the wrong
+  node first — if it doesn't encode the requested RegionId, rather than
+  trusting the label-text match alone. Plain `--region` text (no known
+  RegionId) is unaffected and keeps matching by exact label text only, as
+  before.
+
 **Added — `masters update --target-action-price` / `masters targetactions get` (#707):**
 
 - Live recon (2026-08-04, campaign 713234191, `ksamatadirect` account,

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -234,6 +234,7 @@ from typing import (
     Sequence,
     Set,
     Tuple,
+    Union,
 )
 
 from .._captcha import find_captcha_marker, find_marker
@@ -4556,7 +4557,9 @@ def _verify_saved_images(
     return _read_image_content_ids(page)
 
 
-def _set_region(page: "Page", regions: List[str]) -> None:
+def _set_region(
+    page: "Page", regions: "Sequence[Union[str, Tuple[str, Optional[int]]]]"
+) -> None:
     """Select each of ``regions`` in the "Регион показов" tree/tag widget.
 
     Issue #653 re-recon, 2026-08-02: Yandex replaced the old text-combobox
@@ -4597,8 +4600,27 @@ def _set_region(page: "Page", regions: List[str]) -> None:
     extra nesting needed no code change. This function's existing
     retry/actionability-wait already tolerates the section's few-hundred-ms
     render lag after ``_wait_for_step2`` returns.
+
+    Issue #657: each entry in ``regions`` may be a plain ``str`` (matched by
+    exact label text only, same as before — this is what plain ``--region``
+    gives, since it carries no known RegionId) or a ``(name, region_id)``
+    pair (what ``--region-id``, resolved via ``_resolve_region_ids``, gives).
+    Exact-text label matching alone only proves the right NAME was clicked —
+    Yandex's GeoRegions names are not globally unique, so a same-named
+    decoy elsewhere in the auto-expanded tree could in principle be the one
+    Playwright's ``is_visible()``/click actually lands on. When a
+    ``region_id`` is known, this additionally reads the checked checkbox's
+    own ``id`` attribute — confirmed live it is always
+    ``id="region-node-<RegionId>"`` — and refuses (raising, without ever
+    reaching the terminal "Запустить"/"Сохранить" click) if that id doesn't
+    encode the requested RegionId, rather than trusting the label-text match
+    alone to mean the right region was actually selected.
     """
     for region in regions:
+        if isinstance(region, tuple):
+            region, expected_region_id = region
+        else:
+            expected_region_id = None
         # XPath, not a plain data-testid selector: the tree auto-expands
         # every ancestor/descendant of a text match (see docstring), so
         # multiple RegionsTreeNode.Checkbox.label elements can be on screen
@@ -4622,6 +4644,7 @@ def _set_region(page: "Page", regions: List[str]) -> None:
         checkbox = page.locator(
             f"{label_xpath}//input[@data-testid='{_REGION_CHECKBOX_TESTID}']"
         )
+        matched_wrong_id = None
 
         # Live testing (issue #653) found opening the popup and filtering
         # the tree is flaky under real network conditions — the popup can
@@ -4683,14 +4706,43 @@ def _set_region(page: "Page", regions: List[str]) -> None:
                 # region, so confirm the input actually ended up checked
                 # rather than trusting the click — same read-back convention
                 # as _verify_created/_verify_saved.
+                node = checkbox.nth(i)
                 with contextlib.suppress(PlaywrightError):
-                    if checkbox.nth(i).is_checked():
+                    if not node.is_checked():
+                        continue
+                    if expected_region_id is None:
                         clicked = True
                         break
+                    # Issue #657: exact-text label match alone only proves
+                    # the right NAME was clicked — GeoRegions names are not
+                    # globally unique, so verify the checked node's own
+                    # identity too, via its stable
+                    # ``id="region-node-<RegionId>"`` attribute (confirmed
+                    # live). Uncheck it immediately on a mismatch so a wrong
+                    # region isn't left silently selected alongside whatever
+                    # the caller resolves next.
+                    node_id = node.get_attribute("id") or ""
+                    if node_id == f"region-node-{expected_region_id}":
+                        clicked = True
+                        break
+                    with contextlib.suppress(PlaywrightError):
+                        handle.click()
+                    matched_wrong_id = node_id
             if clicked:
                 break
 
         if not clicked:
+            if matched_wrong_id is not None:
+                raise BrowserSessionError(
+                    f"Selecting region {region!r} (RegionId "
+                    f"{expected_region_id}) matched a tree node by label "
+                    f"text, but that node's id ({matched_wrong_id!r}) does "
+                    "not encode the requested RegionId — Yandex's "
+                    "GeoRegions dictionary has more than one region named "
+                    f"{region!r}, and the wrong one was about to be "
+                    "selected. Re-run with --headful to inspect the tree "
+                    "and disambiguate manually."
+                )
             if (
                 last_open_exc is not None
                 and not page.locator(_REGION_LAUNCHER_TESTID).count()
@@ -4917,7 +4969,7 @@ def create_master(
     *,
     headlines: List[str],
     texts: List[str],
-    regions: List[str],
+    regions: "Sequence[Union[str, Tuple[str, Optional[int]]]]",
     weekly_budget: Optional[int] = None,
     launch: bool = True,
 ) -> Dict[str, Any]:

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -1526,10 +1526,20 @@ def copy(
     format_output(result, output_format, output)
 
 
-def _resolve_region_ids(ctx: click.Context, region_ids: "tuple[int, ...]") -> list:
+def _resolve_region_ids(
+    ctx: click.Context, region_ids: "tuple[int, ...]"
+) -> "list[tuple[str, int]]":
     """Resolve RegionId values to Yandex's canonical GeoRegionName via the
     GeoRegions dictionary — the exact text the Мастер кампаний region widget
     accepts, so callers don't have to guess Yandex's own wording (issue #652).
+
+    Returns ``(name, region_id)`` pairs, not bare names (issue #657): the
+    resolved RegionId travels alongside its name all the way into
+    ``_set_region``, which checks it against the DOM node it actually
+    clicked (``id="region-node-<RegionId>"``) rather than trusting an
+    exact-text label match alone — text match only proves the right NAME was
+    clicked, not the right underlying region, since GeoRegions names are not
+    globally unique (see the ambiguity check below).
 
     Unlike the rest of this group (see module docstring — masters needs no
     Yandex Direct API credentials), this one lookup does require valid API
@@ -1561,15 +1571,18 @@ def _resolve_region_ids(ctx: click.Context, region_ids: "tuple[int, ...]") -> li
 
     # Yandex's GeoRegions names are not globally unique (distinct IDs under
     # different parents can share a name, e.g. several "Сосновка" entries).
-    # `_set_region` matches the browser widget's autocomplete by exact name
-    # text and clicks the first visible option with no RegionId/parent
-    # verification, so a resolved name that is ambiguous in the full
-    # dictionary could silently select the wrong region before an immediate
-    # live launch (issue #652 follow-up). Look up every GeoRegions entry
-    # sharing one of the resolved names (SelectionCriteria is mandatory per
-    # the WSDL — GetGeoRegionsRequest.SelectionCriteria has minOccurs=1 — so
-    # ExactNames must be supplied) and refuse rather than guess if any name
-    # has more than one distinct owning RegionId.
+    # Issue #657: `_set_region` no longer trusts an exact-text label match
+    # alone — it now confirms the clicked checkbox's own
+    # ``id="region-node-<RegionId>"`` equals the requested RegionId, so an
+    # ambiguous name can no longer silently select the WRONG region live.
+    # This pre-flight check stays as defense in depth: it fails fast with a
+    # clear API-level error before a browser is even opened, rather than
+    # deferring to `_set_region`'s harder-to-diagnose in-page identity
+    # mismatch. Look up every GeoRegions entry sharing one of the resolved
+    # names (SelectionCriteria is mandatory per the WSDL —
+    # GetGeoRegionsRequest.SelectionCriteria has minOccurs=1 — so ExactNames
+    # must be supplied) and refuse rather than guess if any name has more
+    # than one distinct owning RegionId.
     resolved = [found[rid] for rid in region_ids]
     name_check = client.dictionaries().post(
         data={
@@ -1593,7 +1606,7 @@ def _resolve_region_ids(ctx: click.Context, region_ids: "tuple[int, ...]") -> li
             "be matched reliably. Use --region with the fully qualified "
             "text instead."
         )
-    return resolved
+    return list(zip(resolved, region_ids))
 
 
 @masters.command()
@@ -1689,7 +1702,13 @@ def add(
     if not regions and not region_ids:
         raise click.UsageError("At least one of --region/--region-id is required.")
 
-    all_regions = list(regions) + _resolve_region_ids(ctx, region_ids)
+    # (name, region_id) pairs — plain --region text has no known RegionId
+    # (region_id=None), so `_set_region` can only verify it by exact-text
+    # label match; --region-id-resolved entries carry their RegionId through
+    # so `_set_region` can additionally confirm DOM node identity (#657).
+    all_regions = [(region, None) for region in regions] + _resolve_region_ids(
+        ctx, region_ids
+    )
 
     result = _with_session(
         ctx,

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -18,6 +18,7 @@ GridCampaigns response these tests replay, and FakePage's ``request``/``on``
 additions below for how that replay is faked.
 """
 
+import contextlib
 import json
 import unittest
 from pathlib import Path
@@ -8380,20 +8381,29 @@ class TestSetRegion(unittest.TestCase):
             f"//input[@data-testid='{browser_masters._REGION_CHECKBOX_TESTID}']"
         )
 
-    def _region_node(self, region, checked, visible=True):
-        """A (label, input) pair whose label click toggles the input."""
+    def _region_node(self, region, checked, visible=True, node_id=None):
+        """A (label, input) pair whose label click toggles the input.
+
+        ``node_id`` models the checkbox's stable ``id="region-node-<id>"``
+        attribute (issue #657) — ``None`` means the fake node has no ``id``
+        attribute at all, same as any test written before that issue.
+        """
         state = {"checked": False}
 
         def _toggle():
             state["checked"] = not state["checked"]
             if state["checked"]:
                 checked.append(region)
+            else:
+                with contextlib.suppress(ValueError):
+                    checked.remove(region)
 
         label = _FakeLocatorHandle(visible=visible, on_click=_toggle)
-        box = _FakeLocatorHandle(get_checked=lambda: state["checked"])
+        attrs = {"id": node_id} if node_id is not None else {}
+        box = _FakeLocatorHandle(get_checked=lambda: state["checked"], attrs=attrs)
         return label, box
 
-    def _page_for_region(self, region, checkbox_visible=True):
+    def _page_for_region(self, region, checkbox_visible=True, node_id=None):
         launcher = _FakeLocatorHandle()
         editor = _FakeLocatorHandle()
         locators = {
@@ -8402,7 +8412,7 @@ class TestSetRegion(unittest.TestCase):
         }
         checked = []
         if checkbox_visible:
-            label, box = self._region_node(region, checked)
+            label, box = self._region_node(region, checked, node_id=node_id)
             locators[self._label_xpath(region)] = _FakeLocator([label])
             locators[self._checkbox_xpath(region)] = _FakeLocator([box])
         return FakePage(locators=locators), checked
@@ -8413,6 +8423,59 @@ class TestSetRegion(unittest.TestCase):
         browser_masters._set_region(page, ["Москва"])
 
         self.assertEqual(checked, ["Москва"])
+
+    def test_accepts_a_plain_string_region_with_no_identity_check(self):
+        # A plain str entry (what --region gives, with no known RegionId)
+        # must keep working exactly as before #657 — no id attribute is
+        # ever read for it.
+        page, checked = self._page_for_region("Москва", node_id=None)
+
+        browser_masters._set_region(page, ["Москва"])
+
+        self.assertEqual(checked, ["Москва"])
+
+    def test_accepts_a_name_region_id_pair_whose_node_id_matches(self):
+        # Issue #657: a (name, region_id) pair whose checked node's
+        # id="region-node-<RegionId>" matches the requested RegionId must
+        # select successfully, same as a plain string.
+        page, checked = self._page_for_region("Москва", node_id="region-node-213")
+
+        browser_masters._set_region(page, [("Москва", 213)])
+
+        self.assertEqual(checked, ["Москва"])
+
+    def test_rejects_a_node_whose_id_does_not_match_the_requested_region_id(self):
+        # The GeoRegions dictionary is not name-unique — a checkbox whose
+        # LABEL matches "Сосновка" exactly could still be the WRONG
+        # Сосновка. If its id doesn't encode the requested RegionId, this
+        # must raise instead of silently selecting the wrong region.
+        page, checked = self._page_for_region("Сосновка", node_id="region-node-999")
+
+        with (
+            patch.object(browser_masters, "_REGION_FILTER_TIMEOUT_MS", 10),
+            self.assertRaises(BrowserSessionError) as ctx,
+        ):
+            browser_masters._set_region(page, [("Сосновка", 111)])
+
+        self.assertIn("Сосновка", str(ctx.exception))
+        self.assertIn("111", str(ctx.exception))
+        # The wrong node must not be left checked after the mismatch —
+        # it's clicked once to select, then clicked again to undo it.
+        self.assertEqual(checked, [])
+
+    def test_rejects_a_node_with_no_id_attribute_when_region_id_is_requested(self):
+        # A checkbox with no id attribute at all (e.g. markup drift) cannot
+        # be confirmed as the right node, so a requested RegionId must still
+        # refuse rather than assume a match.
+        page, checked = self._page_for_region("Москва", node_id=None)
+
+        with (
+            patch.object(browser_masters, "_REGION_FILTER_TIMEOUT_MS", 10),
+            self.assertRaises(BrowserSessionError),
+        ):
+            browser_masters._set_region(page, [("Москва", 213)])
+
+        self.assertEqual(checked, [])
 
     def test_raises_when_launcher_missing(self):
         page = FakePage(locators={})
@@ -9204,7 +9267,7 @@ class TestMastersAddCommand(unittest.TestCase):
         _, kwargs = mock_create.call_args
         self.assertEqual(kwargs["headlines"], ["Заголовок 1", "Заголовок 2"])
         self.assertEqual(kwargs["texts"], ["Текст"])
-        self.assertEqual(kwargs["regions"], ["Москва"])
+        self.assertEqual(kwargs["regions"], [("Москва", None)])
         self.assertTrue(kwargs["launch"])
 
     def test_draft_flag_disables_launch(self):
@@ -9317,7 +9380,7 @@ class TestMastersAddCommand(unittest.TestCase):
         self.assertEqual(body["method"], "getGeoRegions")
         self.assertEqual(body["params"]["SelectionCriteria"]["RegionIds"], [213])
         _, kwargs = mock_create.call_args
-        self.assertEqual(kwargs["regions"], ["Москва"])
+        self.assertEqual(kwargs["regions"], [("Москва", 213)])
 
     def test_region_and_region_id_combine(self):
         service = Mock()
@@ -9359,7 +9422,7 @@ class TestMastersAddCommand(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0, result.output)
         _, kwargs = mock_create.call_args
-        self.assertEqual(kwargs["regions"], ["Москва", "Санкт-Петербург"])
+        self.assertEqual(kwargs["regions"], [("Москва", None), ("Санкт-Петербург", 2)])
 
     def test_unknown_region_id_raises_usage_error(self):
         service = Mock()
@@ -9425,7 +9488,7 @@ class TestResolveRegionIds(unittest.TestCase):
         with patch("direct_cli.commands.masters.create_client", return_value=client):
             result = _resolve_region_ids(Mock(), (213, 2))
 
-        self.assertEqual(result, ["Москва", "Санкт-Петербург"])
+        self.assertEqual(result, [("Москва", 213), ("Санкт-Петербург", 2)])
 
     def test_ambiguous_region_name_raises_usage_error(self):
         """Two distinct RegionIds sharing one GeoRegionName must not resolve
@@ -9505,7 +9568,7 @@ class TestResolveRegionIds(unittest.TestCase):
         with patch("direct_cli.commands.masters.create_client", return_value=client):
             result = _resolve_region_ids(Mock(), (213,))
 
-        self.assertEqual(result, ["Москва"])
+        self.assertEqual(result, [("Москва", 213)])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `masters add --region-id` resolved to Yandex's canonical `GeoRegionName` (#652) and handed a bare name to `_set_region`, which selects the region tree/tag-group widget's checkbox by exact label-text match only.
- Yandex's `GeoRegions` names are not globally unique — a text-only match could in principle land on a same-named decoy checkbox belonging to a different `RegionId` than the one requested. `_resolve_region_ids`'s ambiguity guard already caught known-ambiguous names up front, but gave no protection against a click landing on the wrong same-named node at runtime.
- `_resolve_region_ids` now returns `(name, region_id)` pairs instead of bare names, threaded through `masters add` / `create_master` into `_set_region`. When a `region_id` is known, `_set_region` additionally reads the checked checkbox's own `id` attribute (confirmed live it is always `id="region-node-<RegionId>"`) and refuses — unchecking the wrong node first — if it doesn't encode the requested `RegionId`.
- Plain `--region` text (no known `RegionId`) is unaffected and keeps matching by exact label text only, as before.
- Re-evaluated the pre-flight ambiguity check in `_resolve_region_ids`: kept as defense in depth, since it fails fast with a clear API-level error before a browser is even opened, instead of deferring to `_set_region`'s harder-to-diagnose in-page identity mismatch.

Closes #657

## Test plan
- [x] `pytest tests/test_masters.py -q` (465 passed)
- [x] `pytest tests/test_masters.py tests/test_comprehensive.py tests/test_cli.py -q` (535 passed)
- [x] `black --check` / `flake8` on changed files
- [x] Added unit tests: plain-string region unaffected, `(name, region_id)` match succeeds, node-id mismatch raises and unchecks, missing `id` attribute with a requested RegionId raises

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkQ9rmoZeLCcbCd1tmK1fQ