### PR TITLE
fix(masters): click visible label for hidden directs-helps checkbox

### DIFF
--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -726,14 +726,24 @@ def _clear_text_field(field: Any) -> bool:
     return True
 
 
-# XPath fragment: the checkbox immediately following the "Директ помогает"
-# heading. Confirmed live — a plain HTML checkbox, not a custom toggle
-# component (see fixture). Deliberately scoped to the FIRST following
-# checkbox only, so the nested "Оптимизировать расширенные настройки..."
-# checkbox that appears once this one is checked is never touched.
-_DIRECT_HELPS_CHECKBOX_XPATH = (
-    "xpath=//*[self::h1 or self::h2 or self::h3][normalize-space(text())="
-    "'Директ помогает']/following::input[@type='checkbox'][1]"
+# "Директ помогает" auto-recommendations toggle (issue #724, live
+# diagnosis): the underlying ``<input type="checkbox">`` is a classic
+# visually-hidden accessible-toggle input (wrapped in a clip-rect-0 div) —
+# ``is_visible()`` is False, so Playwright's ``.check()``/``.uncheck()``,
+# which both require visibility before clicking, hang until timeout. The
+# actually-clickable element is the sibling
+# ``[data-testid="CampaignRecommendationsEditor.AcceptRecommendations.label"]``,
+# which wraps a visible toggle div
+# (``data-testid="CampaignRecommendationsEditor.AcceptRecommendations"``)
+# whose ``data-checked`` attribute ("true"/"false") reflects state —
+# confirmed live: clicking the label flips both ``data-checked`` and the
+# hidden input's own ``is_checked()``. ``_set_directs_helps``/
+# ``_read_directs_helps`` therefore click/read the label's toggle div.
+_DIRECT_HELPS_TOGGLE_LABEL_SELECTOR = (
+    '[data-testid="CampaignRecommendationsEditor.AcceptRecommendations.label"]'
+)
+_DIRECT_HELPS_TOGGLE_DIV_SELECTOR = (
+    '[data-testid="CampaignRecommendationsEditor.AcceptRecommendations"]'
 )
 
 # XPath fragment: the "Цель продвижения" dropdown's trigger button. Confirmed
@@ -1815,17 +1825,25 @@ def _set_campaign_name(page: "Page", name: str) -> None:
 def _set_directs_helps(page: "Page", enabled: bool) -> None:
     """Check/uncheck the "Директ помогает" auto-recommendations checkbox.
 
-    Scoped to the FIRST checkbox following the "Директ помогает" heading only
-    (see ``_DIRECT_HELPS_CHECKBOX_XPATH``) — checking it reveals a second,
+    Clicks the visible label/toggle div, not the underlying
+    ``<input type="checkbox">`` (see ``_DIRECT_HELPS_TOGGLE_LABEL_SELECTOR``'s
+    docstring, issue #724): that input is visually-hidden, so
+    ``.check()``/``.uncheck()`` — which require visibility — hang until
+    timeout. Clicking the label is a no-op if the toggle is already in the
+    requested state (unlike ``.check()``/``.uncheck()``, a plain ``.click()``
+    would flip it either way), so this only clicks when
+    ``_read_directs_helps`` reports the opposite of ``enabled``. Scoped to
+    the "Директ помогает" toggle only — checking it reveals a second,
     nested checkbox ("Оптимизировать расширенные настройки...") that is out
     of scope for Этап A and must be left untouched.
     """
-    checkbox = page.locator(_DIRECT_HELPS_CHECKBOX_XPATH).first
+    current = _read_directs_helps(page)
+    if current is enabled:
+        return
+
+    label = page.locator(_DIRECT_HELPS_TOGGLE_LABEL_SELECTOR).first
     try:
-        if enabled:
-            checkbox.check()
-        else:
-            checkbox.uncheck()
+        label.click()
     except PlaywrightError as exc:
         raise BrowserSessionError(
             "Could not find or toggle the 'Директ помогает' checkbox "
@@ -2258,13 +2276,25 @@ def _read_weekly_budget(page: "Page") -> Optional[int]:
 def _read_directs_helps(page: "Page") -> Optional[bool]:
     """Read the "Директ помогает" checkbox's current checked state.
 
-    Returns ``None`` if the field can't be found/read (inconclusive).
+    Reads the visible toggle div's ``data-checked`` attribute, not the
+    underlying ``<input type="checkbox">``'s ``is_checked()`` (issue #724):
+    the input is visually-hidden, and while ``is_checked()`` itself doesn't
+    require visibility, keeping the read path on the same element
+    ``_set_directs_helps`` clicks avoids the two ever silently disagreeing
+    if Yandex's toggle implementation changes. Returns ``None`` if the field
+    can't be found/read, OR if ``data-checked`` holds neither "true" nor
+    "false" (inconclusive either way).
     """
-    checkbox = page.locator(_DIRECT_HELPS_CHECKBOX_XPATH).first
+    toggle = page.locator(_DIRECT_HELPS_TOGGLE_DIV_SELECTOR).first
     try:
-        return checkbox.is_checked()
+        value = toggle.get_attribute("data-checked")
     except PlaywrightError:
         return None
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    return None
 
 
 def _read_promotion_goal_label(page: "Page") -> Optional[str]:

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -1837,18 +1837,26 @@ def _set_directs_helps(page: "Page", enabled: bool) -> None:
     nested checkbox ("Оптимизировать расширенные настройки...") that is out
     of scope for Этап A and must be left untouched.
 
-    The pre-click read polls via ``_read_until_matches`` instead of a
-    one-shot ``_read_directs_helps`` call (Codex, cycle-review round 1 of
-    PR #731): ``_wait_for_edit_form`` only guarantees the first headline
-    slot has rendered, so a one-shot read right after can catch
+    The pre-click read polls only while INCONCLUSIVE (``None``), not until
+    it matches ``enabled`` (Codex, cycle-review round 2 of PR #731, fixing
+    the round-1 fix): ``_wait_for_edit_form`` only guarantees the first
+    headline slot has rendered, so a one-shot read right after can catch
     ``data-checked`` still unset/absent (``None``) while the toggle is
     ALREADY in the requested state — the same hydration race
     ``_read_until_matches``'s own docstring documents for every other field.
     Treating that transient ``None`` as "opposite of ``enabled``" would
     click the label and invert an already-correct state instead of leaving
-    it alone.
+    it alone. But polling for ``enabled`` specifically (via
+    ``_read_until_matches``) is wrong once the read is settled: on a
+    genuine state CHANGE, ``_read_directs_helps`` stably reports the
+    opposite of ``enabled`` until the click below actually flips it —
+    nothing makes it converge to ``enabled`` on its own — so that would
+    burn the full ``_VERIFY_FIELD_READ_TIMEOUT_MS`` on every real toggle
+    for no reason. Only ``None`` is a signal worth waiting out.
     """
-    current = _read_until_matches(page, _read_directs_helps, enabled)
+    current = _read_until_matches(
+        page, _read_directs_helps, None, matches=lambda actual, _exp: actual is not None
+    )
     if current is enabled:
         return
 

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -1836,8 +1836,19 @@ def _set_directs_helps(page: "Page", enabled: bool) -> None:
     the "Директ помогает" toggle only — checking it reveals a second,
     nested checkbox ("Оптимизировать расширенные настройки...") that is out
     of scope for Этап A and must be left untouched.
+
+    The pre-click read polls via ``_read_until_matches`` instead of a
+    one-shot ``_read_directs_helps`` call (Codex, cycle-review round 1 of
+    PR #731): ``_wait_for_edit_form`` only guarantees the first headline
+    slot has rendered, so a one-shot read right after can catch
+    ``data-checked`` still unset/absent (``None``) while the toggle is
+    ALREADY in the requested state — the same hydration race
+    ``_read_until_matches``'s own docstring documents for every other field.
+    Treating that transient ``None`` as "opposite of ``enabled``" would
+    click the label and invert an already-correct state instead of leaving
+    it alone.
     """
-    current = _read_directs_helps(page)
+    current = _read_until_matches(page, _read_directs_helps, enabled)
     if current is enabled:
         return
 

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -3296,6 +3296,31 @@ class TestSetDirectsHelps(unittest.TestCase):
         self.assertFalse(state["toggled"])
         self.assertGreaterEqual(ticks["count"], 1)
 
+    def test_does_not_poll_out_the_full_timeout_on_a_real_change(self):
+        # Regression (Codex, cycle-review round 2 of PR #731 — cloud
+        # fallback, inline finding P2): a genuine state CHANGE has
+        # _read_directs_helps stably reporting the opposite of `enabled`
+        # until the label click below actually flips it — nothing makes it
+        # converge to `enabled` on its own. Polling via _read_until_matches
+        # against `enabled` (the round-1 fix's first attempt) would burn the
+        # full _VERIFY_FIELD_READ_TIMEOUT_MS on every real toggle. The fix
+        # polls only while the read is inconclusive (None); a settled,
+        # stable, non-None read (even if it's the opposite of `enabled`)
+        # must be accepted immediately — zero wait_for_timeout ticks.
+        ticks = {"count": 0}
+        state = {"toggled": False}
+        page = _directs_helps_page(
+            False, on_toggle=lambda v: state.__setitem__("toggled", True)
+        )
+        page.wait_for_timeout = lambda timeout: ticks.__setitem__(
+            "count", ticks["count"] + 1
+        )
+
+        browser_masters._set_directs_helps(page, True)
+
+        self.assertTrue(state["toggled"])
+        self.assertEqual(ticks["count"], 0)
+
 
 class TestSetPromotionGoal(unittest.TestCase):
     """``_set_promotion_goal`` (issue #631, Этап A) — open dropdown, click, verify.

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -214,6 +214,27 @@ class _FakeLocatorHandle:
             self._on_upload(path)
 
 
+class _DynamicAttrsLocatorHandle(_FakeLocatorHandle):
+    """A handle whose ``get_attribute`` reads LIVE state via a callable.
+
+    ``_FakeLocatorHandle.get_attribute`` reads a snapshot dict fixed at
+    construction time — insufficient for the "Директ помогает" toggle
+    (issue #724), whose ``data-checked`` must reflect whatever the sibling
+    label's click handler last wrote to shared test state. ``get_attrs`` is
+    called on every ``get_attribute()``, mirroring how a real re-read always
+    sees the DOM's current attribute value.
+    """
+
+    def __init__(self, *args, get_attrs, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._get_attrs = get_attrs
+
+    def get_attribute(self, name):
+        if self._raises:
+            raise PlaywrightError("element detached")
+        return self._get_attrs().get(name)
+
+
 class _FakeContentEditableHandle(_FakeLocatorHandle):
     """A slot that models the REAL contenteditable semantics (issue #655 review).
 
@@ -3161,16 +3182,45 @@ class TestSetWeeklyBudget(unittest.TestCase):
             browser_masters._set_weekly_budget(page, 95000)
 
 
+def _directs_helps_page(initial_checked, on_toggle=None):
+    """Build a FakePage modeling the label/toggle-div pair (issue #724).
+
+    The real toggle's underlying ``<input>`` is visually-hidden — Yandex's
+    clickable element is a sibling ``.label``, and state is read from the
+    toggle div's ``data-checked`` attribute, not the input. ``attrs`` is a
+    single shared dict so the label's click handler and the div's
+    ``get_attribute("data-checked")`` observe the same mutable state, mirroring
+    how the real DOM's label click flips the sibling div's attribute.
+    """
+    attrs = {"data-checked": "true" if initial_checked else "false"}
+
+    def _toggle():
+        attrs["data-checked"] = "false" if attrs["data-checked"] == "true" else "true"
+        if on_toggle is not None:
+            on_toggle(attrs["data-checked"] == "true")
+
+    label_handle = _FakeLocatorHandle(on_click=_toggle)
+    div_handle = _FakeLocatorHandle(attrs=attrs)
+    return FakePage(
+        locators={
+            browser_masters._DIRECT_HELPS_TOGGLE_LABEL_SELECTOR: _FakeLocator(
+                [label_handle]
+            ),
+            browser_masters._DIRECT_HELPS_TOGGLE_DIV_SELECTOR: _FakeLocator(
+                [div_handle]
+            ),
+        }
+    )
+
+
 class TestSetDirectsHelps(unittest.TestCase):
-    """``_set_directs_helps`` (issue #631, Этап A) — check/uncheck, idempotent API."""
+    """``_set_directs_helps`` (issue #631, Этап A; issue #724 label/data-checked
+    rewrite) — click the visible label, idempotent no-op when already matching."""
 
     def test_enables_checkbox(self):
-        state = {"checked": False}
-        handle = _FakeLocatorHandle(on_check=lambda v: state.__setitem__("checked", v))
-        page = FakePage(
-            locators={
-                browser_masters._DIRECT_HELPS_CHECKBOX_XPATH: _FakeLocator([handle])
-            }
+        state = {}
+        page = _directs_helps_page(
+            False, on_toggle=lambda v: state.__setitem__("checked", v)
         )
 
         browser_masters._set_directs_helps(page, True)
@@ -3178,17 +3228,24 @@ class TestSetDirectsHelps(unittest.TestCase):
         self.assertTrue(state["checked"])
 
     def test_disables_checkbox(self):
-        state = {"checked": True}
-        handle = _FakeLocatorHandle(on_check=lambda v: state.__setitem__("checked", v))
-        page = FakePage(
-            locators={
-                browser_masters._DIRECT_HELPS_CHECKBOX_XPATH: _FakeLocator([handle])
-            }
+        state = {}
+        page = _directs_helps_page(
+            True, on_toggle=lambda v: state.__setitem__("checked", v)
         )
 
         browser_masters._set_directs_helps(page, False)
 
         self.assertFalse(state["checked"])
+
+    def test_is_noop_when_already_in_requested_state(self):
+        state = {"toggled": False}
+        page = _directs_helps_page(
+            True, on_toggle=lambda v: state.__setitem__("toggled", True)
+        )
+
+        browser_masters._set_directs_helps(page, True)
+
+        self.assertFalse(state["toggled"])
 
     def test_raises_browser_session_error_when_checkbox_missing(self):
         page = FakePage(locators={})
@@ -3999,12 +4056,30 @@ class TestUpdateMaster(unittest.TestCase):
                 [budget_handle]
             )
         if directs_helps_state is not None:
-            checkbox_handle = _FakeLocatorHandle(
-                on_check=lambda v: directs_helps_state.__setitem__("checked", v),
-                get_checked=lambda: directs_helps_state.get("checked", False),
+            # Issue #724: the toggle's real clickable element is the label,
+            # and state lives in the sibling div's `data-checked` attribute —
+            # so the label's on_click and the div's get_attribute must read/
+            # write the SAME shared `directs_helps_state`, mirroring the real
+            # DOM's label-click-flips-sibling-attribute behavior.
+            def _directs_helps_attrs():
+                return {
+                    "data-checked": (
+                        "true" if directs_helps_state.get("checked", False) else "false"
+                    )
+                }
+
+            def _toggle_directs_helps():
+                directs_helps_state["checked"] = not directs_helps_state.get(
+                    "checked", False
+                )
+
+            label_handle = _FakeLocatorHandle(on_click=_toggle_directs_helps)
+            div_handle = _DynamicAttrsLocatorHandle(get_attrs=_directs_helps_attrs)
+            locators[browser_masters._DIRECT_HELPS_TOGGLE_LABEL_SELECTOR] = (
+                _FakeLocator([label_handle])
             )
-            locators[browser_masters._DIRECT_HELPS_CHECKBOX_XPATH] = _FakeLocator(
-                [checkbox_handle]
+            locators[browser_masters._DIRECT_HELPS_TOGGLE_DIV_SELECTOR] = _FakeLocator(
+                [div_handle]
             )
         if name_state is not None:
             # The rename modal's "Применить" only updates the header's
@@ -4559,19 +4634,21 @@ class TestUpdateMaster(unittest.TestCase):
         self.assertIn("did not save as requested", str(ctx.exception))
 
     def test_raises_when_saved_directs_helps_does_not_match_requested(self):
-        checkbox_state = {"checked": False}  # never actually flips to True
         save_handle = _FakeTextLocatorHandle(visible=True)
-        checkbox_handle = _FakeLocatorHandle(
-            on_check=lambda v: None,
-            get_checked=lambda: checkbox_state["checked"],
-        )
+        # Label click is a no-op — models "Yandex silently rejected the
+        # toggle": data-checked never actually flips to true (issue #724).
+        label_handle = _FakeLocatorHandle(on_click=lambda: None)
+        div_handle = _FakeLocatorHandle(attrs={"data-checked": "false"})
         edit_form_ready_selector = (
             f'[data-testid="{browser_masters._EDIT_FORM_READY_TESTID}"]'
         )
         page = FakePage(
             locators={
-                browser_masters._DIRECT_HELPS_CHECKBOX_XPATH: _FakeLocator(
-                    [checkbox_handle]
+                browser_masters._DIRECT_HELPS_TOGGLE_LABEL_SELECTOR: _FakeLocator(
+                    [label_handle]
+                ),
+                browser_masters._DIRECT_HELPS_TOGGLE_DIV_SELECTOR: _FakeLocator(
+                    [div_handle]
                 ),
                 edit_form_ready_selector: _FakeLocator([_FakeLocatorHandle()]),
             },

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -3253,6 +3253,49 @@ class TestSetDirectsHelps(unittest.TestCase):
         with self.assertRaises(BrowserSessionError):
             browser_masters._set_directs_helps(page, True)
 
+    def test_waits_out_hydration_before_deciding_to_click(self):
+        # Regression (Codex, cycle-review round 1 of PR #731): a one-shot
+        # _read_directs_helps() can catch data-checked mid-hydration —
+        # absent/unset, read as None — while the toggle is ALREADY in the
+        # requested state. Treating that None as "opposite of enabled" would
+        # click the label and actually INVERT the real (already-correct)
+        # state. Models data-checked missing for one tick, then settling to
+        # "true" (already matches enabled=True) — must poll via
+        # _read_until_matches and end up NOT clicking.
+        ticks = {"count": 0}
+        state = {"toggled": False}
+
+        def _toggle():
+            state["toggled"] = True
+
+        def _get_attrs():
+            if ticks["count"] < 1:
+                return {}
+            return {"data-checked": "true"}
+
+        label_handle = _FakeLocatorHandle(on_click=_toggle)
+        div_handle = _DynamicAttrsLocatorHandle(get_attrs=_get_attrs)
+
+        class _DelayedHydrationPage(FakePage):
+            def wait_for_timeout(self, timeout):
+                ticks["count"] += 1
+
+        page = _DelayedHydrationPage(
+            locators={
+                browser_masters._DIRECT_HELPS_TOGGLE_LABEL_SELECTOR: _FakeLocator(
+                    [label_handle]
+                ),
+                browser_masters._DIRECT_HELPS_TOGGLE_DIV_SELECTOR: _FakeLocator(
+                    [div_handle]
+                ),
+            }
+        )
+
+        browser_masters._set_directs_helps(page, True)
+
+        self.assertFalse(state["toggled"])
+        self.assertGreaterEqual(ticks["count"], 1)
+
 
 class TestSetPromotionGoal(unittest.TestCase):
     """``_set_promotion_goal`` (issue #631, Этап A) — open dropdown, click, verify.


### PR DESCRIPTION
## Summary
- `_set_directs_helps` (`direct_cli/browser/masters.py`) called `.check()`/`.uncheck()` on the "Директ помогает" checkbox's real `<input type="checkbox">`, which is visually-hidden (classic accessible-toggle pattern). Playwright's `.check()`/`.uncheck()` require visibility before acting, so both hang until timeout — `--directs-helps`/`--no-directs-helps` never worked through this path (confirmed live in #724).
- Fixed by clicking the sibling visible label (`[data-testid="CampaignRecommendationsEditor.AcceptRecommendations.label"]`) instead, and only when `_read_directs_helps` reports the opposite of the requested state (a plain `.click()` toggles either way, unlike `.check()`/`.uncheck()`).
- `_read_directs_helps` now reads the adjacent toggle div's (`[data-testid="CampaignRecommendationsEditor.AcceptRecommendations"]`) `data-checked` attribute instead of the hidden input's `is_checked()`, keeping the read/write paths on the same element.

Closes #724

## Test plan
- [x] `pytest tests/test_masters.py -k "DirectsHelps or directs_helps"` — 8 passed (rewrote `TestSetDirectsHelps` + `update_master` directs_helps fixtures for the label/`data-checked` model)
- [x] Full offline suite: `pytest -q` — 3043 passed, 8 skipped (62 `test_integration_write.py` errors pre-exist without this change — confirmed via `git stash`, they require live credentials not present in this environment)
- [x] `black --check` / `flake8` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)