### PR TITLE
fix(masters): support two-step ARCHIVED<->ACTIVE status transitions (#758)

### DIFF
--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -2034,7 +2034,20 @@ def resume_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
     archive path below.
     """
     _goto_overview_page(page, campaign_id)
+    # _goto_overview_page only guarantees the title rendered (issue #683) --
+    # the separate status-text element can still read as unrecognised
+    # (None) on the very first call right after navigation. Poll briefly
+    # for a recognised status before branching on it, so a hydration race
+    # here doesn't silently skip the ARCHIVED/unarchive branch and fall
+    # through to a doomed search for a resume button that an ARCHIVED page
+    # does not have (issue #758 follow-up). _suspend_or_resume's own
+    # ``current_status is None`` check below remains the final safety net
+    # for a genuinely unrecognised status that never hydrates.
+    deadline = time.monotonic() + _STATUS_CHANGE_TIMEOUT_MS / 1000
     current_status = _read_status_text(page)
+    while current_status is None and time.monotonic() < deadline:
+        page.wait_for_timeout(250)
+        current_status = _read_status_text(page)
     if current_status == "ARCHIVED":
         _click_menu_item(
             page,

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -44,16 +44,42 @@ exists for Мастер кампаний — only archive; see the issue comment
 the campaigns-grid row menu and the overview page's own "⋮" menu were
 inspected live: neither has a "Удалить" item, only "Архивировать" (grid
 row menu also has Перейти/Редактировать/Статистика/Запустить-Остановить;
-overview menu has only Клонировать/Архивировать). Confirmed live,
-stable ``data-testid`` attributes back the overview menu:
-``CampaignHeader.MenuTrigger`` (opens the "⋮" dropdown) and
-``CampaignHeader.Menu.archive`` (the "Архивировать" menu item) — unlike
-suspend/resume's text-based matching, this does not depend on Russian
-button copy. Archiving is verified via ``fetch_masters_list`` (the grid
-API's ``primaryStatus``), not the overview page's status text — no
-archived-campaign overview fixture has been captured, so there is no
-confirmed status-text marker for "archived" on that page the way there is
-for "Кампания остановлена"/"активна".
+overview menu has only Клонировать/Архивировать, or just Клонировать —
+see the transition matrix below). Confirmed live, stable ``data-testid``
+attributes back the overview menu: ``CampaignHeader.MenuTrigger`` (opens
+the "⋮" dropdown), ``CampaignHeader.Menu.archive`` (the "Архивировать"
+menu item), and ``CampaignHeader.Menu.unarchive`` (the "Разархивировать"
+item, ARCHIVED-only) — unlike suspend/resume's text-based matching, none
+of these depend on Russian button copy. Archiving is verified via
+``fetch_masters_list`` (the grid API's ``primaryStatus``); the overview
+page's own status text ALSO has a confirmed marker for "archived" now
+(issue #730, "Кампания в\xa0архиве" — see ``_read_status_text``), which
+the two-step transitions below rely on for their intermediate check.
+
+Two-step status transitions (issue #758, live-confirmed 2026-08-05 against
+campaign 713277109 through a full round trip archived -> ... -> archived).
+Both ``resume_master`` and ``archive_master`` are single clicks that only
+work from one specific starting status — the UI has no direct
+ARCHIVED<->ACTIVE transition, and this module now walks the intermediate
+step itself instead of failing:
+
+============  ============================================  ============
+Status        "⋮" menu contents / action button              -> leads to
+============  ============================================  ============
+ARCHIVED      menu: ONLY "Разархивировать" (unarchive item). -> SUSPENDED
+              No resume button on the page at all.
+SUSPENDED     button: "Возобновить кампанию".                -> ACTIVE or
+              menu: Клонировать + Архивировать.                 MODERATION
+ACTIVE /      button: "Остановить кампанию".                 -> SUSPENDED
+MODERATION    menu: ONLY "Клонировать" — no archive item.
+============  ============================================  ============
+
+Resuming a SUSPENDED campaign can land in either ACTIVE or MODERATION
+depending on whether Yandex decides the campaign needs re-review (a fresh
+or edited campaign goes to moderation; an already-approved one returns
+directly to ACTIVE) — this is not something the caller can predict ahead
+of time, so ``resume_master`` treats both as success and returns whichever
+one actually happened.
 
 ``update_master`` (issue #631, Этап A) — live-verified against campaign
 107707079 (see ``tests/fixtures/masters_wizard_edit_stage_a.html`` for the
@@ -359,7 +385,15 @@ _SUSPEND_BUTTON_TEXTS = ("Остановить кампанию", "Приост�
 
 # How long to wait, after clicking the action button, for the status text to
 # actually change before giving up and reporting a possible false success.
-_STATUS_CHANGE_TIMEOUT_MS = 10_000
+# Raised from 10s to 60s (issue #758 live verification, 2026-08-05): both a
+# plain suspend and the unarchive->SUSPENDED leg of resume_master timed out
+# at 10s against campaign 713277109 despite the click having genuinely
+# landed (a later `masters get` confirmed the status had in fact changed) --
+# Yandex's own status-text update lagged past the old budget under real
+# conditions. 60s is a practical safety margin, not a measured p99; see
+# follow-up issue for a precise measurement and a possible rework of this
+# whole polling budget.
+_STATUS_CHANGE_TIMEOUT_MS = 60_000
 
 # Overview page's header title, confirmed live (issue #683) as the earliest
 # stable marker of a rendered wizard overview page — present on BOTH a
@@ -417,6 +451,11 @@ _ARCHIVE_MENU_ITEM_SELECTOR = '[data-testid="CampaignHeader.Menu.archive"]'
 # Confirmed live (issue #659) alongside the archive item above — same menu,
 # same testid convention.
 _CLONE_MENU_ITEM_SELECTOR = '[data-testid="CampaignHeader.Menu.clone"]'
+# Confirmed live 2026-08-05 (issue #758) on campaign 713277109: an ARCHIVED
+# campaign's "⋮" menu contains ONLY this item — there is no "Возобновить"
+# button on the page at all, which is why resume_master could never work
+# starting from ARCHIVED (see the module docstring's transition matrix).
+_UNARCHIVE_MENU_ITEM_SELECTOR = '[data-testid="CampaignHeader.Menu.unarchive"]'
 
 # Issues #723/#725: live testing found that clicking a trigger element that
 # is itself visible/enabled (CampaignHeader.MenuTrigger for the "⋮" menu,
@@ -1858,21 +1897,68 @@ def _click_and_wait_for_popup(
     ) from last_exc
 
 
+def _wait_for_status(
+    page: "Page",
+    campaign_id: int,
+    *,
+    current_status: str,
+    target_statuses: Tuple[str, ...],
+    action_description: str,
+) -> str:
+    """Poll ``_read_status_text`` until it matches one of ``target_statuses``
+    or ``_STATUS_CHANGE_TIMEOUT_MS`` elapses; raise ``BrowserSessionError``
+    on timeout.
+
+    Shared by ``_suspend_or_resume`` (the ordinary one-click suspend/resume)
+    and ``resume_master``'s unarchive->SUSPENDED step (issue #758) — both
+    need the identical "click already happened, now confirm the status text
+    actually caught up" loop, just against a different click and a
+    different target. Factored out so a future change to the polling
+    strategy (see ``_STATUS_CHANGE_TIMEOUT_MS``'s own comment about a
+    possible rework, issue #764) only needs to happen once.
+    """
+    deadline = time.monotonic() + _STATUS_CHANGE_TIMEOUT_MS / 1000
+    new_status = current_status
+    while time.monotonic() < deadline:
+        new_status = _read_status_text(page)
+        if new_status in target_statuses:
+            break
+        page.wait_for_timeout(250)
+
+    if new_status not in target_statuses:
+        raise BrowserSessionError(
+            f"{action_description} for campaign {campaign_id}, but its "
+            f"status did not change to any of {target_statuses!r} within "
+            f"{_STATUS_CHANGE_TIMEOUT_MS / 1000:.0f}s (still {new_status!r}). "
+            "The click may not have hit the right element, or Yandex is "
+            "slow to apply it — verify manually before retrying."
+        )
+    return new_status
+
+
 def _suspend_or_resume(
     page: "Page",
     campaign_id: int,
     *,
-    target_status: str,
+    target_statuses: Tuple[str, ...],
     button_texts: Tuple[str, ...],
 ) -> Dict[str, Any]:
     """Shared body for ``suspend_master``/``resume_master``.
 
-    Idempotent: if the campaign is already in ``target_status``, does not
-    click anything and returns the current state with a warning (mirrors the
-    rest of the CLI's suspend/resume convention). Otherwise clicks the
-    matching action button and re-reads the status to confirm the mutation
-    actually took effect — a click that doesn't visibly change the status is
-    reported as a hard error, not a silent success.
+    Idempotent: if the campaign is already in one of ``target_statuses``,
+    does not click anything and returns the current state with a warning
+    (mirrors the rest of the CLI's suspend/resume convention). Otherwise
+    clicks the matching action button and re-reads the status to confirm the
+    mutation actually took effect — a click that doesn't visibly change the
+    status is reported as a hard error, not a silent success.
+
+    ``target_statuses`` is a tuple, not a single status, because resuming a
+    SUSPENDED campaign can land in either ACTIVE or MODERATION depending on
+    whether Yandex decides the campaign needs re-review (issue #758,
+    live-confirmed 2026-08-05 — see the module docstring's transition
+    matrix); the caller cannot predict which one ahead of time, and treating
+    MODERATION as a failure here would make a perfectly successful resume
+    time out.
 
     A DRAFT campaign's overview page has no ACTIVE/SUSPENDED status and no
     action button to click (issue #660, see module docstring's "DRAFT
@@ -1893,30 +1979,21 @@ def _suspend_or_resume(
             f"Could not determine current status for campaign {campaign_id} "
             "(unrecognised status text) — refusing to click blind."
         )
-    if current_status == target_status:
+    if current_status in target_statuses:
         print_warning(
-            f"Campaign {campaign_id} is already {target_status}; not clicking."
+            f"Campaign {campaign_id} is already {current_status}; not clicking."
         )
         return {"CampaignId": campaign_id, "Status": current_status}
 
     _click_action_button(page, button_texts)
 
-    deadline = time.monotonic() + _STATUS_CHANGE_TIMEOUT_MS / 1000
-    new_status = current_status
-    while time.monotonic() < deadline:
-        new_status = _read_status_text(page)
-        if new_status == target_status:
-            break
-        page.wait_for_timeout(250)
-
-    if new_status != target_status:
-        raise BrowserSessionError(
-            f"Clicked the action button for campaign {campaign_id}, but its "
-            f"status did not change to {target_status} within "
-            f"{_STATUS_CHANGE_TIMEOUT_MS / 1000:.0f}s (still {new_status!r}). "
-            "The click may not have hit the right element, or Yandex is "
-            "slow to apply it — verify manually before retrying."
-        )
+    new_status = _wait_for_status(
+        page,
+        campaign_id,
+        current_status=current_status,
+        target_statuses=target_statuses,
+        action_description="Clicked the action button",
+    )
 
     return {"CampaignId": campaign_id, "Status": new_status}
 
@@ -1930,21 +2007,53 @@ def suspend_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
     return _suspend_or_resume(
         page,
         campaign_id,
-        target_status="SUSPENDED",
+        target_statuses=("SUSPENDED",),
         button_texts=_SUSPEND_BUTTON_TEXTS,
     )
 
 
 def resume_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
-    """Resume a stopped Мастер кампаний, verifying the status actually changed.
+    """Resume a Мастер кампаний, verifying the status actually changed.
 
     "Возобновить кампанию" is confirmed live (see module docstring /
     ``tests/fixtures/masters_wizard_overview.html``).
+
+    If the campaign is currently ARCHIVED, first clicks "Разархивировать"
+    (issue #758, live-confirmed 2026-08-05) and waits for SUSPENDED — an
+    ARCHIVED campaign's overview page has no resume button at all, only
+    this menu item, and it does not itself lead to ACTIVE. Once SUSPENDED
+    (whether it started there or just arrived via unarchive), proceeds with
+    the ordinary one-click resume, accepting either ACTIVE or MODERATION as
+    success (see ``_suspend_or_resume``'s docstring for why both are valid).
+
+    Navigates to the overview page itself first to read the current status
+    — ``_suspend_or_resume`` navigates again below, which is a harmless
+    repeat (``_goto_overview_page`` is idempotent) rather than trusting a
+    status read against whatever page ``page`` happened to be on before this
+    call, the same tradeoff ``archive_master`` makes for its own suspend-then-
+    archive path below.
     """
+    _goto_overview_page(page, campaign_id)
+    current_status = _read_status_text(page)
+    if current_status == "ARCHIVED":
+        _click_menu_item(
+            page,
+            campaign_id,
+            item_selector=_UNARCHIVE_MENU_ITEM_SELECTOR,
+            item_label="Разархивировать",
+        )
+        _wait_for_status(
+            page,
+            campaign_id,
+            current_status=current_status,
+            target_statuses=("SUSPENDED",),
+            action_description="Clicked 'Разархивировать'",
+        )
+
     return _suspend_or_resume(
         page,
         campaign_id,
-        target_status="ACTIVE",
+        target_statuses=("ACTIVE", "MODERATION"),
         button_texts=_RESUME_BUTTON_TEXTS,
     )
 
@@ -1959,6 +2068,47 @@ def _find_master_row(
     return None
 
 
+def _click_menu_item(
+    page: "Page",
+    campaign_id: int,
+    *,
+    item_selector: str,
+    item_label: str,
+) -> None:
+    """Open the overview page's "⋮" menu and click ``item_selector``.
+
+    Shared by ``archive_master`` (Архивировать) and ``resume_master``
+    (Разархивировать, issue #758) — both need the exact same
+    open-menu-then-click-item sequence, backed by confirmed-live
+    ``data-testid`` selectors, not guessed text (see module docstring).
+    Reuses ``_click_and_wait_for_popup`` for its hydration-race retries
+    (issues #723/#725) rather than duplicating that click logic here.
+    """
+    try:
+        _click_and_wait_for_popup(
+            page,
+            trigger_selector=_MENU_TRIGGER_SELECTOR,
+            popup_selector=item_selector,
+            description=f"the campaign menu for {campaign_id}",
+        )
+    except BrowserSessionError as exc:
+        raise BrowserSessionError(
+            f"Could not open the campaign menu for {campaign_id} and find "
+            f"'{item_label}' ({_MENU_TRIGGER_SELECTOR!r} / {item_selector!r}) "
+            "— Yandex may have changed the overview page's markup."
+        ) from exc
+
+    item = page.locator(item_selector).first
+    try:
+        item.click()
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            f"Could not click '{item_label}' for campaign {campaign_id} "
+            f"({item_selector!r} found but not clickable) — Yandex may have "
+            "changed the overview page's menu."
+        ) from exc
+
+
 def archive_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
     """Archive a Мастер кампаний, verifying the grid actually reports it archived.
 
@@ -1968,11 +2118,18 @@ def archive_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
     campaign is already archived, does not click anything and returns the
     current row with a warning (mirrors ``suspend_master``/``resume_master``).
 
-    Opens the campaign's overview page, clicks the "⋮" menu trigger, then the
-    "Архивировать" item (both selected via confirmed-live ``data-testid``
-    attributes, not guessed text — see module docstring), and re-reads the
-    campaigns grid via ``fetch_masters_list`` to confirm ``Status ==
-    "ARCHIVED"`` before reporting success — never trusting the click alone.
+    If the campaign is currently ACTIVE or MODERATION, first suspends it
+    (issue #758, live-confirmed 2026-08-05) and waits for SUSPENDED — the
+    "Архивировать" menu item is not present at all until the campaign is
+    SUSPENDED (see module docstring's transition matrix). Reuses
+    ``suspend_master`` rather than duplicating its click/verify logic.
+
+    Once SUSPENDED, opens the campaign's overview page, clicks the "⋮" menu
+    trigger, then the "Архивировать" item (both selected via confirmed-live
+    ``data-testid`` attributes, not guessed text — see module docstring),
+    and re-reads the campaigns grid via ``fetch_masters_list`` to confirm
+    ``Status == "ARCHIVED"`` before reporting success — never trusting the
+    click alone.
     """
     existing = _find_master_row(page, campaign_id)
     if existing is None:
@@ -1993,30 +2150,16 @@ def archive_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
 
     _goto_overview_page(page, campaign_id)
 
-    try:
-        _click_and_wait_for_popup(
-            page,
-            trigger_selector=_MENU_TRIGGER_SELECTOR,
-            popup_selector=_ARCHIVE_MENU_ITEM_SELECTOR,
-            description=f"the campaign menu for {campaign_id}",
-        )
-    except BrowserSessionError as exc:
-        raise BrowserSessionError(
-            f"Could not open the campaign menu for {campaign_id} and find "
-            f"'Архивировать' ({_MENU_TRIGGER_SELECTOR!r} / "
-            f"{_ARCHIVE_MENU_ITEM_SELECTOR!r}) — Yandex may have changed the "
-            "overview page's markup."
-        ) from exc
+    if existing["Status"] in ("ACTIVE", "MODERATION"):
+        suspend_master(page, campaign_id)
+        _goto_overview_page(page, campaign_id)
 
-    archive_item = page.locator(_ARCHIVE_MENU_ITEM_SELECTOR).first
-    try:
-        archive_item.click()
-    except PlaywrightError as exc:
-        raise BrowserSessionError(
-            f"Could not click 'Архивировать' for campaign {campaign_id} "
-            f"({_ARCHIVE_MENU_ITEM_SELECTOR!r} found but not clickable) — "
-            "Yandex may have changed the overview page's menu."
-        ) from exc
+    _click_menu_item(
+        page,
+        campaign_id,
+        item_selector=_ARCHIVE_MENU_ITEM_SELECTOR,
+        item_label="Архивировать",
+    )
 
     deadline = time.monotonic() + _ARCHIVE_VERIFY_TIMEOUT_MS / 1000
     updated = existing

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -2698,6 +2698,64 @@ class TestSuspendResumeMaster(unittest.TestCase):
         self.assertIn("Разархивировать", str(ctx.exception))
         self.assertIn("did not change to any of ('SUSPENDED',)", str(ctx.exception))
 
+    def test_resume_from_archived_waits_for_status_to_hydrate(self):
+        # issue #758 follow-up: _goto_overview_page only guarantees the
+        # title rendered (issue #683) -- the separate status-text element
+        # can still read as unrecognised (None) on the very first call right
+        # after navigation. resume_master must not silently skip the
+        # ARCHIVED/unarchive branch just because that first read raced the
+        # page's own hydration -- it must poll for a recognised status
+        # before branching, then take the unarchive-then-resume path once
+        # the true ARCHIVED status is observed, never falling straight
+        # through to a doomed search for a resume button that an ARCHIVED
+        # page does not have.
+        calls = {"n": 0, "unarchive_clicks": 0}
+
+        def _unarchive():
+            calls["unarchive_clicks"] += 1
+            calls["status"] = "Кампания остановлена"
+
+        def _resume():
+            calls["status"] = "Кампания активна"
+
+        page = FakePage(
+            locators={
+                browser_masters._MENU_TRIGGER_SELECTOR: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                ),
+                browser_masters._UNARCHIVE_MENU_ITEM_SELECTOR: _FakeLocator(
+                    [_FakeLocatorHandle(on_click=_unarchive)]
+                ),
+            },
+            text_buttons={
+                "Возобновить кампанию": _FakeGetByTextLocator(
+                    [_FakeTextLocatorHandle(visible=True, on_click=_resume)]
+                )
+            },
+        )
+        calls["status"] = "Кампания в\xa0архиве"
+
+        def fake_inner_text(selector=None):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                # The overview title has rendered but the status element
+                # has not hydrated yet -- no recognised marker in the body.
+                return ""
+            return calls["status"]
+
+        page.inner_text = fake_inner_text
+
+        result = browser_masters.resume_master(page, 713277109)
+
+        self.assertEqual(result, {"CampaignId": 713277109, "Status": "ACTIVE"})
+        self.assertEqual(
+            calls["unarchive_clicks"],
+            1,
+            "resume_master must click 'Разархивировать' even when the "
+            "first status read after navigation raced the page's own "
+            "hydration and came back unrecognised",
+        )
+
 
 class TestMastersSuspendResumeCommand(unittest.TestCase):
     """CLI wiring for `masters suspend`/`masters resume`."""

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -2424,9 +2424,12 @@ class TestSuspendResumeMaster(unittest.TestCase):
         result = browser_masters.resume_master(page, 42)
 
         self.assertEqual(result, {"CampaignId": 42, "Status": "ACTIVE"})
+        # resume_master now navigates once itself (issue #758, to check for
+        # ARCHIVED) and _suspend_or_resume navigates again -- a harmless
+        # repeat visit to the same idempotent overview page, not a regression.
         self.assertEqual(
             page.navigated_to,
-            [browser_masters.WIZARD_OVERVIEW_URL.format(campaign_id=42)],
+            [browser_masters.WIZARD_OVERVIEW_URL.format(campaign_id=42)] * 2,
         )
 
     def test_suspend_clicks_candidate_button_and_verifies(self):
@@ -2562,6 +2565,138 @@ class TestSuspendResumeMaster(unittest.TestCase):
         with self.assertRaises(BrowserSessionError) as ctx:
             browser_masters.resume_master(page, 713231614)
         self.assertIn("DRAFT", str(ctx.exception))
+
+    def _archived_page_with_unarchive(self, next_status_text, resume_button_text=None):
+        """An ARCHIVED overview page whose "⋮" menu has only "Разархивировать".
+
+        Models issue #758's live-confirmed shape: no resume button exists on
+        an ARCHIVED page at all — clicking the unarchive menu item flips the
+        (mutable) status text to ``next_status_text`` (SUSPENDED in the
+        success path). ``resume_button_text``, if given, additionally wires
+        up a resume button that flips the status again once SUSPENDED is
+        reached — modeling the second, ordinary one-click leg of the resume.
+        """
+        state = {"status": "Кампания в\xa0архиве"}
+
+        def _unarchive():
+            state["status"] = next_status_text
+
+        text_buttons = {}
+        if resume_button_text is not None:
+
+            def _resume():
+                state["status"] = "Кампания активна"
+
+            text_buttons[resume_button_text] = _FakeGetByTextLocator(
+                [_FakeTextLocatorHandle(visible=True, on_click=_resume)]
+            )
+
+        page = FakePage(
+            locators={
+                browser_masters._MENU_TRIGGER_SELECTOR: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                ),
+                browser_masters._UNARCHIVE_MENU_ITEM_SELECTOR: _FakeLocator(
+                    [_FakeLocatorHandle(on_click=_unarchive)]
+                ),
+            },
+            text_buttons=text_buttons,
+        )
+        page.inner_text = lambda selector=None: state["status"]
+        return page
+
+    def test_resume_from_archived_unarchives_then_resumes(self):
+        # issue #758: ARCHIVED has no resume button at all -- resume_master
+        # must click "Разархивировать" first, wait for SUSPENDED, THEN do
+        # the ordinary one-click resume to ACTIVE/MODERATION.
+        page = self._archived_page_with_unarchive(
+            "Кампания остановлена", resume_button_text="Возобновить кампанию"
+        )
+
+        result = browser_masters.resume_master(page, 713277109)
+
+        self.assertEqual(result, {"CampaignId": 713277109, "Status": "ACTIVE"})
+
+    def test_resume_from_archived_can_end_in_moderation(self):
+        # Yandex may send a resumed campaign to moderation instead of ACTIVE
+        # (live-confirmed 2026-08-05) -- this must still be reported as
+        # success, with the actual status returned, not normalised to ACTIVE.
+        state_holder = {}
+
+        def _resume_to_moderation():
+            state_holder["status"] = "Кампания на\xa0модерации"
+
+        page = FakePage(
+            locators={
+                browser_masters._MENU_TRIGGER_SELECTOR: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                ),
+                browser_masters._UNARCHIVE_MENU_ITEM_SELECTOR: _FakeLocator(
+                    [
+                        _FakeLocatorHandle(
+                            on_click=lambda: state_holder.__setitem__(
+                                "status", "Кампания остановлена"
+                            )
+                        )
+                    ]
+                ),
+            },
+            text_buttons={
+                "Возобновить кампанию": _FakeGetByTextLocator(
+                    [
+                        _FakeTextLocatorHandle(
+                            visible=True, on_click=_resume_to_moderation
+                        )
+                    ]
+                )
+            },
+        )
+        state_holder["status"] = "Кампания в\xa0архиве"
+        page.inner_text = lambda selector=None: state_holder["status"]
+
+        result = browser_masters.resume_master(page, 713277109)
+
+        self.assertEqual(result, {"CampaignId": 713277109, "Status": "MODERATION"})
+
+    def test_resume_direct_from_suspended_can_end_in_moderation(self):
+        # Same MODERATION-as-success behaviour on the ordinary (non-archived)
+        # one-click resume path, not just after an unarchive step.
+        page = self._page_with_button(
+            "Кампания остановлена",
+            "Возобновить кампанию",
+            next_status_text="Кампания на\xa0модерации",
+        )
+
+        result = browser_masters.resume_master(page, 42)
+
+        self.assertEqual(result, {"CampaignId": 42, "Status": "MODERATION"})
+
+    def test_resume_from_archived_raises_when_unarchive_menu_item_missing(self):
+        # Menu opens but has no unarchive item -- must fail loudly, not
+        # silently skip straight to (futile) resume-button clicking.
+        page = FakePage(
+            locators={
+                browser_masters._MENU_TRIGGER_SELECTOR: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                ),
+            },
+            body_text="Кампания в\xa0архиве",
+        )
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.resume_master(page, 713277109)
+        self.assertIn("Разархивировать", str(ctx.exception))
+
+    def test_resume_from_archived_raises_when_status_never_becomes_suspended(self):
+        # The unarchive click "succeeds" but the status text never flips to
+        # SUSPENDED -- must not silently fall through to the resume-button
+        # search (which would then fail with a confusing, unrelated error).
+        page = self._archived_page_with_unarchive("Кампания в\xa0архиве")
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.resume_master(page, 713277109)
+        self.assertIn("Разархивировать", str(ctx.exception))
+        self.assertIn("did not change to any of ('SUSPENDED',)", str(ctx.exception))
 
 
 class TestMastersSuspendResumeCommand(unittest.TestCase):
@@ -2917,6 +3052,73 @@ class TestArchiveMaster(unittest.TestCase):
 
         self.assertIn("DRAFT", str(ctx.exception))
         self.assertEqual(page.navigated_to, [])
+
+    def _active_page_with_suspend_and_menu(self, suspend_button_text):
+        """An ACTIVE/MODERATION overview page: "Остановить кампанию" button
+        AND the "⋮" menu with an archive item — models issue #758's
+        confirmed shape where the menu has no archive item at all until the
+        campaign is SUSPENDED, so archive_master must suspend first."""
+        state = {"status": "Кампания активна"}
+
+        def _suspend():
+            state["status"] = "Кампания остановлена"
+
+        def _archive():
+            state["status"] = "ARCHIVED_VIA_MENU"
+
+        page = FakePage(
+            locators={
+                browser_masters._MENU_TRIGGER_SELECTOR: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                ),
+                browser_masters._ARCHIVE_MENU_ITEM_SELECTOR: _FakeLocator(
+                    [_FakeLocatorHandle(on_click=_archive)]
+                ),
+            },
+            text_buttons={
+                suspend_button_text: _FakeGetByTextLocator(
+                    [_FakeTextLocatorHandle(visible=True, on_click=_suspend)]
+                )
+            },
+        )
+        page.inner_text = lambda selector=None: state["status"]
+        return page, state
+
+    def test_archives_from_active_suspends_first(self):
+        # issue #758: an ACTIVE campaign's menu has no "Архивировать" item at
+        # all -- archive_master must click "Остановить кампанию" first, wait
+        # for SUSPENDED, THEN open the menu and click "Архивировать".
+        page, state = self._active_page_with_suspend_and_menu("Остановить кампанию")
+
+        with patch(
+            "direct_cli.browser.masters.fetch_masters_list",
+            side_effect=lambda page, status="all": [
+                self._row(
+                    "ARCHIVED" if state["status"] == "ARCHIVED_VIA_MENU" else "ACTIVE"
+                )
+            ],
+        ):
+            result = browser_masters.archive_master(page, 42)
+
+        self.assertEqual(result, self._row("ARCHIVED"))
+
+    def test_archives_from_moderation_suspends_first(self):
+        page, state = self._active_page_with_suspend_and_menu("Остановить кампанию")
+        state["status"] = "Кампания на\xa0модерации"
+
+        with patch(
+            "direct_cli.browser.masters.fetch_masters_list",
+            side_effect=lambda page, status="all": [
+                self._row(
+                    "ARCHIVED"
+                    if state["status"] == "ARCHIVED_VIA_MENU"
+                    else "MODERATION"
+                )
+            ],
+        ):
+            result = browser_masters.archive_master(page, 42)
+
+        self.assertEqual(result, self._row("ARCHIVED"))
 
 
 class TestMastersArchiveCommand(unittest.TestCase):
@@ -6134,9 +6336,7 @@ class TestUpdateMaster(unittest.TestCase):
         # under the "Дополнительные параметры" spoiler) — independent of
         # --landing-url/LinkInput.
         utm_input_state = {"value": "utm_source=old&utm_medium=cpc"}
-        page, save_clicks = self._page_with_save_button(
-            utm_input_state=utm_input_state
-        )
+        page, save_clicks = self._page_with_save_button(utm_input_state=utm_input_state)
 
         result = browser_masters.update_master(
             page, 42, tracking_params="utm_source=yandex&utm_medium=cpc"
@@ -6157,9 +6357,7 @@ class TestUpdateMaster(unittest.TestCase):
 
     def test_clears_tracking_params_with_empty_string(self):
         utm_input_state = {"value": "utm_source=yandex"}
-        page, save_clicks = self._page_with_save_button(
-            utm_input_state=utm_input_state
-        )
+        page, save_clicks = self._page_with_save_button(utm_input_state=utm_input_state)
 
         result = browser_masters.update_master(page, 42, tracking_params="")
 


### PR DESCRIPTION
## Summary

`resume_master`/`archive_master` in `direct_cli/browser/masters.py` treated status changes as a single click, but Yandex's Мастер кампаний UI requires an intermediate step for some transitions — both commands failed instead of completing:

```
direct masters resume 713277109   # ARCHIVED -> failed: "Could not find an action button ('Возобновить кампанию', 'Возобновить')"
direct masters archive 713277109  # ACTIVE   -> failed: "Could not open the campaign menu ... and find 'Архивировать'"
```

## Confirmed live (2026-08-05, campaign 713277109, full round trip)

| Current status | Overview page | Action | Result |
|---|---|---|---|
| **ARCHIVED** | "⋮" menu has **only** "Разархивировать" (`CampaignHeader.Menu.unarchive`). No resume button on the page at all | click menu item | **SUSPENDED** |
| **SUSPENDED** | "Возобновить кампанию" button. Menu: Клонировать + Архивировать | click button | **ACTIVE** or **MODERATION** |
| **ACTIVE / MODERATION** | "Остановить кампанию" button. Menu: **only** Клонировать — no archive item | click button | **SUSPENDED** |

## Changes

- `resume_master`: when ARCHIVED, clicks "Разархивировать" and waits for SUSPENDED before the ordinary one-click resume.
- `archive_master`: when ACTIVE/MODERATION, suspends first (reusing `suspend_master`) before opening the menu.
- `_suspend_or_resume` now accepts `target_statuses: Tuple[str, ...]` instead of a single status — resuming can land in either ACTIVE or MODERATION depending on whether Yandex re-reviews the campaign, and both are success.
- Extracted `_click_menu_item` (shared archive/unarchive click sequence) and `_wait_for_status` (shared poll-until-status-changes loop) to avoid duplicating logic across the two-step paths — found by a 4-agent `/simplify` pass (reuse/simplification/efficiency/altitude), applied after live verification.
- `_STATUS_CHANGE_TIMEOUT_MS` raised 10s → 60s: live verification showed the old budget was too tight even for the pre-existing one-click suspend/resume, independent of this fix. Follow-up for a precise measurement: #764.
- Module docstring updated with the confirmed transition matrix; removed a stale claim that no ARCHIVED status-text marker existed (already fixed by #730).

## Testing

- Added tests in `tests/test_masters.py`: unarchive-then-resume ordering, MODERATION-as-success (both via unarchive and direct resume), suspend-then-archive ordering (from ACTIVE and MODERATION), missing-menu-item and never-reaches-SUSPENDED failure cases.
- `pytest tests/test_masters.py -q` — 578 passed.
- Full offline suite — 3227 passed, 23 skipped.
- Live-verified end-to-end on campaign 713277109: archived → unarchived (SUSPENDED) → resumed (MODERATION) → suspended → archived (back to original state).

Closes #758

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxckacfkzqVnPLZQbZLFUJ