### PR TITLE
fix(masters): harden archive_master/copy_master — TOCTOU race, transient verify errors

### DIFF
--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -2782,23 +2782,32 @@ def _reverify_status_or_raise(
     ``page.goto(GRID_URL)``s (a cross-page navigation away from the
     overview page the menu belongs to), destroying the just-opened menu and
     making the caller's very next click target a locator that no longer
-    exists in the DOM. ``_read_status_text`` reads the same normalized
-    ``"SUSPENDED"``/``"ACTIVE"``/``"MODERATION"``/``"ARCHIVED"`` values
-    straight from the overview page's own body text, exactly like
+    exists in the DOM. ``_wait_for_recognised_status`` reads the same
+    normalized ``"SUSPENDED"``/``"ACTIVE"``/``"MODERATION"``/``"ARCHIVED"``
+    values straight from the overview page's own body text, exactly like
     ``suspend_master``/``resume_master`` already do around their own
-    clicks, so the re-check never navigates at all.
+    clicks, so the re-check never navigates at all — and, cycle-review
+    finding on issue #797, polls for a moment (like every other status
+    branch in this module) rather than reading once: ``_goto_overview_page``
+    only guarantees the *title* rendered, not the status element, which is
+    documented (see ``_wait_for_recognised_status``'s own docstring) as a
+    separate render pass that routinely reads as unrecognised for a moment
+    right after. A single unguarded ``_read_status_text`` here would
+    misattribute that hydration lag to "another session changed it" and
+    abort a perfectly legitimate archive/clone.
 
     Raises ``BrowserSessionError`` naming ``action_label`` (e.g.
-    "Архивировать", "Клонировать") if the overview page's status text no
-    longer reads as ``expected_status`` (including an unrecognised/missing
-    status, treated the same as "changed" — this function has no way to
-    tell a vanished campaign apart from unrecognised markup once already on
-    its overview page, so it fails closed either way) — appending
-    ``not_found_hint``/``changed_status_hint`` respectively, for a
+    "Архивировать", "Клонировать") if the overview page's status text still
+    does not read as ``expected_status`` once hydration is given a chance to
+    catch up (including a status that never becomes recognised at all,
+    treated the same as "changed" — this function has no way to tell a
+    vanished campaign apart from persistently unrecognised markup once
+    already on its overview page, so it fails closed either way) —
+    appending ``not_found_hint``/``changed_status_hint`` respectively, for a
     caller-specific pointer to the right next step (mirrors
     ``delete_master``'s own "use `masters archive` instead" hint).
     """
-    current_status = _read_status_text(page)
+    current_status = _wait_for_recognised_status(page)
     if current_status is None:
         hint = f" {not_found_hint}" if not_found_hint else ""
         raise BrowserSessionError(

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -2763,47 +2763,57 @@ def _reverify_status_or_raise(
     action_label: str,
     not_found_hint: str = "",
     changed_status_hint: str = "",
-) -> Dict[str, Any]:
-    """Re-read ``campaign_id``'s row right before an irreversible click and
-    abort if it is no longer ``expected_status`` (TOCTOU guard, issue #797,
-    same shape as ``delete_master``'s own re-check, issue #793 Finding 1).
+) -> None:
+    """Re-read the overview page's own status text right before an
+    irreversible click and abort if it is no longer ``expected_status``
+    (TOCTOU guard, issue #797, same shape as ``delete_master``'s own
+    re-check, issue #793 Finding 1).
 
     An up-front status guard, read once at the top of a function, can go
     stale by the time that function's own irreversible click actually
     fires — everything in between (navigating to the overview page, opening
     the "⋮" menu, waiting for a popup to render) is real elapsed time in
     which another session on a shared/agency account could transition the
-    campaign. Re-reading via ``_find_master_row(..., status="all")``
-    (so even an unexpected status is still caught, not silently excluded by
-    a narrower filter) immediately before the click closes that window,
-    mirroring ``delete_master``'s "never click against an unconfirmed
-    state" convention.
+    campaign. Both callers of this helper (``archive_master``,
+    ``copy_master``) run it AFTER the overview page's "⋮" menu is already
+    open and IMMEDIATELY before clicking one of its items — re-reading via
+    ``_find_master_row``/``fetch_masters_list`` here would call
+    ``_capture_grid_campaigns_request``, which unconditionally
+    ``page.goto(GRID_URL)``s (a cross-page navigation away from the
+    overview page the menu belongs to), destroying the just-opened menu and
+    making the caller's very next click target a locator that no longer
+    exists in the DOM. ``_read_status_text`` reads the same normalized
+    ``"SUSPENDED"``/``"ACTIVE"``/``"MODERATION"``/``"ARCHIVED"`` values
+    straight from the overview page's own body text, exactly like
+    ``suspend_master``/``resume_master`` already do around their own
+    clicks, so the re-check never navigates at all.
 
-    Returns the freshly re-read row on success. Raises
-    ``BrowserSessionError`` naming ``action_label`` (e.g. "Архивировать",
-    "Клонировать") if the row vanished entirely or its status no longer
-    matches ``expected_status`` — appending ``not_found_hint``/
-    ``changed_status_hint`` to each case respectively, for a caller-specific
-    pointer to the right next step (mirrors ``delete_master``'s own
-    "use `masters archive` instead" hint).
+    Raises ``BrowserSessionError`` naming ``action_label`` (e.g.
+    "Архивировать", "Клонировать") if the overview page's status text no
+    longer reads as ``expected_status`` (including an unrecognised/missing
+    status, treated the same as "changed" — this function has no way to
+    tell a vanished campaign apart from unrecognised markup once already on
+    its overview page, so it fails closed either way) — appending
+    ``not_found_hint``/``changed_status_hint`` respectively, for a
+    caller-specific pointer to the right next step (mirrors
+    ``delete_master``'s own "use `masters archive` instead" hint).
     """
-    current = _find_master_row(page, campaign_id, status="all")
-    if current is None:
+    current_status = _read_status_text(page)
+    if current_status is None:
         hint = f" {not_found_hint}" if not_found_hint else ""
         raise BrowserSessionError(
             f"Campaign {campaign_id} was {expected_status} moments ago but "
-            "is no longer in the campaigns grid at all — it may have just "
-            f"been removed by another session. Not clicking "
-            f"'{action_label}'.{hint}"
+            "its overview page no longer shows a recognised status — "
+            "another session may have just changed or removed it. Not "
+            f"clicking '{action_label}'.{hint}"
         )
-    if current["Status"] != expected_status:
+    if current_status != expected_status:
         hint = f" {changed_status_hint}" if changed_status_hint else ""
         raise BrowserSessionError(
             f"Campaign {campaign_id} was {expected_status} moments ago but "
-            f"is now {current['Status']} — another session likely changed "
-            f"it concurrently. Not clicking '{action_label}'.{hint}"
+            f"is now {current_status} — another session likely changed it "
+            f"concurrently. Not clicking '{action_label}'.{hint}"
         )
-    return current
 
 
 def _poll_master_row_tolerant(
@@ -2993,6 +3003,20 @@ def archive_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
     )
 
     if updated is None or updated["Status"] != "ARCHIVED":
+        if isinstance(verify_exc, BrowserAuthError):
+            # Unlike copy_master (not idempotent -- a retried click would
+            # create a SECOND campaign, so it deliberately re-wraps this as
+            # a plain BrowserSessionError below), archive_master itself is
+            # idempotent (see the ARCHIVED early-return above): re-raising
+            # BrowserAuthError here lets _with_session
+            # (direct_cli/commands/masters.py) retry the whole call under a
+            # fresh session -- if the archive already landed, the retry
+            # just returns the already-ARCHIVED row without clicking again.
+            # _poll_master_row_tolerant tolerating every BrowserSessionError
+            # (issue #797 Finding 2) would otherwise silently swallow this
+            # into a generic timeout, losing that fast auto-heal path for a
+            # session that expired mid-poll.
+            raise verify_exc
         if verify_exc is not None:
             raise BrowserSessionError(
                 f"Clicked 'Архивировать' for campaign {campaign_id} — the "

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -2983,6 +2983,8 @@ def archive_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
             campaign_id,
             expected_status="SUSPENDED",
             action_label="Архивировать",
+            not_found_hint="Check `masters list` to see whether it was "
+            "already archived or removed by another session.",
             changed_status_hint="Re-run `masters archive` if you still "
             "intend to archive it.",
         )
@@ -3512,6 +3514,8 @@ def copy_master(
         campaign_id,
         expected_status=existing["Status"],
         action_label="Клонировать",
+        not_found_hint="Check `masters list` to see whether it was already "
+        "removed by another session.",
         changed_status_hint="Re-run `masters copy` if you still intend to "
         "clone it — this is not idempotent, so check first whether an "
         "earlier attempt already created a copy.",

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -3488,11 +3488,17 @@ def copy_master(
     quietly changed underneath this function is a worse failure mode than
     for an idempotent action, since a caller who retries after a false
     failure risks creating an unwanted duplicate campaign. The re-check
-    requires the status to still match what this function itself just read
-    (``expected_status=existing["Status"]``) — unlike
-    ``archive_master``/``delete_master``, cloning has no single required
-    status, so "changed at all" (not "changed to some specific wrong
-    value") is the signal this function treats as unsafe to click through.
+    requires the status to still match a status read from the SAME source
+    (the overview page's own status text, via ``_wait_for_recognised_status``
+    right after ``_goto_overview_page``) — not the up-front guard's grid
+    read: the grid's ``primaryStatus`` vocabulary is broader than and can
+    lag the overview page's four recognised values (cycle-review finding,
+    module docstring documents a 45+s DRAFT->MODERATION lag), so comparing
+    across sources would false-abort a legitimate, unchanged clone whenever
+    the two disagree. Unlike ``archive_master``/``delete_master``, cloning
+    has no single required status, so "changed at all" (not "changed to
+    some specific wrong value") is the signal this function treats as
+    unsafe to click through.
     """
     existing = _find_master_row(page, campaign_id)
     if existing is None:
@@ -3502,6 +3508,25 @@ def copy_master(
         )
 
     _goto_overview_page(page, campaign_id)
+
+    # The re-check below compares against THIS overview-page read, not
+    # `existing["Status"]` (cycle-review finding on issue #797): the grid's
+    # primaryStatus vocabulary is broader than and can lag
+    # _read_status_text's four recognised values (module docstring
+    # documents a 45+s DRAFT->MODERATION lag) -- comparing a grid-derived
+    # expected status against an overview-derived current status would
+    # false-abort a legitimate, unchanged clone whenever the two sources
+    # disagree, exactly the "another session changed it" false positive the
+    # re-check exists to avoid. Reading both sides from the overview page,
+    # like archive_master already does (SUSPENDED-vs-SUSPENDED, both from
+    # the overview), eliminates the cross-source mismatch entirely.
+    starting_status = _wait_for_recognised_status(page)
+    if starting_status is None:
+        raise BrowserSessionError(
+            f"Could not determine campaign {campaign_id}'s status from its "
+            "overview page — Yandex may have changed the page's markup, or "
+            "the campaign is in a status this tool does not recognise."
+        )
 
     try:
         _click_and_wait_for_popup(
@@ -3521,7 +3546,7 @@ def copy_master(
     _reverify_status_or_raise(
         page,
         campaign_id,
-        expected_status=existing["Status"],
+        expected_status=starting_status,
         action_label="Клонировать",
         not_found_hint="Check `masters list` to see whether it was already "
         "removed by another session.",

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -2755,12 +2755,110 @@ def _find_master_row(
     return None
 
 
+def _reverify_status_or_raise(
+    page: "Page",
+    campaign_id: int,
+    *,
+    expected_status: str,
+    action_label: str,
+    not_found_hint: str = "",
+    changed_status_hint: str = "",
+) -> Dict[str, Any]:
+    """Re-read ``campaign_id``'s row right before an irreversible click and
+    abort if it is no longer ``expected_status`` (TOCTOU guard, issue #797,
+    same shape as ``delete_master``'s own re-check, issue #793 Finding 1).
+
+    An up-front status guard, read once at the top of a function, can go
+    stale by the time that function's own irreversible click actually
+    fires — everything in between (navigating to the overview page, opening
+    the "⋮" menu, waiting for a popup to render) is real elapsed time in
+    which another session on a shared/agency account could transition the
+    campaign. Re-reading via ``_find_master_row(..., status="all")``
+    (so even an unexpected status is still caught, not silently excluded by
+    a narrower filter) immediately before the click closes that window,
+    mirroring ``delete_master``'s "never click against an unconfirmed
+    state" convention.
+
+    Returns the freshly re-read row on success. Raises
+    ``BrowserSessionError`` naming ``action_label`` (e.g. "Архивировать",
+    "Клонировать") if the row vanished entirely or its status no longer
+    matches ``expected_status`` — appending ``not_found_hint``/
+    ``changed_status_hint`` to each case respectively, for a caller-specific
+    pointer to the right next step (mirrors ``delete_master``'s own
+    "use `masters archive` instead" hint).
+    """
+    current = _find_master_row(page, campaign_id, status="all")
+    if current is None:
+        hint = f" {not_found_hint}" if not_found_hint else ""
+        raise BrowserSessionError(
+            f"Campaign {campaign_id} was {expected_status} moments ago but "
+            "is no longer in the campaigns grid at all — it may have just "
+            f"been removed by another session. Not clicking "
+            f"'{action_label}'.{hint}"
+        )
+    if current["Status"] != expected_status:
+        hint = f" {changed_status_hint}" if changed_status_hint else ""
+        raise BrowserSessionError(
+            f"Campaign {campaign_id} was {expected_status} moments ago but "
+            f"is now {current['Status']} — another session likely changed "
+            f"it concurrently. Not clicking '{action_label}'.{hint}"
+        )
+    return current
+
+
+def _poll_master_row_tolerant(
+    page: "Page",
+    campaign_id: int,
+    *,
+    timeout_ms: int,
+    is_done: "Callable[[Optional[Dict[str, Any]]], bool]",
+) -> Tuple[Optional[Dict[str, Any]], Optional[BrowserSessionError]]:
+    """Poll ``_find_master_row`` until ``is_done`` is satisfied or
+    ``timeout_ms`` elapses, tolerating transient ``BrowserSessionError``s
+    instead of letting the first one abort the loop (issue #797, same shape
+    as ``delete_master``'s own tolerant verify loop, issue #793 Finding 2).
+
+    The caller's own click has already happened by the time this runs —
+    immediate and, for every ``masters`` action but ``suspend``/``resume``,
+    irreversible — so a mid-poll ``BrowserSessionError`` from
+    ``_find_master_row`` (HTTP 5xx, non-JSON, captcha, mid-poll session
+    expiry) must not read as "the action failed" when it almost certainly
+    already succeeded. Each error is treated as an inconclusive poll: the
+    loop keeps going until the deadline rather than propagating immediately.
+
+    Returns ``(last_row, last_error)``. ``last_row`` is the most recent
+    successful read (``None`` if every poll errored, or if the row
+    genuinely was not found while ``is_done`` kept requesting more).
+    ``last_error`` is the most recent ``BrowserSessionError``, cleared back
+    to ``None`` on the next successful poll — so a caller can tell "timed
+    out with a transient error on the final poll" (report that error, per
+    ``delete_master``'s "click already landed" message) apart from "timed
+    out with a clean but not-yet-matching read" (report a plain timeout).
+    """
+    deadline = _clock.now() + timeout_ms / 1000
+    last_row: Optional[Dict[str, Any]] = None
+    last_error: Optional[BrowserSessionError] = None
+    while _clock.now() < deadline:
+        try:
+            last_row = _find_master_row(page, campaign_id, status="all")
+            last_error = None
+        except BrowserSessionError as exc:
+            last_error = exc
+            page.wait_for_timeout(250)
+            continue
+        if is_done(last_row):
+            break
+        page.wait_for_timeout(250)
+    return last_row, last_error
+
+
 def _click_menu_item(
     page: "Page",
     campaign_id: int,
     *,
     item_selector: str,
     item_label: str,
+    pre_click_check: "Optional[Callable[[], None]]" = None,
 ) -> None:
     """Open the overview page's "⋮" menu and click ``item_selector``.
 
@@ -2770,6 +2868,14 @@ def _click_menu_item(
     ``data-testid`` selectors, not guessed text (see module docstring).
     Reuses ``_click_and_wait_for_popup`` for its hydration-race retries
     (issues #723/#725) rather than duplicating that click logic here.
+
+    ``pre_click_check`` (issue #797), if given, runs AFTER the menu is
+    confirmed open but BEFORE ``item_selector`` is clicked — the narrowest
+    possible window for a caller's own TOCTOU re-check (e.g.
+    ``archive_master``'s ``_reverify_status_or_raise``) to still catch a
+    status change that happened while the menu was opening, without
+    re-introducing the wider window a re-check placed before this whole
+    function would leave between itself and the actual click.
     """
     try:
         _click_and_wait_for_popup(
@@ -2784,6 +2890,9 @@ def _click_menu_item(
             f"'{item_label}' ({_MENU_TRIGGER_SELECTOR!r} / {item_selector!r}) "
             "— Yandex may have changed the overview page's markup."
         ) from exc
+
+    if pre_click_check is not None:
+        pre_click_check()
 
     item = page.locator(item_selector).first
     try:
@@ -2817,6 +2926,23 @@ def archive_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
     and re-reads the campaigns grid via ``fetch_masters_list`` to confirm
     ``Status == "ARCHIVED"`` before reporting success — never trusting the
     click alone.
+
+    Re-verifies SUSPENDED status a SECOND time immediately before the click
+    (issue #797, same TOCTOU shape as ``delete_master``'s own re-check,
+    issue #793 Finding 1): the up-front guard above and the click are
+    separated by ``_goto_overview_page``, an optional ``suspend_master``
+    round trip, and the "⋮" menu's own open-then-find retry loop — real
+    elapsed time in which another session on a shared/agency account could
+    move the campaign again. "Архивировать" is never clicked against a row
+    this function has not just re-confirmed is still SUSPENDED (see
+    ``_reverify_status_or_raise``).
+
+    The post-click verify loop tolerates transient ``BrowserSessionError``s
+    from ``_find_master_row`` (issue #797, same tolerant-poll shape as
+    issue #793 Finding 2, via ``_poll_master_row_tolerant``) instead of
+    letting one propagate as a hard failure: the click is immediate, so a
+    mid-poll HTTP 5xx/captcha/auth blip must not read as "the archive
+    failed" when it may have already succeeded.
     """
     existing = _find_master_row(page, campaign_id)
     if existing is None:
@@ -2841,22 +2967,41 @@ def archive_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
         suspend_master(page, campaign_id)
         _goto_overview_page(page, campaign_id)
 
+    def _reverify_suspended():
+        _reverify_status_or_raise(
+            page,
+            campaign_id,
+            expected_status="SUSPENDED",
+            action_label="Архивировать",
+            changed_status_hint="Re-run `masters archive` if you still "
+            "intend to archive it.",
+        )
+
     _click_menu_item(
         page,
         campaign_id,
         item_selector=_ARCHIVE_MENU_ITEM_SELECTOR,
         item_label="Архивировать",
+        pre_click_check=_reverify_suspended,
     )
 
-    deadline = _clock.now() + _ARCHIVE_VERIFY_TIMEOUT_MS / 1000
-    updated = existing
-    while _clock.now() < deadline:
-        updated = _find_master_row(page, campaign_id)
-        if updated is not None and updated["Status"] == "ARCHIVED":
-            break
-        page.wait_for_timeout(250)
+    updated, verify_exc = _poll_master_row_tolerant(
+        page,
+        campaign_id,
+        timeout_ms=_ARCHIVE_VERIFY_TIMEOUT_MS,
+        is_done=lambda row: row is not None and row["Status"] == "ARCHIVED",
+    )
 
     if updated is None or updated["Status"] != "ARCHIVED":
+        if verify_exc is not None:
+            raise BrowserSessionError(
+                f"Clicked 'Архивировать' for campaign {campaign_id} — the "
+                "click itself landed and was NOT rejected, but the "
+                "campaigns grid could not be re-read to confirm the "
+                f"archive within {_ARCHIVE_VERIFY_TIMEOUT_MS / 1000:.0f}s "
+                f"({verify_exc}). Check the campaign's status in the UI "
+                "before retrying."
+            ) from verify_exc
         raise BrowserSessionError(
             f"Clicked 'Архивировать' for campaign {campaign_id}, but the "
             f"campaigns grid did not report it as ARCHIVED within "
@@ -3295,6 +3440,24 @@ def copy_master(
     created but not launched, mirroring ``masters add``'s ``--draft``
     default. ``launch=True`` clicks "Запустить кампанию" instead, launching
     the copy immediately in production.
+
+    Re-verifies the source campaign's status a SECOND time immediately
+    before the "Клонировать" click (issue #797, same TOCTOU shape as
+    ``delete_master``'s own re-check, issue #793 Finding 1, via the shared
+    ``_reverify_status_or_raise``): the up-front guard above and this click
+    are separated by ``_goto_overview_page`` and the "⋮" menu's own
+    open-then-find retry loop — real elapsed time in which another session
+    on a shared/agency account could change or remove the campaign. This
+    matters more here than for archive/delete: ``copy_master`` is
+    explicitly non-idempotent (see above) — clicking against a row that
+    quietly changed underneath this function is a worse failure mode than
+    for an idempotent action, since a caller who retries after a false
+    failure risks creating an unwanted duplicate campaign. The re-check
+    requires the status to still match what this function itself just read
+    (``expected_status=existing["Status"]``) — unlike
+    ``archive_master``/``delete_master``, cloning has no single required
+    status, so "changed at all" (not "changed to some specific wrong
+    value") is the signal this function treats as unsafe to click through.
     """
     existing = _find_master_row(page, campaign_id)
     if existing is None:
@@ -3319,6 +3482,16 @@ def copy_master(
             f"{_CLONE_MENU_ITEM_SELECTOR!r}) — Yandex may have changed the "
             "overview page's markup."
         ) from exc
+
+    _reverify_status_or_raise(
+        page,
+        campaign_id,
+        expected_status=existing["Status"],
+        action_label="Клонировать",
+        changed_status_hint="Re-run `masters copy` if you still intend to "
+        "clone it — this is not idempotent, so check first whether an "
+        "earlier attempt already created a copy.",
+    )
 
     clone_item = page.locator(_CLONE_MENU_ITEM_SELECTOR).first
     try:
@@ -3360,31 +3533,38 @@ def copy_master(
     # The clone/terminal-button click above already happened — irreversible,
     # not idempotent (a retry would re-click and create a SECOND copy). If
     # the saved session is invalidated in exactly this window,
-    # fetch_masters_list's own assert_authenticated raises BrowserAuthError;
-    # letting that propagate as-is would make _with_session
+    # fetch_masters_list's own assert_authenticated raises BrowserAuthError
+    # — a narrower subclass of BrowserSessionError, which _poll_master_row_
+    # tolerant below already treats as a tolerable transient poll error, not
+    # just this specific subclass (issue #797, same "any BrowserSessionError
+    # is transient, not just BrowserAuthError" fix as archive_master; the
+    # previous version here only caught BrowserAuthError, so a plain
+    # transient HTTP 5xx/captcha still propagated raw). Letting any such
+    # error propagate unguarded would make _with_session
     # (direct_cli/commands/masters.py) retry this ENTIRE function under a
-    # fresh session, silently duplicating the campaign. Re-raise as a plain
-    # BrowserSessionError so that retry does not trigger, and name new_id so
+    # fresh session, silently duplicating the campaign — so a timeout while
+    # every poll errored still raises a plain BrowserSessionError (never a
+    # BrowserAuthError) so that retry does not trigger, and names new_id so
     # the caller can check the clone that already exists instead of losing
     # track of it.
-    updated = None
-    deadline = _clock.now() + _CLONE_VERIFY_TIMEOUT_MS / 1000
-    try:
-        while _clock.now() < deadline:
-            updated = _find_master_row(page, new_id, status="all")
-            if updated is not None:
-                break
-            page.wait_for_timeout(250)
-    except BrowserAuthError as exc:
-        raise BrowserSessionError(
-            f"Yandex redirected to campaign {new_id} after cloning "
-            f"{campaign_id}, but the session was invalidated while "
-            "verifying it in the campaigns grid — the clone was likely "
-            f"created; check campaign {new_id} manually rather than "
-            "retrying (this is not idempotent)."
-        ) from exc
+    updated, verify_exc = _poll_master_row_tolerant(
+        page,
+        new_id,
+        timeout_ms=_CLONE_VERIFY_TIMEOUT_MS,
+        is_done=lambda row: row is not None,
+    )
 
     if updated is None:
+        if verify_exc is not None:
+            raise BrowserSessionError(
+                f"Yandex redirected to campaign {new_id} after cloning "
+                f"{campaign_id} — the redirect itself happened and the "
+                "clone was likely created, but the campaigns grid could "
+                f"not be re-read to confirm it within "
+                f"{_CLONE_VERIFY_TIMEOUT_MS / 1000:.0f}s ({verify_exc}). "
+                f"Check campaign {new_id} manually rather than retrying "
+                "(this is not idempotent)."
+            ) from verify_exc
         raise BrowserSessionError(
             f"Yandex redirected to campaign {new_id} after cloning "
             f"{campaign_id}, but it did not appear in the campaigns grid "

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -3955,7 +3955,9 @@ class TestArchiveMaster(unittest.TestCase):
             "StartDate": "2025-01-01",
         }
 
-    def _page_with_menu(self, menu_trigger=None, archive_item=None):
+    def _page_with_menu(
+        self, menu_trigger=None, archive_item=None, body_text="Кампания остановлена"
+    ):
         locators = {}
         if menu_trigger is not None:
             locators[browser_masters._MENU_TRIGGER_SELECTOR] = _FakeLocator(
@@ -3965,7 +3967,7 @@ class TestArchiveMaster(unittest.TestCase):
             locators[browser_masters._ARCHIVE_MENU_ITEM_SELECTOR] = _FakeLocator(
                 [archive_item]
             )
-        return FakePage(locators=locators)
+        return FakePage(locators=locators, body_text=body_text)
 
     def test_archives_and_verifies_via_grid(self):
         # "SUSPENDED" (not the raw grid "STOPPED") -- see the comment on
@@ -3977,9 +3979,16 @@ class TestArchiveMaster(unittest.TestCase):
         def _flip():
             state["status"] = "ARCHIVED"
 
+        # The TOCTOU re-check (issue #797) reads the overview page's own
+        # status text (_read_status_text), NOT the campaigns grid --
+        # navigating to the grid mid-recheck would destroy the "⋮" menu this
+        # test's archive_item click depends on (see _reverify_status_or_raise's
+        # docstring). "Кампания остановлена" is _read_status_text's own
+        # SUSPENDED marker.
         page = self._page_with_menu(
             menu_trigger=_FakeLocatorHandle(),
             archive_item=_FakeLocatorHandle(on_click=_flip),
+            body_text="Кампания остановлена",
         )
 
         with patch(
@@ -4056,6 +4065,7 @@ class TestArchiveMaster(unittest.TestCase):
         page = self._page_with_menu(
             menu_trigger=_FakeLocatorHandle(),
             archive_item=_FakeLocatorHandle(),
+            body_text="Кампания остановлена",
         )
 
         with patch(
@@ -4162,27 +4172,26 @@ class TestArchiveMaster(unittest.TestCase):
 
     def test_toctou_aborts_without_clicking_when_status_changed_before_click(self):
         # issue #797 Finding 1 (same TOCTOU shape as delete_master, issue
-        # #793 Finding 1): the up-front guard reads SUSPENDED once, but
-        # opening the "⋮" menu (_click_and_wait_for_popup's own retry loop)
-        # takes real time -- another session could move the campaign off
-        # SUSPENDED before 'Архивировать' is clicked. fetch_masters_list is
-        # called: once for the up-front guard, once for the TOCTOU re-check
-        # right after the menu opens but before the item click. Flip status
-        # on the second call.
-        calls = {"n": 0}
+        # #793 Finding 1): the up-front guard reads SUSPENDED once via
+        # fetch_masters_list, but opening the "⋮" menu
+        # (_click_and_wait_for_popup's own retry loop) takes real time --
+        # another session could move the campaign off SUSPENDED before
+        # 'Архивировать' is clicked. The TOCTOU re-check itself reads the
+        # overview page's own status text (_read_status_text), not the grid
+        # (see _reverify_status_or_raise's docstring for why) -- flip the
+        # page's body text to ACTIVE to model that concurrent change.
         archive_clicked = []
-
-        def _fetch(page, status="all"):
-            calls["n"] += 1
-            status_now = "SUSPENDED" if calls["n"] == 1 else "ACTIVE"
-            return [self._row(status_now)]
 
         page = self._page_with_menu(
             menu_trigger=_FakeLocatorHandle(),
             archive_item=_FakeLocatorHandle(on_click=lambda: archive_clicked.append(1)),
+            body_text="Кампания активна",
         )
 
-        with patch("direct_cli.browser.masters.fetch_masters_list", side_effect=_fetch):
+        with patch(
+            "direct_cli.browser.masters.fetch_masters_list",
+            return_value=[self._row("SUSPENDED")],
+        ):
             with self.assertRaises(BrowserSessionError) as ctx:
                 browser_masters.archive_master(page, 42)
 
@@ -4192,28 +4201,25 @@ class TestArchiveMaster(unittest.TestCase):
         self.assertEqual(archive_clicked, [])
 
     def test_toctou_aborts_without_clicking_when_campaign_vanished_before_click(self):
-        # Same TOCTOU window, but the row disappeared entirely (e.g.
-        # archived or deleted by another session) rather than merely
-        # changing status.
-        calls = {"n": 0}
+        # Same TOCTOU window, but the overview page no longer shows a
+        # recognised status text (e.g. archived or deleted by another
+        # session) rather than merely showing a different one.
         archive_clicked = []
-
-        def _fetch(page, status="all"):
-            calls["n"] += 1
-            if calls["n"] == 1:
-                return [self._row("SUSPENDED")]
-            return []
 
         page = self._page_with_menu(
             menu_trigger=_FakeLocatorHandle(),
             archive_item=_FakeLocatorHandle(on_click=lambda: archive_clicked.append(1)),
+            body_text="",
         )
 
-        with patch("direct_cli.browser.masters.fetch_masters_list", side_effect=_fetch):
+        with patch(
+            "direct_cli.browser.masters.fetch_masters_list",
+            return_value=[self._row("SUSPENDED")],
+        ):
             with self.assertRaises(BrowserSessionError) as ctx:
                 browser_masters.archive_master(page, 42)
 
-        self.assertIn("no longer", str(ctx.exception))
+        self.assertIn("no longer shows a recognised status", str(ctx.exception))
         self.assertEqual(archive_clicked, [])
 
     def test_verify_loop_tolerates_transient_error_then_succeeds(self):
@@ -4221,7 +4227,9 @@ class TestArchiveMaster(unittest.TestCase):
         # issue #793 Finding 2): a transient BrowserSessionError on the
         # FIRST poll after a successful, irreversible click must not
         # propagate -- it must be treated as inconclusive and polling must
-        # continue.
+        # continue. The TOCTOU re-check (before the click) reads the
+        # overview page's own status text, not fetch_masters_list, so every
+        # fetch_masters_list call here is a POST-click verify poll.
         state = {"status": "SUSPENDED"}
         poll_calls = {"n": 0}
 
@@ -4230,22 +4238,23 @@ class TestArchiveMaster(unittest.TestCase):
 
         def _fetch(page, status="all"):
             poll_calls["n"] += 1
-            # Call 1: up-front guard. Call 2: TOCTOU re-check. Call 3: first
-            # verify poll -- raise here. Call 4+: verify polls succeed.
-            if poll_calls["n"] == 3:
+            # Call 1: up-front guard. Call 2: first verify poll -- raise
+            # here. Call 3+: verify polls succeed.
+            if poll_calls["n"] == 2:
                 raise BrowserSessionError("Campaigns grid API returned HTTP 500")
             return [self._row(state["status"])]
 
         page = self._page_with_menu(
             menu_trigger=_FakeLocatorHandle(),
             archive_item=_FakeLocatorHandle(on_click=_archive),
+            body_text="Кампания остановлена",
         )
 
         with patch("direct_cli.browser.masters.fetch_masters_list", side_effect=_fetch):
             result = browser_masters.archive_master(page, 42)
 
         self.assertEqual(result, self._row("ARCHIVED"))
-        self.assertGreaterEqual(poll_calls["n"], 4)
+        self.assertGreaterEqual(poll_calls["n"], 3)
 
     def test_verify_loop_reports_click_already_landed_when_every_poll_errors(self):
         # issue #797 Finding 2: if every poll until the deadline errors, the
@@ -4255,14 +4264,16 @@ class TestArchiveMaster(unittest.TestCase):
         page = self._page_with_menu(
             menu_trigger=_FakeLocatorHandle(),
             archive_item=_FakeLocatorHandle(),
+            body_text="Кампания остановлена",
         )
 
         calls = {"n": 0}
 
         def _fetch(page, status="all"):
             calls["n"] += 1
-            if calls["n"] <= 2:
-                # up-front guard + TOCTOU re-check both see SUSPENDED.
+            if calls["n"] <= 1:
+                # up-front guard sees SUSPENDED (the TOCTOU re-check reads
+                # the overview page's own status text, not the grid).
                 return [self._row("SUSPENDED")]
             raise BrowserSessionError("Campaigns grid API returned HTTP 500")
 
@@ -4272,6 +4283,35 @@ class TestArchiveMaster(unittest.TestCase):
 
         self.assertIn("landed", str(ctx.exception))
         self.assertIn("HTTP 500", str(ctx.exception))
+
+    def test_verify_loop_reraises_auth_error_for_with_sessions_auto_heal(self):
+        # cycle-review finding on issue #797: unlike copy_master (not
+        # idempotent -- a retried click would create a SECOND campaign, so
+        # it deliberately keeps BrowserAuthError wrapped as a plain
+        # BrowserSessionError), archive_master IS idempotent (see the
+        # already-ARCHIVED early return). _poll_master_row_tolerant
+        # tolerates every BrowserSessionError including BrowserAuthError
+        # (issue #797 Finding 2), so without this re-raise a session that
+        # expires mid-poll would surface as a generic timeout instead of
+        # letting _with_session (direct_cli/commands/masters.py) retry the
+        # whole idempotent call under a fresh session.
+        page = self._page_with_menu(
+            menu_trigger=_FakeLocatorHandle(),
+            archive_item=_FakeLocatorHandle(),
+            body_text="Кампания остановлена",
+        )
+
+        calls = {"n": 0}
+
+        def _fetch(page, status="all"):
+            calls["n"] += 1
+            if calls["n"] <= 1:
+                return [self._row("SUSPENDED")]
+            raise BrowserAuthError("stale session, detected mid-poll")
+
+        with patch("direct_cli.browser.masters.fetch_masters_list", side_effect=_fetch):
+            with self.assertRaises(BrowserAuthError):
+                browser_masters.archive_master(page, 42)
 
 
 class TestMastersArchiveCommand(unittest.TestCase):
@@ -5184,7 +5224,7 @@ class TestCopyMaster(unittest.TestCase):
     SOURCE_ID = 42
     NEW_ID = 4200
 
-    def _source_row(self, status="STOPPED"):
+    def _source_row(self, status="SUSPENDED"):
         return {
             "CampaignId": self.SOURCE_ID,
             "Name": "Мастер тестовый",
@@ -5209,6 +5249,7 @@ class TestCopyMaster(unittest.TestCase):
         step2_ready=True,
         terminal_button_text=None,
         redirect_on_click=True,
+        body_text="Кампания остановлена",
     ):
         locators = {}
         if menu_trigger is not None:
@@ -5224,7 +5265,12 @@ class TestCopyMaster(unittest.TestCase):
                 _FakeLocator([_FakeLocatorHandle()])
             )
 
-        page = FakePage(locators=locators)
+        # The TOCTOU re-check (issue #797) reads the overview page's own
+        # status text (_read_status_text), NOT the campaigns grid -- see
+        # _reverify_status_or_raise's docstring. Defaults to SOURCE_ID's
+        # default "STOPPED" grid status normalized to SUSPENDED's own
+        # _read_status_text marker.
+        page = FakePage(locators=locators, body_text=body_text)
 
         if terminal_button_text is not None:
 
@@ -5380,13 +5426,13 @@ class TestCopyMaster(unittest.TestCase):
         calls = []
 
         def _fetch_masters_list(page, status="all"):
-            # Call 1: the up-front source-campaign lookup. Call 2: issue
-            # #797's TOCTOU re-check right before the 'Клонировать' click
-            # (_reverify_status_or_raise) -- both must succeed. Only the
-            # post-click lookup (finding new_id), call 3+, hits the
-            # invalidated session.
+            # Call 1: the up-front source-campaign lookup (the TOCTOU
+            # re-check reads the overview page's own status text, not
+            # fetch_masters_list -- see _reverify_status_or_raise's
+            # docstring). Only the post-click lookup (finding new_id), call
+            # 2+, hits the invalidated session.
             calls.append(status)
-            if len(calls) <= 2:
+            if len(calls) <= 1:
                 return [self._source_row()]
             raise BrowserAuthError("stale session, detected mid-body")
 
@@ -5403,28 +5449,27 @@ class TestCopyMaster(unittest.TestCase):
     def test_toctou_aborts_without_clicking_when_status_changed_before_click(self):
         # issue #797 Finding 1 (same TOCTOU shape as delete_master, issue
         # #793 Finding 1): the up-front guard reads the source campaign's
-        # status once, but opening the "⋮" menu (_click_and_wait_for_popup's
-        # own retry loop) takes real time -- another session could change
-        # the campaign before 'Клонировать' is clicked. fetch_masters_list
-        # is called: once for the up-front guard, once for the TOCTOU
-        # re-check right after the menu opens but before the item click.
-        # Flip status on the second call -- copy_master has no single
-        # required status, so ANY change from what was first read is what
-        # this re-check refuses to click through.
-        calls = {"n": 0}
+        # status once via fetch_masters_list, but opening the "⋮" menu
+        # (_click_and_wait_for_popup's own retry loop) takes real time --
+        # another session could change the campaign before 'Клонировать' is
+        # clicked. The TOCTOU re-check itself reads the overview page's own
+        # status text (_read_status_text), not the grid (see
+        # _reverify_status_or_raise's docstring) -- flip the page's body
+        # text to ARCHIVED to model that concurrent change. copy_master has
+        # no single required status, so ANY change from what was first read
+        # is what this re-check refuses to click through.
         clone_clicked = []
-
-        def _fetch(page, status="all"):
-            calls["n"] += 1
-            status_now = "STOPPED" if calls["n"] == 1 else "ARCHIVED"
-            return [self._source_row(status=status_now)]
 
         page = self._page(
             menu_trigger=_FakeLocatorHandle(),
             clone_item=_FakeLocatorHandle(on_click=lambda: clone_clicked.append(1)),
+            body_text="Кампания в\xa0архиве",
         )
 
-        with patch("direct_cli.browser.masters.fetch_masters_list", side_effect=_fetch):
+        with patch(
+            "direct_cli.browser.masters.fetch_masters_list",
+            return_value=[self._source_row(status="STOPPED")],
+        ):
             with self.assertRaises(BrowserSessionError) as ctx:
                 browser_masters.copy_master(page, self.SOURCE_ID)
 
@@ -5434,28 +5479,25 @@ class TestCopyMaster(unittest.TestCase):
         self.assertEqual(clone_clicked, [])
 
     def test_toctou_aborts_without_clicking_when_campaign_vanished_before_click(self):
-        # Same TOCTOU window, but the row disappeared entirely (e.g. deleted
-        # or archived-and-purged by another session) rather than merely
-        # changing status.
-        calls = {"n": 0}
+        # Same TOCTOU window, but the overview page no longer shows a
+        # recognised status text (e.g. deleted or archived-and-purged by
+        # another session) rather than merely showing a different one.
         clone_clicked = []
-
-        def _fetch(page, status="all"):
-            calls["n"] += 1
-            if calls["n"] == 1:
-                return [self._source_row()]
-            return []
 
         page = self._page(
             menu_trigger=_FakeLocatorHandle(),
             clone_item=_FakeLocatorHandle(on_click=lambda: clone_clicked.append(1)),
+            body_text="",
         )
 
-        with patch("direct_cli.browser.masters.fetch_masters_list", side_effect=_fetch):
+        with patch(
+            "direct_cli.browser.masters.fetch_masters_list",
+            return_value=[self._source_row(status="STOPPED")],
+        ):
             with self.assertRaises(BrowserSessionError) as ctx:
                 browser_masters.copy_master(page, self.SOURCE_ID)
 
-        self.assertIn("no longer", str(ctx.exception))
+        self.assertIn("no longer shows a recognised status", str(ctx.exception))
         self.assertEqual(clone_clicked, [])
 
     def test_new_campaign_verify_loop_tolerates_transient_error_then_succeeds(self):
@@ -5477,10 +5519,11 @@ class TestCopyMaster(unittest.TestCase):
 
         def _fetch(page, status="all"):
             calls["n"] += 1
-            # Call 1: up-front guard. Call 2: TOCTOU re-check. Call 3: first
-            # post-click poll for NEW_ID -- raise here (transient, NOT an
-            # auth error). Call 4+: succeeds.
-            if calls["n"] == 3:
+            # Call 1: up-front guard (the TOCTOU re-check reads the
+            # overview page's own status text, not fetch_masters_list).
+            # Call 2: first post-click poll for NEW_ID -- raise here
+            # (transient, NOT an auth error). Call 3+: succeeds.
+            if calls["n"] == 2:
                 raise BrowserSessionError("Campaigns grid API returned HTTP 500")
             return [self._source_row(), self._new_row()]
 
@@ -5488,7 +5531,7 @@ class TestCopyMaster(unittest.TestCase):
             result = browser_masters.copy_master(page, self.SOURCE_ID)
 
         self.assertEqual(result["CampaignId"], self.NEW_ID)
-        self.assertGreaterEqual(calls["n"], 4)
+        self.assertGreaterEqual(calls["n"], 3)
 
     def test_new_campaign_verify_loop_reports_click_already_landed_when_every_poll_errors(  # noqa: E501
         self,
@@ -5508,8 +5551,9 @@ class TestCopyMaster(unittest.TestCase):
 
         def _fetch(page, status="all"):
             calls["n"] += 1
-            if calls["n"] <= 2:
-                # up-front guard + TOCTOU re-check both succeed.
+            if calls["n"] <= 1:
+                # up-front guard succeeds (the TOCTOU re-check reads the
+                # overview page's own status text, not fetch_masters_list).
                 return [self._source_row()]
             raise BrowserSessionError("Campaigns grid API returned HTTP 500")
 
@@ -11531,14 +11575,17 @@ class TestGotoOverviewPage(unittest.TestCase):
                     [_FakeLocatorHandle()]
                 ),
             },
+            # The TOCTOU re-check (issue #797) reads the overview page's own
+            # status text (_read_status_text), not fetch_masters_list -- see
+            # _reverify_status_or_raise's docstring.
+            body_text="Кампания остановлена",
         )
-        # "SUSPENDED" (not the raw grid "STOPPED") for the first two reads --
-        # fetch_masters_list itself normalizes STOPPED -> SUSPENDED before
-        # archive_master ever sees a row (_PRIMARY_STATUS_TO_CLI_STATUS), so
-        # the fixture must match what the real function returns. Three
-        # entries, not two: the up-front guard, issue #797's TOCTOU
-        # re-check right before the click (_reverify_status_or_raise), and
-        # the post-click verify poll.
+        # "SUSPENDED" (not the raw grid "STOPPED") -- fetch_masters_list
+        # itself normalizes STOPPED -> SUSPENDED before archive_master ever
+        # sees a row (_PRIMARY_STATUS_TO_CLI_STATUS), so the fixture must
+        # match what the real function returns. Two entries: the up-front
+        # guard, and the post-click verify poll (the TOCTOU re-check itself
+        # reads the overview page's body text above, not this mock).
         _row = {
             "CampaignId": 1,
             "Name": "x",
@@ -11549,7 +11596,6 @@ class TestGotoOverviewPage(unittest.TestCase):
         with patch(
             "direct_cli.browser.masters.fetch_masters_list",
             side_effect=[
-                [_row],
                 [_row],
                 [{**_row, "Status": "ARCHIVED"}],
             ],

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -4313,6 +4313,49 @@ class TestArchiveMaster(unittest.TestCase):
             with self.assertRaises(BrowserAuthError):
                 browser_masters.archive_master(page, 42)
 
+    def test_toctou_recheck_tolerates_status_text_hydration_lag(self):
+        # cycle-review finding (codex) on issue #797: _goto_overview_page
+        # only guarantees the title rendered (issue #683), not the status
+        # element -- _wait_for_recognised_status's own docstring documents
+        # it as a separate render pass that "routinely reads as None for a
+        # moment" right after. A single unguarded _read_status_text at the
+        # TOCTOU re-check would misattribute that hydration lag to
+        # "another session changed it" and abort a legitimate archive.
+        # This page's status text is empty for the first two reads (the
+        # lag), then hydrates to the real SUSPENDED marker -- the re-check
+        # must tolerate that instead of failing closed on the first read.
+        reads = {"n": 0}
+        archive_clicked = []
+
+        class _SlowStatusPage(FakePage):
+            def inner_text(self, selector=None):
+                reads["n"] += 1
+                if reads["n"] <= 2:
+                    return ""
+                return "Кампания остановлена"
+
+        page = _SlowStatusPage(
+            locators={
+                browser_masters._MENU_TRIGGER_SELECTOR: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                ),
+                browser_masters._ARCHIVE_MENU_ITEM_SELECTOR: _FakeLocator(
+                    [_FakeLocatorHandle(on_click=lambda: archive_clicked.append(1))]
+                ),
+            }
+        )
+
+        with patch(
+            "direct_cli.browser.masters.fetch_masters_list",
+            side_effect=lambda page, status="all": [
+                self._row("ARCHIVED" if archive_clicked else "SUSPENDED")
+            ],
+        ):
+            result = browser_masters.archive_master(page, 42)
+
+        self.assertEqual(result, self._row("ARCHIVED"))
+        self.assertEqual(archive_clicked, [1])
+
 
 class TestMastersArchiveCommand(unittest.TestCase):
     """CLI wiring for `masters archive` (issue #633)."""

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -5293,6 +5293,7 @@ class TestCopyMaster(unittest.TestCase):
         terminal_button_text=None,
         redirect_on_click=True,
         body_text="Кампания остановлена",
+        page_class=FakePage,
     ):
         locators = {}
         if menu_trigger is not None:
@@ -5312,8 +5313,10 @@ class TestCopyMaster(unittest.TestCase):
         # status text (_read_status_text), NOT the campaigns grid -- see
         # _reverify_status_or_raise's docstring. Defaults to SOURCE_ID's
         # default "STOPPED" grid status normalized to SUSPENDED's own
-        # _read_status_text marker.
-        page = FakePage(locators=locators, body_text=body_text)
+        # _read_status_text marker. page_class lets a test model the
+        # overview status text changing between the up-front read and the
+        # re-check's own read (both now come from the overview page).
+        page = page_class(locators=locators, body_text=body_text)
 
         if terminal_button_text is not None:
 
@@ -5356,6 +5359,40 @@ class TestCopyMaster(unittest.TestCase):
             page.navigated_to[0],
             browser_masters.WIZARD_OVERVIEW_URL.format(campaign_id=self.SOURCE_ID),
         )
+
+    def test_toctou_recheck_does_not_false_abort_on_grid_overview_status_mismatch(
+        self,
+    ):
+        # cycle-review finding (codex) on issue #797: the grid's
+        # primaryStatus vocabulary is broader than and can lag
+        # _read_status_text's four recognised values (module docstring
+        # documents a 45+s DRAFT->MODERATION lag) -- comparing the up-front
+        # grid-derived status against the re-check's overview-derived
+        # status would false-abort a legitimate, unchanged clone whenever
+        # the two sources disagree. Model that disagreement directly: the
+        # grid reports a status _read_status_text can't recognise at all
+        # (e.g. TEMPORARILY_PAUSED), while the overview page's own status
+        # text is a perfectly valid, UNCHANGING "Кампания остановлена". The
+        # re-check must compare against the overview's own up-front read
+        # (also "Кампания остановлена"), not the grid's, so it must NOT
+        # abort here.
+        page = self._page(
+            menu_trigger=_FakeLocatorHandle(),
+            clone_item=_FakeLocatorHandle(),
+            terminal_button_text=browser_masters._SAVE_DRAFT_BUTTON_TEXT,
+            body_text="Кампания остановлена",
+        )
+
+        with patch(
+            "direct_cli.browser.masters.fetch_masters_list",
+            side_effect=lambda page, status="all": [
+                self._source_row(status="TEMPORARILY_PAUSED"),
+                self._new_row(),
+            ],
+        ):
+            result = browser_masters.copy_master(page, self.SOURCE_ID)
+
+        self.assertEqual(result["CampaignId"], self.NEW_ID)
 
     def test_launch_true_clicks_launch_button(self):
         page = self._page(
@@ -5491,22 +5528,34 @@ class TestCopyMaster(unittest.TestCase):
 
     def test_toctou_aborts_without_clicking_when_status_changed_before_click(self):
         # issue #797 Finding 1 (same TOCTOU shape as delete_master, issue
-        # #793 Finding 1): the up-front guard reads the source campaign's
-        # status once via fetch_masters_list, but opening the "⋮" menu
-        # (_click_and_wait_for_popup's own retry loop) takes real time --
-        # another session could change the campaign before 'Клонировать' is
-        # clicked. The TOCTOU re-check itself reads the overview page's own
-        # status text (_read_status_text), not the grid (see
-        # _reverify_status_or_raise's docstring) -- flip the page's body
-        # text to ARCHIVED to model that concurrent change. copy_master has
-        # no single required status, so ANY change from what was first read
-        # is what this re-check refuses to click through.
+        # #793 Finding 1): the up-front status read (_wait_for_recognised_
+        # status, right after _goto_overview_page -- cycle-review finding:
+        # this must come from the SAME overview-page source the re-check
+        # itself reads, not the up-front grid guard) happens once, but
+        # opening the "⋮" menu (_click_and_wait_for_popup's own retry loop)
+        # takes real time -- another session could change the campaign
+        # before 'Клонировать' is clicked. Flip the page's body text to
+        # ARCHIVED on the SECOND read (the re-check) to model that
+        # concurrent change; the first read (up-front) still sees SUSPENDED.
+        # copy_master has no single required status, so ANY change from
+        # what was first read is what this re-check refuses to click
+        # through.
         clone_clicked = []
+        reads = {"n": 0}
+
+        class _StatusChangesPage(FakePage):
+            def inner_text(self, selector=None):
+                reads["n"] += 1
+                return (
+                    "Кампания остановлена"
+                    if reads["n"] == 1
+                    else "Кампания в\xa0архиве"
+                )
 
         page = self._page(
             menu_trigger=_FakeLocatorHandle(),
             clone_item=_FakeLocatorHandle(on_click=lambda: clone_clicked.append(1)),
-            body_text="Кампания в\xa0архиве",
+            page_class=_StatusChangesPage,
         )
 
         with patch(
@@ -5524,13 +5573,21 @@ class TestCopyMaster(unittest.TestCase):
     def test_toctou_aborts_without_clicking_when_campaign_vanished_before_click(self):
         # Same TOCTOU window, but the overview page no longer shows a
         # recognised status text (e.g. deleted or archived-and-purged by
-        # another session) rather than merely showing a different one.
+        # another session) rather than merely showing a different one. The
+        # up-front read still sees SUSPENDED; only the re-check's read goes
+        # unrecognised.
         clone_clicked = []
+        reads = {"n": 0}
+
+        class _StatusVanishesPage(FakePage):
+            def inner_text(self, selector=None):
+                reads["n"] += 1
+                return "Кампания остановлена" if reads["n"] == 1 else ""
 
         page = self._page(
             menu_trigger=_FakeLocatorHandle(),
             clone_item=_FakeLocatorHandle(on_click=lambda: clone_clicked.append(1)),
-            body_text="",
+            page_class=_StatusVanishesPage,
         )
 
         with patch(

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -3968,7 +3968,11 @@ class TestArchiveMaster(unittest.TestCase):
         return FakePage(locators=locators)
 
     def test_archives_and_verifies_via_grid(self):
-        state = {"status": "STOPPED"}
+        # "SUSPENDED" (not the raw grid "STOPPED") -- see the comment on
+        # test_raises_when_menu_trigger_not_found for why this must match
+        # fetch_masters_list's own normalized value (issue #797's TOCTOU
+        # re-check compares against it before the click).
+        state = {"status": "SUSPENDED"}
 
         def _flip():
             state["status"] = "ARCHIVED"
@@ -4019,9 +4023,15 @@ class TestArchiveMaster(unittest.TestCase):
     def test_raises_when_menu_trigger_not_found(self):
         page = self._page_with_menu()  # no menu_trigger locator registered
 
+        # "SUSPENDED" (not the raw grid "STOPPED") -- fetch_masters_list
+        # itself normalizes STOPPED -> SUSPENDED (_PRIMARY_STATUS_TO_CLI_
+        # STATUS) before archive_master ever sees a row, and issue #797's
+        # TOCTOU re-check (_reverify_status_or_raise) now compares against
+        # that normalized value, so the fixture must match what the real
+        # function returns, not the pre-normalization grid string.
         with patch(
             "direct_cli.browser.masters.fetch_masters_list",
-            return_value=[self._row("STOPPED")],
+            return_value=[self._row("SUSPENDED")],
         ):
             with self.assertRaises(BrowserSessionError) as ctx:
                 browser_masters.archive_master(page, 42)
@@ -4033,7 +4043,7 @@ class TestArchiveMaster(unittest.TestCase):
 
         with patch(
             "direct_cli.browser.masters.fetch_masters_list",
-            return_value=[self._row("STOPPED")],
+            return_value=[self._row("SUSPENDED")],
         ):
             with self.assertRaises(BrowserSessionError) as ctx:
                 browser_masters.archive_master(page, 42)
@@ -4041,8 +4051,8 @@ class TestArchiveMaster(unittest.TestCase):
         self.assertIn("Архивировать", str(ctx.exception))
 
     def test_raises_when_status_never_becomes_archived(self):
-        # The click succeeds but the grid keeps reporting STOPPED -- must not
-        # report success on the click alone.
+        # The click succeeds but the grid keeps reporting SUSPENDED -- must
+        # not report success on the click alone.
         page = self._page_with_menu(
             menu_trigger=_FakeLocatorHandle(),
             archive_item=_FakeLocatorHandle(),
@@ -4050,7 +4060,7 @@ class TestArchiveMaster(unittest.TestCase):
 
         with patch(
             "direct_cli.browser.masters.fetch_masters_list",
-            return_value=[self._row("STOPPED")],
+            return_value=[self._row("SUSPENDED")],
         ):
             with self.assertRaises(BrowserSessionError) as ctx:
                 browser_masters.archive_master(page, 42)
@@ -4111,13 +4121,21 @@ class TestArchiveMaster(unittest.TestCase):
         # for SUSPENDED, THEN open the menu and click "Архивировать".
         page, state = self._active_page_with_suspend_and_menu("Остановить кампанию")
 
+        # Grid status by state, mirroring fetch_masters_list's own
+        # normalized "SUSPENDED" (issue #797's TOCTOU re-check,
+        # _reverify_status_or_raise, requires the grid to actually report
+        # SUSPENDED once suspend_master's own poll sees the overview page's
+        # "Кампания остановлена" text -- not still ACTIVE).
+        def _status_for_grid():
+            if state["status"] == "ARCHIVED_VIA_MENU":
+                return "ARCHIVED"
+            if state["status"] == "Кампания остановлена":
+                return "SUSPENDED"
+            return "ACTIVE"
+
         with patch(
             "direct_cli.browser.masters.fetch_masters_list",
-            side_effect=lambda page, status="all": [
-                self._row(
-                    "ARCHIVED" if state["status"] == "ARCHIVED_VIA_MENU" else "ACTIVE"
-                )
-            ],
+            side_effect=lambda page, status="all": [self._row(_status_for_grid())],
         ):
             result = browser_masters.archive_master(page, 42)
 
@@ -4127,19 +4145,133 @@ class TestArchiveMaster(unittest.TestCase):
         page, state = self._active_page_with_suspend_and_menu("Остановить кампанию")
         state["status"] = "Кампания на\xa0модерации"
 
+        def _status_for_grid():
+            if state["status"] == "ARCHIVED_VIA_MENU":
+                return "ARCHIVED"
+            if state["status"] == "Кампания остановлена":
+                return "SUSPENDED"
+            return "MODERATION"
+
         with patch(
             "direct_cli.browser.masters.fetch_masters_list",
-            side_effect=lambda page, status="all": [
-                self._row(
-                    "ARCHIVED"
-                    if state["status"] == "ARCHIVED_VIA_MENU"
-                    else "MODERATION"
-                )
-            ],
+            side_effect=lambda page, status="all": [self._row(_status_for_grid())],
         ):
             result = browser_masters.archive_master(page, 42)
 
         self.assertEqual(result, self._row("ARCHIVED"))
+
+    def test_toctou_aborts_without_clicking_when_status_changed_before_click(self):
+        # issue #797 Finding 1 (same TOCTOU shape as delete_master, issue
+        # #793 Finding 1): the up-front guard reads SUSPENDED once, but
+        # opening the "⋮" menu (_click_and_wait_for_popup's own retry loop)
+        # takes real time -- another session could move the campaign off
+        # SUSPENDED before 'Архивировать' is clicked. fetch_masters_list is
+        # called: once for the up-front guard, once for the TOCTOU re-check
+        # right after the menu opens but before the item click. Flip status
+        # on the second call.
+        calls = {"n": 0}
+        archive_clicked = []
+
+        def _fetch(page, status="all"):
+            calls["n"] += 1
+            status_now = "SUSPENDED" if calls["n"] == 1 else "ACTIVE"
+            return [self._row(status_now)]
+
+        page = self._page_with_menu(
+            menu_trigger=_FakeLocatorHandle(),
+            archive_item=_FakeLocatorHandle(on_click=lambda: archive_clicked.append(1)),
+        )
+
+        with patch("direct_cli.browser.masters.fetch_masters_list", side_effect=_fetch):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters.archive_master(page, 42)
+
+        self.assertIn("is now", str(ctx.exception))
+        self.assertIn("ACTIVE", str(ctx.exception))
+        self.assertIn("Not clicking", str(ctx.exception))
+        self.assertEqual(archive_clicked, [])
+
+    def test_toctou_aborts_without_clicking_when_campaign_vanished_before_click(self):
+        # Same TOCTOU window, but the row disappeared entirely (e.g.
+        # archived or deleted by another session) rather than merely
+        # changing status.
+        calls = {"n": 0}
+        archive_clicked = []
+
+        def _fetch(page, status="all"):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return [self._row("SUSPENDED")]
+            return []
+
+        page = self._page_with_menu(
+            menu_trigger=_FakeLocatorHandle(),
+            archive_item=_FakeLocatorHandle(on_click=lambda: archive_clicked.append(1)),
+        )
+
+        with patch("direct_cli.browser.masters.fetch_masters_list", side_effect=_fetch):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters.archive_master(page, 42)
+
+        self.assertIn("no longer", str(ctx.exception))
+        self.assertEqual(archive_clicked, [])
+
+    def test_verify_loop_tolerates_transient_error_then_succeeds(self):
+        # issue #797 Finding 2 (same tolerant-poll shape as delete_master,
+        # issue #793 Finding 2): a transient BrowserSessionError on the
+        # FIRST poll after a successful, irreversible click must not
+        # propagate -- it must be treated as inconclusive and polling must
+        # continue.
+        state = {"status": "SUSPENDED"}
+        poll_calls = {"n": 0}
+
+        def _archive():
+            state["status"] = "ARCHIVED"
+
+        def _fetch(page, status="all"):
+            poll_calls["n"] += 1
+            # Call 1: up-front guard. Call 2: TOCTOU re-check. Call 3: first
+            # verify poll -- raise here. Call 4+: verify polls succeed.
+            if poll_calls["n"] == 3:
+                raise BrowserSessionError("Campaigns grid API returned HTTP 500")
+            return [self._row(state["status"])]
+
+        page = self._page_with_menu(
+            menu_trigger=_FakeLocatorHandle(),
+            archive_item=_FakeLocatorHandle(on_click=_archive),
+        )
+
+        with patch("direct_cli.browser.masters.fetch_masters_list", side_effect=_fetch):
+            result = browser_masters.archive_master(page, 42)
+
+        self.assertEqual(result, self._row("ARCHIVED"))
+        self.assertGreaterEqual(poll_calls["n"], 4)
+
+    def test_verify_loop_reports_click_already_landed_when_every_poll_errors(self):
+        # issue #797 Finding 2: if every poll until the deadline errors, the
+        # final message must say the click already landed, not just repeat
+        # a generic "did not report it as ARCHIVED" (which would falsely
+        # suggest the click itself may not have worked).
+        page = self._page_with_menu(
+            menu_trigger=_FakeLocatorHandle(),
+            archive_item=_FakeLocatorHandle(),
+        )
+
+        calls = {"n": 0}
+
+        def _fetch(page, status="all"):
+            calls["n"] += 1
+            if calls["n"] <= 2:
+                # up-front guard + TOCTOU re-check both see SUSPENDED.
+                return [self._row("SUSPENDED")]
+            raise BrowserSessionError("Campaigns grid API returned HTTP 500")
+
+        with patch("direct_cli.browser.masters.fetch_masters_list", side_effect=_fetch):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters.archive_master(page, 42)
+
+        self.assertIn("landed", str(ctx.exception))
+        self.assertIn("HTTP 500", str(ctx.exception))
 
 
 class TestMastersArchiveCommand(unittest.TestCase):
@@ -5248,11 +5380,13 @@ class TestCopyMaster(unittest.TestCase):
         calls = []
 
         def _fetch_masters_list(page, status="all"):
-            # First call (before the click) looks up the source campaign and
-            # must succeed; only the post-click lookup (finding new_id) hits
-            # the invalidated session.
+            # Call 1: the up-front source-campaign lookup. Call 2: issue
+            # #797's TOCTOU re-check right before the 'Клонировать' click
+            # (_reverify_status_or_raise) -- both must succeed. Only the
+            # post-click lookup (finding new_id), call 3+, hits the
+            # invalidated session.
             calls.append(status)
-            if len(calls) == 1:
+            if len(calls) <= 2:
                 return [self._source_row()]
             raise BrowserAuthError("stale session, detected mid-body")
 
@@ -5265,6 +5399,128 @@ class TestCopyMaster(unittest.TestCase):
 
         self.assertNotIsInstance(ctx.exception, BrowserAuthError)
         self.assertIn(str(self.NEW_ID), str(ctx.exception))
+
+    def test_toctou_aborts_without_clicking_when_status_changed_before_click(self):
+        # issue #797 Finding 1 (same TOCTOU shape as delete_master, issue
+        # #793 Finding 1): the up-front guard reads the source campaign's
+        # status once, but opening the "⋮" menu (_click_and_wait_for_popup's
+        # own retry loop) takes real time -- another session could change
+        # the campaign before 'Клонировать' is clicked. fetch_masters_list
+        # is called: once for the up-front guard, once for the TOCTOU
+        # re-check right after the menu opens but before the item click.
+        # Flip status on the second call -- copy_master has no single
+        # required status, so ANY change from what was first read is what
+        # this re-check refuses to click through.
+        calls = {"n": 0}
+        clone_clicked = []
+
+        def _fetch(page, status="all"):
+            calls["n"] += 1
+            status_now = "STOPPED" if calls["n"] == 1 else "ARCHIVED"
+            return [self._source_row(status=status_now)]
+
+        page = self._page(
+            menu_trigger=_FakeLocatorHandle(),
+            clone_item=_FakeLocatorHandle(on_click=lambda: clone_clicked.append(1)),
+        )
+
+        with patch("direct_cli.browser.masters.fetch_masters_list", side_effect=_fetch):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters.copy_master(page, self.SOURCE_ID)
+
+        self.assertIn("is now", str(ctx.exception))
+        self.assertIn("ARCHIVED", str(ctx.exception))
+        self.assertIn("Not clicking", str(ctx.exception))
+        self.assertEqual(clone_clicked, [])
+
+    def test_toctou_aborts_without_clicking_when_campaign_vanished_before_click(self):
+        # Same TOCTOU window, but the row disappeared entirely (e.g. deleted
+        # or archived-and-purged by another session) rather than merely
+        # changing status.
+        calls = {"n": 0}
+        clone_clicked = []
+
+        def _fetch(page, status="all"):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return [self._source_row()]
+            return []
+
+        page = self._page(
+            menu_trigger=_FakeLocatorHandle(),
+            clone_item=_FakeLocatorHandle(on_click=lambda: clone_clicked.append(1)),
+        )
+
+        with patch("direct_cli.browser.masters.fetch_masters_list", side_effect=_fetch):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters.copy_master(page, self.SOURCE_ID)
+
+        self.assertIn("no longer", str(ctx.exception))
+        self.assertEqual(clone_clicked, [])
+
+    def test_new_campaign_verify_loop_tolerates_transient_error_then_succeeds(self):
+        # issue #797 Finding 2 (same tolerant-poll shape as delete_master,
+        # issue #793 Finding 2, and the same fix this module's own
+        # test_auth_error_during_post_click_verification_is_not_retried
+        # already covers for BrowserAuthError specifically): a transient
+        # plain BrowserSessionError on the FIRST post-click poll must not
+        # propagate -- it must be treated as inconclusive and polling must
+        # continue, unlike the pre-#797 code which only tolerated
+        # BrowserAuthError here.
+        page = self._page(
+            menu_trigger=_FakeLocatorHandle(),
+            clone_item=_FakeLocatorHandle(),
+            terminal_button_text=browser_masters._SAVE_DRAFT_BUTTON_TEXT,
+        )
+
+        calls = {"n": 0}
+
+        def _fetch(page, status="all"):
+            calls["n"] += 1
+            # Call 1: up-front guard. Call 2: TOCTOU re-check. Call 3: first
+            # post-click poll for NEW_ID -- raise here (transient, NOT an
+            # auth error). Call 4+: succeeds.
+            if calls["n"] == 3:
+                raise BrowserSessionError("Campaigns grid API returned HTTP 500")
+            return [self._source_row(), self._new_row()]
+
+        with patch("direct_cli.browser.masters.fetch_masters_list", side_effect=_fetch):
+            result = browser_masters.copy_master(page, self.SOURCE_ID)
+
+        self.assertEqual(result["CampaignId"], self.NEW_ID)
+        self.assertGreaterEqual(calls["n"], 4)
+
+    def test_new_campaign_verify_loop_reports_click_already_landed_when_every_poll_errors(  # noqa: E501
+        self,
+    ):
+        # issue #797 Finding 2: if every post-click poll until the deadline
+        # errors with a plain (non-auth) BrowserSessionError, the final
+        # message must say the clone was likely created, not just repeat a
+        # generic "did not appear in the campaigns grid" (which would
+        # falsely suggest cloning itself may not have worked).
+        page = self._page(
+            menu_trigger=_FakeLocatorHandle(),
+            clone_item=_FakeLocatorHandle(),
+            terminal_button_text=browser_masters._SAVE_DRAFT_BUTTON_TEXT,
+        )
+
+        calls = {"n": 0}
+
+        def _fetch(page, status="all"):
+            calls["n"] += 1
+            if calls["n"] <= 2:
+                # up-front guard + TOCTOU re-check both succeed.
+                return [self._source_row()]
+            raise BrowserSessionError("Campaigns grid API returned HTTP 500")
+
+        with patch("direct_cli.browser.masters.fetch_masters_list", side_effect=_fetch):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters.copy_master(page, self.SOURCE_ID)
+
+        self.assertNotIsInstance(ctx.exception, BrowserAuthError)
+        self.assertIn("likely created", str(ctx.exception))
+        self.assertIn(str(self.NEW_ID), str(ctx.exception))
+        self.assertIn("HTTP 500", str(ctx.exception))
 
 
 class TestMastersCopyCommand(unittest.TestCase):
@@ -11276,27 +11532,26 @@ class TestGotoOverviewPage(unittest.TestCase):
                 ),
             },
         )
+        # "SUSPENDED" (not the raw grid "STOPPED") for the first two reads --
+        # fetch_masters_list itself normalizes STOPPED -> SUSPENDED before
+        # archive_master ever sees a row (_PRIMARY_STATUS_TO_CLI_STATUS), so
+        # the fixture must match what the real function returns. Three
+        # entries, not two: the up-front guard, issue #797's TOCTOU
+        # re-check right before the click (_reverify_status_or_raise), and
+        # the post-click verify poll.
+        _row = {
+            "CampaignId": 1,
+            "Name": "x",
+            "Status": "SUSPENDED",
+            "Type": "TEXT",
+            "StartDate": "2025-01-01",
+        }
         with patch(
             "direct_cli.browser.masters.fetch_masters_list",
             side_effect=[
-                [
-                    {
-                        "CampaignId": 1,
-                        "Name": "x",
-                        "Status": "STOPPED",
-                        "Type": "TEXT",
-                        "StartDate": "2025-01-01",
-                    }
-                ],
-                [
-                    {
-                        "CampaignId": 1,
-                        "Name": "x",
-                        "Status": "ARCHIVED",
-                        "Type": "TEXT",
-                        "StartDate": "2025-01-01",
-                    }
-                ],
+                [_row],
+                [_row],
+                [{**_row, "Status": "ARCHIVED"}],
             ],
         ):
             browser_masters.archive_master(page, 1)


### PR DESCRIPTION
## Summary

Follow-up to PR #794 (delete_master hardening, closing #793/#791): local code review of that PR found `archive_master` and `copy_master` (`direct_cli/browser/masters.py`) share the exact same "read row → click → poll `_find_master_row`" shape but were left unhardened, tracked as issue #797.

**Finding 1 — TOCTOU race (both functions).** The up-front status guard was read once, well before each function's own irreversible click — on a shared/agency account another session could change the campaign's status in the real elapsed time spent navigating and opening the "⋮" menu. Both functions now re-verify status immediately before their click via a new shared `_reverify_status_or_raise` helper, aborting with an explicit message if the row vanished or its status changed.

- `archive_master`'s re-check runs via `_click_menu_item`'s new `pre_click_check` hook — fires right after the menu is confirmed open, right before the item click, the narrowest window achievable without splitting that function.
- `copy_master` requires the status to still match what it first read (`expected_status=existing["Status"]`) — cloning has no single required status the way archiving requires `SUSPENDED`, so "changed at all" is the unsafe signal here.

**Finding 2 — non-tolerant post-click verify loop (both functions, `copy_master` worse).** Both post-click verify loops let a transient `BrowserSessionError` from `_find_master_row` (HTTP 5xx/captcha/auth blip) propagate raw and abort, even though the click had already landed. `copy_master`'s loop only caught the narrower `BrowserAuthError`. Both now use a new shared `_poll_master_row_tolerant` helper (same tolerant-poll shape as `delete_master`'s own PR #794 fix) — a timeout while every poll errored reports that the click already landed, rather than reading like the action itself failed. This matters more for `copy_master`: it's explicitly non-idempotent, so a false failure risks a caller retrying into a duplicate campaign.

## Test changes

Fixed 5 pre-existing test fixtures that used the raw grid status string `"STOPPED"` instead of `fetch_masters_list`'s own normalized `"SUSPENDED"` — harmless before this fix (archive_master never compared against the intermediate status), now caught by the new TOCTOU re-check.

Added 8 new tests (4 each to `TestArchiveMaster`/`TestCopyMaster`) covering both findings, mirroring PR #794's own test additions for `delete_master`.

## Testing

- `pytest tests/test_masters.py` — 736 passed
- `pytest` (full offline suite) — 3385 passed, 23 skipped
- `black`/`flake8` clean

No live browser verification performed — this changes only error-handling/re-verification logic around existing click paths, same class of change as PR #794 which also shipped without a live archive/copy mutation run (`masters archive`/`masters copy` are DANGEROUS/manual-only per `smoke_matrix.py`).

Closes #797

🤖 Generated with [Claude Code](https://claude.com/claude-code)