### PR TITLE
fix: pin vcrpy>=8.2.0 to fix aiohttp 3.14 incompatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+**Fixed — `vcrpy>=6.0` allowed a version incompatible with aiohttp>=3.14 (#737):**
+
+- vcrpy's aiohttp stub (`vcr/stubs/aiohttp_stubs.py`) built its `MockStream`
+  on `aiohttp.streams.AsyncStreamReaderMixin`, which aiohttp 3.14 removed
+  (folded into aiohttp's own `StreamReader`). Any vcrpy release below 8.2.0
+  raised `AttributeError` at cassette-patcher construction time under
+  aiohttp>=3.14, breaking the entire `pytest.mark.vcr` layer — including
+  replay of already-committed cassettes.
+- Pinned dev dependency to `vcrpy>=8.2.0`, which builds `MockStream` on
+  `asyncio.StreamReader` directly instead of the removed mixin.
+
 **Fixed — `masters add --region-id` verified only by label text, not RegionId identity (#657):**
 
 - `--region-id` resolved to Yandex's canonical `GeoRegionName` (#652) and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,12 @@
   raised `AttributeError` at cassette-patcher construction time under
   aiohttp>=3.14, breaking the entire `pytest.mark.vcr` layer — including
   replay of already-committed cassettes.
-- Pinned dev dependency to `vcrpy>=8.2.0`, which builds `MockStream` on
-  `asyncio.StreamReader` directly instead of the removed mixin.
+- Pinned dev dependency to `vcrpy>=8.2.0` on Python>=3.10, which builds
+  `MockStream` on `asyncio.StreamReader` directly instead of the removed
+  mixin. `vcrpy>=8.2.0` itself requires Python>=3.10 (as does aiohttp>=3.14),
+  so Python 3.9 keeps `vcrpy>=6.0,<8.0.0` — aiohttp>=3.14 can't install
+  there either, so the incompatible pairing can't occur on that
+  interpreter.
 
 **Fixed — `masters add --region-id` verified only by label text, not RegionId identity (#657):**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,12 @@ dev = [
     "pytest-cov>=2.0",
     "pytest-recording>=0.13",
     "pytest-xdist>=3.0",
-    "vcrpy>=6.0",
+    # >=8.2.0: vcrpy's aiohttp stub (vcr/stubs/aiohttp_stubs.py) built its
+    # MockStream on streams.AsyncStreamReaderMixin, which aiohttp 3.14 removed
+    # (folded into aiohttp's own StreamReader). Older vcrpy raises
+    # AttributeError at cassette-patcher construction time under aiohttp>=3.14,
+    # breaking the entire VCR layer (issue #737).
+    "vcrpy>=8.2.0",
     "black>=22.0",
     "flake8>=4.0",
     "mypy>=1.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,12 @@ dev = [
     # MockStream on streams.AsyncStreamReaderMixin, which aiohttp 3.14 removed
     # (folded into aiohttp's own StreamReader). Older vcrpy raises
     # AttributeError at cassette-patcher construction time under aiohttp>=3.14,
-    # breaking the entire VCR layer (issue #737).
-    "vcrpy>=8.2.0",
+    # breaking the entire VCR layer (issue #737). vcrpy>=8.2.0 requires
+    # Python>=3.10 (as does aiohttp>=3.14 itself), so Python 3.9 stays on the
+    # last 3.9-compatible vcrpy release — aiohttp>=3.14 can't install there
+    # either, so the incompatible pairing can't occur on that interpreter.
+    "vcrpy>=8.2.0; python_version >= '3.10'",
+    "vcrpy>=6.0,<8.0.0; python_version < '3.10'",
     "black>=22.0",
     "flake8>=4.0",
     "mypy>=1.8",


### PR DESCRIPTION
## Summary
- vcrpy releases below 8.2.0 build `MockStream` on `aiohttp.streams.AsyncStreamReaderMixin`, which aiohttp 3.14 removed (folded into aiohttp's own `StreamReader`). This raises `AttributeError` at cassette-patcher construction time under aiohttp>=3.14, breaking the entire `pytest.mark.vcr` layer — including replay of already-committed cassettes.
- Confirmed by diffing vcrpy 8.1.1 (still references the removed mixin) vs 8.2.0 (rewritten to build on `asyncio.StreamReader` directly) release wheels.
- Pinned the dev dependency to `vcrpy>=8.2.0` in `pyproject.toml` and documented the reason inline + in CHANGELOG.

Closes #737

## Test plan
- [x] `pytest tests/test_read_cassettes.py -k campaigns_get -v` passes in replay mode, no network/token
- [x] Full offline suite: `pytest -q` → 3108 passed, 23 skipped, 34 subtests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZF79fANgpyP6m1aE6xB2c