### PR TITLE
fix(masters): re-navigate on any checks mismatch, not just tracking_params (#790)

### DIFF
--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -5308,9 +5308,38 @@ def _verify_saved(
         return found
 
     mismatches = _run_checks()
-    # Set when the tracking_params block below re-navigates, so these checks
-    # can be re-run against the page that navigation actually fetched.
+    # Set when either re-navigation block below fires, so later per-section
+    # checks (tracking_params/audience/etc.) can tell a fresh load happened.
     _re_navigated = False
+
+    if mismatches:
+        # RE-NAVIGATE on a mismatch in any of ``checks``, not just re-poll
+        # the same page (issue #790, same staleness class as #769/#774's
+        # tracking_params fix below): a stale render served by the post-save
+        # reload above is PAGE-level, not field-specific (see the
+        # tracking_params block's own docstring note a few lines down) — a
+        # ``landing_url``-only ``update_master`` call has no tracking_params
+        # branch to fall through into, so without this its own mismatch from
+        # a stale first load was never retried and was reported as a false
+        # "did not save" even though the value was confirmed present via a
+        # later fresh load (confirmed live, issue #790: the edit page showed
+        # the OLD query string on the immediate post-save reload, but a
+        # fresh navigation moments later showed the correct new value).
+        # ``_read_until_matches`` cannot see past this on its own — it only
+        # re-polls the same DOM the (possibly stale) navigation produced;
+        # only a genuinely new ``page.goto`` re-fetches it.
+        for _attempt in range(_VERIFY_RELOAD_MAX_ATTEMPTS - 1):
+            page.wait_for_timeout(_VERIFY_RELOAD_BACKOFF_MS)
+            page.goto(url, wait_until="commit")
+            assert_not_captcha(page.content())
+            assert_authenticated(page.content())
+            _wait_for_edit_form(page, campaign_id)
+            _re_navigated = True
+            if _audience_touched:
+                _wait_for_audience_section(page)
+            mismatches = _run_checks()
+            if not mismatches:
+                break
 
     if tracking_params is not None:
         # Wait for the section to be READABLE before judging it (issue

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -8152,6 +8152,52 @@ class TestUpdateMaster(unittest.TestCase):
             )
         self.assertIn("landing_url", str(ctx.exception))
 
+    def test_a_stale_landing_url_reload_is_recovered_by_re_navigating(self):
+        # Issue #790: live-reproduced 15/15 against real Мастер кампаний —
+        # `masters update --landing-url` on a URL whose CURRENT value already
+        # carries a query string reported a mismatch (the old query tail
+        # showing as "extra") even though the save genuinely took effect. The
+        # immediate post-save reload served a stale render (same class of
+        # race as #769/#774's tracking_params staleness, confirmed PAGE-level
+        # not field-specific); a fresh navigation moments later showed the
+        # correct new value. `_verify_saved` must re-navigate on a
+        # `landing_url` mismatch instead of only re-polling the same stale
+        # page — this must succeed, not raise.
+        original_value = "https://lp.example.ru/old?utm_source=old"
+        new_value = "https://lp.example.ru/new?utm_source=new"
+
+        class _RecoversOnReNavigationHandle(_FakeContentEditableHandle):
+            def text_content(self):
+                # The first post-save reload (one goto beyond the initial
+                # edit-page open) is stale; the second goto (the re-
+                # navigation retry) sees the real, saved value.
+                if len(page.navigated_to) > 2:
+                    return new_value
+                if len(page.navigated_to) > 1:
+                    return original_value
+                return super().text_content()
+
+        url_handle = _RecoversOnReNavigationHandle(text=original_value)
+        clear_handle = _FakeLocatorHandle()
+        edit_form_ready_selector = (
+            f'[data-testid="{browser_masters._EDIT_FORM_READY_TESTID}"]'
+        )
+        save_handle = _FakeTextLocatorHandle(visible=True)
+        page = FakePage(
+            locators={
+                browser_masters._EDIT_URL_INPUT_TESTID: _FakeLocator([url_handle]),
+                browser_masters._EDIT_URL_CLEAR_BUTTON_TESTID: _FakeLocator(
+                    [clear_handle]
+                ),
+                edit_form_ready_selector: _FakeLocator([_FakeLocatorHandle()]),
+            },
+            role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
+        )
+
+        result = browser_masters.update_master(page, 42, landing_url=new_value)
+
+        self.assertEqual(result["LandingUrl"], new_value)
+
     def test_updates_name_together_with_weekly_budget(self):
         budget_state = {}
         name_state = {}


### PR DESCRIPTION
## Summary

`_verify_saved`'s re-navigate-on-mismatch retry (added for `tracking_params` by #769/#774) was scoped to `if tracking_params is not None`. The underlying race — a post-save reload serving a stale render — is **page-level, not field-specific** (already documented in the code's own comments), so `landing_url`-only `masters update` calls had no fallback: a mismatch on the first (possibly stale) post-save reload was reported as a hard "did not save" failure even though the value was genuinely saved.

Generalizes the retry to fire whenever the initial `_run_checks()` pass (`weekly_budget`/`directs_helps`/`promotion_goal`/`name`/`landing_url`/`gender`) reports any mismatch, not only when `tracking_params` is present.

Closes #790

## Live verification

Reproduced live against real Мастер кампаний, then confirmed the fix:

1. Before the fix: `masters update 713234191 --landing-url "...?utm_test=repro790"` raised `landing_url: expected '...?utm_test=repro790', page now shows '...detox_ya'` — but `masters get` (grid API) already showed the correct saved value the whole time, and a fresh browser navigation to the edit page moments later also showed the correct value. Confirmed this is a stale-render race, not a real save failure.
2. After the fix: 5 back-to-back `masters update --landing-url` runs against the same live campaign, each replacing a URL that already carried a query string with a new one — all succeeded on the first try, no verify failures.
3. Restored the campaign's original `LandingUrl` afterward; confirmed via `masters get`.

## Tests

- Added `test_a_stale_landing_url_reload_is_recovered_by_re_navigating` in `tests/test_masters.py`, mirroring the existing `TestVerifyTrackingParamsReloadRetry` pattern: a landing-URL field handle that reports the stale value on the first post-save reload and the correct value only after a re-navigation — `update_master` must succeed, not raise.
- `test_raises_when_saved_landing_url_does_not_match_requested` (a permanently-wrong value) still passes — the retry doesn't paper over genuine save failures.
- Full offline suite: `pytest -q` → 3328 passed, 23 skipped, 39 subtests passed.
- `black --check` / `flake8` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)