### PR TITLE
docs(masters): confirm edit-page region widget renders for LAUNCHED campaigns (#776)

### DIFF
--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -8785,20 +8785,22 @@ def _verify_created(
 
     The reload target is ``WIZARD_EDIT_URL``, not the overview URL the click
     redirects to. A freshly LAUNCHED campaign's overview page is the stats
-    dashboard, which has no region widget at all; the edit page is ASSUMED to
-    render "Регион показов" for both DRAFT and non-DRAFT campaigns (a DRAFT
+    dashboard, which has no region widget at all; the edit page renders
+    "Регион показов" for both DRAFT and non-DRAFT campaigns (a DRAFT
     overview happens to render the wizard form too — issue #660 — but
     relying on that would make this check silently status-dependent).
 
-    **That assumption is not field-proven (issue #776).**
-    ``_read_region_tags`` is live-verified on the CREATE page only (#653);
-    no existing command reads region from the edit page (``update_master``
-    has no region option), and the live edit-page fixtures are targeted
-    extracts that neither contain nor exclude the widget. If the assumption
-    is wrong, ``_read_until_matches`` exhausts its budget, returns an empty
-    read, and this raises AFTER the campaign was irreversibly launched — a
-    false failure, not data loss. It cannot be confirmed until goal support
-    makes a successful create possible at all (see ``create_master``).
+    **Confirmed live for a non-DRAFT campaign (issue #776).** Once goal
+    support unblocked a successful create (#777), this was checked directly
+    against an existing production campaign rather than a fresh
+    ``--launch`` — no need to publish new live ads to observe a rendering
+    fact that does not depend on how the campaign got to ACTIVE.
+    ``masters get`` confirmed campaign 713234191's ``Status`` as ``ACTIVE``
+    (real impressions/clicks/cost, not a draft); reloading its
+    ``WIZARD_EDIT_URL`` rendered ``RegionsTreeTagGroup.tags-wrapper``
+    visible (``offsetParent !== null``) with 36 region tags. The edit page
+    does render the region widget for a genuinely launched campaign, so
+    ``_verify_created``'s reload-and-reread approach is sound as written.
 
     Region tags are compared as a SUBSET, not for equality: Yandex renders a
     tag per accepted selection, and selecting a region can bring implied


### PR DESCRIPTION
## Summary

Settles issue #776's unproven assumption: does `WIZARD_EDIT_URL` render the "Регион показов" widget (`RegionsTreeTagGroup.tags-wrapper`) for a genuinely **LAUNCHED** (non-DRAFT) Мастер кампаний campaign, not just on the create page?

## Verification (live, read-only, no `--launch`)

Once goal support unblocked `masters add` (#777/#779), the obvious next step looked like creating a fresh test campaign with `--launch` — but that publishes real live ads with real budget spend and no rollback. Instead: the rendering fact in question doesn't depend on *how* a campaign became ACTIVE, so it was checked against an **existing production campaign** already running before this issue:

```
$ masters get 713234191 --format json
{
  "CampaignId": 713234191,
  "Status": "ACTIVE",
  "LandingUrl": "https://lp.ksamata.ru/detox_ya",
  "Stats": {"impressions": "11 271", "clicks": "388", "cost": "457,22 ₽"}
}
```

Confirmed non-DRAFT with real impressions/clicks/spend. Reloading its `WIZARD_EDIT_URL` and inspecting the DOM:

```js
document.querySelector('[data-testid="RegionsTreeTagGroup.tags-wrapper"]')
// found, offsetParent !== null (visible), 36 region tags rendered
```

**Result:** the edit page does render the region widget for a genuinely launched campaign. `_verify_created`'s existing reload-and-reread approach (`direct_cli/browser/masters.py`) was already correct — no code change to the verification logic itself.

## Changes

Only `_verify_created`'s docstring: replaced the "not field-proven" / risk-flagged wording with the confirmed live-verification note (campaign ID, method, result), per the issue's own resolution steps (#2: "capture ... replace the softened docstring wording with a real live-verification note").

No new fixture was captured — the check used the DOM directly (`data-testid` presence + visibility + tag count) rather than a saved HTML snapshot, since the goal was answering a yes/no rendering question, not adding new fixture-based test coverage.

## Tests

- `pytest -k masters` — 678 passed, 9 subtests passed (offline, unaffected by this docs-only change)
- `black --check` / `flake8` clean

Closes #776

🤖 Generated with [Claude Code](https://claude.com/claude-code)