### PR TITLE
fix(masters): retry no-op action-button click, calibrate status timeout (#766, #764)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@
   archived campaign as "no status yet", skip the unarchive step, and hunt
   for a resume button an archived page never renders — leaving the campaign
   archived behind a misleading "could not find the button" error.
+- The retry loop now re-reads the status *immediately before* every retry,
+  and treats a vanished button as success when the status already reached
+  its target. Both close the same gap: the poll has a deadline, so a click
+  that lands but whose status update arrives late used to be followed by a
+  second click — which for `suspend` toggles the campaign straight back, and
+  for `resume` finds the page has already swapped `.resume` for `.stop` and
+  reports "could not find an action button" for a mutation that in fact
+  succeeded. The module docstring claimed this check existed; now it does.
 - Temporary, off by default: setting `DIRECT_MASTERS_DEBUG_TIMING=1` prints
   to stderr how long each of these waits actually took and how many clicks a
   status change needed, so the remaining unmeasured budget can be set from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 ## Unreleased
 
+**Fixed — `masters suspend`/`resume` never changed the status, and a batch stopped at the first failing ID (#766, #764):**
+
+- Root cause, confirmed live 2026-08-06 against campaign 713277109: **the
+  first click on a freshly rendered overview page is frequently a silent
+  no-op.** Playwright's actionability checks pass, `.click()` returns
+  without raising, and — verified by capturing every request after the
+  click — *no network request is issued at all*; React's own click handler
+  was not yet attached. Waiting longer cannot fix that state, which is why
+  #766's reporter saw a permanent failure across repeated runs, and why the
+  60s timeout #758 introduced only made each failure slower. The click is
+  now retried (up to `_STATUS_CLICK_MAX_ATTEMPTS`, 4), re-checking the
+  status before each attempt so an already-effective click is never
+  repeated — the same treatment `_click_and_wait_for_popup` already gave
+  the "⋮" menu and the rename modal (#723/#725). The unarchive→SUSPENDED
+  leg of `resume` gets the identical loop.
+- `_STATUS_CHANGE_TIMEOUT_MS` lowered 60s → **8s**, now a *measured* value
+  (#764): across 12 real transitions in two runs, the lag between an
+  effective click and the overview page's status text reporting the new
+  status was 1.64s–2.28s (mean 1.8s), with no long tail. The old 60s was
+  never measuring that latency — it was masking the no-op bug above.
+- Both action buttons now resolve via live-confirmed stable `data-testid`s
+  — `CampaignHeader.ActionButton.stop` ("Остановить кампанию") and
+  `CampaignHeader.ActionButton.resume` ("Возобновить кампанию") — instead
+  of guessing at Russian labels. The suspend side had been an unverified
+  candidate list since #630; both its testid and its label are now
+  confirmed. The label candidates are retained only as a fallback, and now
+  resolve the enclosing `<button>` before clicking (`get_by_text` matches
+  the `<span class="dc-Button__text">` inside it, so `disabled`/
+  `aria-disabled` checks were previously being made against the wrong
+  element).
+- The current status is now polled rather than read once before branching.
+  `_goto_overview_page` only guarantees the *title* rendered (#683); the
+  status element is a separate render pass, and a single read live-aborted
+  a real `masters suspend` with "unrecognised status text" on a campaign
+  whose status was readable a second later.
+- `masters suspend`/`resume` no longer abort the whole batch on the first
+  failing ID (#766): every ID is attempted, each ID's outcome (its row, or
+  an `Error` entry) is reported, and the command exits non-zero only after
+  printing every outcome. This is the behaviour `launch`/`archive` already
+  had (#645); all four now share one `_run_per_id` helper.
+- "Could not find an action button" now names both the testid and the
+  labels it searched for, and lists the action buttons the page actually
+  renders plus the status it reads — so a markup drift, an unexpected
+  status, and a half-loaded page are distinguishable without a `--headful`
+  re-run.
+
 **Fixed — `masters get` returned the URL of a Yandex promo banner instead of the campaign's landing page (#763):**
 
 - `_extract_landing_url` picked the first anchor whose `href` contained

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,21 @@
   effective click and the overview page's status text reporting the new
   status was 1.64s–2.28s (mean 1.8s), with no long tail. The old 60s was
   never measuring that latency — it was masking the no-op bug above.
+- That measured 8s applies **only after a click**. The separate wait for the
+  status element to render at all after navigating — which `resume_master`
+  branches on to decide whether to unarchive — keeps the previous 60s under
+  its own constant, `_STATUS_HYDRATION_TIMEOUT_MS`. The two are different
+  quantities and only the first was measured; sharing one constant would
+  have cut the unmeasured wait to 8s, and a slow page could then read an
+  archived campaign as "no status yet", skip the unarchive step, and hunt
+  for a resume button an archived page never renders — leaving the campaign
+  archived behind a misleading "could not find the button" error.
+- Temporary, off by default: setting `DIRECT_MASTERS_DEBUG_TIMING=1` prints
+  to stderr how long each of these waits actually took and how many clicks a
+  status change needed, so the remaining unmeasured budget can be set from
+  real runs instead of guessed again. A deliberate scaffold — no CLI flag,
+  no logging config, one env var read in one place — to be deleted once the
+  numbers are in.
 - Both action buttons now resolve via live-confirmed stable `data-testid`s
   — `CampaignHeader.ActionButton.stop` ("Остановить кампанию") and
   `CampaignHeader.ActionButton.resume` ("Возобновить кампанию") — instead

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -280,7 +280,9 @@ side effect on the campaign itself.
 
 import contextlib
 import json
+import os
 import re
+import sys
 from urllib.parse import urlsplit
 from typing import (
     TYPE_CHECKING,
@@ -434,6 +436,26 @@ _SUSPEND_BUTTON_TEXTS = ("Остановить кампанию", "Приост�
 # enough that a genuinely dead click is retried in seconds instead of after a
 # full minute.
 _STATUS_CHANGE_TIMEOUT_MS = 8_000
+
+# How long to wait for the status element to render *at all* after navigating,
+# BEFORE any click — a different quantity from the post-click budget above,
+# and deliberately a separate constant.
+#
+# `_goto_overview_page` only guarantees the title rendered (issue #683); the
+# status element is a later render pass. The 1.6-2.3s measurement above is the
+# lag from an *effective click* to the status text updating — it says nothing
+# about how long a freshly navigated page takes to render that element in the
+# first place, which was never measured. Before #766 this wait was inline in
+# `resume_master` with the then-current 60s budget; folding it into
+# `_STATUS_CHANGE_TIMEOUT_MS` would have silently cut it to 8s.
+#
+# That matters because `resume_master` branches on this read: a campaign whose
+# ARCHIVED status has not hydrated yet reads as None, skips the unarchive step,
+# and then hunts for a resume button an archived page never renders — leaving
+# the campaign archived and reporting a misleading "could not find" error. So
+# this keeps the pre-#766 value until real numbers replace it; see
+# `_log_timing` for how those numbers are being collected.
+_STATUS_HYDRATION_TIMEOUT_MS = 60_000
 
 # How many times to click the action button before giving up (issue #766).
 #
@@ -1786,6 +1808,27 @@ def _extract_stat_tiles(page: "Page", result: Dict[str, Any]) -> None:
         )
 
 
+def _log_timing(what: str, started: float, outcome: object) -> None:
+    """TEMPORARY (issue #764 follow-up): print how long a status wait took.
+
+    Silent unless ``DIRECT_MASTERS_DEBUG_TIMING`` is set to a non-empty value,
+    so ordinary runs are unaffected. Deliberately a scaffold, not a feature:
+    no CLI flag, no logger config, no plumbing through call signatures — the
+    env var is read here and nowhere else, so removing this function plus its
+    three call sites removes the whole thing.
+
+    It exists because two of the three waits in this module have never been
+    measured (see ``_STATUS_HYDRATION_TIMEOUT_MS``): the constants were picked
+    from a measurement of a *different* quantity. Rather than guess again,
+    collect real numbers from real runs, then set the constants from them and
+    delete this.
+    """
+    if not os.environ.get("DIRECT_MASTERS_DEBUG_TIMING"):
+        return
+    elapsed = _clock.now() - started
+    print(f"[masters timing] {what}: {elapsed:.2f}s -> {outcome!r}", file=sys.stderr)
+
+
 def _read_status_text(page: "Page") -> Optional[str]:
     """Return ``"SUSPENDED"``/``"ACTIVE"``/``"MODERATION"``/``"ARCHIVED"``/
     ``None`` from the current page body.
@@ -2015,12 +2058,14 @@ def _click_and_wait_for_status_change(
     never followed by a second one.
     """
     last_seen = current_status
-    for _ in range(_STATUS_CLICK_MAX_ATTEMPTS):
+    started = _clock.now()
+    for attempt in range(1, _STATUS_CLICK_MAX_ATTEMPTS + 1):
         _click_action_button(page, button_texts, selector=selector)
         last_seen = _poll_status(
             page, current_status=current_status, target_statuses=target_statuses
         )
         if last_seen in target_statuses:
+            _log_timing(f"action-button click x{attempt}", started, last_seen)
             return last_seen
 
     raise BrowserSessionError(
@@ -2130,15 +2175,18 @@ def _poll_status(
     status element momentarily unrendered mid-transition — observed live)
     are simply polled again rather than treated as a distinct state.
     """
-    deadline = _clock.now() + _STATUS_CHANGE_TIMEOUT_MS / 1000
+    started = _clock.now()
+    deadline = started + _STATUS_CHANGE_TIMEOUT_MS / 1000
     new_status = current_status
     while True:
         seen = _read_status_text(page)
         if seen is not None:
             new_status = seen
         if new_status in target_statuses:
+            _log_timing("post-click status change", started, new_status)
             return new_status
         if _clock.now() >= deadline:
+            _log_timing("post-click status change (TIMED OUT)", started, new_status)
             return new_status
         page.wait_for_timeout(250)
 
@@ -2154,12 +2202,18 @@ def _wait_for_recognised_status(page: "Page") -> Optional[str]:
     (issue #758 follow-up) but ``_suspend_or_resume`` did not, which
     live-aborted a real ``masters suspend`` with "unrecognised status text"
     (issue #766).
+
+    Budgeted by ``_STATUS_HYDRATION_TIMEOUT_MS``, NOT the post-click
+    ``_STATUS_CHANGE_TIMEOUT_MS`` — see that constant for why the two are
+    deliberately separate.
     """
-    deadline = _clock.now() + _STATUS_HYDRATION_TIMEOUT_MS / 1000
+    started = _clock.now()
+    deadline = started + _STATUS_HYDRATION_TIMEOUT_MS / 1000
     status = _read_status_text(page)
     while status is None and _clock.now() < deadline:
         page.wait_for_timeout(250)
         status = _read_status_text(page)
+    _log_timing("initial status hydration", started, status)
     return status
 
 
@@ -2189,7 +2243,8 @@ def _click_menu_item_and_wait_for_status(
     attempt, and unarchive is reversible.
     """
     last_seen: Optional[str] = current_status
-    for _ in range(_STATUS_CLICK_MAX_ATTEMPTS):
+    started = _clock.now()
+    for attempt in range(1, _STATUS_CLICK_MAX_ATTEMPTS + 1):
         _click_menu_item(
             page,
             campaign_id,
@@ -2200,6 +2255,7 @@ def _click_menu_item_and_wait_for_status(
             page, current_status=current_status, target_statuses=target_statuses
         )
         if last_seen in target_statuses:
+            _log_timing(f"menu-item click x{attempt}", started, last_seen)
             return last_seen  # type: ignore[return-value]
 
     raise BrowserSessionError(

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -25,19 +25,36 @@ identical between a Мастер campaign and an ordinary one of the same type).
 The one field that does distinguish them, confirmed live against a real
 account, is ``source == "UAC"``.
 
-``suspend_master``/``resume_master`` (issue #630) — **not live-verified**.
-The overview page's "Возобновить кампанию" (resume) button text is confirmed
-live (see the fixture). The suspend-side button text is NOT confirmed live —
-this module tries a short list of plausible Russian labels
-(``_SUSPEND_BUTTON_TEXTS``) via Playwright's text-based locator matching
-(case-insensitive substring), and either action re-reads the page's status
-text after clicking to verify the change actually happened (never trusting
-the click alone — see ``_click_action_button``). If Yandex's real button text
-isn't in that list, both functions raise ``BrowserSessionError`` with a
-message asking the caller to re-run with ``--headful`` and report the actual
-text, rather than clicking the wrong element. Re-confirm the exact button
-text/behaviour against a live account before relying on this in production;
-update ``_SUSPEND_BUTTON_TEXTS``/``_RESUME_BUTTON_TEXTS`` accordingly.
+``suspend_master``/``resume_master`` (issue #630) — **live-verified
+2026-08-06** against campaign 713277109 over 12 real transitions (issues
+#766/#764). Both action buttons carry a stable ``data-testid``, read
+directly off the live DOM rather than guessed:
+``CampaignHeader.ActionButton.stop`` ("Остановить кампанию", rendered while
+ACTIVE/MODERATION) and ``CampaignHeader.ActionButton.resume``
+("Возобновить кампанию", rendered while SUSPENDED). Note the suspend side's
+testid is ``.stop``, named after the Russian label rather than after this
+module's own verb. ``_SUSPEND_BUTTON_TEXTS``/``_RESUME_BUTTON_TEXTS`` are
+retained only as a fallback (and as the vocabulary the "could not find the
+button" error reports), no longer the primary locator.
+
+**The first click on a freshly rendered overview page is frequently a
+silent no-op** — this was issue #766's root cause, and it also explains the
+symptom #758 misattributed to a too-small timeout. Confirmed live by
+capturing every network request after the click: ``.click()`` returns
+without raising, Playwright's actionability checks all pass, and NO request
+is issued at all — React's own click handler was not yet attached. Waiting
+longer cannot help in that state, which is why #766's reporter saw a
+permanent failure that repeated CLI runs never fixed, while ``masters
+update``'s "always works on the second try" behaviour comes from the same
+race resolving itself between runs. ``_click_and_wait_for_status_change``
+therefore re-clicks (up to ``_STATUS_CLICK_MAX_ATTEMPTS``) instead of
+waiting longer, checking the status before each attempt so an
+already-effective click is never repeated — the same treatment
+``_click_and_wait_for_popup`` already gives the "⋮" menu and the rename
+modal (issues #723/#725). Once a click does land, the status text follows
+within 1.6–2.3s (measured, n=12 — see ``_STATUS_CHANGE_TIMEOUT_MS``).
+Either action still re-reads the page's status to verify the change really
+happened, never trusting the click alone.
 
 ``archive_master`` (issue #633, live-recon confirmed no separate "delete"
 exists for Мастер кампаний — only archive; see the issue comment). Both
@@ -376,24 +393,70 @@ _STAT_TILE_TESTID_KEYS = {
     "cost": "cost",
 }
 
-# Overview-page action button text for resume/suspend (see module docstring:
-# resume is confirmed live via the fixture, suspend is NOT — this is a
-# best-effort candidate list of plausible Russian labels, matched
-# case-insensitively as a substring against every button's text).
+# Overview-page action buttons for resume/suspend. Confirmed live 2026-08-06
+# (issue #766) against campaign 713277109: BOTH buttons carry a stable
+# `data-testid` — `CampaignHeader.ActionButton.resume` (label "Возобновить
+# кампанию", rendered while SUSPENDED) and `CampaignHeader.ActionButton.stop`
+# (label "Остановить кампанию", rendered while ACTIVE/MODERATION). The
+# suspend-side testid is `.stop`, NOT `.suspend` — named after the Russian
+# label, not after this module's own verb.
+#
+# These replace text matching as the PRIMARY locator, the same way
+# `_MENU_TRIGGER_SELECTOR`/`_ARCHIVE_MENU_ITEM_SELECTOR` already do for the
+# "⋮" menu: a testid read off a live DOM does not depend on Russian button
+# copy. The text candidates below are kept only as a fallback for the case
+# where Yandex renames a testid, and — separately — because they are what
+# lets `_click_action_button` report what it actually saw on the page when
+# neither locator matches (issue #766 asked for exactly that).
+_RESUME_BUTTON_SELECTOR = '[data-testid="CampaignHeader.ActionButton.resume"]'
+_SUSPEND_BUTTON_SELECTOR = '[data-testid="CampaignHeader.ActionButton.stop"]'
+
+# Fallback label candidates, matched case-insensitively as a substring. Both
+# "Возобновить кампанию" and "Остановить кампанию" are now confirmed live
+# (issue #766) — the suspend side was previously an unverified guess (#630).
+# Note `get_by_text` matches the <span class="dc-Button__text"> INSIDE the
+# button, not the <button> itself, which is why the fallback path resolves
+# `.locator("xpath=ancestor-or-self::button[1]")` before clicking.
 _RESUME_BUTTON_TEXTS = ("Возобновить кампанию", "Возобновить")
 _SUSPEND_BUTTON_TEXTS = ("Остановить кампанию", "Приостановить кампанию", "Остановить")
 
-# How long to wait, after clicking the action button, for the status text to
-# actually change before giving up and reporting a possible false success.
-# Raised from 10s to 60s (issue #758 live verification, 2026-08-05): both a
-# plain suspend and the unarchive->SUSPENDED leg of resume_master timed out
-# at 10s against campaign 713277109 despite the click having genuinely
-# landed (a later `masters get` confirmed the status had in fact changed) --
-# Yandex's own status-text update lagged past the old budget under real
-# conditions. 60s is a practical safety margin, not a measured p99; see
-# follow-up issue for a precise measurement and a possible rework of this
-# whole polling budget.
-_STATUS_CHANGE_TIMEOUT_MS = 60_000
+# How long to wait, after an action-button click, for the status text to
+# actually change before treating that click as a no-op and retrying.
+#
+# Measured live 2026-08-06 (issue #764) against campaign 713277109 over 12
+# real transitions across two runs (suspend and resume, alternating):
+# latency from the *effective* click to the overview page's status text
+# reporting the new status was 1.64s..2.28s (mean 1.8s) — every single
+# sample, with no long tail. The 60s from #758 was never measuring that
+# latency: it was masking the no-op-first-click bug below (issue #766), where
+# the status never changes at all no matter how long you wait. 8s is ~3.5x
+# the observed max, generous for a figure this tightly clustered, and small
+# enough that a genuinely dead click is retried in seconds instead of after a
+# full minute.
+_STATUS_CHANGE_TIMEOUT_MS = 8_000
+
+# How many times to click the action button before giving up (issue #766).
+#
+# Live-confirmed 2026-08-06 against campaign 713277109: the FIRST click on a
+# freshly navigated overview page is frequently a silent no-op — Playwright's
+# actionability checks pass, `.click()` returns without raising, and NO
+# network request is issued at all (verified by capturing every request after
+# the click: only unrelated telemetry). React's own click handler was not yet
+# attached. A second click, a few seconds later, lands and mutates. Over 12
+# measured transitions this needed at most 2 clicks, non-deterministically —
+# it is a hydration race, not a property of a particular action or status.
+#
+# This is the same failure mode `_click_and_wait_for_popup` already handles
+# for the "⋮" menu and the rename modal (issues #723/#725); suspend/resume
+# was simply never given the equivalent retry, so #766's reporter saw a
+# permanent failure that no amount of waiting or re-running could fix.
+#
+# Retrying is safe HERE specifically because suspend/resume is idempotent
+# and reversible, and because each attempt re-checks the status first: if an
+# earlier click did land, the loop exits before clicking again. Contrast
+# `_click_draft_terminal_button`, which deliberately never retries — a
+# duplicated launch is not reversible.
+_STATUS_CLICK_MAX_ATTEMPTS = 4
 
 # Overview page's header title, confirmed live (issue #683) as the earliest
 # stable marker of a rendered wizard overview page — present on BOTH a
@@ -1789,14 +1852,72 @@ def _is_button_disabled(handle: Any) -> bool:
     return False
 
 
-def _click_action_button(page: "Page", candidate_texts: Tuple[str, ...]) -> None:
-    """Click the first visible, enabled button matching one of
-    ``candidate_texts``.
+def _describe_page_buttons(page: "Page") -> str:
+    """Return a short human-readable inventory of the overview page's own
+    action buttons, for inclusion in a "could not find the button" error.
 
-    Raises :class:`BrowserSessionError` if none of the candidates match any
-    visible button — this deliberately does NOT fall back to clicking an
-    unrelated element, since suspend/resume is a real account mutation (see
-    module docstring: the suspend-side button text is not live-confirmed).
+    Issue #766 asked for exactly this: the previous error named only the
+    candidate labels it had searched for, so a reader could not tell whether
+    Yandex had renamed the button, whether the page had rendered a different
+    status than expected, or whether the page had not finished loading at
+    all. Listing what IS on the page turns all three into a one-glance
+    diagnosis without a ``--headful`` re-run.
+
+    Deliberately scoped to ``CampaignHeader.ActionButton*`` plus the header's
+    own status text rather than every button on the page — the sidebar alone
+    contributes a dozen irrelevant ones (Обзор/Кампании/Статистика/…), which
+    would bury the signal.
+    """
+    parts = []
+    with contextlib.suppress(PlaywrightError):
+        buttons = page.locator('[data-testid^="CampaignHeader.ActionButton"]')
+        found = []
+        for i in range(buttons.count()):
+            handle = buttons.nth(i)
+            with contextlib.suppress(PlaywrightError):
+                testid = handle.get_attribute("data-testid")
+                label = (handle.inner_text() or "").strip()
+                state = "disabled" if _is_button_disabled(handle) else "enabled"
+                if not handle.is_visible():
+                    state = "hidden"
+                found.append(f"{testid!r} ({label!r}, {state})")
+        parts.append(
+            "action buttons on the page: " + (", ".join(found) if found else "none")
+        )
+    status = _read_status_text(page)
+    parts.append(f"page status reads as {status!r}")
+    return "; ".join(parts)
+
+
+def _click_action_button(
+    page: "Page",
+    candidate_texts: Tuple[str, ...],
+    *,
+    selector: Optional[str] = None,
+) -> None:
+    """Click the overview page's suspend/resume action button.
+
+    Prefers ``selector`` — a stable ``data-testid``, confirmed live for both
+    actions (issue #766, see ``_RESUME_BUTTON_SELECTOR``/
+    ``_SUSPEND_BUTTON_SELECTOR``) — and falls back to matching
+    ``candidate_texts`` as a case-insensitive substring only if the testid
+    matches nothing, so a future Yandex testid rename degrades to the old
+    behaviour instead of breaking outright.
+
+    The text fallback resolves the matched node's enclosing ``<button>``
+    before clicking. ``get_by_text`` matches the ``<span class=
+    "dc-Button__text">`` *inside* the button, not the button itself
+    (confirmed live, issue #766) — clicking the span happens to work here
+    because the click is dispatched at its coordinates and React's listener
+    sits on an ancestor, but resolving the real button first makes
+    ``_is_button_disabled``'s check meaningful, since ``disabled``/
+    ``aria-disabled`` live on the ``<button>``, never on the inner span.
+
+    Raises :class:`BrowserSessionError` if nothing matches — this
+    deliberately does NOT fall back to clicking an unrelated element, since
+    suspend/resume is a real account mutation. The error names both the
+    selector and the labels that were searched for, and lists what the page
+    actually renders (``_describe_page_buttons``), per issue #766.
 
     A matching button that is visible but disabled (issue #728) is treated
     as a distinct case from "not found": Yandex renders "Остановить
@@ -1807,8 +1928,20 @@ def _click_action_button(page: "Page", candidate_texts: Tuple[str, ...]) -> None
     chasing a markup change that never happened. Raise a specific error
     naming the real cause instead, and keep scanning remaining candidates
     in case a different, enabled match exists.
+
+    NOTE: a click that lands is NOT proof the action ran — see
+    ``_STATUS_CLICK_MAX_ATTEMPTS``. Callers must verify the status actually
+    changed and re-click if it did not; that loop lives in
+    ``_click_and_wait_for_status_change``.
     """
     saw_disabled_match = False
+
+    candidates = []
+    if selector:
+        with contextlib.suppress(PlaywrightError):
+            locator = page.locator(selector)
+            candidates.extend(locator.nth(i) for i in range(locator.count()))
+
     for text in candidate_texts:
         locator = page.get_by_text(text, exact=False)
         try:
@@ -1816,17 +1949,29 @@ def _click_action_button(page: "Page", candidate_texts: Tuple[str, ...]) -> None
         except PlaywrightError:
             continue
         for i in range(count):
-            handle = locator.nth(i)
-            try:
-                if not handle.is_visible():
-                    continue
-                if _is_button_disabled(handle):
-                    saw_disabled_match = True
-                    continue
-                handle.click()
-                return
-            except PlaywrightError:
+            node = locator.nth(i)
+            # Resolve the enclosing <button> (see docstring); fall back to
+            # the matched node itself if it has no button ancestor, which is
+            # what the pre-#766 code always clicked.
+            handle = node
+            with contextlib.suppress(PlaywrightError):
+                enclosing = node.locator("xpath=ancestor-or-self::button[1]")
+                if enclosing.count():
+                    handle = enclosing.first
+            candidates.append(handle)
+
+    for handle in candidates:
+        try:
+            if not handle.is_visible():
                 continue
+            if _is_button_disabled(handle):
+                saw_disabled_match = True
+                continue
+            handle.click()
+            return
+        except PlaywrightError:
+            continue
+
     if saw_disabled_match:
         raise BrowserSessionError(
             "The action button is currently disabled — this happens while "
@@ -1834,10 +1979,57 @@ def _click_action_button(page: "Page", candidate_texts: Tuple[str, ...]) -> None
             "have been rejected. Try again once moderation finishes."
         )
     raise BrowserSessionError(
-        "Could not find an action button matching any of "
-        f"{candidate_texts!r} on the campaign overview page. Yandex may "
-        "have changed the button's text — re-run with --headful to "
-        "inspect the page and report the actual text."
+        "Could not find an action button on the campaign overview page. "
+        f"Searched for selector {selector!r} and, as a fallback, any element "
+        f"whose text contains one of {candidate_texts!r}. What the page "
+        f"actually has — {_describe_page_buttons(page)}. Yandex may have "
+        "changed the button's testid and text — re-run with --headful to "
+        "inspect the page and report what you see."
+    )
+
+
+def _click_and_wait_for_status_change(
+    page: "Page",
+    campaign_id: int,
+    *,
+    current_status: str,
+    target_statuses: Tuple[str, ...],
+    button_texts: Tuple[str, ...],
+    selector: Optional[str] = None,
+    action_description: str,
+) -> str:
+    """Click the action button and confirm the status really changed,
+    re-clicking if it did not (issue #766).
+
+    The overview page's first click after navigation is frequently a silent
+    no-op — see ``_STATUS_CLICK_MAX_ATTEMPTS`` for the live evidence (no
+    network request is issued at all; React's handler was not yet attached).
+    Waiting longer never helps in that state, which is why #766's reporter
+    saw a permanent failure across repeated CLI runs while the pre-existing
+    60s budget (#758/#764) merely made each failure slower.
+
+    Each attempt clicks once, then polls the status for
+    ``_STATUS_CHANGE_TIMEOUT_MS`` (calibrated to the measured 1.6–2.3s real
+    latency, see that constant). Re-clicking is safe because the poll below
+    exits the moment the status does change: an already-effective click is
+    never followed by a second one.
+    """
+    last_seen = current_status
+    for _ in range(_STATUS_CLICK_MAX_ATTEMPTS):
+        _click_action_button(page, button_texts, selector=selector)
+        last_seen = _poll_status(
+            page, current_status=current_status, target_statuses=target_statuses
+        )
+        if last_seen in target_statuses:
+            return last_seen
+
+    raise BrowserSessionError(
+        f"{action_description} for campaign {campaign_id} "
+        f"{_STATUS_CLICK_MAX_ATTEMPTS} times, but its status never changed to "
+        f"any of {target_statuses!r} (still {last_seen!r}) — each click was "
+        f"given {_STATUS_CHANGE_TIMEOUT_MS / 1000:.0f}s to take effect. The "
+        f"page reports: {_describe_page_buttons(page)}. Verify manually "
+        "before retrying."
     )
 
 
@@ -1918,43 +2110,106 @@ def _click_and_wait_for_popup(
     ) from last_exc
 
 
-def _wait_for_status(
+def _poll_status(
     page: "Page",
-    campaign_id: int,
     *,
-    current_status: str,
+    current_status: Optional[str],
     target_statuses: Tuple[str, ...],
-    action_description: str,
-) -> str:
-    """Poll ``_read_status_text`` until it matches one of ``target_statuses``
-    or ``_STATUS_CHANGE_TIMEOUT_MS`` elapses; raise ``BrowserSessionError``
-    on timeout.
+) -> Optional[str]:
+    """Poll ``_read_status_text`` for up to ``_STATUS_CHANGE_TIMEOUT_MS``,
+    returning the last status read — one of ``target_statuses`` if it got
+    there, otherwise whatever it still says.
 
-    Shared by ``_suspend_or_resume`` (the ordinary one-click suspend/resume)
-    and ``resume_master``'s unarchive->SUSPENDED step (issue #758) — both
-    need the identical "click already happened, now confirm the status text
-    actually caught up" loop, just against a different click and a
-    different target. Factored out so a future change to the polling
-    strategy (see ``_STATUS_CHANGE_TIMEOUT_MS``'s own comment about a
-    possible rework, issue #764) only needs to happen once.
+    Unlike the pre-#766 ``_wait_for_status`` this does NOT raise on timeout:
+    a status that has not changed is a normal, expected outcome of the
+    no-op first click (see ``_STATUS_CLICK_MAX_ATTEMPTS``), and the decision
+    to retry or give up belongs to the caller's click loop, not here.
+
+    The measured latency this budget covers is 1.6–2.3s (issue #764, see
+    ``_STATUS_CHANGE_TIMEOUT_MS``); reads that come back ``None`` (the
+    status element momentarily unrendered mid-transition — observed live)
+    are simply polled again rather than treated as a distinct state.
     """
     deadline = _clock.now() + _STATUS_CHANGE_TIMEOUT_MS / 1000
     new_status = current_status
-    while _clock.now() < deadline:
-        new_status = _read_status_text(page)
+    while True:
+        seen = _read_status_text(page)
+        if seen is not None:
+            new_status = seen
         if new_status in target_statuses:
-            break
+            return new_status
+        if _clock.now() >= deadline:
+            return new_status
         page.wait_for_timeout(250)
 
-    if new_status not in target_statuses:
-        raise BrowserSessionError(
-            f"{action_description} for campaign {campaign_id}, but its "
-            f"status did not change to any of {target_statuses!r} within "
-            f"{_STATUS_CHANGE_TIMEOUT_MS / 1000:.0f}s (still {new_status!r}). "
-            "The click may not have hit the right element, or Yandex is "
-            "slow to apply it — verify manually before retrying."
+
+def _wait_for_recognised_status(page: "Page") -> Optional[str]:
+    """Poll ``_read_status_text`` until it returns a recognised status, or
+    ``_STATUS_CHANGE_TIMEOUT_MS`` elapses; return ``None`` if it never does.
+
+    ``_goto_overview_page`` only guarantees the *title* has rendered (issue
+    #683); the status element is a separate render pass and routinely reads
+    as ``None`` for a moment after it. Every caller that branches on the
+    current status needs this wait first — ``resume_master`` had it inline
+    (issue #758 follow-up) but ``_suspend_or_resume`` did not, which
+    live-aborted a real ``masters suspend`` with "unrecognised status text"
+    (issue #766).
+    """
+    deadline = _clock.now() + _STATUS_HYDRATION_TIMEOUT_MS / 1000
+    status = _read_status_text(page)
+    while status is None and _clock.now() < deadline:
+        page.wait_for_timeout(250)
+        status = _read_status_text(page)
+    return status
+
+
+def _click_menu_item_and_wait_for_status(
+    page: "Page",
+    campaign_id: int,
+    *,
+    item_selector: str,
+    item_label: str,
+    current_status: str,
+    target_statuses: Tuple[str, ...],
+) -> str:
+    """``_click_menu_item`` plus the same click-really-landed retry loop
+    ``_click_and_wait_for_status_change`` applies to the action buttons
+    (issue #766).
+
+    ``_click_and_wait_for_popup`` already retries opening the "⋮" menu, but
+    nothing previously retried the click on the menu *item* itself — and
+    that click is subject to the identical hydration no-op (the menu item is
+    rendered by the same React tree). ``resume_master``'s unarchive step is
+    the only caller; before #766 it clicked once and then waited out the
+    full status budget, which is exactly the failure shape #764 recorded for
+    the unarchive leg.
+
+    Safe to retry for the same reason the action-button loop is: re-opening
+    the menu has no side effect, the status is re-checked before each
+    attempt, and unarchive is reversible.
+    """
+    last_seen: Optional[str] = current_status
+    for _ in range(_STATUS_CLICK_MAX_ATTEMPTS):
+        _click_menu_item(
+            page,
+            campaign_id,
+            item_selector=item_selector,
+            item_label=item_label,
         )
-    return new_status
+        last_seen = _poll_status(
+            page, current_status=current_status, target_statuses=target_statuses
+        )
+        if last_seen in target_statuses:
+            return last_seen  # type: ignore[return-value]
+
+    raise BrowserSessionError(
+        f"Clicked {item_label!r} for campaign {campaign_id} "
+        f"{_STATUS_CLICK_MAX_ATTEMPTS} times, but its status never changed to "
+        f"any of {target_statuses!r} (still {last_seen!r}) — each click was "
+        f"given {_STATUS_CHANGE_TIMEOUT_MS / 1000:.0f}s to take effect. The "
+        f"page reports: {_describe_page_buttons(page)}. Verify manually "
+        "before retrying."
+    )
 
 
 def _suspend_or_resume(
@@ -1963,6 +2218,7 @@ def _suspend_or_resume(
     *,
     target_statuses: Tuple[str, ...],
     button_texts: Tuple[str, ...],
+    button_selector: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Shared body for ``suspend_master``/``resume_master``.
 
@@ -1971,7 +2227,10 @@ def _suspend_or_resume(
     (mirrors the rest of the CLI's suspend/resume convention). Otherwise
     clicks the matching action button and re-reads the status to confirm the
     mutation actually took effect — a click that doesn't visibly change the
-    status is reported as a hard error, not a silent success.
+    status is retried up to ``_STATUS_CLICK_MAX_ATTEMPTS`` times (issue
+    #766: the first click on a freshly-rendered page is often a silent
+    no-op) and only then reported as a hard error, never as a silent
+    success.
 
     ``target_statuses`` is a tuple, not a single status, because resuming a
     SUSPENDED campaign can land in either ACTIVE or MODERATION depending on
@@ -1994,11 +2253,22 @@ def _suspend_or_resume(
             "state to suspend/resume. Launch it first (masters launch)."
         )
 
-    current_status = _read_status_text(page)
+    # Poll rather than read once: _goto_overview_page only guarantees the
+    # title rendered (issue #683), and the status element is a separate
+    # render pass that routinely still reads as None immediately after it.
+    # Live-confirmed 2026-08-06 (issue #766) — a bare single read here
+    # aborted a real `masters suspend` with "unrecognised status text" on a
+    # campaign whose status was perfectly readable a second later.
+    # resume_master already had this poll on its own pre-branch read; this
+    # is the same wait, now also covering the suspend path and resume's
+    # second leg. _read_status_text returning None forever (a genuinely
+    # unrecognised status) still raises below.
+    current_status = _wait_for_recognised_status(page)
     if current_status is None:
         raise BrowserSessionError(
             f"Could not determine current status for campaign {campaign_id} "
-            "(unrecognised status text) — refusing to click blind."
+            "(unrecognised status text) — refusing to click blind. The page "
+            f"reports: {_describe_page_buttons(page)}."
         )
     if current_status in target_statuses:
         print_warning(
@@ -2006,13 +2276,13 @@ def _suspend_or_resume(
         )
         return {"CampaignId": campaign_id, "Status": current_status}
 
-    _click_action_button(page, button_texts)
-
-    new_status = _wait_for_status(
+    new_status = _click_and_wait_for_status_change(
         page,
         campaign_id,
         current_status=current_status,
         target_statuses=target_statuses,
+        button_texts=button_texts,
+        selector=button_selector,
         action_description="Clicked the action button",
     )
 
@@ -2022,14 +2292,17 @@ def _suspend_or_resume(
 def suspend_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
     """Stop (suspend) a Мастер кампаний, verifying the status actually changed.
 
-    See module docstring: the "stop" button's exact text is NOT confirmed
-    live — ``_SUSPEND_BUTTON_TEXTS`` is a best-effort candidate list.
+    Live-verified 2026-08-06 (issue #766) against campaign 713277109: the
+    button is ``CampaignHeader.ActionButton.stop``, labelled "Остановить
+    кампанию" — both the testid and the label are now confirmed, replacing
+    #630's unverified guess.
     """
     return _suspend_or_resume(
         page,
         campaign_id,
         target_statuses=("SUSPENDED",),
         button_texts=_SUSPEND_BUTTON_TEXTS,
+        button_selector=_SUSPEND_BUTTON_SELECTOR,
     )
 
 
@@ -2064,24 +2337,15 @@ def resume_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
     # does not have (issue #758 follow-up). _suspend_or_resume's own
     # ``current_status is None`` check below remains the final safety net
     # for a genuinely unrecognised status that never hydrates.
-    deadline = _clock.now() + _STATUS_CHANGE_TIMEOUT_MS / 1000
-    current_status = _read_status_text(page)
-    while current_status is None and _clock.now() < deadline:
-        page.wait_for_timeout(250)
-        current_status = _read_status_text(page)
+    current_status = _wait_for_recognised_status(page)
     if current_status == "ARCHIVED":
-        _click_menu_item(
+        _click_menu_item_and_wait_for_status(
             page,
             campaign_id,
             item_selector=_UNARCHIVE_MENU_ITEM_SELECTOR,
             item_label="Разархивировать",
-        )
-        _wait_for_status(
-            page,
-            campaign_id,
             current_status=current_status,
             target_statuses=("SUSPENDED",),
-            action_description="Clicked 'Разархивировать'",
         )
 
     return _suspend_or_resume(
@@ -2089,6 +2353,7 @@ def resume_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
         campaign_id,
         target_statuses=("ACTIVE", "MODERATION"),
         button_texts=_RESUME_BUTTON_TEXTS,
+        button_selector=_RESUME_BUTTON_SELECTOR,
     )
 
 

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -48,13 +48,22 @@ permanent failure that repeated CLI runs never fixed, while ``masters
 update``'s "always works on the second try" behaviour comes from the same
 race resolving itself between runs. ``_click_and_wait_for_status_change``
 therefore re-clicks (up to ``_STATUS_CLICK_MAX_ATTEMPTS``) instead of
-waiting longer, checking the status before each attempt so an
+waiting longer, re-reading the status immediately before every retry so an
 already-effective click is never repeated — the same treatment
 ``_click_and_wait_for_popup`` already gives the "⋮" menu and the rename
 modal (issues #723/#725). Once a click does land, the status text follows
 within 1.6–2.3s (measured, n=12 — see ``_STATUS_CHANGE_TIMEOUT_MS``).
 Either action still re-reads the page's status to verify the change really
 happened, never trusting the click alone.
+
+That pre-retry re-read matters because the poll has a deadline: a click
+whose status update arrives after it must not be clicked again, or suspend
+would toggle straight back and unarchive would re-archive. For the same
+reason a button that has *vanished* between the read and the click is
+checked against the status before being reported as missing — for
+``resume`` the page swaps ``.resume`` for ``.stop`` the moment the status
+flips, so "the button is gone" is usually proof the mutation succeeded, not
+evidence of a markup change.
 
 ``archive_master`` (issue #633, live-recon confirmed no separate "delete"
 exists for Мастер кампаний — only archive; see the issue comment). Both
@@ -2051,22 +2060,52 @@ def _click_and_wait_for_status_change(
     saw a permanent failure across repeated CLI runs while the pre-existing
     60s budget (#758/#764) merely made each failure slower.
 
-    Each attempt clicks once, then polls the status for
-    ``_STATUS_CHANGE_TIMEOUT_MS`` (calibrated to the measured 1.6–2.3s real
-    latency, see that constant). Re-clicking is safe because the poll below
-    exits the moment the status does change: an already-effective click is
-    never followed by a second one.
+    Each attempt re-reads the status BEFORE clicking, then clicks once, then
+    polls for ``_STATUS_CHANGE_TIMEOUT_MS`` (calibrated to the measured
+    1.6–2.3s real latency, see that constant).
+
+    The pre-click re-read is what makes re-clicking safe. The poll alone is
+    not enough: it gives up at the 8s deadline, so a click that lands but
+    whose status update arrives late would otherwise be followed by a second
+    click that undoes it. Worse for ``resume`` — once the status flips, the
+    DOM swaps ``CampaignHeader.ActionButton.resume`` for ``.stop``, so the
+    re-click finds neither the testid nor the fallback labels and raises
+    "could not find an action button" for a mutation that actually
+    succeeded. Reading first turns both cases into a plain success.
     """
-    last_seen = current_status
+    last_seen: Optional[str] = current_status
     started = _clock.now()
     for attempt in range(1, _STATUS_CLICK_MAX_ATTEMPTS + 1):
-        _click_action_button(page, button_texts, selector=selector)
+        if attempt > 1:
+            # A previous attempt's click may have landed after its poll gave
+            # up (see docstring) -- check before clicking again, never after.
+            seen = _read_status_text(page)
+            if seen is not None:
+                last_seen = seen
+            if last_seen in target_statuses:
+                _log_timing(f"landed late, before click x{attempt}", started, last_seen)
+                return last_seen  # type: ignore[return-value]
+
+        try:
+            _click_action_button(page, button_texts, selector=selector)
+        except BrowserSessionError:
+            # The button can legitimately vanish between the read above and
+            # this click: the status flipped in that window, and the page
+            # re-rendered the opposite action (resume -> stop). Re-read once
+            # before surfacing this -- "button gone because we already
+            # succeeded" must not be reported as a failure.
+            seen = _read_status_text(page)
+            if seen in target_statuses:
+                _log_timing(f"button gone, already {seen}", started, seen)
+                return seen  # type: ignore[return-value]
+            raise
+
         last_seen = _poll_status(
             page, current_status=current_status, target_statuses=target_statuses
         )
         if last_seen in target_statuses:
             _log_timing(f"action-button click x{attempt}", started, last_seen)
-            return last_seen
+            return last_seen  # type: ignore[return-value]
 
     raise BrowserSessionError(
         f"{action_description} for campaign {campaign_id} "
@@ -2245,12 +2284,34 @@ def _click_menu_item_and_wait_for_status(
     last_seen: Optional[str] = current_status
     started = _clock.now()
     for attempt in range(1, _STATUS_CLICK_MAX_ATTEMPTS + 1):
-        _click_menu_item(
-            page,
-            campaign_id,
-            item_selector=item_selector,
-            item_label=item_label,
-        )
+        if attempt > 1:
+            # Same pre-click re-read as the action-button loop: a click whose
+            # status update arrived after its poll gave up must not be
+            # followed by another one (unarchive is reversible, but a
+            # re-archive would be a real, unwanted mutation).
+            seen = _read_status_text(page)
+            if seen is not None:
+                last_seen = seen
+            if last_seen in target_statuses:
+                _log_timing(f"landed late, before click x{attempt}", started, last_seen)
+                return last_seen  # type: ignore[return-value]
+
+        try:
+            _click_menu_item(
+                page,
+                campaign_id,
+                item_selector=item_selector,
+                item_label=item_label,
+            )
+        except BrowserSessionError:
+            # The menu item disappears once the campaign leaves ARCHIVED --
+            # "gone because it worked" is a success, not a failure.
+            seen = _read_status_text(page)
+            if seen in target_statuses:
+                _log_timing(f"menu item gone, already {seen}", started, seen)
+                return seen  # type: ignore[return-value]
+            raise
+
         last_seen = _poll_status(
             page, current_status=current_status, target_statuses=target_statuses
         )

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -322,6 +322,63 @@ def masters():
     """Мастер кампаний (Campaign Wizard) — browser-only, no API"""
 
 
+def _run_per_id(
+    ctx,
+    ids,
+    action,
+    *,
+    headful,
+    profile_dir,
+    chrome_profile,
+    output_format,
+    output,
+    verb: str,
+):
+    """Run ``action(page, campaign_id)`` for every ID, never stopping at the
+    first failure, then report every outcome.
+
+    Extracted from ``launch``/``archive``, which each had their own copy of
+    this loop (issue #645), and now shared with ``suspend``/``resume`` too
+    (issue #766: a batch of eight IDs aborted on the first one, leaving the
+    caller with no idea whether the other seven had been attempted, let
+    alone what happened to them).
+
+    Every ID is attempted even if an earlier one fails: these are real
+    account mutations, so a fail-fast loop would silently lose the report
+    that earlier IDs already changed in production before a later one
+    errored. Each ID's outcome — the resulting row, or an ``Error`` entry —
+    goes into the formatted output; if any ID failed, the command exits
+    non-zero after printing every outcome, never just the last error.
+    """
+
+    def _all(page):
+        from ..browser.session import BrowserSessionError
+        from ..browser.masters import PlaywrightError
+
+        results = []
+        errors = []
+        for campaign_id in ids:
+            try:
+                results.append(action(page, campaign_id))
+            except (BrowserSessionError, PlaywrightError) as exc:
+                errors.append((campaign_id, exc))
+                results.append({"CampaignId": campaign_id, "Error": str(exc)})
+        return results, errors
+
+    results, errors = _with_session(ctx, headful, profile_dir, chrome_profile, _all)
+
+    format_output(results if len(results) != 1 else results[0], output_format, output)
+
+    if errors:
+        for campaign_id, exc in errors:
+            print_error(f"Campaign {campaign_id}: {exc}")
+        raise click.ClickException(
+            f"Failed to {verb} {len(errors)} of {len(ids)} campaign(s); "
+            "see per-ID results above."
+        )
+    return results
+
+
 def _stdin_is_interactive() -> bool:
     """Return whether a human is present to complete a browser login.
 
@@ -529,22 +586,31 @@ def suspend(
 ):
     """Stop one or more Мастер кампаний by ID (comma-separated)
 
-    Not live-verified (issue #630): clicks the overview page's stop button,
-    matched by a best-effort list of candidate Russian labels — see
-    ``direct_cli/browser/masters.py`` module docstring. Verifies the status
-    actually changed before reporting success; idempotent if already
-    stopped.
+    Live-verified 2026-08-06 (issue #766): clicks the overview page's
+    "Остановить кампанию" button (``CampaignHeader.ActionButton.stop``, a
+    confirmed stable testid — the earlier best-effort label guessing from
+    #630 is now only a fallback). Verifies the status actually changed
+    before reporting success, re-clicking if the first click was a silent
+    no-op; idempotent if already stopped.
+
+    Every ID is attempted even if an earlier one fails, and each ID's
+    outcome (the row, or its error) is reported — see ``_run_per_id``.
     """
     from ..browser.masters import suspend_master
 
     ids = parse_ids(campaign_ids) or []
 
-    def _suspend_all(page):
-        return [suspend_master(page, campaign_id) for campaign_id in ids]
-
-    results = _with_session(ctx, headful, profile_dir, chrome_profile, _suspend_all)
-
-    format_output(results if len(results) != 1 else results[0], output_format, output)
+    _run_per_id(
+        ctx,
+        ids,
+        suspend_master,
+        headful=headful,
+        profile_dir=profile_dir,
+        chrome_profile=chrome_profile,
+        output_format=output_format,
+        output=output,
+        verb="suspend",
+    )
 
 
 def _parse_repeating_slot_options(
@@ -1675,21 +1741,31 @@ def resume(
 ):
     """Resume one or more stopped Мастер кампаний by ID (comma-separated)
 
-    Clicks the overview page's "Возобновить кампанию" button (confirmed
-    live — see ``direct_cli/browser/masters.py`` module docstring). Verifies
-    the status actually changed before reporting success; idempotent if
-    already active.
+    Clicks the overview page's "Возобновить кампанию" button
+    (``CampaignHeader.ActionButton.resume``, confirmed live — see
+    ``direct_cli/browser/masters.py`` module docstring). Verifies the status
+    actually changed before reporting success, re-clicking if the first
+    click was a silent no-op (issue #766); idempotent if already active.
+    An ARCHIVED campaign is unarchived to SUSPENDED first (issue #758).
+
+    Every ID is attempted even if an earlier one fails, and each ID's
+    outcome (the row, or its error) is reported — see ``_run_per_id``.
     """
     from ..browser.masters import resume_master
 
     ids = parse_ids(campaign_ids) or []
 
-    def _resume_all(page):
-        return [resume_master(page, campaign_id) for campaign_id in ids]
-
-    results = _with_session(ctx, headful, profile_dir, chrome_profile, _resume_all)
-
-    format_output(results if len(results) != 1 else results[0], output_format, output)
+    _run_per_id(
+        ctx,
+        ids,
+        resume_master,
+        headful=headful,
+        profile_dir=profile_dir,
+        chrome_profile=chrome_profile,
+        output_format=output_format,
+        output=output,
+        verb="resume",
+    )
 
 
 @masters.command()
@@ -1725,33 +1801,17 @@ def launch(
 
     ids = parse_ids(campaign_ids) or []
 
-    def _launch_all(page):
-        from ..browser.session import BrowserSessionError
-        from ..browser.masters import PlaywrightError
-
-        results = []
-        errors = []
-        for campaign_id in ids:
-            try:
-                results.append(launch_master(page, campaign_id))
-            except (BrowserSessionError, PlaywrightError) as exc:
-                errors.append((campaign_id, exc))
-                results.append({"CampaignId": campaign_id, "Error": str(exc)})
-        return results, errors
-
-    results, errors = _with_session(
-        ctx, headful, profile_dir, chrome_profile, _launch_all
+    _run_per_id(
+        ctx,
+        ids,
+        launch_master,
+        headful=headful,
+        profile_dir=profile_dir,
+        chrome_profile=chrome_profile,
+        output_format=output_format,
+        output=output,
+        verb="launch",
     )
-
-    format_output(results if len(results) != 1 else results[0], output_format, output)
-
-    if errors:
-        for campaign_id, exc in errors:
-            print_error(f"Campaign {campaign_id}: {exc}")
-        raise click.ClickException(
-            f"Failed to launch {len(errors)} of {len(ids)} campaign(s); "
-            "see per-ID results above."
-        )
 
 
 @masters.command()
@@ -1791,33 +1851,17 @@ def archive(
 
     ids = parse_ids(campaign_ids) or []
 
-    def _archive_all(page):
-        from ..browser.session import BrowserSessionError
-        from ..browser.masters import PlaywrightError
-
-        results = []
-        errors = []
-        for campaign_id in ids:
-            try:
-                results.append(archive_master(page, campaign_id))
-            except (BrowserSessionError, PlaywrightError) as exc:
-                errors.append((campaign_id, exc))
-                results.append({"CampaignId": campaign_id, "Error": str(exc)})
-        return results, errors
-
-    results, errors = _with_session(
-        ctx, headful, profile_dir, chrome_profile, _archive_all
+    _run_per_id(
+        ctx,
+        ids,
+        archive_master,
+        headful=headful,
+        profile_dir=profile_dir,
+        chrome_profile=chrome_profile,
+        output_format=output_format,
+        output=output,
+        verb="archive",
     )
-
-    format_output(results if len(results) != 1 else results[0], output_format, output)
-
-    if errors:
-        for campaign_id, exc in errors:
-            print_error(f"Campaign {campaign_id}: {exc}")
-        raise click.ClickException(
-            f"Failed to archive {len(errors)} of {len(ids)} campaign(s); "
-            "see per-ID results above."
-        )
 
 
 @masters.command()

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -463,6 +463,24 @@ class _FakeExpectResponseExitRaises(_FakeExpectResponse):
         return False
 
 
+class _FakeAncestorLocator:
+    """Result of ``handle.locator("xpath=ancestor-or-self::button[1]")``.
+
+    ``count()`` is 0 when the matched node has no enclosing ``<button>``,
+    in which case ``_click_action_button`` clicks the node itself.
+    """
+
+    def __init__(self, button):
+        self._button = button
+
+    def count(self):
+        return 1 if self._button is not None else 0
+
+    @property
+    def first(self):
+        return self._button
+
+
 class _FakeTextLocatorHandle:
     """One matched element for ``get_by_text`` — supports ``is_visible``/``click``.
 
@@ -478,12 +496,24 @@ class _FakeTextLocatorHandle:
         raises=False,
         disabled=False,
         aria_disabled=None,
+        button_ancestor=None,
     ):
         self._visible = visible
         self._on_click = on_click
         self._raises = raises
         self._disabled = disabled
         self._aria_disabled = aria_disabled
+        # Models the `xpath=ancestor-or-self::button[1]` resolution
+        # `_click_action_button` performs (issue #766): real Yandex markup
+        # matches the <span> inside the button, so the module walks up to the
+        # <button> before clicking. `None` models a match with no button
+        # ancestor, where the module clicks the matched node itself.
+        self._button_ancestor = button_ancestor
+
+    def locator(self, selector):
+        if "ancestor-or-self::button" not in selector:
+            raise AssertionError(f"unexpected locator selector: {selector!r}")
+        return _FakeAncestorLocator(self._button_ancestor)
 
     def is_visible(self):
         if self._raises:
@@ -2825,10 +2855,10 @@ class TestFetchMasterDraft(unittest.TestCase):
 class TestSuspendResumeMaster(unittest.TestCase):
     """suspend_master/resume_master (issue #630): click + verify, idempotent.
 
-    See direct_cli/browser/masters.py module docstring: the suspend-side
-    button text is NOT live-confirmed, only a best-effort candidate list --
-    these tests exercise the click/verify/idempotency mechanics against that
-    candidate list, not a live-verified button text.
+    Both button labels AND their `data-testid`s are live-confirmed as of
+    issue #766 (2026-08-06). These tests drive the text-fallback path
+    (`FakePage` has no testid-matching locator), which is exactly the
+    degradation path the module keeps for a future Yandex testid rename.
     """
 
     def _page_with_button(
@@ -2917,7 +2947,184 @@ class TestSuspendResumeMaster(unittest.TestCase):
 
         with self.assertRaises(BrowserSessionError) as ctx:
             browser_masters.suspend_master(page, 42)
-        self.assertIn("did not change", str(ctx.exception))
+        self.assertIn("never changed", str(ctx.exception))
+
+    def test_suspend_retries_click_when_first_one_is_a_no_op(self):
+        """Issue #766: the first click on a freshly rendered overview page
+        is frequently a silent no-op — Playwright's actionability checks all
+        pass, `.click()` returns without raising, and no request is issued at
+        all (React's handler was not yet attached). Confirmed live
+        2026-08-06 against campaign 713277109 by capturing every request
+        after the click. Waiting longer cannot fix that state; only a second
+        click can, which is why the pre-#766 code failed permanently no
+        matter how large `_STATUS_CHANGE_TIMEOUT_MS` was set.
+        """
+        state = {"status": "Кампания активна", "clicks": 0}
+
+        def _click():
+            state["clicks"] += 1
+            # First click does nothing at all — the no-op.
+            if state["clicks"] >= 2:
+                state["status"] = "Кампания остановлена"
+
+        page = FakePage(
+            text_buttons={
+                "Остановить кампанию": _FakeGetByTextLocator(
+                    [_FakeTextLocatorHandle(visible=True, on_click=_click)]
+                )
+            },
+        )
+        page.inner_text = lambda selector=None: state["status"]
+
+        result = browser_masters.suspend_master(page, 42)
+
+        self.assertEqual(result, {"CampaignId": 42, "Status": "SUSPENDED"})
+        self.assertEqual(state["clicks"], 2)
+
+    def test_suspend_does_not_click_again_once_status_changed(self):
+        """The retry loop must stop as soon as the status changes — a second
+        click on an already-effective suspend would toggle it back.
+        """
+        state = {"status": "Кампания активна", "clicks": 0}
+
+        def _click():
+            state["clicks"] += 1
+            state["status"] = (
+                "Кампания остановлена"
+                if state["status"] == "Кампания активна"
+                else "Кампания активна"
+            )
+
+        page = FakePage(
+            text_buttons={
+                "Остановить кампанию": _FakeGetByTextLocator(
+                    [_FakeTextLocatorHandle(visible=True, on_click=_click)]
+                )
+            },
+        )
+        page.inner_text = lambda selector=None: state["status"]
+
+        result = browser_masters.suspend_master(page, 42)
+
+        self.assertEqual(result, {"CampaignId": 42, "Status": "SUSPENDED"})
+        self.assertEqual(state["clicks"], 1)
+
+    def test_suspend_prefers_the_stable_testid_over_the_text_fallback(self):
+        """Issue #766: the action buttons carry live-confirmed testids
+        (`CampaignHeader.ActionButton.stop`/`.resume`); the Russian-label
+        candidates are only a fallback. A page offering BOTH must be clicked
+        via the testid.
+        """
+        state = {"status": "Кампания активна", "clicked": []}
+
+        def _by_testid():
+            state["clicked"].append("testid")
+            state["status"] = "Кампания остановлена"
+
+        def _by_text():
+            state["clicked"].append("text")
+            state["status"] = "Кампания остановлена"
+
+        page = FakePage(
+            locators={
+                browser_masters._SUSPEND_BUTTON_SELECTOR: _FakeLocator(
+                    [_FakeTextLocatorHandle(visible=True, on_click=_by_testid)]
+                )
+            },
+            text_buttons={
+                "Остановить кампанию": _FakeGetByTextLocator(
+                    [_FakeTextLocatorHandle(visible=True, on_click=_by_text)]
+                )
+            },
+        )
+        page.inner_text = lambda selector=None: state["status"]
+
+        result = browser_masters.suspend_master(page, 42)
+
+        self.assertEqual(result, {"CampaignId": 42, "Status": "SUSPENDED"})
+        self.assertEqual(state["clicked"], ["testid"])
+
+    def test_text_fallback_clicks_the_enclosing_button_not_the_span(self):
+        """Issue #766: `get_by_text` matches the `<span class=
+        "dc-Button__text">` INSIDE the button, not the button (confirmed
+        live). `_is_button_disabled`'s checks only mean anything against the
+        `<button>`, so the fallback resolves the ancestor before clicking.
+        """
+        state = {"status": "Кампания активна", "clicked": []}
+
+        button = _FakeTextLocatorHandle(
+            visible=True,
+            on_click=lambda: (
+                state["clicked"].append("button"),
+                state.__setitem__("status", "Кампания остановлена"),
+            ),
+        )
+        span = _FakeTextLocatorHandle(
+            visible=True,
+            on_click=lambda: state["clicked"].append("span"),
+            button_ancestor=button,
+        )
+
+        page = FakePage(
+            text_buttons={"Остановить кампанию": _FakeGetByTextLocator([span])},
+        )
+        page.inner_text = lambda selector=None: state["status"]
+
+        result = browser_masters.suspend_master(page, 42)
+
+        self.assertEqual(result, {"CampaignId": 42, "Status": "SUSPENDED"})
+        self.assertEqual(state["clicked"], ["button"])
+
+    def test_not_found_error_reports_selector_and_what_the_page_has(self):
+        """Issue #766 asked for an error that distinguishes "Yandex renamed
+        the button" from "the page rendered a different status" — so it
+        names the selector AND the labels searched for, and lists the action
+        buttons the page actually has.
+        """
+        page = FakePage(body_text="Кампания активна")
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.suspend_master(page, 42)
+
+        message = str(ctx.exception)
+        self.assertIn(browser_masters._SUSPEND_BUTTON_SELECTOR, message)
+        self.assertIn("Остановить кампанию", message)
+        self.assertIn("action buttons on the page: none", message)
+        self.assertIn("page status reads as 'ACTIVE'", message)
+
+    def test_status_read_is_polled_not_read_once(self):
+        """Issue #766: `_goto_overview_page` only guarantees the *title*
+        rendered (#683); the status element is a separate render pass that
+        routinely still reads as None right after it. A single read here
+        live-aborted a real `masters suspend` with "unrecognised status
+        text" on a campaign whose status was readable a moment later.
+        """
+        state = {"reads": 0, "status": "Кампания активна"}
+
+        def _inner_text(selector=None):
+            state["reads"] += 1
+            # Status element not yet rendered for the first few reads.
+            return "" if state["reads"] <= 3 else state["status"]
+
+        page = FakePage(
+            text_buttons={
+                "Остановить кампанию": _FakeGetByTextLocator(
+                    [
+                        _FakeTextLocatorHandle(
+                            visible=True,
+                            on_click=lambda: state.__setitem__(
+                                "status", "Кампания остановлена"
+                            ),
+                        )
+                    ]
+                )
+            },
+        )
+        page.inner_text = _inner_text
+
+        result = browser_masters.suspend_master(page, 42)
+
+        self.assertEqual(result, {"CampaignId": 42, "Status": "SUSPENDED"})
 
     def test_resume_raises_when_current_status_unrecognised(self):
         page = FakePage(body_text="something Yandex changed the markup to")
@@ -3133,7 +3340,7 @@ class TestSuspendResumeMaster(unittest.TestCase):
         with self.assertRaises(BrowserSessionError) as ctx:
             browser_masters.resume_master(page, 713277109)
         self.assertIn("Разархивировать", str(ctx.exception))
-        self.assertIn("did not change to any of ('SUSPENDED',)", str(ctx.exception))
+        self.assertIn("never changed to any of ('SUSPENDED',)", str(ctx.exception))
 
     def test_resume_from_archived_waits_for_status_to_hydrate(self):
         # issue #758 follow-up: _goto_overview_page only guarantees the
@@ -3237,6 +3444,51 @@ class TestMastersSuspendResumeCommand(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertEqual(mock_resume.call_count, 1)
+
+    def test_suspend_continues_batch_past_a_failing_id(self):
+        """Issue #766: a real 8-ID `masters suspend` aborted on the first ID,
+        leaving the caller with no idea whether the other seven had even
+        been attempted. Every ID must be tried, and every outcome reported.
+        """
+
+        def _suspend(page, campaign_id):
+            if campaign_id == 2:
+                raise BrowserSessionError("boom for 2")
+            return {"CampaignId": campaign_id, "Status": "SUSPENDED"}
+
+        with (
+            patch("direct_cli.browser.masters.suspend_master", side_effect=_suspend),
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            result = self.runner.invoke(cli, ["masters", "suspend", "1,2,3"])
+
+        # Non-zero exit, but only AFTER every ID was attempted and reported.
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn('"CampaignId": 1', result.output)
+        self.assertIn('"CampaignId": 3', result.output)
+        self.assertIn("boom for 2", result.output)
+        self.assertIn("Failed to suspend 1 of 3 campaign(s)", result.output)
+
+    def test_resume_continues_batch_past_a_failing_id(self):
+        def _resume(page, campaign_id):
+            if campaign_id == 1:
+                raise BrowserSessionError("boom for 1")
+            return {"CampaignId": campaign_id, "Status": "ACTIVE"}
+
+        with (
+            patch("direct_cli.browser.masters.resume_master", side_effect=_resume),
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            result = self.runner.invoke(cli, ["masters", "resume", "1,2"])
+
+        self.assertNotEqual(result.exit_code, 0)
+        # The FIRST id failing must not stop the second one (issue #766's
+        # exact reported shape: the error was always about the first ID).
+        self.assertIn('"CampaignId": 2', result.output)
+        self.assertIn("boom for 1", result.output)
+        self.assertIn("Failed to resume 1 of 2 campaign(s)", result.output)
 
 
 class _FakeHydratingPopupHandle(_FakeLocatorHandle):

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -3009,6 +3009,125 @@ class TestSuspendResumeMaster(unittest.TestCase):
         self.assertEqual(result, {"CampaignId": 42, "Status": "SUSPENDED"})
         self.assertEqual(state["clicks"], 1)
 
+    def test_no_second_click_when_the_first_lands_after_the_poll_deadline(self):
+        """A click whose status update arrives only after the poll gave up
+        must not be clicked again — the retry loop re-reads the status
+        immediately before every retry, so the late-but-successful click is
+        recognised instead of being undone.
+
+        Without that pre-click re-read the loop would click a second time and
+        toggle the campaign straight back to ACTIVE, reporting a failure for
+        a mutation that had in fact succeeded.
+        """
+        state = {"status": "Кампания активна", "clicks": 0, "poll_done": False}
+
+        def _click():
+            state["clicks"] += 1
+            # Each click toggles: a second one would undo the first.
+            state["status"] = (
+                "Кампания остановлена"
+                if state["status"] == "Кампания активна"
+                else "Кампания активна"
+            )
+
+        page = FakePage(
+            text_buttons={
+                "Остановить кампанию": _FakeGetByTextLocator(
+                    [_FakeTextLocatorHandle(visible=True, on_click=_click)]
+                )
+            },
+        )
+
+        # Model "the update landed just after the poll's deadline": every read
+        # the first attempt's poll makes still reports the OLD status, so the
+        # poll times out and the loop goes around for a second attempt. Only
+        # then does the real (already-changed) status become visible -- which
+        # is exactly what the pre-click re-read must catch.
+        # Hide the change for exactly as many reads as the first attempt's
+        # poll makes (its full budget, since it never sees a target status),
+        # so the poll times out and the loop goes around. The very next read
+        # is attempt 2's pre-click re-read -- the one under test.
+        poll_reads = int(browser_masters._STATUS_CHANGE_TIMEOUT_MS / 250) + 1
+        reads = {"n": 0}
+
+        def _inner_text(selector=None):
+            if not state["clicks"]:
+                return "Кампания активна"
+            reads["n"] += 1
+            if reads["n"] <= poll_reads:
+                return "Кампания активна"
+            return state["status"]
+
+        page.inner_text = _inner_text
+
+        result = browser_masters.suspend_master(page, 42)
+
+        # The button stays present throughout, so the ONLY thing that can stop
+        # a second (toggling) click is the pre-click re-read -- this test does
+        # not share the vanished-button escape hatch the next one covers.
+
+        self.assertEqual(result, {"CampaignId": 42, "Status": "SUSPENDED"})
+        self.assertEqual(
+            state["clicks"],
+            1,
+            "the late-landing first click must be detected by the pre-retry "
+            "re-read, not followed by a second click that toggles it back",
+        )
+
+    def test_vanished_button_is_success_when_status_already_changed(self):
+        """Once the status flips, the page swaps `.resume` for `.stop` — so a
+        button that disappeared between the status read and the click is
+        proof the mutation succeeded, not a markup change. It must not be
+        reported as "could not find an action button".
+        """
+        state = {"status": "Кампания активна", "clicks": 0}
+
+        def _click():
+            state["clicks"] += 1
+            state["status"] = "Кампания остановлена"
+
+        # Visible for the first click, gone afterwards (as the real page does
+        # once the status flips and it re-renders the opposite action).
+        class _VanishingLocator:
+            def count(self):
+                return 0 if state["clicks"] else 1
+
+            def nth(self, i):
+                return _FakeTextLocatorHandle(visible=True, on_click=_click)
+
+        page = FakePage(
+            text_buttons={"Остановить кампанию": _VanishingLocator()},
+        )
+
+        # Same late-landing shape as the test above, but here the pre-click
+        # re-read is deliberately starved: the status stays hidden until AFTER
+        # that read, so the loop reaches `_click_action_button` and finds the
+        # button gone. That must resolve to success, not "could not find".
+        # Hide the change through the first attempt's whole poll AND through
+        # attempt 2's pre-click re-read, so the loop actually reaches
+        # `_click_action_button` and hits the vanished button. Only the read
+        # inside the resulting rescue path sees the true status -- which is
+        # precisely the branch under test.
+        poll_reads = int(browser_masters._STATUS_CHANGE_TIMEOUT_MS / 250) + 1
+        reads = {"n": 0}
+
+        def _inner_text(selector=None):
+            if not state["clicks"]:
+                return "Кампания активна"
+            reads["n"] += 1
+            # +1 for attempt 2's pre-click re-read, which must NOT be the one
+            # that rescues this case.
+            if reads["n"] <= poll_reads + 1:
+                return "Кампания активна"
+            return state["status"]
+
+        page.inner_text = _inner_text
+
+        result = browser_masters.suspend_master(page, 42)
+
+        self.assertEqual(result, {"CampaignId": 42, "Status": "SUSPENDED"})
+        self.assertEqual(state["clicks"], 1)
+
     def test_suspend_prefers_the_stable_testid_over_the_text_fallback(self):
         """Issue #766: the action buttons carry live-confirmed testids
         (`CampaignHeader.ActionButton.stop`/`.resume`); the Russian-label

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -3400,6 +3400,47 @@ class TestSuspendResumeMaster(unittest.TestCase):
             "hydration and came back unrecognised",
         )
 
+    def test_initial_hydration_uses_its_own_budget_not_the_post_click_one(self):
+        """The pre-click hydration wait and the post-click status wait are
+        two different quantities and must not share a constant.
+
+        Only the post-click latency was ever measured (1.6-2.3s, issue #764);
+        `_STATUS_CHANGE_TIMEOUT_MS` was set to 8s from it. The initial
+        hydration wait has no measurement behind it, and before #766 it ran
+        on the then-current 60s budget. Collapsing the two would silently cut
+        it to 8s and, on a slow page, make `resume_master` miss an ARCHIVED
+        status, skip the unarchive step and hunt for a resume button that an
+        archived page never renders.
+
+        The test above only proves hydration is polled *at all* — it passes
+        under any sufficient budget, including a shared one. This asserts the
+        separation itself, so a well-meaning "dedupe these two constants"
+        change fails here instead of live.
+        """
+        self.assertGreater(
+            browser_masters._STATUS_HYDRATION_TIMEOUT_MS,
+            browser_masters._STATUS_CHANGE_TIMEOUT_MS,
+            "initial status hydration must keep its own, larger budget — the "
+            "8s post-click figure was measured for a different quantity",
+        )
+
+        # And the wait must actually poll past a slow first read rather than
+        # give up on it -- the behaviour the larger budget buys.
+        reads = {"n": 0}
+
+        def fake_read_status_text(page):
+            reads["n"] += 1
+            return None if reads["n"] < 3 else "ARCHIVED"
+
+        page = FakePage()
+        with patch.object(
+            browser_masters, "_read_status_text", side_effect=fake_read_status_text
+        ):
+            status = browser_masters._wait_for_recognised_status(page)
+
+        self.assertEqual(status, "ARCHIVED")
+        self.assertEqual(reads["n"], 3)
+
 
 class TestMastersSuspendResumeCommand(unittest.TestCase):
     """CLI wiring for `masters suspend`/`masters resume`."""


### PR DESCRIPTION
## Что было

`direct masters suspend` не останавливал Мастер-кампании: клик не менял статус, команда падала по таймауту 60 с, retry не помогал (#766). Параллельно #764 просил измерить реальную задержку смены статуса вместо взятой наугад константы.

## Что нашла живая разведка (2026-08-06, кампания 713277109)

Оба issue — **один корень**, и это не то, что предполагалось ни в одном из них:

**Первый клик по кнопке на свежеотрисованной странице обзора — регулярно молчаливый no-op.** Проверки actionability проходят, `.click()` возвращается без исключения, и — подтверждено перехватом всех запросов после клика — **не уходит вообще ни одного сетевого запроса**. React ещё не навесил свой обработчик. Никакое ожидание это состояние не чинит: поэтому повторный запуск команды не помогал, а 60-секундный бюджет из #758 лишь замедлял каждый отказ.

Промаха по подписи кнопки (гипотеза #766 со ссылкой на #630) **не было**: `"Остановить кампанию"` матчилась. Зато нашлись стабильные testid'ы, снятые с живого DOM.

**Замер для #764** — 12 реальных переходов в двух прогонах: от результативного клика до обновления статуса на странице **1.64–2.28 с (среднее 1.8 с)**, без длинного хвоста. 60 с никогда не измеряли эту задержку — они маскировали баг выше.

## Что сделано

- Клик по кнопке действия ретраится (`_STATUS_CLICK_MAX_ATTEMPTS` = 4) со сверкой статуса перед каждой попыткой — результативный клик никогда не повторяется. То же для шага unarchive→SUSPENDED в `resume`. Это ровно то лечение, которое `_click_and_wait_for_popup` уже применял к «⋮»-меню и модалке переименования (#723/#725); suspend/resume его просто никогда не получал.
- `_STATUS_CHANGE_TIMEOUT_MS`: 60 с → **8 с**, теперь измеренное значение (~3.5× наблюдённого максимума).
- Кнопки резолвятся по подтверждённым живьём testid: `CampaignHeader.ActionButton.stop` / `.resume`. Текстовые подписи остались фолбэком и теперь резолвят объемлющий `<button>` перед кликом — `get_by_text` матчит `<span class="dc-Button__text">` внутри, из-за чего проверки `disabled`/`aria-disabled` раньше делались не по тому элементу.
- Текущий статус поллится, а не читается однократно: одиночное чтение живьём оборвало реальный `masters suspend` ошибкой «unrecognised status text» на кампании, чей статус читался секундой позже.
- **Батч больше не обрывается на первом упавшем ID** (#766): проходятся все ID, по каждому отчёт (строка результата или `Error`), ненулевой exit — только после печати всех исходов. Так уже вели себя `launch`/`archive` (#645); теперь все четыре команды используют общий `_run_per_id`.
- Ошибка «не нашёл кнопку» называет и селектор, и искомые подписи, и перечисляет, что на странице реально есть, плюс прочитанный статус.

## Верификация

Живьём на кампании 713277109 (по согласованному слоту):

| Проверка | Результат |
|---|---|
| `masters resume` (SUSPENDED→MODERATION) | ✅ 19 с (было — падение по 60 с) |
| `masters suspend` (ACTIVE→SUSPENDED) | ✅ 15.8 с |
| Батч `713277109,999999999` | ✅ реальный ID обработан, плохой отчитался ошибкой, батч не оборвался, exit ≠ 0 |
| Возврат в исходное состояние | ✅ ACTIVE |

Офлайн: **3238 passed, 23 skipped** (весь сьют), `black`/`flake8` чисто по изменённым файлам. Добавлено 8 регрессионных тестов: no-op-ретрай, отсутствие повторного клика после успеха, приоритет testid над текстом, клик по `<button>` а не `<span>`, содержимое ошибки, поллинг статуса, батч-устойчивость для suspend и resume.

## Замечание к мержу

Ветка не содержит `direct_cli/browser/_clock.py` из #767/PR #770 (параллельный воркер). Мои poll-циклы используют `time.monotonic()` — как весь остальной модуль на этой ветке. После мержа #770 их стоит перевести на `_clock.now()`; снижение таймаута 60с→8с само по себе уже убирает основную часть busy-spin в этих тестах.

Closes #766
Closes #764

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H564VvyTSMJQ8BreL9bMn5