### PR TITLE
fix(masters): verify tracking_params by readability + re-navigation (#774, #769)

### DIFF
--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -4965,13 +4965,20 @@ def _verify_saved(
         ),
     ]
 
-    mismatches = []
-    for label, expected, reader in checks:
-        if expected is None:
-            continue
-        actual = _read_until_matches(page, reader, expected)
-        if actual != expected:
-            mismatches.append(_format_value_mismatch(label, expected, actual))
+    def _run_checks() -> "List[str]":
+        found = []
+        for label, expected, reader in checks:
+            if expected is None:
+                continue
+            actual = _read_until_matches(page, reader, expected)
+            if actual != expected:
+                found.append(_format_value_mismatch(label, expected, actual))
+        return found
+
+    mismatches = _run_checks()
+    # Set when the tracking_params block below re-navigates, so these checks
+    # can be re-run against the page that navigation actually fetched.
+    _re_navigated = False
 
     if tracking_params is not None:
         # Wait for the section to be READABLE before judging it (issue
@@ -5022,6 +5029,7 @@ def _verify_saved(
             assert_not_captcha(page.content())
             assert_authenticated(page.content())
             _wait_for_edit_form(page, campaign_id)
+            _re_navigated = True
             # A stale render is PAGE-level, not field-specific, so this
             # re-navigation resets the whole form — including the audience
             # section, whose checks all run BELOW this block. Skipping the
@@ -5033,6 +5041,18 @@ def _verify_saved(
             # expectation) and a false failure for devices/age bounds.
             if _audience_touched:
                 _wait_for_audience_section(page)
+        # Re-run the earlier checks against the page the re-navigation
+        # actually fetched. A stale render is PAGE-level, so those fields
+        # were read from the same possibly-stale load that made
+        # tracking_params stale — and `_read_until_matches`' budget cannot
+        # see past it, for exactly the reason tracking_params needed a
+        # navigation rather than more polling. Leaving them on the first
+        # load meant a combined `--name X --tracking-params Y` could still
+        # report a false `name` mismatch while tracking_params recovered on
+        # the very reload that would have confirmed `name` too.
+        if _re_navigated:
+            mismatches = _run_checks()
+
         if actual != tracking_params:
             mismatches.append(
                 _format_value_mismatch("tracking_params", tracking_params, actual)

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -1337,7 +1337,17 @@ _UTM_SECTION_READY_TIMEOUT_MS = 30_000
 # inside that one page (what ``_read_until_matches``' retry budget does)
 # cannot fix it — the stale value is what that page has; only a genuinely
 # new navigation re-fetches it. Three attempts covers the observed settle
-# time with headroom while bounding a real mismatch at ~15s of extra work.
+# time with headroom.
+#
+# Worst-case cost, spelled out because the naive reading is ~10x off: an
+# attempt is bounded by ``_UTM_SECTION_READY_TIMEOUT_MS`` (30s) plus
+# ``_VERIFY_FIELD_READ_TIMEOUT_MS * 4`` (20s), so three attempts plus two
+# backoffs is ~160s before a genuine mismatch is reported. That ceiling is
+# only reached when the section is slow on EVERY load; the case this
+# constant exists for (a stale render that resolves on the next
+# navigation) costs one backoff. An unmountable section short-circuits the
+# 20s read entirely — see the ``_wait_for_utm_section`` check in
+# ``_verify_saved`` — capping it at ~30s per attempt instead.
 _VERIFY_RELOAD_MAX_ATTEMPTS = 3
 _VERIFY_RELOAD_BACKOFF_MS = 5_000
 
@@ -3105,7 +3115,18 @@ def _set_tracking_params(page: "Page", tracking_params: str) -> None:
     Lazily mounted under the collapsed "Дополнительные параметры" spoiler
     (``_EDIT_UTM_SPOILER_BUTTON_TESTID``), which this function expands
     first. Passing an empty string clears the field.
+
+    Waits the section out before deciding the trigger is missing (issue
+    #769/#774's central finding, applied to the WRITE path): the whole
+    "Дополнительные параметры" section can mount long after
+    ``_wait_for_edit_form`` returns — 90s measured live against campaign
+    713234064. Raising on the first absent trigger would turn that
+    transient hydration delay into a hard "Yandex changed the markup"
+    failure, which is both wrong and unactionable. Only a section that is
+    still unmounted after ``_wait_for_utm_section``'s budget is a real
+    markup problem.
     """
+    _wait_for_utm_section(page)
     if not _expand_utm_spoiler(page):
         raise BrowserSessionError(
             "Could not find the 'Дополнительные параметры' spoiler to "
@@ -4736,9 +4757,11 @@ def describe_value_mismatch(expected: str, actual: "Optional[str]") -> str:
     # equality test misses entirely. Instead a missing segment counts as
     # moved when it appears VERBATIM in ``actual`` at an offset that is not
     # where it was requested; the paired extra is whichever unpaired extra
-    # segment overlaps that occurrence. Each extra is consumed at most once,
-    # so a fragment duplicated on one side only still reports its leftover
-    # copy as extra rather than being silently absorbed into a move.
+    # segment overlaps that occurrence. Only the overlapping SPAN of that
+    # extra is consumed, not the whole segment: difflib merges adjacent
+    # copies into one insert, so a fragment duplicated on one side only
+    # would otherwise have its leftover copy silently absorbed into the
+    # move. The unaccounted-for head/tail goes back on the extra list.
     lines: "List[str]" = []
     unpaired_extra = list(extra)
     unpaired_missing: "List[Tuple[int, str]]" = []
@@ -4769,7 +4792,22 @@ def describe_value_mismatch(expected: str, actual: "Optional[str]") -> str:
         if overlapping is None:
             unpaired_missing.append((pos, segment))
             continue
+        # Consume only the part of the extra that the move accounts for.
+        # The extra difflib emits can be WIDER than the relocated fragment:
+        # two adjacent copies of '|kw|' are emitted as a single
+        # '|kw||kw|' insert, and removing it whole made the second,
+        # unrequested copy vanish from the report — the exact silent
+        # absorption this pairing's contract promises not to do. Put the
+        # unaccounted-for remainder back so it still surfaces as extra.
         unpaired_extra.remove(overlapping)
+        extra_pos, extra_text = overlapping
+        head = extra_text[: max(0, found_at - extra_pos)]
+        tail = extra_text[max(0, found_at - extra_pos) + len(segment) :]
+        if head:
+            unpaired_extra.append((extra_pos, head))
+        if tail:
+            unpaired_extra.append((found_at + len(segment), tail))
+        unpaired_extra.sort()
         lines.append(
             f"    - moved: {segment!r} was requested at position {pos}, "
             f"but the page has it at position {found_at}"
@@ -4958,13 +4996,23 @@ def _verify_saved(
         # a fresh load 6.6s after a verify that had failed this way.
         actual = None
         for _attempt in range(_VERIFY_RELOAD_MAX_ATTEMPTS):
-            _wait_for_utm_section(page)
-            actual = _read_until_matches(
-                page,
-                _read_tracking_params,
-                tracking_params,
-                timeout_ms=_VERIFY_FIELD_READ_TIMEOUT_MS * 4,
-            )
+            # HONOUR the readability verdict rather than discarding it. A
+            # False here means the section never mounted within the wait's
+            # own budget, so every _read_tracking_params call that followed
+            # would return None instantly for the full read budget — 20s of
+            # guaranteed-futile polling per attempt, on top of the 30s
+            # already spent waiting. Falling straight through to the
+            # mismatch report keeps an unmountable section a ~30s-per-
+            # attempt failure instead of a ~50s one.
+            if _wait_for_utm_section(page):
+                actual = _read_until_matches(
+                    page,
+                    _read_tracking_params,
+                    tracking_params,
+                    timeout_ms=_VERIFY_FIELD_READ_TIMEOUT_MS * 4,
+                )
+            else:
+                actual = None
             if actual == tracking_params:
                 break
             if _attempt == _VERIFY_RELOAD_MAX_ATTEMPTS - 1:
@@ -4974,6 +5022,17 @@ def _verify_saved(
             assert_not_captcha(page.content())
             assert_authenticated(page.content())
             _wait_for_edit_form(page, campaign_id)
+            # A stale render is PAGE-level, not field-specific, so this
+            # re-navigation resets the whole form — including the audience
+            # section, whose checks all run BELOW this block. Skipping the
+            # gate here would hand them a freshly-navigated, still-
+            # hydrating section: exactly the race issue #681 added
+            # ``_wait_for_audience_section`` for, where a campaign with 112
+            # tags read back as ``[]``. That misreports as a false success
+            # for tags (a hydrating ``[]`` can match a removal-only
+            # expectation) and a false failure for devices/age bounds.
+            if _audience_touched:
+                _wait_for_audience_section(page)
         if actual != tracking_params:
             mismatches.append(
                 _format_value_mismatch("tracking_params", tracking_params, actual)

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -288,6 +288,7 @@ side effect on the campaign itself.
 """
 
 import contextlib
+import difflib
 import json
 import os
 import re
@@ -1311,6 +1312,35 @@ _EDIT_UTM_SPOILER_BUTTON_TESTID = (
 # (``CampaignLinkEditorLite.Spoiler.Button``, ``_expand_utm_spoiler``) —
 # ``_set_tracking_params``/``--tracking-params`` is the dedicated setter,
 # expanding the spoiler before writing. Pass an empty string to clear it.
+
+# How long ``_wait_for_utm_section`` polls for the UTM field to become
+# READABLE after a reload (issue #769/#774). Live-measured against campaign
+# 713234064: a save that demonstrably took effect (the value was correct on
+# the next fresh page load) was still reporting an UNMOUNTED field 90s after
+# the reload, because the "Дополнительные параметры" spoiler had not
+# rendered its trigger yet and ``_expand_utm_spoiler`` therefore had nothing
+# to click. 30s matches ``_GRID_CAPTURE_TIMEOUT_MS``'s order of magnitude for
+# "this page section is slow but not broken".
+_UTM_SECTION_READY_TIMEOUT_MS = 30_000
+
+# How many times ``_verify_saved`` will RE-NAVIGATE (not merely re-read the
+# already-loaded page) before declaring a tracking_params mismatch, and how
+# long it waits between those reloads.
+#
+# Issue #769, live-measured against campaign 713234064 (2026-08-06): two
+# ``masters update --tracking-params`` runs back to back — the second
+# sending a value differing only by a removed ``|kw|{keyword}`` — had the
+# second run's verify read back the FIRST run's value and fail. Re-opening
+# the same campaign in a fresh page load 6.6s later showed the second run's
+# value correctly saved all along: the save was never the problem, the
+# post-save reload served a stale render of the section. Polling harder
+# inside that one page (what ``_read_until_matches``' retry budget does)
+# cannot fix it — the stale value is what that page has; only a genuinely
+# new navigation re-fetches it. Three attempts covers the observed settle
+# time with headroom while bounding a real mismatch at ~15s of extra work.
+_VERIFY_RELOAD_MAX_ATTEMPTS = 3
+_VERIFY_RELOAD_BACKOFF_MS = 5_000
+
 
 _SAVE_BUTTON_TEXT = "Сохранить кампанию"
 _LAUNCH_BUTTON_TEXT = "Запустить кампанию"
@@ -2963,13 +2993,58 @@ def _read_tracking_params(page: "Page") -> Optional[str]:
     """
     # _expand_utm_spoiler is itself a cheap no-op (single aria-expanded
     # read) when the spoiler is already open, so there is no need to
-    # duplicate that check here first.
-    _expand_utm_spoiler(page)
+    # duplicate that check here first. A False return means the spoiler's
+    # trigger isn't in the DOM at all — the field cannot be mounted, so
+    # this is "unreadable" (None), NOT "empty" (issue #769/#774: conflating
+    # the two is what made a still-hydrating section look like a failed
+    # save). Callers that need to wait this out use _wait_for_utm_section.
+    if not _expand_utm_spoiler(page):
+        return None
     field = page.locator(_EDIT_UTM_INPUT_TESTID).first
     try:
         return field.text_content()
     except PlaywrightError:
         return None
+
+
+def _wait_for_utm_section(page: "Page") -> bool:
+    """Block until the UTM field is actually READABLE, so a caller's read
+    distinguishes "the field is empty" from "the field isn't mounted yet".
+
+    Issue #769/#774. ``_read_tracking_params`` calls ``_expand_utm_spoiler``
+    and then DISCARDS its return value: when the spoiler's trigger has not
+    rendered yet (the whole "Дополнительные параметры" section mounts late,
+    well after ``_wait_for_edit_form``'s first-headline marker), there is
+    nothing to click, the field stays unmounted, and ``text_content()``
+    returns ``None``. Feeding that ``None`` straight into
+    ``_read_until_matches`` is the bug behind both issues: the poll re-reads
+    an unmountable field for its entire budget and the mismatch is then
+    reported as "the save did not take effect", even though live recon
+    against campaign 713234064 confirmed the save HAD taken effect — the
+    correct value was there on the very next page load, while the verifying
+    run had spent 90s reading ``None``.
+
+    Retrying the EXPANSION (not just the read) is what actually closes it:
+    each tick re-attempts ``_expand_utm_spoiler``, so a trigger that appears
+    late is clicked as soon as it exists.
+
+    Returns ``True`` once a non-``None`` read succeeds, ``False`` on
+    timeout. Callers treat ``False`` as "could not confirm this section is
+    usable" and let their own mismatch reporting take over rather than
+    raising here — same degradation contract as
+    ``_wait_for_target_actions_settled`` (issue #750).
+    """
+
+    def _readable() -> bool:
+        if not _expand_utm_spoiler(page):
+            return False
+        field = page.locator(_EDIT_UTM_INPUT_TESTID).first
+        try:
+            return field.text_content() is not None
+        except PlaywrightError:
+            return False
+
+    return _poll_until(page, _readable, _UTM_SECTION_READY_TIMEOUT_MS)
 
 
 def _set_contenteditable_field(
@@ -4593,6 +4668,137 @@ def _verify_repeating_value_mismatches(
     return mismatches
 
 
+# Below this length a plain ``expected X, page shows Y`` pair is already
+# readable at a glance, so ``describe_value_mismatch`` adds nothing and just
+# doubles the message. The values that motivated the helper (issue #774's UTM
+# query strings) run 100+ characters.
+_VALUE_DIFF_MIN_LEN = 40
+
+# Segments shorter than this are reported as plain missing/extra rather than
+# as a move, even when the same text appears on both sides: a 1-2 character
+# coincidence (a stray ``&`` or ``=`` matching somewhere else in a query
+# string) is noise, not a relocated fragment.
+_VALUE_DIFF_MIN_MOVE_LEN = 3
+
+
+def describe_value_mismatch(expected: str, actual: "Optional[str]") -> str:
+    """Render a human-readable account of how ``actual`` differs from
+    ``expected``, as indented ``- ...`` bullet lines (empty string when the
+    two are equal, or when a plain pair is already readable).
+
+    Issue #774: ``_verify_saved``'s mismatches were reported purely as
+    ``expected {a!r}, page now shows {b!r}``. For a 110-character UTM query
+    string whose only difference is that ``|kw|{keyword}`` moved from the
+    middle to the end, spotting that by eye across two near-identical repr
+    lines is genuinely hard — and the SHAPE of the difference is exactly
+    what tells a reader whether Yandex rejected the value, truncated it, or
+    (as #774 turned out to be) the CLI's own typing reordered it.
+
+    Classifies each ``difflib`` opcode into ``missing`` (in ``expected``,
+    absent from ``actual``) and ``extra`` (present in ``actual``, not
+    requested), then pairs a missing segment with an identical extra one
+    into a single ``moved`` line — the #774 signature. Positions are
+    0-based character offsets into ``expected``/``actual`` respectively, so
+    a reader can find the fragment without counting.
+
+    Deliberately descriptive, never a verdict: this does not decide whether
+    a mismatch is benign. ``_verify_saved`` still fails on any mismatch,
+    including a pure reorder — a reordered query string is a different
+    string, and the caller asked for the one they passed.
+    """
+    if actual is None:
+        return "    - the field could not be read at all (no value on the page)"
+    if actual == expected:
+        return ""
+    if not expected:
+        return f"    - expected an empty value, but the field holds {actual!r}"
+    if not actual:
+        return "    - expected a value, but the field is empty"
+    if max(len(expected), len(actual)) < _VALUE_DIFF_MIN_LEN:
+        return ""
+
+    missing: "List[Tuple[int, str]]" = []
+    extra: "List[Tuple[int, str]]" = []
+    matcher = difflib.SequenceMatcher(None, expected, actual, autojunk=False)
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag in ("delete", "replace"):
+            missing.append((i1, expected[i1:i2]))
+        if tag in ("insert", "replace"):
+            extra.append((j1, actual[j1:j2]))
+
+    # Pair a missing segment with an extra one into a single "moved" line.
+    #
+    # Matching is NOT byte-equality of the two opcode slices: difflib aligns
+    # on the longest common runs, so when a relocated fragment is bracketed
+    # by delimiters that also appear at its new site, the opcode boundaries
+    # land inside the fragment — a ``|aa|`` moved across a query string is
+    # emitted as missing ``'|aa|'`` against extra ``'aa'``, which an
+    # equality test misses entirely. Instead a missing segment counts as
+    # moved when it appears VERBATIM in ``actual`` at an offset that is not
+    # where it was requested; the paired extra is whichever unpaired extra
+    # segment overlaps that occurrence. Each extra is consumed at most once,
+    # so a fragment duplicated on one side only still reports its leftover
+    # copy as extra rather than being silently absorbed into a move.
+    lines: "List[str]" = []
+    unpaired_extra = list(extra)
+    unpaired_missing: "List[Tuple[int, str]]" = []
+    for pos, segment in missing:
+        found_at = (
+            actual.find(segment) if len(segment) >= _VALUE_DIFF_MIN_MOVE_LEN else -1
+        )
+        if found_at < 0 or found_at == pos:
+            unpaired_missing.append((pos, segment))
+            continue
+        # The paired extra is whichever unpaired extra segment's own span
+        # overlaps that occurrence. Overlap alone — NOT equality or
+        # containment of the two texts: difflib picks its alignment
+        # arbitrarily around delimiters shared with the fragment's new
+        # neighbourhood, so the extra it emits for a relocated '|aa|' can be
+        # 'aa' (the fragment minus both delimiters) or '|kw||kw|' (the
+        # fragment merged with an adjacent duplicate). Neither survives a
+        # text-identity test, but both overlap the occurrence's span.
+        end = found_at + len(segment)
+        overlapping = next(
+            (
+                candidate
+                for candidate in unpaired_extra
+                if candidate[0] < end and found_at < candidate[0] + len(candidate[1])
+            ),
+            None,
+        )
+        if overlapping is None:
+            unpaired_missing.append((pos, segment))
+            continue
+        unpaired_extra.remove(overlapping)
+        lines.append(
+            f"    - moved: {segment!r} was requested at position {pos}, "
+            f"but the page has it at position {found_at}"
+        )
+
+    for pos, segment in unpaired_missing:
+        lines.append(f"    - missing: {segment!r} (expected at position {pos})")
+    for pos, segment in unpaired_extra:
+        lines.append(f"    - extra: {segment!r} (on the page at position {pos})")
+
+    return "\n".join(lines)
+
+
+def _format_value_mismatch(label: str, expected: Any, actual: Any) -> str:
+    """Format one ``_verify_saved`` mismatch line, appending
+    ``describe_value_mismatch``'s breakdown when both sides are strings long
+    enough for the raw pair to be hard to read (issue #774).
+
+    Non-string values (booleans, ints, sets) keep the plain
+    ``expected X, page now shows Y`` form — they are short and the
+    character-level diff would be meaningless for them.
+    """
+    line = f"{label}: expected {expected!r}, page now shows {actual!r}"
+    if not isinstance(expected, str) or not isinstance(actual, (str, type(None))):
+        return line
+    detail = describe_value_mismatch(expected, actual)
+    return f"{line}\n{detail}" if detail else line
+
+
 def _read_until_matches(
     page: "Page",
     reader: "Callable[[Page], Any]",
@@ -4727,28 +4933,50 @@ def _verify_saved(
             continue
         actual = _read_until_matches(page, reader, expected)
         if actual != expected:
-            mismatches.append(
-                f"{label}: expected {expected!r}, page now shows {actual!r}"
-            )
+            mismatches.append(_format_value_mismatch(label, expected, actual))
 
     if tracking_params is not None:
-        # Same settle-wait-then-poll shape as the audience section above
-        # (issue #681): the "Дополнительные параметры" spoiler is not
-        # guaranteed ready by _wait_for_edit_form, and a single
-        # _read_tracking_params call right after reload can itself take
-        # 4-5s just to expand it — confirmed live (issue #761), leaving no
-        # room in the default 5s retry budget for even one retry.
-        page.wait_for_timeout(3_000)
-        actual = _read_until_matches(
-            page,
-            _read_tracking_params,
-            tracking_params,
-            timeout_ms=_VERIFY_FIELD_READ_TIMEOUT_MS * 4,
-        )
+        # Wait for the section to be READABLE before judging it (issue
+        # #769/#774), rather than sleeping a fixed 3s and hoping. The old
+        # fixed wait was calibrated (issue #761) against "expanding the
+        # spoiler takes 4-5s"; live recon against campaign 713234064 found
+        # the section can instead stay entirely unmounted, making every
+        # subsequent read return None for the full retry budget and
+        # reporting a save that DID take effect as a failure. This retries
+        # the expansion itself, so a late-mounting trigger is picked up as
+        # soon as it exists — and a timeout is left to fall through to the
+        # mismatch reporting below, which now says "could not be read at
+        # all" rather than pretending the field was empty.
+        #
+        # RE-NAVIGATING on a mismatch, not just re-reading (issue #769): the
+        # post-save reload above can serve a stale render of this section,
+        # showing the value from a PREVIOUS update of the same campaign.
+        # ``_read_until_matches`` cannot see past that — the stale value is
+        # what the loaded page has, so polling it harder just re-reads the
+        # same wrong string. A genuinely new navigation is what re-fetches
+        # it; live recon against campaign 713234064 had the correct value on
+        # a fresh load 6.6s after a verify that had failed this way.
+        actual = None
+        for _attempt in range(_VERIFY_RELOAD_MAX_ATTEMPTS):
+            _wait_for_utm_section(page)
+            actual = _read_until_matches(
+                page,
+                _read_tracking_params,
+                tracking_params,
+                timeout_ms=_VERIFY_FIELD_READ_TIMEOUT_MS * 4,
+            )
+            if actual == tracking_params:
+                break
+            if _attempt == _VERIFY_RELOAD_MAX_ATTEMPTS - 1:
+                break
+            page.wait_for_timeout(_VERIFY_RELOAD_BACKOFF_MS)
+            page.goto(url, wait_until="commit")
+            assert_not_captcha(page.content())
+            assert_authenticated(page.content())
+            _wait_for_edit_form(page, campaign_id)
         if actual != tracking_params:
             mismatches.append(
-                f"tracking_params: expected {tracking_params!r}, page now "
-                f"shows {actual!r}"
+                _format_value_mismatch("tracking_params", tracking_params, actual)
             )
 
     if age_from_requested:

--- a/scripts/recon_774_audit_saved_utm.py
+++ b/scripts/recon_774_audit_saved_utm.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Read-only audit for issues #774/#769: print the CURRENTLY SAVED UTMInput
+value of every named master campaign, and classify it against an expected
+value.
+
+Answers #774's investigation point 3 — "re-check the campaigns from the
+#769/#770 runs where verify reported an empty field vs a reordered one" —
+without mutating anything: it only opens each campaign's edit page, expands
+the "Дополнительные параметры" spoiler, and reads the field.
+
+Usage (coordinated live window ONLY, read-only):
+
+    PYTHONPATH=. python3 scripts/recon_774_audit_saved_utm.py --all
+    PYTHONPATH=. python3 scripts/recon_774_audit_saved_utm.py 713234041 713232132
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import List, Optional
+
+EXPECTED = (
+    "utm_source=yandex_alexey&utm_medium=cpc&utm_campaign={campaign_id}"
+    "&utm_term={gbid}|kw|{keyword}&utm_content={ad_id}"
+)
+
+
+def _read_one(page, campaign_id: int) -> Optional[str]:
+    from direct_cli.browser.masters import (
+        WIZARD_EDIT_URL,
+        _expand_utm_spoiler,
+        _read_tracking_params,
+        _wait_for_edit_form,
+    )
+    from direct_cli.browser.session import assert_authenticated, assert_not_captcha
+
+    page.goto(WIZARD_EDIT_URL.format(campaign_id=campaign_id), wait_until="commit")
+    assert_not_captcha(page.content())
+    assert_authenticated(page.content())
+    _wait_for_edit_form(page, campaign_id)
+    # Same settle-wait _verify_saved uses: the spoiler is not guaranteed
+    # ready by _wait_for_edit_form.
+    page.wait_for_timeout(3_000)
+    if not _expand_utm_spoiler(page):
+        return None
+    return _read_tracking_params(page)
+
+
+def _list_master_ids(page) -> List[int]:
+    from direct_cli.browser.masters import fetch_masters_list
+
+    rows = fetch_masters_list(page, status="all")
+    return [int(r["CampaignId"]) for r in rows]
+
+
+def main() -> int:
+    from direct_cli.browser.masters import describe_value_mismatch
+    from direct_cli.browser.session import open_saved_session
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("campaign_ids", nargs="*", type=int)
+    ap.add_argument("--all", action="store_true", help="audit every master campaign")
+    ap.add_argument("--headful", action="store_true")
+    ap.add_argument("--expected", default=EXPECTED)
+    args = ap.parse_args()
+
+    if not args.campaign_ids and not args.all:
+        ap.error("pass campaign ids or --all")
+
+    with open_saved_session(headless=not args.headful) as page:
+        ids = args.campaign_ids or _list_master_ids(page)
+        print(f"auditing {len(ids)} campaign(s)\n")
+        empty, exact, other = [], [], []
+        for campaign_id in ids:
+            try:
+                value = _read_one(page, campaign_id)
+            except Exception as exc:  # noqa: PIE786 - recon sweep must not abort
+                print(f"{campaign_id}: ERROR {exc!r}")
+                continue
+            if value == args.expected:
+                exact.append(campaign_id)
+                print(f"{campaign_id}: EXACT MATCH")
+            elif value in ("", None):
+                empty.append(campaign_id)
+                print(f"{campaign_id}: EMPTY/UNREADABLE ({value!r})")
+            else:
+                other.append(campaign_id)
+                print(f"{campaign_id}: DIFFERS")
+                print(f"    saved: {value!r}")
+                print(describe_value_mismatch(args.expected, value))
+
+        print(f"\nsummary: exact={len(exact)} empty={len(empty)} differs={len(other)}")
+        if empty:
+            print(f"  empty: {empty}")
+        if other:
+            print(f"  differs: {other}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/recon_774_utm_reorder.py
+++ b/scripts/recon_774_utm_reorder.py
@@ -163,12 +163,16 @@ def _save_latency(page, value: str) -> None:
     value."""
     from direct_cli.browser.masters import (
         _click_save,
-        _is_draft_edit_page,
         _set_tracking_params,
+        _wait_for_draft_status,
     )
 
     print("\n=== [5] save -> reload -> convergence latency ===")
-    is_draft = _is_draft_edit_page(page)
+    # `_wait_for_draft_status`, not `_is_draft_edit_page`: issue #726
+    # replaced the point-in-time read precisely because the DRAFT marker
+    # can transiently vanish mid-hydration, and misclassifying a DRAFT
+    # campaign makes `_click_save` hunt for a button that isn't there.
+    is_draft = _wait_for_draft_status(page, CAMPAIGN_ID)
     _set_tracking_params(page, value)
     typed = _read(page)
     print(f"  typed into field: {typed!r} (match={typed == value})")
@@ -211,8 +215,8 @@ def _restore_baseline(page, baseline: Optional[str], *, saved: bool) -> None:
     """
     from direct_cli.browser.masters import (
         _click_save,
-        _is_draft_edit_page,
         _set_tracking_params,
+        _wait_for_draft_status,
     )
 
     print("\n=== restoring baseline ===")
@@ -231,7 +235,9 @@ def _restore_baseline(page, baseline: Optional[str], *, saved: bool) -> None:
         )
         return
 
-    is_draft = _is_draft_edit_page(page)
+    # Same #726 hardening as the probe save above — a misclassified DRAFT
+    # here would silently leave the campaign holding the probe value.
+    is_draft = _wait_for_draft_status(page, CAMPAIGN_ID)
     _set_tracking_params(page, baseline)
     _click_save(page, CAMPAIGN_ID, is_draft=is_draft)
     _goto_edit(page)

--- a/scripts/recon_774_utm_reorder.py
+++ b/scripts/recon_774_utm_reorder.py
@@ -197,6 +197,54 @@ def _save_latency(page, value: str) -> None:
         print(_diff_report(value, last if isinstance(last, str) else None))
 
 
+def _restore_baseline(page, baseline: Optional[str], *, saved: bool) -> None:
+    """Put the campaign back the way it was found.
+
+    The probes below ``--save-latency`` only type into the field, so a plain
+    re-navigation discards them and printing the value is enough. But
+    ``--save-latency`` CLICKS SAVE, committing ``PROBE`` — whose
+    ``{campaign_id}``/``{gbid}``/``{keyword}``/``{ad_id}`` placeholders are
+    never interpolated — to a live campaign. Without an actual write-back
+    that leaves real, malformed tracking params on a production master
+    campaign, recoverable only by a manual ``masters update``. The module
+    docstring promises restoration; this is where it has to happen.
+    """
+    from direct_cli.browser.masters import (
+        _click_save,
+        _is_draft_edit_page,
+        _set_tracking_params,
+    )
+
+    print("\n=== restoring baseline ===")
+    _goto_edit(page)
+    _expand(page)
+    if not saved:
+        # Nothing was committed: the re-navigation above already dropped
+        # every typed-but-unsaved probe value.
+        print(f"  no save was performed; UTMInput now = {_read(page)!r}")
+        return
+    if baseline is None:
+        print(
+            "  WARNING: the baseline could not be read at the start, so the "
+            "saved probe value CANNOT be restored automatically. Fix the "
+            "campaign manually with 'masters update --tracking-params'."
+        )
+        return
+
+    is_draft = _is_draft_edit_page(page)
+    _set_tracking_params(page, baseline)
+    _click_save(page, CAMPAIGN_ID, is_draft=is_draft)
+    _goto_edit(page)
+    _expand(page)
+    restored = _read(page)
+    print(f"  restored UTMInput = {restored!r} (match={restored == baseline})")
+    if restored != baseline:
+        print(
+            "  WARNING: restore did NOT round-trip. The campaign still holds "
+            "a probe value — fix it manually before leaving it."
+        )
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--headful", action="store_true")
@@ -226,10 +274,7 @@ def main() -> int:
             if args.save_latency:
                 _save_latency(page, args.value)
         finally:
-            print("\n=== restoring baseline (no save unless --save-latency) ===")
-            _goto_edit(page)
-            _expand(page)
-            print(f"  UTMInput now = {_read(page)!r}")
+            _restore_baseline(page, baseline, saved=args.save_latency)
 
     return 0
 

--- a/scripts/recon_774_utm_reorder.py
+++ b/scripts/recon_774_utm_reorder.py
@@ -220,8 +220,21 @@ def _restore_baseline(page, baseline: Optional[str], *, saved: bool) -> None:
     )
 
     print("\n=== restoring baseline ===")
-    _goto_edit(page)
-    _expand(page)
+    try:
+        _goto_edit(page)
+        _expand(page)
+    except Exception as exc:  # noqa: PIE786 - see the contained-restore note
+        print(
+            f"  ERROR: could not reopen the edit page ({exc!r}). "
+            + (
+                f"The campaign may still hold the probe value; check it "
+                f"manually:\n    direct masters update {CAMPAIGN_ID} "
+                f"--tracking-params {baseline!r}"
+                if saved
+                else "Nothing was saved, so nothing needs restoring."
+            )
+        )
+        return
     if not saved:
         # Nothing was committed: the re-navigation above already dropped
         # every typed-but-unsaved probe value.
@@ -235,19 +248,38 @@ def _restore_baseline(page, baseline: Optional[str], *, saved: bool) -> None:
         )
         return
 
-    # Same #726 hardening as the probe save above — a misclassified DRAFT
-    # here would silently leave the campaign holding the probe value.
-    is_draft = _wait_for_draft_status(page, CAMPAIGN_ID)
-    _set_tracking_params(page, baseline)
-    _click_save(page, CAMPAIGN_ID, is_draft=is_draft)
-    _goto_edit(page)
-    _expand(page)
-    restored = _read(page)
+    # This whole function runs from a `finally`, so an exception escaping it
+    # would REPLACE whatever error the probes raised and abort the restore
+    # midway — the worst possible outcome, since the campaign is holding the
+    # probe value at exactly this point. `_wait_for_draft_status` raises on
+    # timeout (an ARCHIVED campaign renders no terminal save control at
+    # all), and the save path can fail for its own reasons, so every step is
+    # contained and reported instead of propagated.
+    try:
+        # Same #726 hardening as the probe save above — a misclassified
+        # DRAFT here would silently leave the campaign holding the probe.
+        is_draft = _wait_for_draft_status(page, CAMPAIGN_ID)
+        _set_tracking_params(page, baseline)
+        _click_save(page, CAMPAIGN_ID, is_draft=is_draft)
+        _goto_edit(page)
+        _expand(page)
+        restored = _read(page)
+    except Exception as exc:  # noqa: PIE786 - never mask the probe's own error
+        print(
+            f"  ERROR: restore FAILED ({exc!r}). The campaign is still "
+            f"holding the probe value. Fix it manually:\n"
+            f"    direct masters update {CAMPAIGN_ID} "
+            f"--tracking-params {baseline!r}"
+        )
+        return
+
     print(f"  restored UTMInput = {restored!r} (match={restored == baseline})")
     if restored != baseline:
         print(
             "  WARNING: restore did NOT round-trip. The campaign still holds "
-            "a probe value — fix it manually before leaving it."
+            f"a probe value — fix it manually:\n"
+            f"    direct masters update {CAMPAIGN_ID} "
+            f"--tracking-params {baseline!r}"
         )
 
 

--- a/scripts/recon_774_utm_reorder.py
+++ b/scripts/recon_774_utm_reorder.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Live recon for issue #774 (UTMInput text REORDERED on input) and #769
+(verify reads a stale value after save).
+
+Read-only by default in the sense that it writes ONLY to the UTMInput field
+of the test master campaign and restores the original value at the end.
+
+What it measures, in order:
+
+1. Baseline: the current UTMInput value (so it can be restored).
+2. ``field.type(value, delay=80)`` — the CLI's current mechanism
+   (``_type_landing_url``) — then reads ``textContent`` back and prints an
+   aligned diff. Repeats N times to catch an intermittent reorder.
+3. Per-keystroke trace: types the same value one character at a time,
+   reading ``textContent`` after EVERY character, and prints the first
+   index at which the readback stops being a prefix of what was typed.
+   That pinpoints exactly which keystroke triggers the reorder.
+4. Alternative input mechanisms, each verified the same way:
+   - ``insertText`` via CDP-less ``page.keyboard.insert_text`` (no per-key
+     key events, but still fires a real ``beforeinput``/``input``).
+   - ``fill()`` (known not to fire the widget's listeners; measured for
+     completeness).
+5. #769: after a save, polls the reloaded page's UTMInput value once per
+   second for up to 60s, printing the value and when it converges — i.e.
+   how long Yandex actually takes to make the saved value readable.
+
+Usage (coordinated live window ONLY):
+
+    PYTHONPATH=. python3 scripts/recon_774_utm_reorder.py --headful
+    PYTHONPATH=. python3 scripts/recon_774_utm_reorder.py --save-latency
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from typing import Optional
+
+CAMPAIGN_ID = int(__import__("os").environ.get("RECON_774_CAMPAIGN_ID", "713234191"))
+WIZARD_EDIT_URL = f"https://direct.yandex.ru/wizard/campaigns/{CAMPAIGN_ID}/edit/"
+
+UTM_INPUT = '[data-testid="CampaignLinkEditorLite.UTMInput"]'
+
+PROBE = (
+    "utm_source=yandex_alexey&utm_medium=cpc&utm_campaign={campaign_id}"
+    "&utm_term={gbid}|kw|{keyword}&utm_content={ad_id}"
+)
+
+
+def _open(headless: bool):
+    from direct_cli.browser.session import open_saved_session
+
+    return open_saved_session(headless=headless)
+
+
+def _goto_edit(page) -> None:
+    from direct_cli.browser.masters import _wait_for_edit_form
+    from direct_cli.browser.session import assert_authenticated, assert_not_captcha
+
+    page.goto(WIZARD_EDIT_URL, wait_until="commit")
+    assert_not_captcha(page.content())
+    assert_authenticated(page.content())
+    _wait_for_edit_form(page, CAMPAIGN_ID)
+
+
+def _expand(page) -> bool:
+    from direct_cli.browser.masters import _expand_utm_spoiler
+
+    return _expand_utm_spoiler(page)
+
+
+def _read(page) -> Optional[str]:
+    loc = page.locator(UTM_INPUT).first
+    try:
+        return loc.text_content()
+    except Exception:  # noqa: PIE786 - recon probe: any read failure means "unreadable"
+        return None
+
+
+def _clear(page) -> bool:
+    from direct_cli.browser.masters import _clear_text_field
+
+    field = page.locator(UTM_INPUT).first
+    field.click()
+    return _clear_text_field(field)
+
+
+def _diff_report(expected: str, actual: Optional[str]) -> str:
+    from direct_cli.browser.masters import describe_value_mismatch
+
+    return describe_value_mismatch(expected, actual)
+
+
+def _probe_type(page, value: str, *, rounds: int, delay: int) -> None:
+    print(f"\n=== [2] field.type(delay={delay}) x{rounds} ===")
+    field = page.locator(UTM_INPUT).first
+    for r in range(rounds):
+        _clear(page)
+        field.type(value, delay=delay)
+        actual = _read(page)
+        ok = actual == value
+        print(f"  round {r + 1}: match={ok}")
+        if not ok:
+            print(f"    typed  : {value!r}")
+            print(f"    readback: {actual!r}")
+            print(_diff_report(value, actual))
+
+
+def _probe_per_key(page, value: str, *, delay: int) -> None:
+    print(f"\n=== [3] per-keystroke trace (delay={delay}) ===")
+    field = page.locator(UTM_INPUT).first
+    _clear(page)
+    field.click()
+    diverged_at = None
+    for i, ch in enumerate(value):
+        page.keyboard.type(ch, delay=delay)
+        actual = _read(page) or ""
+        want = value[: i + 1]
+        if actual != want and diverged_at is None:
+            diverged_at = i
+            print(f"  FIRST DIVERGENCE at index {i} (char {ch!r}):")
+            print(f"    wanted  : {want!r}")
+            print(f"    readback: {actual!r}")
+    final = _read(page)
+    print(f"  final match={final == value}")
+    if final != value:
+        print(f"    final readback: {final!r}")
+        print(_diff_report(value, final))
+    if diverged_at is None:
+        print("  no divergence observed during typing")
+
+
+def _probe_insert_text(page, value: str) -> None:
+    print("\n=== [4a] keyboard.insert_text ===")
+    _clear(page)
+    page.locator(UTM_INPUT).first.click()
+    page.keyboard.insert_text(value)
+    actual = _read(page)
+    print(f"  match={actual == value}")
+    if actual != value:
+        print(f"    readback: {actual!r}")
+        print(_diff_report(value, actual))
+
+
+def _probe_fill(page, value: str) -> None:
+    print("\n=== [4b] fill() ===")
+    field = page.locator(UTM_INPUT).first
+    try:
+        field.fill(value)
+    except Exception as exc:  # noqa: PIE786 - recon probe reports, never aborts
+        print(f"  fill() raised: {exc!r}")
+        return
+    actual = _read(page)
+    print(f"  match={actual == value}")
+    if actual != value:
+        print(f"    readback: {actual!r}")
+        print(_diff_report(value, actual))
+
+
+def _save_latency(page, value: str) -> None:
+    """#769: measure how long after a save the reloaded page shows the new
+    value."""
+    from direct_cli.browser.masters import (
+        _click_save,
+        _is_draft_edit_page,
+        _set_tracking_params,
+    )
+
+    print("\n=== [5] save -> reload -> convergence latency ===")
+    is_draft = _is_draft_edit_page(page)
+    _set_tracking_params(page, value)
+    typed = _read(page)
+    print(f"  typed into field: {typed!r} (match={typed == value})")
+    t0 = time.monotonic()
+    _click_save(page, CAMPAIGN_ID, is_draft=is_draft)
+    print(f"  save clicked at t={time.monotonic() - t0:.1f}s")
+
+    _goto_edit(page)
+    _expand(page)
+    print(f"  reload complete at t={time.monotonic() - t0:.1f}s")
+    last = object()
+    converged_at = None
+    deadline = t0 + 90
+    while time.monotonic() < deadline:
+        actual = _read(page)
+        if actual != last:
+            print(f"    t={time.monotonic() - t0:5.1f}s value={actual!r}")
+            last = actual
+        if actual == value and converged_at is None:
+            converged_at = time.monotonic() - t0
+            print(f"  CONVERGED at t={converged_at:.1f}s")
+            break
+        page.wait_for_timeout(1000)
+    if converged_at is None:
+        print(f"  NEVER converged within 90s; last={last!r}")
+        print(_diff_report(value, last if isinstance(last, str) else None))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--headful", action="store_true")
+    ap.add_argument("--rounds", type=int, default=3)
+    ap.add_argument("--delay", type=int, default=80)
+    ap.add_argument("--value", default=PROBE)
+    ap.add_argument(
+        "--save-latency",
+        action="store_true",
+        help="run the #769 save/reload convergence probe (MUTATES + saves)",
+    )
+    args = ap.parse_args()
+
+    with _open(headless=not args.headful) as page:
+        _goto_edit(page)
+        if not _expand(page):
+            print("could not expand the 'Дополнительные параметры' spoiler")
+            return 1
+        baseline = _read(page)
+        print(f"=== [1] baseline UTMInput = {baseline!r} ===")
+
+        try:
+            _probe_type(page, args.value, rounds=args.rounds, delay=args.delay)
+            _probe_per_key(page, args.value, delay=args.delay)
+            _probe_insert_text(page, args.value)
+            _probe_fill(page, args.value)
+            if args.save_latency:
+                _save_latency(page, args.value)
+        finally:
+            print("\n=== restoring baseline (no save unless --save-latency) ===")
+            _goto_edit(page)
+            _expand(page)
+            print(f"  UTMInput now = {_read(page)!r}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/recon_774_utm_reorder.py
+++ b/scripts/recon_774_utm_reorder.py
@@ -224,16 +224,28 @@ def _restore_baseline(page, baseline: Optional[str], *, saved: bool) -> None:
         _goto_edit(page)
         _expand(page)
     except Exception as exc:  # noqa: PIE786 - see the contained-restore note
-        print(
-            f"  ERROR: could not reopen the edit page ({exc!r}). "
-            + (
-                f"The campaign may still hold the probe value; check it "
+        # `baseline is None` must be checked BEFORE offering a paste-able
+        # command: `_read` returns None on any locator failure and `saved`
+        # is independent of it, so the two combine. `--tracking-params` is
+        # a plain string option, so a formatted None would be pasted as the
+        # LITERAL 'None' and written to the campaign — corrupting the field
+        # instead of restoring it. Mirrors the `baseline is None` guard
+        # below.
+        if not saved:
+            detail = "Nothing was saved, so nothing needs restoring."
+        elif baseline is None:
+            detail = (
+                "The campaign may still hold the probe value, and the "
+                "baseline was never readable, so it cannot be restored "
+                "automatically — recover it by hand."
+            )
+        else:
+            detail = (
+                f"The campaign may still hold the probe value; restore it "
                 f"manually:\n    direct masters update {CAMPAIGN_ID} "
                 f"--tracking-params {baseline!r}"
-                if saved
-                else "Nothing was saved, so nothing needs restoring."
             )
-        )
+        print(f"  ERROR: could not reopen the edit page ({exc!r}). {detail}")
         return
     if not saved:
         # Nothing was committed: the re-navigation above already dropped

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -11355,6 +11355,363 @@ class TestApplyImageOperations(unittest.TestCase):
         self.assertEqual(page.save_clicks, [])
 
 
+class TestUtmSectionReadability(unittest.TestCase):
+    """``_read_tracking_params`` / ``_wait_for_utm_section`` — issue
+    #769/#774's real root cause: a late-mounting "Дополнительные параметры"
+    section made a save that DID take effect look like a failed one.
+
+    Live recon against campaign 713234064 (2026-08-06): after a save whose
+    value was demonstrably correct on the next page load, the verifying run
+    read the UTM field as unmounted for a full 90s. ``_expand_utm_spoiler``
+    returned ``False`` (its trigger wasn't in the DOM yet), that return was
+    discarded, and ``text_content()`` on the unmounted field yielded
+    ``None`` — which ``_verify_saved`` then reported as a mismatch.
+    """
+
+    @staticmethod
+    def _page(*, spoiler_appears_after=0, value="utm_source=x"):
+        """An edit page whose UTM spoiler trigger only mounts after
+        ``spoiler_appears_after`` ``wait_for_timeout`` ticks."""
+        ticks = {"n": 0}
+        expanded = {"open": False}
+
+        class _LateSpoilerLocator:
+            def __init__(self, handles):
+                self._handles = handles
+
+            def _mounted(self):
+                return ticks["n"] >= spoiler_appears_after
+
+            def count(self):
+                return len(self._handles) if self._mounted() else 0
+
+            def nth(self, i):
+                return self._handles[i]
+
+            @property
+            def first(self):
+                if not self._mounted():
+                    return _FakeLocatorHandle(raises=True)
+                return self._handles[0]
+
+        spoiler_handle = _DynamicAttrsLocatorHandle(
+            get_attrs=lambda: {
+                "aria-expanded": "true" if expanded["open"] else "false"
+            },
+            on_click=lambda: expanded.__setitem__("open", True),
+        )
+
+        class _UtmFieldLocator:
+            @property
+            def first(self):
+                # Models Playwright's real behaviour for a locator matching
+                # nothing in a still-hydrating section: `.first` resolves,
+                # and `text_content()` returns an EMPTY STRING rather than
+                # raising. That is precisely why the pre-fix
+                # `_read_tracking_params` could not tell "not mounted yet"
+                # from "genuinely cleared" — a fake that raises here would
+                # hide the bug instead of reproducing it.
+                if not expanded["open"]:
+                    return _FakeContentEditableHandle(text="")
+                return _FakeContentEditableHandle(text=value)
+
+            def count(self):
+                return 1 if expanded["open"] else 0
+
+        class _TickingPage(FakePage):
+            def wait_for_timeout(self, timeout):
+                ticks["n"] += 1
+                super().wait_for_timeout(timeout)
+
+        return _TickingPage(
+            locators={
+                browser_masters._EDIT_UTM_SPOILER_BUTTON_TESTID: (
+                    _LateSpoilerLocator([spoiler_handle])
+                ),
+                browser_masters._EDIT_UTM_INPUT_TESTID: _UtmFieldLocator(),
+            }
+        )
+
+    def test_unmountable_spoiler_reads_as_none_not_empty_string(self):
+        # THE bug: an absent spoiler must be "I could not read this"
+        # (None), never "the field is empty" ("") — the latter is
+        # indistinguishable from a genuinely cleared field and is what made
+        # #774's investigation point 3 look like data loss.
+        page = self._page(spoiler_appears_after=10**9)
+
+        self.assertIsNone(browser_masters._read_tracking_params(page))
+
+    def test_wait_retries_the_expansion_until_the_trigger_mounts(self):
+        # Retrying the READ alone never recovers — the spoiler has to be
+        # clicked once its trigger finally exists.
+        page = self._page(spoiler_appears_after=3, value="utm_source=late")
+
+        self.assertTrue(browser_masters._wait_for_utm_section(page))
+        self.assertEqual(browser_masters._read_tracking_params(page), "utm_source=late")
+
+    def test_wait_returns_false_on_timeout_without_raising(self):
+        # Degradation contract (mirrors _wait_for_target_actions_settled):
+        # a timeout is reported to the caller, not raised, so the caller's
+        # own mismatch reporting stays the single place failures surface.
+        page = self._page(spoiler_appears_after=10**9)
+
+        self.assertFalse(browser_masters._wait_for_utm_section(page))
+
+    def test_an_already_open_section_is_readable_immediately(self):
+        page = self._page(spoiler_appears_after=0, value="utm_source=ready")
+
+        self.assertTrue(browser_masters._wait_for_utm_section(page))
+        self.assertEqual(
+            browser_masters._read_tracking_params(page), "utm_source=ready"
+        )
+
+
+class TestVerifyTrackingParamsReloadRetry(unittest.TestCase):
+    """``_verify_saved`` re-NAVIGATES before failing a tracking_params check
+    (issue #769).
+
+    Live-reproduced 2026-08-06 against campaign 713234064: two
+    ``masters update --tracking-params`` runs back to back had the second
+    run's verify read back the FIRST run's value. Re-opening the campaign in
+    a fresh page load 6.6s later showed the second value correctly saved —
+    the save was fine, the post-save reload served a stale render. Polling
+    the already-loaded page harder cannot fix that; only a new navigation
+    re-fetches the section.
+    """
+
+    NEW = "utm_source=new&utm_medium=cpc&utm_campaign={campaign_id}&utm_term={gbid}"
+    STALE = "utm_source=old&utm_medium=cpc&utm_campaign={campaign_id}&utm_term={gbid}"
+
+    @staticmethod
+    def _page(values_by_load):
+        """Edit page whose UTM field yields ``values_by_load[n]`` on the
+        n-th POST-SAVE load — the last entry repeats for further loads.
+
+        ``update_master`` navigates once to open the form before saving;
+        that load is not counted, so ``values_by_load[0]`` is what
+        ``_verify_saved``'s own post-save reload sees (the stale render in
+        the #769 scenario) and ``[1]`` is what a re-navigation gets.
+        """
+        loads = {"n": -2}
+        expanded = {"open": False}
+
+        def _current():
+            i = min(loads["n"], len(values_by_load) - 1)
+            return values_by_load[i]
+
+        spoiler_handle = _DynamicAttrsLocatorHandle(
+            get_attrs=lambda: {
+                "aria-expanded": "true" if expanded["open"] else "false"
+            },
+            on_click=lambda: expanded.__setitem__("open", True),
+        )
+
+        class _UtmFieldLocator:
+            @property
+            def first(self):
+                return _FakeContentEditableHandle(text=_current())
+
+            def count(self):
+                return 1
+
+        class _ReloadingPage(FakePage):
+            def goto(self, url, **kwargs):
+                loads["n"] += 1
+                # A real navigation re-collapses the lazily-mounted spoiler.
+                expanded["open"] = False
+                return super().goto(url, **kwargs)
+
+        save_handle = _FakeTextLocatorHandle(visible=True)
+        edit_form_ready = f'[data-testid="{browser_masters._EDIT_FORM_READY_TESTID}"]'
+        return _ReloadingPage(
+            locators={
+                browser_masters._EDIT_UTM_SPOILER_BUTTON_TESTID: _FakeLocator(
+                    [spoiler_handle]
+                ),
+                browser_masters._EDIT_UTM_INPUT_TESTID: _UtmFieldLocator(),
+                edit_form_ready: _FakeLocator([_FakeLocatorHandle()]),
+            },
+            role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
+        )
+
+    def test_a_stale_first_read_is_recovered_by_re_navigating(self):
+        # First post-save load serves the PREVIOUS value; the next load has
+        # the real one. Must succeed, not raise.
+        page = self._page([self.STALE, self.NEW])
+
+        result = browser_masters.update_master(page, 42, tracking_params=self.NEW)
+
+        self.assertEqual(result["TrackingParams"], self.NEW)
+
+    def test_a_persistently_wrong_value_still_fails(self):
+        # The retry must not paper over a genuine save failure: a value that
+        # never converges is still reported.
+        page = self._page([self.STALE])
+
+        with self.assertRaises(browser_masters.BrowserSessionError) as ctx:
+            browser_masters.update_master(page, 42, tracking_params=self.NEW)
+
+        self.assertIn("tracking_params", str(ctx.exception))
+
+    def test_a_genuine_failure_message_carries_the_readable_diff(self):
+        # Issue #774's second ask: the failure a user actually sees must
+        # explain WHAT differs, not just print two long strings.
+        page = self._page([self.STALE])
+
+        with self.assertRaises(browser_masters.BrowserSessionError) as ctx:
+            browser_masters.update_master(page, 42, tracking_params=self.NEW)
+
+        self.assertIn("missing", str(ctx.exception))
+
+
+class TestDescribeValueMismatch(unittest.TestCase):
+    """``describe_value_mismatch`` — issue #774's readable diff for long
+    near-identical strings in ``_verify_saved``'s failure message."""
+
+    # The exact pair from issue #774: the reporter's requested value, and the
+    # value a screenshot of the UI showed after the "failed" save.
+    EXPECTED = (
+        "utm_source=yandex_alexey&utm_medium=cpc&utm_campaign={campaign_id}"
+        "&utm_term={gbid}|kw|{keyword}&utm_content={ad_id}"
+    )
+    REORDERED = (
+        "utm_source=yandex_alexey&utm_medium=cpc&utm_campaign={campaign_id}"
+        "&utm_term={gbid}&utm_content={ad_id}|kw|{keyword}"
+    )
+
+    def test_reports_a_relocated_fragment_as_a_single_moved_line(self):
+        # The whole point of the helper: #774's signature must collapse to
+        # ONE line naming the fragment and both positions, not two
+        # 110-character reprs the reader has to align by eye.
+        detail = browser_masters.describe_value_mismatch(self.EXPECTED, self.REORDERED)
+
+        self.assertEqual(len(detail.splitlines()), 1, detail)
+        self.assertIn("moved", detail)
+        self.assertIn("|kw|{keyword}", detail)
+        self.assertNotIn("missing", detail)
+        self.assertNotIn("extra", detail)
+
+    def test_moved_line_names_both_positions(self):
+        detail = browser_masters.describe_value_mismatch(self.EXPECTED, self.REORDERED)
+
+        self.assertIn(str(self.EXPECTED.index("|kw|{keyword}")), detail)
+        self.assertIn(str(self.REORDERED.index("|kw|{keyword}")), detail)
+
+    def test_reports_a_dropped_tail_as_missing_not_moved(self):
+        # #769's original hypothesis (Yandex truncating the tail) must read
+        # differently from #774's reorder — that distinction is the reason
+        # the helper exists.
+        truncated = self.EXPECTED.replace("|kw|{keyword}", "")
+
+        detail = browser_masters.describe_value_mismatch(self.EXPECTED, truncated)
+
+        self.assertIn("missing", detail)
+        self.assertIn("|kw|{keyword}", detail)
+        self.assertNotIn("moved", detail)
+
+    def test_reports_unrequested_text_as_extra(self):
+        detail = browser_masters.describe_value_mismatch(
+            self.EXPECTED, self.EXPECTED + "&utm_extra=1"
+        )
+
+        self.assertIn("extra", detail)
+        self.assertIn("utm_extra=1", detail)
+
+    def test_empty_page_value_is_called_out_in_words(self):
+        # Distinguishing "" from a reorder is #774's investigation point 3;
+        # a character diff against "" would be useless noise.
+        detail = browser_masters.describe_value_mismatch(self.EXPECTED, "")
+
+        self.assertEqual(detail.strip(), "- expected a value, but the field is empty")
+
+    def test_unreadable_field_is_distinguished_from_an_empty_one(self):
+        detail = browser_masters.describe_value_mismatch(self.EXPECTED, None)
+
+        self.assertIn("could not be read", detail)
+
+    def test_equal_values_produce_no_detail(self):
+        self.assertEqual(
+            browser_masters.describe_value_mismatch(self.EXPECTED, self.EXPECTED), ""
+        )
+
+    def test_short_values_produce_no_detail(self):
+        # A short pair is already readable as two reprs; adding a diff would
+        # only double the message.
+        self.assertEqual(browser_masters.describe_value_mismatch("abc", "abd"), "")
+
+    def test_a_one_sided_duplicate_reports_the_move_and_keeps_the_leftover(self):
+        # A fragment present twice in `actual` but once in `expected`. The
+        # relocation is reported as a move; the SECOND, unrequested copy is
+        # a genuine addition and must still show up rather than being
+        # absorbed by that pairing.
+        expected = "a" * 30 + "|kw|" + "b" * 30
+        actual = "a" * 30 + "b" * 30 + "|kw|" + "|kw|"
+
+        detail = browser_masters.describe_value_mismatch(expected, actual)
+
+        self.assertIn("moved", detail)
+        self.assertIn("|kw|", detail)
+        # Nothing silently vanishes: the extra copy is accounted for.
+        self.assertEqual(detail.count("|kw|"), detail.count("|kw|"))
+        self.assertTrue(detail.strip(), detail)
+
+    def test_two_distinct_relocations_produce_two_moved_lines(self):
+        # The pairing bookkeeping itself: two DISTINCT relocated fragments
+        # must produce two distinct moved lines, not one fragment matched
+        # against both extras.
+        expected = "x" * 20 + "|aaaa|" + "y" * 20 + "|bbbb|" + "z" * 20
+        actual = "x" * 20 + "y" * 20 + "|aaaa|" + "z" * 20 + "|bbbb|"
+
+        detail = browser_masters.describe_value_mismatch(expected, actual)
+
+        self.assertEqual(detail.count("moved"), 2, detail)
+        self.assertIn("aaaa", detail)
+        self.assertIn("bbbb", detail)
+
+    def test_a_two_character_coincidence_is_not_called_a_move(self):
+        # _VALUE_DIFF_MIN_MOVE_LEN: a stray delimiter that happens to occur
+        # elsewhere is noise, and calling it "moved" would bury the real
+        # difference. Reported as plain missing/extra instead.
+        expected = "q" * 25 + "ab" + "r" * 25
+        actual = "q" * 25 + "r" * 25 + "ab"
+
+        detail = browser_masters.describe_value_mismatch(expected, actual)
+
+        self.assertNotIn("moved", detail)
+        self.assertIn("missing", detail)
+
+
+class TestFormatValueMismatch(unittest.TestCase):
+    """``_format_value_mismatch`` — the ``_verify_saved`` line wrapper that
+    appends ``describe_value_mismatch``'s breakdown (issue #774)."""
+
+    def test_long_string_mismatch_keeps_the_raw_pair_and_adds_the_diff(self):
+        expected = TestDescribeValueMismatch.EXPECTED
+        actual = TestDescribeValueMismatch.REORDERED
+
+        line = browser_masters._format_value_mismatch(
+            "tracking_params", expected, actual
+        )
+
+        # The raw pair stays — it is what a reader copies into a re-run.
+        self.assertIn(f"expected {expected!r}", line)
+        self.assertIn(f"page now shows {actual!r}", line)
+        self.assertIn("moved", line)
+
+    def test_non_string_values_keep_the_plain_form(self):
+        line = browser_masters._format_value_mismatch("weekly_budget", 95000, 80000)
+
+        self.assertEqual(line, "weekly_budget: expected 95000, page now shows 80000")
+        self.assertEqual(len(line.splitlines()), 1)
+
+    def test_unreadable_string_field_still_gets_a_worded_detail(self):
+        line = browser_masters._format_value_mismatch(
+            "tracking_params", TestDescribeValueMismatch.EXPECTED, None
+        )
+
+        self.assertIn("could not be read", line)
+
+
 class TestVerifyImageSetMismatches(unittest.TestCase):
     """``_verify_image_set_mismatches`` — absolute end-state verification
     generalizing ``_verify_image_mismatches``'s hardcoded "removed count ==

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -11563,6 +11563,152 @@ class TestVerifyTrackingParamsReloadRetry(unittest.TestCase):
 
         self.assertIn("missing", str(ctx.exception))
 
+    def test_an_unmountable_section_fails_without_burning_the_read_budget(self):
+        # Cycle-review of PR #780: `_wait_for_utm_section` returns False when
+        # the section never mounts, but that verdict was discarded — so the
+        # caller went on to spend the FULL `_read_until_matches` budget
+        # re-reading a field that returns None instantly, ~50s per attempt
+        # (30s wait + 20s read) instead of failing fast on the wait alone.
+        # Driven through `_verify_saved` directly: the WRITE path expands the
+        # same spoiler, so an always-absent trigger would fail there first and
+        # never reach the read budget this test is about.
+        class _NeverMountingSpoiler:
+            @property
+            def first(self):
+                # `_expand_utm_spoiler` resolves `.first` before probing
+                # `.count()`; the handle is never actually used because the
+                # count is 0.
+                return _FakeLocatorHandle()
+
+            def count(self):
+                return 0
+
+        page = self._page([self.NEW])
+        page.goto(browser_masters.WIZARD_EDIT_URL.format(campaign_id=42))
+        page._locators[browser_masters._EDIT_UTM_SPOILER_BUTTON_TESTID] = (
+            _NeverMountingSpoiler()
+        )
+
+        # Counting `_read_until_matches` entries is what actually
+        # discriminates the two code paths. Counting field reads does NOT:
+        # `_read_tracking_params` short-circuits on the same absent spoiler,
+        # so the field locator is untouched whether or not the caller
+        # honours the readability verdict — an assertion on field reads
+        # passes against the unfixed code too.
+        real_read_until = browser_masters._read_until_matches
+        budget_entries = {"n": 0}
+
+        def _counting_read_until(page_, reader, expected, **kwargs):
+            if reader is browser_masters._read_tracking_params:
+                budget_entries["n"] += 1
+            return real_read_until(page_, reader, expected, **kwargs)
+
+        with patch.object(browser_masters, "_read_until_matches", _counting_read_until):
+            with self.assertRaises(browser_masters.BrowserSessionError) as ctx:
+                browser_masters._verify_saved(
+                    page,
+                    42,
+                    weekly_budget=None,
+                    promotion_goal=None,
+                    directs_helps=None,
+                    tracking_params=self.NEW,
+                )
+
+        # Reported as unreadable, not as an empty field (issue #774 point 3).
+        self.assertIn("could not be read", str(ctx.exception))
+        # The unreadable verdict short-circuits: not one read budget is
+        # opened on a field that cannot be mounted.
+        self.assertEqual(budget_entries["n"], 0)
+
+    def test_re_navigation_re_runs_the_audience_hydration_gate(self):
+        # Cycle-review of PR #780: the stale-render reload is page-level, but
+        # the retry loop re-navigated WITHOUT re-running
+        # `_wait_for_audience_section`. Every audience check runs after the
+        # tracking_params block, so on a combined update they then read a
+        # freshly-navigated, still-hydrating section — the exact race #681
+        # added that gate for.
+        # Driven through `_verify_saved` directly rather than
+        # `update_master`, so the fake page needs no device dropdown to
+        # write through — the gate's re-run on re-navigation is the whole
+        # subject here, not the setter.
+        calls = {"gate": 0}
+        page = self._page([self.STALE, self.NEW])
+        # `_verify_saved` navigates itself; `_page` counts post-save loads
+        # from -2 because `update_master` opens the form first.
+        page.goto(browser_masters.WIZARD_EDIT_URL.format(campaign_id=42))
+
+        def _counting_gate(_page):
+            calls["gate"] += 1
+
+        # The devices check itself has no fake dropdown to read and will
+        # therefore report a mismatch; irrelevant here — the subject is
+        # whether the gate ran again after the re-navigation.
+        with patch.object(
+            browser_masters, "_wait_for_audience_section", _counting_gate
+        ):
+            with contextlib.suppress(browser_masters.BrowserSessionError):
+                browser_masters._verify_saved(
+                    page,
+                    42,
+                    weekly_budget=None,
+                    promotion_goal=None,
+                    directs_helps=None,
+                    tracking_params=self.NEW,
+                    devices={"desktop"},
+                )
+
+        # Once for the initial post-save reload, once for the re-navigation.
+        self.assertEqual(calls["gate"], 2)
+
+    def test_the_writer_tolerates_a_late_mounting_spoiler(self):
+        # Cycle-review of PR #780: this PR's central finding is that the
+        # "Дополнительные параметры" section can stay unmounted long after
+        # `_wait_for_edit_form` returns (90s measured live). The READ path
+        # now waits that out; the WRITE path still raised on the first
+        # missing trigger, so the same slow load hard-fails the update with
+        # a "Yandex may have changed the page's markup" message that is
+        # wrong for a transient hydration delay.
+        # Driven straight at `_set_tracking_params`, so the late-mounting
+        # trigger is consumed by the WRITE path alone. Going through
+        # `update_master` would let the verify path's own probes exhaust the
+        # unmounted window first, and the test would pass either way.
+        # Must exceed `_SPOILER_EXPAND_MAX_ATTEMPTS`: `_expand_utm_spoiler`
+        # already retries its own click that many times, so a shorter delay
+        # is absorbed there and the test passes without the outer wait.
+        mounts = {"left": browser_masters._SPOILER_EXPAND_MAX_ATTEMPTS + 2}
+        expanded = {"open": False}
+        field = _FakeContentEditableHandle(text="")
+
+        class _LateMountingHandle(_DynamicAttrsLocatorHandle):
+            # `_expand_utm_spoiler` probes `count()` on the HANDLE, not on
+            # the locator — putting the counter on the locator leaves it
+            # never called and the "late mount" never happens.
+            def count(self):
+                if mounts["left"] > 0:
+                    mounts["left"] -= 1
+                    return 0
+                return 1
+
+        spoiler_handle = _LateMountingHandle(
+            get_attrs=lambda: {
+                "aria-expanded": "true" if expanded["open"] else "false"
+            },
+            on_click=lambda: expanded.__setitem__("open", True),
+        )
+
+        page = FakePage(
+            locators={
+                browser_masters._EDIT_UTM_SPOILER_BUTTON_TESTID: _FakeLocator(
+                    [spoiler_handle]
+                ),
+                browser_masters._EDIT_UTM_INPUT_TESTID: _FakeLocator([field]),
+            }
+        )
+
+        browser_masters._set_tracking_params(page, self.NEW)
+
+        self.assertEqual(field.text_content(), self.NEW)
+
 
 class TestDescribeValueMismatch(unittest.TestCase):
     """``describe_value_mismatch`` — issue #774's readable diff for long
@@ -11651,9 +11797,16 @@ class TestDescribeValueMismatch(unittest.TestCase):
 
         self.assertIn("moved", detail)
         self.assertIn("|kw|", detail)
-        # Nothing silently vanishes: the extra copy is accounted for.
-        self.assertEqual(detail.count("|kw|"), detail.count("|kw|"))
-        self.assertTrue(detail.strip(), detail)
+        # Nothing silently vanishes: the extra copy is accounted for on its
+        # OWN line. The previous assertion here compared `detail.count(...)`
+        # to itself — a tautology that passed while the leftover was in fact
+        # being absorbed, because difflib emits the two adjacent copies as a
+        # single '|kw||kw|' insert that the move-pairing consumed whole.
+        extra_lines = [
+            line for line in detail.splitlines() if line.strip().startswith("- extra")
+        ]
+        self.assertEqual(len(extra_lines), 1, detail)
+        self.assertIn("|kw|", extra_lines[0])
 
     def test_two_distinct_relocations_produce_two_moved_lines(self):
         # The pairing bookkeeping itself: two DISTINCT relocated fragments

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -11660,6 +11660,55 @@ class TestVerifyTrackingParamsReloadRetry(unittest.TestCase):
         # Once for the initial post-save reload, once for the re-navigation.
         self.assertEqual(calls["gate"], 2)
 
+    def test_other_fields_are_re_verified_on_the_re_navigated_page(self):
+        # Cycle-review round 2 of PR #780: a stale render is PAGE-level, so
+        # the fields checked BEFORE the tracking_params block are stale on
+        # the same initial load that made tracking_params stale. They were
+        # read once and never re-read on the page the re-navigation just
+        # fetched, so a combined update could still false-fail on `name`
+        # while tracking_params recovered — the exact false "did not save"
+        # this PR exists to remove.
+        loads = {"n": -2}
+        names = ["stale name", "new name"]
+
+        def _current_name():
+            return names[min(max(loads["n"], 0), len(names) - 1)]
+
+        class _NameHandle(_FakeLocatorHandle):
+            def inner_text(self, timeout=None):
+                return _current_name()
+
+        class _NameLocator:
+            @property
+            def first(self):
+                return _NameHandle()
+
+            def count(self):
+                return 1
+
+        page = self._page([self.STALE, self.NEW])
+        original_goto = page.goto
+
+        def _tracking_goto(url, **kwargs):
+            loads["n"] += 1
+            return original_goto(url, **kwargs)
+
+        page.goto = _tracking_goto
+        page._locators[browser_masters._NAME_HEADER_SELECTOR] = _NameLocator()
+        page.goto(browser_masters.WIZARD_EDIT_URL.format(campaign_id=42))
+
+        # `name` is stale on the first post-save load and correct on the
+        # re-navigated one, exactly like tracking_params.
+        browser_masters._verify_saved(
+            page,
+            42,
+            weekly_budget=None,
+            promotion_goal=None,
+            directs_helps=None,
+            name="new name",
+            tracking_params=self.NEW,
+        )
+
     def test_the_writer_tolerates_a_late_mounting_spoiler(self):
         # Cycle-review of PR #780: this PR's central finding is that the
         # "Дополнительные параметры" section can stay unmounted long after


### PR DESCRIPTION
## TL;DR

Live recon **disproves #774's premise** and finds the real root cause of both issues: the CLI never reorders the text it types, and Yandex never rejected it. Two distinct **verify-side** defects made saves that *did* take effect report as failures.

## #774 — the reorder is not an input bug

12 typing trials across two campaigns and four mechanisms — `field.type(delay=80)`, per-keystroke with a readback after **every** character, `keyboard.insert_text`, `fill()` — produced **zero divergence**, including at the `|` character.

The reorder in the reporter's screenshot is a **pre-existing saved value** on that campaign. A read-only audit of all 38 master campaigns (`scripts/recon_774_audit_saved_utm.py`) found campaign 713234064 holding `...utm_term={gbid}&utm_content={ad_id}|kw|{keyword}` — durable backend state, not something input produced. Typing the *correct* order into that same campaign and saving round-trips perfectly.

## #774 point 3 — "verify showed an empty field"

`_read_tracking_params` called `_expand_utm_spoiler` and **discarded its return value**. When the lazily-mounted "Дополнительные параметры" section hasn't rendered its trigger yet, there is nothing to click, the field stays unmounted, and `text_content()` yields a value indistinguishable from *"the field is genuinely empty"*.

Measured live on 713234064: a save whose value was correct on the very next page load was read as unmounted **for a full 90s**.

- An unexpandable spoiler now reads as `None` ("unreadable"), never `""`.
- `_wait_for_utm_section` retries the **expansion**, not just the read, so a late-mounting trigger is clicked as soon as it exists.
- Replaces a fixed 3s sleep calibrated for a different failure mode (#761).

## #769 — real, and it survives the above

Two `masters update --tracking-params` runs back to back had the second run's verify read back the **first** run's value. Re-opening the campaign in a fresh page load 6.6s later showed the second value correctly saved all along — the post-save reload served a **stale render**. Polling that one page harder cannot see past it; only a new navigation re-fetches the section.

`_verify_saved` now re-navigates up to `_VERIFY_RELOAD_MAX_ATTEMPTS` (3) times before failing a tracking_params check.

**Verified live** — the exact two-call sequence from the issue failed before this change and succeeds after it:

```
call 1 --tracking-params "...utm_term={gbid}|kw|{keyword}&utm_content={ad_id}"  -> ok
call 2 --tracking-params "...utm_term={gbid}&utm_content={ad_id}"               -> ok
```

## #774 point 2 — readable diff

`describe_value_mismatch` renders a mismatch as *what moved / what's missing / what's extra*, with positions:

```
- moved: '|kw|{keyword}' was requested at position 82, but the page has it at position 102
```

instead of two 110-character reprs the reader must align by eye. A reorder now reads differently from a truncation — exactly the distinction that misled #769's original diagnosis. Pairing matches a relocated fragment by **span overlap** rather than text identity, since difflib splits segments at delimiters shared with the fragment's new neighbourhood. Applied to every string check in `_verify_saved`.

## Verification

- Full offline suite: **3289 passed**, 23 skipped.
- New tests are non-vacuous — each was confirmed to **fail** against the pre-fix code (the readability test reproduces `'' is not None`; the retry test reproduces #769's exact error message).
- `black` + `flake8` clean on all touched files.
- Live: `masters update --tracking-params` end-to-end on 713234064.

## Test-master state

Campaigns 713234191 and 713234064 restored to their exact pre-session baselines (confirmed by a final read-only audit).

## Note for follow-up

The reorder itself is genuine, durable, Yandex-side state on some campaigns, but this PR does **not** attempt to normalize or accept it: a reordered query string is a different string, and `_verify_saved` still fails on any mismatch — it just now explains the difference clearly. Whether Yandex reorders on save under some condition is a separate question worth its own issue.

Closes #774
Closes #769

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9w5QHu8WASv3K8HoRm3kJ