### PR TITLE
fix(masters): refuse blind click when directs-helps state never resolves (#736)

### DIFF
--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -2069,10 +2069,28 @@ def _set_directs_helps(page: "Page", enabled: bool) -> None:
     nothing makes it converge to ``enabled`` on its own — so that would
     burn the full ``_VERIFY_FIELD_READ_TIMEOUT_MS`` on every real toggle
     for no reason. Only ``None`` is a signal worth waiting out.
+
+    If ``current`` is STILL ``None`` once the poll times out — not a
+    transient hydration gap but a genuinely unreadable/absent
+    ``data-checked`` for the whole window — this raises instead of
+    clicking (issue #736, Codex round-3 finding on PR #731): clicking the
+    visible label without knowing the toggle's real state can invert an
+    already-correct value and commit that on a live Yandex account. A
+    click is only safe once the pre-click state is actually known.
     """
     current = _read_until_matches(
         page, _read_directs_helps, None, matches=lambda actual, _exp: actual is not None
     )
+    if current is None:
+        raise BrowserSessionError(
+            "Could not read the 'Директ помогает' checkbox's current state "
+            "('Автоматически применять рекомендации') on the campaign edit "
+            "page — its data-checked attribute stayed unreadable for "
+            f"{_VERIFY_FIELD_READ_TIMEOUT_MS / 1000:.0f}s. Refusing to click "
+            "blind, since that could invert an already-correct state. "
+            "Yandex may have changed the page's markup, or the page is "
+            "still hydrating — re-run with --headful to inspect the page."
+        )
     if current is enabled:
         return
 

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -3576,6 +3576,54 @@ class TestSetDirectsHelps(unittest.TestCase):
         self.assertTrue(state["toggled"])
         self.assertEqual(ticks["count"], 0)
 
+    def test_raises_instead_of_clicking_blind_when_state_never_resolves(self):
+        # Regression (issue #736, Codex round-3 finding on PR #731): if
+        # data-checked stays unreadable/absent (None) for the WHOLE poll
+        # timeout — not just a transient hydration tick — _set_directs_helps
+        # must never click the label with an unknown pre-click state, since
+        # that click could invert an already-correct toggle and commit that
+        # on a live Yandex account. It must raise BrowserSessionError and
+        # leave the label untouched instead.
+        state = {"toggled": False}
+
+        def _toggle():
+            state["toggled"] = True
+
+        def _get_attrs():
+            return {}
+
+        label_handle = _FakeLocatorHandle(on_click=_toggle)
+        div_handle = _DynamicAttrsLocatorHandle(get_attrs=_get_attrs)
+
+        page = FakePage(
+            locators={
+                browser_masters._DIRECT_HELPS_TOGGLE_LABEL_SELECTOR: _FakeLocator(
+                    [label_handle]
+                ),
+                browser_masters._DIRECT_HELPS_TOGGLE_DIV_SELECTOR: _FakeLocator(
+                    [div_handle]
+                ),
+            }
+        )
+
+        # Keeps the test fast: _read_until_matches's timeout_ms default is
+        # bound to _VERIFY_FIELD_READ_TIMEOUT_MS at function-definition time,
+        # so patching the module constant alone would not shrink it —
+        # advancing the monotonic clock it polls against does.
+        fake_now = {"value": 0.0}
+
+        def _fake_monotonic():
+            fake_now["value"] += browser_masters._VERIFY_FIELD_READ_TIMEOUT_MS
+            return fake_now["value"]
+
+        with patch.object(
+            browser_masters.time, "monotonic", side_effect=_fake_monotonic
+        ):
+            with self.assertRaises(BrowserSessionError):
+                browser_masters._set_directs_helps(page, True)
+
+        self.assertFalse(state["toggled"])
+
 
 class TestSetPromotionGoal(unittest.TestCase):
     """``_set_promotion_goal`` (issue #631, Этап A) — open dropdown, click, verify.


### PR DESCRIPTION
## Summary
- `_set_directs_helps` (`direct_cli/browser/masters.py`) polled `data-checked` while it stayed `None` during SPA hydration, but if the read was still `None` after the full poll timeout, the code fell through and clicked the label anyway — with no idea of the toggle's real state.
- On an already-correct toggle, that blind click inverts it, and the subsequent save persists the wrong value on a live Yandex account.
- This was round-3 cycle-review finding from PR #731 (fix #724), tracked separately as #736 since it needed a 4th review cycle.

## Changes
- `_set_directs_helps` now raises `BrowserSessionError` instead of clicking blind when `_read_until_matches` times out still unresolved (`None`).
- Added a regression test (`TestSetDirectsHelps::test_raises_instead_of_clicking_blind_when_state_never_resolves`) modeling `data-checked` staying unreadable for the entire poll window — asserts the label is never clicked and `BrowserSessionError` is raised.

Other Codex round-3 suggestions (reading the hidden `<input>` via `is_checked()`, re-reading state right after the click) were evaluated: the hidden-input read was deliberately rejected in #724 to keep the read/click path on the same element; re-reading after save is already covered by `_verify_saved`'s post-save reload verification.

Closes #736

## Test plan
- [x] `pytest tests/test_masters.py -k TestSetDirectsHelps -v` — 7 passed
- [x] `pytest tests/test_masters.py -q` — 481 passed
- [x] `flake8 direct_cli/browser/masters.py tests/test_masters.py`
- [x] `black --check direct_cli/browser/masters.py tests/test_masters.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RS5VxAJpiME3VD6L3AxzW