### PR TITLE
feat(masters)!: require conversion goals for `masters add` (#777)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,25 @@ one testid differs: with an empty table the create page renders its
 `MiniGrid.AddButton` form once a first row exists). `_add_target_action`
 now tries both.
 
+Trying both triggers has a cost that had to be paid for explicitly (review
+of #779, found independently by both reviewers): clicking the trigger that
+is *not* on the current render is the expected path, not an error — and
+with no explicit `timeout=`, Playwright charges its **30s default**
+actionability auto-wait for each miss. Since the create page's table always
+starts empty, the populated-table trigger tried first was absent on every
+single `masters add`, adding a guaranteed ~30s stall to the happy path and
+multiplying to minutes in the documented no-goals-offered failure case
+(5 attempts × 2 triggers). Both trigger clicks are now bounded by
+`_POPUP_APPEAR_TIMEOUT_MS`, and the attempt order is picked from the
+table's current row count so the empty-table create path goes straight to
+the trigger that exists. The order is only a hint — both are still tried,
+so a stale or mid-hydration count costs at most one bounded click. The
+offline harness could not have caught this on timing alone: the fake
+locator raises instantly for an absent selector, so the production cost
+never surfaces as a slow test — the same structural blind spot `_clock.py`
+documents for poll deadlines. The tests therefore assert on the `timeout=`
+argument itself.
+
 `create_master` also gained a **pre-click gate** for the goals, mirroring
 the existing headline/text gate: the table is read back before the terminal
 button is clicked, and a missing row or a price that did not stick aborts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,10 +56,32 @@ button is clicked, and a missing row or a price that did not stick aborts
 punishes by silently swallowing the click, so there is no "afterwards" in
 which to observe it. The returned result now includes `TargetActions`.
 
-**Still not field-proven:** #744's post-click redirect and #776's region
-widget on a launched campaign remain unverified — this change removes the
-blocker that made them unobservable, but no create has yet been accepted by
-Yandex and observed end to end.
+**Live-verified end to end (2026-08-06).** With the goal requirement
+satisfied, a `--draft` create was accepted by Yandex and produced campaign
+713337891 — the first create this CLI has ever completed. That settles
+**#744**: the terminal click *does* redirect, and the id is read straight
+off it, exactly as modelled on `copy_master`. The id was cross-checked
+against a grid diff (79 rows → 80, the single new row being 713337891,
+status `DRAFT`) so it is a real campaign id rather than a URL-parsing
+artefact, and the goal was confirmed to have persisted server-side by
+re-reading it from a separate page (goal 236386933 at price 150).
+
+**Still open — deliberately not exercised:**
+
+- The `--launch` leg. It shares `_click_terminal_button` and the same
+  redirect with `--draft`, but it publishes live advertising with no
+  rollback, so it was not run to tick a box.
+- **#776** (region widget on a LAUNCHED campaign) consequently stays
+  blocked: checking it requires a launched campaign, which is the same
+  irreversible publish.
+- The test campaign 713337891 **could not be archived** and remains a
+  DRAFT on the account. `masters archive` refuses it correctly: a DRAFT's
+  overview page has no "⋮" menu (#660), and Мастер кампаний has no delete
+  anywhere in the UI — the only route to archiving is to *launch* the
+  campaign first. Spending real money to tidy up a test was the worse
+  trade. A DRAFT does not serve, does not spend, and does not appear to
+  users. Worth tracking as its own issue: creating a draft via this CLI is
+  currently a one-way door.
 
 **Fixed — `masters add --region-id` crashed with a bare `KeyError: 'GeoRegions'` (#775):**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,65 @@
 
 ## Unreleased
 
+### BREAKING CHANGES
+
+**`masters add` now requires `--add-target-action` (#777).**
+
+`masters add` previously could not create a campaign at all. Yandex's create
+form requires at least one Яндекс Метрика conversion goal, `create_master`
+had no way to set one, and the rejection is **silent**: live recon (#744,
+2026-08-06) filled the form correctly, clicked "Сохранить как черновик", and
+watched `page.url` for 48s — no redirect, no campaign, while both terminal
+buttons kept reporting `visible=True`, `enabled=True`, `aria-disabled=None`.
+There is no DOM signal distinguishing "rejected" from "still working".
+
+- New required option `masters add --add-target-action "goal_id=price"`
+  (repeatable). Deliberately the **same flag name and syntax** as
+  `masters update --add-target-action` rather than a new spelling for the
+  same concept, per the project's no-legacy-aliases rule. Goals are
+  identified by numeric Metrika goal id, never by display name — consistent
+  with every other target-action entry point in the module.
+- Required at the Click level (`required=True`), not validated after the
+  fact: the live evidence says a create without a goal cannot succeed, so
+  failing before a browser is even launched beats a ~48s silent-rejection
+  timeout. `create_master` enforces the same invariant with a `ValueError`
+  for direct API callers.
+- The price is mandatory, as it already is on `masters update`. On the edit
+  page a newly added row's price input starts empty and Yandex rejects
+  saving it that way; on the create page it instead arrives **pre-filled
+  with a Yandex suggestion** (observed: "160"). Neither is a documented
+  default, and publishing a CPA the caller never chose is worse than
+  requiring one, so both paths overwrite it.
+- **Migration:** add `--add-target-action "<metrika_goal_id>=<price>"` to
+  existing `masters add` invocations. `masters targetactions get` lists the
+  goal ids available on an existing campaign; on the create page the goals
+  come from the Metrika counter Yandex auto-discovers from the landing
+  page's domain, so a domain with no counter installed cannot be used.
+
+Live recon of the create page (2026-08-06) settled #777's open question:
+the create page renders the **same** `TargetActionsSection` widget as the
+edit page, with the same `AddTargetAction.{category}.{goal_id}` popup
+options and the same resulting
+`TargetActions.{category}.{goal_id}[.PriceInput|.CloseButton]` row testids —
+so `_add_target_action` is reused wholesale rather than duplicated. Exactly
+one testid differs: with an empty table the create page renders its
+"Добавить" trigger as `TargetActions.OTHER.AddTargetButton`, without the
+`MiniGrid` segment (confirmed live that it switches to the edit page's
+`MiniGrid.AddButton` form once a first row exists). `_add_target_action`
+now tries both.
+
+`create_master` also gained a **pre-click gate** for the goals, mirroring
+the existing headline/text gate: the table is read back before the terminal
+button is clicked, and a missing row or a price that did not stick aborts
+*before* anything is published. This is the one field whose absence Yandex
+punishes by silently swallowing the click, so there is no "afterwards" in
+which to observe it. The returned result now includes `TargetActions`.
+
+**Still not field-proven:** #744's post-click redirect and #776's region
+widget on a launched campaign remain unverified — this change removes the
+blocker that made them unobservable, but no create has yet been accepted by
+Yandex and observed end to end.
+
 **Fixed — `masters add --region-id` crashed with a bare `KeyError: 'GeoRegions'` (#775):**
 
 - `_resolve_region_ids`' ambiguity pre-flight (the second `getGeoRegions`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,20 @@ never surfaces as a slow test — the same structural blind spot `_clock.py`
 documents for poll deadlines. The tests therefore assert on the `timeout=`
 argument itself.
 
+Bounding that click also made a new failure mode reachable, and the error
+message had to follow (review round 2). "The trigger is present but never
+became clickable in time" now lands in the same exhausted-retry branch as
+"the goal isn't on offer" — and the message blamed the Metrika counter,
+the promotion goal, or changed markup for both. On a slow render (this
+section is documented to hydrate for seconds) that sends the user to audit
+a setup that is fine, the exact opposite of the "precise error over opaque
+timeout" rule this PR exists to uphold. The branch is now split by whether
+any attempt actually got a trigger clicked: if none did, the error names
+the click bound and the hydration race and suggests a re-run; if one did
+and the popup still had no matching option, the counter/promotion-goal
+diagnosis stands, since that one was genuinely observed rather than
+inferred.
+
 `create_master` also gained a **pre-click gate** for the goals, mirroring
 the existing headline/text gate: the table is read back before the terminal
 button is clicked, and a missing row or a price that did not stick aborts

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ direct masters adimages add 72349978 --image-file /path/to/a.png --image-file /p
 direct masters adimages delete 72349978 --position 2
 direct masters adimages delete 72349978 --all
 direct masters adimages set 72349978 --image-file /path/to/a.png --image-file /path/to/b.png
-direct masters add https://example.com/ --headline "Заголовок 1" --headline "Заголовок 2" --text "Текст объявления" --region Москва --weekly-budget 50000 --draft
-direct masters add https://example.com/ --headline "Заголовок 1" --text "Текст объявления" --region-id 213 --weekly-budget 50000 --draft
+direct masters add https://example.com/ --headline "Заголовок 1" --headline "Заголовок 2" --text "Текст объявления" --region Москва --add-target-action "236386933=150" --weekly-budget 50000 --draft
+direct masters add https://example.com/ --headline "Заголовок 1" --text "Текст объявления" --region-id 213 --add-target-action "236386933=150" --weekly-budget 50000 --draft
 direct masters copy 72349978
 direct masters copy 72349978 --launch
 ```
@@ -55,6 +55,18 @@ direct masters copy 72349978 --launch
 (`not-archived`/`active`/`stopped`/`archived`/`all`, default `not-archived`).
 It always reads the logged-in browser session's own account — there is no
 `--login`/agency support for managed clients.
+
+`masters add` creates a new Мастер кампаний. Besides `--headline`/`--text`
+and one of `--region`/`--region-id`, it **requires `--add-target-action`**
+(`"goal_id=price"`, repeatable — the same flag name and syntax as
+`masters update --add-target-action`): Yandex's create form refuses to submit
+without at least one Яндекс Метрика conversion goal, and refuses *silently* —
+both terminal buttons keep reporting visible/enabled with no `aria-disabled`,
+so a goal-less attempt would otherwise fail as an unexplained timeout after
+the whole form was filled in. The goals on offer come from the Metrika counter
+Yandex auto-discovers from the landing page's domain, so a domain with no
+counter installed cannot be used here. There is no sandbox and no rollback for
+Мастер кампаний — double-check every flag before running it for real.
 
 `masters update` edits a single Мастер кампаний's settings page. It currently
 covers the simplest scalar fields (Этап A of a larger, staged rollout — see

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -3418,6 +3418,16 @@ def _add_target_action(page: "Page", goal_id: int, price: float) -> None:
             _TARGET_ACTION_ADD_BUTTON_EMPTY_TESTID_TEMPLATE,
         )
     ]
+    # The order is not a preference — it decides which trigger eats the
+    # miss (issue #779 review). Both are tried either way and each click is
+    # timeout-bounded below, so this only shifts WHICH one is attempted
+    # first: the empty-table `AddTargetButton` for a table that currently
+    # has no rows (every `create_master` first goal, and any edit page
+    # whose table is empty), the `MiniGrid.AddButton` otherwise. Probing
+    # the row count is a plain `count()` with no auto-wait, so a wrong
+    # guess here costs one bounded click, never a hang.
+    if _target_action_row_count(page) == 0:
+        add_button_testids.reverse()
     add_buttons = [
         page.locator(f'[data-testid="{testid}"]').first for testid in add_button_testids
     ]
@@ -3435,7 +3445,17 @@ def _add_target_action(page: "Page", goal_id: int, price: float) -> None:
         clicked = False
         for add_button in add_buttons:
             try:
-                add_button.click()
+                # An EXPLICIT short timeout, not Playwright's 30s default
+                # (issue #779 review): clicking the trigger that ISN'T on
+                # this render is the expected path here, not an error, so
+                # the default would charge ~30s of actionability auto-wait
+                # for every miss — on every `masters add`, since the create
+                # page's table always starts empty — and
+                # _TARGET_ACTION_ADD_OPTION_MAX_ATTEMPTS times that in the
+                # documented no-goals-offered failure case. A trigger that
+                # is present is present immediately, so bounding this costs
+                # the happy path nothing.
+                add_button.click(timeout=_POPUP_APPEAR_TIMEOUT_MS)
                 clicked = True
                 break
             except PlaywrightError as exc:
@@ -4160,6 +4180,50 @@ def _read_target_actions_or_none(page: "Page") -> Optional[List[Dict[str, Any]]]
         results.append({"GoalId": goal_id, "Name": name, "Price": price})
 
     return results
+
+
+def _target_action_row_count(page: "Page") -> int:
+    """How many goal rows the "Целевые действия" table currently holds.
+
+    Used only to pick which "Добавить" trigger ``_add_target_action`` tries
+    FIRST (issue #779 review) — an empty table renders the create page's
+    ``AddTargetButton``, a populated one the ``MiniGrid.AddButton``. This is
+    a hint, never a decision: both triggers are attempted regardless, so a
+    stale or mid-hydration count costs at most one bounded click. That is
+    also why this deliberately does NOT wait for the table to settle the way
+    ``_created_target_action_mismatches`` does — the settling loop exists for
+    reads whose ANSWER must be trustworthy, and paying seconds of it to
+    reorder two cheap attempts would cost more than the miss it avoids.
+
+    Returns ``0`` on any read failure, which is the safe default: an
+    unreadable table is most likely one that has not rendered rows yet.
+    """
+    prefix = f"TargetActions.{_TARGET_ACTIONS_CATEGORY}."
+    try:
+        raw_testids = [
+            page.locator(f'[data-testid^="{prefix}"]')
+            .nth(i)
+            .get_attribute("data-testid")
+            for i in range(page.locator(f'[data-testid^="{prefix}"]').count())
+        ]
+    except PlaywrightError:
+        return 0
+    rows = 0
+    for testid in raw_testids:
+        if not testid or not testid.startswith(prefix):
+            continue
+        suffix = testid[len(prefix) :]
+        # Same skip-the-children convention as ``_read_target_actions_or_none``
+        # — and it also excludes the two "Добавить" triggers themselves,
+        # which share this prefix but never parse as an int.
+        if suffix.endswith((".PriceInput", ".CloseButton")):
+            continue
+        try:
+            int(suffix)
+        except ValueError:
+            continue
+        rows += 1
+    return rows
 
 
 def _wait_for_target_actions_settled(page: "Page") -> bool:

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -3437,6 +3437,13 @@ def _add_target_action(page: "Page", goal_id: int, price: float) -> None:
     option = page.locator(f'[data-testid="{option_testid}"]').first
 
     opened = False
+    # Whether ANY attempt got as far as clicking a trigger (issue #779
+    # review round 2). This is what separates the two ways the retry loop
+    # can be exhausted: never clicking means no trigger was actionable
+    # (absent, or present but too slow for the bound below), whereas
+    # clicking and still seeing no option means the popup opened and the
+    # goal genuinely was not in it — the counter/promotion-goal diagnosis.
+    ever_clicked = False
     last_exc: Optional[Exception] = None
     for _ in range(_TARGET_ACTION_ADD_OPTION_MAX_ATTEMPTS):
         # Only ONE of the two triggers exists on any given render, so a
@@ -3457,6 +3464,7 @@ def _add_target_action(page: "Page", goal_id: int, price: float) -> None:
                 # the happy path nothing.
                 add_button.click(timeout=_POPUP_APPEAR_TIMEOUT_MS)
                 clicked = True
+                ever_clicked = True
                 break
             except PlaywrightError as exc:
                 last_exc = exc
@@ -3471,6 +3479,41 @@ def _add_target_action(page: "Page", goal_id: int, price: float) -> None:
             continue
 
     if not opened:
+        # Which failure this was decides what to tell the user (issue #779
+        # review round 2). Bounding the trigger click made "the trigger IS
+        # there but never became clickable in time" newly reachable here —
+        # this section is documented to hydrate for seconds (see
+        # ``_wait_for_target_actions_settled`` and
+        # ``_TARGET_ACTION_SETTLE_TIMEOUT_MS``), and Playwright's
+        # ``TimeoutError`` cannot tell "absent" from "present but not
+        # actionable". Re-probing with a plain ``count()`` (no auto-wait, so
+        # it cannot itself hang) does distinguish them, and blaming the
+        # Metrika counter for a hydration race would send the user to audit
+        # a setup that is fine — the exact opposite of this module's
+        # "precise error over opaque timeout" rule.
+        trigger_present = False
+        if not ever_clicked:
+            for testid in add_button_testids:
+                try:
+                    if page.locator(f'[data-testid="{testid}"]').count() > 0:
+                        trigger_present = True
+                        break
+                except PlaywrightError:
+                    continue
+
+        if trigger_present:
+            raise BrowserSessionError(
+                "The 'Добавить' target-action trigger is on the page but "
+                f"never became clickable within {_POPUP_APPEAR_TIMEOUT_MS}ms, "
+                f"across {_TARGET_ACTION_ADD_OPTION_MAX_ATTEMPTS} attempts, "
+                f"so goal {goal_id} could not be added. The 'Целевые "
+                "действия' section is known to hydrate slowly, so this is "
+                "most likely a still-rendering page rather than a "
+                "configuration problem — re-run, or re-run with --headful "
+                "to watch it. If it persists, the goal may genuinely not be "
+                "on offer (see below)."
+            ) from last_exc
+
         raise BrowserSessionError(
             f"Could not find goal {goal_id} in the 'Добавить' target-action "
             "popup. On the campaign edit page this table only exists when "
@@ -3485,6 +3528,16 @@ def _add_target_action(page: "Page", goal_id: int, price: float) -> None:
             "the create page the counter is auto-discovered from the "
             "landing page's domain, so a domain with no Metrika counter "
             "installed offers no goals at all."
+            + (
+                ""
+                if ever_clicked
+                # The popup was never even opened, so "the goal isn't in it"
+                # is an inference, not an observation — say so rather than
+                # asserting a diagnosis the run could not actually make.
+                else " The 'Добавить' trigger was not found on the page "
+                "either, so if the goal setup is correct, the page may not "
+                "have finished hydrating — re-run to rule that out."
+            )
         ) from last_exc
 
     option.click()

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -175,12 +175,12 @@ single status field. Not yet covered: an inline validation-error TEXT is
 not itself surfaced to the caller (only the resulting mismatch is) — a
 follow-up could read and report Yandex's actual rejection reason.
 
-``create_master`` (issue #632) — live recon only, NOT live-verified end to end
-(no campaign has ever actually been launched/saved during recon — see
-``tests/fixtures/masters_wizard_create.html``; the individual form fields,
-including the conversion-goal widget re-reconned for #777, have each been
-driven live, but no terminal click has yet been accepted by
-Yandex). Covers exactly the "Конверсии
+``create_master`` (issue #632) — **live-verified end to end for the DRAFT
+leg** (#777, 2026-08-06): a full ``--draft`` create was accepted by Yandex
+and produced campaign 713337891, confirmed by a grid diff (79 → 80 rows).
+The ``--launch`` leg remains unexercised on purpose — it publishes live
+advertising with no rollback. See ``tests/fixtures/masters_wizard_create.html``
+for the form recon. Covers exactly the "Конверсии
 и трафик" Мастер кампаний type (the other five tile types on the create
 modal — Товарная кампания, Продажи на маркетплейсах, Подписчики в
 телеграм-канал, Продвижение бизнеса без сайта, Продвижение специалистов — are
@@ -8146,14 +8146,23 @@ def create_master(
     redirect (``_wait_for_created_campaign_id``), which also gives
     ``_verify_created`` a page to reload for the display-region check.
 
-    **Caveat — the create path's redirect is still unconfirmed** (issue
-    #744 live recon, 2026-08-06). It is modelled on ``copy_master``'s
-    live-verified redirect through the identical form and button. Issue
-    #777 removed the blocker that made it unobservable (the form could not
-    be given a goal, so the terminal click was always rejected), but until
-    a create is actually accepted and observed live, treat the ID/region-
-    verification path here as designed-and-unit-tested rather than
-    field-proven.
+    **The create path's redirect is now live-verified** (issue #744, closed
+    by #777's live pass 2026-08-06). Once the goal requirement above was
+    satisfied, a ``launch=False`` create was accepted by Yandex end to end
+    and produced campaign 713337891: the terminal click DID redirect, and
+    ``_wait_for_created_campaign_id`` read the id straight off it — exactly
+    the shape modelled on ``copy_master``. The id was cross-checked against
+    a ``fetch_masters_list`` grid diff (79 rows → 80, the one new row being
+    713337891, status ``DRAFT``), so it is a real campaign id rather than
+    an artefact of URL parsing, and the goal was confirmed to have persisted
+    server-side by re-reading it from a separate page
+    (``fetch_master_target_actions``: goal 236386933 at price 150).
+
+    Not verified: the ``launch=True`` leg. Both buttons share
+    ``_click_terminal_button`` and the same redirect, but "Запустить
+    кампанию" publishes live advertising with no rollback, so it was
+    deliberately not exercised — see ``archive_master``'s DRAFT limitation
+    below for why that decision also left the test campaign in place.
     """
     if not headlines:
         raise ValueError("create_master requires at least one headline.")

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -176,8 +176,11 @@ not itself surfaced to the caller (only the resulting mismatch is) — a
 follow-up could read and report Yandex's actual rejection reason.
 
 ``create_master`` (issue #632) — live recon only, NOT live-verified end to end
-(no campaign was ever actually launched/saved during recon — see
-``tests/fixtures/masters_wizard_create.html``). Covers exactly the "Конверсии
+(no campaign has ever actually been launched/saved during recon — see
+``tests/fixtures/masters_wizard_create.html``; the individual form fields,
+including the conversion-goal widget re-reconned for #777, have each been
+driven live, but no terminal click has yet been accepted by
+Yandex). Covers exactly the "Конверсии
 и трафик" Мастер кампаний type (the other five tile types on the create
 modal — Товарная кампания, Продажи на маркетплейсах, Подписчики в
 телеграм-канал, Продвижение бизнеса без сайта, Продвижение специалистов — are
@@ -194,6 +197,22 @@ auto-populates headlines/texts by scanning the landing page). This module
 therefore requires the caller to pass headlines/texts/regions explicitly
 rather than trusting Yandex's AI-generated copy silently, given the "no
 sandbox, no rollback" risk profile called out in issue #632.
+
+**A required-field marker is not the list of required fields** (issue #777,
+live recon 2026-08-06). A FOURTH field is mandatory despite carrying no such
+marker: "Целевые действия" needs at least one Яндекс Метрика conversion goal,
+or Yandex refuses the form with "Добавьте хотя бы одну цель для сайта, чтобы
+создать и запустить кампанию". Worse, it refuses SILENTLY — both terminal
+buttons keep reporting ``visible=True``, ``enabled=True``,
+``aria-disabled=None`` in the rejected state, so there is no DOM signal
+separating "rejected" from "still working"; #744's recon watched ``page.url``
+for 48s before the cause was found. ``create_master`` therefore takes a
+REQUIRED ``target_actions`` mapping and refuses an empty one up front, and
+gates the terminal click on the goal rows actually being present with the
+requested prices (``_created_target_action_mismatches``). The widget itself
+is the same one the edit page uses — see
+``_TARGET_ACTION_ADD_BUTTON_EMPTY_TESTID_TEMPLATE`` for the single testid
+that differs — so ``_add_target_action`` is shared between both paths.
 
 **Save/launch verification.** Ported from ``update_master``'s
 ``_verify_saved`` pattern (issue #631 review finding, see the CHANGELOG
@@ -1076,6 +1095,23 @@ _TARGET_ACTION_PRICE_TESTID_TEMPLATE = "TargetActions.{category}.{goal_id}.Price
 _TARGET_ACTION_CLOSE_TESTID_TEMPLATE = "TargetActions.{category}.{goal_id}.CloseButton"
 _TARGET_ACTION_ADD_BUTTON_TESTID_TEMPLATE = (
     "TargetActions.{category}.MiniGrid.AddButton"
+)
+# The create page's EMPTY-table variant of the same button (issue #777 live
+# recon, 2026-08-06, create wizard for ksamata.ru). Every other testid in
+# this section is identical between the create and edit pages — the section
+# container, the ``AddTargetAction.{category}.{goal_id}`` popup options, and
+# the resulting row's ``TargetActions.{category}.{goal_id}[.PriceInput|
+# .CloseButton]`` — but the "Добавить" trigger is NOT: with no rows yet, the
+# create page renders it as ``TargetActions.OTHER.AddTargetButton``, with no
+# ``MiniGrid`` segment (there is no grid to hang it off yet). Confirmed live
+# that once the first row exists, the create page ALSO renders the
+# ``MiniGrid.AddButton`` form — so the two are alternatives for the first
+# add only, not two permanently distinct pages. ``_add_target_action``
+# therefore tries both rather than branching on which page it is on, which
+# keeps one code path shared by ``create_master`` and ``update_master``
+# (issue #777 step 2) and degrades gracefully if Yandex settles on one name.
+_TARGET_ACTION_ADD_BUTTON_EMPTY_TESTID_TEMPLATE = (
+    "TargetActions.{category}.AddTargetButton"
 )
 _TARGET_ACTION_ADD_OPTION_TESTID_TEMPLATE = "AddTargetAction.{category}.{goal_id}"
 
@@ -3331,8 +3367,8 @@ def _set_target_action_price(page: "Page", goal_id: int, price: float) -> None:
     except PlaywrightError as exc:
         raise BrowserSessionError(
             f"Could not find or fill the target-action price input for goal "
-            f"{goal_id} in the 'Целевые действия' table on the campaign "
-            "edit page. This table only exists when the promotion goal is "
+            f"{goal_id} in the 'Целевые действия' table. On the campaign "
+            "edit page this table only exists when the promotion goal is "
             "'max-conversions', and only shows goals already added to it — "
             f"pass --promotion-goal max-conversions, and confirm goal "
             f"{goal_id} is already listed (add it first with "
@@ -3361,15 +3397,30 @@ def _add_target_action(page: "Page", goal_id: int, price: float) -> None:
     because the target here is a per-goal-id OPTION inside the popup, not
     the popup's own container.
 
-    A freshly clicked option renders with an EMPTY price input (confirmed
-    live — not a page default), so this always fills one — there is no
-    "add with no price" caller path; the CLI-boundary parse requires a
-    price for exactly this reason (see ``_parse_add_target_action_options``).
+    A freshly clicked option's price input must not be trusted to be
+    meaningful, so this always fills one — there is no "add with no price"
+    caller path; the CLI-boundary parse requires a price for exactly this
+    reason (see ``_parse_add_target_action_options``). On the edit page the
+    input starts genuinely EMPTY and Yandex rejects saving it that way; on
+    the create page (issue #777 recon) it instead arrives PRE-FILLED with a
+    Yandex-suggested value (observed: "160"). Neither is a documented
+    default, and silently publishing a CPA the caller never chose is worse
+    than requiring one, so both paths overwrite it.
+
+    Works on the create page as well as the edit page — see
+    ``_TARGET_ACTION_ADD_BUTTON_EMPTY_TESTID_TEMPLATE`` for the one testid
+    that differs there, which the trigger loop below tries as an alternative.
     """
-    add_button_testid = _TARGET_ACTION_ADD_BUTTON_TESTID_TEMPLATE.format(
-        category=_TARGET_ACTIONS_CATEGORY
-    )
-    add_button = page.locator(f'[data-testid="{add_button_testid}"]').first
+    add_button_testids = [
+        template.format(category=_TARGET_ACTIONS_CATEGORY)
+        for template in (
+            _TARGET_ACTION_ADD_BUTTON_TESTID_TEMPLATE,
+            _TARGET_ACTION_ADD_BUTTON_EMPTY_TESTID_TEMPLATE,
+        )
+    ]
+    add_buttons = [
+        page.locator(f'[data-testid="{testid}"]').first for testid in add_button_testids
+    ]
     option_testid = _TARGET_ACTION_ADD_OPTION_TESTID_TEMPLATE.format(
         category=_TARGET_ACTIONS_CATEGORY, goal_id=goal_id
     )
@@ -3378,10 +3429,18 @@ def _add_target_action(page: "Page", goal_id: int, price: float) -> None:
     opened = False
     last_exc: Optional[Exception] = None
     for _ in range(_TARGET_ACTION_ADD_OPTION_MAX_ATTEMPTS):
-        try:
-            add_button.click()
-        except PlaywrightError as exc:
-            last_exc = exc
+        # Only ONE of the two triggers exists on any given render, so a
+        # click failure on the first is expected, not an error — fall
+        # through to the other before giving up on this attempt.
+        clicked = False
+        for add_button in add_buttons:
+            try:
+                add_button.click()
+                clicked = True
+                break
+            except PlaywrightError as exc:
+                last_exc = exc
+        if not clicked:
             continue
         try:
             option.wait_for(state="visible", timeout=_POPUP_APPEAR_TIMEOUT_MS)
@@ -3394,7 +3453,7 @@ def _add_target_action(page: "Page", goal_id: int, price: float) -> None:
     if not opened:
         raise BrowserSessionError(
             f"Could not find goal {goal_id} in the 'Добавить' target-action "
-            "popup on the campaign edit page. This table only exists when "
+            "popup. On the campaign edit page this table only exists when "
             "the promotion goal is 'max-conversions' — pass "
             "--promotion-goal max-conversions if that's not already the "
             "case. Otherwise the popup only lists goals from the "
@@ -3402,7 +3461,10 @@ def _add_target_action(page: "Page", goal_id: int, price: float) -> None:
             "table — confirm goal "
             f"{goal_id} belongs to that counter and isn't already listed "
             "(`masters targetactions get`), or Yandex may have changed the "
-            "page's markup — re-run with --headful to inspect the page."
+            "page's markup — re-run with --headful to inspect the page. On "
+            "the create page the counter is auto-discovered from the "
+            "landing page's domain, so a domain with no Metrika counter "
+            "installed offers no goals at all."
         ) from last_exc
 
     option.click()
@@ -7692,6 +7754,61 @@ def _click_terminal_button(page: "Page", text: str) -> None:
     )
 
 
+def _created_target_action_mismatches(
+    page: "Page", target_actions: Dict[int, float]
+) -> List[str]:
+    """Compare the create page's CURRENT "Целевые действия" rows against the
+    goals/prices the caller asked for — ``create_master``'s pre-click gate
+    (issue #777).
+
+    Deliberately a pre-click check with no post-click twin, unlike
+    ``_repeating_values_mismatches``: this is the one field whose absence
+    Yandex punishes by silently swallowing the terminal click (no redirect,
+    no error, buttons still ``enabled``/``aria-disabled=None``), so
+    observing it afterwards is impossible by construction — there is no
+    "afterwards" to observe.
+
+    Reuses ``_wait_for_target_actions_settled``/
+    ``_read_target_actions_or_none`` rather than a one-shot read for the
+    hydration reasons documented on those functions: this section's row
+    count genuinely dips to zero mid-render, and reading a truthful-but-
+    incomplete snapshot here would abort a create that was in fact fine.
+    A settle timeout is reported as a mismatch rather than passed over —
+    refusing to click on an unreadable table is the safe direction when the
+    click is an irreversible publish.
+    """
+    if not _wait_for_target_actions_settled(page):
+        return [
+            "the 'Целевые действия' table did not finish loading, so the "
+            "requested goals could not be confirmed"
+        ]
+
+    rows = _read_target_actions_or_none(page)
+    if rows is None:
+        return ["the 'Целевые действия' table could not be read"]
+
+    actual = {
+        row["GoalId"]: row.get("Price") for row in rows if row.get("GoalId") is not None
+    }
+
+    mismatches = []
+    for goal_id, price in target_actions.items():
+        if goal_id not in actual:
+            mismatches.append(
+                f"goal {goal_id} is not listed in the table (present: "
+                f"{sorted(actual)!r})"
+            )
+        elif not _target_action_price_matches(price, actual[goal_id]):
+            # An empty/wrong price is not cosmetic here: Yandex's own
+            # client-side validation rejects a row with no price, which is
+            # the same silent-swallow failure as a missing goal.
+            mismatches.append(
+                f"goal {goal_id}: expected price {price}, page holds "
+                f"{actual[goal_id]!r}"
+            )
+    return mismatches
+
+
 def _repeating_values_mismatches(
     page: "Page", *, headlines: List[str], texts: List[str]
 ) -> List[str]:
@@ -7982,6 +8099,7 @@ def create_master(
     headlines: List[str],
     texts: List[str],
     regions: "Sequence[Union[str, Tuple[str, Optional[int]]]]",
+    target_actions: Dict[int, float],
     weekly_budget: Optional[int] = None,
     launch: bool = True,
 ) -> Dict[str, Any]:
@@ -8008,20 +8126,34 @@ def create_master(
     alone — mirrors ``update_master``'s ``_verify_saved`` convention (issue
     #631 review).
 
+    ``target_actions`` maps a Yandex Metrika goal id to its CPA price, and
+    is REQUIRED — at least one entry (issue #777). Yandex's create form
+    refuses to submit without a conversion goal ("Добавьте хотя бы одну
+    цель для сайта, чтобы создать и запустить кампанию"), and it refuses
+    *silently*: both terminal buttons keep reporting ``visible=True``,
+    ``enabled=True``, ``aria-disabled=None`` in the rejected state, so a
+    goal-less call could only ever fail as an opaque
+    ``_wait_for_created_campaign_id`` timeout. Rejecting it here instead
+    fails fast, before a browser is even driven through the whole form.
+    Goals are identified by numeric Metrika goal id, never by display name
+    — the same convention as every other target-action entry point in this
+    module (see ``_TARGET_ACTION_ROW_TESTID_TEMPLATE``). The goals offered
+    on the create page come from the Metrika counter Yandex auto-discovers
+    from ``url``'s domain, so a domain with no counter installed has none
+    to pick and cannot be used here at all.
+
     Returns the created campaign's ``CampaignId``, read from the post-click
     redirect (``_wait_for_created_campaign_id``), which also gives
     ``_verify_created`` a page to reload for the display-region check.
 
     **Caveat — the create path's redirect is still unconfirmed** (issue
     #744 live recon, 2026-08-06). It is modelled on ``copy_master``'s
-    live-verified redirect through the identical form and button, but no
-    create attempt has yet been accepted by Yandex to observe it directly:
-    the form requires at least one conversion goal, which this function
-    cannot set, so the terminal click is silently rejected and no campaign
-    is created (see ``_wait_for_created_campaign_id``). That failure mode is
-    reported as an error, not as success — but until goal support lands,
-    treat the ID/region-verification path here as designed-and-unit-tested
-    rather than field-proven.
+    live-verified redirect through the identical form and button. Issue
+    #777 removed the blocker that made it unobservable (the form could not
+    be given a goal, so the terminal click was always rejected), but until
+    a create is actually accepted and observed live, treat the ID/region-
+    verification path here as designed-and-unit-tested rather than
+    field-proven.
     """
     if not headlines:
         raise ValueError("create_master requires at least one headline.")
@@ -8029,6 +8161,12 @@ def create_master(
         raise ValueError("create_master requires at least one ad text.")
     if not regions:
         raise ValueError("create_master requires at least one region.")
+    if not target_actions:
+        raise ValueError(
+            "create_master requires at least one target action (conversion "
+            "goal): Yandex's create form silently refuses to submit without "
+            "one."
+        )
 
     # ``wait_until="commit"``, not ``domcontentloaded`` (issue #685):
     # confirmed live the create page can take long enough to hydrate that
@@ -8063,6 +8201,17 @@ def create_master(
     if weekly_budget is not None:
         _set_weekly_budget_on_create(page, weekly_budget)
 
+    # Issue #777: at least one conversion goal, or Yandex silently rejects
+    # the terminal click below. Live recon (2026-08-06) confirmed the create
+    # page's "Целевые действия" widget is the same one the edit page uses —
+    # same section container, same per-goal popup options, same resulting
+    # row/price/close testids — so this reuses ``_add_target_action``
+    # wholesale rather than growing a create-specific setter (the one testid
+    # that does differ is handled inside it). Ordered after the budget for
+    # the same reason the section sits below it on the page.
+    for goal_id, price in target_actions.items():
+        _add_target_action(page, goal_id, price)
+
     # Gate the click, don't just report on it afterwards (issue #655
     # round-3 review): _add_repeating_values believing it wrote the right
     # values is not the same as the page actually holding them — a click
@@ -8081,6 +8230,24 @@ def create_master(
             "was requested: " + "; ".join(pre_click_mismatches) + ". Yandex "
             "may have changed the page's markup, or a slot silently failed "
             "to clear — re-run with --headful to inspect the page."
+        )
+
+    # Same gate for the goals (issue #777), and for a sharper reason: a
+    # missing/empty-priced goal row is the ONE discrepancy Yandex punishes
+    # by silently swallowing the terminal click — the buttons stay
+    # visible/enabled with no aria-disabled, so a post-click check could
+    # only ever observe it as an opaque _wait_for_created_campaign_id
+    # timeout. Reading the rows back here converts that into a precise
+    # error, before anything is published.
+    goal_mismatches = _created_target_action_mismatches(page, target_actions)
+    if goal_mismatches:
+        raise BrowserSessionError(
+            "Refusing to click the create page's terminal button: before "
+            "clicking, the 'Целевые действия' table does not hold the "
+            "requested conversion goal(s): " + "; ".join(goal_mismatches) + ". "
+            "Yandex silently rejects a create with no valid goal, so this "
+            "would otherwise fail as an unexplained timeout — re-run with "
+            "--headful to inspect the page."
         )
 
     button_label = _LAUNCH_BUTTON_TEXT if launch else _SAVE_DRAFT_BUTTON_TEXT
@@ -8113,6 +8280,7 @@ def create_master(
         "Headlines": headlines,
         "Texts": texts,
         "Regions": regions,
+        "TargetActions": target_actions,
         "Launched": launch,
     }
     if weekly_budget is not None:

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -2076,6 +2076,22 @@ def _resolve_region_ids(
     "(unlike the rest of `masters`). Combines with --region.",
 )
 @click.option(
+    "--add-target-action",
+    "add_target_actions",
+    multiple=True,
+    required=True,
+    help=(
+        'Conversion goal to optimize for: "goal_id=price" where goal_id is '
+        "the Yandex Metrika goal ID and price is its CPA in account "
+        "currency. Repeat for multiple goals. REQUIRED — Yandex's create "
+        "form silently refuses to submit without at least one goal. The "
+        "goal must belong to the Metrika counter Yandex auto-discovers "
+        "from the landing page's domain, so a domain with no counter "
+        "installed cannot be used. Same flag name and syntax as `masters "
+        "update --add-target-action`."
+    ),
+)
+@click.option(
     "--weekly-budget",
     type=int,
     help="Weekly budget in account currency (Недельный бюджет)",
@@ -2097,6 +2113,7 @@ def add(
     texts,
     regions,
     region_ids,
+    add_target_actions,
     weekly_budget,
     draft,
     headful,
@@ -2126,6 +2143,13 @@ def add(
     wording the region widget expects; it requires Yandex Direct API
     credentials, unlike the rest of this command.
 
+    --add-target-action is required (issue #777): Yandex's create form
+    refuses to submit without at least one conversion goal, and refuses
+    SILENTLY — both terminal buttons stay visible and enabled in the
+    rejected state, so a goal-less run could only ever surface as an
+    unexplained timeout. It takes the same "goal_id=price" syntax as
+    `masters update --add-target-action`.
+
     By default the campaign is launched immediately (--launch). Pass
     --draft to save it as a draft instead (Сохранить как черновик) without
     going live.
@@ -2134,6 +2158,8 @@ def add(
 
     if not regions and not region_ids:
         raise click.UsageError("At least one of --region/--region-id is required.")
+
+    parsed_target_actions = _parse_add_target_action_options(add_target_actions)
 
     # (name, region_id) pairs — plain --region text has no known RegionId
     # (region_id=None), so `_set_region` can only verify it by exact-text
@@ -2154,6 +2180,7 @@ def add(
             headlines=list(headlines),
             texts=list(texts),
             regions=all_regions,
+            target_actions=parsed_target_actions,
             weekly_budget=weekly_budget,
             launch=not draft,
         ),

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -749,10 +749,14 @@ def _parse_add_target_action_options(
 
     Same shape as ``_parse_target_action_price_options`` (goal id, never a
     label — see that function's docstring), but the price is NOT optional
-    here: live recon (issue #717) confirmed a freshly added row's price
-    input starts empty and Yandex's own client-side validation rejects
-    saving it empty, so there is no page default to fall back to — always
-    require ``"goal_id=price"``, never a bare goal id.
+    here, and on both pages that use this parse. On the EDIT page live recon
+    (issue #717) confirmed a freshly added row's price input starts empty
+    and Yandex's own client-side validation rejects saving it empty. On the
+    CREATE page (issue #777 recon) it instead arrives pre-filled with a
+    Yandex suggestion — but that is not a documented default either, and
+    publishing a CPA the caller never chose is worse than requiring one. So
+    neither page offers a default worth inheriting: always require
+    ``"goal_id=price"``, never a bare goal id.
     """
     parsed: "dict[int, float]" = {}
     for raw in values:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "direct-cli"
-version = "0.5.1"
+version = "0.6.0"
 description = "Command-line interface for Yandex Direct API"
 readme = "README.md"
 license = {text = "MIT"}

--- a/scripts/test_dangerous_commands.sh
+++ b/scripts/test_dangerous_commands.sh
@@ -43,9 +43,13 @@ non-critical campaign, confirming before/after state in the web UI):
   - direct masters launch <campaign_id>
     (publishes a DRAFT campaign -- irreversible, there is no `masters unlaunch`)
   - direct masters add <url> --headline ... --text ... --region ...
+      --add-target-action "<goal_id>=<price>"
     (creates a brand-new campaign -- NOT idempotent, a second run creates a
     second campaign; verify with --draft first, then delete/archive the
-    test campaign by hand after checking it in the web UI)
+    test campaign by hand after checking it in the web UI.
+    --add-target-action is REQUIRED since 0.6.0 -- Yandex's create form
+    silently refuses a campaign with no conversion goal. Note a --draft
+    created this way currently cannot be archived at all, see issue #782)
 
 Interactive human-in-the-loop login (opens a visible browser window and
 blocks waiting for a person to sign in -- cannot run unattended):

--- a/tests/fixtures/masters_wizard_create.html
+++ b/tests/fixtures/masters_wizard_create.html
@@ -322,8 +322,27 @@ Header: editable auto-generated campaign name, e.g. "ksamata.ru от 01.08.26"
     here that this recon pass could not observe (needs a second live check
     against a domain with no counter before assuming this is always optional).
 
-17. "Целевые действия" — starts empty, "Добавить" button only; optional (CPA
-    per-goal target list, matches issue #631 field description).
+17. "Целевые действия" — starts empty, "Добавить" button only (CPA per-goal
+    target list, matches issue #631 field description).
+
+    CORRECTION (issue #777 live recon, 2026-08-06): this section is NOT
+    optional, despite carrying no required marker in the UI. Yandex refuses
+    to submit the form without at least one goal — "Добавьте хотя бы одну
+    цель для сайта, чтобы создать и запустить кампанию" — and refuses
+    SILENTLY: both terminal buttons keep reporting visible=True,
+    enabled=True, aria-disabled=None in the rejected state. #744's recon
+    lost 48s to this before the cause was found. "Not marked required in
+    the UI" is not evidence a field is optional on this form.
+
+    The same recon captured the testids this text snapshot could not (it is
+    a text-content dump, not a DOM dump). They match the EDIT page's:
+    `TargetActionsSection`, `AddTargetAction.OTHER.<goalId>` popup options,
+    and `TargetActions.OTHER.<goalId>[.PriceInput|.CloseButton]` rows.
+    The one difference: with an empty table the "Добавить" trigger here is
+    `TargetActions.OTHER.AddTargetButton` (no `MiniGrid` segment), switching
+    to the edit page's `TargetActions.OTHER.MiniGrid.AddButton` once a first
+    row exists. A freshly added row's price input arrives PRE-FILLED with a
+    Yandex suggestion (observed "160"), unlike the edit page's empty one.
 
 18. "Недельный бюджет" — empty numeric input with a "₽" suffix; not marked
     required, but functionally this is very likely enforced server-side (a

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -140,6 +140,9 @@ class _FakeLocatorHandle:
         self._get_value = get_value
         self._get_checked = get_checked
         self._on_upload = on_upload
+        # Every `timeout=` this handle's click() was called with, in order
+        # (issue #779 review) — see click().
+        self.click_timeouts = []
         # {selector: _FakeLocatorHandle} for a SCOPED child lookup — models
         # Playwright's Locator.locator(), e.g. `label.locator("xpath=.//input
         # [...]")` (issue #656: _set_region reads a checkbox scoped off the
@@ -177,6 +180,12 @@ class _FakeLocatorHandle:
             raise PlaywrightError("Timeout waiting for element state")
 
     def click(self, timeout=None):
+        # Record every click's timeout, including the ones that raise
+        # (issue #779 review): a trigger that ISN'T on the page is exactly
+        # the call whose missing `timeout=` costs Playwright's 30s default,
+        # and this fake raises instantly, so the argument is the only
+        # observable an offline test has for that cost.
+        self.click_timeouts.append(timeout)
         if self._raises:
             raise PlaywrightError("element detached")
         if not self._visible:
@@ -5389,6 +5398,144 @@ class TestAddTargetAction(unittest.TestCase):
             browser_masters._add_target_action(page, 226158067, 77)
         self.assertIn("226158067", str(ctx.exception))
         self.assertIn("max-conversions", str(ctx.exception))
+
+    def _empty_add_button_testid(self):
+        testid = browser_masters._TARGET_ACTION_ADD_BUTTON_EMPTY_TESTID_TEMPLATE.format(
+            category=browser_masters._TARGET_ACTIONS_CATEGORY
+        )
+        return f'[data-testid="{testid}"]'
+
+    def test_bounds_the_click_on_a_trigger_that_is_not_on_the_page(self):
+        """Every candidate trigger must be clicked with an EXPLICIT short
+        ``timeout=`` (issue #779 review, found independently by both
+        reviewers).
+
+        ``_add_target_action`` tries both trigger testids because only one
+        of them exists on any given render — so a click against the absent
+        one is the EXPECTED path, not an edge case, and it runs on every
+        single ``masters add``: the create page's table always starts
+        empty, so the ``MiniGrid.AddButton`` variant tried first is never
+        there for the first goal. With no explicit ``timeout=``, Playwright
+        applies its 30s default action timeout (nothing in ``direct_cli/``
+        calls ``set_default_timeout``), so that expected miss costs ~30s of
+        auto-wait before falling through to the trigger that does exist —
+        and the documented no-Metrika-counter failure case multiplies it by
+        ``_TARGET_ACTION_ADD_OPTION_MAX_ATTEMPTS``.
+
+        This is unobservable through the fake's timing: ``_FakeLocator.first``
+        raises INSTANTLY for an absent selector, so the production cost
+        never shows up as a slow test — the same structural blind spot
+        ``_clock.py`` documents for poll deadlines. The argument passed to
+        ``click()`` is therefore the only thing an offline test can assert
+        on, which is why the fake records it.
+        """
+        # Create-page shape: only the empty-table trigger exists, so the
+        # MiniGrid one tried first is absent.
+        missing_trigger = _FakeLocatorHandle(raises=True)
+        present_trigger = _FakeLocatorHandle()
+        option = _FakeLocatorHandle()
+        price_field = _FakeLocatorHandle()
+        price_field.fill = lambda value: None
+
+        page = FakePage(
+            locators={
+                self._add_button_testid(): _FakeLocator([missing_trigger]),
+                self._empty_add_button_testid(): _FakeLocator([present_trigger]),
+                self._option_testid(226158067): _FakeLocator([option]),
+                self._price_testid(226158067): _FakeLocator([price_field]),
+            }
+        )
+
+        browser_masters._add_target_action(page, 226158067, 77)
+
+        # An empty table must go STRAIGHT to the trigger that exists there,
+        # never paying for the MiniGrid variant at all.
+        self.assertEqual(
+            missing_trigger.click_timeouts,
+            [],
+            "an empty table clicked the populated-table trigger — the "
+            "ordering that keeps `masters add`'s first goal from paying "
+            "for a known-absent trigger has regressed",
+        )
+        self.assertTrue(present_trigger.click_timeouts)
+
+        # And every trigger click, whichever is tried, stays bounded: the
+        # ordering is a hint, so the OTHER trigger is still attempted
+        # whenever the hint is wrong (a non-empty table on the create page,
+        # a mid-hydration row count), and that attempt must not fall back
+        # to Playwright's 30s default.
+        for timeout in present_trigger.click_timeouts:
+            self.assertIsNotNone(
+                timeout,
+                "click() was called with no explicit timeout, so Playwright's "
+                "30s default applies to a trigger that may be absent",
+            )
+            self.assertLessEqual(
+                timeout,
+                browser_masters._POPUP_APPEAR_TIMEOUT_MS,
+                "the trigger click's timeout must stay short — a present "
+                "trigger is present immediately",
+            )
+
+    def test_bounds_the_click_when_the_row_count_hint_is_wrong(self):
+        """The row-count hint only reorders the attempts — when it points at
+        the wrong trigger the other is still tried, and THAT click is the
+        one whose missing ``timeout=`` would cost Playwright's 30s default
+        (issue #779 review).
+
+        Modelled here as a populated table (so the hint picks
+        ``MiniGrid.AddButton`` first) on which only the empty-table trigger
+        actually renders — the create page's state mid-hydration, and the
+        reason the ordering must stay a hint rather than a branch.
+        """
+        missing_trigger = _FakeLocatorHandle(raises=True)
+        present_trigger = _FakeLocatorHandle()
+        option = _FakeLocatorHandle()
+        price_field = _FakeLocatorHandle()
+        price_field.fill = lambda value: None
+
+        row_testid = browser_masters._TARGET_ACTION_ROW_TESTID_TEMPLATE.format(
+            category=browser_masters._TARGET_ACTIONS_CATEGORY, goal_id=111222333
+        )
+        prefix_selector = (
+            f'[data-testid^="TargetActions.'
+            f'{browser_masters._TARGET_ACTIONS_CATEGORY}."]'
+        )
+
+        page = FakePage(
+            locators={
+                # A row already in the table — the hint therefore says
+                # "populated", so MiniGrid.AddButton is tried first...
+                prefix_selector: _FakeLocator(
+                    [_FakeLocatorHandle(attrs={"data-testid": row_testid})]
+                ),
+                # ...but only the empty-table trigger is actually present.
+                self._add_button_testid(): _FakeLocator([missing_trigger]),
+                self._empty_add_button_testid(): _FakeLocator([present_trigger]),
+                self._option_testid(226158067): _FakeLocator([option]),
+                self._price_testid(226158067): _FakeLocator([price_field]),
+            }
+        )
+
+        browser_masters._add_target_action(page, 226158067, 77)
+
+        self.assertTrue(
+            missing_trigger.click_timeouts,
+            "the wrong-hint fall-through was never exercised — this test no "
+            "longer covers the click it is meant to bound",
+        )
+        for timeout in missing_trigger.click_timeouts + present_trigger.click_timeouts:
+            self.assertIsNotNone(
+                timeout,
+                "click() was called with no explicit timeout, so Playwright's "
+                "30s default applies to a trigger known to be absent",
+            )
+            self.assertLessEqual(
+                timeout,
+                browser_masters._POPUP_APPEAR_TIMEOUT_MS,
+                "the trigger click's timeout must stay short — a present "
+                "trigger is present immediately",
+            )
 
     def test_raises_with_context_when_price_fill_fails_after_add(self):
         add_button = _FakeLocatorHandle()

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -12415,6 +12415,11 @@ class TestCreateMaster(unittest.TestCase):
     # see _redirect_to_overview below.
     CREATED_ID = 713299001
 
+    # The Metrika goal id / CPA the create-page tests add (issue #777).
+    # A real goal id from the live recon's auto-discovered counter.
+    GOAL_ID = 236386933
+    GOAL_PRICE = 150
+
     def _full_page(
         self,
         region="Москва",
@@ -12423,6 +12428,10 @@ class TestCreateMaster(unittest.TestCase):
         redirect=True,
         node_id=None,
         page_after_redirect_has_no_form=False,
+        offer_goal_ids=None,
+        add_button_testid=None,
+        drop_goal_rows_after_add=False,
+        revert_goal_price_after_add=None,
     ):
         url_state = {}
         headline_state = []
@@ -12541,8 +12550,129 @@ class TestCreateMaster(unittest.TestCase):
             },
         )
 
+        # "Целевые действия" widget (issue #777 live recon, 2026-08-06).
+        # Modelled exactly as the create page behaves: the table starts
+        # EMPTY with only an add trigger, clicking it reveals one
+        # AddTargetAction.OTHER.<goalId> option per goal on the
+        # auto-discovered Metrika counter, and clicking an option appends a
+        # row whose PriceInput arrives PRE-FILLED with a Yandex suggestion
+        # (not empty, unlike the edit page) — which _add_target_action must
+        # overwrite rather than accept.
+        offer_goal_ids = (
+            [self.GOAL_ID] if offer_goal_ids is None else list(offer_goal_ids)
+        )
+        # Which of the two live-observed trigger testids this page renders.
+        # The create page's empty table uses AddTargetButton; the edit page
+        # (and the create page once a row exists) uses MiniGrid.AddButton.
+        # Defaulting to the empty-table form is what makes these tests cover
+        # the create page's actual markup rather than the edit page's.
+        add_button_testid = add_button_testid or (
+            browser_masters._TARGET_ACTION_ADD_BUTTON_EMPTY_TESTID_TEMPLATE.format(
+                category=browser_masters._TARGET_ACTIONS_CATEGORY
+            )
+        )
+        goal_rows = {}
+        goal_price_state = {}
+        target_action_popup_open = {"value": False}
+
+        def _fill_goal_price(goal_id, value):
+            """The price fill, plus the two ways a successful
+            ``_add_target_action`` can still leave the table wrong by the
+            time the terminal button is reached (issue #777's pre-click
+            gate). Both are modelled here, at the LAST step of the add, so
+            they land after the add believes it succeeded and before the
+            gate reads the table back.
+            """
+            goal_price_state[goal_id] = value
+            if drop_goal_rows_after_add:
+                # A React re-render dropping the row behind us.
+                goal_rows.clear()
+                page._locators[row_prefix_selector] = _FakeLocator([])
+            elif revert_goal_price_after_add is not None:
+                goal_price_state[goal_id] = revert_goal_price_after_add
+
+        def _make_goal_locators():
+            """Row/price locators for goals currently in the table."""
+            out = {}
+            for goal_id in goal_rows:
+                price_testid = (
+                    browser_masters._TARGET_ACTION_PRICE_TESTID_TEMPLATE.format(
+                        category=browser_masters._TARGET_ACTIONS_CATEGORY,
+                        goal_id=goal_id,
+                    )
+                )
+                out[f'[data-testid="{price_testid}"]'] = _FakeLocator(
+                    [
+                        _FakeLocatorHandle(
+                            on_fill=lambda v, g=goal_id: _fill_goal_price(g, v),
+                            get_value=lambda g=goal_id: goal_price_state.get(g, ""),
+                        )
+                    ]
+                )
+            return out
+
+        def _add_goal_row(goal_id):
+            goal_rows[goal_id] = True
+            # Pre-filled Yandex suggestion, confirmed live — the value
+            # _add_target_action must not trust.
+            goal_price_state.setdefault(goal_id, "160")
+            page._locators.update(_make_goal_locators())
+            row_template = browser_masters._TARGET_ACTION_ROW_TESTID_TEMPLATE
+            page._locators[row_prefix_selector] = _FakeLocator(
+                [
+                    _FakeLocatorHandle(
+                        attrs={
+                            "data-testid": row_template.format(
+                                category=browser_masters._TARGET_ACTIONS_CATEGORY,
+                                goal_id=g,
+                            )
+                        }
+                    )
+                    for g in goal_rows
+                ]
+            )
+
+        row_prefix_selector = (
+            f'[data-testid^="TargetActions.'
+            f'{browser_masters._TARGET_ACTIONS_CATEGORY}."]'
+        )
+        # The options are hidden until the trigger opens the popup, which is
+        # exactly the state _add_target_action's wait_for(state="visible")
+        # polls — a fake that renders them visible from the start would let
+        # a broken trigger pass.
+        goal_option_handles = []
+        goal_option_locators = {}
+        for _goal_id in offer_goal_ids:
+            _option_testid = (
+                browser_masters._TARGET_ACTION_ADD_OPTION_TESTID_TEMPLATE.format(
+                    category=browser_masters._TARGET_ACTIONS_CATEGORY,
+                    goal_id=_goal_id,
+                )
+            )
+            _handle = _FakeLocatorHandle(
+                visible=False,
+                on_click=lambda g=_goal_id: _add_goal_row(g),
+            )
+            goal_option_handles.append(_handle)
+            goal_option_locators[f'[data-testid="{_option_testid}"]'] = _FakeLocator(
+                [_handle]
+            )
+
+        def _open_target_action_popup():
+            target_action_popup_open["value"] = True
+            for handle in goal_option_handles:
+                handle._visible = True
+
         page = FakePage(
             locators={
+                browser_masters._TARGET_ACTIONS_SECTION_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                ),
+                row_prefix_selector: _FakeLocator([]),
+                f'[data-testid="{add_button_testid}"]': _FakeLocator(
+                    [_FakeLocatorHandle(on_click=_open_target_action_popup)]
+                ),
+                **goal_option_locators,
                 browser_masters._CREATE_URL_INPUT_TESTID: _FakeLocator([url_field]),
                 browser_masters._CREATE_NEXT_BUTTON_TESTID: _FakeLocator([next_button]),
                 headline_selector: _FakeLocator([headline_field]),
@@ -12647,6 +12777,10 @@ class TestCreateMaster(unittest.TestCase):
             "budget": budget_state,
             "launch_clicks": launch_clicks,
             "draft_clicks": draft_clicks,
+            # Issue #777: {goal_id: price-as-filled}, so a test can assert
+            # the CALLER's price landed rather than Yandex's pre-filled
+            # suggestion.
+            "goal_prices": goal_price_state,
         }
 
     def test_launches_by_default(self):
@@ -12658,6 +12792,7 @@ class TestCreateMaster(unittest.TestCase):
             headlines=["Заголовок"],
             texts=["Текст объявления"],
             regions=["Москва"],
+            target_actions={self.GOAL_ID: self.GOAL_PRICE},
         )
 
         self.assertEqual(state["url"]["url"], "https://ksamata.ru/")
@@ -12675,6 +12810,10 @@ class TestCreateMaster(unittest.TestCase):
                 "Headlines": ["Заголовок"],
                 "Texts": ["Текст объявления"],
                 "Regions": ["Москва"],
+                # Issue #777: the conversion goal(s) the create form
+                # required, echoed back so the caller can see which CPA was
+                # actually published.
+                "TargetActions": {self.GOAL_ID: self.GOAL_PRICE},
                 "Launched": True,
             },
         )
@@ -12699,6 +12838,7 @@ class TestCreateMaster(unittest.TestCase):
             headlines=["Заголовок"],
             texts=["Текст объявления"],
             regions=["Москва"],
+            target_actions={self.GOAL_ID: self.GOAL_PRICE},
             launch=False,
         )
 
@@ -12715,6 +12855,7 @@ class TestCreateMaster(unittest.TestCase):
             headlines=["Заголовок"],
             texts=["Текст объявления"],
             regions=["Москва"],
+            target_actions={self.GOAL_ID: self.GOAL_PRICE},
             weekly_budget=50000,
         )
 
@@ -12730,16 +12871,193 @@ class TestCreateMaster(unittest.TestCase):
             headlines=["Заголовок"],
             texts=["Текст объявления"],
             regions=["Москва"],
+            target_actions={self.GOAL_ID: self.GOAL_PRICE},
         )
 
         self.assertNotIn("WeeklyBudget", result)
+
+    def test_raises_value_error_when_no_target_actions(self):
+        """Issue #777: Yandex silently swallows the terminal click when the
+        form has no conversion goal, so a goal-less call must be refused
+        outright rather than driven through the whole form and left to fail
+        as an opaque redirect timeout."""
+        page, state = self._full_page()
+
+        with self.assertRaises(ValueError):
+            browser_masters.create_master(
+                page,
+                "https://ksamata.ru/",
+                headlines=["Заголовок"],
+                texts=["Текст объявления"],
+                regions=["Москва"],
+                target_actions={},
+            )
+
+        # Fails fast: nothing was published, and no browser work was done.
+        self.assertEqual(state["launch_clicks"], [])
+        self.assertEqual(state["draft_clicks"], [])
+        self.assertEqual(page.navigated_to, [])
+
+    def test_adds_the_requested_goal_with_its_price_before_clicking(self):
+        """The goal must reach the page, and its price must be the one the
+        caller asked for — not the value Yandex pre-fills (issue #777 live
+        recon found the create page's new row arrives holding a suggested
+        "160", unlike the edit page's empty input)."""
+        page, state = self._full_page()
+
+        browser_masters.create_master(
+            page,
+            "https://ksamata.ru/",
+            headlines=["Заголовок"],
+            texts=["Текст объявления"],
+            regions=["Москва"],
+            target_actions={self.GOAL_ID: 250},
+        )
+
+        self.assertEqual(state["goal_prices"], {self.GOAL_ID: "250"})
+        self.assertEqual(len(state["launch_clicks"]), 1)
+
+    def test_adds_multiple_goals_in_one_create(self):
+        second_goal = 236386932
+        page, state = self._full_page(offer_goal_ids=[self.GOAL_ID, second_goal])
+
+        browser_masters.create_master(
+            page,
+            "https://ksamata.ru/",
+            headlines=["Заголовок"],
+            texts=["Текст объявления"],
+            regions=["Москва"],
+            target_actions={self.GOAL_ID: 250, second_goal: 75},
+        )
+
+        self.assertEqual(state["goal_prices"], {self.GOAL_ID: "250", second_goal: "75"})
+        self.assertEqual(len(state["launch_clicks"]), 1)
+
+    def test_uses_the_create_pages_empty_table_add_trigger(self):
+        """The create page's empty "Целевые действия" table renders its
+        "Добавить" button as ``TargetActions.OTHER.AddTargetButton``, NOT
+        the edit page's ``MiniGrid.AddButton`` (issue #777 live recon) —
+        the one testid that differs between the two pages. ``_full_page``
+        already defaults to the create-page form, so this asserts the
+        default is the one being exercised."""
+        page, state = self._full_page()
+
+        browser_masters.create_master(
+            page,
+            "https://ksamata.ru/",
+            headlines=["Заголовок"],
+            texts=["Текст объявления"],
+            regions=["Москва"],
+            target_actions={self.GOAL_ID: self.GOAL_PRICE},
+        )
+
+        self.assertEqual(len(state["launch_clicks"]), 1)
+
+    def test_still_works_against_the_edit_pages_add_trigger(self):
+        """The same code path must keep working when the page renders the
+        OTHER trigger name — confirmed live that the create page itself
+        switches to ``MiniGrid.AddButton`` once a first row exists, so
+        neither testid may be assumed."""
+        page, state = self._full_page(
+            add_button_testid=(
+                browser_masters._TARGET_ACTION_ADD_BUTTON_TESTID_TEMPLATE.format(
+                    category=browser_masters._TARGET_ACTIONS_CATEGORY
+                )
+            )
+        )
+
+        browser_masters.create_master(
+            page,
+            "https://ksamata.ru/",
+            headlines=["Заголовок"],
+            texts=["Текст объявления"],
+            regions=["Москва"],
+            target_actions={self.GOAL_ID: self.GOAL_PRICE},
+        )
+
+        self.assertEqual(state["goal_prices"], {self.GOAL_ID: "150"})
+        self.assertEqual(len(state["launch_clicks"]), 1)
+
+    def test_raises_before_clicking_when_the_goal_is_not_offered(self):
+        """A goal that isn't on the auto-discovered Metrika counter never
+        appears as an option — that must abort BEFORE the terminal click,
+        since a create without a valid goal is silently rejected."""
+        page, state = self._full_page(offer_goal_ids=[])
+
+        with self.assertRaises(browser_masters.BrowserSessionError):
+            browser_masters.create_master(
+                page,
+                "https://ksamata.ru/",
+                headlines=["Заголовок"],
+                texts=["Текст объявления"],
+                regions=["Москва"],
+                target_actions={self.GOAL_ID: self.GOAL_PRICE},
+            )
+
+        self.assertEqual(state["launch_clicks"], [])
+        self.assertEqual(state["draft_clicks"], [])
+
+    def test_raises_before_clicking_when_the_goal_row_silently_vanished(self):
+        """The pre-click gate, and the reason it exists (issue #777).
+
+        ``_add_target_action`` succeeding is not proof the row survived —
+        a React re-render can drop it, and Yandex punishes a goal-less form
+        by SILENTLY swallowing the terminal click (no redirect, no error,
+        both buttons still ``enabled``/``aria-disabled=None``). Without
+        this gate the run would publish nothing and fail 48s later as an
+        unexplained redirect timeout. Modelled by letting the add succeed
+        and then clearing the table behind it.
+        """
+        page, state = self._full_page(drop_goal_rows_after_add=True)
+
+        with self.assertRaises(browser_masters.BrowserSessionError) as ctx:
+            browser_masters.create_master(
+                page,
+                "https://ksamata.ru/",
+                headlines=["Заголовок"],
+                texts=["Текст объявления"],
+                regions=["Москва"],
+                target_actions={self.GOAL_ID: self.GOAL_PRICE},
+            )
+
+        self.assertIn("Целевые действия", str(ctx.exception))
+        self.assertIn(str(self.GOAL_ID), str(ctx.exception))
+        # Nothing was published — the whole point of gating BEFORE the click.
+        self.assertEqual(state["launch_clicks"], [])
+        self.assertEqual(state["draft_clicks"], [])
+
+    def test_raises_before_clicking_when_the_goal_price_did_not_stick(self):
+        """A row with the wrong/blank price is rejected by Yandex's own
+        client-side validation exactly like a missing row — same silent
+        swallow, so the gate must check the price too, not just presence."""
+        # Yandex's suggested value creeping back after the fill.
+        page, state = self._full_page(revert_goal_price_after_add="160")
+
+        with self.assertRaises(browser_masters.BrowserSessionError) as ctx:
+            browser_masters.create_master(
+                page,
+                "https://ksamata.ru/",
+                headlines=["Заголовок"],
+                texts=["Текст объявления"],
+                regions=["Москва"],
+                target_actions={self.GOAL_ID: self.GOAL_PRICE},
+            )
+
+        self.assertIn(str(self.GOAL_ID), str(ctx.exception))
+        self.assertEqual(state["launch_clicks"], [])
+        self.assertEqual(state["draft_clicks"], [])
 
     def test_raises_value_error_when_no_headlines(self):
         page, _ = self._full_page()
 
         with self.assertRaises(ValueError):
             browser_masters.create_master(
-                page, "https://ksamata.ru/", headlines=[], texts=["t"], regions=["r"]
+                page,
+                "https://ksamata.ru/",
+                headlines=[],
+                texts=["t"],
+                regions=["r"],
+                target_actions={self.GOAL_ID: self.GOAL_PRICE},
             )
 
     def test_raises_value_error_when_no_texts(self):
@@ -12747,7 +13065,12 @@ class TestCreateMaster(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             browser_masters.create_master(
-                page, "https://ksamata.ru/", headlines=["h"], texts=[], regions=["r"]
+                page,
+                "https://ksamata.ru/",
+                headlines=["h"],
+                texts=[],
+                regions=["r"],
+                target_actions={self.GOAL_ID: self.GOAL_PRICE},
             )
 
     def test_raises_value_error_when_no_regions(self):
@@ -12755,7 +13078,12 @@ class TestCreateMaster(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             browser_masters.create_master(
-                page, "https://ksamata.ru/", headlines=["h"], texts=["t"], regions=[]
+                page,
+                "https://ksamata.ru/",
+                headlines=["h"],
+                texts=["t"],
+                regions=[],
+                target_actions={self.GOAL_ID: self.GOAL_PRICE},
             )
 
     def test_invalid_url_stops_before_step2(self):
@@ -12771,6 +13099,7 @@ class TestCreateMaster(unittest.TestCase):
                 headlines=["h"],
                 texts=["t"],
                 regions=["Москва"],
+                target_actions={self.GOAL_ID: self.GOAL_PRICE},
             )
 
     def test_step1_timeout_raises_when_url_field_never_renders(self):
@@ -12792,6 +13121,7 @@ class TestCreateMaster(unittest.TestCase):
                     headlines=["h"],
                     texts=["t"],
                     regions=["Москва"],
+                    target_actions={self.GOAL_ID: self.GOAL_PRICE},
                 )
         self.assertIn("step 1", str(ctx.exception))
 
@@ -12835,6 +13165,7 @@ class TestCreateMaster(unittest.TestCase):
                 headlines=["Заголовок"],
                 texts=["Текст объявления"],
                 regions=["Москва"],
+                target_actions={self.GOAL_ID: self.GOAL_PRICE},
             )
         # The whole point: caught BEFORE the irreversible click, not after.
         self.assertEqual(len(state["launch_clicks"]), 0)
@@ -12882,6 +13213,7 @@ class TestCreateMaster(unittest.TestCase):
                 headlines=["Заголовок"],
                 texts=["Текст объявления"],
                 regions=["Москва"],
+                target_actions={self.GOAL_ID: self.GOAL_PRICE},
             )
         self.assertEqual(len(state["launch_clicks"]), 1)  # the click DID happen
         self.assertIn("did not take effect as requested", str(ctx.exception))
@@ -12902,6 +13234,7 @@ class TestCreateMaster(unittest.TestCase):
             headlines=["Заголовок"],
             texts=["Текст объявления"],
             regions=["Москва"],
+            target_actions={self.GOAL_ID: self.GOAL_PRICE},
         )
 
         self.assertEqual(result["CampaignId"], 713299123)
@@ -12923,6 +13256,7 @@ class TestCreateMaster(unittest.TestCase):
                     headlines=["Заголовок"],
                     texts=["Текст объявления"],
                     regions=["Москва"],
+                    target_actions={self.GOAL_ID: self.GOAL_PRICE},
                 )
 
         self.assertEqual(len(state["launch_clicks"]), 1)  # the click DID happen
@@ -12952,6 +13286,7 @@ class TestCreateMaster(unittest.TestCase):
                     headlines=["Заголовок"],
                     texts=["Текст объявления"],
                     regions=["Москва"],
+                    target_actions={self.GOAL_ID: self.GOAL_PRICE},
                 )
 
         self.assertEqual(len(state["launch_clicks"]), 1)  # the click DID happen
@@ -12979,6 +13314,7 @@ class TestCreateMaster(unittest.TestCase):
             headlines=["Заголовок"],
             texts=["Текст объявления"],
             regions=["Москва"],
+            target_actions={self.GOAL_ID: self.GOAL_PRICE},
         )  # must not raise
 
         self.assertEqual(result["CampaignId"], self.CREATED_ID)
@@ -12999,6 +13335,7 @@ class TestCreateMaster(unittest.TestCase):
             headlines=["Заголовок"],
             texts=["Текст объявления"],
             regions=[("Москва", 213)],
+            target_actions={self.GOAL_ID: self.GOAL_PRICE},
         )  # must not raise
 
         self.assertEqual(result["Regions"], [("Москва", 213)])
@@ -13027,6 +13364,7 @@ class TestCreateMaster(unittest.TestCase):
             headlines=["Заголовок"],
             texts=["Текст объявления"],
             regions=["Москва"],
+            target_actions={self.GOAL_ID: self.GOAL_PRICE},
             weekly_budget=50000,
         )  # must not raise: the campaign really was created
 
@@ -13072,6 +13410,8 @@ class TestMastersAddCommand(unittest.TestCase):
                     "Заголовок 2",
                     "--text",
                     "Текст",
+                    "--add-target-action",
+                    "236386933=150",
                     "--region",
                     "Москва",
                 ],
@@ -13083,6 +13423,10 @@ class TestMastersAddCommand(unittest.TestCase):
         self.assertEqual(kwargs["headlines"], ["Заголовок 1", "Заголовок 2"])
         self.assertEqual(kwargs["texts"], ["Текст"])
         self.assertEqual(kwargs["regions"], [("Москва", None)])
+        # Issue #777: parsed through the same "goal_id=price" helper
+        # `masters update --add-target-action` uses, so both commands
+        # accept exactly the same syntax for the same flag name.
+        self.assertEqual(kwargs["target_actions"], {236386933: 150.0})
         self.assertTrue(kwargs["launch"])
 
     def test_draft_flag_disables_launch(self):
@@ -13102,6 +13446,8 @@ class TestMastersAddCommand(unittest.TestCase):
                     "h",
                     "--text",
                     "t",
+                    "--add-target-action",
+                    "236386933=150",
                     "--region",
                     "Москва",
                     "--draft",
@@ -13129,6 +13475,8 @@ class TestMastersAddCommand(unittest.TestCase):
                     "h",
                     "--text",
                     "t",
+                    "--add-target-action",
+                    "236386933=150",
                     "--region",
                     "Москва",
                     "--weekly-budget",
@@ -13151,10 +13499,58 @@ class TestMastersAddCommand(unittest.TestCase):
                 "h",
                 "--text",
                 "t",
+                "--add-target-action",
+                "236386933=150",
             ],
         )
         self.assertNotEqual(result.exit_code, 0)
         self.assertIn("--region/--region-id", result.output)
+
+    def test_add_target_action_is_required(self):
+        """Issue #777: Yandex's create form is silently rejected without a
+        conversion goal — both terminal buttons keep reporting
+        visible/enabled/aria-disabled=None — so a goal-less invocation must
+        be refused at the CLI boundary rather than driven through a whole
+        browser session that can only end in an unexplained timeout."""
+        result = self.runner.invoke(
+            cli,
+            [
+                "masters",
+                "add",
+                "https://ksamata.ru/",
+                "--headline",
+                "h",
+                "--text",
+                "t",
+                "--region",
+                "Москва",
+            ],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("--add-target-action", result.output)
+
+    def test_add_target_action_rejects_a_bare_goal_id_with_no_price(self):
+        """Same "goal_id=price" syntax as `masters update
+        --add-target-action`, including its price requirement — a newly
+        added row's price has no safe default (issue #717/#777)."""
+        result = self.runner.invoke(
+            cli,
+            [
+                "masters",
+                "add",
+                "https://ksamata.ru/",
+                "--headline",
+                "h",
+                "--text",
+                "t",
+                "--region",
+                "Москва",
+                "--add-target-action",
+                "236386933",
+            ],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("goal_id=price", result.output)
 
     def test_region_id_resolves_via_geo_regions_dictionary(self):
         service = Mock()
@@ -13185,6 +13581,8 @@ class TestMastersAddCommand(unittest.TestCase):
                     "h",
                     "--text",
                     "t",
+                    "--add-target-action",
+                    "236386933=150",
                     "--region-id",
                     "213",
                 ],
@@ -13228,6 +13626,8 @@ class TestMastersAddCommand(unittest.TestCase):
                     "h",
                     "--text",
                     "t",
+                    "--add-target-action",
+                    "236386933=150",
                     "--region",
                     "Москва",
                     "--region-id",
@@ -13261,6 +13661,8 @@ class TestMastersAddCommand(unittest.TestCase):
                     "h",
                     "--text",
                     "t",
+                    "--add-target-action",
+                    "236386933=150",
                     "--region-id",
                     "999999",
                 ],

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -5537,6 +5537,79 @@ class TestAddTargetAction(unittest.TestCase):
                 "trigger is present immediately",
             )
 
+    def test_names_the_click_bound_when_no_trigger_ever_became_clickable(self):
+        """Bounding the trigger click made "present but not actionable in
+        time" a NEWLY reachable way into the exhausted-retry branch, and the
+        error must say so (issue #779 review round 2).
+
+        Before the bound, that branch was only reachable after Playwright's
+        30s-per-click default, so attributing it to the Metrika counter /
+        promotion goal / changed markup was fair. With a
+        ``_POPUP_APPEAR_TIMEOUT_MS`` bound it is also reachable on a slow
+        render — and this section is documented to hydrate for seconds
+        (``_TARGET_ACTION_SETTLE_TIMEOUT_MS`` is 10s, and
+        ``_wait_for_target_actions_settled`` exists precisely because its
+        reads are unreliable for over a second). Playwright's ``TimeoutError``
+        cannot tell "absent" from "present but not actionable", so the code
+        cannot distinguish them — but the message can name both, instead of
+        sending the user to audit counter setup that is fine.
+        """
+        # Both triggers time out on every attempt — the shape a still-
+        # hydrating page presents.
+        page = FakePage(
+            locators={
+                self._add_button_testid(): _FakeLocator(
+                    [_FakeLocatorHandle(visible=False)]
+                ),
+                self._empty_add_button_testid(): _FakeLocator(
+                    [_FakeLocatorHandle(visible=False)]
+                ),
+                self._option_testid(226158067): _FakeLocator([_FakeLocatorHandle()]),
+            }
+        )
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._add_target_action(page, 226158067, 77)
+
+        message = str(ctx.exception)
+        self.assertIn("226158067", message)
+        self.assertRegex(
+            message,
+            r"(?i)hydrat|clickable|did not become",
+            "the exhausted-retry error never mentions that the 'Добавить' "
+            "trigger may simply not have become clickable within the short "
+            "bound — on a slow page this sends the user to audit a Metrika "
+            "counter that is fine",
+        )
+        # A present-but-unresponsive trigger is NOT a counter/promotion-goal
+        # problem, so the error must not lead with that diagnosis.
+        self.assertNotIn(
+            "max-conversions",
+            message,
+            "a trigger that is present but slow was blamed on the campaign's "
+            "promotion goal / Metrika counter setup",
+        )
+
+    def test_still_blames_the_counter_when_no_trigger_is_on_the_page_at_all(self):
+        """The counter/promotion-goal diagnosis must survive for the case it
+        was written for — a genuinely absent trigger (issue #779 review
+        round 2). The new hydration branch above must not swallow it."""
+        page = FakePage(
+            locators={
+                # Neither trigger registered at all — the section really
+                # isn't there.
+                self._option_testid(226158067): _FakeLocator([_FakeLocatorHandle()]),
+            }
+        )
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._add_target_action(page, 226158067, 77)
+
+        message = str(ctx.exception)
+        self.assertIn("226158067", message)
+        self.assertIn("max-conversions", message)
+        self.assertIn("targetactions get", message)
+
     def test_raises_with_context_when_price_fill_fails_after_add(self):
         add_button = _FakeLocatorHandle()
         option = _FakeLocatorHandle()


### PR DESCRIPTION
## The blocker

`masters add` could not create a campaign at all. Yandex's create form requires at least one Яндекс Метрика conversion goal, `create_master` had no way to set one, and the rejection is **silent**: #744's live recon filled the form correctly, clicked "Сохранить как черновик", and watched `page.url` for 48s — no redirect, no campaign, while both terminal buttons kept reporting `visible=True`, `enabled=True`, `aria-disabled=None`.

## Live recon — the create page's widget

The issue's open question is settled with live data, not inference:

| | create page | edit page |
|---|---|---|
| `TargetActionsSection` | ✅ same | ✅ |
| `AddTargetAction.{category}.{goal_id}` options | ✅ same | ✅ |
| `TargetActions.{category}.{goal_id}[.PriceInput\|.CloseButton]` | ✅ same | ✅ |
| "Добавить" trigger (empty table) | ⚠️ `TargetActions.OTHER.AddTargetButton` | `TargetActions.OTHER.MiniGrid.AddButton` |
| new row's price input | ⚠️ pre-filled ("160") | empty |

`_add_target_action` is reused wholesale and now tries both trigger testids — confirmed live the create page itself switches to the `MiniGrid` form once a first row exists, so neither name is safe to assume.

## Changes

- **`masters add --add-target-action "goal_id=price"`** (repeatable, required). Same flag name and syntax as `masters update --add-target-action` — not a second spelling for the same concept (no-legacy-aliases rule).
- **Required via Click `required=True`**, not post-hoc validation: a goal-less create cannot succeed, so failing before a browser launches beats a ~48s silent-rejection timeout. `create_master` enforces the same invariant with a `ValueError`.
- **Price stays mandatory.** Neither the edit page's empty input nor the create page's pre-filled suggestion is a documented default; publishing a CPA the caller never chose is worse than requiring one.
- **Pre-click gate** for the goals: the table is read back before the terminal click, and a missing row or a price that did not stick aborts *before* anything is published. This is the one field whose absence Yandex punishes by swallowing the click — there is no "afterwards" in which to observe it.
- Corrects the create fixture's "optional" note on item 17 and the module docstring's "only three fields carry a required marker" claim — the reading that made this bug invisible across three issues. **A required-field marker is not the list of required fields.**

## Live verification — this also closes #744

With the goal requirement satisfied, a `--draft` create was **accepted by Yandex end to end**, producing campaign **713337891** — the first create this CLI has ever completed.

- The terminal click **does** redirect, and the id is read straight off it, exactly as modelled on `copy_master`. **#744's central question is answered.**
- Cross-checked against a grid diff: **79 rows → 80**, the single new row being 713337891, status `DRAFT` — so it is a real campaign id, not a URL-parsing artefact.
- The goal **persisted server-side**, confirmed by re-reading from a separate page (`fetch_master_target_actions`: goal 236386933 at price 150). That also settles the issue's open question 5 — the price requirement carries over from edit to create.

## What I deliberately did NOT do

- **The `--launch` leg.** It shares `_click_terminal_button` and the same redirect with `--draft`, but publishes live advertising with no rollback. I did not run it to tick a box.
- **#776 stays blocked** for that same reason: checking the region widget on a LAUNCHED campaign requires the same irreversible publish. It needs an explicit decision from a human who owns the ad budget, not an agent's judgement call.
- **Campaign 713337891 could not be archived** and remains a DRAFT. `masters archive` refuses it correctly — a DRAFT overview has no "⋮" menu (#660) and Мастер кампаний has no delete, so the only route to archiving is to launch it first. Spending real money to tidy up a test was the worse trade. Filed as **#782**: creating a draft via this CLI is currently a one-way door.

## Tests

`pytest` — **3283 passed, 23 skipped**. `black` + `flake8` clean. CI green on 3.11/3.13/3.14.

Nine new tests. All five mutations I tried are caught:

| Mutation | Caught by |
|---|---|
| drop the create-page trigger fallback | 15 tests |
| skip the price fill | 15 tests |
| drop the pre-click gate | `..._goal_row_silently_vanished`, `..._goal_price_did_not_stick` |
| gate ignores price, checks presence only | `..._goal_price_did_not_stick` |
| CLI flag not required | `test_add_target_action_is_required` |

The gate initially *survived* its mutation — the two `..._after_add` fake hooks were added specifically to close that hole.

Rebased onto `main` (picks up #775's `--region-id` fix, which this live pass hit and which was already fixed in #778). Version 0.5.1 → 0.6.0 for the breaking change.

Refs #776, #717, #632, #631, #660.

**Review follow-up:** two error-message-quality findings from the review cycle's round 3 are deferred to **#783** (both branches of `_add_target_action`'s exhausted-retry error diagnose from a bounded timeout that cannot tell "absent" from "not yet rendered"). Neither is a correctness defect — no wrong-publish or data-loss path exists. Four other findings were fixed in `a3e05dc` and `68738dd`.

Closes #777, #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169FNdGq1WimMp2xacj58jd
