### PR TITLE
refactor(commands): hoist set-bids boilerplate into make_set_bids_command

### DIFF
--- a/direct_cli/commands/_set_bids.py
+++ b/direct_cli/commands/_set_bids.py
@@ -1,0 +1,137 @@
+"""Shared factory for v5 ``set-bids`` commands.
+
+Across ``dynamicads``, ``audiencetargets``, ``smartadtargets`` and
+``dynamicfeedadtargets`` the ``set-bids`` subcommand body is the same
+skeleton: collect an optional target selector (``--id``/``--adgroup-id``/
+``--campaign-id``), collect a resource-specific set of optional bid fields,
+require at least one of each group, then post ``{"method": "setBids",
+"params": {"Bids": [bid_data]}}``. Only the bid field set (and the exact
+error text listing them) varies per resource. This factory hoists the single
+body — modeled on :func:`direct_cli.commands._lifecycle.make_lifecycle_command`
+— so each module registers its ``set-bids`` with one call.
+
+``create_client`` is passed in by the calling module (not imported here), the
+same contract as the lifecycle/get factories.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+import click
+
+from ._execute import execute_request
+from ..i18n import t
+from ..output import handle_api_errors
+
+
+class BidField(NamedTuple):
+    cli_option: str
+    kwarg_name: str
+    wsdl_key: str
+    click_type: object
+    help_text: str
+    truthy: bool = False
+
+
+_SELECTOR_FIELDS = (
+    BidField("--id", "target_id", "Id", click.IntRange(min=1), "Target ID"),
+    BidField(
+        "--adgroup-id", "adgroup_id", "AdGroupId", click.IntRange(min=1), "Ad group ID"
+    ),
+    BidField(
+        "--campaign-id",
+        "campaign_id",
+        "CampaignId",
+        click.IntRange(min=1),
+        "Campaign ID",
+    ),
+)
+
+
+def make_set_bids_command(
+    group,
+    service,
+    help_text,
+    bid_fields,
+    create_client,
+    *,
+    selector_error,
+    bid_error,
+    require_selector=True,
+):
+    """Build and register a v5 ``set-bids`` command on *group*.
+
+    Args:
+        group: the module's Click group; the command registers via
+            ``@group.command(name="set-bids", help=help_text)``.
+        service: client service attribute (``group.name`` for all four
+            current callers, passed explicitly for the same patchability
+            reasons as :func:`make_lifecycle_command`).
+        help_text: English short help — the i18n catalog key.
+        bid_fields: tuple of :class:`BidField` for the resource-specific bid
+            options, in the exact order they must render in ``--help``.
+            ``truthy`` (default ``False``) selects a truthy check
+            (``if value:``) instead of ``is not None`` — needed for the
+            untyped ``--priority`` string option, which the original
+            per-module commands treated as absent on an empty string.
+        create_client: the calling module's ``create_client`` symbol.
+        selector_error: English error text (i18n catalog key) raised when the
+            selector requirement (see *require_selector*) is not met.
+        bid_error: English error text (i18n catalog key) raised when no bid
+            field is provided.
+        require_selector: when ``True`` (the default — ``dynamicads``,
+            ``audiencetargets``, ``dynamicfeedadtargets``), a target selector
+            (``--id``/``--adgroup-id``/``--campaign-id``) is required
+            independent of the bid fields. ``smartadtargets`` instead only
+            requires *some* field (selector or bid) to be present — its
+            original command checked ``if not bid_data`` rather than the
+            selector group specifically — so it passes ``False`` here to
+            keep that behavior byte-identical.
+    """
+
+    bid_fields = tuple(
+        field if isinstance(field, BidField) else BidField(*field)
+        for field in bid_fields
+    )
+    all_fields = _SELECTOR_FIELDS + bid_fields
+
+    selector_keys = {field.wsdl_key for field in _SELECTOR_FIELDS}
+    bid_keys = {field.wsdl_key for field in bid_fields}
+
+    def _command(ctx, dry_run, **kwargs):
+        bid_data = {}
+        for field in all_fields:
+            value = kwargs[field.kwarg_name]
+            present = value if field.truthy else value is not None
+            if present:
+                bid_data[field.wsdl_key] = value
+
+        if require_selector:
+            if not (selector_keys & bid_data.keys()):
+                raise click.UsageError(t(selector_error))
+        elif not bid_data:
+            raise click.UsageError(t(selector_error))
+        if not (bid_keys & bid_data.keys()):
+            raise click.UsageError(t(bid_error))
+
+        body = {"method": "setBids", "params": {"Bids": [bid_data]}}
+        execute_request(ctx, service, body, dry_run, create_client)
+
+    _command.__name__ = "set_bids"
+    _command.__qualname__ = "set_bids"
+
+    _command = handle_api_errors(_command)
+    _command = click.pass_context(_command)
+    _command = click.option(
+        "--dry-run", is_flag=True, help="Show request without sending"
+    )(_command)
+    for field in reversed(all_fields):
+        _command = click.option(
+            field.cli_option,
+            field.kwarg_name,
+            type=field.click_type,
+            help=field.help_text,
+        )(_command)
+
+    return group.command(name="set-bids", help=help_text)(_command)

--- a/direct_cli/commands/audiencetargets.py
+++ b/direct_cli/commands/audiencetargets.py
@@ -10,6 +10,7 @@ from ..output import handle_api_errors
 from ._execute import execute_request
 from ._get import make_get_command
 from ._lifecycle import register_lifecycle_commands
+from ._set_bids import make_set_bids_command
 from ..utils import (
     MICRO_RUBLES,
     add_criteria_csv,
@@ -138,42 +139,31 @@ def add(
     execute_request(ctx, "audiencetargets", body, dry_run, create_client)
 
 
-@audiencetargets.command(name="set-bids")
-@click.option("--id", "target_id", type=click.IntRange(min=1), help="Target ID")
-@click.option("--adgroup-id", type=click.IntRange(min=1), help="Ad group ID")
-@click.option("--campaign-id", type=click.IntRange(min=1), help="Campaign ID")
-@click.option("--context-bid", type=MICRO_RUBLES, help="Context bid in micro-rubles")
-@click.option("--priority", help="Strategy priority")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def set_bids(ctx, target_id, adgroup_id, campaign_id, context_bid, priority, dry_run):
-    """Set audience target bids"""
-    bid_data = {}
-    if target_id is not None:
-        bid_data["Id"] = target_id
-    if adgroup_id is not None:
-        bid_data["AdGroupId"] = adgroup_id
-    if campaign_id is not None:
-        bid_data["CampaignId"] = campaign_id
-    if context_bid is not None:
-        bid_data["ContextBid"] = context_bid
-    if priority:
-        bid_data["StrategyPriority"] = priority
-    bid_fields = {k for k in ("ContextBid", "StrategyPriority") if k in bid_data}
-    selector_fields = {k for k in ("Id", "AdGroupId", "CampaignId") if k in bid_data}
-    if not selector_fields:
-        raise click.UsageError(
-            t("Provide a target selector (--id, --adgroup-id, or --campaign-id)")
-        )
-    if not bid_fields:
-        raise click.UsageError(
-            t("Provide at least one bid field (--context-bid or --priority)")
-        )
-
-    body = {"method": "setBids", "params": {"Bids": [bid_data]}}
-
-    execute_request(ctx, "audiencetargets", body, dry_run, create_client)
+set_bids = make_set_bids_command(
+    audiencetargets,
+    "audiencetargets",
+    "Set audience target bids",
+    (
+        (
+            "--context-bid",
+            "context_bid",
+            "ContextBid",
+            MICRO_RUBLES,
+            "Context bid in micro-rubles",
+        ),
+        (
+            "--priority",
+            "priority",
+            "StrategyPriority",
+            None,
+            "Strategy priority",
+            True,
+        ),
+    ),
+    create_client,
+    selector_error="Provide a target selector (--id, --adgroup-id, or --campaign-id)",
+    bid_error="Provide at least one bid field (--context-bid or --priority)",
+)
 
 
 register_lifecycle_commands(

--- a/direct_cli/commands/dynamicads.py
+++ b/direct_cli/commands/dynamicads.py
@@ -5,11 +5,11 @@ DynamicAds (Webpages) commands
 import click
 
 from ..api import create_client
-from ..i18n import t
 from ..output import handle_api_errors
 from ._execute import execute_request
 from ._get import ids_adgroup_campaign_states_criteria, make_get_command
 from ._lifecycle import register_lifecycle_commands
+from ._set_bids import make_set_bids_command
 from ..utils import (
     MICRO_RUBLES,
     parse_condition_specs,
@@ -97,44 +97,29 @@ register_lifecycle_commands(
 )
 
 
-@dynamicads.command(name="set-bids")
-@click.option("--id", "target_id", type=click.IntRange(min=1), help="Target ID")
-@click.option("--adgroup-id", type=click.IntRange(min=1), help="Ad group ID")
-@click.option("--campaign-id", type=click.IntRange(min=1), help="Campaign ID")
-@click.option("--bid", type=MICRO_RUBLES, help="Search bid in micro-rubles")
-@click.option("--context-bid", type=MICRO_RUBLES, help="Context bid in micro-rubles")
-@click.option("--priority", help="Strategy priority")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def set_bids(
-    ctx, target_id, adgroup_id, campaign_id, bid, context_bid, priority, dry_run
-):
-    """Set dynamic ad target bids"""
-    bid_data = {}
-    if target_id is not None:
-        bid_data["Id"] = target_id
-    if adgroup_id is not None:
-        bid_data["AdGroupId"] = adgroup_id
-    if campaign_id is not None:
-        bid_data["CampaignId"] = campaign_id
-    if bid is not None:
-        bid_data["Bid"] = bid
-    if context_bid is not None:
-        bid_data["ContextBid"] = context_bid
-    if priority:
-        bid_data["StrategyPriority"] = priority
-    bid_fields = {k for k in ("Bid", "ContextBid", "StrategyPriority") if k in bid_data}
-    selector_fields = {k for k in ("Id", "AdGroupId", "CampaignId") if k in bid_data}
-    if not selector_fields:
-        raise click.UsageError(
-            t("Provide a target selector (--id, --adgroup-id, or --campaign-id)")
-        )
-    if not bid_fields:
-        raise click.UsageError(
-            t("Provide at least one bid field " "(--bid, --context-bid, or --priority)")
-        )
-
-    body = {"method": "setBids", "params": {"Bids": [bid_data]}}
-
-    execute_request(ctx, "dynamicads", body, dry_run, create_client)
+set_bids = make_set_bids_command(
+    dynamicads,
+    "dynamicads",
+    "Set dynamic ad target bids",
+    (
+        ("--bid", "bid", "Bid", MICRO_RUBLES, "Search bid in micro-rubles"),
+        (
+            "--context-bid",
+            "context_bid",
+            "ContextBid",
+            MICRO_RUBLES,
+            "Context bid in micro-rubles",
+        ),
+        (
+            "--priority",
+            "priority",
+            "StrategyPriority",
+            None,
+            "Strategy priority",
+            True,
+        ),
+    ),
+    create_client,
+    selector_error="Provide a target selector (--id, --adgroup-id, or --campaign-id)",
+    bid_error="Provide at least one bid field (--bid, --context-bid, or --priority)",
+)

--- a/direct_cli/commands/dynamicfeedadtargets.py
+++ b/direct_cli/commands/dynamicfeedadtargets.py
@@ -5,11 +5,11 @@ DynamicFeedAdTargets commands
 import click
 
 from ..api import create_client
-from ..i18n import t
 from ..output import handle_api_errors
 from ._execute import execute_request
 from ._get import ids_adgroup_campaign_states_criteria, make_get_command
 from ._lifecycle import register_lifecycle_commands
+from ._set_bids import make_set_bids_command
 from ..utils import (
     MICRO_RUBLES,
     parse_condition_specs,
@@ -103,38 +103,21 @@ register_lifecycle_commands(
 )
 
 
-@dynamicfeedadtargets.command(name="set-bids")
-@click.option("--id", "target_id", type=click.IntRange(min=1), help="Target ID")
-@click.option("--adgroup-id", type=click.IntRange(min=1), help="Ad group ID")
-@click.option("--campaign-id", type=click.IntRange(min=1), help="Campaign ID")
-@click.option("--bid", type=MICRO_RUBLES, help="Search bid in micro-rubles")
-@click.option("--context-bid", type=MICRO_RUBLES, help="Context bid in micro-rubles")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def set_bids(ctx, target_id, adgroup_id, campaign_id, bid, context_bid, dry_run):
-    """Set dynamic feed ad target bids"""
-    bid_data = {}
-    if target_id is not None:
-        bid_data["Id"] = target_id
-    if adgroup_id is not None:
-        bid_data["AdGroupId"] = adgroup_id
-    if campaign_id is not None:
-        bid_data["CampaignId"] = campaign_id
-    if bid is not None:
-        bid_data["Bid"] = bid
-    if context_bid is not None:
-        bid_data["ContextBid"] = context_bid
-
-    has_selector = any(k in bid_data for k in ("Id", "AdGroupId", "CampaignId"))
-    has_bid = any(k in bid_data for k in ("Bid", "ContextBid"))
-    if not has_selector:
-        raise click.UsageError(
-            t("Provide a target selector (--id, --adgroup-id, or --campaign-id)")
-        )
-    if not has_bid:
-        raise click.UsageError(t("Provide at least one bid (--bid or --context-bid)"))
-
-    body = {"method": "setBids", "params": {"Bids": [bid_data]}}
-
-    execute_request(ctx, "dynamicfeedadtargets", body, dry_run, create_client)
+set_bids = make_set_bids_command(
+    dynamicfeedadtargets,
+    "dynamicfeedadtargets",
+    "Set dynamic feed ad target bids",
+    (
+        ("--bid", "bid", "Bid", MICRO_RUBLES, "Search bid in micro-rubles"),
+        (
+            "--context-bid",
+            "context_bid",
+            "ContextBid",
+            MICRO_RUBLES,
+            "Context bid in micro-rubles",
+        ),
+    ),
+    create_client,
+    selector_error="Provide a target selector (--id, --adgroup-id, or --campaign-id)",
+    bid_error="Provide at least one bid (--bid or --context-bid)",
+)

--- a/direct_cli/commands/smartadtargets.py
+++ b/direct_cli/commands/smartadtargets.py
@@ -10,6 +10,7 @@ from ..output import handle_api_errors
 from ._execute import execute_request
 from ._get import ids_adgroup_campaign_states_criteria, make_get_command
 from ._lifecycle import register_lifecycle_commands
+from ._set_bids import make_set_bids_command
 from ..utils import (
     MICRO_RUBLES,
     parse_condition_specs,
@@ -173,55 +174,38 @@ register_lifecycle_commands(
 )
 
 
-@smartadtargets.command(name="set-bids")
-@click.option("--id", "target_id", type=click.IntRange(min=1), help="Target ID")
-@click.option("--adgroup-id", type=click.IntRange(min=1), help="Ad group ID")
-@click.option("--campaign-id", type=click.IntRange(min=1), help="Campaign ID")
-@click.option("--average-cpc", type=MICRO_RUBLES, help="Average CPC in micro-rubles")
-@click.option("--average-cpa", type=MICRO_RUBLES, help="Average CPA in micro-rubles")
-@click.option("--priority", help="Strategy priority")
-@click.option("--dry-run", is_flag=True, help="Show request without sending")
-@click.pass_context
-@handle_api_errors
-def set_bids(
-    ctx,
-    target_id,
-    adgroup_id,
-    campaign_id,
-    average_cpc,
-    average_cpa,
-    priority,
-    dry_run,
-):
-    """Set smart ad target bids"""
-    bid_data = {}
-    if target_id is not None:
-        bid_data["Id"] = target_id
-    if adgroup_id is not None:
-        bid_data["AdGroupId"] = adgroup_id
-    if campaign_id is not None:
-        bid_data["CampaignId"] = campaign_id
-    if average_cpc is not None:
-        bid_data["AverageCpc"] = average_cpc
-    if average_cpa is not None:
-        bid_data["AverageCpa"] = average_cpa
-    if priority:
-        bid_data["StrategyPriority"] = priority
-    bid_fields = {
-        k for k in ("AverageCpc", "AverageCpa", "StrategyPriority") if k in bid_data
-    }
-    if not bid_data:
-        raise click.UsageError(
-            t("Provide target selection and bid fields for set-bids")
-        )
-    if not bid_fields:
-        raise click.UsageError(
-            t(
-                "Provide at least one bid field"
-                " (--average-cpc, --average-cpa, or --priority)"
-            )
-        )
-
-    body = {"method": "setBids", "params": {"Bids": [bid_data]}}
-
-    execute_request(ctx, "smartadtargets", body, dry_run, create_client)
+set_bids = make_set_bids_command(
+    smartadtargets,
+    "smartadtargets",
+    "Set smart ad target bids",
+    (
+        (
+            "--average-cpc",
+            "average_cpc",
+            "AverageCpc",
+            MICRO_RUBLES,
+            "Average CPC in micro-rubles",
+        ),
+        (
+            "--average-cpa",
+            "average_cpa",
+            "AverageCpa",
+            MICRO_RUBLES,
+            "Average CPA in micro-rubles",
+        ),
+        (
+            "--priority",
+            "priority",
+            "StrategyPriority",
+            None,
+            "Strategy priority",
+            True,
+        ),
+    ),
+    create_client,
+    selector_error="Provide target selection and bid fields for set-bids",
+    bid_error=(
+        "Provide at least one bid field (--average-cpc, --average-cpa, or --priority)"
+    ),
+    require_selector=False,
+)


### PR DESCRIPTION
## Summary

Closes #589 (C12).

Investigation of issue #589's three items found #11 (`_*_lifecycle()` → `register_lifecycle_commands`) and #13 (`execute_add`/`execute_request` tail) already implemented and adopted across the codebase in earlier commits — the only remaining gap was **C12**: `set-bids` boilerplate duplicated across `dynamicads`, `audiencetargets`, `smartadtargets`, `dynamicfeedadtargets`.

- Added `direct_cli/commands/_set_bids.py::make_set_bids_command`, modeled on the existing `_lifecycle.py`/`_get.py` factory pattern.
- Each module now registers `set-bids` with one call, passing its resource-specific bid fields as `BidField` tuples.
- Preserved two subtle behavioral quirks byte-identically:
  - `--priority` uses a truthy check (`if value:`), not `is not None`, matching all 4 originals.
  - `smartadtargets set-bids` never actually required a target selector (checked `if not bid_data` instead of the selector group) — kept via `require_selector=False`.

## Test plan

- [x] `pytest` — full offline suite: 3123 passed, 23 skipped (no changes)
- [x] `black`/`flake8` on touched files — clean
- [x] Manual `--help` diff for all 4 `set-bids` commands — option order/text unchanged
- [x] Manual dry-run payload checks incl. error paths (missing selector, missing bid, smartadtargets' selector-optional quirk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rkv1ZdgUPefeXM5q3eepTe