### PR TITLE
feat(masters): add --landing-url to update for UTM edit/removal (#757)

### DIFF
--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -1109,6 +1109,50 @@ _NAME_HEADER_SELECTOR = '[data-testid="CampaignHeader.TitleName"]'
 _NAME_MODAL_INPUT_SELECTOR = '[data-testid="ModalEditTitle.CampaignName"]'
 _NAME_MODAL_ACCEPT_SELECTOR = '[data-testid="AcceptButton"]'
 
+# "Ссылка на продвигаемую страницу" field on the EDIT page (issue #757,
+# live-confirmed 2026-08-04 against campaign 713277109) — a DIFFERENT
+# component from the create page's ``CampaignFormUrl`` (module docstring's
+# "Two distinct pages" note): the edit page renders it under a
+# ``CampaignLinkEditorLite`` namespace instead, but the field itself is the
+# same kind of widget — a ``contenteditable`` ``<div role="textbox">`` that
+# must be clicked, cleared, and re-typed exactly like
+# ``_CREATE_URL_INPUT_TESTID`` (see ``_type_landing_url``'s docstring for why
+# a retry-with-verify loop is required). There is no separate "Далее"/
+# suggestions-popup step here — the field lives directly on the single
+# whole-form edit page and is committed by the same terminal
+# ``_click_save`` as every other field this module writes.
+#
+# Confirmed live: this field (and its own Clear button) is READ-ONLY
+# whenever the campaign's current status is ARCHIVED — the Clear button's
+# ``disabled`` attribute is ``true`` and the field's own ``contentEditable``
+# stays ``"false"`` even after a click, exactly the "click does nothing"
+# symptom of a disabled contenteditable widget. The field becomes editable
+# again as soon as the campaign leaves ARCHIVED (confirmed live via
+# ``masters resume``/the overview page's "Разархивировать" flow — see issue
+# #758 for the gap in ``resume_master`` this surfaced). ``_set_landing_url``
+# raises a clear, named error for this rather than letting the click/type
+# attempt fail with an opaque markup-changed message.
+_EDIT_URL_INPUT_TESTID = '[data-testid="CampaignLinkEditorLite.LinkInput.Textinput"]'
+_EDIT_URL_CLEAR_BUTTON_TESTID = (
+    '[data-testid="CampaignLinkEditorLite.LinkInput.Textinput.Clear"]'
+)
+
+# The separate "UTM-метки и параметры URL" field under "Дополнительные
+# параметры" (``CampaignLinkEditorLite.UTMInput``) is NOT used by
+# ``_set_landing_url``/``--landing-url`` — confirmed live it is an
+# independent, normally-empty helper field for appending EXTRA parameters on
+# top of whatever the main URL field already has, not a decomposed
+# domain/UTM split of the same value. The main field above already contains
+# the full URL including any UTM query string (confirmed live: a campaign
+# with UTM params baked into its landing URL shows the ENTIRE
+# ``?utm_source=...&...`` string in the main field, with the UTM helper
+# field still empty) — so setting/clearing UTM params is just setting/
+# clearing query string on the one URL this module already treats as a
+# single opaque string, exactly like ``_extract_landing_url``'s own read
+# path. No dedicated ``--clear-utm`` flag is needed as a result: passing
+# ``--landing-url`` with the bare domain (no query string) removes the UTM
+# template the same way as passing any other replacement value.
+
 _SAVE_BUTTON_TEXT = "Сохранить кампанию"
 _LAUNCH_BUTTON_TEXT = "Запустить кампанию"
 _SAVE_DRAFT_BUTTON_TEXT = "Сохранить как черновик"
@@ -2293,6 +2337,92 @@ def _set_campaign_name(page: "Page", name: str) -> None:
             "кампании') on the campaign edit page — Yandex may have changed "
             "the page's markup. Re-run with --headful to inspect the page."
         ) from exc
+
+
+def _read_landing_url(page: "Page") -> Optional[str]:
+    """Read the edit page's current "Ссылка на продвигаемую страницу" value.
+
+    Returns ``None`` if the field can't be found/read (inconclusive) — same
+    convention as ``_read_campaign_name``. An empty string is a real,
+    distinguishable value (the field genuinely cleared, not unreadable).
+    """
+    field = page.locator(_EDIT_URL_INPUT_TESTID).first
+    try:
+        return field.text_content()
+    except PlaywrightError:
+        return None
+
+
+def _set_landing_url(page: "Page", url: str) -> None:
+    """Set the edit page's "Ссылка на продвигаемую страницу" field.
+
+    Reuses the same contenteditable click/clear/type-with-verify mechanics
+    as the create page's ``_fill_landing_url``/``_type_landing_url`` (issue
+    #690's keystroke-dropping race applies here too — same widget family,
+    different testid namespace, see ``_EDIT_URL_INPUT_TESTID``'s docstring)
+    but WITHOUT that function's step-1-specific "Далее"/suggestions-popup
+    handling: this field lives directly on the single whole-form edit page,
+    with no separate continuation step — typing a new value and letting the
+    terminal ``_click_save`` commit it (like every other field
+    ``update_master`` writes) is the whole flow.
+
+    Passing an empty string clears the field down to Yandex's placeholder,
+    which mirrors the Clear button's own effect — the way this module lets
+    a caller remove the UTM template while keeping the bare domain is
+    passing a ``url`` with no query string, not a separate flag (see
+    ``_EDIT_URL_INPUT_TESTID``'s docstring for why no distinct UTM field
+    exists to clear instead).
+
+    Confirmed live (issue #757) this field — and its Clear button — is
+    READ-ONLY while the campaign's current status is ARCHIVED: raises a
+    named ``BrowserSessionError`` for that case up front rather than
+    reporting the generic "Yandex may have changed the page's markup"
+    symptom a disabled contenteditable produces (a click that lands but
+    changes nothing).
+    """
+    clear_button = page.locator(_EDIT_URL_CLEAR_BUTTON_TESTID).first
+    if _is_button_disabled(clear_button):
+        raise BrowserSessionError(
+            "The landing-page URL field is read-only for this campaign — "
+            "Yandex disables it while the campaign is ARCHIVED. Resume the "
+            "campaign first (e.g. via `masters resume`) before changing "
+            "its landing URL."
+        )
+
+    field = page.locator(_EDIT_URL_INPUT_TESTID).first
+    try:
+        field.click()
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            "Could not find or click the landing-page URL field "
+            f"({_EDIT_URL_INPUT_TESTID!r}) on the campaign edit page — "
+            "Yandex may have changed the page's markup. Re-run with "
+            "--headful to inspect the page."
+        ) from exc
+
+    if not _clear_text_field(field):
+        raise BrowserSessionError(
+            "Could not clear the landing-page URL field on the campaign "
+            "edit page before typing the new value — Yandex may have "
+            "changed the page's markup. Re-run with --headful to inspect "
+            "the page."
+        )
+
+    try:
+        current = field.text_content()
+    except PlaywrightError:
+        current = None
+    if current not in ("", None):
+        raise BrowserSessionError(
+            "Could not clear the landing-page URL field on the campaign "
+            "edit page — Yandex may have changed the page's markup. "
+            "Re-run with --headful to inspect the page."
+        )
+
+    if not url:
+        return
+
+    _type_landing_url(field, url)
 
 
 def _set_directs_helps(page: "Page", enabled: bool) -> None:
@@ -3800,6 +3930,7 @@ def _verify_saved(
     promotion_goal: Optional[str],
     directs_helps: Optional[bool],
     name: Optional[str] = None,
+    landing_url: Optional[str] = None,
     headlines: Optional[Dict[int, str]] = None,
     texts: Optional[Dict[int, str]] = None,
     images_before_ids: Optional[List[str]] = None,
@@ -3873,6 +4004,7 @@ def _verify_saved(
             _read_promotion_goal_label,
         ),
         ("name", name, _read_campaign_name),
+        ("landing_url", landing_url, _read_landing_url),
         (
             "gender",
             None if gender is None else GENDER_CHOICES[gender],
@@ -4167,6 +4299,7 @@ def update_master(
     remove_target_action_goal_ids: Optional[List[int]] = None,
     directs_helps: Optional[bool] = None,
     name: Optional[str] = None,
+    landing_url: Optional[str] = None,
     headlines: Optional[Dict[int, str]] = None,
     texts: Optional[Dict[int, str]] = None,
     images: Optional[Dict[int, str]] = None,
@@ -4191,6 +4324,17 @@ def update_master(
     ``name`` (issue #663) is set via a separate modal (``_set_campaign_name``)
     rather than a plain form field — see module docstring — but is persisted
     by the same terminal ``_click_save`` as every other field here.
+
+    ``landing_url`` (issue #757) replaces the "Ссылка на продвигаемую
+    страницу" field's value WHOLESALE — Yandex has no separate UTM-only sub-
+    field to edit independently (the campaign's UTM template, if any, lives
+    baked into this same URL string as its query string; see
+    ``_EDIT_URL_INPUT_TESTID``'s docstring). To remove an existing UTM
+    template while keeping the landing page itself, pass the bare URL with
+    no query string; passing ``""`` clears the field entirely. Confirmed
+    live this field is READ-ONLY while the campaign's status is ARCHIVED —
+    ``_set_landing_url`` raises naming that requirement rather than
+    surfacing an opaque markup-changed error.
 
     ``headlines``/``texts`` (issue #665, Этап B) map a 0-based slot index to
     its replacement text and REPLACE ONLY THOSE SLOTS — every other headline/
@@ -4309,6 +4453,7 @@ def update_master(
         and not remove_target_action_goal_ids
         and directs_helps is None
         and name is None
+        and landing_url is None
         and not headlines
         and not texts
         and not images
@@ -4324,7 +4469,8 @@ def update_master(
             "(weekly_budget, promotion_goal, goal_price, "
             "target_action_prices, add_target_actions, "
             "remove_target_action_goal_ids, directs_helps, name, "
-            "headlines, texts, images, gender, age_from, age_to, devices, "
+            "landing_url, headlines, texts, images, gender, age_from, "
+            "age_to, devices, "
             "add_audience_tags, remove_audience_tags)."
         )
 
@@ -4351,6 +4497,8 @@ def update_master(
 
     if name is not None:
         _set_campaign_name(page, name)
+    if landing_url is not None:
+        _set_landing_url(page, landing_url)
     if weekly_budget is not None:
         _set_weekly_budget(page, weekly_budget)
     if promotion_goal is not None:
@@ -4510,6 +4658,7 @@ def update_master(
             promotion_goal=promotion_goal,
             directs_helps=directs_helps,
             name=name,
+            landing_url=landing_url,
             headlines=headlines,
             texts=texts,
             images_before_ids=images_before_ids,
@@ -4555,6 +4704,8 @@ def update_master(
         result["DirectsHelps"] = directs_helps
     if name is not None:
         result["Name"] = name
+    if landing_url is not None:
+        result["LandingUrl"] = landing_url
     if headlines:
         result["Headlines"] = headlines
     if texts:
@@ -4942,7 +5093,10 @@ def set_master_images(
 
 
 def _type_landing_url(field: Any, url: str) -> None:
-    """Type ``url`` into step 1's contenteditable field, verifying it landed.
+    """Type ``url`` into a landing-URL contenteditable field, verifying it
+    landed. Shared by the create page's step 1 field and the edit page's
+    "Ссылка на продвигаемую страницу" field (issue #757) — both are the same
+    kind of widget, just under different testid namespaces.
 
     Issue #690 re-recon (2026-08-04): typing this field via
     ``field.type(url)`` intermittently drops characters from the MIDDLE of
@@ -4974,8 +5128,8 @@ def _type_landing_url(field: Any, url: str) -> None:
         except PlaywrightError as exc:
             raise BrowserSessionError(
                 "Could not type into the landing-page URL field on the "
-                "Мастер кампаний create page — Yandex may have changed the "
-                "page's markup. Re-run with --headful to inspect the page."
+                "Мастер кампаний page — Yandex may have changed the page's "
+                "markup. Re-run with --headful to inspect the page."
             ) from exc
         try:
             actual = field.text_content()
@@ -4986,10 +5140,9 @@ def _type_landing_url(field: Any, url: str) -> None:
 
     raise BrowserSessionError(
         f"Typed {url!r} into the landing-page URL field on the Мастер "
-        f"кампаний create page {_TYPE_URL_MAX_ATTEMPTS} times, but the "
-        f"field still shows {actual!r} — Yandex's Combobox widget appears "
-        "to be dropping keystrokes. Re-run with --headful to inspect the "
-        "page."
+        f"кампаний page {_TYPE_URL_MAX_ATTEMPTS} times, but the field "
+        f"still shows {actual!r} — Yandex's Combobox widget appears to be "
+        "dropping keystrokes. Re-run with --headful to inspect the page."
     )
 
 

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -1260,6 +1260,19 @@ def audience_get(
     help="New campaign name (Название кампании)",
 )
 @click.option(
+    "--landing-url",
+    help=(
+        "New landing page URL (Ссылка на продвигаемую страницу), including "
+        "any UTM query string — Yandex has no separate UTM-only field, the "
+        "campaign's UTM template (if any) is just this URL's query string. "
+        "Replaces the WHOLE field value. To remove an existing UTM "
+        "template while keeping the landing page itself, pass the bare URL "
+        "with no query string. Pass an empty string ('') to clear the "
+        "field entirely. Read-only while the campaign is ARCHIVED — resume "
+        "it first via `masters resume`."
+    ),
+)
+@click.option(
     "--headline",
     "headlines",
     multiple=True,
@@ -1384,6 +1397,7 @@ def update(
     remove_target_actions,
     directs_helps,
     name,
+    landing_url,
     headlines,
     texts,
     images,
@@ -1439,6 +1453,14 @@ def update(
     ``--target-action-price``/``--add-target-action``/
     ``--remove-target-action`` in the same call.
 
+    ``--landing-url`` (issue #757) replaces the "Ссылка на продвигаемую
+    страницу" field WHOLESALE, including any UTM query string — Yandex has
+    no separate UTM-only field, the campaign's UTM template (if any) is
+    just this URL's query string. To remove an existing UTM template while
+    keeping the landing page itself, pass the bare URL with no query
+    string; pass an empty string to clear the field entirely. Read-only
+    while the campaign is ARCHIVED — resume it first via `masters resume`.
+
     ``--headline``/``--text``/``--image`` each replace ONE existing
     slot/position at a time rather than the whole list — unlike this CLI's
     usual list-field convention (e.g. ``campaigns update
@@ -1484,6 +1506,7 @@ def update(
         and not remove_target_actions
         and directs_helps is None
         and name is None
+        and landing_url is None
         and not headlines
         and not texts
         and not images
@@ -1498,8 +1521,9 @@ def update(
             "Provide at least one of --weekly-budget, --promotion-goal, "
             "--goal-price, --target-action-price, --add-target-action, "
             "--remove-target-action, --directs-helps/--no-directs-helps, "
-            "--name, --headline, --text, --image, --gender, --age-from, "
-            "--age-to, --device, --add-audience-tag, --remove-audience-tag."
+            "--name, --landing-url, --headline, --text, --image, --gender, "
+            "--age-from, --age-to, --device, --add-audience-tag, "
+            "--remove-audience-tag."
         )
 
     if goal_price is not None and promotion_goal == "max-conversions":
@@ -1604,6 +1628,7 @@ def update(
             remove_target_action_goal_ids=parsed_remove_target_actions,
             directs_helps=directs_helps,
             name=name,
+            landing_url=landing_url,
             headlines=parsed_headlines,
             texts=parsed_texts,
             images=parsed_images,

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -4856,6 +4856,8 @@ class TestUpdateMaster(unittest.TestCase):
         weekly_budget_state=None,
         directs_helps_state=None,
         name_state=None,
+        landing_url_state=None,
+        landing_url_clear_disabled=False,
         headlines_state=None,
         texts_state=None,
         goal_price_state=None,
@@ -4965,6 +4967,32 @@ class TestUpdateMaster(unittest.TestCase):
                 [header_handle]
             )
 
+        landing_url_handle = None
+        if landing_url_state is not None:
+            # Same "shared mutable state" pattern as name_state above, but
+            # via a _FakeContentEditableHandle (the real field is a
+            # contenteditable widget, not a plain <input> — issue #757, same
+            # widget family as the create page's own URL field).
+            landing_url_handle = _FakeContentEditableHandle(
+                text=landing_url_state.get("value", "")
+            )
+            locators[browser_masters._EDIT_URL_INPUT_TESTID] = _FakeLocator(
+                [landing_url_handle]
+            )
+            clear_handle = _FakeLocatorHandle(
+                attrs={"disabled": ""} if landing_url_clear_disabled else {}
+            )
+            locators[browser_masters._EDIT_URL_CLEAR_BUTTON_TESTID] = _FakeLocator(
+                [clear_handle]
+            )
+            # landing_url_handle's own ._text is the state actually mutated
+            # by type()/Backspace and read back by _read_landing_url on the
+            # post-save reload (same object reused across both goto() calls,
+            # mirroring headline_handles/text_handles above) — tests must
+            # assert against page.landing_url_handle.text_content(), NOT the
+            # landing_url_state dict passed in, which is only a starting
+            # value and is never written back to.
+
         if goal_price_state is not None:
             price_handle = _FakeLocatorHandle(
                 on_fill=lambda v: goal_price_state.__setitem__("value", v),
@@ -5038,6 +5066,7 @@ class TestUpdateMaster(unittest.TestCase):
         # above don't all need updating for this one new capability.
         page.headline_handles = headline_handles
         page.text_handles = text_handles
+        page.landing_url_handle = landing_url_handle
         return page, save_clicks
 
     def test_updates_only_weekly_budget(self):
@@ -5983,6 +6012,125 @@ class TestUpdateMaster(unittest.TestCase):
         self.assertEqual(len(save_clicks), 1)
         self.assertEqual(result, {"CampaignId": 42, "Name": "Новое имя"})
 
+    def test_updates_landing_url(self):
+        landing_url_state = {"value": "https://lp.example.ru/old?utm_source=old"}
+        page, save_clicks = self._page_with_save_button(
+            landing_url_state=landing_url_state
+        )
+
+        result = browser_masters.update_master(
+            page, 42, landing_url="https://lp.example.ru/new?utm_source=new"
+        )
+
+        self.assertEqual(
+            page.landing_url_handle.text_content(),
+            "https://lp.example.ru/new?utm_source=new",
+        )
+        self.assertEqual(len(save_clicks), 1)
+        self.assertEqual(
+            result,
+            {
+                "CampaignId": 42,
+                "LandingUrl": "https://lp.example.ru/new?utm_source=new",
+            },
+        )
+
+    def test_clears_utm_by_passing_bare_url(self):
+        # No dedicated --clear-utm flag (module docstring's
+        # _EDIT_URL_INPUT_TESTID note) — removing the UTM template while
+        # keeping the landing page is just passing a replacement URL with no
+        # query string.
+        landing_url_state = {
+            "value": "https://lp.example.ru/page?utm_source=yandex&utm_medium=cpc"
+        }
+        page, save_clicks = self._page_with_save_button(
+            landing_url_state=landing_url_state
+        )
+
+        result = browser_masters.update_master(
+            page, 42, landing_url="https://lp.example.ru/page"
+        )
+
+        self.assertEqual(
+            page.landing_url_handle.text_content(), "https://lp.example.ru/page"
+        )
+        self.assertEqual(len(save_clicks), 1)
+        self.assertEqual(
+            result, {"CampaignId": 42, "LandingUrl": "https://lp.example.ru/page"}
+        )
+
+    def test_clears_landing_url_entirely_with_empty_string(self):
+        landing_url_state = {"value": "https://lp.example.ru/page"}
+        page, save_clicks = self._page_with_save_button(
+            landing_url_state=landing_url_state
+        )
+
+        result = browser_masters.update_master(page, 42, landing_url="")
+
+        self.assertEqual(page.landing_url_handle.text_content(), "")
+        self.assertEqual(len(save_clicks), 1)
+        self.assertEqual(result, {"CampaignId": 42, "LandingUrl": ""})
+
+    def test_raises_when_landing_url_field_is_read_only_archived(self):
+        landing_url_state = {"value": "https://lp.example.ru/page"}
+        page, _save_clicks = self._page_with_save_button(
+            landing_url_state=landing_url_state,
+            landing_url_clear_disabled=True,
+        )
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(
+                page, 42, landing_url="https://lp.example.ru/new"
+            )
+        self.assertIn("ARCHIVED", str(ctx.exception))
+        # The field was never touched — Yandex's own state is unchanged.
+        self.assertEqual(
+            page.landing_url_handle.text_content(), "https://lp.example.ru/page"
+        )
+
+    def test_raises_when_saved_landing_url_does_not_match_requested(self):
+        # The field accepts the new text (so the in-flight type-and-verify
+        # loop inside _type_landing_url is satisfied), but the post-save
+        # RELOAD reads back the OLD value — Yandex silently rejected the
+        # save (or it didn't persist), same "never trust the click alone"
+        # convention as name. Modeled by a handle whose text_content()
+        # reports live (mutated) state up through the save, then reverts to
+        # the original once _verify_saved's own goto() has fired — a second,
+        # separate _FakeContentEditableHandle can't model this because
+        # FakePage.locator() keeps returning the SAME handle object across
+        # both goto() calls (see _page_with_save_button's landing_url_state
+        # comment).
+        original_value = "https://lp.example.ru/old"
+
+        class _RevertsOnReloadHandle(_FakeContentEditableHandle):
+            def text_content(self):
+                if len(page.navigated_to) > 1:
+                    return original_value
+                return super().text_content()
+
+        url_handle = _RevertsOnReloadHandle(text=original_value)
+        clear_handle = _FakeLocatorHandle()
+        edit_form_ready_selector = (
+            f'[data-testid="{browser_masters._EDIT_FORM_READY_TESTID}"]'
+        )
+        save_handle = _FakeTextLocatorHandle(visible=True)
+        page = FakePage(
+            locators={
+                browser_masters._EDIT_URL_INPUT_TESTID: _FakeLocator([url_handle]),
+                browser_masters._EDIT_URL_CLEAR_BUTTON_TESTID: _FakeLocator(
+                    [clear_handle]
+                ),
+                edit_form_ready_selector: _FakeLocator([_FakeLocatorHandle()]),
+            },
+            role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
+        )
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(
+                page, 42, landing_url="https://lp.example.ru/new"
+            )
+        self.assertIn("landing_url", str(ctx.exception))
+
     def test_updates_name_together_with_weekly_budget(self):
         budget_state = {}
         name_state = {}
@@ -6487,6 +6635,51 @@ class TestMastersUpdateCommand(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertEqual(mock_update.call_args.kwargs["name"], "Новое имя")
+
+    def test_passes_landing_url_flag(self):
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {
+                "CampaignId": 42,
+                "LandingUrl": "https://lp.example.ru/new?utm_source=new",
+            }
+            result = self.runner.invoke(
+                cli,
+                [
+                    "masters",
+                    "update",
+                    "42",
+                    "--landing-url",
+                    "https://lp.example.ru/new?utm_source=new",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(
+            mock_update.call_args.kwargs["landing_url"],
+            "https://lp.example.ru/new?utm_source=new",
+        )
+
+    def test_passes_empty_landing_url_flag_to_clear_it(self):
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42, "LandingUrl": ""}
+            result = self.runner.invoke(
+                cli, ["masters", "update", "42", "--landing-url", ""]
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(mock_update.call_args.kwargs["landing_url"], "")
+
+    def test_documents_landing_url_flag(self):
+        result = self.runner.invoke(cli, ["masters", "update", "--help"])
+        self.assertIn("--landing-url", result.output)
 
     def test_passes_promotion_goal_choice(self):
         with (


### PR DESCRIPTION
## Summary
- Adds `masters update --landing-url` to set/replace the campaign's landing-page URL (including any UTM query string) — Yandex's edit page has no separate UTM-only field, the UTM template is just this field's own query string.
- Passing a bare URL (no query string) removes an existing UTM template while keeping the landing page; passing `""` clears the field entirely.
- Confirmed live that the field is read-only while the campaign is `ARCHIVED` — `update_master` now raises a clear `BrowserSessionError` pointing at `masters resume` instead of silently no-opping.
- Live recon found the edit page uses a **distinct** testid namespace (`CampaignLinkEditorLite.*`) from the create page's `CampaignFormUrl.*` — reuses the existing `_type_landing_url` retry-with-verify helper (issue #690) now shared between both flows.
- Post-save verification follows the existing `_verify_saved` reload+re-read convention.

## Test plan
- [x] 5 new browser-layer tests in `TestUpdateMaster` (set, clear-UTM-via-bare-url, clear-entirely, read-only-when-ARCHIVED, save-verification-mismatch) — all pass
- [x] 3 new CLI-layer tests in `TestMastersUpdateCommand` (flag passthrough, empty-string passthrough, `--help` documents the flag)
- [x] Full offline suite: `pytest` — 3211 passed, 23 skipped
- [x] `black`/`flake8` clean
- [x] `masters update --help` renders cleanly
- [x] Live-verified against the test master (campaign 713277109) — field located, edited, UTM cleared/restored; master returned to its exact original state (URL + `ARCHIVED` status) before this PR was written

Closes #757

🤖 Generated with [Claude Code](https://claude.com/claude-code)