### PR TITLE
fix(masters): read landing-page link scoped under CampaignHeader (#763)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+**Fixed — `masters get` returned the URL of a Yandex promo banner instead of the campaign's landing page (#763):**
+
+- `_extract_landing_url` picked the first anchor whose `href` contained
+  `utm_source=`. Live recon confirmed the overview page always also renders
+  a Yandex promo banner ("Yandex Neuro Ads") whose own href is itself
+  UTM-tagged (`ya.ru/project/yna/?utm_source=yandex&...`). Once the
+  campaign's own `LandingUrl` carried no UTM tail of its own (e.g. right
+  after `update --landing-url`, per #761), that banner became the *only*
+  href-based match and was silently reported as the campaign's `LandingUrl`
+  — this was not a caching issue, as the issue's title suggested, the
+  selector was simply reading the wrong anchor. When the campaign's URL did
+  carry a UTM tail, both anchors matched and the campaign's own link won
+  only by DOM order, i.e. the old selector was correct by accident.
+- Replaced with `_OVERVIEW_LANDING_LINK_SELECTOR`
+  (`[data-testid="CampaignHeader"] a[data-testid="Link"]`), confirmed live
+  to resolve to exactly the campaign's own link (1 match) regardless of
+  whether its URL carries UTM params. `masters get`'s output format is
+  unchanged — `LandingUrl` still carries the full href including any UTM
+  tail.
+
 **Changed — `SmartCampaign` bidding-strategy builder dedup (#592):**
 
 - The `build_smart_campaign_search_strategy` / `build_smart_campaign_network_strategy`

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -404,6 +404,26 @@ _STATUS_CHANGE_TIMEOUT_MS = 60_000
 # Title">` with no explicit `role` attribute), this selector is exact.
 _OVERVIEW_TITLE_SELECTOR = '[data-testid="CampaignHeader.Title"]'
 
+# Overview page's landing-page link, confirmed live 2026-08-06 (issue #763).
+# The previous selector, `a[href*='utm_source=']`, targeted the *content* of
+# an href rather than a stable element identity, and that content is not
+# unique to the campaign's own link: the page always also renders a Yandex
+# promo banner ("Yandex Neuro Ads") whose href is itself UTM-tagged
+# (`ya.ru/project/yna/?utm_source=yandex&utm_medium=direct&...`). When the
+# campaign's own LandingUrl carries no UTM tail (e.g. right after `update
+# --landing-url` with UTMInput left untouched, per #761), that banner becomes
+# the *only* href-based match and `.first` silently returns it instead of the
+# campaign's link — this is the exact "stale LandingUrl" symptom reported in
+# #763 (it isn't a cache: the selector was simply reading the wrong anchor).
+# When the campaign's LandingUrl does carry a UTM tail, both anchors match
+# and the campaign's own link happens to win only by DOM order, i.e. the old
+# selector was correct by accident in that case.
+# `[data-testid="Link"]` alone is not unique either (8 matches on a typical
+# overview page: sidebar entries, footer links, the campaign-id caption,
+# etc.) — scoping to the `CampaignHeader` container is required and yields
+# exactly 1 match in both cases confirmed live above.
+_OVERVIEW_LANDING_LINK_SELECTOR = '[data-testid="CampaignHeader"] a[data-testid="Link"]'
+
 # How long to wait for `_OVERVIEW_TITLE_SELECTOR` to render after navigating
 # to WIZARD_OVERVIEW_URL (issue #683). Confirmed live: the overview page can
 # take several seconds after `wait_until="commit"` returns before its React
@@ -1648,8 +1668,9 @@ def _extract_status(page: "Page", result: Dict[str, Any]) -> None:
 
 def _extract_landing_url(page: "Page", result: Dict[str, Any]) -> None:
     # The landing-page link's visible text is the bare domain, but its href
-    # carries the full UTM-templated URL — see the confirmed fixture example.
-    link = page.locator("a[href*='utm_source=']").first
+    # carries the full URL, including any UTM tail. See
+    # _OVERVIEW_LANDING_LINK_SELECTOR above for why this selector is required.
+    link = page.locator(_OVERVIEW_LANDING_LINK_SELECTOR).first
     try:
         href = link.get_attribute("href")
         if href:

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -2011,7 +2011,7 @@ class TestFetchMaster(unittest.TestCase):
                 browser_masters._OVERVIEW_TITLE_SELECTOR: _FakeLocator(
                     [_FakeLocatorHandle(text=title)]
                 ),
-                "a[href*='utm_source=']": _FakeLocator(
+                browser_masters._OVERVIEW_LANDING_LINK_SELECTOR: _FakeLocator(
                     [
                         _FakeLocatorHandle(
                             attrs={
@@ -2073,6 +2073,76 @@ class TestFetchMaster(unittest.TestCase):
                 "cost": "22 613,58 ₽",
             },
         )
+
+    def test_landing_url_ignores_yandex_promo_banner(self):
+        # Issue #763: the overview page always also renders a Yandex promo
+        # banner ("Yandex Neuro Ads") whose own href carries an unrelated
+        # utm_source= tag. The old selector, `a[href*='utm_source=']`, had no
+        # way to tell that banner apart from the campaign's own link once the
+        # campaign's LandingUrl carried no UTM tail of its own (e.g. right
+        # after `update --landing-url` per #761) -- it would then match only
+        # the banner and silently report *its* URL as the campaign's
+        # LandingUrl. _OVERVIEW_LANDING_LINK_SELECTOR must resolve to the
+        # campaign's own link (scoped under CampaignHeader), never the
+        # banner, regardless of which anchors happen to carry utm_source=.
+        page = FakePage(
+            locators={
+                browser_masters._OVERVIEW_TITLE_SELECTOR: _FakeLocator(
+                    [_FakeLocatorHandle(text="Мастер Тест")]
+                ),
+                browser_masters._OVERVIEW_LANDING_LINK_SELECTOR: _FakeLocator(
+                    [
+                        _FakeLocatorHandle(
+                            attrs={"href": "https://lp.ksamata.ru/detox_ya"}
+                        )
+                    ]
+                ),
+                # A banner-like anchor that an href-content selector would
+                # match, but the header-scoped selector above must not.
+                "a[href*='utm_source=']": _FakeLocator(
+                    [
+                        _FakeLocatorHandle(
+                            attrs={
+                                "href": (
+                                    "https://ya.ru/project/yna/?utm_source=yandex"
+                                    "&utm_medium=direct&utm_campaign=label"
+                                )
+                            }
+                        )
+                    ]
+                ),
+            },
+            body_text="Кампания активна",
+        )
+
+        result = browser_masters.fetch_master(page, 713234191)
+
+        self.assertEqual(result["LandingUrl"], "https://lp.ksamata.ru/detox_ya")
+
+    def test_landing_url_reads_utm_tagged_link_in_full(self):
+        # When the campaign's own LandingUrl does carry a UTM tail (recorded
+        # directly in the link, pre-#761 style), the header-scoped selector
+        # must still read the whole href, UTM params included.
+        href = (
+            "https://lp.ksamata.ru/detox_ya?utm_source=yandex&utm_medium=cpc&"
+            "utm_campaign=cid|{campaign_id}|{source_type}&"
+            "utm_content=gid|{gbid}|aid|{ad_id}&utm_term={keyword}"
+        )
+        page = FakePage(
+            locators={
+                browser_masters._OVERVIEW_TITLE_SELECTOR: _FakeLocator(
+                    [_FakeLocatorHandle(text="Мастер Тест")]
+                ),
+                browser_masters._OVERVIEW_LANDING_LINK_SELECTOR: _FakeLocator(
+                    [_FakeLocatorHandle(attrs={"href": href})]
+                ),
+            },
+            body_text="Кампания активна",
+        )
+
+        result = browser_masters.fetch_master(page, 713277109)
+
+        self.assertEqual(result["LandingUrl"], href)
 
     def test_active_status_recognised(self):
         page = self._page_for(status_text="Кампания активна")
@@ -6479,7 +6549,7 @@ class TestUpdateMaster(unittest.TestCase):
             page.landing_url_handle.text_content(), "https://lp.example.ru/page"
         )
 
-    def test_raises_generic_error_when_landing_url_field_is_read_only_but_status_unclear(
+    def test_raises_generic_error_when_landing_url_field_is_read_only_but_status_unclear(  # noqa: E501
         self,
     ):
         # Companion: when the field can't be cleared but _read_status_text


### PR DESCRIPTION
## Summary

`direct masters get` returned the URL of a Yandex promo banner instead of the campaign's actual landing page.

Closes #763

## Root cause (not a cache — a wrong selector)

`_extract_landing_url` picked the first anchor whose `href` contained `utm_source=`. Live recon (2026-08-06, real account) confirmed the overview page always also renders a Yandex promo banner ("Yandex Neuro Ads") whose own href is itself UTM-tagged (`ya.ru/project/yna/?utm_source=yandex&...`).

- Once the campaign's own `LandingUrl` carried no UTM tail of its own (e.g. right after `update --landing-url`, per #761), that banner became the *only* href-based match and was silently reported as the campaign's `LandingUrl` — the exact "stale LandingUrl" symptom from #763.
- When the campaign's URL did carry a UTM tail, both anchors matched and the campaign's own link won only by DOM order — the old selector was correct by accident in that case, not because it was reading the right element.

## Fix

Replaced the href-content match with `_OVERVIEW_LANDING_LINK_SELECTOR = '[data-testid="CampaignHeader"] a[data-testid="Link"]'`, confirmed live to resolve to exactly the campaign's own link (1 match) on both a campaign with a UTM-tagged URL and one without. `masters get`'s output format is unchanged — `LandingUrl` still carries the full href including any UTM tail.

## Tests

- Updated `TestFetchMaster._page_for` to register the new selector.
- Added `test_landing_url_ignores_yandex_promo_banner` — regression test confirmed red on the old selector, green on the fix.
- Added `test_landing_url_reads_utm_tagged_link_in_full` — confirms the UTM-tagged-URL case still reads correctly.
- Full offline suite: 3230 passed, 23 skipped. `black`/`flake8` clean (outside pre-existing `_vendor/` debt, tracked separately in axisrow/tapi-yandex-direct#27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxckacfkzqVnPLZQbZLFUJ