### PR TITLE
fix(masters): handle absent GeoRegions key in --region-id pre-flight (#775)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,22 @@
   `ExactNames`. The lookup is now pinned to `language="ru"` — which is also
   the name the Russian-language Мастер кампаний region widget has to match
   downstream, so an unpinned locale was wrong for `_set_region` regardless.
-- A name the pre-flight cannot match is **not** silently treated as
-  unambiguous — that would quietly disable #657's safety net. The check is
-  skipped for that name and a warning says so. `_set_region` still enforces
-  the real guarantee in-page by confirming the clicked node's
-  `id="region-node-<RegionId>"` equals the requested RegionId.
+- The ambiguity pre-flight now selects on **`Name`** (substring search)
+  instead of `ExactNames`. Confirmed live: `ExactNames` returns **no rows at
+  all**, for any spelling, even for a region that demonstrably exists —
+  `ExactNames["Москва"]` yields `result == {}` while `RegionIds[213]`
+  resolves to exactly that name. Built on `ExactNames`, the check could
+  therefore never fire; it was dead code. `Name` does return rows and does
+  surface real ambiguity (measured: 97 distinct RegionIds named "Сосновка"),
+  and exact matches are filtered from its substring hits client-side so that
+  "Новая Москва" cannot make "Москва" look ambiguous.
+- A name with no rows is **not** reported. `Name` legitimately returns
+  nothing for top-level regions (live: `Name="Москва"` matches only "Новая
+  Москва"/"Менеуз-Москва", never Москва itself), so warning there would fire
+  on the most common `--region-id` values and train the user to ignore it.
+  The real guarantee is downstream regardless: `_set_region` confirms the
+  clicked node's `id="region-node-<RegionId>"` equals the requested RegionId
+  and refuses before any save click.
 
 **Fixed — `masters suspend`/`resume` never changed the status, and a batch stopped at the first failing ID (#766, #764):**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+**Fixed — `masters add --region-id` crashed with a bare `KeyError: 'GeoRegions'` (#775):**
+
+- `_resolve_region_ids`' ambiguity pre-flight (the second `getGeoRegions`
+  call, added by #657) indexed `result["GeoRegions"]` unconditionally.
+  Confirmed live 2026-08-06: Yandex **omits the key entirely** when
+  `ExactNames` matches nothing — `result` comes back as `{}`, not as
+  `{"GeoRegions": []}`. Every `--region-id` run therefore died with
+  `✗ 'GeoRegions'` before a browser was ever opened, making the flag
+  unusable (`--region "Москва"` was the workaround). Both `getGeoRegions`
+  responses are now read defensively, `None` result included.
+- Root cause of the empty match: the `ExactNames` round-trip was
+  **locale-crossed**. `create_client` defaults to `language="en"`, so call 1
+  resolved 213 to `"Moscow"`, and that English name was fed straight back
+  into call 2's `ExactNames`. The lookup is now pinned to `language="ru"` —
+  which is also the name the Russian-language Мастер кампаний region widget
+  has to match downstream, so `en` was wrong for `_set_region` regardless.
+- A name the pre-flight cannot match is **not** silently treated as
+  unambiguous — that would quietly disable #657's safety net. The check is
+  skipped for that name and a warning says so. `_set_region` still enforces
+  the real guarantee in-page by confirming the clicked node's
+  `id="region-node-<RegionId>"` equals the requested RegionId.
+
 **Fixed — `masters suspend`/`resume` never changed the status, and a batch stopped at the first failing ID (#766, #764):**
 
 - Root cause, confirmed live 2026-08-06 against campaign 713277109: **the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,14 @@
   unusable (`--region "Москва"` was the workaround). Both `getGeoRegions`
   responses are now read defensively, `None` result included.
 - Root cause of the empty match: the `ExactNames` round-trip was
-  **locale-crossed**. `create_client` defaults to `language="en"`, so call 1
-  resolved 213 to `"Moscow"`, and that English name was fed straight back
-  into call 2's `ExactNames`. The lookup is now pinned to `language="ru"` —
-  which is also the name the Russian-language Мастер кампаний region widget
-  has to match downstream, so `en` was wrong for `_set_region` regardless.
+  **locale-crossed**. The lookup went through `client_from_ctx`, which
+  passes no `language` at all, and the vendored client omits the
+  `Accept-Language` header entirely when it is `None` — so the locale was
+  left to Yandex, which answered in English. Call 1 resolved 213 to
+  `"Moscow"`, and that English name was fed straight back into call 2's
+  `ExactNames`. The lookup is now pinned to `language="ru"` — which is also
+  the name the Russian-language Мастер кампаний region widget has to match
+  downstream, so an unpinned locale was wrong for `_set_region` regardless.
 - A name the pre-flight cannot match is **not** silently treated as
   unambiguous — that would quietly disable #657's safety net. The check is
   skipped for that name and a warning says so. `_set_region` still enforces

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -1984,47 +1984,50 @@ def _resolve_region_ids(
     # clear API-level error before a browser is even opened, rather than
     # deferring to `_set_region`'s harder-to-diagnose in-page identity
     # mismatch. Look up every GeoRegions entry sharing one of the resolved
-    # names (SelectionCriteria is mandatory per the WSDL —
-    # GetGeoRegionsRequest.SelectionCriteria has minOccurs=1 — so ExactNames
-    # must be supplied) and refuse rather than guess if any name has more
-    # than one distinct owning RegionId.
-    resolved = [found[rid] for rid in region_ids]
-    name_check = client.dictionaries().post(
-        data={
-            "method": "getGeoRegions",
-            "params": {
-                "FieldNames": ["GeoRegionId", "GeoRegionName"],
-                "SelectionCriteria": {"ExactNames": sorted(set(resolved))},
-            },
-        }
-    )
-    # Yandex omits the `GeoRegions` key entirely (``result == {}``) when
-    # `ExactNames` matches nothing — it does NOT return an empty list. Indexing
-    # the key unconditionally turned every `--region-id` run into a bare
-    # ``KeyError: 'GeoRegions'`` before a browser was ever opened (issue #775).
-    # The `language="ru"` pin above removes the locale-crossed round-trip
-    # (unpinned, Yandex answered in English) that made an empty match the
-    # *normal* case, but it does not guarantee every name round-trips through
-    # `ExactNames`, so the shape is still handled.
+    # names and refuse rather than guess if any name has more than one
+    # distinct owning RegionId.
     #
-    # A name with no rows is not evidence of uniqueness, so it is not silently
-    # treated as unambiguous: the check is skipped for that name and said so
-    # out loud. `_set_region` still enforces the real safety net downstream by
-    # confirming the clicked node's ``id="region-node-<RegionId>"``.
+    # The criterion is `Name` (substring search), NOT `ExactNames`. Confirmed
+    # live 2026-08-06 (issue #775): `ExactNames` returns **no rows at all**,
+    # for any spelling, even for a region that demonstrably exists —
+    # `ExactNames["Москва"]` yields `result == {}` while `RegionIds[213]`
+    # resolves to exactly that name. Built on `ExactNames`, this pre-flight
+    # could therefore never fire: every name looked "unchecked", so the
+    # check was dead code that only produced a warning on every ordinary run.
+    # `Name` does return rows and does surface real ambiguity (measured: 97
+    # distinct RegionIds named "Сосновка"), so exact matches are filtered
+    # client-side from its substring hits.
+    #
+    # `Name` takes a single string, not a list, so this is one request per
+    # distinct name — in practice one, since `--region-id` is rarely repeated.
+    resolved = [found[rid] for rid in region_ids]
     name_owners = {}
-    for item in (name_check.data["result"] or {}).get("GeoRegions") or []:
-        name_owners.setdefault(item["GeoRegionName"], set()).add(item["GeoRegionId"])
-
-    unchecked = sorted({name for name in resolved if name not in name_owners})
-    if unchecked:
-        print_warning(
-            "Could not pre-check region name uniqueness for: "
-            f"{', '.join(unchecked)} — Yandex's GeoRegions dictionary "
-            "returned no ExactNames match for these names. Proceeding; the "
-            "region selected in the browser is still verified against the "
-            "requested RegionId."
+    for name in sorted(set(resolved)):
+        name_check = client.dictionaries().post(
+            data={
+                "method": "getGeoRegions",
+                "params": {
+                    "FieldNames": ["GeoRegionId", "GeoRegionName"],
+                    "SelectionCriteria": {"Name": name},
+                },
+            }
         )
+        # Yandex omits the `GeoRegions` key entirely (``result == {}``) when
+        # nothing matches — it does NOT return an empty list. Indexing the key
+        # unconditionally turned every `--region-id` run into a bare
+        # ``KeyError: 'GeoRegions'`` before a browser was ever opened (#775).
+        for item in (name_check.data["result"] or {}).get("GeoRegions") or []:
+            if item["GeoRegionName"] == name:
+                name_owners.setdefault(name, set()).add(item["GeoRegionId"])
 
+    # A name with no rows is NOT reported: `Name` legitimately returns nothing
+    # for top-level regions (confirmed live — `Name="Москва"` matches only
+    # "Новая Москва"/"Менеуз-Москва", never Москва itself), so warning here
+    # would fire on the most common `--region-id` values and train the user to
+    # ignore it. Absence of rows means "could not check", and the real
+    # guarantee is downstream anyway: `_set_region` confirms the clicked
+    # node's ``id="region-node-<RegionId>"`` matches the requested RegionId
+    # and refuses before any save click.
     ambiguous = sorted(
         {name for name in resolved if len(name_owners.get(name, ())) > 1}
     )

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -1937,10 +1937,14 @@ def _resolve_region_ids(
     credentials, resolved the same way as any other command: it is only
     reached when the caller actually passes ``--region-id``.
 
-    The lookup is pinned to ``language="ru"`` (issue #775). ``create_client``
-    defaults to ``language="en"``, which resolved 213 to "Moscow" — a name the
-    Russian-language Мастер кампаний region widget cannot match, and one that
-    Yandex's own ``ExactNames`` lookup does not round-trip either.
+    The lookup is pinned to ``language="ru"`` (issue #775). It used to go
+    through ``client_from_ctx``, which passes no ``language`` at all — and
+    the vendored client omits the ``Accept-Language`` header entirely when
+    it is ``None`` (``_vendor/tapi_yandex_direct/tapi_yandex_direct.py``),
+    leaving the locale to Yandex. In practice Yandex answered in English,
+    resolving 213 to "Moscow" — a name the Russian-language Мастер кампаний
+    region widget cannot match, and one Yandex's own ``ExactNames`` lookup
+    does not round-trip either.
     """
     if not region_ids:
         return []
@@ -1998,9 +2002,10 @@ def _resolve_region_ids(
     # `ExactNames` matches nothing — it does NOT return an empty list. Indexing
     # the key unconditionally turned every `--region-id` run into a bare
     # ``KeyError: 'GeoRegions'`` before a browser was ever opened (issue #775).
-    # The `language="ru"` pin above removes the locale-crossed round-trip that
-    # made an empty match the *normal* case, but it does not guarantee every
-    # name round-trips through `ExactNames`, so the shape is still handled.
+    # The `language="ru"` pin above removes the locale-crossed round-trip
+    # (unpinned, Yandex answered in English) that made an empty match the
+    # *normal* case, but it does not guarantee every name round-trips through
+    # `ExactNames`, so the shape is still handled.
     #
     # A name with no rows is not evidence of uniqueness, so it is not silently
     # treated as unambiguous: the check is skipped for that name and said so

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -68,7 +68,7 @@ from typing import Optional
 import click
 from click.core import ParameterSource
 
-from ..api import client_from_ctx, create_client
+from ..api import create_client
 from ..browser.masters import AGE_FROM_CHOICES as _AGE_FROM_CHOICES
 from ..browser.masters import AGE_TO_CHOICES as _AGE_TO_CHOICES
 from ..browser.masters import DEVICE_OPTION_VALUES as _DEVICE_OPTION_VALUES
@@ -1936,10 +1936,20 @@ def _resolve_region_ids(
     Yandex Direct API credentials), this one lookup does require valid API
     credentials, resolved the same way as any other command: it is only
     reached when the caller actually passes ``--region-id``.
+
+    The lookup is pinned to ``language="ru"`` (issue #775). ``create_client``
+    defaults to ``language="en"``, which resolved 213 to "Moscow" — a name the
+    Russian-language Мастер кампаний region widget cannot match, and one that
+    Yandex's own ``ExactNames`` lookup does not round-trip either.
     """
     if not region_ids:
         return []
-    client = client_from_ctx(ctx, create_client)
+    client = create_client(
+        token=ctx.obj.get("token"),
+        login=ctx.obj.get("login"),
+        sandbox=ctx.obj.get("sandbox"),
+        language="ru",
+    )
     body = {
         "method": "getGeoRegions",
         "params": {
@@ -1950,7 +1960,7 @@ def _resolve_region_ids(
     result = client.dictionaries().post(data=body)
     found = {
         item["GeoRegionId"]: item["GeoRegionName"]
-        for item in result.data["result"]["GeoRegions"]
+        for item in (result.data["result"] or {}).get("GeoRegions") or []
     }
     missing = [rid for rid in region_ids if rid not in found]
     if missing:
@@ -1984,11 +1994,35 @@ def _resolve_region_ids(
             },
         }
     )
+    # Yandex omits the `GeoRegions` key entirely (``result == {}``) when
+    # `ExactNames` matches nothing — it does NOT return an empty list. Indexing
+    # the key unconditionally turned every `--region-id` run into a bare
+    # ``KeyError: 'GeoRegions'`` before a browser was ever opened (issue #775).
+    # The `language="ru"` pin above removes the locale-crossed round-trip that
+    # made an empty match the *normal* case, but it does not guarantee every
+    # name round-trips through `ExactNames`, so the shape is still handled.
+    #
+    # A name with no rows is not evidence of uniqueness, so it is not silently
+    # treated as unambiguous: the check is skipped for that name and said so
+    # out loud. `_set_region` still enforces the real safety net downstream by
+    # confirming the clicked node's ``id="region-node-<RegionId>"``.
     name_owners = {}
-    for item in name_check.data["result"]["GeoRegions"]:
+    for item in (name_check.data["result"] or {}).get("GeoRegions") or []:
         name_owners.setdefault(item["GeoRegionName"], set()).add(item["GeoRegionId"])
 
-    ambiguous = sorted({name for name in resolved if len(name_owners[name]) > 1})
+    unchecked = sorted({name for name in resolved if name not in name_owners})
+    if unchecked:
+        print_warning(
+            "Could not pre-check region name uniqueness for: "
+            f"{', '.join(unchecked)} — Yandex's GeoRegions dictionary "
+            "returned no ExactNames match for these names. Proceeding; the "
+            "region selected in the browser is still verified against the "
+            "requested RegionId."
+        )
+
+    ambiguous = sorted(
+        {name for name in resolved if len(name_owners.get(name, ())) > 1}
+    )
     if ambiguous:
         raise click.UsageError(
             "--region-id resolved to ambiguous region name(s): "

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -13354,9 +13354,11 @@ class TestResolveRegionIds(unittest.TestCase):
 
         second_call_body = service.post.call_args_list[1].kwargs["data"]
         self.assertIn("SelectionCriteria", second_call_body["params"])
+        # `Name`, not `ExactNames` — the latter returns no rows at all from
+        # the live API, which made this whole pre-flight dead code (#775).
         self.assertEqual(
-            second_call_body["params"]["SelectionCriteria"]["ExactNames"],
-            ["Сосновка"],
+            second_call_body["params"]["SelectionCriteria"]["Name"],
+            "Сосновка",
         )
 
     def test_unique_region_name_resolves_normally(self):
@@ -13388,16 +13390,23 @@ class TestResolveRegionIds(unittest.TestCase):
         client.dictionaries.return_value = service
 
         with patch("direct_cli.commands.masters.create_client", return_value=client):
-            result = _resolve_region_ids(Mock(), (213,))
+            with patch("direct_cli.commands.masters.print_warning") as mock_warning:
+                result = _resolve_region_ids(Mock(), (213,))
 
         self.assertEqual(result, [("Москва", 213)])
+        # The happy path must be silent — a warning on every ordinary run
+        # would train the user to ignore it (review of PR #778).
+        mock_warning.assert_not_called()
 
     def test_ambiguity_preflight_without_georegions_key_does_not_crash(self):
         """Issue #775: Yandex omits `GeoRegions` from `result` entirely when
-        `ExactNames` matches nothing — `result` is `{}`, not
-        `{"GeoRegions": []}`. Indexing it unconditionally made every
-        `--region-id` run die with a bare `KeyError: 'GeoRegions'` before a
-        browser was opened. The empty pre-flight must resolve normally."""
+        nothing matches — `result` is `{}`, not `{"GeoRegions": []}`. Indexing
+        it unconditionally made every `--region-id` run die with a bare
+        `KeyError: 'GeoRegions'` before a browser was opened. The empty
+        pre-flight must resolve normally, and must NOT warn: `Name` returns no
+        rows for top-level regions (confirmed live — `Name="Москва"` matches
+        only "Новая Москва"/"Менеуз-Москва", never Москва itself), so warning
+        here would fire on the most common `--region-id` values."""
         from direct_cli.commands.masters import _resolve_region_ids
 
         service = Mock()
@@ -13419,10 +13428,43 @@ class TestResolveRegionIds(unittest.TestCase):
                 result = _resolve_region_ids(_region_ctx(), (213,))
 
         self.assertEqual(result, [("Москва", 213)])
-        # An unmatched name is not evidence of uniqueness — the skipped check
-        # must be reported, not silently swallowed.
-        mock_warning.assert_called_once()
-        self.assertIn("Москва", mock_warning.call_args.args[0])
+        mock_warning.assert_not_called()
+
+    def test_substring_hits_do_not_count_as_ambiguity(self):
+        """`Name` is a SUBSTRING search, so its rows include unrelated regions
+        that merely contain the name (live: `Name="Москва"` returns "Новая
+        Москва" and "Менеуз-Москва"). Only exact-name rows may count toward
+        ambiguity — otherwise an ordinary region would look ambiguous and be
+        refused."""
+        from direct_cli.commands.masters import _resolve_region_ids
+
+        service = Mock()
+        service.post.side_effect = [
+            Mock(
+                data={
+                    "result": {
+                        "GeoRegions": [{"GeoRegionId": 213, "GeoRegionName": "Москва"}]
+                    }
+                }
+            ),
+            Mock(
+                data={
+                    "result": {
+                        "GeoRegions": [
+                            {"GeoRegionId": 162734, "GeoRegionName": "Новая Москва"},
+                            {"GeoRegionId": 176800, "GeoRegionName": "Менеуз-Москва"},
+                        ]
+                    }
+                }
+            ),
+        ]
+        client = Mock()
+        client.dictionaries.return_value = service
+
+        with patch("direct_cli.commands.masters.create_client", return_value=client):
+            result = _resolve_region_ids(_region_ctx(), (213,))
+
+        self.assertEqual(result, [("Москва", 213)])
 
     def test_initial_lookup_without_georegions_key_reports_unknown_ids(self):
         """The same absent-key shape on the FIRST call must surface as the
@@ -13459,8 +13501,7 @@ class TestResolveRegionIds(unittest.TestCase):
         client.dictionaries.return_value = service
 
         with patch("direct_cli.commands.masters.create_client", return_value=client):
-            with patch("direct_cli.commands.masters.print_warning"):
-                result = _resolve_region_ids(_region_ctx(), (213,))
+            result = _resolve_region_ids(_region_ctx(), (213,))
 
         self.assertEqual(result, [("Москва", 213)])
 

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -13465,10 +13465,10 @@ class TestResolveRegionIds(unittest.TestCase):
         self.assertEqual(result, [("Москва", 213)])
 
     def test_lookup_is_pinned_to_russian_locale(self):
-        """Issue #775: `create_client` defaults to `language="en"`, which
-        resolved 213 to "Moscow" — a name the Russian-language Мастер
-        кампаний region widget cannot match, and one Yandex's own
-        `ExactNames` lookup does not round-trip."""
+        """Issue #775: unpinned, no `Accept-Language` header is sent at all
+        and Yandex answered in English, resolving 213 to "Moscow" — a name
+        the Russian-language Мастер кампаний region widget cannot match, and
+        one Yandex's own `ExactNames` lookup does not round-trip."""
         from direct_cli.commands.masters import _resolve_region_ids
 
         service = Mock()

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -13271,6 +13271,13 @@ class TestMastersAddCommand(unittest.TestCase):
         mock_create.assert_not_called()
 
 
+def _region_ctx(token="t", login="l", sandbox=False):
+    """A minimal Click-context stand-in for `_resolve_region_ids`."""
+    ctx = Mock()
+    ctx.obj = {"token": token, "login": login, "sandbox": sandbox}
+    return ctx
+
+
 class TestResolveRegionIds(unittest.TestCase):
     """Unit tests for `_resolve_region_ids` (issue #652)."""
 
@@ -13384,6 +13391,103 @@ class TestResolveRegionIds(unittest.TestCase):
             result = _resolve_region_ids(Mock(), (213,))
 
         self.assertEqual(result, [("Москва", 213)])
+
+    def test_ambiguity_preflight_without_georegions_key_does_not_crash(self):
+        """Issue #775: Yandex omits `GeoRegions` from `result` entirely when
+        `ExactNames` matches nothing — `result` is `{}`, not
+        `{"GeoRegions": []}`. Indexing it unconditionally made every
+        `--region-id` run die with a bare `KeyError: 'GeoRegions'` before a
+        browser was opened. The empty pre-flight must resolve normally."""
+        from direct_cli.commands.masters import _resolve_region_ids
+
+        service = Mock()
+        service.post.side_effect = [
+            Mock(
+                data={
+                    "result": {
+                        "GeoRegions": [{"GeoRegionId": 213, "GeoRegionName": "Москва"}]
+                    }
+                }
+            ),
+            Mock(data={"result": {}}),
+        ]
+        client = Mock()
+        client.dictionaries.return_value = service
+
+        with patch("direct_cli.commands.masters.create_client", return_value=client):
+            with patch("direct_cli.commands.masters.print_warning") as mock_warning:
+                result = _resolve_region_ids(_region_ctx(), (213,))
+
+        self.assertEqual(result, [("Москва", 213)])
+        # An unmatched name is not evidence of uniqueness — the skipped check
+        # must be reported, not silently swallowed.
+        mock_warning.assert_called_once()
+        self.assertIn("Москва", mock_warning.call_args.args[0])
+
+    def test_initial_lookup_without_georegions_key_reports_unknown_ids(self):
+        """The same absent-key shape on the FIRST call must surface as the
+        actionable "Unknown --region-id value(s)" UsageError, not a KeyError."""
+        from direct_cli.commands.masters import _resolve_region_ids
+
+        service = Mock()
+        service.post.return_value = Mock(data={"result": {}})
+        client = Mock()
+        client.dictionaries.return_value = service
+
+        with patch("direct_cli.commands.masters.create_client", return_value=client):
+            with self.assertRaises(click.UsageError) as cm:
+                _resolve_region_ids(_region_ctx(), (999999,))
+
+        self.assertIn("Unknown --region-id value(s): 999999", str(cm.exception))
+
+    def test_null_result_does_not_crash(self):
+        """A `result` of `None` is the same class of shape as a missing key."""
+        from direct_cli.commands.masters import _resolve_region_ids
+
+        service = Mock()
+        service.post.side_effect = [
+            Mock(
+                data={
+                    "result": {
+                        "GeoRegions": [{"GeoRegionId": 213, "GeoRegionName": "Москва"}]
+                    }
+                }
+            ),
+            Mock(data={"result": None}),
+        ]
+        client = Mock()
+        client.dictionaries.return_value = service
+
+        with patch("direct_cli.commands.masters.create_client", return_value=client):
+            with patch("direct_cli.commands.masters.print_warning"):
+                result = _resolve_region_ids(_region_ctx(), (213,))
+
+        self.assertEqual(result, [("Москва", 213)])
+
+    def test_lookup_is_pinned_to_russian_locale(self):
+        """Issue #775: `create_client` defaults to `language="en"`, which
+        resolved 213 to "Moscow" — a name the Russian-language Мастер
+        кампаний region widget cannot match, and one Yandex's own
+        `ExactNames` lookup does not round-trip."""
+        from direct_cli.commands.masters import _resolve_region_ids
+
+        service = Mock()
+        service.post.return_value = Mock(
+            data={
+                "result": {
+                    "GeoRegions": [{"GeoRegionId": 213, "GeoRegionName": "Москва"}]
+                }
+            }
+        )
+        client = Mock()
+        client.dictionaries.return_value = service
+
+        with patch(
+            "direct_cli.commands.masters.create_client", return_value=client
+        ) as mock_create:
+            _resolve_region_ids(_region_ctx(), (213,))
+
+        self.assertEqual(mock_create.call_args.kwargs["language"], "ru")
 
 
 class _FakeAudienceTagsPage(FakePage):


### PR DESCRIPTION
## Problem

`masters add --region-id 213` failed with a bare, unactionable error and never opened a browser:

```
✗ 'GeoRegions'
Aborted!
```

`--region "Москва"` worked, and was the workaround.

## Root cause

`KeyError` in `_resolve_region_ids`' **ambiguity pre-flight** — the second `getGeoRegions` call added by #657, not the initial ID lookup:

```python
for item in name_check.data["result"]["GeoRegions"]:
```

Confirmed live: Yandex **omits the `GeoRegions` key entirely** when nothing matches — `result` is `{}`, not `{"GeoRegions": []}`.

## Fix

1. **Both** `getGeoRegions` responses are read defensively — `(result["result"] or {}).get("GeoRegions") or []` — covering the absent key *and* a `None` result. The first call's identical unguarded pattern is fixed too, and now surfaces as the actionable `Unknown --region-id value(s): …` `UsageError` instead of a `KeyError`.

2. **Locale pinned to `ru`.** The lookup previously went through `client_from_ctx`, which passes no `language` at all — and the vendored client omits the `Accept-Language` header entirely when it is `None`, leaving the locale to Yandex, which answered in English (`213 -> "Moscow"`). It now calls `create_client(..., language="ru")` directly. Beyond the round-trip, the resolved name is what `_set_region` must match in the **Russian-language** Мастер кампаний widget downstream.

3. **The ambiguity pre-flight now selects on `Name`, not `ExactNames`** — this came out of review, and it turned out `ExactNames` made the whole check dead code. Probed live:

   ```
   ExactNames["Москва"] -> result keys=[]        (no rows, any spelling)
   Name="Москва"        -> "Новая Москва", "Менеуз-Москва"   (never Москва itself)
   Name="Сосновка"      -> 97 distinct RegionIds sharing the name
   ```

   `ExactNames` returns nothing even for a region that demonstrably exists, so #657's guard could never fire. `Name` does return rows and does surface real ambiguity; exact matches are filtered from its substring hits client-side so "Новая Москва" cannot make "Москва" look ambiguous.

4. **A name with no rows is not warned about.** `Name` legitimately returns nothing for top-level regions, so warning there would fire on the most common `--region-id` values and train the user to ignore it. The real guarantee is downstream regardless: `_set_region` confirms the clicked node's `id="region-node-<RegionId>"` equals the requested RegionId and refuses before any save click.

## Verification

**Live, against production (read-only):**

```
--region-id 213    -> ("Москва", 213)            silent
--region-id 2      -> ("Санкт-Петербург", 2)     silent
--region-id 213 2  -> both, in order            silent
--region-id 27068  -> UsageError: ambiguous "Сосновка"   ← guard now actually fires
--region-id 999999 -> UsageError: unknown id
```

**Tests:** 9 in `TestResolveRegionIds`, the four regression cases verified **red before the fix** (reproducing the exact `KeyError: 'GeoRegions'`):

- `test_ambiguity_preflight_without_georegions_key_does_not_crash` — the reported crash; also asserts the happy path stays silent.
- `test_substring_hits_do_not_count_as_ambiguity` — "Новая Москва" must not make "Москва" ambiguous.
- `test_initial_lookup_without_georegions_key_reports_unknown_ids` — same shape on call 1 → `UsageError`, not `KeyError`.
- `test_null_result_does_not_crash` — `result: None`.
- `test_lookup_is_pinned_to_russian_locale` — asserts `language="ru"`.

Full offline suite: **3273 passed, 23 skipped**. `black` + `flake8` clean.

## Review

Reviewed locally by `/code-review` and the Codex companion. Codex: approve, no findings. `/code-review`: 5 findings → 3 FIX (all resolved), 2 SKIP, 1 disproved. Triage detail in [this comment](https://github.com/axisrow/direct-cli/pull/778#issuecomment-5201130592).

## Known gap (out of scope)

`--profile` and the 1Password/Bitwarden refs never reach `create_client` in this code path. This is **pre-existing and unchanged** by this PR (`client_from_ctx` passed the same three kwargs, and `masters` is in `_NO_CREDENTIALS_GROUPS`, whose early return never stores `profile` in `ctx.obj`). An active profile still works, via `get_credentials`' own fallback. Worth a separate issue.

Closes #775

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EqPmLYCqrG37rPecHG53BT