### PR TITLE
chore: clean up flake8 backlog (E501/PIE786/SIM105/SIM102/N806/N817)

### DIFF
--- a/direct_cli/_smoke_probes.py
+++ b/direct_cli/_smoke_probes.py
@@ -34,7 +34,7 @@ def _advideo_get_accepts(client: Any, candidate: str) -> bool:
     try:
         _extract_items(client.advideos().post(data=body))
         return True
-    except Exception:
+    except Exception:  # noqa: PIE786 - probe must degrade to a benign skip
         return False
 
 
@@ -47,7 +47,7 @@ def advideo_probe_id() -> Optional[str]:
     """
     try:
         client = create_client()
-    except Exception:
+    except Exception:  # noqa: PIE786 - probe must degrade to a benign skip
         return None
 
     env_id = os.getenv("YANDEX_DIRECT_TEST_ADVIDEO_ID")
@@ -64,7 +64,7 @@ def advideo_probe_id() -> Optional[str]:
     }
     try:
         creatives = _extract_items(client.creatives().post(data=body))
-    except Exception:
+    except Exception:  # noqa: PIE786 - probe must degrade to a benign skip
         return None
 
     for creative in creatives:
@@ -88,7 +88,7 @@ def _first_campaign_id(client: Any) -> Optional[int]:
     }
     try:
         campaigns = _extract_items(client.campaigns().post(data=body))
-    except Exception:
+    except Exception:  # noqa: PIE786 - probe must degrade to a benign skip
         return None
     if not campaigns:
         return None
@@ -119,7 +119,7 @@ def retargeting_goal_probe_id() -> Optional[str]:
 
     try:
         client = create_client()
-    except Exception:
+    except Exception:  # noqa: PIE786 - probe must degrade to a benign skip
         return None
 
     campaign_id = _first_campaign_id(client)
@@ -136,7 +136,7 @@ def retargeting_goal_probe_id() -> Optional[str]:
                 }
             )
         )
-    except Exception:
+    except Exception:  # noqa: PIE786 - probe must degrade to a benign skip
         return None
 
     for goal in goals:

--- a/direct_cli/auth.py
+++ b/direct_cli/auth.py
@@ -715,7 +715,7 @@ def _resolve_client_login_via_api(token: str) -> Optional[str]:
             login = clients[0].get("Login")
             if login:
                 return login
-    except Exception as exc:  # best-effort; never block login on this
+    except Exception as exc:  # noqa: PIE786 - best-effort; never block login on this
         logging.debug("resolve client login via API failed: %s", exc)
     return None
 
@@ -782,7 +782,7 @@ def _resolve_profile_credentials(
                         if matches:
                             prof["login"] = resolved
                         save_auth_store(store)
-                except Exception as exc:  # best-effort persistence
+                except Exception as exc:  # noqa: PIE786 - best-effort persistence
                     logging.debug("login migration persist failed: %s", exc)
 
     if not final_token:

--- a/direct_cli/commands/_campaigns_base.py
+++ b/direct_cli/commands/_campaigns_base.py
@@ -141,7 +141,8 @@ def _time_targeting_schedule_option(values: Sequence[str]) -> Optional[dict]:
     if len(items) > TIME_TARGETING_SCHEDULE_MAX_ITEMS:
         raise click.UsageError(
             t(
-                "--time-targeting-schedule must contain at most {TIME_TARGETING_SCHEDULE_MAX_ITEMS} items"
+                "--time-targeting-schedule must contain at most "
+                "{TIME_TARGETING_SCHEDULE_MAX_ITEMS} items"
             ).format(
                 TIME_TARGETING_SCHEDULE_MAX_ITEMS=TIME_TARGETING_SCHEDULE_MAX_ITEMS
             )
@@ -437,7 +438,10 @@ def _build_package_bidding_strategy(
     ):
         raise click.UsageError(
             t(
-                "{campaign_label}.PackageBiddingStrategy requires --package-platform-search-result, --package-platform-product-gallery, and --package-platform-network"
+                "{campaign_label}.PackageBiddingStrategy requires "
+                "--package-platform-search-result, "
+                "--package-platform-product-gallery, and "
+                "--package-platform-network"
             ).format(campaign_label=campaign_label)
         )
 
@@ -623,7 +627,10 @@ _TEXT_SEARCH_STRATEGY_OPTIONS = [
     click.option(
         "--text-search-exploration-min-budget",
         type=MICRO_RUBLES,
-        help="TextCampaign Search ExplorationBudget.MinimumExplorationBudget in micro-rubles",
+        help=(
+            "TextCampaign Search ExplorationBudget.MinimumExplorationBudget "
+            "in micro-rubles"
+        ),
     ),
     click.option(
         "--text-search-exploration-is-custom",

--- a/direct_cli/commands/_campaigns_dynamic.py
+++ b/direct_cli/commands/_campaigns_dynamic.py
@@ -245,7 +245,9 @@ def build_add_block(
             if legacy_provided:
                 raise click.UsageError(
                     t(
-                        "DynamicTextCampaign Search typed flags (--dyn-search-*) cannot be combined with the legacy CPA-shape flags {arg0}; use the matching --dyn-search-* equivalent"
+                        "DynamicTextCampaign Search typed flags (--dyn-search-*) "
+                        "cannot be combined with the legacy CPA-shape flags "
+                        "{arg0}; use the matching --dyn-search-* equivalent"
                     ).format(arg0=", ".join(sorted(legacy_provided)))
                 )
         # WSDL DynamicTextCampaignAddItem.PriorityGoals (line 2186)

--- a/direct_cli/commands/adgroups.py
+++ b/direct_cli/commands/adgroups.py
@@ -96,7 +96,8 @@ def _validate_tracking_params(tracking_params: Optional[str]) -> None:
     ):
         raise click.UsageError(
             t(
-                "--tracking-params must be at most {_TRACKING_PARAMS_MAX_LENGTH} characters"
+                "--tracking-params must be at most "
+                "{_TRACKING_PARAMS_MAX_LENGTH} characters"
             ).format(_TRACKING_PARAMS_MAX_LENGTH=_TRACKING_PARAMS_MAX_LENGTH)
         )
 
@@ -369,7 +370,8 @@ def _reject_mixed_update_subtype_flags(
         second_subtype, second_flags = provided_by_subtype[1]
         raise click.UsageError(
             t(
-                "{first_subtype} update flags ({arg0}) cannot be combined with {second_subtype} update flags ({arg1})."
+                "{first_subtype} update flags ({arg0}) cannot be combined "
+                "with {second_subtype} update flags ({arg1})."
             ).format(
                 first_subtype=first_subtype,
                 arg0=", ".join(first_flags),
@@ -1019,7 +1021,10 @@ def _bulk_add_adgroups(ctx, *, campaign_id, from_file, adgroups_json, dry_run):
 @click.option(
     "--campaign-id",
     type=click.IntRange(min=1),
-    help="Campaign ID (required in single-item mode; batch default in --from-file mode)",
+    help=(
+        "Campaign ID (required in single-item mode; batch default in "
+        "--from-file mode)"
+    ),
 )
 @click.option(
     "--type",

--- a/direct_cli/commands/ads/_cli.py
+++ b/direct_cli/commands/ads/_cli.py
@@ -986,7 +986,10 @@ def add(
     "--from-file",
     "from_file",
     type=click.Path(exists=True, dir_okay=False, readable=True),
-    help="Path to a JSONL file (one flag-form ad-update object per line) for batch update",
+    help=(
+        "Path to a JSONL file (one flag-form ad-update object per line) "
+        "for batch update"
+    ),
 )
 @click.option(
     "--ads-json",

--- a/direct_cli/commands/ads/objects.py
+++ b/direct_cli/commands/ads/objects.py
@@ -200,7 +200,14 @@ def build_ad_object(*, adgroup_id, ad_type, mobile_provided, flags, flag_for=Non
     if ad_type_norm not in _ADS_ADD_SUPPORTED_TYPES:
         raise click.UsageError(
             t(
-                "Invalid value for '--type': {ad_type!r} is not one of 'TEXT_AD', 'TEXT_IMAGE_AD', 'MOBILE_APP_AD', 'DYNAMIC_TEXT_AD', 'MOBILE_APP_IMAGE_AD', 'RESPONSIVE_AD', 'SHOPPING_AD', 'LISTING_AD', 'SMART_AD_BUILDER_AD', 'TEXT_AD_BUILDER_AD', 'MOBILE_APP_AD_BUILDER_AD', 'MOBILE_APP_CPC_VIDEO_AD_BUILDER_AD', 'CPC_VIDEO_AD_BUILDER_AD', 'CPM_BANNER_AD_BUILDER_AD', 'CPM_VIDEO_AD_BUILDER_AD'."
+                "Invalid value for '--type': {ad_type!r} is not one of "
+                "'TEXT_AD', 'TEXT_IMAGE_AD', 'MOBILE_APP_AD', "
+                "'DYNAMIC_TEXT_AD', 'MOBILE_APP_IMAGE_AD', 'RESPONSIVE_AD', "
+                "'SHOPPING_AD', 'LISTING_AD', 'SMART_AD_BUILDER_AD', "
+                "'TEXT_AD_BUILDER_AD', 'MOBILE_APP_AD_BUILDER_AD', "
+                "'MOBILE_APP_CPC_VIDEO_AD_BUILDER_AD', "
+                "'CPC_VIDEO_AD_BUILDER_AD', 'CPM_BANNER_AD_BUILDER_AD', "
+                "'CPM_VIDEO_AD_BUILDER_AD'."
             ).format(ad_type=ad_type)
         )
 
@@ -591,7 +598,14 @@ def build_ad_update_object(*, ad_id, ad_type, flags, flag_for=None):
     if ad_type_norm not in _ADS_UPDATE_SUPPORTED_TYPES:
         raise click.UsageError(
             t(
-                "Invalid value for '--type': {ad_type!r} is not one of 'TEXT_AD', 'TEXT_IMAGE_AD', 'MOBILE_APP_AD', 'DYNAMIC_TEXT_AD', 'MOBILE_APP_IMAGE_AD', 'RESPONSIVE_AD', 'SHOPPING_AD', 'LISTING_AD', 'SMART_AD_BUILDER_AD', 'TEXT_AD_BUILDER_AD', 'MOBILE_APP_AD_BUILDER_AD', 'MOBILE_APP_CPC_VIDEO_AD_BUILDER_AD', 'CPC_VIDEO_AD_BUILDER_AD', 'CPM_BANNER_AD_BUILDER_AD', 'CPM_VIDEO_AD_BUILDER_AD'."
+                "Invalid value for '--type': {ad_type!r} is not one of "
+                "'TEXT_AD', 'TEXT_IMAGE_AD', 'MOBILE_APP_AD', "
+                "'DYNAMIC_TEXT_AD', 'MOBILE_APP_IMAGE_AD', 'RESPONSIVE_AD', "
+                "'SHOPPING_AD', 'LISTING_AD', 'SMART_AD_BUILDER_AD', "
+                "'TEXT_AD_BUILDER_AD', 'MOBILE_APP_AD_BUILDER_AD', "
+                "'MOBILE_APP_CPC_VIDEO_AD_BUILDER_AD', "
+                "'CPC_VIDEO_AD_BUILDER_AD', 'CPM_BANNER_AD_BUILDER_AD', "
+                "'CPM_VIDEO_AD_BUILDER_AD'."
             ).format(ad_type=ad_type)
         )
 
@@ -642,7 +656,8 @@ def build_ad_update_object(*, ad_id, ad_type, flags, flag_for=None):
     except click.UsageError as exc:
         raise click.UsageError(
             t(
-                "{arg0} --type selects the existing ad subtype update block; it does not convert an ad between subtypes."
+                "{arg0} --type selects the existing ad subtype update "
+                "block; it does not convert an ad between subtypes."
             ).format(arg0=exc.message)
         )
 
@@ -816,7 +831,8 @@ def build_ad_update_object(*, ad_id, ad_type, flags, flag_for=None):
     if len(ad_data) == 1:
         raise click.UsageError(
             t(
-                "ads update requires at least one updatable field for --type {ad_type_norm}."
+                "ads update requires at least one updatable field for "
+                "--type {ad_type_norm}."
             ).format(ad_type_norm=ad_type_norm)
         )
 

--- a/direct_cli/commands/campaigns.py
+++ b/direct_cli/commands/campaigns.py
@@ -1144,7 +1144,10 @@ def get(
 @click.option(
     "--unified-search-pay-cpa",
     type=MICRO_RUBLES,
-    help="UnifiedCampaign Search StrategyPayForConversionAdd.Cpa in micro-rubles (#363)",
+    help=(
+        "UnifiedCampaign Search StrategyPayForConversionAdd.Cpa in "
+        "micro-rubles (#363)"
+    ),
 )
 @click.option(
     "--unified-search-exploration-min-budget",
@@ -1193,7 +1196,10 @@ def get(
 @click.option(
     "--unified-network-average-cpc",
     type=MICRO_RUBLES,
-    help="UnifiedCampaign Network StrategyAverageCpcAdd.AverageCpc in micro-rubles (#366)",
+    help=(
+        "UnifiedCampaign Network StrategyAverageCpcAdd.AverageCpc in "
+        "micro-rubles (#366)"
+    ),
 )
 @click.option(
     "--unified-network-cpa",
@@ -1538,7 +1544,9 @@ def add(
     if campaign_type_norm not in supported_types:
         raise click.UsageError(
             t(
-                "Invalid value for '--type': {campaign_type!r} is not one of 'TEXT_CAMPAIGN', 'UNIFIED_CAMPAIGN', 'DYNAMIC_TEXT_CAMPAIGN', 'SMART_CAMPAIGN', 'MOBILE_APP_CAMPAIGN', 'CPM_BANNER_CAMPAIGN'."
+                "Invalid value for '--type': {campaign_type!r} is not one of "
+                "'TEXT_CAMPAIGN', 'UNIFIED_CAMPAIGN', 'DYNAMIC_TEXT_CAMPAIGN', "
+                "'SMART_CAMPAIGN', 'MOBILE_APP_CAMPAIGN', 'CPM_BANNER_CAMPAIGN'."
             ).format(campaign_type=campaign_type)
         )
 
@@ -2436,7 +2444,8 @@ def add(
         if provided:
             raise click.UsageError(
                 t(
-                    "{package_label}.PackageBiddingStrategy cannot be combined with {arg0}"
+                    "{package_label}.PackageBiddingStrategy cannot be combined "
+                    "with {arg0}"
                 ).format(package_label=package_label, arg0=", ".join(sorted(provided)))
             )
     if smart_package_bidding_strategy_obj is not None:
@@ -2509,7 +2518,8 @@ def add(
         if provided:
             raise click.UsageError(
                 t(
-                    "SmartCampaign.PackageBiddingStrategy cannot be combined with {arg0}"
+                    "SmartCampaign.PackageBiddingStrategy cannot be combined "
+                    "with {arg0}"
                 ).format(arg0=", ".join(sorted(provided)))
             )
 
@@ -2599,7 +2609,12 @@ def add(
             ):
                 raise click.UsageError(
                     t(
-                        "--priority-goals on UnifiedCampaign is only valid with --network-strategy or --search-strategy in {{AVERAGE_CPA_MULTIPLE_GOALS, PAY_FOR_CONVERSION_MULTIPLE_GOALS, MAX_PROFIT}}; got --network-strategy={network_strategy!r}, --search-strategy={search_strategy!r}"
+                        "--priority-goals on UnifiedCampaign is only valid with "
+                        "--network-strategy or --search-strategy in "
+                        "{{AVERAGE_CPA_MULTIPLE_GOALS, "
+                        "PAY_FOR_CONVERSION_MULTIPLE_GOALS, MAX_PROFIT}}; got "
+                        "--network-strategy={network_strategy!r}, "
+                        "--search-strategy={search_strategy!r}"
                     ).format(
                         network_strategy=network_strategy,
                         search_strategy=search_strategy,
@@ -2619,7 +2634,8 @@ def add(
         if provided:
             raise click.UsageError(
                 t(
-                    "{campaign_type_norm} BiddingStrategy typed parameters are tracked in #290; got {arg0}"
+                    "{campaign_type_norm} BiddingStrategy typed parameters are "
+                    "tracked in #290; got {arg0}"
                 ).format(
                     campaign_type_norm=campaign_type_norm,
                     arg0=", ".join(sorted(provided)),
@@ -3132,7 +3148,10 @@ def add(
 @click.option(
     "--unified-search-pay-cpa",
     type=MICRO_RUBLES,
-    help="UnifiedCampaign Search StrategyPayForConversionAdd.Cpa in micro-rubles (#363)",
+    help=(
+        "UnifiedCampaign Search StrategyPayForConversionAdd.Cpa in "
+        "micro-rubles (#363)"
+    ),
 )
 @click.option(
     "--unified-search-exploration-min-budget",
@@ -3178,7 +3197,10 @@ def add(
 @click.option(
     "--unified-network-average-cpc",
     type=MICRO_RUBLES,
-    help="UnifiedCampaign Network StrategyAverageCpcAdd.AverageCpc in micro-rubles (#366)",
+    help=(
+        "UnifiedCampaign Network StrategyAverageCpcAdd.AverageCpc in "
+        "micro-rubles (#366)"
+    ),
 )
 @click.option(
     "--unified-network-cpa",
@@ -4335,13 +4357,17 @@ def update(
     if campaign_type_norm is not None and campaign_type_norm not in subtype_supported:
         raise click.UsageError(
             t(
-                "Invalid value for '--type': {campaign_type!r} is not one of 'TEXT_CAMPAIGN', 'UNIFIED_CAMPAIGN', 'DYNAMIC_TEXT_CAMPAIGN', 'SMART_CAMPAIGN', 'MOBILE_APP_CAMPAIGN', 'CPM_BANNER_CAMPAIGN'."
+                "Invalid value for '--type': {campaign_type!r} is not one of "
+                "'TEXT_CAMPAIGN', 'UNIFIED_CAMPAIGN', 'DYNAMIC_TEXT_CAMPAIGN', "
+                "'SMART_CAMPAIGN', 'MOBILE_APP_CAMPAIGN', 'CPM_BANNER_CAMPAIGN'."
             ).format(campaign_type=campaign_type)
         )
     if subtype_flags_provided and campaign_type_norm is None:
         raise click.UsageError(
             t(
-                "{arg0} requires --type (TEXT_CAMPAIGN | UNIFIED_CAMPAIGN | DYNAMIC_TEXT_CAMPAIGN | SMART_CAMPAIGN | MOBILE_APP_CAMPAIGN | CPM_BANNER_CAMPAIGN)."
+                "{arg0} requires --type (TEXT_CAMPAIGN | UNIFIED_CAMPAIGN | "
+                "DYNAMIC_TEXT_CAMPAIGN | SMART_CAMPAIGN | MOBILE_APP_CAMPAIGN | "
+                "CPM_BANNER_CAMPAIGN)."
             ).format(arg0=", ".join(sorted(subtype_flags_provided)))
         )
     if campaign_type_norm is not None:
@@ -4995,7 +5021,8 @@ def update(
                 if provided:
                     raise click.UsageError(
                         t(
-                            "{package_label}.PackageBiddingStrategy cannot be combined with {arg0}"
+                            "{package_label}.PackageBiddingStrategy cannot be "
+                            "combined with {arg0}"
                         ).format(
                             package_label=package_label,
                             arg0=", ".join(sorted(provided)),
@@ -5490,7 +5517,8 @@ def update(
         if not sub_block:
             raise click.UsageError(
                 t(
-                    "--type {campaign_type_norm} requires at least one subtype-specific field to update."
+                    "--type {campaign_type_norm} requires at least one "
+                    "subtype-specific field to update."
                 ).format(campaign_type_norm=campaign_type_norm)
             )
         subtype_container = {

--- a/direct_cli/commands/feeds.py
+++ b/direct_cli/commands/feeds.py
@@ -59,7 +59,8 @@ def _file_feed_payload(
     if len(filename) > _FILE_FEED_MAX_FILENAME_LENGTH:
         raise click.UsageError(
             t(
-                "FileFeed.Filename must be at most {_FILE_FEED_MAX_FILENAME_LENGTH} characters."
+                "FileFeed.Filename must be at most "
+                "{_FILE_FEED_MAX_FILENAME_LENGTH} characters."
             ).format(_FILE_FEED_MAX_FILENAME_LENGTH=_FILE_FEED_MAX_FILENAME_LENGTH)
         )
 

--- a/direct_cli/commands/keywords.py
+++ b/direct_cli/commands/keywords.py
@@ -106,7 +106,8 @@ def _coerce_keyword_field(field: str, raw_value: Any, row_index: int) -> Any:
         except (TypeError, ValueError):
             raise click.UsageError(
                 t(
-                    "Row {row_index} field {field!r}: expected integer, got {raw_value!r}"
+                    "Row {row_index} field {field!r}: expected integer, "
+                    "got {raw_value!r}"
                 ).format(row_index=row_index, field=field, raw_value=raw_value)
             )
     if kind == "micro":
@@ -143,7 +144,9 @@ def _normalize_keyword_row(
         flag = _KEYWORD_BATCH_DEFERRED_FIELDS[field]
         raise click.UsageError(
             t(
-                "Keyword row {row_index} field {field!r} is intentionally unsupported in batch mode; use the single-item typed option {flag} instead."
+                "Keyword row {row_index} field {field!r} is intentionally "
+                "unsupported in batch mode; use the single-item typed "
+                "option {flag} instead."
             ).format(row_index=row_index, field=field, flag=flag)
         )
 
@@ -165,7 +168,8 @@ def _normalize_keyword_row(
         if default_adgroup_id is None:
             raise click.UsageError(
                 t(
-                    "Row {row_index}: missing 'AdGroupId' and no default --adgroup-id provided"
+                    "Row {row_index}: missing 'AdGroupId' and no default "
+                    "--adgroup-id provided"
                 ).format(row_index=row_index)
             )
         item["AdGroupId"] = default_adgroup_id
@@ -581,9 +585,18 @@ def _bulk_add(
 
 
 _DEPRECATED_KEYWORDS_UPDATE_OPTIONS = {
-    "bid": "--bid is no longer accepted on 'keywords update'; use: direct bids set --keyword-id ID --bid VALUE",
-    "context_bid": "--context-bid is no longer accepted on 'keywords update'; use: direct bids set --keyword-id ID --network-bid VALUE",
-    "status": "--status is no longer accepted on 'keywords update'; status is not mutable via the keywords API",
+    "bid": (
+        "--bid is no longer accepted on 'keywords update'; use: "
+        "direct bids set --keyword-id ID --bid VALUE"
+    ),
+    "context_bid": (
+        "--context-bid is no longer accepted on 'keywords update'; use: "
+        "direct bids set --keyword-id ID --network-bid VALUE"
+    ),
+    "status": (
+        "--status is no longer accepted on 'keywords update'; status is "
+        "not mutable via the keywords API"
+    ),
 }
 
 

--- a/direct_cli/commands/reports.py
+++ b/direct_cli/commands/reports.py
@@ -21,7 +21,7 @@ def _load_report_types() -> list:
         from ..reports_coverage import load_cached_reports_spec
 
         return load_cached_reports_spec()["report_types"]
-    except Exception:
+    except Exception:  # noqa: PIE786 - fall back to the hardcoded snapshot default
         return [
             "ACCOUNT_PERFORMANCE_REPORT",
             "CAMPAIGN_PERFORMANCE_REPORT",
@@ -40,7 +40,7 @@ def _load_processing_modes() -> list:
         from ..reports_coverage import load_cached_reports_spec
 
         return load_cached_reports_spec()["processing_modes"]
-    except Exception:
+    except Exception:  # noqa: PIE786 - fall back to the hardcoded snapshot default
         return ["auto", "online", "offline"]
 
 
@@ -50,7 +50,7 @@ def _load_date_range_types() -> list:
         from ..reports_coverage import load_cached_reports_spec
 
         return load_cached_reports_spec()["date_range_types"]
-    except Exception:
+    except Exception:  # noqa: PIE786 - fall back to the hardcoded snapshot default
         return [
             "TODAY",
             "YESTERDAY",
@@ -75,7 +75,7 @@ def _load_report_field_usage() -> dict:
         from ..reports_coverage import load_cached_reports_spec
 
         return load_cached_reports_spec().get("field_usage", {})
-    except Exception:
+    except Exception:  # noqa: PIE786 - fall back to the hardcoded snapshot default
         return {}
 
 
@@ -85,7 +85,7 @@ def _load_filter_operators() -> list:
         from ..reports_coverage import load_cached_reports_spec
 
         return load_cached_reports_spec().get("filter_operators", [])
-    except Exception:
+    except Exception:  # noqa: PIE786 - fall back to the hardcoded snapshot default
         return [
             "EQUALS",
             "NOT_EQUALS",

--- a/direct_cli/commands/reports.py
+++ b/direct_cli/commands/reports.py
@@ -173,7 +173,8 @@ def _parse_attribution_models(models: str | None) -> list[str] | None:
     if invalid:
         allowed = ", ".join(sorted(ATTRIBUTION_MODELS))
         raise ValueError(
-            f"Invalid attribution model(s): {', '.join(invalid)}. Expected one of: {allowed}"
+            f"Invalid attribution model(s): {', '.join(invalid)}. "
+            f"Expected one of: {allowed}"
         )
     return normalized
 

--- a/direct_cli/commands/retargeting.py
+++ b/direct_cli/commands/retargeting.py
@@ -56,7 +56,8 @@ def _validate_description(description: Optional[str]) -> None:
     ):
         raise click.UsageError(
             t(
-                "--description must be at most {_RETARGETING_DESCRIPTION_MAX_LENGTH} characters"
+                "--description must be at most "
+                "{_RETARGETING_DESCRIPTION_MAX_LENGTH} characters"
             ).format(
                 _RETARGETING_DESCRIPTION_MAX_LENGTH=_RETARGETING_DESCRIPTION_MAX_LENGTH
             )

--- a/direct_cli/commands/strategies.py
+++ b/direct_cli/commands/strategies.py
@@ -377,7 +377,8 @@ def _build_strategy_fields(
         )
         raise click.UsageError(
             t(
-                "{arg0} is not valid for --type {strategy_type}. Allowed strategy field flags: {allowed_flags}."
+                "{arg0} is not valid for --type {strategy_type}. Allowed "
+                "strategy field flags: {allowed_flags}."
             ).format(
                 arg0=", ".join(incompatible),
                 strategy_type=strategy_type,
@@ -816,7 +817,8 @@ def update(
         # silent no-op.
         raise click.UsageError(
             t(
-                "strategies update requires at least one field for --type {strategy_type}."
+                "strategies update requires at least one field for "
+                "--type {strategy_type}."
             ).format(strategy_type=strategy_type)
         )
     if strategy_type:

--- a/direct_cli/commands/v4account.py
+++ b/direct_cli/commands/v4account.py
@@ -183,7 +183,8 @@ def _reject_disallowed_flags(
         )
         raise click.UsageError(
             t(
-                "{arg0} not valid for --action {action}. Valid flags for {action}: {arg1}"
+                "{arg0} not valid for --action {action}. Valid flags for "
+                "{action}: {arg1}"
             ).format(
                 arg0=", ".join(offenders), action=action, arg1=", ".join(valid_flags)
             )

--- a/direct_cli/commands/v4events.py
+++ b/direct_cli/commands/v4events.py
@@ -62,7 +62,8 @@ def _events_log_filter(
             if unknown:
                 raise click.UsageError(
                     t(
-                        "--filter-event-type has unknown values: {arg0}. Valid values: {arg1}"
+                        "--filter-event-type has unknown values: {arg0}. "
+                        "Valid values: {arg1}"
                     ).format(arg0=", ".join(unknown), arg1=", ".join(EVENT_TYPES))
                 )
             filter_obj["EventType"] = types

--- a/direct_cli/i18n.py
+++ b/direct_cli/i18n.py
@@ -96,7 +96,7 @@ def resolve_locale(ctx: Optional[click.Context] = None) -> str:
     if ctx is not None:
         try:
             root = ctx.find_root()
-        except Exception:  # pragma: no cover - defensive
+        except Exception:  # pragma: no cover - defensive  # noqa: PIE786
             root = ctx
         if isinstance(root.obj, dict):
             normalized = normalize_locale(root.obj.get("locale"))

--- a/direct_cli/reports_coverage.py
+++ b/direct_cli/reports_coverage.py
@@ -324,12 +324,12 @@ def refresh_reports_cache() -> dict[str, Exception]:
     errors: dict[str, Exception] = {}
     try:
         raw = fetch_reports_spec(use_cache=False)
-    except Exception as exc:
+    except Exception as exc:  # noqa: PIE786 - reported per-stage via errors dict
         return {"fetch": exc}
 
     try:
         spec = parse_reports_spec(raw)
-    except Exception as exc:
+    except Exception as exc:  # noqa: PIE786 - reported per-stage via errors dict
         return {"parse": exc}
 
     spec_file = REPORTS_CACHE_DIR / "spec.json"
@@ -337,7 +337,7 @@ def refresh_reports_cache() -> dict[str, Exception]:
         spec_file.write_text(
             json.dumps(spec, indent=2, ensure_ascii=False), encoding="utf-8"
         )
-    except Exception as exc:
+    except Exception as exc:  # noqa: PIE786 - reported per-stage via errors dict
         return {"write": exc}
 
     return errors
@@ -350,7 +350,7 @@ def get_reports_coverage_policy() -> dict:
         report_types_count = len(spec.get("report_types", []))
         field_count = len(spec.get("field_compatibility", {}))
         header_count = len(spec.get("request_headers", {}))
-    except Exception:
+    except Exception:  # noqa: PIE786 - fall back to the hardcoded snapshot default
         report_types_count = 0
         field_count = 0
         header_count = 0

--- a/direct_cli/reports_coverage.py
+++ b/direct_cli/reports_coverage.py
@@ -229,9 +229,11 @@ def parse_reports_spec(raw: dict[str, str]) -> dict:
     if "headers" in raw:
         text = _extract_text(raw["headers"])
         for mode in ("auto", "online", "offline"):
-            if re.search(rf"\b{mode}\b", text, re.IGNORECASE):
-                if mode not in spec["processing_modes"]:
-                    spec["processing_modes"].append(mode)
+            if (
+                re.search(rf"\b{mode}\b", text, re.IGNORECASE)
+                and mode not in spec["processing_modes"]
+            ):
+                spec["processing_modes"].append(mode)
 
     if not spec["processing_modes"]:
         raise ValueError(

--- a/direct_cli/v4_contracts.py
+++ b/direct_cli/v4_contracts.py
@@ -54,7 +54,10 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
         source_status=SOURCE_CONFIRMED_LIVE,
         live_probe_allowed=True,
         example_param=["client-login"],
-        notes="Live rejects object params with error_code=9; pass the login array directly.",
+        notes=(
+            "Live rejects object params with error_code=9; pass the login "
+            "array directly."
+        ),
     ),
     "GetCreditLimits": V4MethodContract(
         method="GetCreditLimits",
@@ -285,7 +288,10 @@ V4_METHOD_CONTRACTS: dict[str, V4MethodContract] = {
         source_status=SOURCE_CONFIRMED_LIVE,
         live_probe_allowed=True,
         example_param={"CampaignIDS": [123]},
-        notes="Standalone public method page was not discoverable; live probe confirms CampaignIDS.",
+        notes=(
+            "Standalone public method page was not discoverable; live "
+            "probe confirms CampaignIDS."
+        ),
     ),
     "CreateNewWordstatReport": V4MethodContract(
         method="CreateNewWordstatReport",

--- a/direct_cli/wsdl_coverage.py
+++ b/direct_cli/wsdl_coverage.py
@@ -7,7 +7,7 @@ that the CLI implements all available services and methods.
 
 from __future__ import annotations
 
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree as ET  # noqa: N817 - standard stdlib alias
 from functools import lru_cache
 from io import StringIO
 from pathlib import Path

--- a/direct_cli/wsdl_coverage.py
+++ b/direct_cli/wsdl_coverage.py
@@ -350,13 +350,13 @@ def refresh_all_caches() -> dict:
     for service in sorted(all_services):
         try:
             fetch_wsdl(service, use_cache=False)
-        except Exception as exc:
+        except Exception as exc:  # noqa: PIE786 - per-service, batch continues
             errors[service] = exc
 
     for namespace in sorted(IMPORTED_XSD_REGISTRY):
         try:
             fetch_imported_xsd(namespace, use_cache=False)
-        except Exception as exc:
+        except Exception as exc:  # noqa: PIE786 - collected per-item, batch continues
             errors[f"xsd:{namespace}"] = exc
     return errors
 

--- a/tests/_orphan_store.py
+++ b/tests/_orphan_store.py
@@ -112,7 +112,7 @@ def drain(
     for id_ in bucket:
         try:
             deleter(id_)
-        except Exception:
+        except Exception:  # noqa: PIE786 - undeleted IDs retry on the next run
             survived.append(id_)
     if survived:
         data[kind] = survived

--- a/tests/_orphan_store.py
+++ b/tests/_orphan_store.py
@@ -19,6 +19,7 @@ broken by store corruption.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import tempfile
@@ -48,10 +49,8 @@ def _read(path: Path = ORPHAN_STORE_PATH) -> Dict[str, List[int]]:
 
 def _write(data: Dict[str, List[int]], path: Path = ORPHAN_STORE_PATH) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    try:
+    with contextlib.suppress(OSError):
         os.chmod(path.parent, 0o700)
-    except OSError:
-        pass
     fd, tmp = tempfile.mkstemp(dir=path.parent)
     try:
         os.chmod(tmp, 0o600)
@@ -59,10 +58,8 @@ def _write(data: Dict[str, List[int]], path: Path = ORPHAN_STORE_PATH) -> None:
             f.write(json.dumps(data, ensure_ascii=False, indent=2))
         os.replace(tmp, path)
     except Exception:
-        try:
+        with contextlib.suppress(OSError):
             os.unlink(tmp)
-        except OSError:
-            pass
         raise
 
 
@@ -72,10 +69,9 @@ def add(kind: str, id_: int, path: Path = ORPHAN_STORE_PATH) -> None:
     bucket = data.setdefault(kind, [])
     if id_ not in bucket:
         bucket.append(int(id_))
-    try:
+    # best-effort; never fail a test on store IO
+    with contextlib.suppress(OSError):
         _write(data, path)
-    except OSError:
-        pass  # best-effort; never fail a test on store IO
 
 
 def remove(kind: str, id_: int, path: Path = ORPHAN_STORE_PATH) -> None:
@@ -87,10 +83,8 @@ def remove(kind: str, id_: int, path: Path = ORPHAN_STORE_PATH) -> None:
     data[kind] = [x for x in bucket if x != id_]
     if not data[kind]:
         del data[kind]
-    try:
+    with contextlib.suppress(OSError):
         _write(data, path)
-    except OSError:
-        pass
 
 
 def drain(
@@ -118,7 +112,5 @@ def drain(
         data[kind] = survived
     else:
         data.pop(kind, None)
-    try:
+    with contextlib.suppress(OSError):
         _write(data, path)
-    except OSError:
-        pass

--- a/tests/api_coverage_payloads.py
+++ b/tests/api_coverage_payloads.py
@@ -1,74 +1,251 @@
 """Shared dry-run payload coverage cases for API schema gates."""
 
 DRY_RUN_PAYLOAD_EXCLUSIONS = {
-    "adextensions.get": "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria tests.",
-    "adgroups.get": "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria tests.",
-    "adimages.get": "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria tests.",
-    "advideos.get": "Read-path required SelectionCriteria is covered by WSDL selection criteria tests.",
-    "audiencetargets.get": "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria tests.",
-    "bidmodifiers.get": "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria tests.",
-    "bids.get": "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria tests.",
-    "businesses.get": "Read path omits optional SelectionCriteria when --ids is absent.",
-    "campaigns.get": "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria tests.",
+    "adextensions.get": (
+        "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria "
+        "tests."
+    ),
+    "adgroups.get": (
+        "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria "
+        "tests."
+    ),
+    "adimages.get": (
+        "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria "
+        "tests."
+    ),
+    "advideos.get": (
+        "Read-path required SelectionCriteria is covered by WSDL selection criteria "
+        "tests."
+    ),
+    "audiencetargets.get": (
+        "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria "
+        "tests."
+    ),
+    "bidmodifiers.get": (
+        "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria "
+        "tests."
+    ),
+    "bids.get": (
+        "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria "
+        "tests."
+    ),
+    "businesses.get": (
+        "Read path omits optional SelectionCriteria when --ids is absent."
+    ),
+    "campaigns.get": (
+        "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria "
+        "tests."
+    ),
     "clients.get": "Read path omits optional SelectionCriteria when --ids is absent.",
-    "creatives.get": "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria tests.",
-    "dynamicads.get": "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria tests.",
-    "dynamicfeedadtargets.get": "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria tests.",
+    "creatives.get": (
+        "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria "
+        "tests."
+    ),
+    "dynamicads.get": (
+        "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria "
+        "tests."
+    ),
+    "dynamicfeedadtargets.get": (
+        "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria "
+        "tests."
+    ),
     "feeds.get": "Read path omits optional SelectionCriteria when --ids is absent.",
-    "keywordbids.get": "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria tests.",
-    "keywords.get": "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria tests.",
-    "leads.get": "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria tests.",
-    "negativekeywordsharedsets.get": "Read path omits optional SelectionCriteria when --ids is absent.",
-    "retargeting.get": "Read path omits optional SelectionCriteria when --ids is absent.",
-    "sitelinks.get": "Read path omits optional SelectionCriteria when --ids is absent.",
-    "smartadtargets.get": "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria tests.",
-    "turbopages.get": "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria tests.",
+    "keywordbids.get": (
+        "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria "
+        "tests."
+    ),
+    "keywords.get": (
+        "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria "
+        "tests."
+    ),
+    "leads.get": (
+        "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria "
+        "tests."
+    ),
+    "negativekeywordsharedsets.get": (
+        "Read path omits optional SelectionCriteria when --ids is absent."
+    ),
+    "retargeting.get": (
+        "Read path omits optional SelectionCriteria when --ids is absent."
+    ),
+    "sitelinks.get": (
+        "Read path omits optional SelectionCriteria when --ids is absent."
+    ),
+    "smartadtargets.get": (
+        "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria "
+        "tests."
+    ),
+    "turbopages.get": (
+        "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria "
+        "tests."
+    ),
     "vcards.get": "Read path omits optional SelectionCriteria when --ids is absent.",
-    "ads.get": "Read path with rich field-selection options; payload contract differs from mutating coverage focus.",
-    "agencyclients.add": "Runtime-deprecated method (Yandex error 3500); CLI rejects with UsageError before reaching dry-run. See RUNTIME_DEPRECATED_METHODS.",
-    "agencyclients.get": "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria tests.",
-    "dynamicfeedadtargets.add": "Covered by test_dry_run.py::test_dynamicfeedadtargets_add_payload.",
-    "dynamicfeedadtargets.delete": "Covered by test_dry_run.py::test_dynamicfeedadtargets_delete_payload.",
-    "dynamicfeedadtargets.resume": "Covered by test_dry_run.py::test_dynamicfeedadtargets_resume_payload.",
-    "dynamicfeedadtargets.set-bids": "Covered by test_dry_run.py::test_dynamicfeedadtargets_set_bids_payload.",
-    "dynamicfeedadtargets.suspend": "Covered by test_dry_run.py::test_dynamicfeedadtargets_suspend_payload.",
+    "ads.get": (
+        "Read path with rich field-selection options; payload contract differs from "
+        "mutating coverage focus."
+    ),
+    "agencyclients.add": (
+        "Runtime-deprecated method (Yandex error 3500); CLI rejects with UsageError "
+        "before reaching dry-run. See RUNTIME_DEPRECATED_METHODS."
+    ),
+    "agencyclients.get": (
+        "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria "
+        "tests."
+    ),
+    "dynamicfeedadtargets.add": (
+        "Covered by test_dry_run.py::test_dynamicfeedadtargets_add_payload."
+    ),
+    "dynamicfeedadtargets.delete": (
+        "Covered by test_dry_run.py::test_dynamicfeedadtargets_delete_payload."
+    ),
+    "dynamicfeedadtargets.resume": (
+        "Covered by test_dry_run.py::test_dynamicfeedadtargets_resume_payload."
+    ),
+    "dynamicfeedadtargets.set-bids": (
+        "Covered by test_dry_run.py::test_dynamicfeedadtargets_set_bids_payload."
+    ),
+    "dynamicfeedadtargets.suspend": (
+        "Covered by test_dry_run.py::test_dynamicfeedadtargets_suspend_payload."
+    ),
     "strategies.add": "Covered by test_dry_run.py::test_strategies_add_payload.",
-    "strategies.archive": "Covered by test_dry_run.py::test_strategies_archive_payload.",
-    "strategies.get": "Covered by test_dry_run.py::test_strategies_get_default_field_names_payload.",
-    "strategies.unarchive": "Covered by test_dry_run.py::test_strategies_unarchive_payload.",
+    "strategies.archive": (
+        "Covered by test_dry_run.py::test_strategies_archive_payload."
+    ),
+    "strategies.get": (
+        "Covered by test_dry_run.py::test_strategies_get_default_field_names_payload."
+    ),
+    "strategies.unarchive": (
+        "Covered by test_dry_run.py::test_strategies_unarchive_payload."
+    ),
     "strategies.update": "Covered by test_dry_run.py::test_strategies_update_payload.",
-    "reports.get": "Reports API uses a custom TSV endpoint; payload contract is covered by test_reports_request_builder_contract.",
-    "v4account.account-management": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
-    "v4account.enable-shared-account": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
-    "v4events.get-events-log": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
-    "v4forecast.create": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
-    "v4forecast.delete": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
-    "v4forecast.get": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
-    "v4forecast.list": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
-    "v4finance.check-payment": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
-    "v4finance.create-invoice": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
-    "v4finance.get-clients-units": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
-    "v4finance.get-credit-limits": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
-    "v4finance.pay-campaigns": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
-    "v4finance.pay-campaigns-by-card": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
-    "v4finance.transfer-money": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
-    "v4adimage.get": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
-    "v4adimage.set": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
-    "v4keywords.get-suggestion": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
-    "v4meta.get-available-versions": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
-    "v4meta.get-version": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
-    "v4meta.ping-api": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
-    "v4meta.ping-api-x": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
-    "v4goals.get-retargeting-goals": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
-    "v4goals.get-stat-goals": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
-    "v4tags.get-banners": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
-    "v4tags.get-campaigns": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
-    "v4tags.update-banners": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
-    "v4tags.update-campaigns": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
-    "v4wordstat.create-report": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
-    "v4wordstat.delete-report": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
-    "v4wordstat.get-report": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
-    "v4wordstat.list-reports": "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run tests.",
+    "reports.get": (
+        "Reports API uses a custom TSV endpoint; payload contract is covered by "
+        "test_reports_request_builder_contract."
+    ),
+    "v4account.account-management": (
+        "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run "
+        "tests."
+    ),
+    "v4account.enable-shared-account": (
+        "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run "
+        "tests."
+    ),
+    "v4events.get-events-log": (
+        "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run "
+        "tests."
+    ),
+    "v4forecast.create": (
+        "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run "
+        "tests."
+    ),
+    "v4forecast.delete": (
+        "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run "
+        "tests."
+    ),
+    "v4forecast.get": (
+        "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run "
+        "tests."
+    ),
+    "v4forecast.list": (
+        "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run "
+        "tests."
+    ),
+    "v4finance.check-payment": (
+        "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run "
+        "tests."
+    ),
+    "v4finance.create-invoice": (
+        "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run "
+        "tests."
+    ),
+    "v4finance.get-clients-units": (
+        "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run "
+        "tests."
+    ),
+    "v4finance.get-credit-limits": (
+        "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run "
+        "tests."
+    ),
+    "v4finance.pay-campaigns": (
+        "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run "
+        "tests."
+    ),
+    "v4finance.pay-campaigns-by-card": (
+        "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run "
+        "tests."
+    ),
+    "v4finance.transfer-money": (
+        "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run "
+        "tests."
+    ),
+    "v4adimage.get": (
+        "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run "
+        "tests."
+    ),
+    "v4adimage.set": (
+        "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run "
+        "tests."
+    ),
+    "v4keywords.get-suggestion": (
+        "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run "
+        "tests."
+    ),
+    "v4meta.get-available-versions": (
+        "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run "
+        "tests."
+    ),
+    "v4meta.get-version": (
+        "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run "
+        "tests."
+    ),
+    "v4meta.ping-api": (
+        "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run "
+        "tests."
+    ),
+    "v4meta.ping-api-x": (
+        "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run "
+        "tests."
+    ),
+    "v4goals.get-retargeting-goals": (
+        "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run "
+        "tests."
+    ),
+    "v4goals.get-stat-goals": (
+        "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run "
+        "tests."
+    ),
+    "v4tags.get-banners": (
+        "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run "
+        "tests."
+    ),
+    "v4tags.get-campaigns": (
+        "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run "
+        "tests."
+    ),
+    "v4tags.update-banners": (
+        "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run "
+        "tests."
+    ),
+    "v4tags.update-campaigns": (
+        "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run "
+        "tests."
+    ),
+    "v4wordstat.create-report": (
+        "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run "
+        "tests."
+    ),
+    "v4wordstat.delete-report": (
+        "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run "
+        "tests."
+    ),
+    "v4wordstat.get-report": (
+        "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run "
+        "tests."
+    ),
+    "v4wordstat.list-reports": (
+        "V4 Live method is not covered by V5 WSDL schemas; covered by focused dry-run "
+        "tests."
+    ),
 }
 
 PAYLOAD_CASES = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ CLI changes, run with ``--record-mode=rewrite`` and a valid
 before committing.
 """
 
+import contextlib
 import json
 import os
 import re
@@ -64,7 +65,7 @@ def pytest_xdist_auto_num_workers(config):
             if expr.evaluate(lambda name, m=marker: name == m):
                 return 1
         return None
-    except Exception:
+    except Exception:  # noqa: PIE786 - private pytest API, fall back conservatively
         # Private parser unavailable/changed (compile or evaluate): serialize if
         # any live marker is named at all — over-serializing never races.
         return 1 if any(m in markexpr for m in _LIVE_MARKERS) else None
@@ -471,10 +472,8 @@ def _has_result_errors(output: str, key: str) -> bool:
 
 def _safe_delete(*args):
     """Best-effort delete — ignore errors (resource may already be gone)."""
-    try:
+    with contextlib.suppress(Exception):
         _invoke(*args)
-    except Exception:
-        pass
 
 
 # ── session-scoped ───────────────────────────────────────────────────────

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -15,7 +15,7 @@ import importlib.util
 import re
 import subprocess
 import sys
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree as ET  # noqa: N817 - standard stdlib alias
 from pathlib import Path
 
 import pytest

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -265,8 +265,8 @@ def _assert_body_matches_wsdl(body: dict, service: str, operation: str):
                     if item["min_occurs"] > 0
                 }
                 assert required <= set(value[0]), (
-                    f"{service}.{operation}.{field['name']} missing required item keys: "
-                    f"{sorted(required - set(value[0]))}"
+                    f"{service}.{operation}.{field['name']} missing required "
+                    f"item keys: {sorted(required - set(value[0]))}"
                 )
         elif field["item_fields"] and isinstance(value, dict):
             required = {
@@ -311,7 +311,10 @@ class TestApiCoverage:
             assert policy["coverage"] in (
                 "contract-tests",
                 "contract-tests+spec-snapshot",
-            ), f"Unexpected coverage policy for non-WSDL service {service_name}: {policy}"
+            ), (
+                f"Unexpected coverage policy for non-WSDL service "
+                f"{service_name}: {policy}"
+            )
 
     def test_service_method_coverage(self):
         failures = []
@@ -337,11 +340,13 @@ class TestApiCoverage:
 
             if missing:
                 failures.append(
-                    f"{cli_name} -> {api_service}: missing API methods {sorted(missing)}"
+                    f"{cli_name} -> {api_service}: missing API methods "
+                    f"{sorted(missing)}"
                 )
             if extra:
                 failures.append(
-                    f"{cli_name} -> {api_service}: unexpected CLI methods {sorted(extra)}"
+                    f"{cli_name} -> {api_service}: unexpected CLI methods "
+                    f"{sorted(extra)}"
                 )
 
         assert failures == [], "API coverage gaps detected:\n" + "\n".join(failures)
@@ -594,7 +599,7 @@ class TestApiCoverage:
     def test_reports_get_cli_path_forwards_header_flags_to_create_client(
         self, monkeypatch
     ):
-        """--processing-mode, --skip-*, --return-money-in-micros must reach create_client."""
+        """--processing-mode/--skip-*/--return-money-in-micros reach create_client."""
         captured = {}
         reports_module = importlib.import_module("direct_cli.commands.reports")
 
@@ -870,7 +875,7 @@ class TestApiCoverage:
         assert schema_gate["nested_schema_violations"] == []
 
     def test_get_selection_criteria_fields_have_typed_cli_options_or_waiver(self):
-        """Every WSDL get SelectionCriteria field is exposed as a typed flag or waived."""
+        """Every WSDL get SelectionCriteria field is a typed flag or waived."""
         expected_options = {
             "adextensions": {
                 "Ids": "ids",
@@ -1733,7 +1738,7 @@ class TestApiCoverage:
         assert report["model_gaps"]["live_discovered_missing_methods"] == 11
 
     def test_reports_get_cli_skip_report_summary_forwarded(self, monkeypatch):
-        """--skip-report-summary must reach create_client as skip_report_summary=True."""
+        """--skip-report-summary reaches create_client as skip_report_summary=True."""
         captured = {}
         reports_module = importlib.import_module("direct_cli.commands.reports")
 
@@ -2082,7 +2087,7 @@ class TestApiCoverage:
         )
 
     def test_get_operation_request_schema_resolves_imports(self):
-        """agencyclients.add Notification (gc:NotificationAdd) must resolve nested fields."""
+        """agencyclients.add Notification (gc:NotificationAdd) resolves nested."""
         schema = get_operation_request_schema(fetch_wsdl("agencyclients"), "add")
         notification = next(
             (f for f in schema["fields"] if f["name"] == "Notification"), None

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -322,7 +322,7 @@ class TestApiCoverage:
         for cli_name, api_service in sorted(CLI_TO_API_SERVICE.items()):
             try:
                 wsdl_xml = fetch_wsdl(api_service)
-            except Exception as exc:
+            except Exception as exc:  # noqa: PIE786 - per-service, others still run
                 failures.append(
                     f"{cli_name} -> {api_service}: WSDL fetch failed: {exc}"
                 )

--- a/tests/test_auth_oauth.py
+++ b/tests/test_auth_oauth.py
@@ -387,7 +387,9 @@ class TestAuthOAuth:
     ):
         env_path = tmp_path / ".env"
         env_path.write_text(
-            "OTHER=value\nYANDEX_DIRECT_TOKEN=old-token\nYANDEX_DIRECT_LOGIN=old-login\n",
+            "OTHER=value\n"
+            "YANDEX_DIRECT_TOKEN=old-token\n"
+            "YANDEX_DIRECT_LOGIN=old-login\n",
             encoding="utf-8",
         )
         with patch.dict(os.environ, {}, clear=False):

--- a/tests/test_dry_run_campaigns.py
+++ b/tests/test_dry_run_campaigns.py
@@ -1077,7 +1077,10 @@ def test_campaigns_add_notification_payload():
 
 
 def test_campaigns_add_time_targeting_payload():
-    schedule_row = "1,0,0,50,50,100,100,150,200,200,150,100,100,80,70,100,100,100,50,50,40,30,0,0,0"
+    schedule_row = (
+        "1,0,0,50,50,100,100,150,200,200,150,100,100,80,70,100,100,100,50,50,"
+        "40,30,0,0,0"
+    )
     body = _dry_run(
         *_cpa_base_args(),
         "--time-targeting-schedule",
@@ -2753,7 +2756,7 @@ def test_campaigns_update_mobile_app_wb_maximum_clicks_network_payload():
     }
 
 
-def test_campaigns_update_mobile_app_average_cpc_network_weekly_budget_clears_custom_period():
+def test_campaigns_update_mobile_app_average_cpc_network_weekly_budget_clears_custom_period():  # noqa: E501
     body = _dry_run(
         "campaigns",
         "update",
@@ -2836,7 +2839,7 @@ def test_campaigns_update_mobile_app_average_cpi_network_custom_period_payload()
     }
 
 
-def test_campaigns_update_mobile_app_rejects_network_budget_type_without_matching_budget():
+def test_campaigns_update_mobile_app_rejects_network_budget_type_without_matching_budget():  # noqa: E501
     result = _rejected(
         "campaigns",
         "update",
@@ -2854,7 +2857,7 @@ def test_campaigns_update_mobile_app_rejects_network_budget_type_without_matchin
     )
 
 
-def test_campaigns_update_mobile_app_rejects_network_budget_type_without_supported_strategy():
+def test_campaigns_update_mobile_app_rejects_network_budget_type_without_supported_strategy():  # noqa: E501
     result = _rejected(
         "campaigns",
         "update",

--- a/tests/test_dry_run_strategy_text.py
+++ b/tests/test_dry_run_strategy_text.py
@@ -627,7 +627,7 @@ def test_campaigns_add_dynamic_text_network_rejects_partial_custom_period():
     )
 
 
-def test_campaigns_add_dynamic_text_network_weekly_click_package_combined_ceilings_payload():
+def test_campaigns_add_dynamic_text_network_weekly_click_package_combined_ceilings_payload():  # noqa: E501
     """#365: WSDL StrategyWeeklyClickPackageAdd allows AverageCpc + BidCeiling."""
     body = _dry_run(
         "campaigns",
@@ -1099,7 +1099,7 @@ def test_campaigns_add_dynamic_text_network_wb_maximum_clicks_bare_payload():
     assert network == {"BiddingStrategyType": "WB_MAXIMUM_CLICKS"}
 
 
-def test_campaigns_add_dynamic_text_network_wb_maximum_conversion_rate_only_goal_payload():
+def test_campaigns_add_dynamic_text_network_wb_maximum_conversion_rate_only_goal_payload():  # noqa: E501
     """#365: only GoalId is WSDL-required for WbMaximumConversionRate."""
     body = _dry_run(
         "campaigns",
@@ -1147,7 +1147,7 @@ def test_campaigns_add_dynamic_text_network_rejects_reserve_return_over_100():
     assert "Invalid value for '--dyn-network-reserve-return'" in result.output
 
 
-def test_campaigns_add_dynamic_text_network_rejects_wb_maximum_conversion_rate_without_goal():
+def test_campaigns_add_dynamic_text_network_rejects_wb_maximum_conversion_rate_without_goal():  # noqa: E501
     """#365: WSDL minOccurs=1 GoalId on WbMaximumConversionRate is enforced."""
     result = _rejected(
         "campaigns",
@@ -2922,7 +2922,7 @@ def test_campaigns_add_text_network_search_cpa_plus_network_wb_max_clicks_payloa
     }
 
 
-def test_campaigns_add_text_network_search_cpa_plus_network_weekly_click_package_payload():
+def test_campaigns_add_text_network_search_cpa_plus_network_weekly_click_package_payload():  # noqa: E501
     """#364: shared --bid-ceiling routes to BOTH sides when both subtypes
     accept it (WeeklyClickPackage carries BidCeiling per WSDL line 1486)."""
     body = _dry_run(
@@ -4814,7 +4814,7 @@ def test_campaigns_update_dynamic_text_search_standalone_budget_type_payload():
     }
 
 
-def test_campaigns_update_dynamic_text_search_rejects_budget_type_on_non_budget_subtype():
+def test_campaigns_update_dynamic_text_search_rejects_budget_type_on_non_budget_subtype():  # noqa: E501
     """#362: BudgetType is only supported on the eight Wb*/AverageCp*/
     AverageRoi/AverageCrr/PayFor*Crr subtypes that carry both
     WeeklySpendLimit and CustomPeriodBudget. WeeklyClickPackage has no

--- a/tests/test_dry_run_strategy_unified.py
+++ b/tests/test_dry_run_strategy_unified.py
@@ -534,7 +534,7 @@ def test_campaigns_add_unified_network_rejects_required_pay_for_conversion():
     assert "--goal-id" in result.output
 
 
-def test_campaigns_add_unified_network_rejects_required_wb_maximum_conversion_rate_goal():
+def test_campaigns_add_unified_network_rejects_required_wb_maximum_conversion_rate_goal():  # noqa: E501
     result = _rejected(
         *_unified_network_add_base(),
         "--network-strategy",
@@ -1215,7 +1215,7 @@ def test_campaigns_add_unified_network_rejects_package_with_typed_flag_no_strate
     assert "--unified-network-average-cpc" in result.output
 
 
-def test_campaigns_add_unified_network_average_cpa_multiple_goals_with_priority_goals_payload():
+def test_campaigns_add_unified_network_average_cpa_multiple_goals_with_priority_goals_payload():  # noqa: E501
     """#366: ``AVERAGE_CPA_MULTIPLE_GOALS`` is a settable Strategy*Add
     subtype on ``UnifiedCampaignStrategyAddBase`` (campaigns.xml 1631-1654)
     and ``UnifiedCampaignAddItem.PriorityGoals`` is a real WSDL field
@@ -1243,7 +1243,7 @@ def test_campaigns_add_unified_network_average_cpa_multiple_goals_with_priority_
     }
 
 
-def test_campaigns_add_unified_network_pay_for_conversion_multiple_goals_with_priority_goals_payload():
+def test_campaigns_add_unified_network_pay_for_conversion_multiple_goals_with_priority_goals_payload():  # noqa: E501
     body = _dry_run(
         *_unified_network_add_base(),
         "--network-strategy",
@@ -1287,7 +1287,7 @@ def test_campaigns_add_unified_network_max_profit_with_priority_goals_payload():
     }
 
 
-def test_campaigns_add_unified_network_rejects_priority_goals_for_non_multi_goal_strategy():
+def test_campaigns_add_unified_network_rejects_priority_goals_for_non_multi_goal_strategy():  # noqa: E501
     """#373 (refines #366): an explicit per-side --network-strategy whose
     subtype builder does not consume PriorityGoals must be rejected
     up-front so the items are not silently dropped. WSDL-valid

--- a/tests/test_integration_write.py
+++ b/tests/test_integration_write.py
@@ -230,7 +230,7 @@ class TestWriteCampaignDraftLifecycle:
             assert_success(r, "campaigns draft add")
             try:
                 cid = parse_add_result(r)
-            except Exception:
+            except Exception:  # noqa: PIE786 - malformed response shape varies
                 # ID unknown; cleanup in finally is skipped — manual recovery
                 # via campaign name
                 pass

--- a/tests/test_integration_write.py
+++ b/tests/test_integration_write.py
@@ -69,6 +69,7 @@ Sandbox-limited (confirmed via live recording, ``@pytest.mark.sandbox_limitation
 Part of axisrow/yandex-direct-mcp-plugin#61 (Etap 3).
 """
 
+import contextlib
 import json
 from typing import Any, Dict, List, Optional
 
@@ -174,14 +175,15 @@ class TestWriteCampaigns:
 
             if suspend_ok:
                 r = _invoke("campaigns", "resume", "--id", str(cid))
-                if r.exit_code != 0 or _has_result_errors(r.output, "ResumeResults"):
-                    if not _is_sandbox_error(
-                        r.output, extra_patterns=_CAMPAIGN_STATUS_PATTERNS
-                    ):
-                        pytest.fail(
-                            "campaigns resume failed (CLI regression?): "
-                            f"{r.output[:500]}"
-                        )
+                if (
+                    r.exit_code != 0 or _has_result_errors(r.output, "ResumeResults")
+                ) and not _is_sandbox_error(
+                    r.output, extra_patterns=_CAMPAIGN_STATUS_PATTERNS
+                ):
+                    pytest.fail(
+                        "campaigns resume failed (CLI regression?): "
+                        f"{r.output[:500]}"
+                    )
 
             # archive — sandbox DRAFT campaigns return embedded
             # ArchiveResults errors (Code 8303) with HTTP 200.
@@ -228,12 +230,10 @@ class TestWriteCampaignDraftLifecycle:
 
         try:
             assert_success(r, "campaigns draft add")
-            try:
+            # ID unknown on failure; cleanup in finally is skipped — manual
+            # recovery via campaign name
+            with contextlib.suppress(Exception):
                 cid = parse_add_result(r)
-            except Exception:  # noqa: PIE786 - malformed response shape varies
-                # ID unknown; cleanup in finally is skipped — manual recovery
-                # via campaign name
-                pass
 
             r = _invoke(
                 "campaigns",
@@ -1093,13 +1093,13 @@ class TestWriteStrategies:
             "--weekly-spend-limit",
             "300000000",
         )
-        _STRATEGY_ADD_SANDBOX_PATTERNS = (
+        _strategy_add_sandbox_patterns = (
             "без кошелька",
             "inconsistent object state",
         )
         if r.exit_code != 0 or _has_result_errors(r.output, "AddResults"):
             if _is_sandbox_error(
-                r.output, extra_patterns=_STRATEGY_ADD_SANDBOX_PATTERNS
+                r.output, extra_patterns=_strategy_add_sandbox_patterns
             ):
                 pytest.skip(f"strategies add not supported (sandbox): {r.output[:200]}")
             pytest.fail(f"strategies add failed (CLI regression?): {r.output[:500]}")

--- a/tests/test_integration_write.py
+++ b/tests/test_integration_write.py
@@ -44,17 +44,23 @@ Passing in replay (10 tests, cassettes up to date):
 Sandbox-limited (confirmed via live recording, ``@pytest.mark.sandbox_limitation``):
 
   Category A — disabled in sandbox, supported in live API (codes 8800/1000/5004):
-  - ads add/update/delete         — sandbox does not persist adgroups across calls (code 8800)
+  - ads add/update/delete         — sandbox does not persist adgroups across calls
+    (code 8800)
   - keywords add/update/delete    — same (code 8800)
-  - bids set                      — depends on keyword persistence, sandbox_keyword fixture fails (code 8800 chain)
+  - bids set                      — depends on keyword persistence, sandbox_keyword
+    fixture fails (code 8800 chain)
   - keywordbids set               — same (code 8800 chain)
   - sitelinks add/delete          — sandbox service permanently unavailable (code 1000)
-  - adimages add/delete           — sandbox rejects valid 450x450 PNG uploads (code 5004)
-  - audiencetargets add/delete    — sandbox does not persist adgroup/retargeting list (code 8800)
+  - adimages add/delete           — sandbox rejects valid 450x450 PNG uploads
+    (code 5004)
+  - audiencetargets add/delete    — sandbox does not persist adgroup/retargeting list
+    (code 8800)
 
   Category B — unsupported resource type in sandbox (code 3500):
-  - dynamicads add/delete         — sandbox does not support DYNAMIC_TEXT_CAMPAIGN creation
-  - smartadtargets add/update/delete — sandbox does not support SMART_CAMPAIGN + SMART_AD_GROUP chain
+  - dynamicads add/delete         — sandbox does not support DYNAMIC_TEXT_CAMPAIGN
+    creation
+  - smartadtargets add/update/delete — sandbox does not support SMART_CAMPAIGN +
+    SMART_AD_GROUP chain
 
   Category C — account-permission limited in sandbox (code 3001):
   - agencyclients add-passport-organization — current sandbox agency account can read
@@ -173,7 +179,8 @@ class TestWriteCampaigns:
                         r.output, extra_patterns=_CAMPAIGN_STATUS_PATTERNS
                     ):
                         pytest.fail(
-                            f"campaigns resume failed (CLI regression?): {r.output[:500]}"
+                            "campaigns resume failed (CLI regression?): "
+                            f"{r.output[:500]}"
                         )
 
             # archive — sandbox DRAFT campaigns return embedded
@@ -192,7 +199,8 @@ class TestWriteCampaigns:
             if r.exit_code != 0 or _has_result_errors(r.output, "UnarchiveResults"):
                 if not _is_sandbox_error(r.output, extra_patterns=_ARCHIVE_PATTERNS):
                     pytest.fail(
-                        f"campaigns unarchive failed (CLI regression?): {r.output[:500]}"
+                        "campaigns unarchive failed (CLI regression?): "
+                        f"{r.output[:500]}"
                     )
             else:
                 assert_success(r, "campaigns unarchive")
@@ -223,7 +231,9 @@ class TestWriteCampaignDraftLifecycle:
             try:
                 cid = parse_add_result(r)
             except Exception:
-                pass  # ID unknown; cleanup in finally is skipped — manual recovery via campaign name
+                # ID unknown; cleanup in finally is skipped — manual recovery
+                # via campaign name
+                pass
 
             r = _invoke(
                 "campaigns",
@@ -317,7 +327,10 @@ class TestWriteAdGroups:
 @pytest.mark.vcr
 @pytest.mark.sandbox_limitation(
     category="disabled",
-    reason="Sandbox does not persist adgroups; ads add always returns 'Ad group not found'",
+    reason=(
+        "Sandbox does not persist adgroups; ads add always returns "
+        "'Ad group not found'"
+    ),
 )
 class TestWriteAds:
     """Confirms the Type-field fix from PR #12 works with live API."""
@@ -352,7 +365,8 @@ class TestWriteAds:
             if _is_sandbox_error(err_text):
                 pytest.skip(f"adgroup not persisted in sandbox: {first['Errors']}")
             pytest.fail(
-                f"API rejected ads add (potential Type-field regression): {first['Errors']}"
+                "API rejected ads add (potential Type-field regression): "
+                f"{first['Errors']}"
             )
 
         ad_id = first["Id"]
@@ -377,7 +391,10 @@ class TestWriteAds:
 @pytest.mark.vcr
 @pytest.mark.sandbox_limitation(
     category="disabled",
-    reason="Sandbox does not persist adgroups; keywords add always returns 'Ad group not found'",
+    reason=(
+        "Sandbox does not persist adgroups; keywords add always returns "
+        "'Ad group not found'"
+    ),
 )
 class TestWriteKeywords:
     def test_add_update_delete(self, sandbox_adgroup):
@@ -429,7 +446,10 @@ class TestWriteKeywords:
 @pytest.mark.vcr
 @pytest.mark.sandbox_limitation(
     category="disabled",
-    reason="Sandbox does not persist adgroups/keywords (code 8800 chain); inline _is_sandbox_error provides runtime defense",
+    reason=(
+        "Sandbox does not persist adgroups/keywords (code 8800 chain); "
+        "inline _is_sandbox_error provides runtime defense"
+    ),
 )
 class TestWriteBids:
     def test_set_bid(self, sandbox_keyword):
@@ -938,7 +958,10 @@ class TestWriteDynamicAds:
 @pytest.mark.vcr
 @pytest.mark.sandbox_limitation(
     category="unsupported",
-    reason="Sandbox does not support creating SMART_CAMPAIGN (code 3500); sandbox_smart_adgroup fixture skips before the test body runs",
+    reason=(
+        "Sandbox does not support creating SMART_CAMPAIGN (code 3500); "
+        "sandbox_smart_adgroup fixture skips before the test body runs"
+    ),
 )
 class TestWriteSmartAdTargets:
     """Live-API regression guard for typed smart ad target flags."""
@@ -1034,13 +1057,18 @@ class TestWriteNegativeKeywordSharedSets:
 @pytest.mark.vcr
 @pytest.mark.sandbox_limitation(
     category="disabled",
-    reason="Strategies require non-draft campaigns; sandbox campaigns are always DRAFT so add/update/archive may be rejected (codes 8800 / Invalid object status)",
+    reason=(
+        "Strategies require non-draft campaigns; sandbox campaigns are always "
+        "DRAFT so add/update/archive may be rejected (codes 8800 / Invalid "
+        "object status)"
+    ),
 )
 class TestWriteStrategies:
     """Full strategies lifecycle: add → get → update → archive → unarchive.
 
     Cassette must be recorded with
-    ``pytest --record-mode=once -m integration_write tests/test_integration_write.py::TestWriteStrategies``
+    ``pytest --record-mode=once -m integration_write
+    tests/test_integration_write.py::TestWriteStrategies``
 
     NOTE: the currently committed cassette captures only the first
     ``strategies add`` interaction (Yandex sandbox rejects public strategy
@@ -1138,7 +1166,8 @@ class TestWriteRetargetingUpdate:
     """Retargeting list update lifecycle (separate from add-delete coverage).
 
     Cassette must be recorded with
-    ``pytest --record-mode=once -m integration_write tests/test_integration_write.py::TestWriteRetargetingUpdate``
+    ``pytest --record-mode=once -m integration_write
+    tests/test_integration_write.py::TestWriteRetargetingUpdate``
     once credentials are available.
     """
 
@@ -1213,7 +1242,8 @@ class TestWriteBidsRead:
     ``--sandbox`` test setup.  To re-record, temporarily drop the
     ``--sandbox`` injection in ``conftest._invoke`` and rerun:
 
-    ``pytest --record-mode=once -m integration_write tests/test_integration_write.py::TestWriteBidsRead``
+    ``pytest --record-mode=once -m integration_write
+    tests/test_integration_write.py::TestWriteBidsRead``
 
     then restore ``_invoke`` and ``sed`` the host back to
     ``api-sandbox.direct.yandex.ru`` in the new cassettes.

--- a/tests/test_v4_live_contracts.py
+++ b/tests/test_v4_live_contracts.py
@@ -298,7 +298,7 @@ def test_v4_live_wordstat_lifecycle_opt_in_write():
         try:
             call_v4(client, "DeleteWordstatReport", report_id)
             _orphan_store.remove("v4wordstat", report_id)
-        except Exception:
+        except Exception:  # noqa: PIE786 - must not mask the real test failure
             # Leave the ID in the store; next run's ``drain`` will retry.
             pass
 
@@ -337,5 +337,5 @@ def test_v4_live_forecast_lifecycle_opt_in_write():
         try:
             call_v4(client, "DeleteForecastReport", forecast_id)
             _orphan_store.remove("v4forecast", forecast_id)
-        except Exception:
+        except Exception:  # noqa: PIE786 - must not mask the real test failure
             pass

--- a/tests/test_v5_live_write.py
+++ b/tests/test_v5_live_write.py
@@ -42,6 +42,7 @@ Coverage status (issue #59):
       6000 if the account has no shared wallet)
 """
 
+import contextlib
 import json
 import os
 import sys
@@ -359,10 +360,9 @@ def test_v5_live_draft_campaign_create_get_delete() -> None:
 
     try:
         _assert_success(add_result, "campaigns add")
-        try:
+        # ID unknown on failure; cleanup skipped — manual recovery via name
+        with contextlib.suppress(Exception):
             created_campaign_id = _extract_first_id(add_result.output)
-        except Exception:
-            pass  # ID unknown; cleanup skipped — manual recovery via name
 
         get_result = _invoke_live(
             "campaigns",

--- a/tests/test_wsdl_parity_gate.py
+++ b/tests/test_wsdl_parity_gate.py
@@ -279,7 +279,10 @@ SILENT_LOSS_PROBES: list[tuple[str, list[str], str]] = [
         "--filter-average-cpc",
     ),
     (
-        "campaigns.add SMART_CAMPAIGN + --filter-average-cpc without AVERAGE_CPC_PER_FILTER",
+        (
+            "campaigns.add SMART_CAMPAIGN + --filter-average-cpc without "
+            "AVERAGE_CPC_PER_FILTER"
+        ),
         [
             "campaigns",
             "add",
@@ -2513,7 +2516,8 @@ for _campaign_op in ("add", "update"):
                 (
                     "campaigns",
                     _campaign_op,
-                    f"TextCampaign.BiddingStrategy.Search.{_subtype}.CustomPeriodBudget",
+                    f"TextCampaign.BiddingStrategy.Search.{_subtype}."
+                    "CustomPeriodBudget",
                 )
             ] = _text_search_custom_period_flags
             for (
@@ -4677,7 +4681,9 @@ OPTIONAL_FIELD_DEFAULT_FOLLOWUPS: dict[tuple[str, str], dict[str, str]] = {
     },
     ("dynamicfeedadtargets", "add"): {
         "issue": "#303",
-        "note": "dynamicfeedadtargets.add optional WSDL path needs typed support or N/A.",
+        "note": (
+            "dynamicfeedadtargets.add optional WSDL path needs typed " "support or N/A."
+        ),
     },
     ("retargeting", "add"): {
         "issue": "#256",


### PR DESCRIPTION
## Summary

Resolves the entire flake8 backlog tracked in #643 (~186 findings across 31 files). `flake8 direct_cli tests --exclude=_vendor` now reports 0 findings.

- **E501 (145)** — mechanical reflow to 88 chars. Long strings passed to `t()` for i18n use implicit string concatenation, which preserves the exact runtime value (verified byte-identical), so translation catalog keys are unaffected. 12 test names too long to wrap on their own got a targeted `# noqa: E501` rather than a rename, to avoid changing pytest node IDs.
- **PIE786 (28)** — every `except Exception:` reviewed individually. All were judged intentional broad-catch sites (probes, cache refreshers, login-resolution fallbacks, orphan-store retry cleanup, live-test teardown) and got a `# noqa: PIE786` with inline rationale, mirroring the existing `masters.py::_with_session` precedent. No exception type was narrowed, including in the live-test files (`test_v4_live_contracts.py`, `test_v5_live_write.py`, `test_integration_write.py`, `conftest.py`) called out in the issue as needing explicit per-case sign-off.
- **SIM105 (8)** — converted `try/except/pass` cleanup blocks to `contextlib.suppress`; two sites overlapped with PIE786 and were resolved together.
- **SIM102/N806/N817 (5)** — trivial fixes (merged nested ifs, lowercased a local variable). The two `N817` findings for `import xml.etree.ElementTree as ET` got a targeted `# noqa` instead of a rename — `ET` is the standard stdlib idiom used in Python's own docs.

Closes #643

## Test plan

- [x] `flake8 direct_cli tests --exclude=_vendor` → 0 findings
- [x] `black --check direct_cli tests --exclude=_vendor` → clean
- [x] `pytest -q --ignore=tests/test_read_cassettes.py --ignore=tests/test_integration_write.py` → 3042 passed, 8 skipped (identical to pre-change baseline)
- [x] `pytest -m integration_live_write -v` → 21 skipped, no collection errors (no live credentials in this environment)
- [x] `tests/test_integration_write.py` and `tests/test_read_cassettes.py` (excluded above) verified via git-stash A/B to have the same pre-existing `aiohttp.streams.AsyncStreamReaderMixin` VCR/version-mismatch errors before and after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U1jmdZcAFQ4N5tctboCXKw