### PR TITLE
test(v4): record readonly VCR cassettes for 7 uncovered v4 methods

### DIFF
--- a/tests/cassettes/test_read_cassettes/test_balance_get_no_shared_account.yaml
+++ b/tests/cassettes/test_read_cassettes/test_balance_get_no_shared_account.yaml
@@ -1,0 +1,53 @@
+interactions:
+- request:
+    body: '{"method":"AccountManagement","param":{"Action":"Get","SelectionCriteria":{"Logins":["REDACTED"]}},"token":"<REDACTED>","locale":"en"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '134'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      authorization:
+      - REDACTED
+      client-login:
+      - REDACTED
+    method: POST
+    uri: https://api-sandbox.direct.yandex.ru/live/v4/json/
+  response:
+    body:
+      string: '{"data":{"Accounts":[],"ActionsResult":[{"Errors":[{"FaultDetail":"","FaultCode":515,"FaultString":"Shared
+        account must be connected."}],"Login":"REDACTED","AccountID":null}]}}'
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Aug 2026 03:40:29 GMT
+      RequestId:
+      - '3928838124887125187'
+      Set-Cookie:
+      - REDACTED
+      Transfer-Encoding:
+      - chunked
+      X-Accel-Info:
+      - reqid:0000000000000000000,cmd:direct.json-api/AccountManagement
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '181'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_read_cassettes/test_read_command[v4adimage_get].yaml
+++ b/tests/cassettes/test_read_cassettes/test_read_command[v4adimage_get].yaml
@@ -1,0 +1,52 @@
+interactions:
+- request:
+    body: '{"method":"AdImageAssociation","param":{"Action":"Get","SelectionCriteria":{}},"token":"<REDACTED>","locale":"en"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '114'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      authorization:
+      - REDACTED
+      client-login:
+      - REDACTED
+    method: POST
+    uri: https://api-sandbox.direct.yandex.ru/live/v4/json/
+  response:
+    body:
+      string: '{"data":{"AdImageAssociations":[],"TotalObjectsCount":"0"}}'
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Aug 2026 03:40:25 GMT
+      RequestId:
+      - '5448372471665298376'
+      Set-Cookie:
+      - REDACTED
+      Transfer-Encoding:
+      - chunked
+      X-Accel-Info:
+      - reqid:0000000000000000000,cmd:direct.json-api/AdImageAssociation
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '59'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_read_cassettes/test_v4account_get_accounts_no_shared_account.yaml
+++ b/tests/cassettes/test_read_cassettes/test_v4account_get_accounts_no_shared_account.yaml
@@ -1,0 +1,53 @@
+interactions:
+- request:
+    body: '{"method":"AccountManagement","param":{"Action":"Get","SelectionCriteria":{"Logins":["REDACTED"]}},"token":"<REDACTED>","locale":"en"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '134'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      authorization:
+      - REDACTED
+      client-login:
+      - REDACTED
+    method: POST
+    uri: https://api-sandbox.direct.yandex.ru/live/v4/json/
+  response:
+    body:
+      string: '{"data":{"Accounts":[],"ActionsResult":[{"Errors":[{"FaultDetail":"","FaultString":"Shared
+        account must be connected.","FaultCode":515}],"Login":"REDACTED","AccountID":null}]}}'
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Aug 2026 03:40:27 GMT
+      RequestId:
+      - '8966139497678673949'
+      Set-Cookie:
+      - REDACTED
+      Transfer-Encoding:
+      - chunked
+      X-Accel-Info:
+      - reqid:0000000000000000000,cmd:direct.json-api/AccountManagement
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '181'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_read_cassettes/test_v4forecast_get_unknown_forecast.yaml
+++ b/tests/cassettes/test_read_cassettes/test_v4forecast_get_unknown_forecast.yaml
@@ -1,0 +1,52 @@
+interactions:
+- request:
+    body: '{"method":"GetForecast","param":1,"token":"<REDACTED>","locale":"en"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '69'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      authorization:
+      - REDACTED
+      client-login:
+      - REDACTED
+    method: POST
+    uri: https://api-sandbox.direct.yandex.ru/live/v4/json/
+  response:
+    body:
+      string: '{"error_str":"The specified budget forecast report does not exist","error_code":73,"error_detail":""}'
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Aug 2026 03:40:31 GMT
+      RequestId:
+      - '2901054350453295873'
+      Set-Cookie:
+      - REDACTED
+      Transfer-Encoding:
+      - chunked
+      X-Accel-Info:
+      - reqid:0000000000000000000,cmd:direct.json-api/GetForecast
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '101'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_read_cassettes/test_v4goals_get_retargeting_goals_server_error.yaml
+++ b/tests/cassettes/test_read_cassettes/test_v4goals_get_retargeting_goals_server_error.yaml
@@ -1,0 +1,52 @@
+interactions:
+- request:
+    body: '{"method":"GetRetargetingGoals","param":{"CampaignIDS":[700012672]},"token":"<REDACTED>","locale":"en"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '103'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      authorization:
+      - REDACTED
+      client-login:
+      - REDACTED
+    method: POST
+    uri: https://api-sandbox.direct.yandex.ru/live/v4/json/
+  response:
+    body:
+      string: '{"error_detail":"","error_str":"Internal server error","error_code":500}'
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Aug 2026 03:40:37 GMT
+      RequestId:
+      - '6916589731900846434'
+      Set-Cookie:
+      - REDACTED
+      Transfer-Encoding:
+      - chunked
+      X-Accel-Info:
+      - reqid:0000000000000000000,cmd:direct.json-api/GetRetargetingGoals
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '72'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_read_cassettes/test_v4tags_get_banners_server_error.yaml
+++ b/tests/cassettes/test_read_cassettes/test_v4tags_get_banners_server_error.yaml
@@ -1,0 +1,52 @@
+interactions:
+- request:
+    body: '{"method":"GetBannersTags","param":{"CampaignIDS":[700012672]},"token":"<REDACTED>","locale":"en"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '98'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      authorization:
+      - REDACTED
+      client-login:
+      - REDACTED
+    method: POST
+    uri: https://api-sandbox.direct.yandex.ru/live/v4/json/
+  response:
+    body:
+      string: '{"error_str":"Internal server error","error_code":500,"error_detail":""}'
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Aug 2026 03:40:41 GMT
+      RequestId:
+      - '4981479891964039717'
+      Set-Cookie:
+      - REDACTED
+      Transfer-Encoding:
+      - chunked
+      X-Accel-Info:
+      - reqid:0000000000000000000,cmd:direct.json-api/GetBannersTags
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '72'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_read_cassettes/test_v4wordstat_get_report_unknown_report.yaml
+++ b/tests/cassettes/test_read_cassettes/test_v4wordstat_get_report_unknown_report.yaml
@@ -1,0 +1,103 @@
+interactions:
+- request:
+    body: '{"method":"GetWordstatReport","param":1,"token":"<REDACTED>","locale":"en"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '75'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      authorization:
+      - REDACTED
+      client-login:
+      - REDACTED
+    method: POST
+    uri: https://api-sandbox.direct.yandex.ru/live/v4/json/
+  response:
+    body:
+      string: '{"error_detail":"","error_str":"Login temporarily unavailable","error_code":52}'
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Aug 2026 03:40:33 GMT
+      RequestId:
+      - '3258136130878189315'
+      Set-Cookie:
+      - REDACTED
+      Transfer-Encoding:
+      - chunked
+      X-Accel-Info:
+      - reqid:0000000000000000000,cmd:direct.json-api/GetWordstatReport
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '79'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"method":"GetWordstatReport","param":1,"token":"<REDACTED>","locale":"en"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '75'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      authorization:
+      - REDACTED
+      client-login:
+      - REDACTED
+      cookie:
+      - REDACTED
+    method: POST
+    uri: https://api-sandbox.direct.yandex.ru/live/v4/json/
+  response:
+    body:
+      string: '{"error_code":91,"error_detail":"","error_str":"The specified wordstat
+        report does not exist"}'
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Aug 2026 03:40:35 GMT
+      RequestId:
+      - '2455260119534387331'
+      Transfer-Encoding:
+      - chunked
+      X-Accel-Info:
+      - reqid:0000000000000000000,cmd:direct.json-api/GetWordstatReport
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '94'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_read_cassettes.py
+++ b/tests/test_read_cassettes.py
@@ -33,9 +33,25 @@ vendored v4 Live client through the same ``requests``/``urllib3`` transport as
 v5 — there is no incompatibility. Earlier recording attempts hung because the
 v4 adapter retried request-limit errors (code 54/55) in an unbounded loop; that
 loop is now bounded (``v4/adapter.py`` ``retry_request``), so ``--record-mode=
-rewrite`` no longer hangs. The ``v4finance check-payment`` case is recorded as a
-*deterministic error* (``error_code=370``, "Transaction does not exist"), so it
-asserts a non-zero exit and the error string instead of success.
+rewrite`` no longer hangs.
+
+Several v4 read commands have no success path available on the recording
+sandbox account (no shared account connected, no forecasts/reports/banners
+created) and are instead recorded as *deterministic errors* — a stable,
+side-effect-free response confirmed reproducible across repeated live calls,
+not a transient failure:
+
+    v4finance check-payment            error_code=370 (transaction unknown)
+    v4account account-management get   FaultCode=515 (no shared account)
+    balance                            FaultCode=515 (no shared account)
+    v4forecast get                     error_code=73  (forecast unknown)
+    v4wordstat get-report              error_code=91  (report unknown)
+    v4goals get-retargeting-goals      error_code=500 (no Metrica counter)
+    v4tags get-banners                 error_code=500 (no banners)
+
+Each of these has its own dedicated test (not a ``READ_CASES`` row) that
+asserts a non-zero exit and the specific error code/string, since the shared
+``test_read_command`` only asserts success (exit 0, non-empty output).
 """
 
 from __future__ import annotations
@@ -203,6 +219,7 @@ READ_CASES: list[tuple[str, list[str]]] = [
         "v4finance_get_clients_units",
         ["v4finance", "get-clients-units", "--logins", _REAL_LOGIN or _REDACTED],
     ),
+    ("v4adimage_get", ["v4adimage", "get"]),
 ]
 
 
@@ -254,3 +271,118 @@ def test_v4finance_check_payment_unknown_transaction() -> None:
     assert (
         "error_code=370" in result.output
     ), f"expected error_code=370 in output, got: {result.output}"
+
+
+# ── v4 read commands with deterministic error responses ────────────────────
+#
+# The sandbox account has no shared account connected, so both
+# ``v4account account-management --action Get`` and ``balance`` answer
+# deterministically with FaultCode=515 ("Shared account must be connected.").
+# Neither call has side effects, so the error response makes a stable,
+# secret-free readonly cassette (issue #649).
+
+
+@pytest.mark.vcr
+def test_v4account_get_accounts_no_shared_account() -> None:
+    """v4account account-management --action Get replays FaultCode=515."""
+    result = _invoke_read(
+        [
+            "v4account",
+            "account-management",
+            "--action",
+            "Get",
+            "--logins",
+            _REAL_LOGIN or _REDACTED,
+        ]
+    )
+    assert (
+        result.exit_code != 0
+    ), f"expected non-zero exit, got {result.exit_code}\noutput: {result.output}"
+    assert (
+        "515" in result.output
+    ), f"expected FaultCode=515 in output, got: {result.output}"
+
+
+@pytest.mark.vcr
+def test_balance_get_no_shared_account() -> None:
+    """balance replays FaultCode=515 for a sandbox account with no shared account."""
+    result = _invoke_read(["balance", "--logins", _REAL_LOGIN or _REDACTED])
+    assert (
+        result.exit_code != 0
+    ), f"expected non-zero exit, got {result.exit_code}\noutput: {result.output}"
+    assert (
+        "515" in result.output
+    ), f"expected FaultCode=515 in output, got: {result.output}"
+
+
+# A syntactically valid, non-existent forecast/report id — the v4 Live API
+# answers deterministically ("does not exist") rather than an empty success
+# body, which is what the sandbox account also returns for any real id (the
+# sandbox has no forecasts/reports at all).
+_NONEXISTENT_V4_ID = 1
+
+
+@pytest.mark.vcr
+def test_v4forecast_get_unknown_forecast() -> None:
+    """v4forecast get replays a deterministic error_code=73 for a missing id."""
+    result = _invoke_read(
+        ["v4forecast", "get", "--forecast-id", str(_NONEXISTENT_V4_ID)]
+    )
+    assert (
+        result.exit_code != 0
+    ), f"expected non-zero exit, got {result.exit_code}\noutput: {result.output}"
+    assert (
+        "error_code=73" in result.output
+    ), f"expected error_code=73 in output, got: {result.output}"
+
+
+@pytest.mark.vcr
+def test_v4wordstat_get_report_unknown_report() -> None:
+    """v4wordstat get-report replays a deterministic error_code=91 for a missing id."""
+    result = _invoke_read(
+        ["v4wordstat", "get-report", "--report-id", str(_NONEXISTENT_V4_ID)]
+    )
+    assert (
+        result.exit_code != 0
+    ), f"expected non-zero exit, got {result.exit_code}\noutput: {result.output}"
+    assert (
+        "error_code=91" in result.output
+    ), f"expected error_code=91 in output, got: {result.output}"
+
+
+@pytest.mark.vcr
+def test_v4goals_get_retargeting_goals_server_error() -> None:
+    """v4goals get-retargeting-goals replays a deterministic error_code=500.
+
+    The sandbox campaign has no Metrica counter linked, so the v4 Live API
+    answers with a stable internal error rather than an empty list —
+    confirmed reproducible across repeated live calls.
+    """
+    result = _invoke_read(
+        ["v4goals", "get-retargeting-goals", "--campaign-ids", SANDBOX_CAMPAIGN_ID]
+    )
+    assert (
+        result.exit_code != 0
+    ), f"expected non-zero exit, got {result.exit_code}\noutput: {result.output}"
+    assert (
+        "error_code=500" in result.output
+    ), f"expected error_code=500 in output, got: {result.output}"
+
+
+@pytest.mark.vcr
+def test_v4tags_get_banners_server_error() -> None:
+    """v4tags get-banners replays a deterministic error_code=500.
+
+    The sandbox campaign has no banners, so the v4 Live API answers with a
+    stable internal error rather than an empty list — confirmed reproducible
+    across repeated live calls.
+    """
+    result = _invoke_read(
+        ["v4tags", "get-banners", "--campaign-ids", SANDBOX_CAMPAIGN_ID]
+    )
+    assert (
+        result.exit_code != 0
+    ), f"expected non-zero exit, got {result.exit_code}\noutput: {result.output}"
+    assert (
+        "error_code=500" in result.output
+    ), f"expected error_code=500 in output, got: {result.output}"


### PR DESCRIPTION
## Summary
- Adds readonly VCR cassettes for the 7 v4 Live methods flagged in #649 as uncovered: `v4account_get_accounts`, `balance_get`, `v4adimage_get`, `v4forecast_get`, `v4wordstat_get_report`, `v4goals_get_retargeting_goals`, `v4tags_get_banners`.
- `v4adimage_get` records a success response and joins `READ_CASES` (same pattern as the existing 34 rows).
- The other 6 have no success path available on the recording sandbox account (no shared account connected, no forecasts/reports/banners) and are instead recorded as **deterministic errors** — confirmed reproducible across repeated live calls, not transient failures — following the existing `v4finance check-payment` pattern:
  - `v4account account-management --action Get` / `balance` → `FaultCode=515` ("Shared account must be connected")
  - `v4forecast get` → `error_code=73` ("forecast does not exist")
  - `v4wordstat get-report` → `error_code=91` ("report does not exist")
  - `v4goals get-retargeting-goals` / `v4tags get-banners` → `error_code=500` (internal error, no counter/banners on the sandbox campaign)
- Updated the module docstring to document the deterministic-error recording convention for future contributors.

Cassettes were checked for leaked secrets (`y0_` token prefix, real login) before committing — none found; the existing `conftest.py` scrubbers (token-in-body, login-echo, Client-Login header) cover these v4 bodies correctly.

Closes #649

## Test plan
- [x] `pytest tests/test_read_cassettes.py -q` (offline replay, no token/network) — 46 passed
- [x] Full offline suite: `pytest tests/ -m "not integration and not v4_live_read and not integration_live_write"` — 3105 passed, 23 skipped
- [x] `black --check` / `ruff check` on the changed test file
- [x] `grep -r "y0_"` and login-string search across new cassettes — no matches