### PR TITLE
feat(masters): add --add-target-action/--remove-target-action to update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,47 @@
   `ads.resume` (both are safely exercisable via `direct --sandbox`), not
   `DANGEROUS`.
 
+**Added — `masters update --add-target-action` / `--remove-target-action` (#717):**
+
+- Live recon (2026-08-04, test campaign 713277109) of the "Целевые
+  действия" table's own "Добавить" popup (`--target-action-price` (#707)
+  only ever replaced an EXISTING row's price, adding/removing a row was
+  explicitly out of scope there). Clicking
+  `TargetActions.OTHER.MiniGrid.AddButton` opens
+  `AddTargetAction.OTHER` — a list rendered BELOW the table (not a modal)
+  of `[role="option"]` entries, one per goal in the campaign's linked
+  Metrika counter that ISN'T already a row; Yandex filters already-added
+  goals out of this list itself, so there is no "goal already added" error
+  state to reproduce — a goal id absent from the list is either not the
+  counter's or already present. Confirmed live a freshly clicked option
+  renders with an EMPTY price input (not a page default as originally
+  guessed) and saving with it still empty is rejected client-side.
+  Removing a row via its `CloseButton` needs no confirmation and removes
+  it from the DOM immediately.
+- `masters update --add-target-action "<goal_id>=<price>"` (repeatable)
+  adds a NEW goal row and sets its price in one step — the price is
+  REQUIRED (unlike `--target-action-price`, which only ever fills a price
+  that's already there), since Yandex has no default for a freshly added
+  row and rejects saving one with an empty price. The goal must belong to
+  the campaign's linked Metrika counter and not already be a row —
+  identified purely by its numeric Metrika goal id, same "never by label"
+  rule as `--target-action-price` (goal labels are not unique across an
+  account, see #707's CHANGELOG entry).
+- `masters update --remove-target-action "<goal_id>"` (repeatable) removes
+  an EXISTING goal row. Both flags share `--target-action-price`'s
+  `--promotion-goal max-conversions`-only gating (refused up front
+  together with `--promotion-goal max-clicks`), and the CLI refuses
+  passing the same goal id to more than one of
+  `--target-action-price`/`--add-target-action`/`--remove-target-action`
+  in the same call. Verified via `_verify_saved`'s existing
+  reload-and-reread convention (#704/#716) — a save Yandex silently
+  rejects client-side, or that a hydration race under-reads, is
+  distinguished from a genuine mismatch by retrying the read before
+  reporting a hard error.
+- Part of #681/#648 (Этап C, target actions/CPA sub-item); follow-up to
+  #707, whose CHANGELOG entry documented add/remove as explicitly out of
+  scope.
+
 **BREAKING CHANGES — dropped Python 3.9 support (#737):**
 
 - `vcrpy` 8.1.1 references `aiohttp.streams.AsyncStreamReaderMixin`, removed in

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -2461,7 +2461,9 @@ def _read_target_actions(page: "Page") -> List[Dict[str, Any]]:
     exist for the campaign's current promotion goal (mirrors
     ``_read_goal_price``'s "inconclusive/absent" convention) — callers that
     need to distinguish "no goals configured" from "section not on this
-    page" should check ``promotion_goal`` separately.
+    page"/"row scan failed" should use ``_read_target_actions_or_none``
+    instead (used by ``_verify_saved``'s add/remove verification, where that
+    distinction is safety-critical — see its docstring).
 
     Goal ids are discovered via ``_read_testid_suffixes`` on the row-testid
     prefix (same convention as ``_read_image_content_ids``), skipping the
@@ -2474,13 +2476,39 @@ def _read_target_actions(page: "Page") -> List[Dict[str, Any]]:
     between rows, which a bare prefix scan cannot do for a repeated child
     testid.
     """
+    rows = _read_target_actions_or_none(page)
+    return [] if rows is None else rows
+
+
+def _read_target_actions_or_none(page: "Page") -> Optional[List[Dict[str, Any]]]:
+    """Same read as ``_read_target_actions``, but returns ``None`` — distinct
+    from ``[]`` — for EITHER of the two ways this read can fail to be
+    conclusive: the section never became visible, OR (Codex adversarial
+    review of #717) the section WAS visible but enumerating its rows itself
+    failed this attempt (a transient mid-scan DOM hiccup, not the same as
+    the table genuinely having zero rows). ``_read_target_actions`` itself
+    collapses both of those into ``[]`` — a legitimate simplification for
+    its read-only callers (``fetch_master_target_actions``,
+    ``target_action_prices`` verification), for whom "couldn't read" and
+    "genuinely empty" are both handled the same way (retry, then report
+    what was last seen). ``--add-target-action``/``--remove-target-action``
+    verification cannot afford that collapse: a removed goal reported
+    "absent" from a read that never actually saw the table would silently
+    confirm a removal that may not have happened server-side — see
+    ``_verify_saved``.
+    """
     section = page.locator(_TARGET_ACTIONS_SECTION_TESTID).first
     try:
         section.wait_for(state="visible", timeout=_TARGET_ACTION_WAIT_TIMEOUT_MS)
     except PlaywrightError:
-        return []
+        return None
 
     prefix = f"TargetActions.{_TARGET_ACTIONS_CATEGORY}."
+    try:
+        row_elements = page.locator(f'[data-testid^="{prefix}"]')
+        row_elements.count()
+    except PlaywrightError:
+        return None
     row_suffixes = _read_testid_suffixes(
         page, prefix, skip_suffixes=(".PriceInput", ".CloseButton")
     )
@@ -3013,12 +3041,19 @@ def _verify_saved(
 
     if target_action_prices:
 
-        def _read_target_action_prices(p: "Page") -> Dict[int, Optional[float]]:
-            return {row["GoalId"]: row["Price"] for row in _read_target_actions(p)}
+        def _read_target_action_prices(
+            p: "Page",
+        ) -> Optional[Dict[int, Optional[float]]]:
+            rows = _read_target_actions_or_none(p)
+            if rows is None:
+                return None
+            return {row["GoalId"]: row["Price"] for row in rows}
 
         def _target_action_prices_match(
-            actual: Dict[int, Optional[float]], expected: Dict[int, float]
+            actual: Optional[Dict[int, Optional[float]]], expected: Dict[int, float]
         ) -> bool:
+            if actual is None:
+                return False
             return all(
                 _target_action_price_matches(price, actual.get(goal_id))
                 for goal_id, price in expected.items()
@@ -3030,13 +3065,20 @@ def _verify_saved(
             target_action_prices,
             matches=_target_action_prices_match,
         )
-        for goal_id, expected_price in target_action_prices.items():
-            actual_price = actual_target_actions.get(goal_id)
-            if not _target_action_price_matches(expected_price, actual_price):
-                mismatches.append(
-                    f"target_action_price[{goal_id}]: expected "
-                    f"{expected_price!r}, page now shows {actual_price!r}"
-                )
+        if actual_target_actions is None:
+            mismatches.append(
+                "target_action_price: could not read the 'Целевые действия' "
+                "table after saving (row scan never succeeded) — unable to "
+                "confirm the price took effect"
+            )
+        else:
+            for goal_id, expected_price in target_action_prices.items():
+                actual_price = actual_target_actions.get(goal_id)
+                if not _target_action_price_matches(expected_price, actual_price):
+                    mismatches.append(
+                        f"target_action_price[{goal_id}]: expected "
+                        f"{expected_price!r}, page now shows {actual_price!r}"
+                    )
 
     if add_target_actions or remove_target_action_goal_ids:
 
@@ -3044,20 +3086,17 @@ def _verify_saved(
             p: "Page",
         ) -> Optional[Dict[int, Optional[float]]]:
             # ``None`` (as opposed to ``{}``) means the table could not be
-            # read this attempt (section not yet hydrated after the reload —
-            # ``_read_target_actions`` returns ``[]`` for that SAME reason it
-            # returns ``[]`` for a genuinely empty table, see its docstring).
-            # Distinguishing the two here is required so a removed goal is
-            # never confirmed absent from a read that never actually saw the
-            # table — see ``_add_remove_match``.
-            section = page.locator(_TARGET_ACTIONS_SECTION_TESTID).first
-            try:
-                section.wait_for(
-                    state="visible", timeout=_TARGET_ACTION_WAIT_TIMEOUT_MS
-                )
-            except PlaywrightError:
+            # read this attempt — see ``_read_target_actions_or_none``'s
+            # docstring (Codex adversarial review of #717) for the two
+            # distinct failure modes it collapses into ``None``. Either way
+            # this is NOT the same as a genuinely empty table — the
+            # distinction is required so a removed goal is never confirmed
+            # absent from a read that never actually saw the table — see
+            # ``_add_remove_match``.
+            rows = _read_target_actions_or_none(p)
+            if rows is None:
                 return None
-            return {row["GoalId"]: row["Price"] for row in _read_target_actions(p)}
+            return {row["GoalId"]: row["Price"] for row in rows}
 
         def _add_remove_match(
             actual: Optional[Dict[int, Optional[float]]], _expected: Any
@@ -3550,6 +3589,7 @@ def fetch_master_target_actions(page: "Page", campaign_id: int) -> Dict[str, Any
     all), or it is but no goal has been added to it yet. This function does
     not distinguish the two; callers that need to know which should also
     check ``promotion_goal`` via ``fetch_master``.
+
     """
     page.goto(WIZARD_EDIT_URL.format(campaign_id=campaign_id), wait_until="commit")
     assert_not_captcha(page.content())

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -3589,7 +3589,6 @@ def fetch_master_target_actions(page: "Page", campaign_id: int) -> Dict[str, Any
     all), or it is but no goal has been added to it yet. This function does
     not distinguish the two; callers that need to know which should also
     check ``promotion_goal`` via ``fetch_master``.
-
     """
     page.goto(WIZARD_EDIT_URL.format(campaign_id=campaign_id), wait_until="commit")
     assert_not_captcha(page.content())

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -873,14 +873,56 @@ _VERIFY_FIELD_READ_TIMEOUT_MS = 5_000
 #
 # There is no separate "select this goal for optimization" control — a
 # goal's presence AS A ROW in this table (added via
-# ``TargetActions.OTHER.MiniGrid.AddButton``'s search popup, out of scope
-# here) is what makes it "selected"; filling its ``PriceInput`` is the only
-# action, confirming issue #707's open question about whether a distinct
-# selection flag is needed (it is not).
+# ``TargetActions.OTHER.MiniGrid.AddButton``'s search popup) is what makes it
+# "selected"; filling its ``PriceInput`` is the only action, confirming issue
+# #707's open question about whether a distinct selection flag is needed (it
+# is not).
+#
+# Add/remove (issue #717 recon, 2026-08-04, live campaign 713277109
+# temporarily unarchived for this — see ``_TARGET_ACTION_UNARCHIVE_NOTE``
+# below): clicking ``TargetActions.OTHER.MiniGrid.AddButton`` opens a
+# ``[data-testid="AddTargetAction.OTHER"]`` list BELOW the table (not a
+# separate modal), containing one ``[role="option"]`` per goal the
+# campaign's linked Metrika counter has that is NOT ALREADY a row in the
+# table — Yandex filters already-added goals out of this list itself, so
+# there is no "already added" error state to reproduce; a goal id absent
+# from the list is either not the counter's or already present. Each
+# option's own testid is ``AddTargetAction.OTHER.<goalId>`` — the same
+# numeric Metrika goal id used everywhere else in this module. A text search
+# input (``SelectSearchTargetInput``, placeholder "Поиск") also lives in
+# this list but is not needed here: this module identifies a goal purely by
+# id (see the "Goal ids ... never by its label" note above), so clicking the
+# id-scoped option directly is both simpler and immune to a goal's display
+# name changing.
+#
+# Confirmed live: clicking an option adds a new row with an EMPTY price
+# input — not a page default as issue #717 speculated. Saving with that
+# field still empty is rejected client-side (the row's
+# ``data-form-error`` flips to ``"true"``, a red icon appears, and the
+# terminal save click does not persist) — so ``_add_target_action`` requires
+# a price, unlike ``_set_target_action_price`` which only ever touches a
+# price that's already there. The list stays open after a click (no
+# auto-close) — irrelevant here since this module never needs to add more
+# than one goal per popup open.
+#
+# Removal is simpler: ``TargetActions.OTHER.<goalId>.CloseButton`` removes
+# the row from the DOM immediately on click, no confirmation dialog.
 _TARGET_ACTIONS_SECTION_TESTID = '[data-testid="TargetActionsSection"]'
 _TARGET_ACTIONS_CATEGORY = "OTHER"
 _TARGET_ACTION_ROW_TESTID_TEMPLATE = "TargetActions.{category}.{goal_id}"
 _TARGET_ACTION_PRICE_TESTID_TEMPLATE = "TargetActions.{category}.{goal_id}.PriceInput"
+_TARGET_ACTION_CLOSE_TESTID_TEMPLATE = "TargetActions.{category}.{goal_id}.CloseButton"
+_TARGET_ACTION_ADD_BUTTON_TESTID_TEMPLATE = (
+    "TargetActions.{category}.MiniGrid.AddButton"
+)
+_TARGET_ACTION_ADD_OPTION_TESTID_TEMPLATE = "AddTargetAction.{category}.{goal_id}"
+
+# How many times ``_click_and_wait_for_popup``-style retries are attempted
+# for the add-popup's option to become visible/clickable — same hydration
+# race as every other menu/modal trigger in this module (issues #723/#725),
+# confirmed live here too: the first click after the section scrolls into
+# view frequently lands before the popup's React handler is ready.
+_TARGET_ACTION_ADD_OPTION_MAX_ATTEMPTS = 5
 
 # How long to wait for the "Целевые действия" section to render before
 # concluding a requested goal row genuinely isn't there — same hydration
@@ -2301,11 +2343,111 @@ def _set_target_action_price(page: "Page", goal_id: int, price: float) -> None:
             "edit page. This table only exists when the promotion goal is "
             "'max-conversions', and only shows goals already added to it — "
             f"pass --promotion-goal max-conversions, and confirm goal "
-            f"{goal_id} is already listed (add it via --headful first if "
-            "not; adding a brand-new goal row is not supported by this CLI "
-            "yet). If the goal should already be there, Yandex may have "
-            "changed the page's markup — re-run with --headful to inspect "
-            "the page."
+            f"{goal_id} is already listed (add it first with "
+            "--add-target-action, or via --headful). If the goal should "
+            "already be there, Yandex may have changed the page's markup — "
+            "re-run with --headful to inspect the page."
+        ) from exc
+
+
+def _add_target_action(page: "Page", goal_id: int, price: float) -> None:
+    """Add a NEW row to the "Целевые действия" table for ``goal_id`` and set
+    its price, via the table's own "Добавить" popup.
+
+    ``goal_id`` must be one of the campaign's linked Metrika counter's goals
+    that ISN'T already a row — Yandex's own popup list only ever offers
+    those (see ``_TARGET_ACTIONS_CATEGORY``'s docstring), so a goal id that's
+    already present or that doesn't belong to the counter simply never
+    appears as a clickable option; both cases surface as the same "option
+    never appeared" ``BrowserSessionError`` below, since this module has no
+    separate way to tell them apart without guessing at Yandex's internal
+    reasoning.
+
+    The popup opens BELOW the table (not a modal) and does not auto-close
+    after a click — same "open via retry, no need to close" shape as
+    ``_click_and_wait_for_popup``, reimplemented here rather than reused
+    because the target here is a per-goal-id OPTION inside the popup, not
+    the popup's own container.
+
+    A freshly clicked option renders with an EMPTY price input (confirmed
+    live — not a page default), so this always fills one — there is no
+    "add with no price" caller path; the CLI-boundary parse requires a
+    price for exactly this reason (see ``_parse_target_action_options``).
+    """
+    add_button_testid = _TARGET_ACTION_ADD_BUTTON_TESTID_TEMPLATE.format(
+        category=_TARGET_ACTIONS_CATEGORY
+    )
+    add_button = page.locator(f'[data-testid="{add_button_testid}"]').first
+    option_testid = _TARGET_ACTION_ADD_OPTION_TESTID_TEMPLATE.format(
+        category=_TARGET_ACTIONS_CATEGORY, goal_id=goal_id
+    )
+    option = page.locator(f'[data-testid="{option_testid}"]').first
+
+    opened = False
+    last_exc: Optional[Exception] = None
+    for _ in range(_TARGET_ACTION_ADD_OPTION_MAX_ATTEMPTS):
+        try:
+            add_button.click()
+        except PlaywrightError as exc:
+            last_exc = exc
+            continue
+        try:
+            option.wait_for(state="visible", timeout=_POPUP_APPEAR_TIMEOUT_MS)
+            opened = True
+            break
+        except PlaywrightError as exc:
+            last_exc = exc
+            continue
+
+    if not opened:
+        raise BrowserSessionError(
+            f"Could not find goal {goal_id} in the 'Добавить' target-action "
+            "popup on the campaign edit page. This table only exists when "
+            "the promotion goal is 'max-conversions' — pass "
+            "--promotion-goal max-conversions if that's not already the "
+            "case. Otherwise the popup only lists goals from the "
+            "campaign's linked Metrika counter that AREN'T already in the "
+            "table — confirm goal "
+            f"{goal_id} belongs to that counter and isn't already listed "
+            "(`masters targetactions get`), or Yandex may have changed the "
+            "page's markup — re-run with --headful to inspect the page."
+        ) from last_exc
+
+    option.click()
+
+    try:
+        _set_target_action_price(page, goal_id, price)
+    except BrowserSessionError as exc:
+        raise BrowserSessionError(
+            f"Added goal {goal_id} to the 'Целевые действия' table but "
+            f"could not fill its price: {exc}"
+        ) from exc
+
+
+def _remove_target_action(page: "Page", goal_id: int) -> None:
+    """Remove an EXISTING row from the "Целевые действия" table for
+    ``goal_id``, via that row's own close button.
+
+    Raises ``BrowserSessionError`` naming the requirement if the row is
+    absent — mirrors ``_set_target_action_price``'s "must already be a row"
+    guard rather than silently no-op'ing on an already-absent goal.
+    """
+    close_testid = _TARGET_ACTION_CLOSE_TESTID_TEMPLATE.format(
+        category=_TARGET_ACTIONS_CATEGORY, goal_id=goal_id
+    )
+    close_button = page.locator(f'[data-testid="{close_testid}"]').first
+    try:
+        close_button.click()
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            f"Could not find or click the remove button for goal {goal_id} "
+            "in the 'Целевые действия' table on the campaign edit page. "
+            "This table only exists when the promotion goal is "
+            "'max-conversions' — pass --promotion-goal max-conversions if "
+            f"that's not already the case. Otherwise confirm goal {goal_id} "
+            "is currently listed (`masters targetactions get`), or Yandex "
+            "may have changed the page's markup — re-run with --headful to "
+            "inspect the page."
         ) from exc
 
 
@@ -2813,6 +2955,8 @@ def _verify_saved(
     images_replaced_ids: Optional[Set[str]] = None,
     goal_price: Optional[float] = None,
     target_action_prices: Optional[Dict[int, float]] = None,
+    add_target_actions: Optional[Dict[int, float]] = None,
+    remove_target_action_goal_ids: Optional[List[int]] = None,
     clicked_button_label: str = _SAVE_BUTTON_TEXT,
 ) -> None:
     """Reload the edit page and confirm every requested field actually saved.
@@ -2894,6 +3038,43 @@ def _verify_saved(
                     f"{expected_price!r}, page now shows {actual_price!r}"
                 )
 
+    if add_target_actions or remove_target_action_goal_ids:
+
+        def _read_target_action_goal_ids(p: "Page") -> Dict[int, Optional[float]]:
+            return {row["GoalId"]: row["Price"] for row in _read_target_actions(p)}
+
+        def _add_remove_match(
+            actual: Dict[int, Optional[float]], _expected: Any
+        ) -> bool:
+            added_ok = all(
+                _target_action_price_matches(price, actual.get(goal_id))
+                for goal_id, price in (add_target_actions or {}).items()
+            )
+            removed_ok = not any(
+                goal_id in actual for goal_id in remove_target_action_goal_ids or []
+            )
+            return added_ok and removed_ok
+
+        actual_after_add_remove = _read_until_matches(
+            page,
+            _read_target_action_goal_ids,
+            None,
+            matches=_add_remove_match,
+        )
+        for goal_id, expected_price in (add_target_actions or {}).items():
+            actual_price = actual_after_add_remove.get(goal_id)
+            if not _target_action_price_matches(expected_price, actual_price):
+                mismatches.append(
+                    f"add_target_action[{goal_id}]: expected price "
+                    f"{expected_price!r}, page now shows {actual_price!r}"
+                )
+        for goal_id in remove_target_action_goal_ids or []:
+            if goal_id in actual_after_add_remove:
+                mismatches.append(
+                    f"remove_target_action[{goal_id}]: still present in the "
+                    "'Целевые действия' table after save"
+                )
+
     mismatches.extend(
         _verify_repeating_value_mismatches(
             page,
@@ -2938,6 +3119,8 @@ def update_master(
     promotion_goal: Optional[str] = None,
     goal_price: Optional[float] = None,
     target_action_prices: Optional[Dict[int, float]] = None,
+    add_target_actions: Optional[Dict[int, float]] = None,
+    remove_target_action_goal_ids: Optional[List[int]] = None,
     directs_helps: Optional[bool] = None,
     name: Optional[str] = None,
     headlines: Optional[Dict[int, str]] = None,
@@ -3021,16 +3204,33 @@ def update_master(
     its target price in the "Целевые действия" table — the "max-
     conversions" counterpart to ``goal_price`` above. Only exists on the
     page under "max-conversions", and only for a goal ALREADY listed as a
-    row in that table (added via the page's own "Добавить" search popup,
-    out of scope here) — see ``_set_target_action_price``'s docstring.
+    row in that table — see ``_set_target_action_price``'s docstring.
     Passing a goal id not currently in the table raises
     ``BrowserSessionError`` naming that requirement.
+
+    ``add_target_actions``/``remove_target_action_goal_ids`` (issue #717)
+    add/remove rows in that same table via its own "Добавить"
+    popup/close-button, rather than only replacing an existing row's price.
+    ``add_target_actions`` maps a goal id NOT currently in the table to its
+    price (required — a freshly added row's price input starts empty and
+    Yandex rejects saving it empty, see ``_add_target_action``'s docstring);
+    the goal must be one of the campaign's linked Metrika counter's goals,
+    which is all Yandex's own popup ever offers.
+    ``remove_target_action_goal_ids`` lists goal ids to remove. Applied
+    AFTER ``target_action_prices`` (an existing row's price can be
+    corrected first) and BEFORE the loop below adds new rows — a goal id
+    cannot sensibly appear in more than one of ``target_action_prices``/
+    ``add_target_actions``/``remove_target_action_goal_ids`` in the same
+    call; the CLI boundary rejects that combination before this function is
+    reached, this function does not re-validate it.
     """
     if (
         weekly_budget is None
         and promotion_goal is None
         and goal_price is None
         and not target_action_prices
+        and not add_target_actions
+        and not remove_target_action_goal_ids
         and directs_helps is None
         and name is None
         and not headlines
@@ -3040,8 +3240,9 @@ def update_master(
         raise ValueError(
             "update_master requires at least one field to update "
             "(weekly_budget, promotion_goal, goal_price, "
-            "target_action_prices, directs_helps, name, headlines, texts, "
-            "images)."
+            "target_action_prices, add_target_actions, "
+            "remove_target_action_goal_ids, directs_helps, name, "
+            "headlines, texts, images)."
         )
 
     url = WIZARD_EDIT_URL.format(campaign_id=campaign_id)
@@ -3075,6 +3276,10 @@ def update_master(
         _set_goal_price(page, goal_price)
     for goal_id, price in (target_action_prices or {}).items():
         _set_target_action_price(page, goal_id, price)
+    for goal_id in remove_target_action_goal_ids or []:
+        _remove_target_action(page, goal_id)
+    for goal_id, price in (add_target_actions or {}).items():
+        _add_target_action(page, goal_id, price)
     if directs_helps is not None:
         _set_directs_helps(page, directs_helps)
     for index, value in (headlines or {}).items():
@@ -3149,6 +3354,8 @@ def update_master(
             images_replaced_ids=images_replaced_ids,
             goal_price=goal_price,
             target_action_prices=target_action_prices,
+            add_target_actions=add_target_actions,
+            remove_target_action_goal_ids=remove_target_action_goal_ids,
             clicked_button_label=clicked_button_label,
         )
     except BrowserAuthError as exc:
@@ -3169,6 +3376,10 @@ def update_master(
         result["GoalPrice"] = goal_price
     if target_action_prices:
         result["TargetActionPrices"] = target_action_prices
+    if add_target_actions:
+        result["AddedTargetActions"] = add_target_actions
+    if remove_target_action_goal_ids:
+        result["RemovedTargetActionGoalIds"] = remove_target_action_goal_ids
     if directs_helps is not None:
         result["DirectsHelps"] = directs_helps
     if name is not None:

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -2372,7 +2372,7 @@ def _add_target_action(page: "Page", goal_id: int, price: float) -> None:
     A freshly clicked option renders with an EMPTY price input (confirmed
     live — not a page default), so this always fills one — there is no
     "add with no price" caller path; the CLI-boundary parse requires a
-    price for exactly this reason (see ``_parse_target_action_options``).
+    price for exactly this reason (see ``_parse_add_target_action_options``).
     """
     add_button_testid = _TARGET_ACTION_ADD_BUTTON_TESTID_TEMPLATE.format(
         category=_TARGET_ACTIONS_CATEGORY
@@ -3040,12 +3040,30 @@ def _verify_saved(
 
     if add_target_actions or remove_target_action_goal_ids:
 
-        def _read_target_action_goal_ids(p: "Page") -> Dict[int, Optional[float]]:
+        def _read_target_action_goal_ids(
+            p: "Page",
+        ) -> Optional[Dict[int, Optional[float]]]:
+            # ``None`` (as opposed to ``{}``) means the table could not be
+            # read this attempt (section not yet hydrated after the reload —
+            # ``_read_target_actions`` returns ``[]`` for that SAME reason it
+            # returns ``[]`` for a genuinely empty table, see its docstring).
+            # Distinguishing the two here is required so a removed goal is
+            # never confirmed absent from a read that never actually saw the
+            # table — see ``_add_remove_match``.
+            section = page.locator(_TARGET_ACTIONS_SECTION_TESTID).first
+            try:
+                section.wait_for(
+                    state="visible", timeout=_TARGET_ACTION_WAIT_TIMEOUT_MS
+                )
+            except PlaywrightError:
+                return None
             return {row["GoalId"]: row["Price"] for row in _read_target_actions(p)}
 
         def _add_remove_match(
-            actual: Dict[int, Optional[float]], _expected: Any
+            actual: Optional[Dict[int, Optional[float]]], _expected: Any
         ) -> bool:
+            if actual is None:
+                return False
             added_ok = all(
                 _target_action_price_matches(price, actual.get(goal_id))
                 for goal_id, price in (add_target_actions or {}).items()
@@ -3061,19 +3079,30 @@ def _verify_saved(
             None,
             matches=_add_remove_match,
         )
-        for goal_id, expected_price in (add_target_actions or {}).items():
-            actual_price = actual_after_add_remove.get(goal_id)
-            if not _target_action_price_matches(expected_price, actual_price):
-                mismatches.append(
-                    f"add_target_action[{goal_id}]: expected price "
-                    f"{expected_price!r}, page now shows {actual_price!r}"
-                )
-        for goal_id in remove_target_action_goal_ids or []:
-            if goal_id in actual_after_add_remove:
-                mismatches.append(
-                    f"remove_target_action[{goal_id}]: still present in the "
-                    "'Целевые действия' table after save"
-                )
+        if actual_after_add_remove is None:
+            # Every retry within the timeout hit a transient hydration
+            # failure — never had a genuine read of the table. Report this
+            # as its own mismatch rather than falling back to `{}`, which
+            # would make every requested removal look like it succeeded.
+            mismatches.append(
+                "target actions: could not read the 'Целевые действия' "
+                "table after saving (section never became visible) — "
+                "unable to confirm add/remove took effect"
+            )
+        else:
+            for goal_id, expected_price in (add_target_actions or {}).items():
+                actual_price = actual_after_add_remove.get(goal_id)
+                if not _target_action_price_matches(expected_price, actual_price):
+                    mismatches.append(
+                        f"add_target_action[{goal_id}]: expected price "
+                        f"{expected_price!r}, page now shows {actual_price!r}"
+                    )
+            for goal_id in remove_target_action_goal_ids or []:
+                if goal_id in actual_after_add_remove:
+                    mismatches.append(
+                        f"remove_target_action[{goal_id}]: still present in "
+                        "the 'Целевые действия' table after save"
+                    )
 
     mismatches.extend(
         _verify_repeating_value_mismatches(

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -2482,20 +2482,31 @@ def _read_target_actions(page: "Page") -> List[Dict[str, Any]]:
 
 def _read_target_actions_or_none(page: "Page") -> Optional[List[Dict[str, Any]]]:
     """Same read as ``_read_target_actions``, but returns ``None`` — distinct
-    from ``[]`` — for EITHER of the two ways this read can fail to be
-    conclusive: the section never became visible, OR (Codex adversarial
-    review of #717) the section WAS visible but enumerating its rows itself
-    failed this attempt (a transient mid-scan DOM hiccup, not the same as
-    the table genuinely having zero rows). ``_read_target_actions`` itself
-    collapses both of those into ``[]`` — a legitimate simplification for
-    its read-only callers (``fetch_master_target_actions``,
-    ``target_action_prices`` verification), for whom "couldn't read" and
-    "genuinely empty" are both handled the same way (retry, then report
-    what was last seen). ``--add-target-action``/``--remove-target-action``
-    verification cannot afford that collapse: a removed goal reported
-    "absent" from a read that never actually saw the table would silently
-    confirm a removal that may not have happened server-side — see
-    ``_verify_saved``.
+    from ``[]`` — the moment ANY step of the row scan fails, rather than
+    only on the section-visibility check.
+
+    ``_read_target_actions`` itself collapses every failure into ``[]`` —
+    a legitimate simplification for its read-only callers
+    (``fetch_master_target_actions``, ``target_action_prices``
+    verification), for whom "couldn't read" and "genuinely empty" are both
+    handled the same way (retry, then report what was last seen).
+    ``--add-target-action``/``--remove-target-action`` verification cannot
+    afford that collapse: a removed goal reported "absent" from a read that
+    never actually saw the table would silently confirm a removal that may
+    not have happened server-side — see ``_verify_saved``.
+
+    Deliberately does NOT delegate row enumeration to
+    ``_read_testid_suffixes`` (unlike ``_read_target_actions``'s first cut,
+    Codex adversarial review of #717 round 2): that helper does its own
+    independent ``page.locator(...).count()`` call and swallows a failure
+    there into ``[]`` — an earlier "probe" ``count()`` call in this function
+    verifying the SAME locator succeeds is not a guarantee the helper's own
+    later, separate call will too (a row can detach between the two), so a
+    probe-then-delegate shape still lets a mid-scan failure collapse into
+    "confirmed empty". Enumerating inline here, with every locator
+    read wrapped in its own failure check, is the only way a raised
+    ``PlaywrightError`` at any point reliably becomes this function's own
+    ``None`` rather than someone else's swallowed ``[]``.
     """
     section = page.locator(_TARGET_ACTIONS_SECTION_TESTID).first
     try:
@@ -2506,15 +2517,20 @@ def _read_target_actions_or_none(page: "Page") -> Optional[List[Dict[str, Any]]]
     prefix = f"TargetActions.{_TARGET_ACTIONS_CATEGORY}."
     try:
         row_elements = page.locator(f'[data-testid^="{prefix}"]')
-        row_elements.count()
+        count = row_elements.count()
+        raw_testids = [
+            row_elements.nth(i).get_attribute("data-testid") for i in range(count)
+        ]
     except PlaywrightError:
         return None
-    row_suffixes = _read_testid_suffixes(
-        page, prefix, skip_suffixes=(".PriceInput", ".CloseButton")
-    )
 
     goal_ids: List[int] = []
-    for suffix in row_suffixes:
+    for testid in raw_testids:
+        if not testid or not testid.startswith(prefix):
+            continue
+        suffix = testid[len(prefix) :]
+        if suffix.endswith((".PriceInput", ".CloseButton")):
+            continue
         try:
             goal_ids.append(int(suffix))
         except ValueError:
@@ -2529,7 +2545,17 @@ def _read_target_actions_or_none(page: "Page") -> Optional[List[Dict[str, Any]]]
         try:
             texts = page.locator(name_selector).all_inner_texts()
         except PlaywrightError:
-            texts = []
+            # Unlike the row-enumeration failure above, a raise HERE is not
+            # ambiguous about whether the row exists — its testid was just
+            # found in the DOM-order scan above, so it does. But its PRICE
+            # is exactly the field `_add_remove_match`/`_target_action_prices_match`
+            # compare against the requested value — a swallowed failure
+            # here would silently read as "price field is empty", which
+            # `_target_action_price_matches` (never matching ``None``)
+            # would then report as a genuine save mismatch rather than the
+            # transient read failure it actually is. Propagate ``None`` for
+            # the whole read rather than guess at this one row's state.
+            return None
         name = texts[0].strip() if texts else None
 
         price_testid = _TARGET_ACTION_PRICE_TESTID_TEMPLATE.format(
@@ -2540,7 +2566,7 @@ def _read_target_actions_or_none(page: "Page") -> Optional[List[Dict[str, Any]]]
                 f'[data-testid="{price_testid}"]'
             ).first.input_value()
         except PlaywrightError:
-            raw_price = ""
+            return None
         price = _parse_target_action_price(raw_price)
 
         results.append({"GoalId": goal_id, "Name": name, "Price": price})

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -671,6 +671,75 @@ def _parse_target_action_price_options(
     return parsed
 
 
+def _parse_add_target_action_options(
+    values: "tuple[str, ...]",
+) -> "dict[int, float]":
+    """Parse repeated ``--add-target-action "goal_id=price"`` CLI values into
+    a goal-id-keyed price map.
+
+    Same shape as ``_parse_target_action_price_options`` (goal id, never a
+    label — see that function's docstring), but the price is NOT optional
+    here: live recon (issue #717) confirmed a freshly added row's price
+    input starts empty and Yandex's own client-side validation rejects
+    saving it empty, so there is no page default to fall back to — always
+    require ``"goal_id=price"``, never a bare goal id.
+    """
+    parsed: "dict[int, float]" = {}
+    for raw in values:
+        if "=" not in raw:
+            raise click.UsageError(
+                f"--add-target-action value {raw!r} must be in the form "
+                '"goal_id=price" (e.g. "159614149=150") — a price is '
+                "required, Yandex has no default for a newly added goal."
+            )
+        goal_part, price_part = raw.split("=", 1)
+        try:
+            goal_id = int(goal_part.strip())
+        except ValueError:
+            raise click.UsageError(
+                f"--add-target-action goal_id {goal_part!r} must be an "
+                "integer (the Yandex Metrika goal ID)."
+            )
+        try:
+            price = float(price_part.strip())
+        except ValueError:
+            raise click.UsageError(
+                f"--add-target-action price {price_part!r} for goal "
+                f"{goal_id} must be a number."
+            )
+        if goal_id in parsed:
+            raise click.UsageError(
+                f"--add-target-action goal {goal_id} was specified more " "than once."
+            )
+        parsed[goal_id] = price
+    return parsed
+
+
+def _parse_remove_target_action_options(values: "tuple[str, ...]") -> "list[int]":
+    """Parse repeated ``--remove-target-action "goal_id"`` CLI values into a
+    list of goal ids, identified the same way as every other target-action
+    option (numeric Yandex Metrika goal id, never a label)."""
+    parsed: "list[int]" = []
+    seen: "set[int]" = set()
+    for raw in values:
+        try:
+            goal_id = int(raw.strip())
+        except ValueError:
+            raise click.UsageError(
+                f"--remove-target-action value {raw!r} must be an integer "
+                "(the Yandex Metrika goal ID, as shown by `masters "
+                "targetactions get`)."
+            )
+        if goal_id in seen:
+            raise click.UsageError(
+                f"--remove-target-action goal {goal_id} was specified more "
+                "than once."
+            )
+        seen.add(goal_id)
+        parsed.append(goal_id)
+    return parsed
+
+
 def _validate_image_path(raw_path: str, *, option_name: str, context: str) -> None:
     """Reject one image path that doesn't exist or that Yandex won't accept.
 
@@ -1009,9 +1078,11 @@ def targetactions():
 
     Мастер кампаний has no Yandex Direct API surface (see this module's own
     docstring), and this table lives only on the campaign's edit page (issue
-    #707) — same reasoning as the ``adimages`` group above. Read-only for
-    now: writing a goal's price is ``masters update --target-action-price``;
-    adding a brand-new goal row is not supported by this CLI yet.
+    #707) — same reasoning as the ``adimages`` group above. Read-only: this
+    group only reads the table. Writing an existing goal's price is
+    ``masters update --target-action-price``; adding/removing a row is
+    ``masters update --add-target-action``/``--remove-target-action``
+    (issue #717).
     """
 
 
@@ -1079,8 +1150,35 @@ def targetactions_get(
         "being set to via --promotion-goal in this same call) "
         "'max-conversions'; under 'max-clicks' the price is set once for "
         "the whole campaign via --goal-price instead. The goal must "
-        "already be listed in the 'Целевые действия' table — adding a "
-        "brand-new goal row is not supported by this CLI yet."
+        "already be listed in the 'Целевые действия' table — to add a "
+        "brand-new row use --add-target-action instead."
+    ),
+)
+@click.option(
+    "--add-target-action",
+    "add_target_actions",
+    multiple=True,
+    help=(
+        'Add a NEW target action (goal): "goal_id=price" where goal_id is '
+        "the Yandex Metrika goal ID (a bare goal_id with no price is "
+        "rejected — a newly added row's price is required, Yandex has no "
+        "default for it). Repeat for multiple goals. The goal must belong "
+        "to the campaign's linked Metrika counter and must NOT already be "
+        "listed — Yandex's own picker only ever offers goals that aren't "
+        "already rows; use --target-action-price to change an EXISTING "
+        "row's price instead. Same 'max-conversions' promotion-goal gating "
+        "as --target-action-price."
+    ),
+)
+@click.option(
+    "--remove-target-action",
+    "remove_target_actions",
+    multiple=True,
+    help=(
+        "Remove an EXISTING target action (goal) by its Yandex Metrika "
+        "goal ID, as shown by `masters targetactions get`. Repeat for "
+        "multiple goals. Same 'max-conversions' promotion-goal gating as "
+        "--target-action-price."
     ),
 )
 @click.option(
@@ -1158,6 +1256,8 @@ def update(
     promotion_goal,
     goal_price,
     target_action_prices,
+    add_target_actions,
+    remove_target_actions,
     directs_helps,
     name,
     headlines,
@@ -1196,8 +1296,18 @@ def update(
     targetactions get`). Only exists on the page under 'max-conversions' —
     passing it together with ``--promotion-goal max-clicks`` is refused up
     front, mirroring ``--goal-price``'s own guard. The goal must already be
-    a row in the table; adding a brand-new goal is not supported by this
-    CLI yet.
+    a row in the table.
+
+    ``--add-target-action``/``--remove-target-action`` (issue #717) add/
+    remove rows in that same table rather than only replacing an existing
+    row's price — same 'max-conversions' gating as ``--target-action-price``.
+    ``--add-target-action "goal_id=price"`` requires a price (Yandex has no
+    default for a freshly added row) and the goal must belong to the
+    campaign's linked Metrika counter and not already be listed.
+    ``--remove-target-action "goal_id"`` requires the goal to already be
+    listed. The same goal id cannot be passed to more than one of
+    ``--target-action-price``/``--add-target-action``/
+    ``--remove-target-action`` in the same call.
 
     ``--headline``/``--text``/``--image`` each replace ONE existing
     slot/position at a time rather than the whole list — unlike this CLI's
@@ -1228,6 +1338,8 @@ def update(
         and promotion_goal is None
         and goal_price is None
         and not target_action_prices
+        and not add_target_actions
+        and not remove_target_actions
         and directs_helps is None
         and name is None
         and not headlines
@@ -1236,9 +1348,9 @@ def update(
     ):
         raise click.UsageError(
             "Provide at least one of --weekly-budget, --promotion-goal, "
-            "--goal-price, --target-action-price, "
-            "--directs-helps/--no-directs-helps, --name, --headline, "
-            "--text, --image."
+            "--goal-price, --target-action-price, --add-target-action, "
+            "--remove-target-action, --directs-helps/--no-directs-helps, "
+            "--name, --headline, --text, --image."
         )
 
     if goal_price is not None and promotion_goal == "max-conversions":
@@ -1249,17 +1361,48 @@ def update(
             "to --promotion-goal max-clicks."
         )
 
-    if target_action_prices and promotion_goal == "max-clicks":
+    if (
+        target_action_prices or add_target_actions or remove_target_actions
+    ) and promotion_goal == "max-clicks":
         raise click.UsageError(
-            "--target-action-price has no effect under --promotion-goal "
+            "--target-action-price/--add-target-action/"
+            "--remove-target-action have no effect under --promotion-goal "
             "max-clicks — that goal's price is set once for the whole "
-            "campaign via --goal-price instead. --target-action-price only "
-            "applies to --promotion-goal max-conversions."
+            "campaign via --goal-price instead. They only apply to "
+            "--promotion-goal max-conversions."
         )
 
     parsed_target_action_prices = _parse_target_action_price_options(
         target_action_prices
     )
+    parsed_add_target_actions = _parse_add_target_action_options(add_target_actions)
+    parsed_remove_target_actions = _parse_remove_target_action_options(
+        remove_target_actions
+    )
+
+    _target_action_goal_ids_seen: "dict[int, str]" = {}
+    for goal_id in parsed_target_action_prices:
+        _target_action_goal_ids_seen[goal_id] = "--target-action-price"
+    for goal_id in parsed_add_target_actions:
+        if goal_id in _target_action_goal_ids_seen:
+            raise click.UsageError(
+                f"Goal {goal_id} was passed to both "
+                f"{_target_action_goal_ids_seen[goal_id]} and "
+                "--add-target-action — a goal can only be targeted by one "
+                "of --target-action-price/--add-target-action/"
+                "--remove-target-action in the same call."
+            )
+        _target_action_goal_ids_seen[goal_id] = "--add-target-action"
+    for goal_id in parsed_remove_target_actions:
+        if goal_id in _target_action_goal_ids_seen:
+            raise click.UsageError(
+                f"Goal {goal_id} was passed to both "
+                f"{_target_action_goal_ids_seen[goal_id]} and "
+                "--remove-target-action — a goal can only be targeted by "
+                "one of --target-action-price/--add-target-action/"
+                "--remove-target-action in the same call."
+            )
+        _target_action_goal_ids_seen[goal_id] = "--remove-target-action"
 
     # Slot counts come from the browser layer's own constants (imported here
     # rather than at module load, matching this module's other deferred
@@ -1300,6 +1443,8 @@ def update(
             promotion_goal=promotion_goal,
             goal_price=goal_price,
             target_action_prices=parsed_target_action_prices,
+            add_target_actions=parsed_add_target_actions,
+            remove_target_action_goal_ids=parsed_remove_target_actions,
             directs_helps=directs_helps,
             name=name,
             headlines=parsed_headlines,

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -5564,6 +5564,76 @@ class TestUpdateMaster(unittest.TestCase):
         # a false "removed_ok" on the first empty scan would never get here.
         self.assertGreater(row_scan_calls["count"], 1)
 
+    def test_raises_when_removal_verify_hits_transient_get_attribute_failure(self):
+        """Codex adversarial review of #717, round 2: the FIRST fix attempt
+        (test above) only made ``.count()`` itself failure-safe — it still
+        delegated the actual per-element read to ``_read_testid_suffixes``,
+        which does its OWN independent ``page.locator(...).count()`` call
+        and swallows ANY failure in that second enumeration (including a
+        raise from ``.nth(i).get_attribute(...)``, not just from
+        ``.count()``) into ``[]``. Reproduced on that version: a no-op
+        removal was reported as successful because the probe ``count()``
+        succeeded while the delegated enumeration's ``get_attribute()``
+        raised once. This test targets exactly that: ``.count()`` NEVER
+        raises, but ``.nth(0).get_attribute(...)`` raises on its first call,
+        succeeding on every later call — the fixed version must enumerate
+        rows inline (no second, independently-failing locator call) so this
+        is caught too."""
+        rows = {159614149: "150"}
+        page = self._dynamic_target_actions_page(rows)
+        original_locator = page.locator
+        get_attribute_calls = {"count": 0}
+
+        close_testid_raw = browser_masters._TARGET_ACTION_CLOSE_TESTID_TEMPLATE.format(
+            category=browser_masters._TARGET_ACTIONS_CATEGORY, goal_id=159614149
+        )
+        close_testid = f'[data-testid="{close_testid_raw}"]'
+        row_prefix_selector = (
+            f'[data-testid^="TargetActions.'
+            f'{browser_masters._TARGET_ACTIONS_CATEGORY}."]'
+        )
+
+        class _FlakyAttributeHandle:
+            def __init__(self, real_handle):
+                self._real = real_handle
+
+            def get_attribute(self, name):
+                get_attribute_calls["count"] += 1
+                if get_attribute_calls["count"] == 1:
+                    raise PlaywrightError("element detached")
+                return self._real.get_attribute(name)
+
+        class _CountNeverFailsLocator:
+            """``.count()`` always succeeds (unlike the sibling test above)
+            — only the PER-ELEMENT read that follows ever raises. A
+            probe-then-delegate fix (round 2's actual bug) never sees this
+            failure at all, since its own probe only calls ``.count()``."""
+
+            def __init__(self, real_locator):
+                self._real = real_locator
+
+            def count(self):
+                return self._real.count()
+
+            def nth(self, i):
+                return _FlakyAttributeHandle(self._real.nth(i))
+
+        def _stub_locator(selector):
+            if selector == close_testid:
+                return _FakeLocator([_FakeLocatorHandle()])  # click is a no-op
+            if selector == row_prefix_selector:
+                return _CountNeverFailsLocator(original_locator(selector))
+            return original_locator(selector)
+
+        page.locator = _stub_locator
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(
+                page, 42, remove_target_action_goal_ids=[159614149]
+            )
+        self.assertIn("did not save as requested", str(ctx.exception))
+        self.assertGreater(get_attribute_calls["count"], 1)
+
     def test_raises_when_removal_verify_read_hits_transient_hydration_failure(
         self,
     ):

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -5499,6 +5499,53 @@ class TestUpdateMaster(unittest.TestCase):
             )
         self.assertIn("did not save as requested", str(ctx.exception))
 
+    def test_raises_when_removal_verify_read_hits_transient_hydration_failure(
+        self,
+    ):
+        """A single transient hydration failure on the FIRST post-save read
+        of the "Целевые действия" section must not be read as "table is
+        empty, so the removed goal is gone" — that is indistinguishable from
+        a genuinely empty table unless _verify_saved treats an unreadable
+        section as its own inconclusive state (not as an empty `{}`) and
+        retries past it. Models: close-button click is a no-op (goal stays
+        in `rows`, mirroring a save Yandex silently rejected), AND the
+        section's own visibility check raises PlaywrightError on its first
+        call after the verify reload, succeeding on every later call."""
+        rows = {159614149: "150"}
+        page = self._dynamic_target_actions_page(rows)
+        original_locator = page.locator
+        section_wait_for_calls = {"count": 0}
+
+        close_testid = browser_masters._TARGET_ACTION_CLOSE_TESTID_TEMPLATE.format(
+            category=browser_masters._TARGET_ACTIONS_CATEGORY, goal_id=159614149
+        )
+
+        class _FlakyOnceSectionHandle(_FakeLocatorHandle):
+            def wait_for(self, state="visible", timeout=None):
+                section_wait_for_calls["count"] += 1
+                if section_wait_for_calls["count"] == 1:
+                    raise PlaywrightError("Timeout waiting for element state")
+
+        flaky_section = _FlakyOnceSectionHandle()
+
+        def _stub_locator(selector):
+            if selector == f'[data-testid="{close_testid}"]':
+                return _FakeLocator([_FakeLocatorHandle()])  # click is a no-op
+            if selector == browser_masters._TARGET_ACTIONS_SECTION_TESTID:
+                return _FakeLocator([flaky_section])
+            return original_locator(selector)
+
+        page.locator = _stub_locator
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(
+                page, 42, remove_target_action_goal_ids=[159614149]
+            )
+        self.assertIn("did not save as requested", str(ctx.exception))
+        # Confirms the retry actually happened past the transient failure —
+        # a false "removed_ok" on the first empty read would never get here.
+        self.assertGreater(section_wait_for_calls["count"], 1)
+
     def test_updates_multiple_fields_in_one_call(self):
         budget_state = {}
         checkbox_state = {"checked": False}

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -5499,6 +5499,71 @@ class TestUpdateMaster(unittest.TestCase):
             )
         self.assertIn("did not save as requested", str(ctx.exception))
 
+    def test_raises_when_removal_verify_hits_transient_row_scan_failure(self):
+        """Codex adversarial review of #717: the section-visibility retry
+        (test above) is NOT enough — a transient failure can also occur
+        INSIDE ``_read_target_actions`` itself (enumerating the row
+        elements) even though the section is visible. Without a matching
+        ``None`` propagation there, that mid-scan hiccup collapses to `[]`,
+        and `_add_remove_match` reads a genuinely-still-present goal as
+        removed. Models: close-button click is a no-op (goal stays in
+        `rows`), section is always visible, but the row-prefix locator's
+        own ``.count()`` raises on its first call after the verify reload,
+        succeeding on every later call."""
+        rows = {159614149: "150"}
+        page = self._dynamic_target_actions_page(rows)
+        original_locator = page.locator
+        row_scan_calls = {"count": 0}
+
+        close_testid_raw = browser_masters._TARGET_ACTION_CLOSE_TESTID_TEMPLATE.format(
+            category=browser_masters._TARGET_ACTIONS_CATEGORY, goal_id=159614149
+        )
+        close_testid = f'[data-testid="{close_testid_raw}"]'
+        row_prefix_selector = (
+            f'[data-testid^="TargetActions.'
+            f'{browser_masters._TARGET_ACTIONS_CATEGORY}."]'
+        )
+
+        class _FlakyOnceCountLocator:
+            """Wraps the REAL row-prefix locator (reflecting the current,
+            unchanged `rows` state) but makes its FIRST `.count()` raise —
+            models a transient mid-scan failure, not a genuinely-empty
+            table. Delegating to the real locator on success (rather than
+            hardcoding an empty result) is essential: a hardcoded `count()
+            == 0` would make the retry look like a real, correct removal
+            confirmation instead of the FALSE one this test exists to catch.
+            """
+
+            def __init__(self, real_locator):
+                self._real = real_locator
+
+            def count(self):
+                row_scan_calls["count"] += 1
+                if row_scan_calls["count"] == 1:
+                    raise PlaywrightError("Timeout waiting for element state")
+                return self._real.count()
+
+            def nth(self, i):
+                return self._real.nth(i)
+
+        def _stub_locator(selector):
+            if selector == close_testid:
+                return _FakeLocator([_FakeLocatorHandle()])  # click is a no-op
+            if selector == row_prefix_selector:
+                return _FlakyOnceCountLocator(original_locator(selector))
+            return original_locator(selector)
+
+        page.locator = _stub_locator
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(
+                page, 42, remove_target_action_goal_ids=[159614149]
+            )
+        self.assertIn("did not save as requested", str(ctx.exception))
+        # Confirms the retry actually happened past the transient failure —
+        # a false "removed_ok" on the first empty scan would never get here.
+        self.assertGreater(row_scan_calls["count"], 1)
+
     def test_raises_when_removal_verify_read_hits_transient_hydration_failure(
         self,
     ):

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -4116,6 +4116,157 @@ class TestSetTargetActionPrice(unittest.TestCase):
             browser_masters._set_target_action_price(page, 159614149, 200)
 
 
+class TestAddTargetAction(unittest.TestCase):
+    """``_add_target_action`` (issue #717): open the "Добавить" popup, click
+    the goal's option, then fill its price via ``_set_target_action_price``.
+    """
+
+    def _add_button_testid(self):
+        testid = browser_masters._TARGET_ACTION_ADD_BUTTON_TESTID_TEMPLATE.format(
+            category=browser_masters._TARGET_ACTIONS_CATEGORY
+        )
+        return f'[data-testid="{testid}"]'
+
+    def _option_testid(self, goal_id):
+        testid = browser_masters._TARGET_ACTION_ADD_OPTION_TESTID_TEMPLATE.format(
+            category=browser_masters._TARGET_ACTIONS_CATEGORY, goal_id=goal_id
+        )
+        return f'[data-testid="{testid}"]'
+
+    def _price_testid(self, goal_id):
+        testid = browser_masters._TARGET_ACTION_PRICE_TESTID_TEMPLATE.format(
+            category=browser_masters._TARGET_ACTIONS_CATEGORY, goal_id=goal_id
+        )
+        return f'[data-testid="{testid}"]'
+
+    def test_clicks_add_button_then_option_then_fills_price(self):
+        add_clicks = {"count": 0}
+        add_button = _FakeLocatorHandle(
+            on_click=lambda: add_clicks.__setitem__("count", add_clicks["count"] + 1)
+        )
+        option_clicked = {"clicked": False}
+        option = _FakeLocatorHandle(
+            on_click=lambda: option_clicked.__setitem__("clicked", True)
+        )
+        price_state = {"value": ""}
+        price_field = _FakeLocatorHandle()
+        price_field.fill = lambda value: price_state.__setitem__("value", value)
+
+        page = FakePage(
+            locators={
+                self._add_button_testid(): _FakeLocator([add_button]),
+                self._option_testid(226158067): _FakeLocator([option]),
+                self._price_testid(226158067): _FakeLocator([price_field]),
+            }
+        )
+
+        browser_masters._add_target_action(page, 226158067, 77)
+
+        self.assertEqual(add_clicks["count"], 1)
+        self.assertTrue(option_clicked["clicked"])
+        self.assertEqual(price_state["value"], "77")
+
+    def test_retries_add_button_click_when_option_not_yet_visible(self):
+        add_clicks = {"count": 0}
+
+        def _on_add_click():
+            add_clicks["count"] += 1
+
+        add_button = _FakeLocatorHandle(on_click=_on_add_click)
+        option = _FakeHydratingPopupHandle(
+            ready_after_attempt=2, click_counter=add_clicks
+        )
+        price_field = _FakeLocatorHandle()
+        price_field.fill = lambda value: None
+
+        page = FakePage(
+            locators={
+                self._add_button_testid(): _FakeLocator([add_button]),
+                self._option_testid(226158067): _FakeLocator([option]),
+                self._price_testid(226158067): _FakeLocator([price_field]),
+            }
+        )
+
+        browser_masters._add_target_action(page, 226158067, 77)  # must not raise
+
+        self.assertEqual(add_clicks["count"], 2)
+
+    def test_raises_when_option_never_appears(self):
+        add_button = _FakeLocatorHandle()
+        page = FakePage(
+            locators={
+                self._add_button_testid(): _FakeLocator([add_button]),
+                self._option_testid(226158067): _FakeLocator(
+                    [_FakeLocatorHandle(visible=False)]
+                ),
+            }
+        )
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._add_target_action(page, 226158067, 77)
+        self.assertIn("226158067", str(ctx.exception))
+        self.assertIn("max-conversions", str(ctx.exception))
+
+    def test_raises_with_context_when_price_fill_fails_after_add(self):
+        add_button = _FakeLocatorHandle()
+        option = _FakeLocatorHandle()
+        page = FakePage(
+            locators={
+                self._add_button_testid(): _FakeLocator([add_button]),
+                self._option_testid(226158067): _FakeLocator([option]),
+                # No price input registered — _set_target_action_price raises.
+            }
+        )
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._add_target_action(page, 226158067, 77)
+        self.assertIn("Added goal 226158067", str(ctx.exception))
+
+
+class TestRemoveTargetAction(unittest.TestCase):
+    """``_remove_target_action`` (issue #717): click an existing row's close
+    button."""
+
+    def _close_testid(self, goal_id):
+        testid = browser_masters._TARGET_ACTION_CLOSE_TESTID_TEMPLATE.format(
+            category=browser_masters._TARGET_ACTIONS_CATEGORY, goal_id=goal_id
+        )
+        return f'[data-testid="{testid}"]'
+
+    def test_clicks_close_button_of_existing_row(self):
+        clicked = {"value": False}
+        close_button = _FakeLocatorHandle(
+            on_click=lambda: clicked.__setitem__("value", True)
+        )
+        page = FakePage(
+            locators={self._close_testid(159614149): _FakeLocator([close_button])}
+        )
+
+        browser_masters._remove_target_action(page, 159614149)
+
+        self.assertTrue(clicked["value"])
+
+    def test_raises_when_row_not_present(self):
+        page = FakePage(locators={})
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._remove_target_action(page, 159614149)
+        self.assertIn("159614149", str(ctx.exception))
+        self.assertIn("max-conversions", str(ctx.exception))
+
+    def test_raises_when_close_click_fails(self):
+        page = FakePage(
+            locators={
+                self._close_testid(159614149): _FakeLocator(
+                    [_FakeLocatorHandle(raises=True)]
+                )
+            }
+        )
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters._remove_target_action(page, 159614149)
+
+
 class TestFetchMasterTargetActions(unittest.TestCase):
     """``fetch_master_target_actions`` (issue #707) — ``masters targetactions
     get``'s browser layer, read-only."""
@@ -5162,6 +5313,192 @@ class TestUpdateMaster(unittest.TestCase):
             )
         self.assertIn("did not save as requested", str(ctx.exception))
 
+    def _dynamic_target_actions_page(self, rows):
+        """A page whose "Целевые действия" table's ROW SET itself mutates —
+        needed for add/remove (issue #717), unlike ``target_action_prices_state``
+        above which only ever mutates an EXISTING row's price. ``rows``:
+        ``{goal_id: price_string}``, mutated in place by add/remove/save
+        clicks; the row-prefix locator and each row's own locators are
+        computed FRESH on every ``page.locator()`` call (mirroring
+        ``_FakeTargetActionsPage``) so a later read sees whatever the
+        earlier click did.
+        """
+        row_prefix_selector = (
+            f'[data-testid^="TargetActions.'
+            f'{browser_masters._TARGET_ACTIONS_CATEGORY}."]'
+        )
+        add_button_testid_raw = (
+            browser_masters._TARGET_ACTION_ADD_BUTTON_TESTID_TEMPLATE.format(
+                category=browser_masters._TARGET_ACTIONS_CATEGORY
+            )
+        )
+        add_button_testid = f'[data-testid="{add_button_testid_raw}"]'
+        edit_form_ready_selector = (
+            f'[data-testid="{browser_masters._EDIT_FORM_READY_TESTID}"]'
+        )
+        save_handle = _FakeTextLocatorHandle(visible=True)
+
+        class _DynamicTargetActionsPage(FakePage):
+            def locator(self, selector):
+                if selector == edit_form_ready_selector:
+                    return _FakeLocator([_FakeLocatorHandle()])
+                if selector == browser_masters._TARGET_ACTIONS_SECTION_TESTID:
+                    return _FakeLocator([_FakeLocatorHandle()])
+                if selector == add_button_testid:
+                    return _FakeLocator([_FakeLocatorHandle()])
+                if selector == row_prefix_selector:
+                    row_testid_template = (
+                        browser_masters._TARGET_ACTION_ROW_TESTID_TEMPLATE
+                    )
+                    category = browser_masters._TARGET_ACTIONS_CATEGORY
+                    return _FakeLocator(
+                        [
+                            _FakeLocatorHandle(
+                                attrs={
+                                    "data-testid": row_testid_template.format(
+                                        category=category,
+                                        goal_id=goal_id,
+                                    )
+                                }
+                            )
+                            for goal_id in rows
+                        ]
+                    )
+                for goal_id in list(rows):
+                    price_testid = (
+                        browser_masters._TARGET_ACTION_PRICE_TESTID_TEMPLATE.format(
+                            category=browser_masters._TARGET_ACTIONS_CATEGORY,
+                            goal_id=goal_id,
+                        )
+                    )
+                    if selector == f'[data-testid="{price_testid}"]':
+                        handle = _FakeLocatorHandle(
+                            on_fill=(lambda v, gid=goal_id: rows.__setitem__(gid, v)),
+                            get_value=(lambda gid=goal_id: rows.get(gid, "")),
+                        )
+                        return _FakeLocator([handle])
+                    close_testid = (
+                        browser_masters._TARGET_ACTION_CLOSE_TESTID_TEMPLATE.format(
+                            category=browser_masters._TARGET_ACTIONS_CATEGORY,
+                            goal_id=goal_id,
+                        )
+                    )
+                    if selector == f'[data-testid="{close_testid}"]':
+                        return _FakeLocator(
+                            [
+                                _FakeLocatorHandle(
+                                    on_click=(lambda gid=goal_id: rows.pop(gid, None))
+                                )
+                            ]
+                        )
+                # An "add" option: matches ANY goal id, not just those
+                # currently in `rows` — clicking it inserts a fresh empty row,
+                # mirroring the real page's freshly-added-row-has-empty-price
+                # behaviour (see _add_target_action's docstring).
+                option_prefix = (
+                    f"AddTargetAction.{browser_masters._TARGET_ACTIONS_CATEGORY}."
+                )
+                if selector.startswith(
+                    f'[data-testid="{option_prefix}'
+                ) and selector.endswith('"]'):
+                    goal_id = int(selector[len(f'[data-testid="{option_prefix}') : -2])
+                    return _FakeLocator(
+                        [
+                            _FakeLocatorHandle(
+                                on_click=(lambda gid=goal_id: rows.setdefault(gid, ""))
+                            )
+                        ]
+                    )
+                return super().locator(selector)
+
+        return _DynamicTargetActionsPage(
+            locators={edit_form_ready_selector: _FakeLocator([_FakeLocatorHandle()])},
+            role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
+        )
+
+    def test_adds_new_target_action_with_price(self):
+        rows = {159614149: "150"}
+        page = self._dynamic_target_actions_page(rows)
+
+        result = browser_masters.update_master(
+            page, 42, add_target_actions={226158067: 77}
+        )
+
+        self.assertEqual(rows, {159614149: "150", 226158067: "77"})
+        self.assertEqual(
+            result, {"CampaignId": 42, "AddedTargetActions": {226158067: 77}}
+        )
+
+    def test_removes_existing_target_action(self):
+        rows = {159614149: "150", 226158067: "77"}
+        page = self._dynamic_target_actions_page(rows)
+
+        result = browser_masters.update_master(
+            page, 42, remove_target_action_goal_ids=[226158067]
+        )
+
+        self.assertEqual(rows, {159614149: "150"})
+        self.assertEqual(
+            result, {"CampaignId": 42, "RemovedTargetActionGoalIds": [226158067]}
+        )
+
+    def test_adds_and_removes_in_the_same_call(self):
+        rows = {159614149: "150"}
+        page = self._dynamic_target_actions_page(rows)
+
+        browser_masters.update_master(
+            page,
+            42,
+            add_target_actions={226158067: 77},
+            remove_target_action_goal_ids=[159614149],
+        )
+
+        self.assertEqual(rows, {226158067: "77"})
+
+    def test_raises_when_added_goal_still_absent_after_save(self):
+        # The option click + price fill both "succeed" (rows gains the goal
+        # during the mutation phase), but the POST-SAVE RELOAD shows it
+        # still absent (Yandex rejected it server-side) — _verify_saved must
+        # catch this. Modeled by dropping the goal back out of `rows` right
+        # as the SECOND goto() (the one _verify_saved issues after the
+        # mutation phase has already run) starts — the first goto() (initial
+        # edit-page load, before any mutation) is a no-op here.
+        rows = {}
+        page = self._dynamic_target_actions_page(rows)
+        original_goto = page.goto
+
+        def _goto_and_drop_on_second_call(url, wait_until=None):
+            if len(page.navigated_to) == 1:
+                rows.pop(226158067, None)
+            original_goto(url, wait_until=wait_until)
+
+        page.goto = _goto_and_drop_on_second_call
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(page, 42, add_target_actions={226158067: 77})
+        self.assertIn("did not save as requested", str(ctx.exception))
+
+    def test_raises_when_removed_goal_still_present_after_save(self):
+        rows = {159614149: "150"}
+        page = self._dynamic_target_actions_page(rows)
+        original_locator = page.locator
+
+        def _stub_locator(selector):
+            close_testid = browser_masters._TARGET_ACTION_CLOSE_TESTID_TEMPLATE.format(
+                category=browser_masters._TARGET_ACTIONS_CATEGORY, goal_id=159614149
+            )
+            if selector == f'[data-testid="{close_testid}"]':
+                return _FakeLocator([_FakeLocatorHandle()])  # click is a no-op
+            return original_locator(selector)
+
+        page.locator = _stub_locator
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(
+                page, 42, remove_target_action_goal_ids=[159614149]
+            )
+        self.assertIn("did not save as requested", str(ctx.exception))
+
     def test_updates_multiple_fields_in_one_call(self):
         budget_state = {}
         checkbox_state = {"checked": False}
@@ -5938,6 +6275,287 @@ class TestMastersUpdateCommand(unittest.TestCase):
             ],
         )
         self.assertNotEqual(result.exit_code, 0)
+
+    def test_documents_add_and_remove_target_action_flags(self):
+        result = self.runner.invoke(cli, ["masters", "update", "--help"])
+        self.assertIn("--add-target-action", result.output)
+        self.assertIn("--remove-target-action", result.output)
+
+    def test_passes_add_target_action(self):
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42}
+            result = self.runner.invoke(
+                cli,
+                [
+                    "masters",
+                    "update",
+                    "42",
+                    "--add-target-action",
+                    "226158067=77",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(
+            mock_update.call_args.kwargs["add_target_actions"], {226158067: 77.0}
+        )
+
+    def test_passes_multiple_add_target_actions(self):
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42}
+            result = self.runner.invoke(
+                cli,
+                [
+                    "masters",
+                    "update",
+                    "42",
+                    "--add-target-action",
+                    "226158067=77",
+                    "--add-target-action",
+                    "267672143=50",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(
+            mock_update.call_args.kwargs["add_target_actions"],
+            {226158067: 77.0, 267672143: 50.0},
+        )
+
+    def test_passes_remove_target_action(self):
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42}
+            result = self.runner.invoke(
+                cli,
+                ["masters", "update", "42", "--remove-target-action", "159614149"],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(
+            mock_update.call_args.kwargs["remove_target_action_goal_ids"],
+            [159614149],
+        )
+
+    def test_passes_multiple_remove_target_actions(self):
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42}
+            result = self.runner.invoke(
+                cli,
+                [
+                    "masters",
+                    "update",
+                    "42",
+                    "--remove-target-action",
+                    "159614149",
+                    "--remove-target-action",
+                    "226158067",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(
+            mock_update.call_args.kwargs["remove_target_action_goal_ids"],
+            [159614149, 226158067],
+        )
+
+    def test_add_target_action_alone_is_a_valid_field(self):
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42}
+            result = self.runner.invoke(
+                cli,
+                ["masters", "update", "42", "--add-target-action", "226158067=77"],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+
+    def test_remove_target_action_alone_is_a_valid_field(self):
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42}
+            result = self.runner.invoke(
+                cli,
+                ["masters", "update", "42", "--remove-target-action", "159614149"],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+
+    def test_rejects_add_target_action_with_max_clicks(self):
+        result = self.runner.invoke(
+            cli,
+            [
+                "masters",
+                "update",
+                "42",
+                "--promotion-goal",
+                "max-clicks",
+                "--add-target-action",
+                "226158067=77",
+            ],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("max-clicks", result.output)
+
+    def test_rejects_remove_target_action_with_max_clicks(self):
+        result = self.runner.invoke(
+            cli,
+            [
+                "masters",
+                "update",
+                "42",
+                "--promotion-goal",
+                "max-clicks",
+                "--remove-target-action",
+                "159614149",
+            ],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("max-clicks", result.output)
+
+    def test_rejects_add_target_action_without_price(self):
+        result = self.runner.invoke(
+            cli,
+            ["masters", "update", "42", "--add-target-action", "226158067"],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("price is required", result.output)
+
+    def test_rejects_non_integer_add_target_action_goal_id(self):
+        result = self.runner.invoke(
+            cli,
+            ["masters", "update", "42", "--add-target-action", "abc=77"],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+
+    def test_rejects_non_numeric_add_target_action_price(self):
+        result = self.runner.invoke(
+            cli,
+            ["masters", "update", "42", "--add-target-action", "226158067=abc"],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+
+    def test_rejects_non_integer_remove_target_action_goal_id(self):
+        result = self.runner.invoke(
+            cli,
+            ["masters", "update", "42", "--remove-target-action", "abc"],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+
+    def test_rejects_duplicate_add_target_action_goal(self):
+        result = self.runner.invoke(
+            cli,
+            [
+                "masters",
+                "update",
+                "42",
+                "--add-target-action",
+                "226158067=77",
+                "--add-target-action",
+                "226158067=88",
+            ],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+
+    def test_rejects_duplicate_remove_target_action_goal(self):
+        result = self.runner.invoke(
+            cli,
+            [
+                "masters",
+                "update",
+                "42",
+                "--remove-target-action",
+                "159614149",
+                "--remove-target-action",
+                "159614149",
+            ],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+
+    def test_rejects_same_goal_in_target_action_price_and_add(self):
+        result = self.runner.invoke(
+            cli,
+            [
+                "masters",
+                "update",
+                "42",
+                "--target-action-price",
+                "159614149=200",
+                "--add-target-action",
+                "159614149=77",
+            ],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("159614149", result.output)
+
+    def test_rejects_same_goal_in_add_and_remove(self):
+        result = self.runner.invoke(
+            cli,
+            [
+                "masters",
+                "update",
+                "42",
+                "--add-target-action",
+                "159614149=77",
+                "--remove-target-action",
+                "159614149",
+            ],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("159614149", result.output)
+
+    def test_rejects_same_goal_in_target_action_price_and_remove(self):
+        result = self.runner.invoke(
+            cli,
+            [
+                "masters",
+                "update",
+                "42",
+                "--target-action-price",
+                "159614149=200",
+                "--remove-target-action",
+                "159614149",
+            ],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("159614149", result.output)
+
+    def test_does_not_call_update_master_when_add_target_action_rejected(self):
+        with patch("direct_cli.browser.masters.update_master") as mock_update:
+            self.runner.invoke(
+                cli,
+                [
+                    "masters",
+                    "update",
+                    "42",
+                    "--promotion-goal",
+                    "max-clicks",
+                    "--add-target-action",
+                    "226158067=77",
+                ],
+            )
+        mock_update.assert_not_called()
 
     def test_passes_directs_helps_flag(self):
         with (


### PR DESCRIPTION
## Summary

- `masters update --add-target-action "<goal_id>=<price>"` (repeatable) adds a new goal row to the "Целевые действия" table and sets its price in one step. Price is **required** — a freshly added row's price input starts empty and Yandex rejects saving it empty (confirmed live, not the page-default behaviour the issue speculated).
- `masters update --remove-target-action "<goal_id>"` (repeatable) removes an existing goal row via its close button.
- Both flags share `--target-action-price`'s `--promotion-goal max-conversions`-only gating, and the CLI refuses passing the same goal id to more than one of `--target-action-price`/`--add-target-action`/`--remove-target-action` in the same call.
- Verified via `_verify_saved`'s existing reload-and-reread convention (#704/#716), with the same hydration-race retry already used elsewhere in this module.

## Live recon (issue's open questions)

Performed against the test master "Тест" (campaign 713277109), temporarily unarchived and returned to ARCHIVED afterward:

- The "Добавить" control opens `AddTargetAction.OTHER` — a list rendered **below** the table (not a modal), of `[role="option"]` entries, one per goal in the campaign's linked Metrika counter.
- **Already-added goals never appear in the list** — Yandex filters them out itself, so there's no "goal already added" error state to reproduce or handle.
- A freshly clicked option renders with an **empty** price input; saving with it still empty is rejected client-side (red inline error, `data-form-error="true"`).
- `CloseButton` removes a row from the DOM immediately, no confirmation dialog.

## Test plan

- [x] `pytest` — full offline suite: 3166 passed, 23 skipped, 34 subtests passed
- [x] `black --check` / `flake8` — clean
- [x] Live verification against test campaign 713277109: add, save, `targetactions get` confirms persistence; remove, save, `targetactions get` confirms removal; campaign re-archived afterward

Closes #717

https://claude.ai/code/session_011cakAwX8UsTXrdB7AaETBk