### PR TITLE
docs(masters): add masters copy to dangerous-commands manual checklist

### DIFF
--- a/scripts/test_dangerous_commands.sh
+++ b/scripts/test_dangerous_commands.sh
@@ -56,6 +56,11 @@ non-critical campaign, confirming before/after state in the web UI):
     silently refuses a campaign with no conversion goal. Note a --draft
     created this way cannot be archived (issue #660) but can be removed
     via `masters delete`, see issue #782)
+  - direct masters copy <campaign_id> [--launch/--draft]
+    (clones an existing campaign via the overview page's "..." menu, issue
+    #659 -- NOT idempotent, a second run creates a second copy, not an
+    update. Verify with --draft first, then delete/archive the test copy
+    by hand after checking it in the web UI.)
 
 Interactive human-in-the-loop login (opens a visible browser window and
 blocks waiting for a person to sign in -- cannot run unattended):


### PR DESCRIPTION
## Summary

Round 2 of `/cycle-review 661` follow-up (#662). PR #661 (`feat(masters): add direct masters copy`) was already merged before round 2 could complete — the review bot (`codex-fork`) hit a job-log-directory ENOENT bug that has since resolved itself (the state dir now auto-creates). Round 1 already found and fixed a critical retry-safety bug in `_with_session` (commit `7736815`, merged as part of `7b5c843`).

Since the PR branch no longer exists, round 2 re-ran Codex's `adversarial-review` (effort=high) directly against current `main`, base-pinned to PR #661's merge-base (`8d00889`), with an explicit focus on re-verifying the round-1 retry-safety fix.

**Result:**
- **Retry-safety fix: SOUND.** Codex traced every code path between the irreversible clone click and the protected post-click `_find_master_row` call and confirmed no `BrowserAuthError` can escape and trigger `_with_session`'s retry. No issues found on the primary concern.
- **One documentation gap (this PR):** `smoke_matrix.py` classifies `masters.copy` `DANGEROUS` with a comment pointing at `scripts/test_dangerous_commands.sh` as the manual checklist, but the script never actually listed `masters copy` — verified 0 occurrences, while the sibling `masters add` entry (same risk profile: no API surface, no sandbox, not idempotent) is documented. This doesn't affect runtime safety (the `smoke_matrix.py` classification already blocks it from automated smoke runs) but the human-facing checklist was incomplete.

## Fix

Added a `direct masters copy` entry to the "Browser-driven Мастер кампаний mutations" block in `scripts/test_dangerous_commands.sh`, adjacent to `masters add`, following the same documentation pattern.

## Test plan

- [x] `bash -n scripts/test_dangerous_commands.sh` — shell syntax valid
- [x] `pytest tests/test_smoke_matrix.py tests/test_comprehensive.py -q` — 42 passed
- [x] Manual diff review — pure documentation addition, no behavior change

Closes #662