### PR TITLE
fix(masters): harden delete_master — TOCTOU race, transient verify errors, virtualized-grid scroll (#793, #791)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,19 +32,27 @@ other than DRAFT.
 - Registered `masters.delete` as `DANGEROUS`/manual-only in
   `smoke_matrix.py`, same rationale as `archive`/`suspend`/`resume`: no API
   surface, no `--sandbox` equivalent, irreversible.
-- **Known limitation:** the campaigns grid is a virtualized SPA (#639/#671)
-  — `delete` needs the target row's DOM node to click its menu, and a row
-  outside the grid's currently-rendered viewport is absent from the DOM
-  entirely, not just off-screen. `delete` best-effort scrolls the row into
-  view first, but that can only act on a node that already resolved; it
-  cannot make an unrendered row appear. This reaches the common case (a
-  just-created DRAFT, which renders near the top of the grid) but an older
-  DRAFT buried under many other campaigns may fail with "Could not open the
-  campaigns grid row menu" even though `masters list` finds it fine (`list`
-  reads the grid's paginated JSON API directly, unaffected by scroll
-  position). See README for the workaround. Driving the grid's own
-  virtual-scroll container to the row's server-known offset would close
-  this gap but is out of scope here; tracked as a follow-up (#791).
+
+**`masters delete` now reaches a DRAFT row buried outside the grid's
+initial render window (#791).**
+
+The campaigns grid is a virtualized SPA (#639/#671) — `delete` needs the
+target row's DOM node to click its menu, and a row outside the grid's
+currently-rendered viewport was previously absent from the DOM entirely,
+with no way to make it appear: `scroll_into_view_if_needed()` only acts on
+a node that has already resolved, and cannot make an unrendered one exist.
+
+Live recon found the grid's virtual-scroll container (a `[data-testid^=
+"Grid.Row-"]` element's closest scrollable ancestor — located structurally
+at runtime, never by a hardcoded CSS-modules class, which Yandex's build
+regenerates on every deploy) responds to a directly-assigned `scrollTop`
+plus a synthetic `scroll` event, the same as a real user scroll would.
+`delete_master` now drives this container one `clientHeight` at a time
+until the target row appears, before falling back to the existing
+`scroll_into_view_if_needed()`/trigger-click retry loop unchanged. Live-
+verified end-to-end 2026-08-06: a fresh DRAFT campaign (713356270) placed
+outside the grid's initial ~10-row render window by its default
+cost-descending sort was reached and deleted successfully.
 
 **`masters delete` hardened against a TOCTOU race and transient verify
 errors (#793).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,27 @@ other than DRAFT.
   virtual-scroll container to the row's server-known offset would close
   this gap but is out of scope here; tracked as a follow-up (#791).
 
+**`masters delete` hardened against a TOCTOU race and transient verify
+errors (#793).**
+
+Code review on #782/PR #784 found two edge cases in `delete_master`
+(`direct_cli/browser/masters.py`):
+
+- The DRAFT-only guard was checked once, well before the irreversible
+  `DeleteCampaignAction` click — on a shared/agency account, another
+  session could move the campaign off DRAFT in that window, and nothing
+  re-checked its status right before the click. `delete_master` now
+  re-reads the row a second time immediately before clicking and aborts
+  ("Not clicking 'Удалить'") if the status changed or the row vanished,
+  instead of clicking against an unconfirmed state.
+- The post-click verify loop let any transient error from
+  `fetch_masters_list` (HTTP 5xx, non-JSON, captcha, mid-poll session
+  expiry) propagate immediately, even though the click is immediate and
+  irreversible and the campaign is almost certainly already gone. The loop
+  now tolerates transient errors and keeps polling until the timeout; if
+  every poll still fails, the error explicitly states the click already
+  landed rather than reading like the delete itself failed.
+
 ### BREAKING CHANGES
 
 **`masters add` now requires `--add-target-action` (#777).**

--- a/README.md
+++ b/README.md
@@ -202,17 +202,11 @@ prompt non-interactively. Same no-`--sandbox` caveat as suspend/resume
 above. **The campaigns grid is a virtualized SPA (#639/#671): `delete`
 locates the row's DOM node to click its menu, and a row that isn't
 currently rendered in the grid's viewport is simply absent from the DOM,
-not just off-screen.** `delete` best-effort scrolls the row into view first,
-but that only works on a node that has already resolved — it cannot make an
-unrendered row appear. In practice this reaches the common case (a DRAFT
-just created by `masters add --draft`, which renders near the top of the
-grid), but an older DRAFT buried under many other campaigns may fail with
-"Could not open the campaigns grid row menu" even though `masters list`
-finds it (list reads the grid's paginated JSON data API directly, not the
-DOM, so it always sees every row regardless of scroll position). If that
-happens, scroll the campaigns grid to the row manually in a real browser
-first, or archive/launch other campaigns to shrink the list, then retry.
-Tracked as a follow-up: #791.
+not just off-screen.** `delete` drives the grid's own internal scroll
+container programmatically until the target row appears (issue #791,
+live-verified against a DRAFT placed outside the initial ~10-row render
+window), so an older DRAFT buried under many other campaigns is reached the
+same as a just-created one.
 
 `add` creates a brand-new "Конверсии и трафик" Мастер кампаний by driving the
 same create wizard a human uses. **It is NOT idempotent** — running it twice

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -660,6 +660,34 @@ _GRID_ROW_DELETE_ITEM_SELECTOR = '[data-testid="DeleteCampaignAction"]'
 # commands/masters.py, same as every --yes/prompt elsewhere in this CLI).
 _DELETE_VERIFY_TIMEOUT_MS = 10_000
 
+# Virtual-scroll driver for a row buried outside the grid's initial render
+# window (issue #791, live-confirmed 2026-08-06 against a fresh DRAFT
+# campaign, 713356270, placed below the fold by the grid's default
+# cost-descending sort). scroll_into_view_if_needed() cannot help here — it
+# only acts on an element that has already resolved to a DOM node, and a
+# virtualized row outside the viewport simply is not one yet. Live recon
+# found the grid's actual scroll container is NOT the row's immediate
+# parent (that element reports overflowY: visible) but its own parent one
+# level up — a `[data-testid^="Grid.Row-"]` element's closest ancestor with
+# `overflowY: auto`/`scroll` and `scrollHeight > clientHeight`. That
+# container's own CSS class (confirmed live: `Grid_grid__WNdri
+# dc-Scrollbar ...`) is a CSS-modules hash Yandex's build regenerates on
+# every deploy (same instability class as every other un-testid'd selector
+# this module avoids elsewhere) — so it is located structurally at runtime,
+# never hardcoded.
+#
+# Setting `scrollTop` directly and dispatching a synthetic `scroll` event
+# (confirmed live: no real wheel/touch event needed) triggers the grid's
+# own virtualization to re-render its visible row window. Scrolling by one
+# `clientHeight` per step (not straight to `scrollHeight`) mirrors a real
+# incremental scroll and reliably surfaces a row several pages down within
+# single-digit steps (measured live: 8 steps for a row ~90% down a ~6000px
+# list) — jumping to the very bottom in one step is not needed and would
+# make "did the target row's own position moved between polls" harder to
+# reason about if the grid ever re-sorts under a live filter change.
+_GRID_SCROLL_MAX_STEPS = 40
+_GRID_SCROLL_STEP_DELAY_MS = 150
+
 # DRAFT overview page support (issue #660, live-confirmed 2026-08-04 against
 # campaign 713231614 — see the module docstring's "DRAFT overview page" note).
 # A DRAFT campaign's overview page (WIZARD_OVERVIEW_URL itself, no "/edit/")
@@ -2840,6 +2868,91 @@ def archive_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
     return updated
 
 
+def _scroll_grid_to_row(page: "Page", campaign_id: int) -> bool:
+    """Drive the campaigns grid's own virtual-scroll container until
+    ``campaign_id``'s row appears in the DOM (issue #791).
+
+    Live-verified end-to-end 2026-08-06 via ``masters delete`` against a
+    fresh DRAFT campaign (713356270) placed outside the grid's initial
+    ~10-row render window by the grid's default cost-descending sort —
+    confirmed absent from the DOM at load, reachable after this function
+    runs, and successfully deleted through the normal trigger-click retry
+    loop below it (no code path change needed there).
+
+    Returns ``True`` once the row is present, ``False`` if it never
+    appeared within ``_GRID_SCROLL_MAX_STEPS`` steps or the container
+    stopped scrolling before that (genuinely virtualized out, or the row
+    does not exist in the grid's current view at all). Never raises on its
+    own — the caller's existing trigger-click retry loop is still the one
+    place that turns "row unreachable" into a raised error, so this is a
+    best-effort nudge exactly like the ``scroll_into_view_if_needed()`` call
+    it runs alongside, just one that can actually reach a row outside the
+    initial render window (see the constants' docstring above for the live
+    recon backing the approach: structural container discovery, direct
+    ``scrollTop`` assignment plus a synthetic ``scroll`` event, one
+    ``clientHeight`` per step).
+    """
+    script = """
+        ([campaignId, maxSteps, stepDelayMs]) => {
+            const rowSelector = `[data-testid="Grid.Row-${campaignId}"]`;
+            const anyRow = document.querySelector('[data-testid^="Grid.Row-"]');
+            if (!anyRow) return false;
+
+            // The scroll container is not the row's immediate parent (that
+            // one is overflow:visible, live-confirmed) -- walk up until an
+            // ancestor is actually scrollable.
+            let container = anyRow.parentElement;
+            while (container) {
+                const style = getComputedStyle(container);
+                const scrollable =
+                    (style.overflowY === "auto" || style.overflowY === "scroll") &&
+                    container.scrollHeight > container.clientHeight;
+                if (scrollable) break;
+                container = container.parentElement;
+            }
+            if (!container) return false;
+
+            return new Promise((resolve) => {
+                let steps = 0;
+                const tick = () => {
+                    if (document.querySelector(rowSelector)) {
+                        resolve(true);
+                        return;
+                    }
+                    if (steps >= maxSteps) {
+                        resolve(false);
+                        return;
+                    }
+                    const before = container.scrollTop;
+                    container.scrollTop = before + container.clientHeight;
+                    container.dispatchEvent(new Event("scroll", {bubbles: true}));
+                    steps += 1;
+                    if (container.scrollTop === before) {
+                        // Reached the end (or never moved) -- one more
+                        // check in case the target rendered on this exact
+                        // frame, then give up.
+                        setTimeout(() => {
+                            resolve(!!document.querySelector(rowSelector));
+                        }, stepDelayMs);
+                        return;
+                    }
+                    setTimeout(tick, stepDelayMs);
+                };
+                tick();
+            });
+        }
+    """
+    try:
+        return bool(
+            page.evaluate(
+                script,
+                [campaign_id, _GRID_SCROLL_MAX_STEPS, _GRID_SCROLL_STEP_DELAY_MS],
+            )
+        )
+    except PlaywrightError:
+        return False
+
+
 def delete_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
     """Permanently delete a DRAFT Мастер кампаний via the campaigns grid's
     own row menu (issue #782).
@@ -2909,11 +3022,15 @@ def delete_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
 
     # The grid is a virtualized SPA (module docstring, issues #639/#671) --
     # a row outside the currently rendered window is simply absent from the
-    # DOM, not just off-screen. scroll_into_view_if_needed() only works on
-    # an element that already resolved, so this is a best-effort nudge, not
-    # a guarantee the row becomes reachable; a row genuinely virtualized out
-    # still fails the retry loop below with an honest error, not a bare
-    # "Yandex changed the markup" misdiagnosis.
+    # DOM, not just off-screen. _scroll_grid_to_row (issue #791) drives the
+    # grid's own virtual-scroll container until the row actually appears —
+    # unlike scroll_into_view_if_needed() below, which only works on an
+    # element that has already resolved and cannot make an unrendered row
+    # appear on its own. Both are best-effort: a row genuinely unreachable
+    # (removed from the grid's current filter/view entirely) still falls
+    # through to the retry loop below, which raises an honest error rather
+    # than a bare "Yandex changed the markup" misdiagnosis.
+    _scroll_grid_to_row(page, campaign_id)
     with contextlib.suppress(PlaywrightError):
         row.scroll_into_view_if_needed(timeout=_POPUP_APPEAR_TIMEOUT_MS)
 

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -2872,6 +2872,21 @@ def delete_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
     (``status=all``, so even an unexpected non-delete outcome like
     "archived instead" would still be caught) before reporting success —
     never trusting the click alone, per this module's dominant convention.
+
+    Re-verifies DRAFT status a SECOND time immediately before the click
+    (issue #793, Finding 1): the up-front guard above and the click are
+    separated by however long the row-menu retry loop takes, which is
+    enough of a window on a shared/agency account for another session to
+    move the campaign off DRAFT — DeleteCampaignAction is never clicked
+    against a row this function has not just re-confirmed is still DRAFT.
+
+    The post-click verify loop tolerates transient ``BrowserSessionError``s
+    from ``_find_master_row`` (issue #793, Finding 2) instead of letting one
+    propagate as a hard failure: the click is immediate and irreversible, so
+    a mid-poll HTTP 5xx/captcha/auth blip must not read as "the delete
+    failed" when it almost certainly already succeeded. If the timeout is
+    reached while every poll errored, the raised message says explicitly
+    that the click already landed.
     """
     existing = _find_master_row(page, campaign_id)
     if existing is None:
@@ -2936,6 +2951,33 @@ def delete_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
             "scrolled into view manually first."
         ) from last_exc
 
+    # TOCTOU re-check (issue #793, Finding 1): the up-front DRAFT guard above
+    # reads the grid via _find_master_row once, but on a shared/agency
+    # account another session could transition the campaign (DRAFT ->
+    # MODERATION/ACTIVE) in the seconds between that read and this click —
+    # opening the row menu alone takes a retry loop. Re-read the row right
+    # before the irreversible click and abort if it is no longer DRAFT,
+    # rather than clicking DeleteCampaignAction against a row whose current
+    # status this module has never confirmed that action is even safe for
+    # (see the field's own docstring above: "NOT re-confirmed here").
+    current = _find_master_row(page, campaign_id, status="all")
+    if current is None:
+        raise BrowserSessionError(
+            f"Campaign {campaign_id} was DRAFT moments ago but is no longer "
+            "in the campaigns grid at all — it may have just been deleted "
+            "or removed by another session. Not clicking 'Удалить'."
+        )
+    if current["Status"] != "DRAFT":
+        raise BrowserSessionError(
+            f"Campaign {campaign_id} was DRAFT moments ago but is now "
+            f"{current['Status']} — another session likely changed it "
+            "concurrently. Not clicking 'Удалить': whether the grid row "
+            "menu's delete action is even safe for a non-DRAFT campaign is "
+            "unconfirmed (see module docstring). Re-run `masters delete` "
+            "if you still intend to remove it, or use `masters archive` "
+            "for its current status."
+        )
+
     delete_item = page.locator(_GRID_ROW_DELETE_ITEM_SELECTOR).first
     try:
         delete_item.click()
@@ -2946,15 +2988,44 @@ def delete_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
             "Yandex may have changed the grid's row menu."
         ) from exc
 
+    # Post-click verify loop (issue #793, Finding 2): the click above is
+    # immediate and irreversible (module docstring — no confirmation dialog
+    # exists). _find_master_row can itself raise BrowserSessionError (HTTP
+    # 5xx, non-JSON, captcha, mid-poll session expiry — see
+    # _fetch_grid_campaigns_page/assert_not_captcha/assert_authenticated) on
+    # any individual poll. Treat that as an inconclusive poll, not a fatal
+    # error: the campaign is very likely already gone, and surfacing a raw
+    # transient exception here would read as "the delete failed", pushing a
+    # caller toward a needless retry against a click that already landed.
     deadline = _clock.now() + _DELETE_VERIFY_TIMEOUT_MS / 1000
     still_present = True
+    verify_exc: Optional[Exception] = None
     while _clock.now() < deadline:
-        still_present = _find_master_row(page, campaign_id, status="all") is not None
+        try:
+            still_present = (
+                _find_master_row(page, campaign_id, status="all") is not None
+            )
+            verify_exc = None
+        except BrowserSessionError as exc:
+            verify_exc = exc
+            page.wait_for_timeout(250)
+            continue
         if not still_present:
             break
         page.wait_for_timeout(250)
 
     if still_present:
+        if verify_exc is not None:
+            raise BrowserSessionError(
+                f"Clicked 'Удалить' for campaign {campaign_id} — the click "
+                "itself landed and was NOT rejected, but the campaigns grid "
+                "could not be re-read to confirm the delete within "
+                f"{_DELETE_VERIFY_TIMEOUT_MS / 1000:.0f}s ({verify_exc}). "
+                "Check the campaign's status in the UI before retrying — a "
+                "retry against an already-deleted campaign will report "
+                "'Could not find' instead of double-deleting, but is "
+                "unnecessary if this already succeeded."
+            ) from verify_exc
         raise BrowserSessionError(
             f"Clicked 'Удалить' for campaign {campaign_id}, but the "
             f"campaigns grid still reports it present within "

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -663,6 +663,9 @@ class FakePage:
         # could not distinguish a correct role-scoped match from an
         # accidental ancestor-container match).
         self._role_elements = role_elements or []
+        # Callable(arg) -> result for evaluate() -- see evaluate()'s own
+        # docstring (issue #791, _scroll_grid_to_row).
+        self._evaluate_side_effect = None
 
     @property
     def url(self):
@@ -717,6 +720,19 @@ class FakePage:
 
     def eval_on_selector_all(self, selector, expression):
         return []
+
+    def evaluate(self, script, arg=None):
+        # _scroll_grid_to_row (issue #791) is the only caller: a test wires
+        # up ``self._evaluate_side_effect`` (a callable taking the same
+        # ``arg`` this method receives) to model the grid's virtual-scroll
+        # container being found/not-found, or a test overrides this method
+        # entirely for an exception path. Defaults to ``False`` (row never
+        # found) so any test that doesn't care about scroll behaviour gets
+        # the same "no-op, fall through to the existing retry loop" shape
+        # as production code hitting a real page without this call wired.
+        if self._evaluate_side_effect is not None:
+            return self._evaluate_side_effect(arg)
+        return False
 
     def locator(self, selector):
         return self._locators.get(selector, _FakeLocator([]))
@@ -4181,6 +4197,74 @@ class TestMastersArchiveCommand(unittest.TestCase):
         self.assertIn("boom on id 3", result.output)
 
 
+class TestScrollGridToRow(unittest.TestCase):
+    """_scroll_grid_to_row (issue #791): drives the campaigns grid's own
+    virtual-scroll container to make a row outside the initial render
+    window appear in the DOM. Unit-level tests against page.evaluate()
+    directly -- TestDeleteMaster covers the integration (call order,
+    best-effort failure handling) within delete_master itself.
+    """
+
+    CAMPAIGN_ID = 713356270
+
+    def test_returns_true_and_passes_expected_args_when_row_found(self):
+        captured = {}
+
+        def _evaluate(arg):
+            captured["arg"] = arg
+            return True
+
+        page = FakePage()
+        page._evaluate_side_effect = _evaluate
+
+        result = browser_masters._scroll_grid_to_row(page, self.CAMPAIGN_ID)
+
+        self.assertTrue(result)
+        self.assertEqual(
+            captured["arg"],
+            [
+                self.CAMPAIGN_ID,
+                browser_masters._GRID_SCROLL_MAX_STEPS,
+                browser_masters._GRID_SCROLL_STEP_DELAY_MS,
+            ],
+        )
+
+    def test_returns_false_when_row_never_found(self):
+        page = FakePage()
+        page._evaluate_side_effect = lambda arg: False
+
+        result = browser_masters._scroll_grid_to_row(page, self.CAMPAIGN_ID)
+
+        self.assertFalse(result)
+
+    def test_returns_false_instead_of_raising_on_playwright_error(self):
+        # Mirrors every other best-effort browser primitive in this module
+        # (scroll_into_view_if_needed's own try/except) -- a page.evaluate()
+        # failure (detached frame, navigation mid-call, etc.) must not
+        # propagate; the caller's retry loop is still the authority on
+        # success/failure.
+        def _raise(arg):
+            raise browser_masters.PlaywrightError("evaluate failed")
+
+        page = FakePage()
+        page._evaluate_side_effect = _raise
+
+        result = browser_masters._scroll_grid_to_row(page, self.CAMPAIGN_ID)
+
+        self.assertFalse(result)
+
+    def test_coerces_truthy_non_bool_result_to_bool(self):
+        # page.evaluate() over CDP can hand back a JS boolean as a Python
+        # bool already, but defensively coerce anyway rather than trust
+        # the exact type.
+        page = FakePage()
+        page._evaluate_side_effect = lambda arg: 1
+
+        result = browser_masters._scroll_grid_to_row(page, self.CAMPAIGN_ID)
+
+        self.assertIs(result, True)
+
+
 class TestDeleteMaster(unittest.TestCase):
     """delete_master (issue #782): DRAFT-only removal via the campaigns
     grid's own row menu — a SEPARATE menu from the overview page's "⋮"
@@ -4329,6 +4413,90 @@ class TestDeleteMaster(unittest.TestCase):
             browser_masters.delete_master(page, self.CAMPAIGN_ID)
 
         self.assertEqual(len(scroll_calls), 1)
+
+    def test_virtual_scroll_runs_before_scroll_into_view(self):
+        # issue #791: _scroll_grid_to_row must run BEFORE
+        # scroll_into_view_if_needed(), since it's the one that can
+        # actually make a row outside the initial render window exist in
+        # the DOM in the first place -- scroll_into_view_if_needed() alone
+        # cannot.
+        state = {"rows": [self._row("DRAFT")]}
+        call_order = []
+
+        def _remove():
+            state["rows"] = []
+
+        trigger_selector = browser_masters._GRID_ROW_ACTIONS_TRIGGER_SELECTOR
+        row_handle = _FakeLocatorHandle(
+            sub_locators={trigger_selector: _FakeLocatorHandle()}
+        )
+        row_handle.scroll_into_view_if_needed = lambda timeout=None: call_order.append(
+            "scroll_into_view"
+        )
+        page = FakePage(
+            locators={
+                self.ROW_SELECTOR: _FakeLocator([row_handle]),
+                browser_masters._GRID_ROW_ACTIONS_POPUP_SELECTOR: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                ),
+                browser_masters._GRID_ROW_DELETE_ITEM_SELECTOR: _FakeLocator(
+                    [_FakeLocatorHandle(on_click=_remove)]
+                ),
+            }
+        )
+
+        def _virtual_scroll(arg):
+            call_order.append("virtual_scroll")
+            return True
+
+        page._evaluate_side_effect = _virtual_scroll
+
+        with patch(
+            "direct_cli.browser.masters.fetch_masters_list",
+            side_effect=lambda page, status="all": list(state["rows"]),
+        ):
+            browser_masters.delete_master(page, self.CAMPAIGN_ID)
+
+        self.assertEqual(call_order, ["virtual_scroll", "scroll_into_view"])
+
+    def test_virtual_scroll_failure_does_not_abort_delete(self):
+        # _scroll_grid_to_row swallows its own PlaywrightError (mirrors
+        # scroll_into_view_if_needed's existing best-effort contract) --
+        # a row genuinely unreachable must still fall through to the
+        # existing trigger-click retry loop, not raise here.
+        state = {"rows": [self._row("DRAFT")]}
+
+        def _remove():
+            state["rows"] = []
+
+        trigger_selector = browser_masters._GRID_ROW_ACTIONS_TRIGGER_SELECTOR
+        row_handle = _FakeLocatorHandle(
+            sub_locators={trigger_selector: _FakeLocatorHandle()}
+        )
+        page = FakePage(
+            locators={
+                self.ROW_SELECTOR: _FakeLocator([row_handle]),
+                browser_masters._GRID_ROW_ACTIONS_POPUP_SELECTOR: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                ),
+                browser_masters._GRID_ROW_DELETE_ITEM_SELECTOR: _FakeLocator(
+                    [_FakeLocatorHandle(on_click=_remove)]
+                ),
+            }
+        )
+
+        def _raise_evaluate(arg):
+            raise browser_masters.PlaywrightError("evaluate failed")
+
+        page._evaluate_side_effect = _raise_evaluate
+
+        with patch(
+            "direct_cli.browser.masters.fetch_masters_list",
+            side_effect=lambda page, status="all": list(state["rows"]),
+        ):
+            result = browser_masters.delete_master(page, self.CAMPAIGN_ID)
+
+        self.assertEqual(result, {"CampaignId": self.CAMPAIGN_ID, "Deleted": True})
 
     def test_scroll_into_view_failure_does_not_abort_delete(self):
         # A row genuinely absent from the DOM (fully virtualized out) makes

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -4406,6 +4406,126 @@ class TestDeleteMaster(unittest.TestCase):
 
         self.assertIn("still reports it present", str(ctx.exception))
 
+    def test_toctou_aborts_without_clicking_when_status_changed_before_click(self):
+        # issue #793 Finding 1: the up-front guard reads DRAFT once, but the
+        # row-menu retry loop takes real time -- another session could move
+        # the campaign off DRAFT before DeleteCampaignAction is clicked.
+        # _find_master_row is called: once for the up-front guard, once for
+        # the TOCTOU re-check right before the click. Flip status on the
+        # second call.
+        calls = {"n": 0}
+        delete_clicked = []
+
+        def _fetch(page, status="all"):
+            calls["n"] += 1
+            status_now = "DRAFT" if calls["n"] == 1 else "MODERATION"
+            return [self._row(status_now)]
+
+        page = self._page_with_row_menu(
+            trigger=_FakeLocatorHandle(),
+            delete_item=_FakeLocatorHandle(on_click=lambda: delete_clicked.append(1)),
+        )
+        page._locators[browser_masters._GRID_ROW_ACTIONS_POPUP_SELECTOR] = _FakeLocator(
+            [_FakeLocatorHandle()]
+        )
+
+        with patch("direct_cli.browser.masters.fetch_masters_list", side_effect=_fetch):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters.delete_master(page, self.CAMPAIGN_ID)
+
+        self.assertIn("is now", str(ctx.exception))
+        self.assertIn("MODERATION", str(ctx.exception))
+        self.assertIn("Not clicking", str(ctx.exception))
+        self.assertEqual(delete_clicked, [])
+
+    def test_toctou_aborts_without_clicking_when_campaign_vanished_before_click(self):
+        # Same TOCTOU window, but the row disappeared entirely (e.g. deleted
+        # by another session) rather than merely changing status.
+        calls = {"n": 0}
+        delete_clicked = []
+
+        def _fetch(page, status="all"):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return [self._row("DRAFT")]
+            return []
+
+        page = self._page_with_row_menu(
+            trigger=_FakeLocatorHandle(),
+            delete_item=_FakeLocatorHandle(on_click=lambda: delete_clicked.append(1)),
+        )
+        page._locators[browser_masters._GRID_ROW_ACTIONS_POPUP_SELECTOR] = _FakeLocator(
+            [_FakeLocatorHandle()]
+        )
+
+        with patch("direct_cli.browser.masters.fetch_masters_list", side_effect=_fetch):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters.delete_master(page, self.CAMPAIGN_ID)
+
+        self.assertIn("no longer", str(ctx.exception))
+        self.assertEqual(delete_clicked, [])
+
+    def test_verify_loop_tolerates_transient_error_then_succeeds(self):
+        # issue #793 Finding 2: a transient BrowserSessionError on the FIRST
+        # poll after a successful, irreversible click must not propagate --
+        # it must be treated as inconclusive and polling must continue.
+        state = {"rows": [self._row("DRAFT")]}
+        poll_calls = {"n": 0}
+
+        def _remove():
+            state["rows"] = []
+
+        def _fetch(page, status="all"):
+            poll_calls["n"] += 1
+            # Call 1: up-front guard. Call 2: TOCTOU re-check. Call 3: first
+            # verify poll -- raise here. Call 4+: verify polls succeed.
+            if poll_calls["n"] == 3:
+                raise BrowserSessionError("Campaigns grid API returned HTTP 500")
+            return list(state["rows"])
+
+        page = self._page_with_row_menu(
+            trigger=_FakeLocatorHandle(),
+            delete_item=_FakeLocatorHandle(on_click=_remove),
+        )
+        page._locators[browser_masters._GRID_ROW_ACTIONS_POPUP_SELECTOR] = _FakeLocator(
+            [_FakeLocatorHandle()]
+        )
+
+        with patch("direct_cli.browser.masters.fetch_masters_list", side_effect=_fetch):
+            result = browser_masters.delete_master(page, self.CAMPAIGN_ID)
+
+        self.assertEqual(result, {"CampaignId": self.CAMPAIGN_ID, "Deleted": True})
+        self.assertGreaterEqual(poll_calls["n"], 4)
+
+    def test_verify_loop_reports_click_already_landed_when_every_poll_errors(self):
+        # issue #793 Finding 2: if every poll until the deadline errors, the
+        # final message must say the click already landed, not just repeat
+        # a generic "still present" (which would falsely suggest the click
+        # itself may not have worked).
+        page = self._page_with_row_menu(
+            trigger=_FakeLocatorHandle(),
+            delete_item=_FakeLocatorHandle(),
+        )
+        page._locators[browser_masters._GRID_ROW_ACTIONS_POPUP_SELECTOR] = _FakeLocator(
+            [_FakeLocatorHandle()]
+        )
+
+        calls = {"n": 0}
+
+        def _fetch(page, status="all"):
+            calls["n"] += 1
+            if calls["n"] <= 2:
+                # up-front guard + TOCTOU re-check both see DRAFT.
+                return [self._row("DRAFT")]
+            raise BrowserSessionError("Campaigns grid API returned HTTP 500")
+
+        with patch("direct_cli.browser.masters.fetch_masters_list", side_effect=_fetch):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters.delete_master(page, self.CAMPAIGN_ID)
+
+        self.assertIn("landed", str(ctx.exception))
+        self.assertIn("HTTP 500", str(ctx.exception))
+
 
 class TestMastersDeleteCommand(unittest.TestCase):
     """CLI wiring for `masters delete` (issue #782), including the


### PR DESCRIPTION
## Summary

Codex's adversarial review (cycle-review, round 4) on PR #784 found three edge cases in `delete_master` (`direct_cli/browser/masters.py`), tracked as issues #793 and #791. This PR fixes all three.

### #793 Finding 1 — TOCTOU on DRAFT status before the irreversible click

`delete_master` read the campaign's DRAFT status once via `_find_master_row`, well before the `DeleteCampaignAction` click (the row-menu open/retry loop takes real time in between). On a shared/agency account, another session could transition the campaign (DRAFT → MODERATION/ACTIVE) inside that window. `delete_master` now re-reads the row a second time immediately before the click and aborts — "Not clicking 'Удалить'" — if the status changed or the row vanished, instead of clicking `DeleteCampaignAction` against an unconfirmed state.

### #793 Finding 2 — transient verify-loop errors surfaced as hard failures

The post-click verify loop called `_find_master_row(page, campaign_id, status="all")`, which can raise `BrowserSessionError` (HTTP 5xx, non-JSON, captcha, mid-poll session expiry) on any individual poll — none of that was caught, so a transient error right after a successful, irreversible click propagated as if the delete itself had failed. The loop now tolerates transient errors and keeps polling until `_DELETE_VERIFY_TIMEOUT_MS`; if every poll still fails, the error explicitly states the click already landed, so a caller doesn't retry against a false premise.

### #791 — virtualized grid row unreachable when scrolled out of the initial render window

The campaigns grid is a virtualized SPA (#639/#671) — `delete` needs the target row's DOM node to click its menu, and a row outside the grid's currently-rendered viewport was previously absent from the DOM entirely, with no way to make it appear (`scroll_into_view_if_needed()` only acts on a node that has already resolved).

Live recon found the grid's virtual-scroll container is a `[data-testid^="Grid.Row-"]` element's closest scrollable ancestor — located structurally at runtime, never by a hardcoded CSS-modules class (which Yandex's build regenerates on every deploy). Directly assigning `scrollTop` plus dispatching a synthetic `scroll` event triggers the grid's own virtualization to re-render its visible row window, same as a real scroll would. New `_scroll_grid_to_row()` drives this one `clientHeight` at a time until the target row appears, then falls through to the existing retry loop unchanged.

## Live verification

Both fixes required a live browser session (queued behind a concurrent session using the same account — coordinated via the orchestrator before any mutation):

- **#793**: both findings are pure logic changes with no new selectors, so verified offline via `FakePage`/mocked `fetch_masters_list` only — no live mutation needed.
- **#791**: required an actual DRAFT campaign buried outside the grid's initial render window. Created a fresh DRAFT (713356270) via the create wizard UI (the CLI's own `masters add --draft` hit an unrelated, separately-tracked bug — see below), confirmed via `page.evaluate` recon that it rendered outside the first ~10 grid rows under the default cost-descending sort, then ran `masters delete 713356270 --yes` through this PR's code unmodified. It located, scrolled to, and deleted the campaign successfully; `masters list --status all` confirmed it gone afterward (79 campaigns, same as before creation).

## Side finding (not fixed here, filed separately)

While creating the test DRAFT campaign, `masters add --draft` hit issue #796 (silent rejection, "Нужно указать хотя бы один регион" — a region is required by the create form's UI validation but wasn't being satisfied by the CLI's own flow in that session). Reproduced manually via the wizard UI to unblock this PR's live verification; the underlying CLI bug is out of scope here and filed as #796.

## Tests

- `TestDeleteMaster`: 4 tests for #793 (TOCTOU × 2, transient-verify-tolerance × 2) + 2 tests for #791 (call order, best-effort failure handling).
- New `TestScrollGridToRow`: 4 unit tests against `page.evaluate()` directly.
- Full `tests/test_masters.py` suite: 728 passed.
- `black`/`flake8` clean.

`masters delete` is DANGEROUS/manual-only per `smoke_matrix.py` (no automated release gate, no `--sandbox`).

Closes #793
Closes #791

🤖 Generated with [Claude Code](https://claude.com/claude-code)