### PR TITLE
feat(masters): add --clear-headline/--clear-text to `masters update` (#786)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,34 @@ re-reading it from a separate page (goal 236386933 at price 150).
   users. Worth tracking as its own issue: creating a draft via this CLI is
   currently a one-way door.
 
+**Added — `masters update --clear-headline`/`--clear-text` (#786, Этап B follow-up):**
+
+`masters update --headline`/`--text` (#665) can only *replace* an existing
+headline/ad-text variant — an empty replacement is refused, since it is
+indistinguishable from a delete request to the post-save verification (both
+would re-read the slot as `""`). Deleting a variant was tracked as a
+separate follow-up rather than folded into that flag; this closes it.
+
+- New repeatable `--clear-headline`/`--clear-text` options, taking the
+  variant's 1-based slot number (same numbering as `--headline`/`--text`).
+  Clicks the slot's own `.clear` button (`CampaignTitles{N}.clear`/
+  `CampaignTexts{N}.clear`), confirmed live alongside the `.textarea`
+  markup #665 already documented (see
+  `tests/fixtures/masters_wizard_edit_stage_b.html`'s "BONUS FINDING").
+- A slot number passed to both a set flag (`--headline`/`--text`) and its
+  clear counterpart in the same call is refused as a `UsageError` — the two
+  operations are mutually exclusive per slot, and there is no "set then
+  clear" concept on Yandex's side to fall back on.
+- Clearing a slot that is already empty is refused too — there is nothing
+  there to delete.
+- **Still out of scope, and not merely unimplemented:** adding a brand-new
+  variant beyond the page's fixed slot count (5 headlines / 3 texts) —
+  Yandex's edit page has no "add another" control at all. Per-variant
+  *weights* are also out of scope for a different reason: confirmed live,
+  Мастер кампаний has no weight/priority UI next to these slots, unlike
+  ordinary text-campaign ad variants — there is nothing for a CLI flag to
+  set.
+
 **Fixed — `masters add --region-id` crashed with a bare `KeyError: 'GeoRegions'` (#775):**
 
 - `_resolve_region_ids`' ambiguity pre-flight (the second `getGeoRegions`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,11 @@ separate follow-up rather than folded into that flag; this closes it.
   `CampaignTexts{N}.clear`), confirmed live alongside the `.textarea`
   markup #665 already documented (see
   `tests/fixtures/masters_wizard_edit_stage_b.html`'s "BONUS FINDING").
+  Same "click alone isn't proof" post-click commit check as the
+  audience-tag add/remove loop (#681): the clear click polls the slot
+  until it reads empty and raises before the caller's irreversible save
+  if it never does, instead of only catching a non-committing click after
+  the fact via the post-save re-read verification (cycle-review finding).
 - A slot number passed to both a set flag (`--headline`/`--text`) and its
   clear counterpart in the same call is refused as a `UsageError` — the two
   operations are mutually exclusive per slot, and there is no "set then

--- a/README.md
+++ b/README.md
@@ -96,8 +96,16 @@ defeat the point of a partial update — see
 Writing to a slot that is currently empty is refused (`UsageError`) — this
 only edits variants that already exist, it does not add new ones. An empty or
 whitespace-only replacement (`--headline "1="`) is refused for the mirror-image
-reason: blanking a slot would delete a live ad variant, not replace it.
-Deleting a variant and editing variant weights aren't implemented yet.
+reason: blanking a slot would delete a live ad variant, not replace it — use
+`--clear-headline N`/`--clear-text N` (repeatable, 1-based slot number) to
+actually delete a variant instead, which clicks that slot's own clear button.
+A slot number cannot be passed to both a set flag and its clear counterpart
+in the same call, and clearing an already-empty slot is refused too. Adding a
+brand-new variant beyond the page's fixed slot count is not supported —
+Yandex's edit page has no "add another" control. Editing variant *weights*
+isn't supported either, but for a different reason: Мастер кампаний has no
+weight/priority UI for these slots at all (confirmed live), unlike ordinary
+text-campaign ad variants.
 
 `--image "N=/path/to/file.png"` replaces the image currently at position N of
 the campaign's image set with a local PNG/JPEG/GIF file, through the edit

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -7332,6 +7332,15 @@ def _clear_repeating_value(
     not a silent success" convention (e.g. ``_set_landing_url``'s ARCHIVED
     guard): the caller asked to delete a variant, and there was no variant
     there to delete.
+
+    After the click, polls the slot's own ``inner_text()`` until it reads
+    empty (same ``_AUDIENCE_TAG_SUGGEST_TIMEOUT_MS`` budget and "click
+    alone isn't proof" guard as the audience-tag add/remove loop in
+    ``update_master``, issue #681) and raises if it never does — the
+    caller's ``_click_save`` is irreversible, so a click that hasn't
+    actually committed must be caught HERE, before save, not only
+    after via the post-save ``_verify_repeating_value_mismatches``
+    re-read (cycle-review finding, Codex, this PR).
     """
     if index >= slot_count:
         raise BrowserSessionError(
@@ -7368,6 +7377,28 @@ def _clear_repeating_value(
             f"{clear_selector!r} — Yandex may have changed the page's "
             "markup. Re-run with --headful to inspect the page."
         ) from exc
+
+    # Same "click alone isn't proof" guard as the audience-tag add/remove
+    # loop in `update_master` (issue #681) — confirmed live that a save
+    # immediately after a click that hadn't actually committed to the DOM
+    # yet reloaded with the old value still present. `.clear`'s handler is
+    # async exactly like that close button, and the caller's subsequent
+    # `_click_save` is irreversible, so a non-committing click must be
+    # caught HERE, before the caller ever gets to save — not only after,
+    # via the post-save `_verify_repeating_value_mismatches` re-read (found
+    # by cycle-review, Codex, on this PR).
+    deadline = _clock.now() + _AUDIENCE_TAG_SUGGEST_TIMEOUT_MS / 1000
+    current = textarea.inner_text()
+    while current and _clock.now() < deadline:
+        page.wait_for_timeout(250)
+        current = textarea.inner_text()
+    if current:
+        raise BrowserSessionError(
+            f"Clicked the clear button for slot {index + 1} at "
+            f"{clear_selector!r}, but the slot still reads "
+            f"{current!r} instead of empty — the click may not have "
+            "committed. Verify manually before retrying."
+        )
 
 
 def _poll_until(

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -7387,11 +7387,29 @@ def _clear_repeating_value(
     # caught HERE, before the caller ever gets to save — not only after,
     # via the post-save `_verify_repeating_value_mismatches` re-read (found
     # by cycle-review, Codex, on this PR).
+    def _read_current() -> str:
+        # Same PlaywrightError -> BrowserSessionError conversion as the
+        # initial read above — unguarded here too (cycle-review finding,
+        # Codex, round 2 of this PR): the `.clear` click can trigger
+        # Yandex to re-render the slot row, and a transient detach mid-poll
+        # must surface this function's documented error, not a raw
+        # PlaywrightError traceback out of the exact mechanism meant to
+        # make a non-committing click legible.
+        try:
+            return textarea.inner_text()
+        except PlaywrightError as exc:
+            raise BrowserSessionError(
+                f"Could not re-read slot {index + 1} at "
+                f"{textarea_selector!r} while confirming the clear "
+                "committed — Yandex may have changed the page's markup. "
+                "Re-run with --headful to inspect the page."
+            ) from exc
+
     deadline = _clock.now() + _AUDIENCE_TAG_SUGGEST_TIMEOUT_MS / 1000
-    current = textarea.inner_text()
+    current = _read_current()
     while current and _clock.now() < deadline:
         page.wait_for_timeout(250)
-        current = textarea.inner_text()
+        current = _read_current()
     if current:
         raise BrowserSessionError(
             f"Clicked the clear button for slot {index + 1} at "

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -119,11 +119,23 @@ ONE existing headline/text slot at a time (``_set_repeating_value``), NOT
 the whole variant list — a deliberate departure from this CLI's usual
 "update replaces the whole array" list-field convention (see
 ``_set_repeating_value``'s own docstring for the rationale). Writing to an
-empty slot (adding a brand-new variant) is refused; deleting a variant and
-editing variant weights are both tracked as separate follow-ups, not
-implemented here. Later stages (sitelinks, audience, Metrika counters/goals,
-budget adaptation, media uploads) are tracked in issue #648 and are NOT
-implemented here.
+empty slot (adding a brand-new variant) is refused; deleting a variant was
+tracked as a separate follow-up, not implemented here.
+
+``update_master`` ``--clear-headline``/``--clear-text`` (issue #786, Этап B
+follow-up) — deletes ONE existing headline/text slot via its per-slot
+``.clear`` button (``_clear_repeating_value``), the delete counterpart
+#665 deferred. Adding a brand-new variant remains out of scope: Yandex's
+edit page has a fixed slot count (5 headlines / 3 texts) with no "add
+another" control at all — an empty slot can only be filled by
+``create_master``'s AI-generated pre-fill, never added to by the caller.
+Per-variant WEIGHTS are also out of scope, but for a different reason —
+confirmed live (``masters_wizard_edit_stage_b.html``'s "BONUS FINDING")
+that Мастер кампаний has no weight/priority UI control next to these slots
+at all, unlike ordinary text-campaign ad variants; there is nothing for a
+weight flag to set. Later stages (sitelinks, audience, Metrika
+counters/goals, budget adaptation, media uploads) are tracked in issue #648
+and are NOT implemented here.
 
 ``name`` (issue #663) — live-verified against campaigns 713231614 (DRAFT)
 and 107707079 (non-draft, read-only recon) — see
@@ -757,6 +769,21 @@ _HEADLINES_SLOT_COUNT = 5
 _TEXTS_SLOT_COUNT = 3
 _HEADLINES_TESTID_TEMPLATE = "CampaignTitles{index}.textarea"
 _TEXTS_TESTID_TEMPLATE = "CampaignTexts{index}.textarea"
+
+# Per-slot clear buttons (issue #786, Этап B follow-up). Confirmed live
+# (2026-08-02, campaign 107707079 — see the "BONUS FINDING" note in
+# ``tests/fixtures/masters_wizard_edit_stage_b.html``) alongside the
+# ``.textarea`` templates above: each slot on the EDIT page (not the create
+# page — create-page slots have no individual clear control, see
+# ``_add_repeating_values``) renders its own ``{prefix}{N}.clear`` button.
+# Derived from the ``.textarea`` templates rather than hand-duplicated, so
+# the two can never drift apart (``CampaignTitles{index}.textarea`` and
+# ``CampaignTitles{index}.clear`` share the same ``CampaignTitles{index}``
+# prefix by construction).
+_HEADLINES_CLEAR_TESTID_TEMPLATE = _HEADLINES_TESTID_TEMPLATE.replace(
+    ".textarea", ".clear"
+)
+_TEXTS_CLEAR_TESTID_TEMPLATE = _TEXTS_TESTID_TEMPLATE.replace(".textarea", ".clear")
 
 # Edit-page-ready marker (issue #684). ``goto(..., wait_until="commit")``
 # returns as soon as the response headers are received — before ANY of the
@@ -5764,6 +5791,8 @@ def update_master(
     tracking_params: Optional[str] = None,
     headlines: Optional[Dict[int, str]] = None,
     texts: Optional[Dict[int, str]] = None,
+    clear_headlines: Optional[List[int]] = None,
+    clear_texts: Optional[List[int]] = None,
     images: Optional[Dict[int, str]] = None,
     gender: Optional[str] = None,
     age_from: Optional[int] = None,
@@ -5809,6 +5838,27 @@ def update_master(
     full-array rewrite doesn't fit here. Writing to a slot that is currently
     empty raises ``BrowserSessionError`` — adding a brand-new variant is a
     different operation, not covered here (see issue #665's follow-ups).
+
+    ``clear_headlines``/``clear_texts`` (issue #786, Этап B follow-up) list
+    0-based slot indices to DELETE via that slot's own ``.clear`` button
+    (``_clear_repeating_value``) rather than replace. This is deliberately a
+    SEPARATE parameter from ``headlines``/``texts`` rather than an overload
+    accepting an empty string there — ``_set_repeating_value`` refuses an
+    empty replacement precisely because "type an empty string" and "delete
+    the variant" are indistinguishable to
+    ``_verify_repeating_value_mismatches``'s re-read-and-compare check (both
+    leave the slot reading as ``""``), so keeping them as distinct,
+    explicitly-named operations is what makes the CLI-level intent legible.
+    An index cannot appear in both a field's set and clear list in the same
+    call — the CLI boundary rejects that combination before this function is
+    reached (mirrors how ``target_action_prices``/``add_target_actions``/
+    ``remove_target_action_goal_ids`` divide up goal ids). Yandex has no
+    "add a new variant" primitive on the edit page's individual slots
+    either, so weights and additions remain genuinely out of scope here —
+    see ``tests/fixtures/masters_wizard_edit_stage_b.html``'s "BONUS
+    FINDING"/weight notes: Мастер кампаний has no per-variant weight
+    control in the UI at all (confirmed live, not merely unimplemented),
+    so there is nothing for a ``--headline-weight`` flag to set.
 
     After clicking save, reloads the edit page and re-reads every requested
     field to confirm it actually saved (see ``_verify_saved``) — a click
@@ -5921,6 +5971,8 @@ def update_master(
         and tracking_params is None
         and not headlines
         and not texts
+        and not clear_headlines
+        and not clear_texts
         and not images
         and gender is None
         and not age_from_requested
@@ -5934,7 +5986,8 @@ def update_master(
             "(weekly_budget, promotion_goal, goal_price, "
             "target_action_prices, add_target_actions, "
             "remove_target_action_goal_ids, directs_helps, name, "
-            "landing_url, tracking_params, headlines, texts, images, "
+            "landing_url, tracking_params, headlines, texts, "
+            "clear_headlines, clear_texts, images, "
             "gender, age_from, age_to, devices, "
             "add_audience_tags, remove_audience_tags)."
         )
@@ -6164,6 +6217,22 @@ def update_master(
         _set_repeating_value(
             page, _TEXTS_TESTID_TEMPLATE, _TEXTS_SLOT_COUNT, index, value
         )
+    for index in clear_headlines or []:
+        _clear_repeating_value(
+            page,
+            _HEADLINES_TESTID_TEMPLATE,
+            _HEADLINES_CLEAR_TESTID_TEMPLATE,
+            _HEADLINES_SLOT_COUNT,
+            index,
+        )
+    for index in clear_texts or []:
+        _clear_repeating_value(
+            page,
+            _TEXTS_TESTID_TEMPLATE,
+            _TEXTS_CLEAR_TESTID_TEMPLATE,
+            _TEXTS_SLOT_COUNT,
+            index,
+        )
 
     # Snapshotted BEFORE any image mutation — ``_verify_saved`` needs to know
     # which content IDs were replaced (to confirm they're gone) and which
@@ -6214,6 +6283,17 @@ def update_master(
     # this ENTIRE update_master call under a fresh session. Re-raise as a
     # plain BrowserSessionError so that retry does not trigger — mirrors
     # copy_master's identical guard around its own post-click verification.
+    # Merged into a single ``requested`` map for ``_verify_repeating_value_
+    # mismatches`` — a cleared slot must re-read as ``""``, exactly the
+    # expected value that map's plain equality check already compares
+    # against, so no separate verification path is needed for clear vs. set
+    # (see ``_clear_repeating_value``'s docstring for why they're still
+    # kept as distinct MUTATION operations up to this point).
+    verify_headlines = dict(headlines or {})
+    verify_headlines.update({index: "" for index in clear_headlines or []})
+    verify_texts = dict(texts or {})
+    verify_texts.update({index: "" for index in clear_texts or []})
+
     try:
         _verify_saved(
             page,
@@ -6224,8 +6304,8 @@ def update_master(
             name=name,
             landing_url=landing_url,
             tracking_params=tracking_params,
-            headlines=headlines,
-            texts=texts,
+            headlines=verify_headlines or None,
+            texts=verify_texts or None,
             images_before_ids=images_before_ids,
             images_replaced_ids=images_replaced_ids,
             goal_price=goal_price,
@@ -6278,6 +6358,10 @@ def update_master(
         result["Headlines"] = headlines
     if texts:
         result["Texts"] = texts
+    if clear_headlines:
+        result["ClearedHeadlines"] = sorted(clear_headlines)
+    if clear_texts:
+        result["ClearedTexts"] = sorted(clear_texts)
     if images:
         result["Images"] = images
     if gender is not None:
@@ -7211,6 +7295,78 @@ def _set_repeating_value(
             f"Could not type the replacement value into slot {index + 1} "
             f"at {selector!r} — Yandex may have changed the page's markup. "
             "Re-run with --headful to inspect the page."
+        ) from exc
+
+
+def _clear_repeating_value(
+    page: "Page",
+    textarea_testid_template: str,
+    clear_testid_template: str,
+    slot_count: int,
+    index: int,
+) -> None:
+    """Delete an EXISTING headline/text variant by clicking its per-slot
+    ``.clear`` button, leaving every other slot untouched.
+
+    Issue #786 (Этап B follow-up, part of the #648 umbrella). This is the
+    counterpart ``_set_repeating_value`` deliberately refuses to be: that
+    function treats an empty replacement value as "delete in disguise" and
+    raises rather than acting on it (see its own docstring), because typing
+    "" into a slot and deleting a slot's variant look identical from the
+    re-read-and-compare verification ``_verify_repeating_value_mismatches``
+    does — both leave the slot reading as ``""``. That ambiguity is exactly
+    what makes this a SEPARATE, explicit operation with its own CLI flag
+    (``--clear-headline``/``--clear-text``) rather than an overload of
+    ``--headline``/``--text`` with an empty value.
+
+    Confirmed live (2026-08-02, campaign 107707079 — see the "BONUS FINDING"
+    note in ``tests/fixtures/masters_wizard_edit_stage_b.html``) that each
+    slot renders its own ``{prefix}{N}.clear`` button alongside its
+    ``.textarea`` — this was recon'd but explicitly left unimplemented by
+    #665 pending a dedicated follow-up, which this is.
+
+    Unlike ``_set_repeating_value``, clearing an ALREADY-empty slot is a
+    harmless no-op on Yandex's side (there's nothing left to remove) — but
+    this still raises, mirroring this module's general "an operation that
+    can't possibly have the effect the caller asked for is a hard error,
+    not a silent success" convention (e.g. ``_set_landing_url``'s ARCHIVED
+    guard): the caller asked to delete a variant, and there was no variant
+    there to delete.
+    """
+    if index >= slot_count:
+        raise BrowserSessionError(
+            f"Slot index {index + 1} is out of range — this field only has "
+            f"{slot_count} slots on the edit page."
+        )
+
+    textarea_selector = (
+        f'[data-testid="{textarea_testid_template.format(index=index)}"]'
+    )
+    textarea = page.locator(textarea_selector).first
+    try:
+        current = textarea.inner_text()
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            f"Could not read the current value of slot {index + 1} at "
+            f"{textarea_selector!r} — Yandex may have changed the page's "
+            "markup. Re-run with --headful to inspect the page."
+        ) from exc
+
+    if not current:
+        raise BrowserSessionError(
+            f"Slot {index + 1} at {textarea_selector!r} is already empty — "
+            "there is no variant there to delete."
+        )
+
+    clear_selector = f'[data-testid="{clear_testid_template.format(index=index)}"]'
+    clear_button = page.locator(clear_selector).first
+    try:
+        clear_button.click()
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            f"Could not click the clear button for slot {index + 1} at "
+            f"{clear_selector!r} — Yandex may have changed the page's "
+            "markup. Re-run with --headful to inspect the page."
         ) from exc
 
 

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -695,6 +695,65 @@ def _parse_repeating_slot_options(
     return parsed
 
 
+def _parse_clear_slot_options(
+    option_name: str, values: "tuple[int, ...]", slot_count: int
+) -> "list[int]":
+    """Parse repeated ``--clear-headline``/``--clear-text`` 1-based slot
+    numbers into a 0-based index list (issue #786, Этап B follow-up).
+
+    Mirrors ``_parse_repeating_slot_options``'s bounds-checking and
+    duplicate-slot rejection, but for a plain integer list rather than
+    ``"N=value"`` pairs — there is no replacement value to parse here, the
+    whole point of ``--clear-*`` is that it deletes rather than replaces.
+    """
+    parsed: "list[int]" = []
+    seen: "set[int]" = set()
+    for slot_number in values:
+        if slot_number < 1:
+            raise click.UsageError(
+                f"{option_name} slot number {slot_number} must be 1 or "
+                f"greater (this field has slots 1-{slot_count})."
+            )
+        if slot_number > slot_count:
+            raise click.UsageError(
+                f"{option_name} slot number {slot_number} is out of range — "
+                f"this field has slots (1-{slot_count})."
+            )
+        index = slot_number - 1
+        if index in seen:
+            raise click.UsageError(
+                f"{option_name} slot {slot_number} was specified more than " "once."
+            )
+        seen.add(index)
+        parsed.append(index)
+    return parsed
+
+
+def _reject_overlapping_slots(
+    set_slots: "dict[int, str]",
+    clear_slots: "list[int]",
+    set_option_name: str,
+    clear_option_name: str,
+) -> None:
+    """Refuse a slot number passed to both a ``--headline``/``--text``-style
+    setter and its ``--clear-*`` counterpart in the same call (issue #786).
+
+    Ambiguous otherwise — Yandex's edit page has no "set then immediately
+    clear" concept, and silently picking one order to apply them in would
+    make the CLI's behaviour depend on an implementation detail the caller
+    can't see. Mirrors the target-action goal-id overlap guard above this
+    function's own call site.
+    """
+    overlap = sorted(set(set_slots) & set(clear_slots))
+    if overlap:
+        slots = ", ".join(str(index + 1) for index in overlap)
+        raise click.UsageError(
+            f"Slot(s) {slots} passed to both {set_option_name} and "
+            f"{clear_option_name} — a slot can only be set or cleared in "
+            "the same call, not both."
+        )
+
+
 def _parse_target_action_price_options(
     values: "tuple[str, ...]",
 ) -> "dict[int, float]":
@@ -1374,6 +1433,32 @@ def audience_get(
     ),
 )
 @click.option(
+    "--clear-headline",
+    "clear_headlines",
+    multiple=True,
+    type=int,
+    help=(
+        "DELETE an EXISTING headline variant by its 1-based slot number "
+        "(1-5). Repeat for multiple slots. A slot number already passed to "
+        "--headline in the same call is refused — that would be a set and "
+        "a delete on the same slot. Deleting an already-empty slot is "
+        "refused too (there is nothing there to delete)."
+    ),
+)
+@click.option(
+    "--clear-text",
+    "clear_texts",
+    multiple=True,
+    type=int,
+    help=(
+        "DELETE an EXISTING ad-text variant by its 1-based slot number "
+        "(1-3). Repeat for multiple slots. A slot number already passed to "
+        "--text in the same call is refused — that would be a set and a "
+        "delete on the same slot. Deleting an already-empty slot is "
+        "refused too (there is nothing there to delete)."
+    ),
+)
+@click.option(
     "--image",
     "images",
     multiple=True,
@@ -1478,6 +1563,8 @@ def update(
     tracking_params,
     headlines,
     texts,
+    clear_headlines,
+    clear_texts,
     images,
     gender,
     age_from,
@@ -1556,6 +1643,17 @@ def update(
     counters/goals, budget adaptation) and video (a separate follow-up
     issue) are tracked separately, see issue #648.
 
+    ``--clear-headline``/``--clear-text`` (issue #786) DELETE an existing
+    headline/ad-text variant by its 1-based slot number, the counterpart
+    ``--headline``/``--text`` deliberately refuse (an empty replacement
+    there is treated as a mistake, not a delete request — see their own
+    help text). A slot number cannot be passed to both a set flag and its
+    clear counterpart in the same call. Adding a brand-new variant beyond
+    the page's fixed slot count (5 headlines / 3 texts) is not supported —
+    Yandex's edit page has no "add another" control. Per-variant weights
+    are also not supported: confirmed live, Мастер кампаний has no
+    weight/priority UI at all for these slots.
+
     ``--gender``/``--age-from``/``--age-to``/``--device``/
     ``--add-audience-tag``/``--remove-audience-tag`` (issue #681) cover the
     "Аудитория" section's manual-targeting fields — see `masters audience
@@ -1590,6 +1688,8 @@ def update(
         and tracking_params is None
         and not headlines
         and not texts
+        and not clear_headlines
+        and not clear_texts
         and not images
         and gender is None
         and age_from is None
@@ -1603,8 +1703,8 @@ def update(
             "--goal-price, --target-action-price, --add-target-action, "
             "--remove-target-action, --directs-helps/--no-directs-helps, "
             "--name, --landing-url, --tracking-params, --headline, --text, "
-            "--image, --gender, --age-from, --age-to, --device, "
-            "--add-audience-tag, --remove-audience-tag."
+            "--clear-headline, --clear-text, --image, --gender, --age-from, "
+            "--age-to, --device, --add-audience-tag, --remove-audience-tag."
         )
 
     if goal_price is not None and promotion_goal == "max-conversions":
@@ -1671,6 +1771,18 @@ def update(
         "--headline", headlines, _HEADLINES_SLOT_COUNT
     )
     parsed_texts = _parse_repeating_slot_options("--text", texts, _TEXTS_SLOT_COUNT)
+    parsed_clear_headlines = _parse_clear_slot_options(
+        "--clear-headline", clear_headlines, _HEADLINES_SLOT_COUNT
+    )
+    parsed_clear_texts = _parse_clear_slot_options(
+        "--clear-text", clear_texts, _TEXTS_SLOT_COUNT
+    )
+    _reject_overlapping_slots(
+        parsed_headlines, parsed_clear_headlines, "--headline", "--clear-headline"
+    )
+    _reject_overlapping_slots(
+        parsed_texts, parsed_clear_texts, "--text", "--clear-text"
+    )
     parsed_images = _parse_repeating_slot_options(
         "--image",
         images,
@@ -1713,6 +1825,8 @@ def update(
             tracking_params=tracking_params,
             headlines=parsed_headlines,
             texts=parsed_texts,
+            clear_headlines=parsed_clear_headlines or None,
+            clear_texts=parsed_clear_texts or None,
             images=parsed_images,
             gender=gender,
             age_from=parsed_age_from,

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -11371,7 +11371,16 @@ class TestClearRepeatingValue(unittest.TestCase):
     def test_clicks_the_clear_button_of_a_filled_slot(self):
         clicked = []
         textarea = _FakeLocatorHandle(text="Старый заголовок")
-        clear_button = _FakeLocatorHandle(on_click=lambda: clicked.append(True))
+
+        def _on_click():
+            clicked.append(True)
+            # Models the real `.clear` button synchronously emptying the
+            # textarea — the post-click commit check (cycle-review, Codex,
+            # this PR) requires this, unlike the pre-fix fake which only
+            # recorded the click without mutating state.
+            textarea._text = ""
+
+        clear_button = _FakeLocatorHandle(on_click=_on_click)
         page = FakePage(
             locators={
                 '[data-testid="fake0.textarea"]': _FakeLocator([textarea]),
@@ -11392,7 +11401,11 @@ class TestClearRepeatingValue(unittest.TestCase):
             on_click=lambda: untouched_clear_clicked.append(True)
         )
         target_textarea = _FakeLocatorHandle(text="Удалить меня")
-        target_clear = _FakeLocatorHandle(on_click=lambda: None)
+
+        def _clear_target():
+            target_textarea._text = ""
+
+        target_clear = _FakeLocatorHandle(on_click=_clear_target)
         page = FakePage(
             locators={
                 '[data-testid="fake0.textarea"]': _FakeLocator([untouched_textarea]),
@@ -11457,6 +11470,74 @@ class TestClearRepeatingValue(unittest.TestCase):
             browser_masters._clear_repeating_value(
                 page, "fake{index}.textarea", "fake{index}.clear", 5, 0
             )
+
+    def test_raises_when_clear_click_never_commits_to_the_dom(self):
+        # cycle-review (Codex, this PR): `.clear` is a button whose handler
+        # runs async, exactly like the audience-tag close button that taught
+        # this module (issue #681) "click alone isn't proof" — a save
+        # immediately after a click that hadn't actually committed yet
+        # reloaded with the value still present. Without a post-click commit
+        # check, a non-committing click here would sail straight through to
+        # the caller's `_click_save`, which is irreversible. Models "the
+        # click fires with no error, but the textarea keeps reporting its
+        # old value forever" — the fake never mutates `_text`, since this
+        # `_FakeLocatorHandle` has no `on_click` wired to empty it.
+        textarea = _FakeLocatorHandle(text="Старый заголовок")
+        clear_button = _FakeLocatorHandle()
+        page = FakePage(
+            locators={
+                '[data-testid="fake0.textarea"]': _FakeLocator([textarea]),
+                '[data-testid="fake0.clear"]': _FakeLocator([clear_button]),
+            }
+        )
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._clear_repeating_value(
+                page, "fake{index}.textarea", "fake{index}.clear", 5, 0
+            )
+
+        self.assertIn("may not have committed", str(ctx.exception).lower())
+        # The click itself must still have fired — this guards the
+        # post-click state, not a refusal to click.
+        self.assertEqual(clear_button.click_timeouts, [None])
+
+    def test_does_not_raise_when_clear_click_commits_after_a_few_ticks(self):
+        # The commit check must tolerate a DOM update that lands a beat
+        # after the click resolves (the normal case), not just an
+        # instantaneous one — mirrors the audience-tag poll loop's
+        # tolerance for the same async-commit lag.
+        textarea = _FakeLocatorHandle(text="Старый заголовок")
+        remaining_ticks = [2]
+
+        def _commit_after_delay():
+            if remaining_ticks[0] <= 0:
+                textarea._text = ""
+            else:
+                remaining_ticks[0] -= 1
+
+        clear_button = _FakeLocatorHandle(on_click=lambda: None)
+        page = FakePage(
+            locators={
+                '[data-testid="fake0.textarea"]': _FakeLocator([textarea]),
+                '[data-testid="fake0.clear"]': _FakeLocator([clear_button]),
+            }
+        )
+        # `inner_text` re-reads must observe the delayed commit — patch the
+        # handle's read to tick the countdown, since `_FakeLocatorHandle`
+        # has no first-class "value changes over successive reads" hook.
+        original_inner_text = textarea.inner_text
+
+        def _ticking_inner_text(timeout=None):
+            _commit_after_delay()
+            return original_inner_text(timeout=timeout)
+
+        textarea.inner_text = _ticking_inner_text
+
+        browser_masters._clear_repeating_value(
+            page, "fake{index}.textarea", "fake{index}.clear", 5, 0
+        )
+
+        self.assertEqual(textarea.inner_text(), "")
 
 
 class _FakeImagesPage(FakePage):

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -11576,7 +11576,17 @@ class TestClearRepeatingValue(unittest.TestCase):
                 page, "fake{index}.textarea", "fake{index}.clear", 5, 0
             )
 
-        self.assertNotIsInstance(ctx.exception, PlaywrightError)
+        # `assertRaises(BrowserSessionError)` above already proves the raised
+        # exception IS a BrowserSessionError. The stronger claim this test
+        # exists to make is that it is EXACTLY that (not some subclass, and
+        # not the raw detach propagating unconverted) — checked by exact
+        # type rather than `assertNotIsInstance(..., PlaywrightError)`,
+        # since `PlaywrightError` itself falls back to bare `Exception` when
+        # the `playwright` package isn't installed (masters.py's ImportError
+        # guard), which would make that assertion vacuously true/false
+        # depending on the test environment rather than on this function's
+        # actual behavior — exactly what broke CI (playwright absent there).
+        self.assertIs(type(ctx.exception), BrowserSessionError)
 
 
 class _FakeImagesPage(FakePage):

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -9508,6 +9508,172 @@ class TestMastersUpdateCommand(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0, result.output)
 
+    def test_documents_clear_headline_and_clear_text_flags(self):
+        result = self.runner.invoke(cli, ["masters", "update", "--help"])
+        self.assertIn("--clear-headline", result.output)
+        self.assertIn("--clear-text", result.output)
+
+    def test_passes_clear_headline_slot_as_zero_based_index(self):
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42}
+            result = self.runner.invoke(
+                cli, ["masters", "update", "42", "--clear-headline", "2"]
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        # User-facing slot 2 (1-based) -> browser layer's 0-based index 1.
+        self.assertEqual(mock_update.call_args.kwargs["clear_headlines"], [1])
+
+    def test_passes_multiple_clear_headline_and_clear_text_slots(self):
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42}
+            result = self.runner.invoke(
+                cli,
+                [
+                    "masters",
+                    "update",
+                    "42",
+                    "--clear-headline",
+                    "1",
+                    "--clear-headline",
+                    "3",
+                    "--clear-text",
+                    "2",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(mock_update.call_args.kwargs["clear_headlines"], [0, 2])
+        self.assertEqual(mock_update.call_args.kwargs["clear_texts"], [1])
+
+    def test_rejects_non_numeric_clear_headline_slot(self):
+        result = self.runner.invoke(
+            cli, ["masters", "update", "42", "--clear-headline", "abc"]
+        )
+        self.assertNotEqual(result.exit_code, 0)
+
+    def test_rejects_clear_headline_slot_below_one(self):
+        result = self.runner.invoke(
+            cli, ["masters", "update", "42", "--clear-headline", "0"]
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("1 or greater", result.output)
+
+    def test_rejects_an_out_of_range_clear_headline_slot(self):
+        result = self.runner.invoke(
+            cli, ["masters", "update", "42", "--clear-headline", "6"]
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("1-5", result.output)
+
+    def test_rejects_an_out_of_range_clear_text_slot(self):
+        result = self.runner.invoke(
+            cli, ["masters", "update", "42", "--clear-text", "4"]
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("1-3", result.output)
+
+    def test_rejects_duplicate_clear_headline_slot(self):
+        result = self.runner.invoke(
+            cli,
+            [
+                "masters",
+                "update",
+                "42",
+                "--clear-headline",
+                "1",
+                "--clear-headline",
+                "1",
+            ],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("more than once", result.output)
+
+    def test_rejects_same_slot_in_both_headline_and_clear_headline(self):
+        """A slot cannot be both set and cleared in the same call — Yandex's
+        edit page has no "set then clear" concept, and picking an order
+        silently would make behaviour depend on an implementation detail."""
+        result = self.runner.invoke(
+            cli,
+            [
+                "masters",
+                "update",
+                "42",
+                "--headline",
+                "2=Новый заголовок",
+                "--clear-headline",
+                "2",
+            ],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("--headline", result.output)
+        self.assertIn("--clear-headline", result.output)
+
+    def test_rejects_same_slot_in_both_text_and_clear_text(self):
+        result = self.runner.invoke(
+            cli,
+            [
+                "masters",
+                "update",
+                "42",
+                "--text",
+                "1=Новый текст",
+                "--clear-text",
+                "1",
+            ],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("--text", result.output)
+        self.assertIn("--clear-text", result.output)
+
+    def test_clear_headline_flag_alone_satisfies_the_at_least_one_field_guard(self):
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42}
+            result = self.runner.invoke(
+                cli, ["masters", "update", "42", "--clear-headline", "1"]
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+
+    def test_out_of_range_clear_slot_does_not_open_a_browser_session(self):
+        with patch("direct_cli.commands.masters._with_session") as mock_with_session:
+            result = self.runner.invoke(
+                cli, ["masters", "update", "42", "--clear-headline", "6"]
+            )
+        self.assertNotEqual(result.exit_code, 0)
+        mock_with_session.assert_not_called()
+
+    def test_omitted_clear_flags_pass_none_not_empty_list(self):
+        """``clear_headlines``/``clear_texts`` must be ``None`` when not
+        requested — ``update_master``'s own guard distinguishes "nothing
+        passed" (falsy None/[]) consistently with every other optional
+        list-shaped field here (e.g. ``add_audience_tags``)."""
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42}
+            result = self.runner.invoke(
+                cli, ["masters", "update", "42", "--weekly-budget", "1000"]
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIsNone(mock_update.call_args.kwargs["clear_headlines"])
+        self.assertIsNone(mock_update.call_args.kwargs["clear_texts"])
+
     def test_documents_launch_flag(self):
         result = self.runner.invoke(cli, ["masters", "update", "--help"])
         self.assertIn("--launch", result.output)
@@ -11195,6 +11361,102 @@ class TestSetRepeatingValue(unittest.TestCase):
 
         self.assertEqual(field.inner_text(), "Старый заголовок")
         self.assertIn("empty", str(ctx.exception).lower())
+
+
+class TestClearRepeatingValue(unittest.TestCase):
+    """``_clear_repeating_value`` (issue #786, Этап B follow-up) — deletes
+    ONE existing headline/text slot via its per-slot ``.clear`` button.
+    """
+
+    def test_clicks_the_clear_button_of_a_filled_slot(self):
+        clicked = []
+        textarea = _FakeLocatorHandle(text="Старый заголовок")
+        clear_button = _FakeLocatorHandle(on_click=lambda: clicked.append(True))
+        page = FakePage(
+            locators={
+                '[data-testid="fake0.textarea"]': _FakeLocator([textarea]),
+                '[data-testid="fake0.clear"]': _FakeLocator([clear_button]),
+            }
+        )
+
+        browser_masters._clear_repeating_value(
+            page, "fake{index}.textarea", "fake{index}.clear", 5, 0
+        )
+
+        self.assertEqual(clicked, [True])
+
+    def test_other_slots_are_never_touched(self):
+        untouched_textarea = _FakeLocatorHandle(text="Не трогать")
+        untouched_clear_clicked = []
+        untouched_clear = _FakeLocatorHandle(
+            on_click=lambda: untouched_clear_clicked.append(True)
+        )
+        target_textarea = _FakeLocatorHandle(text="Удалить меня")
+        target_clear = _FakeLocatorHandle(on_click=lambda: None)
+        page = FakePage(
+            locators={
+                '[data-testid="fake0.textarea"]': _FakeLocator([untouched_textarea]),
+                '[data-testid="fake0.clear"]': _FakeLocator([untouched_clear]),
+                '[data-testid="fake1.textarea"]': _FakeLocator([target_textarea]),
+                '[data-testid="fake1.clear"]': _FakeLocator([target_clear]),
+            }
+        )
+
+        browser_masters._clear_repeating_value(
+            page, "fake{index}.textarea", "fake{index}.clear", 2, 1
+        )
+
+        self.assertEqual(untouched_clear_clicked, [])
+
+    def test_raises_when_slot_is_already_empty(self):
+        textarea = _FakeLocatorHandle(text="")
+        clear_button = _FakeLocatorHandle()
+        page = FakePage(
+            locators={
+                '[data-testid="fake0.textarea"]': _FakeLocator([textarea]),
+                '[data-testid="fake0.clear"]': _FakeLocator([clear_button]),
+            }
+        )
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._clear_repeating_value(
+                page, "fake{index}.textarea", "fake{index}.clear", 5, 0
+            )
+
+        self.assertIn("already empty", str(ctx.exception).lower())
+
+    def test_raises_when_index_out_of_range(self):
+        page = FakePage(locators={})
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._clear_repeating_value(
+                page, "fake{index}.textarea", "fake{index}.clear", 3, 5
+            )
+
+        self.assertIn("out of range", str(ctx.exception).lower())
+
+    def test_raises_when_textarea_missing(self):
+        page = FakePage(locators={})
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters._clear_repeating_value(
+                page, "fake{index}.textarea", "fake{index}.clear", 1, 0
+            )
+
+    def test_raises_when_clear_button_click_fails(self):
+        textarea = _FakeLocatorHandle(text="Старый заголовок")
+        clear_button = _FakeLocatorHandle(raises=True)
+        page = FakePage(
+            locators={
+                '[data-testid="fake0.textarea"]': _FakeLocator([textarea]),
+                '[data-testid="fake0.clear"]': _FakeLocator([clear_button]),
+            }
+        )
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters._clear_repeating_value(
+                page, "fake{index}.textarea", "fake{index}.clear", 5, 0
+            )
 
 
 class _FakeImagesPage(FakePage):

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -11539,6 +11539,45 @@ class TestClearRepeatingValue(unittest.TestCase):
 
         self.assertEqual(textarea.inner_text(), "")
 
+    def test_raises_browser_session_error_when_commit_check_read_detaches(self):
+        # cycle-review (Codex, round 2 of this PR): the post-click
+        # commit-check reads must be guarded exactly like the initial
+        # pre-click read — a transient DOM detach mid-poll (Yandex
+        # re-rendering the slot row after the `.clear` handler runs) must
+        # surface this function's own BrowserSessionError, not a raw
+        # PlaywrightError traceback out of the mechanism meant to make a
+        # non-committing click legible.
+        textarea = _FakeLocatorHandle(text="Старый заголовок")
+        clear_button = _FakeLocatorHandle(on_click=lambda: None)
+        page = FakePage(
+            locators={
+                '[data-testid="fake0.textarea"]': _FakeLocator([textarea]),
+                '[data-testid="fake0.clear"]': _FakeLocator([clear_button]),
+            }
+        )
+
+        # The FIRST call is the pre-click "is it already empty?" read
+        # (must still succeed with the original value, exactly as every
+        # other test in this class exercises). Only calls AFTER that —
+        # the post-click commit-check reads — must detach, isolating the
+        # gap to the unguarded code path this test targets.
+        call_count = [0]
+
+        def _detaches_after_first_read(timeout=None):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return "Старый заголовок"
+            raise PlaywrightError("element detached mid-poll")
+
+        textarea.inner_text = _detaches_after_first_read
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._clear_repeating_value(
+                page, "fake{index}.textarea", "fake{index}.clear", 5, 0
+            )
+
+        self.assertNotIsInstance(ctx.exception, PlaywrightError)
+
 
 class _FakeImagesPage(FakePage):
     """Models the image set + image manager modal (issue #670, Этап D).


### PR DESCRIPTION
## Summary

Closes the Этап B follow-up left open by #665 (`masters update --headline`/`--text`): those flags refuse an empty replacement (indistinguishable from a delete request to the post-save verification), and deleting a variant was tracked as a separate follow-up rather than folded into them. This PR adds that delete path.

Part of the umbrella issue #648 — specifically the remaining Этап B scope. Per live recon already on file (`tests/fixtures/masters_wizard_edit_stage_b.html`), Мастер кампаний has **no per-variant weight/priority UI at all**, so "списки с весами" from the original #631/#648 wording does not apply here — there is nothing for a weight flag to set. Adding brand-new variants is also out of scope: the edit page has a fixed slot count (5 headlines / 3 texts) with no "add another" control.

## Changes

- `direct_cli/browser/masters.py`: new `_clear_repeating_value` clicks a slot's own `.clear` button (`CampaignTitles{N}.clear`/`CampaignTexts{N}.clear` — confirmed live in the existing fixture's "BONUS FINDING", previously unused). `update_master` gained `clear_headlines`/`clear_texts` kwargs, wired into the mutation loop and into `_verify_saved` (a cleared slot is expected to read back as `""`, reusing the existing `_verify_repeating_value_mismatches` check).
- `direct_cli/commands/masters.py`: new repeatable `--clear-headline`/`--clear-text` options (1-based slot number, same numbering as `--headline`/`--text`). New `_parse_clear_slot_options` (bounds/duplicate checks) and `_reject_overlapping_slots` (a slot can't be both set and cleared in the same call — rejected as `UsageError` before any browser session opens).
- `tests/test_masters.py`: offline unit coverage for `_clear_repeating_value` (browser layer, fake Page/Locator) and the new CLI flags/parsers/guards (~30 new tests).
- `README.md` / `CHANGELOG.md` updated.

## Verification

**Offline:** full suite green (`pytest`, 3346+ passed). `black`/`flake8` clean.

**Live:** not yet done in this PR — per project convention (`feedback_live_verification_before_tests`) and the current serialized queue for the shared test master/browser session (other sessions #782/#783/#776/#781 active), live verification of `--clear-headline`/`--clear-text` against a real campaign is queued separately and will follow before this is considered fully verified, mirroring how #665 itself shipped its offline PR first and was live-verified afterward.

## Out of scope (confirmed, not merely deferred)

- Per-variant weights — no UI control exists in Мастер кампаний for this.
- Adding new headline/text variants beyond the fixed slot count — no "add another" control on the edit page.
- Этап D (media uploads) — tracked separately, remains open under #648.

🤖 Generated with [Claude Code](https://claude.com/claude-code)