### PR TITLE
fix(masters): raise clear error for disabled suspend/resume button (#728)

### DIFF
--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -1452,14 +1452,46 @@ def _read_status_text(page: "Page") -> Optional[str]:
     return None
 
 
+def _is_button_disabled(handle: Any) -> bool:
+    """Return whether ``handle`` is disabled — via the ``disabled`` DOM
+    property, the ``disabled`` HTML attribute, or ``aria-disabled`` (issue
+    #728: Yandex renders "Остановить кампанию" as disabled, not hidden,
+    while part of the campaign's creatives are still in moderation/rejected
+    — a plain visibility check does not catch this, and the click then
+    physically lands on a no-op element).
+    """
+    with contextlib.suppress(PlaywrightError, AttributeError):
+        if handle.is_disabled():
+            return True
+    with contextlib.suppress(PlaywrightError):
+        if handle.get_attribute("disabled") is not None:
+            return True
+    with contextlib.suppress(PlaywrightError):
+        if (handle.get_attribute("aria-disabled") or "").lower() == "true":
+            return True
+    return False
+
+
 def _click_action_button(page: "Page", candidate_texts: Tuple[str, ...]) -> None:
-    """Click the first visible button matching one of ``candidate_texts``.
+    """Click the first visible, enabled button matching one of
+    ``candidate_texts``.
 
     Raises :class:`BrowserSessionError` if none of the candidates match any
     visible button — this deliberately does NOT fall back to clicking an
     unrelated element, since suspend/resume is a real account mutation (see
     module docstring: the suspend-side button text is not live-confirmed).
+
+    A matching button that is visible but disabled (issue #728) is treated
+    as a distinct case from "not found": Yandex renders "Остановить
+    кампанию" disabled — not hidden — while part of the campaign's
+    creatives are still in moderation or rejected, so a click there
+    physically lands but is a no-op. Reporting that as the generic "could
+    not find a button, markup may have drifted" error sends the caller
+    chasing a markup change that never happened. Raise a specific error
+    naming the real cause instead, and keep scanning remaining candidates
+    in case a different, enabled match exists.
     """
+    saw_disabled_match = False
     for text in candidate_texts:
         locator = page.get_by_text(text, exact=False)
         try:
@@ -1471,10 +1503,19 @@ def _click_action_button(page: "Page", candidate_texts: Tuple[str, ...]) -> None
             try:
                 if not handle.is_visible():
                     continue
+                if _is_button_disabled(handle):
+                    saw_disabled_match = True
+                    continue
                 handle.click()
                 return
             except PlaywrightError:
                 continue
+    if saw_disabled_match:
+        raise BrowserSessionError(
+            "The action button is currently disabled — this happens while "
+            "part of the campaign's creatives are still on moderation or "
+            "have been rejected. Try again once moderation finishes."
+        )
     raise BrowserSessionError(
         "Could not find an action button matching any of "
         f"{candidate_texts!r} on the campaign overview page. Yandex may "

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -425,15 +425,36 @@ class _FakeTextLocatorHandle:
     status text.
     """
 
-    def __init__(self, visible=True, on_click=None, raises=False):
+    def __init__(
+        self,
+        visible=True,
+        on_click=None,
+        raises=False,
+        disabled=False,
+        aria_disabled=None,
+    ):
         self._visible = visible
         self._on_click = on_click
         self._raises = raises
+        self._disabled = disabled
+        self._aria_disabled = aria_disabled
 
     def is_visible(self):
         if self._raises:
             raise PlaywrightError("element detached")
         return self._visible
+
+    def is_disabled(self):
+        if self._raises:
+            raise PlaywrightError("element detached")
+        return self._disabled
+
+    def get_attribute(self, name):
+        if name == "disabled":
+            return "" if self._disabled else None
+        if name == "aria-disabled":
+            return self._aria_disabled
+        return None
 
     def click(self):
         if self._raises:
@@ -2438,6 +2459,42 @@ class TestSuspendResumeMaster(unittest.TestCase):
 
         with self.assertRaises(BrowserSessionError):
             browser_masters.suspend_master(page, 42)
+
+    def test_suspend_disabled_button_raises_specific_error(self):
+        # issue #728: Yandex renders "Остановить кампанию" disabled (not
+        # hidden) while some of the campaign's creatives are still on
+        # moderation/rejected. Must raise a specific, actionable error
+        # instead of the generic "could not find a button" message that
+        # implies Yandex changed the markup.
+        state = {"status": "Кампания активна"}
+        page = FakePage(
+            text_buttons={
+                "Остановить кампанию": _FakeGetByTextLocator(
+                    [_FakeTextLocatorHandle(visible=True, disabled=True)]
+                )
+            },
+        )
+        page.inner_text = lambda selector=None: state["status"]
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.suspend_master(page, 42)
+        self.assertIn("disabled", str(ctx.exception))
+        self.assertIn("moderation", str(ctx.exception))
+
+    def test_suspend_aria_disabled_button_raises_specific_error(self):
+        state = {"status": "Кампания активна"}
+        page = FakePage(
+            text_buttons={
+                "Остановить кампанию": _FakeGetByTextLocator(
+                    [_FakeTextLocatorHandle(visible=True, aria_disabled="true")]
+                )
+            },
+        )
+        page.inner_text = lambda selector=None: state["status"]
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.suspend_master(page, 42)
+        self.assertIn("disabled", str(ctx.exception))
 
     def _draft_page(self):
         return FakePage(


### PR DESCRIPTION
## Summary
- \`_click_action_button\` in \`direct_cli/browser/masters.py\` only checked button visibility before clicking, not whether it was disabled. Yandex renders "Остановить кампанию"/"Возобновить кампанию" as visible-but-disabled while part of the campaign's creatives are still on moderation or rejected — the click physically landed on a no-op, and the caller got a generic "could not find a button, markup may have drifted" error that pointed at the wrong cause.
- New `_is_button_disabled()` helper checks `is_disabled()`, the `disabled` attribute, and `aria-disabled` before clicking a matching candidate. When every matching button is disabled, `_click_action_button` now raises a specific error naming moderation as the cause instead of the generic markup-drift message.
- `archive_master` was audited too — it clicks a menu item via stable `data-testid` selectors, not a suspend/resume-style action button, and archiving isn't blocked by creative moderation state, so the same pattern doesn't apply there.

## Live verification
Used the sandbox master "Тест" (713277109, `direct playwright login` saved session) to inspect the real overview page DOM. Confirmed the resume button's `data-testid="CampaignHeader.ActionButton.resume"` (useful for a future selector-based rewrite), but could not reproduce the disabled state itself live in this session — moderation on that campaign's creatives (1 image + 3 texts) completed and the rejected element got auto-resubmitted before the button ever rendered disabled. The campaign was returned to ARCHIVED (its original state) at the end of the session. This mirrors the existing "not live-verified" caveat already on the rest of suspend/resume (see the module docstring).

## Test plan
- [x] `pytest tests/test_masters.py -q` — 489 passed, 4 subtests passed
- [x] `black --check` / `flake8` clean
- [x] Two new unit tests added: `test_suspend_disabled_button_raises_specific_error`, `test_suspend_aria_disabled_button_raises_specific_error`

Closes #728

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115UiYWNCMDE6bdyZgPF8JU