### PR TITLE
fix(masters): recognise ARCHIVED status text and widen grid filter (#730)

### DIFF
--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -311,6 +311,16 @@ STATUS_FILTERS = {
 # (fetch_master's status-text parser already produces "SUSPENDED"/"ACTIVE").
 _PRIMARY_STATUS_TO_CLI_STATUS = {"STOPPED": "SUSPENDED"}
 
+# GridCampaigns' primaryStatus value for an archived campaign (issue #730,
+# live-confirmed 2026-08-04 against campaign 713277109 — see
+# ``_widen_filter_status_for_archived``).
+_ARCHIVED_PRIMARY_STATUS = "ARCHIVED"
+
+# ``status`` values whose predicate can match an archived row -- these need
+# ``_widen_filter_status_for_archived`` to run before replaying the captured
+# request, everything else can replay the grid UI's own default filter as-is.
+_ARCHIVE_INCLUDING_STATUSES = frozenset({"archived", "all"})
+
 # Stat-tiles section render marker (issue #708, live recon 2026-08-04 against
 # 12 live ACTIVE campaigns in one account — see _extract_stat_tiles). Each
 # tile carries a stable ``data-testid`` of ``ChartSummary.<key>`` (confirmed
@@ -988,6 +998,34 @@ def _capture_grid_campaigns_request(page: "Page") -> Dict[str, Any]:
     }
 
 
+def _widen_filter_status_for_archived(request: Dict[str, Any]) -> None:
+    """Add ``ARCHIVED`` to the captured request's ``filterStatusIn``, in place.
+
+    Issue #730, live-confirmed 2026-08-04: the grid UI's own default view
+    (whatever ``GRID_URL`` renders without any query string) sends a
+    ``campaignInput.filter.filterStatusIn`` list of exactly ``["ACTIVE",
+    "DRAFT", "MODERATION", "MODERATION_DENIED", "RUN_WARN", "STOPPED",
+    "TEMPORARILY_PAUSED"]`` — no ``"ARCHIVED"``. ``_capture_grid_campaigns_
+    request`` replays that captured body verbatim, so a real archived
+    campaign is excluded server-side, before ``fetch_masters_list``'s own
+    ``STATUS_FILTERS`` predicate ever sees it (confirmed live against
+    campaign 713277109: absent from ``totalCount``/``rowset`` entirely, not
+    merely filtered out downstream). The grid's URL-level ``status-filter``
+    query parameter is already known to be ignored server-side (see module
+    docstring) — mutating this captured GraphQL variable is what actually
+    works.
+    """
+    filter_obj = (
+        request["body"]
+        .setdefault("variables", {})
+        .setdefault("campaignInput", {})
+        .setdefault("filter", {})
+    )
+    status_in = filter_obj.get("filterStatusIn")
+    if isinstance(status_in, list) and _ARCHIVED_PRIMARY_STATUS not in status_in:
+        status_in.append(_ARCHIVED_PRIMARY_STATUS)
+
+
 def _fetch_grid_campaigns_page(
     page: "Page", request: Dict[str, Any], offset: int
 ) -> Dict[str, Any]:
@@ -1032,6 +1070,12 @@ def fetch_masters_list(
     rather than the grid's DOM, paginates through every row
     (``GRID_PAGE_LIMIT`` per page), keeps only rows whose ``source`` is
     ``MASTERS_SOURCE``, and applies ``status`` via ``STATUS_FILTERS``.
+
+    For ``status in {"archived", "all"}`` the captured request's
+    ``filterStatusIn`` is widened first (see
+    ``_widen_filter_status_for_archived``) — otherwise the grid's own default
+    filter excludes archived rows server-side and ``STATUS_FILTERS`` below
+    would never even see them (issue #730).
     """
     status_predicate = STATUS_FILTERS.get(status)
     if status_predicate is None:
@@ -1041,6 +1085,8 @@ def fetch_masters_list(
         )
 
     request = _capture_grid_campaigns_request(page)
+    if status in _ARCHIVE_INCLUDING_STATUSES:
+        _widen_filter_status_for_archived(request)
 
     all_rows: List[Dict[str, Any]] = []
     offset = 0
@@ -1284,14 +1330,9 @@ def _extract_title(page: "Page", result: Dict[str, Any]) -> None:
 
 
 def _extract_status(page: "Page", result: Dict[str, Any]) -> None:
-    try:
-        body_text = page.inner_text("body")
-    except PlaywrightError:
-        body_text = ""
-    if "Кампания остановлена" in body_text:
-        result["Status"] = "SUSPENDED"
-    elif "Кампания активна" in body_text or "Кампания включена" in body_text:
-        result["Status"] = "ACTIVE"
+    status = _read_status_text(page)
+    if status is not None:
+        result["Status"] = status
     else:
         print_warning(
             f"Could not determine status for campaign {result['CampaignId']} "
@@ -1356,14 +1397,13 @@ def _extract_stat_tiles(page: "Page", result: Dict[str, Any]) -> None:
 
 
 def _read_status_text(page: "Page") -> Optional[str]:
-    """Return ``"SUSPENDED"``/``"ACTIVE"``/``"MODERATION"``/``None`` from the
-    current page body.
+    """Return ``"SUSPENDED"``/``"ACTIVE"``/``"MODERATION"``/``"ARCHIVED"``/
+    ``None`` from the current page body.
 
-    Shares the same marker text as ``_extract_status`` but returns the value
-    directly instead of writing into a result dict — used by
-    ``suspend_master``/``resume_master``/``launch_master`` both before and
-    after clicking, to verify the action actually changed the status rather
-    than trusting the click alone.
+    Shared by ``_extract_status`` (``masters get``) and by
+    ``suspend_master``/``resume_master``/``launch_master``, which call this
+    directly both before and after clicking to verify the action actually
+    changed the status rather than trusting the click alone.
 
     ``"Кампания на\xa0модерации"`` (issue #704, live-confirmed 2026-08-04
     against campaign 713271855's overview page right after a real launch) is
@@ -1376,6 +1416,16 @@ def _read_status_text(page: "Page") -> Optional[str]:
     ASCII-space literal here silently never matches (this cost a full
     debugging pass live: the click and the actual status change both
     succeeded every time, only this string comparison was wrong).
+
+    ``"Кампания в\xa0архиве"`` (issue #730, live-confirmed 2026-08-04 against
+    campaign 713277109's overview page, a real archived campaign) fills the
+    gap the module docstring's ``archive_master`` note flagged: no archived
+    overview fixture had been captured before, so this marker was simply
+    missing and ``masters get``/``masters list --status archived`` on an
+    archived campaign either warned "unrecognised status text" or the row
+    was silently excluded by a status predicate that could never match. Same
+    non-breaking-space pitfall as "на\xa0модерации" — the space between "в"
+    and "архиве" is U+00A0, not ASCII.
     """
     try:
         body_text = page.inner_text("body")
@@ -1387,6 +1437,8 @@ def _read_status_text(page: "Page") -> Optional[str]:
         return "ACTIVE"
     if "Кампания на\xa0модерации" in body_text:
         return "MODERATION"
+    if "Кампания в\xa0архиве" in body_text:
+        return "ARCHIVED"
     return None
 
 

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -1734,6 +1734,74 @@ class TestFetchMastersList(unittest.TestCase):
 
         self.assertEqual(len(result), 4)
 
+    def _grid_request_body_with_default_filter_status_in(self):
+        # Live-captured shape (issue #730): the grid UI's own default view
+        # sends this exact filterStatusIn list -- no "ARCHIVED" -- so an
+        # archived campaign is excluded server-side, before
+        # STATUS_FILTERS ever runs. See _widen_filter_status_for_archived.
+        body = dict(self._GRID_REQUEST_BODY)
+        body["variables"] = dict(body["variables"])
+        body["variables"]["campaignInput"] = dict(body["variables"]["campaignInput"])
+        body["variables"]["campaignInput"]["filter"] = {
+            "filterStatusIn": [
+                "ACTIVE",
+                "DRAFT",
+                "MODERATION",
+                "MODERATION_DENIED",
+                "RUN_WARN",
+                "STOPPED",
+                "TEMPORARILY_PAUSED",
+            ]
+        }
+        return body
+
+    def test_status_archived_widens_filter_status_in_before_replaying(self):
+        # Issue #730: without widening, the grid's own default
+        # filterStatusIn (captured verbatim from the live UI) excludes
+        # ARCHIVED server-side -- the replayed pagination POST must carry
+        # "ARCHIVED" or a real archived campaign never appears in rowset at
+        # all, regardless of STATUS_FILTERS below.
+        fixture = _load_grid_campaigns_fixture()
+        body = self._grid_request_body_with_default_filter_status_in()
+        page = self._page([fixture], grid_post_data=json.dumps(body))
+
+        browser_masters.fetch_masters_list(page, status="archived")
+
+        self.assertEqual(len(page.request.calls), 1)
+        posted_body = json.loads(page.request.calls[0][1])
+        status_in = posted_body["variables"]["campaignInput"]["filter"][
+            "filterStatusIn"
+        ]
+        self.assertIn("ARCHIVED", status_in)
+
+    def test_status_all_also_widens_filter_status_in(self):
+        fixture = _load_grid_campaigns_fixture()
+        body = self._grid_request_body_with_default_filter_status_in()
+        page = self._page([fixture], grid_post_data=json.dumps(body))
+
+        browser_masters.fetch_masters_list(page, status="all")
+
+        posted_body = json.loads(page.request.calls[0][1])
+        status_in = posted_body["variables"]["campaignInput"]["filter"][
+            "filterStatusIn"
+        ]
+        self.assertIn("ARCHIVED", status_in)
+
+    def test_status_active_does_not_widen_filter_status_in(self):
+        # Only archive-including statuses need the widen -- leave the grid's
+        # own default filter alone otherwise, matching prior behaviour.
+        fixture = _load_grid_campaigns_fixture()
+        body = self._grid_request_body_with_default_filter_status_in()
+        page = self._page([fixture], grid_post_data=json.dumps(body))
+
+        browser_masters.fetch_masters_list(page, status="active")
+
+        posted_body = json.loads(page.request.calls[0][1])
+        status_in = posted_body["variables"]["campaignInput"]["filter"][
+            "filterStatusIn"
+        ]
+        self.assertNotIn("ARCHIVED", status_in)
+
     def test_paginates_past_the_page_limit(self):
         # totalCount exceeds one page's rowset -> a second request must be
         # made and its rows included, matching the live behaviour that
@@ -1932,6 +2000,22 @@ class TestFetchMaster(unittest.TestCase):
         page = self._page_for(status_text="Кампания активна")
         result = browser_masters.fetch_master(page, 1)
         self.assertEqual(result["Status"], "ACTIVE")
+
+    def test_archived_status_recognised(self):
+        # Issue #730: live-confirmed against campaign 713277109 ("Кампания
+        # в\xa0архиве", non-breaking space between "в" and "архиве") -- this
+        # marker was previously entirely missing, so `masters get` on an
+        # archived campaign reported "unrecognised status text" instead.
+        page = self._page_for(status_text="Кампания в\xa0архиве")
+        result = browser_masters.fetch_master(page, 1)
+        self.assertEqual(result["Status"], "ARCHIVED")
+
+    def test_moderation_status_recognised_by_fetch_master(self):
+        # _extract_status previously duplicated _read_status_text's marker
+        # list but omitted MODERATION -- now both share _read_status_text.
+        page = self._page_for(status_text="Кампания на\xa0модерации")
+        result = browser_masters.fetch_master(page, 1)
+        self.assertEqual(result["Status"], "MODERATION")
 
     def test_unknown_testid_suffix_is_ignored(self):
         # Live recon (issue #708) confirmed exactly 5 stable suffixes


### PR DESCRIPTION
## Summary

- `_extract_status`/`_read_status_text` (`direct_cli/browser/masters.py`) were missing the `"Кампания в\xa0архиве"` marker (non-breaking space, confirmed live against campaign 713277109) — `masters get` on an archived campaign warned "unrecognised status text" instead of reporting `Status: ARCHIVED`. `_extract_status` now delegates to `_read_status_text` instead of duplicating a stale marker list, so it also picks up MODERATION (previously only `_read_status_text` had it).
- `masters list --status archived`/`--status all` never returned archived rows at all: the grid UI's own default `filterStatusIn` (captured verbatim by `_capture_grid_campaigns_request` and replayed unmodified for pagination) excludes `ARCHIVED` server-side — before `STATUS_FILTERS` ever runs client-side. `_widen_filter_status_for_archived` adds `"ARCHIVED"` to that captured list before replaying, only when the requested `status` can actually match an archived row (`"archived"`/`"all"`).

Closes #730

## Live verification

Both fixes verified against the real, already-archived test campaign 713277109 ("Тест") via the saved `direct playwright login` session — read-only, no mutation performed:

```
$ direct masters get 713277109
{
  "CampaignId": 713277109,
  "Name": "Тест",
  "Status": "ARCHIVED",
  ...
}

$ direct masters list --status archived
[... 713277109 "Тест" now included ...]
```

## Test plan

- [x] `pytest -k masters` — 475 passed (470 pre-existing + 5 new regression tests)
- [x] Full offline suite — 3056 passed, 8 skipped, 34 subtests passed, 62 pre-existing unrelated errors in `tests/test_read_cassettes.py` (confirmed present on `main` before this change too, via `git stash`)
- [x] `black --check` / `flake8` clean
- [x] Live verification against campaign 713277109 (read-only)