### PR TITLE
fix(masters): stop asserting a single cause from a bounded timeout in _add_target_action

### DIFF
--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -3676,10 +3676,21 @@ def _add_target_action(page: "Page", goal_id: int, price: float) -> None:
         # ``_TARGET_ACTION_SETTLE_TIMEOUT_MS``), and Playwright's
         # ``TimeoutError`` cannot tell "absent" from "present but not
         # actionable". Re-probing with a plain ``count()`` (no auto-wait, so
-        # it cannot itself hang) does distinguish them, and blaming the
-        # Metrika counter for a hydration race would send the user to audit
-        # a setup that is fine — the exact opposite of this module's
-        # "precise error over opaque timeout" rule.
+        # it cannot itself hang) does distinguish them — but issue #783
+        # found that even a positive ``count()`` read does not prove the
+        # trigger is genuinely actionable (a disabled "Добавить" — e.g. the
+        # linked Metrika counter has no goals on offer — also satisfies
+        # ``count() > 0``), and an exhausted ``option.wait_for`` after a
+        # successful click does not prove the goal is absent from the
+        # popup either (issue #783: the option-wait budget here,
+        # ``_TARGET_ACTION_ADD_OPTION_MAX_ATTEMPTS *
+        # _POPUP_APPEAR_TIMEOUT_MS``, is shorter than the section's
+        # documented hydration bound, ``_TARGET_ACTION_SETTLE_TIMEOUT_MS``).
+        # A bounded timeout only proves "did not happen within the bound",
+        # never "will not happen" — so NEITHER branch below may assert a
+        # single cause; each states both possibilities and lets the caller
+        # judge, with the settled-read/count() probes only shifting which
+        # is likelier.
         trigger_present = False
         if not ever_clicked:
             for testid in add_button_testids:
@@ -3695,13 +3706,27 @@ def _add_target_action(page: "Page", goal_id: int, price: float) -> None:
                 "The 'Добавить' target-action trigger is on the page but "
                 f"never became clickable within {_POPUP_APPEAR_TIMEOUT_MS}ms, "
                 f"across {_TARGET_ACTION_ADD_OPTION_MAX_ATTEMPTS} attempts, "
-                f"so goal {goal_id} could not be added. The 'Целевые "
-                "действия' section is known to hydrate slowly, so this is "
-                "most likely a still-rendering page rather than a "
-                "configuration problem — re-run, or re-run with --headful "
-                "to watch it. If it persists, the goal may genuinely not be "
-                "on offer (see below)."
+                f"so goal {goal_id} could not be added. This has two "
+                "possible causes and a bounded timeout cannot tell them "
+                "apart: (1) the 'Целевые действия' section is known to "
+                "hydrate slowly, so this may just be a still-rendering "
+                "page — re-run, or re-run with --headful to watch it; or "
+                "(2) the trigger is present in the DOM but genuinely not "
+                "actionable — e.g. disabled because the campaign's linked "
+                "Metrika counter has no goals on offer. To rule out (2): "
+                "confirm the campaign's promotion goal is 'max-conversions' "
+                "(pass --promotion-goal max-conversions if not), and confirm "
+                f"goal {goal_id} belongs to the linked Metrika counter and "
+                "isn't already listed (`masters targetactions get`)."
             ) from last_exc
+
+        # A successful trigger click observes only that the popup DID NOT
+        # SHOW the option within the bound above — not that the option is
+        # absent. Gate on a settled read before leaning on that as a cause:
+        # if the section had not yet stabilized, the exhausted retry may
+        # simply have been racing a popup that was correct but slow to
+        # render, not a genuinely missing goal (issue #783).
+        settled = _wait_for_target_actions_settled(page) if ever_clicked else True
 
         raise BrowserSessionError(
             f"Could not find goal {goal_id} in the 'Добавить' target-action "
@@ -3719,13 +3744,22 @@ def _add_target_action(page: "Page", goal_id: int, price: float) -> None:
             "installed offers no goals at all."
             + (
                 ""
-                if ever_clicked
-                # The popup was never even opened, so "the goal isn't in it"
-                # is an inference, not an observation — say so rather than
-                # asserting a diagnosis the run could not actually make.
-                else " The 'Добавить' trigger was not found on the page "
-                "either, so if the goal setup is correct, the page may not "
-                "have finished hydrating — re-run to rule that out."
+                if ever_clicked and settled
+                else (
+                    " The 'Добавить' trigger was not found on the page "
+                    "either, so if the goal setup is correct, the page may "
+                    "not have finished hydrating — re-run to rule that out."
+                    if not ever_clicked
+                    # ever_clicked is True but the row count never settled
+                    # within the wait above — the popup may have been
+                    # correct but still hydrating when the option-wait gave
+                    # up, not proof the goal is genuinely absent.
+                    else " The 'Целевые действия' section had not finished "
+                    "settling when this timed out, so the popup may simply "
+                    "have been slow to render the option rather than "
+                    "missing it — re-run to rule that out before treating "
+                    "this as a counter/promotion-goal problem."
+                )
             )
         ) from last_exc
 

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -5584,6 +5584,15 @@ class TestAddTargetAction(unittest.TestCase):
         cannot tell "absent" from "present but not actionable", so the code
         cannot distinguish them — but the message can name both, instead of
         sending the user to audit counter setup that is fine.
+
+        Issue #783 round 3: a positive ``count()`` read ALSO cannot prove
+        the trigger is genuinely actionable — a disabled "Добавить" (e.g.
+        the linked Metrika counter has no goals on offer) satisfies
+        ``count() > 0`` too. So this branch must no longer claim a single
+        cause; it must carry BOTH the hydration-race explanation and the
+        counter/promotion-goal audit steps inline, since a dangling
+        cross-reference to an unreachable branch left the counter-audit
+        diagnosis unreachable from here entirely.
         """
         # Both triggers time out on every attempt — the shape a still-
         # hydrating page presents.
@@ -5612,13 +5621,22 @@ class TestAddTargetAction(unittest.TestCase):
             "bound — on a slow page this sends the user to audit a Metrika "
             "counter that is fine",
         )
-        # A present-but-unresponsive trigger is NOT a counter/promotion-goal
-        # problem, so the error must not lead with that diagnosis.
-        self.assertNotIn(
+        # The counter/promotion-goal audit steps must be reachable from
+        # THIS message directly — no dangling "(see below)" cross-reference
+        # to an unreachable branch (issue #783 finding 1).
+        self.assertIn(
             "max-conversions",
             message,
-            "a trigger that is present but slow was blamed on the campaign's "
-            "promotion goal / Metrika counter setup",
+            "a genuinely-stuck disabled trigger (count()>0 but never "
+            "actionable) must still surface actionable counter/"
+            "promotion-goal audit steps, not just a 're-run' suggestion "
+            "pointing nowhere",
+        )
+        self.assertIn(
+            "targetactions get",
+            message,
+            "the counter-audit command must be named inline, not left "
+            "behind a dangling cross-reference",
         )
 
     def test_still_blames_the_counter_when_no_trigger_is_on_the_page_at_all(self):
@@ -5655,6 +5673,115 @@ class TestAddTargetAction(unittest.TestCase):
         with self.assertRaises(BrowserSessionError) as ctx:
             browser_masters._add_target_action(page, 226158067, 77)
         self.assertIn("Added goal 226158067", str(ctx.exception))
+
+    def test_does_not_hedge_the_counter_diagnosis_once_the_section_has_settled(
+        self,
+    ):
+        """The counterpart to the two tests below: when the trigger WAS
+        clicked (``ever_clicked=True``) and the "Целевые действия" row count
+        has genuinely settled before the option-wait gives up, the exhausted
+        popup read is a trustworthy observation — the message may keep its
+        confident counter/promotion-goal diagnosis, with no hydration hedge
+        appended (issue #783). Unregistered row-prefix locator here reads a
+        stable 0 on every poll, so ``_wait_for_target_actions_settled``
+        settles immediately."""
+        add_button = _FakeLocatorHandle()
+        page = FakePage(
+            locators={
+                self._add_button_testid(): _FakeLocator([add_button]),
+                self._option_testid(226158067): _FakeLocator(
+                    [_FakeLocatorHandle(visible=False)]
+                ),
+            }
+        )
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._add_target_action(page, 226158067, 77)
+
+        message = str(ctx.exception)
+        self.assertIn("226158067", message)
+        self.assertIn("max-conversions", message)
+        self.assertNotIn(
+            "had not finished settling",
+            message,
+            "a settled section still got the hydration hedge appended, so "
+            "a confident-and-correct diagnosis now reads as uncertain",
+        )
+
+    def test_hedges_the_counter_diagnosis_when_clicked_but_section_never_settled(
+        self,
+    ):
+        """Issue #783 finding 2: ``ever_clicked=True`` observes only that
+        the option did not become visible WITHIN the bound
+        (``_TARGET_ACTION_ADD_OPTION_MAX_ATTEMPTS *
+        _POPUP_APPEAR_TIMEOUT_MS`` = 7500ms), which is shorter than the
+        section's documented hydration bound
+        (``_TARGET_ACTION_SETTLE_TIMEOUT_MS``). If the row count never even
+        settles within that longer bound either, the popup may simply have
+        been slow — the message must not assert the counter/promotion-goal
+        cause alone; it must also carry the hydration-race possibility.
+
+        Models a row-prefix locator whose ``.count()`` never repeats the
+        same value twice in a row, so ``_wait_for_target_actions_settled``
+        can never accumulate a streak and returns ``False``."""
+        add_button = _FakeLocatorHandle()
+        row_prefix_selector = (
+            f'[data-testid^="TargetActions.'
+            f'{browser_masters._TARGET_ACTIONS_CATEGORY}."]'
+        )
+
+        class _NeverStableLocator:
+            def __init__(self):
+                self._n = 0
+
+            def count(self):
+                self._n += 1
+                return self._n % 2
+
+            def nth(self, i):
+                # Only `_target_action_row_count`'s trigger-order hint reads
+                # this (via `.count()` above, always 0 or 1); it is unrelated
+                # to the settling gate under test, so a harmless empty
+                # handle is enough to keep that unrelated call from raising.
+                return _FakeLocatorHandle(attrs={"data-testid": ""})
+
+        page = FakePage(
+            locators={
+                self._add_button_testid(): _FakeLocator([add_button]),
+                self._option_testid(226158067): _FakeLocator(
+                    [_FakeLocatorHandle(visible=False)]
+                ),
+            }
+        )
+        original_locator = page.locator
+        never_stable = _NeverStableLocator()
+
+        def _stub_locator(selector):
+            if selector == row_prefix_selector:
+                return never_stable
+            return original_locator(selector)
+
+        page.locator = _stub_locator
+
+        with (
+            patch.object(browser_masters, "_TARGET_ACTION_SETTLE_TIMEOUT_MS", 50),
+            patch.object(browser_masters, "_TARGET_ACTION_STABLE_TICK_MS", 5),
+        ):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters._add_target_action(page, 226158067, 77)
+
+        message = str(ctx.exception)
+        self.assertIn("226158067", message)
+        # Still names the counter/promotion-goal audit steps — they remain
+        # a real possibility, just no longer the SOLE claimed cause.
+        self.assertIn("max-conversions", message)
+        self.assertRegex(
+            message,
+            r"(?i)had not finished settling|slow to render",
+            "an unsettled section after a clicked trigger must hedge the "
+            "counter/promotion-goal diagnosis with the hydration-race "
+            "possibility, not assert the counter cause alone",
+        )
 
 
 class TestRemoveTargetAction(unittest.TestCase):


### PR DESCRIPTION
## Summary

Round-3 follow-up from #779. Both open findings in #783 come from the same root invariant violation: an expired bounded timeout proves only "did not happen within the bound," never "will not happen" — so neither exhausted-retry branch of `_add_target_action` may assert a confident diagnosis about the failure cause.

### Finding 1 — dangling `(see below)` cross-reference

`direct_cli/browser/masters.py`'s `trigger_present` branch pointed to a "(see below)" that was unreachable from that branch (the first `raise` exits the function). A genuinely-stuck disabled trigger (`count() > 0` but never actionable — e.g. the linked Metrika counter has no goals) was therefore permanently reported as "slow hydration, re-run," with no path to the actionable counter-audit steps.

**Fix:** inlined the counter/promotion-goal audit steps directly into the `trigger_present` message.

### Finding 2 — `ever_clicked=True` overclaimed "observed"

The option-wait budget (`_TARGET_ACTION_ADD_OPTION_MAX_ATTEMPTS × _POPUP_APPEAR_TIMEOUT_MS` = 7500ms) is shorter than the section's documented hydration bound (`_TARGET_ACTION_SETTLE_TIMEOUT_MS` = 10000ms). A correct-but-slow popup could exhaust the retry loop and get confidently blamed on the Metrika counter/promotion-goal setup.

**Fix:** gate that diagnosis on a settled read via `_wait_for_target_actions_settled` before asserting the counter cause alone. When the section had not finished settling, the message now hedges with both the hydration-race and counter-audit possibilities instead of asserting one.

Both messages now carry both hypotheses whenever the observation is inconclusive — the `count()`/settled probes only shift which cause is likelier, never decide it outright.

## Tests

- `test_names_the_click_bound_when_no_trigger_ever_became_clickable` relaxed per issue's suggested fix: the genuinely-stuck path must still surface the counter/promotion-goal audit steps (previously asserted `assertNotIn("max-conversions", ...)`, which locked the dangling cross-reference in place).
- New `test_does_not_hedge_the_counter_diagnosis_once_the_section_has_settled` — confident diagnosis preserved when the section genuinely settled.
- New `test_hedges_the_counter_diagnosis_when_clicked_but_section_never_settled` — both hypotheses surfaced when the settled-read gate times out.
- Full offline suite: `3329 passed, 23 skipped`.
- `black`/`flake8` clean on touched files.

Closes #783
Refs #779, #777, #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)