### PR TITLE
fix(masters): add settling wait for target-actions table completeness (#750)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@
   `_verify_saved`'s add/remove retry loop trusts any read of the table —
   same shape as `_wait_for_audience_section`'s tag-count settling
   (issue #681).
+- Codex adversarial review of this PR (#753) caught a follow-on gap: the
+  settling wait's `bool` return value was being discarded, so a settle
+  TIMEOUT fell straight through into the retry loop — which itself stops
+  at its first matching read — reproducibly letting a still-hydrating,
+  never-settling table report a false "removal confirmed". `_verify_saved`
+  now treats a settle timeout as its own mismatch (same reporting path as
+  every other verification failure) instead of silently proceeding.
 
 **Added — `WeeklySpendLimit` support for HighestPosition/ManualCpm strategies (#610):**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@
   never-settling table report a false "removal confirmed". `_verify_saved`
   now treats a settle timeout as its own mismatch (same reporting path as
   every other verification failure) instead of silently proceeding.
+- A second round of Codex adversarial review found the settling wait and
+  the retry loop's own read are two genuinely separate DOM reads —
+  settling certifying a stable row *count* does not certify that the
+  retry loop's next, independent full-snapshot read lands on the same
+  settled state (reproduced: a stable pre-dip streak followed by a single
+  post-settle empty read was enough to report a no-op removal as
+  successful). The add/remove match predicate now requires
+  `_TARGET_ACTION_STABLE_STREAK` consecutive matching reads of the full
+  requested state, not just one, before accepting it.
 
 **Added — `WeeklySpendLimit` support for HighestPosition/ManualCpm strategies (#610):**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+**Fixed — `masters update --add-target-action`/`--remove-target-action` verification could trust an incomplete first read of the "Целевые действия" table (#750):**
+
+- Round 3 of cycle-review on #749 found that `_verify_saved`'s add/remove
+  verification, while hardened against every *exception*-raising failure
+  mode (rounds 1-2), had no *positive* completeness signal for a read that
+  raises nothing at all: the table can go through a genuine, non-throwing
+  empty/partial interval while hydrating, and a removed goal's absence from
+  that snapshot alone was indistinguishable from a real removal.
+- Live recon against the test master 'Тест' (campaign 713277109) confirmed
+  the race: the row-testid locator's own `.count()` (and even the
+  `TargetActionsSection` element itself) can drop to 0 for over a second,
+  starting a few seconds after `_wait_for_edit_form` returns, before the
+  real row set (re)appears — no section-scoped loading/spinner
+  `data-testid` exists to poll instead.
+- New `_wait_for_target_actions_settled` (`direct_cli/browser/masters.py`)
+  requires 5 consecutive equal row-count reads, 300ms apart, before
+  `_verify_saved`'s add/remove retry loop trusts any read of the table —
+  same shape as `_wait_for_audience_section`'s tag-count settling
+  (issue #681).
+
 **Added — `WeeklySpendLimit` support for HighestPosition/ManualCpm strategies (#610):**
 
 - Live WSDL drift check (`scripts/check_wsdl_drift.py`, 2026-08-04) confirmed

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -4012,72 +4012,88 @@ def _verify_saved(
         # starts, means that loop's first read already lands on a
         # completeness-checked snapshot instead of leaning on repeated
         # reads to average out a race it has no way to detect on its own.
-        # A settle timeout is not fatal here — it falls through to the
-        # existing retry loop, which still has its own
-        # None-on-failure/mismatch reporting for a table that genuinely
-        # never stabilizes.
-        _wait_for_target_actions_settled(page)
-
-        def _read_target_action_goal_ids(
-            p: "Page",
-        ) -> Optional[Dict[int, Optional[float]]]:
-            # ``None`` (as opposed to ``{}``) means the table could not be
-            # read this attempt — see ``_read_target_actions_or_none``'s
-            # docstring (Codex adversarial review of #717) for the two
-            # distinct failure modes it collapses into ``None``. Either way
-            # this is NOT the same as a genuinely empty table — the
-            # distinction is required so a removed goal is never confirmed
-            # absent from a read that never actually saw the table — see
-            # ``_add_remove_match``.
-            rows = _read_target_actions_or_none(p)
-            if rows is None:
-                return None
-            return {row["GoalId"]: row["Price"] for row in rows}
-
-        def _add_remove_match(
-            actual: Optional[Dict[int, Optional[float]]], _expected: Any
-        ) -> bool:
-            if actual is None:
-                return False
-            added_ok = all(
-                _target_action_price_matches(price, actual.get(goal_id))
-                for goal_id, price in (add_target_actions or {}).items()
-            )
-            removed_ok = not any(
-                goal_id in actual for goal_id in remove_target_action_goal_ids or []
-            )
-            return added_ok and removed_ok
-
-        actual_after_add_remove = _read_until_matches(
-            page,
-            _read_target_action_goal_ids,
-            None,
-            matches=_add_remove_match,
-        )
-        if actual_after_add_remove is None:
-            # Every retry within the timeout hit a transient hydration
-            # failure — never had a genuine read of the table. Report this
-            # as its own mismatch rather than falling back to `{}`, which
-            # would make every requested removal look like it succeeded.
+        #
+        # Codex adversarial review of this PR (#753): a settle TIMEOUT must
+        # not be silently swallowed — the retry loop below stops at its
+        # FIRST matching read (``_read_until_matches`` returns as soon as
+        # ``is_match`` is true), so without this check a table that never
+        # settles could still have its very first, still-hydrating read
+        # happen to look like a match (e.g. a removed goal's row genuinely
+        # absent from an incomplete snapshot) and be trusted immediately —
+        # exactly the false-success this settling wait exists to prevent.
+        # Report it as its own mismatch (same shape as the "section never
+        # became visible" case below) rather than raising here, so a
+        # genuinely never-settling table is reported through the same
+        # single ``_verify_saved`` failure path as every other mismatch.
+        if not _wait_for_target_actions_settled(page):
             mismatches.append(
-                "target actions: could not read the 'Целевые действия' "
-                "table after saving (section never became visible) — "
-                "unable to confirm add/remove took effect"
+                "target actions: the 'Целевые действия' table's row count "
+                f"never settled within {_TARGET_ACTION_SETTLE_TIMEOUT_MS / 1000:.0f}s "
+                "after saving — unable to confirm add/remove took effect"
             )
         else:
-            for goal_id, expected_price in (add_target_actions or {}).items():
-                actual_price = actual_after_add_remove.get(goal_id)
-                if not _target_action_price_matches(expected_price, actual_price):
-                    mismatches.append(
-                        f"add_target_action[{goal_id}]: expected price "
-                        f"{expected_price!r}, page now shows {actual_price!r}"
-                    )
-            for goal_id in remove_target_action_goal_ids or []:
-                if goal_id in actual_after_add_remove:
-                    mismatches.append(
-                        f"remove_target_action[{goal_id}]: still present in "
-                        "the 'Целевые действия' table after save"
-                    )
+
+            def _read_target_action_goal_ids(
+                p: "Page",
+            ) -> Optional[Dict[int, Optional[float]]]:
+                # ``None`` (as opposed to ``{}``) means the table could not
+                # be read this attempt — see ``_read_target_actions_or_none``'s
+                # docstring (Codex adversarial review of #717) for the two
+                # distinct failure modes it collapses into ``None``. Either
+                # way this is NOT the same as a genuinely empty table — the
+                # distinction is required so a removed goal is never
+                # confirmed absent from a read that never actually saw the
+                # table — see ``_add_remove_match``.
+                rows = _read_target_actions_or_none(p)
+                if rows is None:
+                    return None
+                return {row["GoalId"]: row["Price"] for row in rows}
+
+            def _add_remove_match(
+                actual: Optional[Dict[int, Optional[float]]], _expected: Any
+            ) -> bool:
+                if actual is None:
+                    return False
+                added_ok = all(
+                    _target_action_price_matches(price, actual.get(goal_id))
+                    for goal_id, price in (add_target_actions or {}).items()
+                )
+                removed_ok = not any(
+                    goal_id in actual for goal_id in remove_target_action_goal_ids or []
+                )
+                return added_ok and removed_ok
+
+            actual_after_add_remove = _read_until_matches(
+                page,
+                _read_target_action_goal_ids,
+                None,
+                matches=_add_remove_match,
+            )
+            if actual_after_add_remove is None:
+                # Every retry within the timeout hit a transient hydration
+                # failure — never had a genuine read of the table. Report
+                # this as its own mismatch rather than falling back to
+                # `{}`, which would make every requested removal look like
+                # it succeeded.
+                mismatches.append(
+                    "target actions: could not read the 'Целевые действия' "
+                    "table after saving (section never became visible) — "
+                    "unable to confirm add/remove took effect"
+                )
+            else:
+                for goal_id, expected_price in (add_target_actions or {}).items():
+                    actual_price = actual_after_add_remove.get(goal_id)
+                    if not _target_action_price_matches(expected_price, actual_price):
+                        mismatches.append(
+                            f"add_target_action[{goal_id}]: expected price "
+                            f"{expected_price!r}, page now shows {actual_price!r}"
+                        )
+                for goal_id in remove_target_action_goal_ids or []:
+                    if goal_id in actual_after_add_remove:
+                        mismatches.append(
+                            f"remove_target_action[{goal_id}]: still present "
+                            "in the 'Целевые действия' table after save"
+                        )
 
     mismatches.extend(
         _verify_repeating_value_mismatches(

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -930,6 +930,28 @@ _TARGET_ACTION_ADD_OPTION_MAX_ATTEMPTS = 5
 # the edit page, below "Цель продвижения").
 _TARGET_ACTION_WAIT_TIMEOUT_MS = 5_000
 
+# Issue #750 (Codex round-3 finding on #749): the section can go through a
+# genuine, non-throwing EMPTY interval mid-hydration — live recon against
+# campaign 713277109 confirmed the row-testid locator's own ``.count()``
+# dips to 0 (and ``TargetActionsSection`` itself briefly leaves the DOM,
+# ``.count() == 0``) for ~1-1.5s starting around 4-4.5s after
+# ``_wait_for_edit_form`` returns, before the real row set (re)appears
+# around 5-5.5s. No section-scoped loading/spinner ``data-testid`` exists
+# to poll instead (confirmed live: the only "loading"-flavoured markup
+# nearby is an unrelated, always-present ``TextInput_disabled`` addon
+# class on the add-action input, not a completeness signal). A single read
+# landing in that dip is not an exception (``_read_target_actions_or_none``
+# returns a genuinely well-formed ``[]``, not ``None``) — it's a truthful
+# snapshot of a table that has not finished loading, which is exactly the
+# gap ``_wait_for_target_actions_settled`` closes: require
+# ``_TARGET_ACTION_STABLE_STREAK`` consecutive equal row-count reads,
+# ``_TARGET_ACTION_STABLE_TICK_MS`` apart, before trusting any read of this
+# table — mirrors ``_wait_for_audience_section``'s tag-count settling
+# (``_AUDIENCE_TAG_STABLE_STREAK``), same class of race, same fix shape.
+_TARGET_ACTION_STABLE_STREAK = 5
+_TARGET_ACTION_STABLE_TICK_MS = 300
+_TARGET_ACTION_SETTLE_TIMEOUT_MS = 10_000
+
 # "Аудитория" section (issue #681, Этап C, live recon 2026-08-04 against
 # campaign 713277109, ksamatadirect account — see module docstring for the
 # archive/unarchive detour needed to reach this campaign's edit page).
@@ -3260,6 +3282,63 @@ def _read_target_actions_or_none(page: "Page") -> Optional[List[Dict[str, Any]]]
     return results
 
 
+def _wait_for_target_actions_settled(page: "Page") -> bool:
+    """Block until the "Целевые действия" table's row count has stopped
+    changing, so a caller's subsequent read is a settled snapshot rather
+    than a mid-hydration one.
+
+    Issue #750 (Codex round-3 finding on #749): rounds 1-2 hardened
+    ``_read_target_actions_or_none`` against every failure mode that
+    surfaces as a raised ``PlaywrightError`` — but live recon against
+    campaign 713277109 confirmed the row-testid locator's ``.count()`` (and
+    even ``TargetActionsSection`` itself) can genuinely, without ever
+    raising, report a transient EMPTY state for over a second while the
+    real row set is still arriving. A caller trusting that read would
+    misreport a genuinely-present goal as removed — the same "truthful but
+    partial snapshot" class of race ``_wait_for_audience_section``'s tag-
+    count settling loop exists to close for the "Аудитория" section, and
+    the fix here is the identical shape: require
+    ``_TARGET_ACTION_STABLE_STREAK`` consecutive equal row-count reads,
+    ``_TARGET_ACTION_STABLE_TICK_MS`` apart, before treating the count as
+    trustworthy, rather than a single read or a bare visibility check.
+
+    A raised ``PlaywrightError`` mid-poll (the section detaching between
+    ticks) is treated the same as "count changed" — it resets the streak
+    rather than propagating, since ``_read_target_actions_or_none`` (the
+    caller's actual read, right after this returns) already has its own
+    ``None``-on-failure handling; this function only needs to decide when
+    a *count* has stopped moving, not to be the failure-reporting layer
+    itself.
+
+    Returns ``True`` once the count has settled, ``False`` on timeout —
+    callers treat a timeout as "could not confirm settling" and let their
+    own read-retry loop's existing failure/mismatch handling take over
+    (mirroring how ``_read_target_actions_or_none`` itself degrades),
+    rather than raising here and pre-empting that reporting.
+    """
+    prefix = f"TargetActions.{_TARGET_ACTIONS_CATEGORY}."
+    row_locator = page.locator(f'[data-testid^="{prefix}"]')
+    previous_count: "Optional[int]" = None
+    stable_streak = 0
+
+    def _row_count_stable() -> bool:
+        nonlocal previous_count, stable_streak
+        current_count = row_locator.count()
+        if previous_count is not None and current_count == previous_count:
+            stable_streak += 1
+        else:
+            stable_streak = 0
+        previous_count = current_count
+        return stable_streak >= _TARGET_ACTION_STABLE_STREAK
+
+    return _poll_until(
+        page,
+        _row_count_stable,
+        _TARGET_ACTION_SETTLE_TIMEOUT_MS,
+        tick_ms=_TARGET_ACTION_STABLE_TICK_MS,
+    )
+
+
 def _parse_target_action_price(raw: str) -> Optional[float]:
     """Parse a target-action price input's raw string value, same
     normalization as ``_goal_price_matches`` (comma decimal separator,
@@ -3925,6 +4004,19 @@ def _verify_saved(
                     )
 
     if add_target_actions or remove_target_action_goal_ids:
+        # Issue #750: a removed goal's absence from the FIRST read of this
+        # table is not by itself proof of removal — the table can go
+        # through a genuine, non-throwing empty/partial interval while
+        # hydrating (see ``_wait_for_target_actions_settled``'s docstring).
+        # Settling once here, before the match-retry loop below even
+        # starts, means that loop's first read already lands on a
+        # completeness-checked snapshot instead of leaning on repeated
+        # reads to average out a race it has no way to detect on its own.
+        # A settle timeout is not fatal here — it falls through to the
+        # existing retry loop, which still has its own
+        # None-on-failure/mismatch reporting for a table that genuinely
+        # never stabilizes.
+        _wait_for_target_actions_settled(page)
 
         def _read_target_action_goal_ids(
             p: "Page",

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -4049,10 +4049,28 @@ def _verify_saved(
                     return None
                 return {row["GoalId"]: row["Price"] for row in rows}
 
+            # Codex adversarial review of this PR (#753), round 2: the
+            # settling wait above and this predicate's own read are TWO
+            # separate DOM reads — settling certifying 5 stable ``.count()``
+            # ticks does not certify that THIS predicate's next, independent
+            # ``_read_target_actions_or_none`` call lands on the same
+            # settled state (reproduced live: a stable pre-dip streak
+            # followed by one post-settle empty read was enough to report a
+            # no-op removal as successful). Rather than trust a single
+            # matching read here either, require
+            # ``_TARGET_ACTION_STABLE_STREAK`` CONSECUTIVE matching reads
+            # of the full add/remove snapshot before accepting it — the
+            # same stability bar ``_wait_for_target_actions_settled``
+            # applies to a bare row count, now applied to the actual
+            # verified state.
+            match_streak = 0
+
             def _add_remove_match(
                 actual: Optional[Dict[int, Optional[float]]], _expected: Any
             ) -> bool:
+                nonlocal match_streak
                 if actual is None:
+                    match_streak = 0
                     return False
                 added_ok = all(
                     _target_action_price_matches(price, actual.get(goal_id))
@@ -4061,13 +4079,19 @@ def _verify_saved(
                 removed_ok = not any(
                     goal_id in actual for goal_id in remove_target_action_goal_ids or []
                 )
-                return added_ok and removed_ok
+                if added_ok and removed_ok:
+                    match_streak += 1
+                else:
+                    match_streak = 0
+                return match_streak >= _TARGET_ACTION_STABLE_STREAK
 
             actual_after_add_remove = _read_until_matches(
                 page,
                 _read_target_action_goal_ids,
                 None,
                 matches=_add_remove_match,
+                timeout_ms=_VERIFY_FIELD_READ_TIMEOUT_MS
+                + _TARGET_ACTION_SETTLE_TIMEOUT_MS,
             )
             if actual_after_add_remove is None:
                 # Every retry within the timeout hit a transient hydration

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -5706,6 +5706,78 @@ class TestUpdateMaster(unittest.TestCase):
         # a false "removed_ok" on the first empty read would never get here.
         self.assertGreater(section_wait_for_calls["count"], 1)
 
+    def test_raises_when_removal_verify_first_read_is_incomplete_not_failed(
+        self,
+    ):
+        """Issue #750 (Codex round-3 finding on #749, NOT fixed by rounds
+        1-2 above): a successful-but-INCOMPLETE first read must not be
+        trusted either — this is the gap those two raise-based tests don't
+        cover. Unlike them, nothing here ever raises ``PlaywrightError``:
+        the row-prefix locator's ``.count()`` genuinely, truthfully returns
+        ``0`` for the first several polls (the goal row hasn't mounted
+        yet — live-confirmed on campaign 713277109, see
+        ``_wait_for_target_actions_settled``'s docstring), then flips back
+        to ``1`` and stays there — the goal was never actually removed
+        server-side. Without a completeness signal gating the very first
+        read the retry loop trusts, ``_add_remove_match`` would see ``{}``
+        on attempt 1, treat "goal absent" as "removal confirmed", and
+        return success despite the goal still being present in every read
+        from attempt 2 onward. Models: close-button click is a no-op (goal
+        stays in `rows`, mirroring a save Yandex silently rejected)."""
+        rows = {159614149: "150"}
+        page = self._dynamic_target_actions_page(rows)
+        original_locator = page.locator
+        row_prefix_selector = (
+            f'[data-testid^="TargetActions.'
+            f'{browser_masters._TARGET_ACTIONS_CATEGORY}."]'
+        )
+        close_testid = browser_masters._TARGET_ACTION_CLOSE_TESTID_TEMPLATE.format(
+            category=browser_masters._TARGET_ACTIONS_CATEGORY, goal_id=159614149
+        )
+        row_scan_calls = {"count": 0}
+
+        class _IncompleteThenRealLocator:
+            """Wraps the REAL row-prefix locator (reflecting `rows`, which
+            still has the "removed" goal in it) but makes the first several
+            ``.count()`` calls report ``0`` — a truthful read of a table
+            that has not finished hydrating, never an exception. Delegates
+            to the real locator afterward so the eventually-settled state
+            still correctly shows the goal as present (removal genuinely
+            did not happen), the same way
+            ``_FlakyOnceCountLocator``/``_CountNeverFailsLocator`` above
+            delegate to the real locator on their own non-flaky path."""
+
+            def __init__(self, real_locator):
+                self._real = real_locator
+
+            def count(self):
+                row_scan_calls["count"] += 1
+                if row_scan_calls["count"] <= 3:
+                    return 0
+                return self._real.count()
+
+            def nth(self, i):
+                return self._real.nth(i)
+
+        def _stub_locator(selector):
+            if selector == f'[data-testid="{close_testid}"]':
+                return _FakeLocator([_FakeLocatorHandle()])  # click is a no-op
+            if selector == row_prefix_selector:
+                return _IncompleteThenRealLocator(original_locator(selector))
+            return original_locator(selector)
+
+        page.locator = _stub_locator
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(
+                page, 42, remove_target_action_goal_ids=[159614149]
+            )
+        self.assertIn("did not save as requested", str(ctx.exception))
+        # Confirms the settling loop actually polled past the incomplete
+        # reads — a premature "removed_ok" on attempt 1 would never
+        # observe more than a couple of `.count()` calls total.
+        self.assertGreater(row_scan_calls["count"], 3)
+
     def test_updates_multiple_fields_in_one_call(self):
         budget_state = {}
         checkbox_state = {"checked": False}

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -5843,6 +5843,117 @@ class TestUpdateMaster(unittest.TestCase):
         # a single early read.
         self.assertGreater(row_scan_calls["count"], 3)
 
+    def test_raises_when_post_settle_read_hits_a_single_transient_empty_dip(
+        self,
+    ):
+        """Codex adversarial review of this PR (#753), round 2: settling
+        successfully confirming a stable row count does NOT certify the
+        SEPARATE read the retry loop performs right after —
+        ``_wait_for_target_actions_settled`` calls ``page.locator(...)``
+        exactly ONCE and polls that single locator's ``.count()``
+        repeatedly, while ``_read_target_actions_or_none`` (the retry
+        loop's own reader) calls ``page.locator(...)`` AGAIN on every
+        attempt — genuinely independent locator acquisitions, not a
+        shared cached one. This models the dip on the SECOND-ever
+        ``page.locator(row_prefix_selector)`` acquisition (settling's is
+        the first) — i.e. the retry loop's very first read — reporting an
+        empty table once before reverting to the real, still-present row
+        on every read from then on (the close-button click is a no-op;
+        the goal never actually left `rows`). Without a stability
+        requirement on the retry loop's own match (not just on the
+        settling pre-check), this single post-settle empty read would be
+        trusted immediately as "goal removed" and ``update_master`` would
+        report success despite the goal never actually leaving `rows`."""
+        rows = {159614149: "150"}
+        page = self._dynamic_target_actions_page(rows)
+        original_locator = page.locator
+        row_prefix_selector = (
+            f'[data-testid^="TargetActions.'
+            f'{browser_masters._TARGET_ACTIONS_CATEGORY}."]'
+        )
+        close_testid = browser_masters._TARGET_ACTION_CLOSE_TESTID_TEMPLATE.format(
+            category=browser_masters._TARGET_ACTIONS_CATEGORY, goal_id=159614149
+        )
+        locator_acquisitions = {"count": 0}
+        read_attempts = {"count": 0}
+
+        class _RealCountLocator:
+            """Wraps the REAL row-prefix locator, always reporting the
+            true, stable count — used for every settling tick (settling
+            acquires this wrapper once and polls it repeatedly)."""
+
+            def __init__(self, real_locator):
+                self._real = real_locator
+
+            def count(self):
+                return self._real.count()
+
+            def nth(self, i):
+                return self._real.nth(i)
+
+        class _RealCountLocatorAfterDip:
+            """Wraps the REAL row-prefix locator, always reporting the
+            true, stable count — used for every retry-loop acquisition
+            AFTER the single dip has already been consumed."""
+
+            def __init__(self, real_locator):
+                self._real = real_locator
+
+            def count(self):
+                read_attempts["count"] += 1
+                return self._real.count()
+
+            def nth(self, i):
+                return self._real.nth(i)
+
+        class _OnceEmptyLocator:
+            """Wraps the REAL row-prefix locator but reports 0 on its
+            ``.count()`` call — used for exactly the retry loop's FIRST,
+            independent post-settle acquisition, globally once."""
+
+            def __init__(self, real_locator):
+                self._real = real_locator
+
+            def count(self):
+                read_attempts["count"] += 1
+                return 0
+
+            def nth(self, i):
+                return self._real.nth(i)
+
+        def _stub_locator(selector):
+            if selector == f'[data-testid="{close_testid}"]':
+                return _FakeLocator([_FakeLocatorHandle()])  # click is a no-op
+            if selector == row_prefix_selector:
+                locator_acquisitions["count"] += 1
+                real = original_locator(selector)
+                if locator_acquisitions["count"] == 1:
+                    # Settling's single locator acquisition: always the
+                    # real, stable count.
+                    return _RealCountLocator(real)
+                if locator_acquisitions["count"] == 2:
+                    # The retry loop's first, independent acquisition:
+                    # empty exactly once, globally.
+                    return _OnceEmptyLocator(real)
+                # Every later retry-loop acquisition: back to the real,
+                # still-present row (the goal was never actually removed).
+                return _RealCountLocatorAfterDip(real)
+            return original_locator(selector)
+
+        page.locator = _stub_locator
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(
+                page, 42, remove_target_action_goal_ids=[159614149]
+            )
+        self.assertIn("did not save as requested", str(ctx.exception))
+        self.assertIn(
+            "still present in the 'Целевые действия' table", str(ctx.exception)
+        )
+        # Confirms the retry loop kept reading past the single post-settle
+        # dip rather than trusting it immediately.
+        self.assertGreater(read_attempts["count"], 1)
+
     def test_updates_multiple_fields_in_one_call(self):
         budget_state = {}
         checkbox_state = {"checked": False}

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -5778,6 +5778,71 @@ class TestUpdateMaster(unittest.TestCase):
         # observe more than a couple of `.count()` calls total.
         self.assertGreater(row_scan_calls["count"], 3)
 
+    def test_raises_when_target_actions_row_count_never_settles(self):
+        """Codex adversarial review of this PR (#753): the settling wait's
+        return value must not be discarded. Models a row-prefix locator
+        whose ``.count()`` NEVER reports the same value twice in a row for
+        the settling wait's whole timeout window — it keeps flipping
+        between the real count (1, goal still present) and 0, so
+        ``_wait_for_target_actions_settled`` can never accumulate
+        ``_TARGET_ACTION_STABLE_STREAK`` consecutive equal reads and times
+        out. Before the fix, a discarded timeout would fall straight into
+        the retry loop below, whose first read could easily land on one of
+        the flipped-to-0 values and be trusted as "goal removed" — a false
+        success despite the goal never actually leaving `rows`. The fixed
+        behavior must report this as a mismatch (raising, not returning
+        success) instead of ever reaching the retry loop at all."""
+        rows = {159614149: "150"}
+        page = self._dynamic_target_actions_page(rows)
+        original_locator = page.locator
+        row_prefix_selector = (
+            f'[data-testid^="TargetActions.'
+            f'{browser_masters._TARGET_ACTIONS_CATEGORY}."]'
+        )
+        close_testid = browser_masters._TARGET_ACTION_CLOSE_TESTID_TEMPLATE.format(
+            category=browser_masters._TARGET_ACTIONS_CATEGORY, goal_id=159614149
+        )
+        row_scan_calls = {"count": 0}
+
+        class _NeverStableLocator:
+            """Wraps the REAL row-prefix locator but alternates its
+            ``.count()`` result between the real count and 0 on every call,
+            so consecutive reads are never equal — settling can never
+            accumulate a streak and must time out."""
+
+            def __init__(self, real_locator):
+                self._real = real_locator
+
+            def count(self):
+                row_scan_calls["count"] += 1
+                return self._real.count() if row_scan_calls["count"] % 2 else 0
+
+            def nth(self, i):
+                return self._real.nth(i)
+
+        def _stub_locator(selector):
+            if selector == f'[data-testid="{close_testid}"]':
+                return _FakeLocator([_FakeLocatorHandle()])  # click is a no-op
+            if selector == row_prefix_selector:
+                return _NeverStableLocator(original_locator(selector))
+            return original_locator(selector)
+
+        page.locator = _stub_locator
+
+        with (
+            patch.object(browser_masters, "_TARGET_ACTION_SETTLE_TIMEOUT_MS", 50),
+            patch.object(browser_masters, "_TARGET_ACTION_STABLE_TICK_MS", 5),
+        ):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters.update_master(
+                    page, 42, remove_target_action_goal_ids=[159614149]
+                )
+        self.assertIn("did not save as requested", str(ctx.exception))
+        self.assertIn("never settled", str(ctx.exception))
+        # Confirms settling actually polled repeatedly rather than trusting
+        # a single early read.
+        self.assertGreater(row_scan_calls["count"], 3)
+
     def test_updates_multiple_fields_in_one_call(self):
         budget_state = {}
         checkbox_state = {"checked": False}


### PR DESCRIPTION
## Summary

- Fixes round 3 of cycle-review on #749 (issue #750): `masters update --add-target-action`/`--remove-target-action` verification had no *positive* completeness signal for the "Целевые действия" table — rounds 1-2 hardened it against every read that raises `PlaywrightError`, but a genuine, non-throwing partial snapshot mid-hydration could still be trusted as "goal confirmed removed".
- Live recon against the test master 'Тест' (campaign 713277109, archived before/after) confirmed the race: the row-testid locator's `.count()` — and even `TargetActionsSection` itself — can drop to 0 for over a second, a few seconds after `_wait_for_edit_form` returns, before the real row set (re)appears. No section-scoped loading/spinner `data-testid` exists.
- Adds `_wait_for_target_actions_settled` (`direct_cli/browser/masters.py`): requires 5 consecutive equal row-count reads, 300ms apart, before `_verify_saved`'s add/remove retry loop trusts any read — same shape as `_wait_for_audience_section`'s tag-count settling (issue #681/#751).
- New regression test `test_raises_when_removal_verify_first_read_is_incomplete_not_failed` models the exact round-3 scenario: a successful-but-empty first read (never raising) followed by a later read where the "removed" goal reappears. Verified the test fails without the fix and passes with it.

Closes #750

## Test plan

- [x] `pytest tests/test_masters.py` — 552 passed
- [x] `pytest` (full offline suite) — 3201 passed, 23 skipped
- [x] `black --check` / `flake8` clean
- [x] New test confirmed to fail on pre-fix code, pass on post-fix code
- [x] Live recon on test master 713277109 only, read-only (no mutation) — verified still `ARCHIVED` at end of session

🤖 Generated with [Claude Code](https://claude.com/claude-code)