### PR TITLE
fix(masters): scope region checkbox lookup and clarify _set_region errors (#656)

### DIFF
--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -5047,9 +5047,6 @@ def _set_region(
         # Targeting the input directly is exactly why this failed with
         # "Could not find 'Москва'" even though the locator matched.
         label = page.locator(label_xpath)
-        checkbox = page.locator(
-            f"{label_xpath}//input[@data-testid='{_REGION_CHECKBOX_TESTID}']"
-        )
         matched_wrong_id = None
 
         # Live testing (issue #653) found opening the popup and filtering
@@ -5071,6 +5068,17 @@ def _set_region(
         #     tree down to zero nodes and can never match.
         clicked = False
         last_open_exc = None
+        # Tracks whether _clear_text_field ever reported failure across
+        # attempts (issue #656). A failed clear here is NOT immediately
+        # fatal the way it is in _add_repeating_values — this field is a
+        # scratch filter, not a slot whose stale content would ship
+        # unreviewed, and a later attempt's own poll decides success. But
+        # if every attempt exhausts with no match, an unset clear means
+        # each retype APPENDED onto the previous one ("МоскваМосква"),
+        # which can never filter-match anything — surfacing that as "check
+        # the region name" would blame the wrong thing when the real cause
+        # is an unsupported Playwright version (see _clear_text_field).
+        clear_ever_failed = False
         for _ in range(_REGION_OPEN_ATTEMPTS):
             launcher = page.locator(_REGION_LAUNCHER_TESTID).first
             editor = page.locator(_REGION_EDITOR_TESTID).first
@@ -5080,7 +5088,8 @@ def _set_region(
                 if not editor.count():
                     launcher.click()
                 editor.click(timeout=_REGION_EDITOR_APPEAR_TIMEOUT_MS)
-                _clear_text_field(editor)
+                if not _clear_text_field(editor):
+                    clear_ever_failed = True
                 editor.type(region)
             except PlaywrightError as exc:
                 last_open_exc = exc
@@ -5111,8 +5120,17 @@ def _set_region(
                 # Clicking a label that is already checked would UNCHECK the
                 # region, so confirm the input actually ended up checked
                 # rather than trusting the click — same read-back convention
-                # as _verify_created/_verify_saved.
-                node = checkbox.nth(i)
+                # as _verify_created/_verify_saved. Scoped off `handle`
+                # itself (issue #656), not a second independent top-level
+                # locator built from the same xpath: two separate
+                # page.locator() calls resolved from the same selector are
+                # not guaranteed to enumerate matches in the same order if
+                # the tree re-renders between them, so indexing both by `i`
+                # could silently pair a label with the WRONG node's
+                # checkbox.
+                node = handle.locator(
+                    f"xpath=.//input[@data-testid='{_REGION_CHECKBOX_TESTID}']"
+                ).first
                 with contextlib.suppress(PlaywrightError):
                     if not node.is_checked():
                         continue
@@ -5159,6 +5177,18 @@ def _set_region(
                     "changed the page's markup. Re-run with --headful to "
                     "inspect the page."
                 ) from last_open_exc
+            if clear_ever_failed:
+                raise BrowserSessionError(
+                    f"Could not find {region!r} in the 'Регион показов' tree "
+                    "after typing it — but the filter field could not be "
+                    "cleared before typing (see _clear_text_field), so each "
+                    "attempt likely typed into leftover text from the "
+                    "previous one instead of a clean field. This usually "
+                    "means Playwright is older than 1.44 (the version that "
+                    "added the 'ControlOrMeta' modifier) — upgrade with "
+                    "'pip install -U playwright' and retry before assuming "
+                    "the region name itself is wrong."
+                )
             raise BrowserSessionError(
                 f"Could not find {region!r} in the 'Регион показов' tree on "
                 "the Мастер кампаний create page — check the region name "

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -92,6 +92,7 @@ class _FakeLocatorHandle:
         get_value=None,
         get_checked=None,
         on_upload=None,
+        sub_locators=None,
     ):
         self._text = text
         self._attrs = attrs or {}
@@ -104,6 +105,16 @@ class _FakeLocatorHandle:
         self._get_value = get_value
         self._get_checked = get_checked
         self._on_upload = on_upload
+        # {selector: _FakeLocatorHandle} for a SCOPED child lookup — models
+        # Playwright's Locator.locator(), e.g. `label.locator("xpath=.//input
+        # [...]")` (issue #656: _set_region reads a checkbox scoped off the
+        # matched label handle itself, not via a second independent
+        # page.locator() call built from the same selector string).
+        self._sub_locators = sub_locators or {}
+
+    def locator(self, selector):
+        handle = self._sub_locators.get(selector)
+        return _FakeLocator([handle] if handle is not None else [])
 
     def inner_text(self):
         if self._raises:
@@ -9034,18 +9045,22 @@ class TestSetRegion(unittest.TestCase):
             f"[normalize-space(.)={browser_masters._xpath_literal(region)}]"
         )
 
-    def _checkbox_xpath(self, region):
-        return (
-            f"{self._label_xpath(region)}"
-            f"//input[@data-testid='{browser_masters._REGION_CHECKBOX_TESTID}']"
-        )
+    # Relative xpath _set_region scopes off the matched label handle itself
+    # (issue #656) — ``handle.locator(_CHECKBOX_SUB_XPATH)``, not a second
+    # independent ``page.locator()`` built from the label's own xpath.
+    _CHECKBOX_SUB_XPATH = (
+        f"xpath=.//input[@data-testid='{browser_masters._REGION_CHECKBOX_TESTID}']"
+    )
 
     def _region_node(self, region, checked, visible=True, node_id=None):
         """A (label, input) pair whose label click toggles the input.
 
         ``node_id`` models the checkbox's stable ``id="region-node-<id>"``
         attribute (issue #657) — ``None`` means the fake node has no ``id``
-        attribute at all, same as any test written before that issue.
+        attribute at all, same as any test written before that issue. The
+        checkbox is wired onto the label as a ``sub_locators`` child (issue
+        #656), mirroring ``_set_region``'s scoped ``handle.locator(...)``
+        lookup, not a separate top-level locator.
         """
         state = {"checked": False}
 
@@ -9057,9 +9072,13 @@ class TestSetRegion(unittest.TestCase):
                 with contextlib.suppress(ValueError):
                     checked.remove(region)
 
-        label = _FakeLocatorHandle(visible=visible, on_click=_toggle)
         attrs = {"id": node_id} if node_id is not None else {}
         box = _FakeLocatorHandle(get_checked=lambda: state["checked"], attrs=attrs)
+        label = _FakeLocatorHandle(
+            visible=visible,
+            on_click=_toggle,
+            sub_locators={self._CHECKBOX_SUB_XPATH: box},
+        )
         return label, box
 
     def _page_for_region(self, region, checkbox_visible=True, node_id=None):
@@ -9073,7 +9092,6 @@ class TestSetRegion(unittest.TestCase):
         if checkbox_visible:
             label, box = self._region_node(region, checked, node_id=node_id)
             locators[self._label_xpath(region)] = _FakeLocator([label])
-            locators[self._checkbox_xpath(region)] = _FakeLocator([box])
         return FakePage(locators=locators), checked
 
     def test_fills_and_selects_each_region(self):
@@ -9137,12 +9155,25 @@ class TestSetRegion(unittest.TestCase):
         self.assertEqual(checked, [])
 
     def test_raises_when_launcher_missing(self):
+        # Issue #656: the popup never opened at all (the launcher itself is
+        # missing) is a DIFFERENT failure from "the popup opened but the
+        # region wasn't in the filtered tree" — the two must raise
+        # distinguishable messages, not just "some BrowserSessionError",
+        # which would pass equally if the code regressed onto the wrong
+        # branch (see test_raises_when_checkbox_not_found for the sibling
+        # case).
         page = FakePage(locators={})
 
-        with self.assertRaises(BrowserSessionError):
+        with self.assertRaises(BrowserSessionError) as ctx:
             browser_masters._set_region(page, ["Москва"])
+        self.assertIn("Could not find or open", str(ctx.exception))
+        self.assertNotIn("Москва", str(ctx.exception))
 
     def test_raises_when_checkbox_not_found(self):
+        # Unlike test_raises_when_launcher_missing, the popup DID open (the
+        # launcher/editor are present) — the region simply never matched a
+        # node in the filtered tree. This must raise the "could not find
+        # {region} in the tree" message, not the launcher-missing one.
         page, _ = self._page_for_region("Атлантида", checkbox_visible=False)
 
         with (
@@ -9151,6 +9182,37 @@ class TestSetRegion(unittest.TestCase):
         ):
             browser_masters._set_region(page, ["Атлантида"])
         self.assertIn("Атлантида", str(ctx.exception))
+        self.assertNotIn("Could not find or open", str(ctx.exception))
+
+    def test_raises_playwright_version_hint_when_clear_never_succeeds(self):
+        # Issue #656: if the filter field's clear (select-all + Backspace)
+        # never succeeds across every retry — the pre-1.44 Playwright
+        # ``ControlOrMeta`` failure _clear_text_field's docstring
+        # describes — each retype APPENDS onto the previous attempt's
+        # leftover text ("МоскваМосква"), which can never filter-match. The
+        # resulting "region not found" must say so, not blame the region
+        # name (a real region that legitimately doesn't exist looks
+        # identical to the caller otherwise).
+        launcher = _FakeLocatorHandle()
+        editor = _FakeContentEditableHandle(supports_modifier=False)
+        page = FakePage(
+            locators={
+                browser_masters._REGION_LAUNCHER_TESTID: _FakeLocator([launcher]),
+                browser_masters._REGION_EDITOR_TESTID: _FakeLocator([editor]),
+                # No label ever matches — an uncleared, ever-appending
+                # filter field can never produce a match.
+            },
+        )
+
+        with (
+            patch.object(browser_masters, "_REGION_FILTER_TIMEOUT_MS", 10),
+            self.assertRaises(BrowserSessionError) as ctx,
+        ):
+            browser_masters._set_region(page, ["Москва"])
+
+        self.assertIn("could not be cleared", str(ctx.exception))
+        self.assertIn("Playwright", str(ctx.exception))
+        self.assertNotIn("check the region name", str(ctx.exception))
 
     def test_does_not_select_a_decoy_whose_name_only_contains_the_region(self):
         # A decoy checkbox whose label merely CONTAINS the region name
@@ -9223,7 +9285,6 @@ class TestSetRegion(unittest.TestCase):
                 browser_masters._REGION_LAUNCHER_TESTID: _FakeLocator([launcher]),
                 browser_masters._REGION_EDITOR_TESTID: _FakeLocator([editor]),
                 self._label_xpath("Москва"): _FlakyLabelLocator(),
-                self._checkbox_xpath("Москва"): _FakeLocator([box]),
             },
         )
 
@@ -9587,18 +9648,30 @@ class TestCreateMaster(unittest.TestCase):
             "xpath=//label[@data-testid='RegionsTreeNode.Checkbox.label']"
             f"[normalize-space(.)={browser_masters._xpath_literal(region)}]"
         )
-        region_checkbox_xpath = (
-            f"{region_label_xpath}"
-            f"//input[@data-testid='{browser_masters._REGION_CHECKBOX_TESTID}']"
-        )
         # The label is what gets clicked; the input is what gets read back
-        # (confirmed live — see _set_region). Model the real toggle.
+        # (confirmed live — see _set_region). Model the real toggle. The
+        # checkbox is wired onto the label as a sub_locators child (issue
+        # #656), mirroring _set_region's scoped handle.locator(...) lookup.
         region_state = {"checked": False}
 
         def _toggle_region():
             region_state["checked"] = not region_state["checked"]
             if region_state["checked"]:
                 region_checked.append(region)
+
+        region_checkbox_handle = _FakeLocatorHandle(
+            get_checked=lambda: region_state["checked"]
+        )
+        region_label_handle = _FakeLocatorHandle(
+            visible=True,
+            on_click=_toggle_region,
+            sub_locators={
+                (
+                    f"xpath=.//input[@data-testid="
+                    f"'{browser_masters._REGION_CHECKBOX_TESTID}']"
+                ): region_checkbox_handle
+            },
+        )
 
         page = FakePage(
             locators={
@@ -9612,12 +9685,7 @@ class TestCreateMaster(unittest.TestCase):
                     [region_launcher]
                 ),
                 browser_masters._REGION_EDITOR_TESTID: _FakeLocator([region_editor]),
-                region_label_xpath: _FakeLocator(
-                    [_FakeLocatorHandle(visible=True, on_click=_toggle_region)]
-                ),
-                region_checkbox_xpath: _FakeLocator(
-                    [_FakeLocatorHandle(get_checked=lambda: region_state["checked"])]
-                ),
+                region_label_xpath: _FakeLocator([region_label_handle]),
                 browser_masters._WEEKLY_BUDGET_INPUT_XPATH: _FakeLocator(
                     [budget_field]
                 ),


### PR DESCRIPTION
## Summary

Addresses 3 of the 4 deferred review points from #656 (follow-up of #653/#655):

- **Point 2** — `_set_region`'s tree-node checkbox is now read via a scoped `handle.locator(...)` off the matched label element itself, instead of a second independent top-level `page.locator()` built from the same xpath. Two separate locator resolutions from the same selector string aren't guaranteed to enumerate matches in the same DOM order if the tree re-renders between them, so indexing both by `i` could in principle pair a label with the wrong node's checkbox.
- **Point 3** — `test_raises_when_launcher_missing`/`test_raises_when_checkbox_not_found` previously only asserted `assertRaises(BrowserSessionError)` with no message check, so both tests would pass identically even if the code took the wrong failure branch. Both now assert on the actual error message content, so "popup never opened" is distinguished from "region not found in the filtered tree".
- **Point 4** — `_set_region` previously called `_clear_text_field(editor)` and ignored its return value. If clearing genuinely fails on every retry (pre-1.44 Playwright missing the `ControlOrMeta` modifier — see `_clear_text_field`'s docstring), each retype appends onto the previous attempt's leftover text and can never filter-match anything, so the eventual "region not found" error is now the actual likely-cause hint ("Playwright is older than 1.44... upgrade with 'pip install -U playwright'") instead of misleadingly telling the caller to check the region name.

**Point 1** (reload-based verification for region in `_verify_created`, mirroring `update_master`'s `_verify_saved`) is **not** included here — it requires knowing the post-click campaign URL/ID, which the module docstring says was never confirmed via live browser recon (`create_master`'s campaign ID source is an open question). Filed as a separate follow-up: #744.

## Test plan

- [x] `pytest tests/test_masters.py -k "TestSetRegion or TestCreateMaster"` — 22 passed (1 new test for the Playwright-version-hint branch)
- [x] `pytest tests/test_masters.py` — 488 passed, 4 subtests passed
- [x] `pytest` (full offline suite) — 3099 passed, 23 skipped, 34 subtests passed
- [x] `black --check` / `flake8` clean

Closes #656 (partially — point 1 tracked in #744).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qqj8gURiLxftYvJ6DgrkFf