### PR TITLE
feat(masters): add --add-metrika-counter/--remove-metrika-counter to `masters update`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@
 
 ### Added
 
+**`masters update --add-metrika-counter`/`--remove-metrika-counter` —
+"Счетчики Яндекс Метрики" section (#648, Этап C).**
+
+Offline implementation mirroring `--add-audience-tag`/`--remove-audience-tag`
+(#681) field-for-field: `--add-metrika-counter TEXT` types into the
+section's search input and clicks the matching autocomplete suggestion by
+its first line of text; `--remove-metrika-counter POSITION` removes a
+counter by its 0-based position via its close button. Testid shapes
+(`MetrikaCountersTagGroup.*`) were confirmed via live read-only recon
+(2026-08-06, campaign 713277109) covering the DOM before and immediately
+after opening the section's editor.
+
+**NOT LIVE-VERIFIED**: unlike the audience-tag flags this mirrors, the
+actual add/remove commit behaviour (whether a click reliably grows/shrinks
+the counter list, whether a save persists it, and what text a caller should
+actually pass — a domain, a numeric counter ID, or something else) has not
+been confirmed against a real Yandex session. See the module comment above
+`_METRIKA_COUNTER_WRAPPER_TESTID` in `direct_cli/browser/masters.py` for
+details. Treat this as an implementation-by-pattern pending a later live
+verification pass, not a confirmed-working feature.
+
 **`masters delete` — remove a DRAFT Мастер кампаний campaign (#782).**
 
 A DRAFT campaign was previously a one-way door: its overview page has no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,25 @@ counter by its 0-based position via its close button. Testid shapes
 (2026-08-06, campaign 713277109) covering the DOM before and immediately
 after opening the section's editor.
 
-**NOT LIVE-VERIFIED**: unlike the audience-tag flags this mirrors, the
-actual add/remove commit behaviour (whether a click reliably grows/shrinks
-the counter list, whether a save persists it, and what text a caller should
-actually pass — a domain, a numeric counter ID, or something else) has not
-been confirmed against a real Yandex session. See the module comment above
-`_METRIKA_COUNTER_WRAPPER_TESTID` in `direct_cli/browser/masters.py` for
-details. Treat this as an implementation-by-pattern pending a later live
-verification pass, not a confirmed-working feature.
+**`--add-metrika-counter`'s expected text CONFIRMED LIVE** (2026-08-06, via
+`mcp claude-in-chrome` against a real Chrome session — separate from the
+Playwright/Chrome-for-Testing browser this module normally drives): a
+suggestion's accessible text is one line shaped `"{label} • {domain/path}
+• {numeric counter id}"` (e.g. `"Ксамата • yandex.ru/maps • 88834924"`).
+Typing just the label is enough to surface the right suggestion
+interactively, but this flag needs the WHOLE string for the exact-match
+lookup to succeed.
+
+**Still NOT LIVE-VERIFIED**: whether `match.click()` actually commits the
+counter into the list and whether that persists through a save — the recon
+session closed the suggestion popup with Escape and reloaded the edit page
+without saving, specifically to avoid mutating this production campaign's
+counter set. See the `_add_metrika_counter` docstring in
+`direct_cli/browser/masters.py` for details, including a possible
+"leftover text after Escape" gap discovered during the same recon (mirrors
+issue #796's target-action price popup). Treat add/remove itself as an
+implementation-by-pattern pending a later live mutation verification pass,
+not a confirmed-working feature.
 
 **`masters delete` — remove a DRAFT Мастер кампаний campaign (#782).**
 

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -1481,6 +1481,69 @@ _AUDIENCE_TAG_STABLE_STREAK = 12
 _AUDIENCE_TAG_STABLE_TICK_MS = 500
 _AUDIENCE_TAG_STABLE_WINDOW_MS = 20_000
 
+# "Счетчики Яндекс Метрики" (MetrikaCountersTagGroup) — issue #648 Этап C.
+# Testid shapes confirmed via LIVE READ-ONLY RECON 2026-08-06, campaign
+# 713277109, mirroring the "Интересы и поисковые запросы"
+# (CustomAudienceAndSearchTermsEditor.TagGroup) widget's own testid family
+# one component name over: ``...tags-wrapper``, ``...tag.{index}``,
+# ``...tag.{index}.close``, ``...editor.Textinput``, ``...editor.listBox``
+# all exist under the ``MetrikaCountersTagGroup`` prefix instead. Recon only
+# covered the DOM BEFORE and immediately after clicking
+# ``MetrikaCountersTagGroup.launcher`` — the actual add/remove COMMIT
+# behaviour (whether a click reliably grows/shrinks the tag list, whether a
+# save persists it) is NOT live-verified, unlike the audience-tag functions
+# this module mirrors. Treat every function below as an offline
+# implementation-by-pattern pending live verification, not a confirmed-
+# working feature.
+#
+# One confirmed STRUCTURAL difference from audience tags: each "tag" here is
+# a whole Metrika counter (domain + numeric counter id + goal count), not a
+# single word/phrase — recon showed each ``...tag.{index}`` div containing
+# TWO separate ``[data-testid="Text"]`` spans, e.g. "gc.ksamata.ru •
+# 72112213" and "30 целей". ``_read_metrika_counters`` returns each tag's
+# whole ``inner_text()`` (both lines, newline-joined) rather than picking one
+# line, since which line (if either) is the "identity" a caller would want
+# to match on is not determined by recon — returning the full text is the
+# only choice that doesn't discard information un-verified.
+#
+# The other confirmed difference: unlike the audience-tag wrapper (always
+# clicked directly to mount its input), the Metrika counters wrapper
+# (``...tags-wrapper``) was already visible in the BEFORE-click recon
+# snapshot with a SEPARATE ``...launcher`` button alongside it — recon did
+# not click the wrapper itself, only the launcher. ``_add_metrika_counter``
+# therefore clicks the launcher, not the wrapper (see
+# ``_add_audience_tag``'s docstring for why ITS wrapper needs a
+# bottom-right-corner click instead of a plain center click on a large
+# campaign — that reasoning doesn't carry over here since recon never
+# exercised the wrapper-click path for this widget at all).
+#
+# Matching a typed suggestion in the popup: same "first line of the option's
+# text, not a constructed testid" convention as
+# ``_AUDIENCE_TAG_LISTBOX_TESTID`` (see that constant's module comment) —
+# recon found one example option testid containing a numeric id
+# (``editor.listBox.88834924``), but never confirmed whether that number is
+# the counter id (usable to build a locator) or something else (e.g. an
+# internal suggestion-row id), so this module does NOT construct a testid
+# from it, deliberately erring on the same conservative side
+# ``_add_audience_tag`` already established for exactly this kind of
+# unconfirmed numeric-id testid.
+_METRIKA_COUNTER_WRAPPER_TESTID = '[data-testid="MetrikaCountersTagGroup.tags-wrapper"]'
+_METRIKA_COUNTER_LAUNCHER_TESTID = '[data-testid="MetrikaCountersTagGroup.launcher"]'
+_METRIKA_COUNTER_INPUT_TESTID = (
+    '[data-testid="MetrikaCountersTagGroup.editor.Textinput"]'
+)
+_METRIKA_COUNTER_LISTBOX_TESTID = (
+    '[data-testid="MetrikaCountersTagGroup.editor.listBox"]'
+)
+_METRIKA_COUNTER_TESTID_TEMPLATE = "MetrikaCountersTagGroup.tag.{index}"
+_METRIKA_COUNTER_CLOSE_TESTID_TEMPLATE = "MetrikaCountersTagGroup.tag.{index}.close"
+
+# Reuses the same 5s budget ``_AUDIENCE_TAG_SUGGEST_TIMEOUT_MS`` uses for its
+# own autocomplete popup — no live timing recon exists yet for THIS widget's
+# popup specifically, so borrowing the sibling widget's already-calibrated
+# value is a more defensible default than inventing an unverified number.
+_METRIKA_COUNTER_SUGGEST_TIMEOUT_MS = _AUDIENCE_TAG_SUGGEST_TIMEOUT_MS
+
 # "Устройства пользователей" (DeviceEditor): a multi-select popup with
 # exactly three checkboxes, confirmed live all pre-checked by default
 # ("Любые" = all three checked, not a fourth distinct value) — mobile,
@@ -4725,6 +4788,189 @@ def _remove_audience_tag(page: "Page", index: int) -> None:
         ) from exc
 
 
+def _read_metrika_counters(page: "Page") -> List[str]:
+    """Read every currently linked Metrika counter's display text in
+    "Счетчики Яндекс Метрики" (in on-page order).
+
+    Mirrors ``_read_audience_tags``: the count isn't known ahead of time, so
+    this reads index 0, 1, 2, ... until a slot's ``inner_text()`` raises,
+    then stops. Each counter tag's text is TWO lines (domain + counter id on
+    the first, "N целей" on the second, per live recon — see the module
+    comment above ``_METRIKA_COUNTER_WRAPPER_TESTID``) — this returns the
+    WHOLE ``inner_text()`` (both lines) as one list entry rather than
+    splitting it, since recon never determined which line (if either) is a
+    caller-meaningful identity to isolate.
+
+    Waits for the tags-wrapper CONTAINER first, same hydration-race guard
+    ``_read_audience_tags`` uses — returns ``[]`` if it never appears rather
+    than raising, since an edit page whose audience section hasn't hydrated
+    yet is a normal, retriable state, not a markup-drift signal.
+    """
+    try:
+        page.locator(_METRIKA_COUNTER_WRAPPER_TESTID).first.wait_for(
+            state="attached", timeout=_METRIKA_COUNTER_SUGGEST_TIMEOUT_MS
+        )
+    except PlaywrightError:
+        return []
+
+    counters: List[str] = []
+    index = 0
+    while True:
+        selector = (
+            f'[data-testid="{_METRIKA_COUNTER_TESTID_TEMPLATE.format(index=index)}"]'
+        )
+        try:
+            text = page.locator(selector).first.inner_text(timeout=1_000).strip()
+        except PlaywrightError:
+            break
+        if not text:
+            break
+        counters.append(text)
+        index += 1
+    return counters
+
+
+def _add_metrika_counter(page: "Page", text: str) -> None:
+    """Add one Metrika counter to "Счетчики Яндекс Метрики" by typing
+    ``text`` into the counter search input and clicking the suggestion row
+    whose FIRST LINE exactly matches it.
+
+    NOT LIVE-VERIFIED (issue #648 recon, 2026-08-06, campaign 713277109):
+    the recon this module is based on confirmed the DOM shape before and
+    immediately after opening the editor, but never actually typed into the
+    input or clicked a suggestion — so the exact text a caller must pass
+    (a domain? a numeric counter id? something else Yandex's own suggestion
+    label shows?) is unconfirmed. This follows ``_add_audience_tag``'s
+    matching convention (first line of the option's full text, not a
+    constructed testid — see that function's docstring and the module
+    comment above ``_METRIKA_COUNTER_LISTBOX_TESTID`` for why) as the most
+    conservative choice available without a live browser, but the semantics
+    of what to pass as ``text`` need live confirmation before this is relied
+    on.
+
+    Unlike ``_add_audience_tag``, this clicks the dedicated
+    ``_METRIKA_COUNTER_LAUNCHER_TESTID`` button to open the editor rather
+    than the tags-wrapper itself — recon found a separate launcher button
+    for this widget (see the module comment above
+    ``_METRIKA_COUNTER_WRAPPER_TESTID``), so there is no equivalent of
+    ``_add_audience_tag``'s "click near the wrapper's bottom-right corner"
+    workaround to replicate here.
+
+    Raises ``BrowserSessionError`` if the launcher/input can't be
+    found/clicked/typed into, or if no suggestion whose first line matches
+    appears within ``_METRIKA_COUNTER_SUGGEST_TIMEOUT_MS``.
+    """
+    launcher = page.locator(_METRIKA_COUNTER_LAUNCHER_TESTID).first
+    try:
+        launcher.click()
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            "Could not click the 'Счетчики Яндекс Метрики' launcher button "
+            "on the campaign edit page — Yandex may have changed the "
+            "page's markup. Re-run with --headful to inspect the page."
+        ) from exc
+
+    field = page.locator(_METRIKA_COUNTER_INPUT_TESTID).first
+    try:
+        field.click()
+        cleared = _clear_text_field(field)
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            "Could not click the 'Счетчики Яндекс Метрики' counter input "
+            "on the campaign edit page — Yandex may have changed the "
+            "page's markup. Re-run with --headful to inspect the page."
+        ) from exc
+    if not cleared:
+        raise BrowserSessionError(
+            "Could not clear the 'Счетчики Яндекс Метрики' counter input "
+            "before typing. This usually means Playwright is older than "
+            "1.44 (the version that added the 'ControlOrMeta' modifier) — "
+            "upgrade with 'pip install -U playwright'."
+        )
+    try:
+        field.type(text)
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            f"Could not type {text!r} into the 'Счетчики Яндекс Метрики' "
+            "counter input on the campaign edit page — Yandex may have "
+            "changed the page's markup. Re-run with --headful to inspect "
+            "the page."
+        ) from exc
+
+    listbox = page.locator(_METRIKA_COUNTER_LISTBOX_TESTID).first
+    options = listbox.get_by_role("option")
+
+    def _find_matching_option():
+        try:
+            count = options.count()
+        except PlaywrightError:
+            return None
+        for i in range(count):
+            option = options.nth(i)
+            try:
+                first_line = option.inner_text(timeout=500).split("\n", 1)[0]
+            except PlaywrightError:
+                continue
+            if first_line == text:
+                return option
+        return None
+
+    deadline = _clock.now() + _METRIKA_COUNTER_SUGGEST_TIMEOUT_MS / 1000
+    match = None
+    while _clock.now() < deadline:
+        match = _find_matching_option()
+        if match is not None:
+            break
+        page.wait_for_timeout(250)
+
+    if match is None:
+        with contextlib.suppress(PlaywrightError):
+            page.keyboard.press("Escape")
+        raise BrowserSessionError(
+            f"No suggestion exactly matching {text!r} appeared in the "
+            "'Счетчики Яндекс Метрики' autocomplete within "
+            f"{_METRIKA_COUNTER_SUGGEST_TIMEOUT_MS / 1000:.0f}s — this may "
+            "not be a valid Metrika counter on Yandex's side, or its "
+            "suggestion label differs from the exact text passed. Re-run "
+            "with --headful to see the actual suggestion list."
+        )
+
+    try:
+        match.click()
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            f"Found a matching suggestion for {text!r} in the 'Счетчики "
+            "Яндекс Метрики' autocomplete but could not click it — Yandex "
+            "may have changed the page's markup. Re-run with --headful to "
+            "inspect the page."
+        ) from exc
+
+
+def _remove_metrika_counter(page: "Page", index: int) -> None:
+    """Remove the Metrika counter currently at position ``index`` in
+    "Счетчики Яндекс Метрики" by clicking its close button.
+
+    ``index`` must reference an EXISTING counter (see
+    ``_read_metrika_counters``) — mirrors ``_remove_audience_tag``'s own
+    position-based (not text-based) removal, for the same reason: two
+    entries could in principle share identical display text, and only a
+    position is guaranteed to identify one specific counter.
+    """
+    selector = (
+        f'[data-testid="'
+        f'{_METRIKA_COUNTER_CLOSE_TESTID_TEMPLATE.format(index=index)}"]'
+    )
+    try:
+        page.locator(selector).first.click()
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            f"Could not remove the Metrika counter at position {index + 1} "
+            f"via {selector!r} on the campaign edit page — Yandex may have "
+            "changed the page's markup, or that position no longer exists. "
+            "Re-run with --headful to inspect the page."
+        ) from exc
+
+
 def _read_target_actions(page: "Page") -> List[Dict[str, Any]]:
     """Read the "Целевые действия" table's current rows.
 
@@ -5646,6 +5892,9 @@ def _verify_saved(
     audience_tags_before: Optional[List[str]] = None,
     add_audience_tags: Optional[List[str]] = None,
     remove_audience_tag_indices: Optional[List[int]] = None,
+    metrika_counters_before: Optional[List[str]] = None,
+    add_metrika_counters: Optional[List[str]] = None,
+    remove_metrika_counter_indices: Optional[List[int]] = None,
     clicked_button_label: str = _SAVE_BUTTON_TEXT,
 ) -> None:
     """Reload the edit page and confirm every requested field actually saved.
@@ -5909,6 +6158,39 @@ def _verify_saved(
             mismatches.append(
                 f"audience_tags: expected {sorted(expected_tags.elements())!r}, "
                 f"page now shows {sorted(actual_tags)!r}"
+            )
+
+    if metrika_counters_before is not None:
+        # Mirrors the audience-tags block immediately above verbatim (same
+        # "expected multiset derived from the pre-mutation baseline, so an
+        # untouched save is asserted UNCHANGED rather than left
+        # unverified" reasoning applies here too) — see that block's own
+        # comments for the full rationale. Not live-verified: this section
+        # has no confirmed settle-timing recon of its own (see the module
+        # comment above ``_METRIKA_COUNTER_WRAPPER_TESTID``), so this uses
+        # the shared default read budget rather than inventing an
+        # unconfirmed multiplier the way the audience-tags block's
+        # ``_AUDIENCE_SECTION_READY_TIMEOUT_MS * 3`` does from its own
+        # live-measured settle time.
+        expected_counters = Counter(metrika_counters_before)
+        for index in remove_metrika_counter_indices or []:
+            expected_counters[metrika_counters_before[index]] -= 1
+        expected_counters += Counter(add_metrika_counters or [])
+
+        def _counter_state_matches(actual_counters: List[str], _expected: Any) -> bool:
+            return Counter(actual_counters) == expected_counters
+
+        actual_counters = _read_until_matches(
+            page,
+            _read_metrika_counters,
+            None,
+            matches=_counter_state_matches,
+        )
+        if not _counter_state_matches(actual_counters, None):
+            mismatches.append(
+                "metrika_counters: expected "
+                f"{sorted(expected_counters.elements())!r}, page now shows "
+                f"{sorted(actual_counters)!r}"
             )
 
     if goal_price is not None:
@@ -6217,6 +6499,8 @@ def update_master(
     devices: Optional[Set[str]] = None,
     add_audience_tags: Optional[List[str]] = None,
     remove_audience_tags: Optional[List[int]] = None,
+    add_metrika_counters: Optional[List[str]] = None,
+    remove_metrika_counters: Optional[List[int]] = None,
     launch: bool = False,
 ) -> Dict[str, Any]:
     """Update one or more Этап A/B/D fields (plus the campaign name) and save.
@@ -6320,9 +6604,25 @@ def update_master(
     positions) — removed low-to-high internally so earlier removals don't
     shift the position of a later one still pending.
 
-    Later Этап C fields — sitelinks, Metrika counters/goals, budget
-    adaptation — plus video (a separate follow-up issue, different upload
-    control/pipeline) are out of scope for this function; see issue #648.
+    ``add_metrika_counters``/``remove_metrika_counters`` (issue #648, Этап
+    C) cover the "Счетчики Яндекс Метрики" section, mirroring
+    ``add_audience_tags``/``remove_audience_tags`` above field-for-field —
+    see ``_add_metrika_counter``/``_remove_metrika_counter``/
+    ``_read_metrika_counters`` for the mechanics. NOT LIVE-VERIFIED (see the
+    module comment above ``_METRIKA_COUNTER_WRAPPER_TESTID``): this is an
+    offline implementation following the audience-tags pattern, pending a
+    later live confirmation pass. ``add_metrika_counters`` appends counters
+    by typing text into the section's search input and clicking the
+    suggestion whose first line matches exactly — a value with no matching
+    suggestion raises rather than silently no-op'ing, same as
+    ``add_audience_tags``. ``remove_metrika_counters`` takes 0-based
+    POSITIONS into the counter list as it exists BEFORE this call, removed
+    high-to-low internally for the same "don't shift a later pending
+    position" reason as ``remove_audience_tags``.
+
+    Later Этап C fields — sitelinks, goals, budget adaptation — plus video
+    (a separate follow-up issue, different upload control/pipeline) are out
+    of scope for this function; see issue #648.
 
     ``launch`` (issue #668) matters only when ``campaign_id`` is currently a
     DRAFT: that edit page has no "Сохранить кампанию" button at all, only a
@@ -6395,6 +6695,8 @@ def update_master(
         and devices is None
         and not add_audience_tags
         and not remove_audience_tags
+        and not add_metrika_counters
+        and not remove_metrika_counters
     ):
         raise ValueError(
             "update_master requires at least one field to update "
@@ -6404,7 +6706,8 @@ def update_master(
             "landing_url, tracking_params, headlines, texts, "
             "clear_headlines, clear_texts, images, "
             "gender, age_from, age_to, devices, "
-            "add_audience_tags, remove_audience_tags)."
+            "add_audience_tags, remove_audience_tags, "
+            "add_metrika_counters, remove_metrika_counters)."
         )
 
     url = WIZARD_EDIT_URL.format(campaign_id=campaign_id)
@@ -6624,6 +6927,59 @@ def update_master(
                 "Verify manually before retrying."
             )
 
+    # Mirrors the audience-tags block immediately above, field-for-field —
+    # same pre-mutation-baseline-snapshot rationale (needed both for
+    # _verify_saved's expected multiset and so remove_metrika_counters below
+    # can remove high-to-low without an earlier removal shifting a later
+    # requested position), and same "capture even on an untouched save" R2-1
+    # guard against silently persisting a stale/empty read. NOT LIVE-
+    # VERIFIED — see the module comment above
+    # _METRIKA_COUNTER_WRAPPER_TESTID.
+    _metrika_requested = bool(add_metrika_counters or remove_metrika_counters)
+    metrika_counters_before = (
+        _read_metrika_counters(page) if _metrika_requested else None
+    )
+    _counters_before = metrika_counters_before or []
+    _running_counter_count = len(_counters_before)  # noqa: SIM113
+    for index in sorted(remove_metrika_counters or [], reverse=True):
+        if index >= len(_counters_before):
+            raise BrowserSessionError(
+                f"Metrika counter position {index + 1} is out of range — "
+                f"this campaign currently has {len(_counters_before)} "
+                f"counter(s) (positions 1-{len(_counters_before)})."
+            )
+        _remove_metrika_counter(page, index)
+        _running_counter_count -= 1
+        deadline = _clock.now() + _METRIKA_COUNTER_SUGGEST_TIMEOUT_MS / 1000
+        actual_count = len(_read_metrika_counters(page))
+        while actual_count != _running_counter_count and _clock.now() < deadline:
+            page.wait_for_timeout(250)
+            actual_count = len(_read_metrika_counters(page))
+        if actual_count != _running_counter_count:
+            raise BrowserSessionError(
+                f"Clicked the close button for the Metrika counter at "
+                f"position {index + 1}, but the counter list still shows "
+                f"{actual_count} counter(s) instead of the expected "
+                f"{_running_counter_count} — the click may not have "
+                "committed. Verify manually before retrying."
+            )
+    for text in add_metrika_counters or []:
+        _add_metrika_counter(page, text)
+        _running_counter_count += 1
+        deadline = _clock.now() + _METRIKA_COUNTER_SUGGEST_TIMEOUT_MS / 1000
+        actual_count = len(_read_metrika_counters(page))
+        while actual_count != _running_counter_count and _clock.now() < deadline:
+            page.wait_for_timeout(250)
+            actual_count = len(_read_metrika_counters(page))
+        if actual_count != _running_counter_count:
+            raise BrowserSessionError(
+                f"Clicked the matching suggestion for {text!r} in "
+                "'Счетчики Яндекс Метрики', but the counter list still "
+                f"shows {actual_count} counter(s) instead of the expected "
+                f"{_running_counter_count} — the click may not have "
+                "committed. Verify manually before retrying."
+            )
+
     for index, value in (headlines or {}).items():
         _set_repeating_value(
             page, _HEADLINES_TESTID_TEMPLATE, _HEADLINES_SLOT_COUNT, index, value
@@ -6737,6 +7093,9 @@ def update_master(
             audience_tags_before=audience_tags_before,
             add_audience_tags=add_audience_tags,
             remove_audience_tag_indices=remove_audience_tags,
+            metrika_counters_before=metrika_counters_before,
+            add_metrika_counters=add_metrika_counters,
+            remove_metrika_counter_indices=remove_metrika_counters,
             clicked_button_label=clicked_button_label,
         )
     except BrowserAuthError as exc:
@@ -6791,6 +7150,10 @@ def update_master(
         result["AddedAudienceTags"] = add_audience_tags
     if remove_audience_tags:
         result["RemovedAudienceTagPositions"] = sorted(remove_audience_tags)
+    if add_metrika_counters:
+        result["AddedMetrikaCounters"] = add_metrika_counters
+    if remove_metrika_counters:
+        result["RemovedMetrikaCounterPositions"] = sorted(remove_metrika_counters)
     if was_draft and launch:
         # Issue #721: the DRAFT edit page's launch click redirects away from
         # /edit/ (already awaited by _click_draft_terminal_button inside

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -4788,6 +4788,31 @@ def _remove_audience_tag(page: "Page", index: int) -> None:
         ) from exc
 
 
+def _metrika_counter_identity(text: str) -> str:
+    """Extract the stable numeric counter id from either of this widget's
+    TWO different text formats (cycle-review finding, issue #648): the
+    autocomplete suggestion ``add_metrika_counter`` is given
+    (``"{label} • {domain/path} • {numeric counter id}"``, one line) and
+    ``_read_metrika_counters``'s read-back of an already-linked tag
+    (``"{domain} • {numeric counter id}\\n{N} целей"``, two lines) are NOT
+    the same string — comparing them for equality (as ``_verify_saved``
+    used to) can never match, so every ``--add-metrika-counter`` reported a
+    false save failure even though the add succeeded. Both formats share
+    one thing: their first line's LAST ``" • "``-delimited token is the
+    counter's own numeric id (confirmed live, issue #648 recon —
+    ``"...88834924"``/``"...72112213"``), which is what actually identifies
+    a counter, unlike the label/domain text that can differ between the
+    suggestion and the tag display for the exact same counter. Returns the
+    input text unchanged if it doesn't contain a `` • `` separator at all
+    (defensive: an id-less string just fails to match anything, the same
+    "no false positive" outcome as before this existed).
+    """
+    first_line = text.split("\n", 1)[0]
+    if " • " not in first_line:
+        return text
+    return first_line.rsplit(" • ", 1)[1]
+
+
 def _read_metrika_counters(page: "Page") -> List[str]:
     """Read every currently linked Metrika counter's display text in
     "Счетчики Яндекс Метрики" (in on-page order).
@@ -6189,13 +6214,33 @@ def _verify_saved(
         # unconfirmed multiplier the way the audience-tags block's
         # ``_AUDIENCE_SECTION_READY_TIMEOUT_MS * 3`` does from its own
         # live-measured settle time.
-        expected_counters = Counter(metrika_counters_before)
+        # Built from _metrika_counter_identity(...), NOT the raw text
+        # (cycle-review finding, issue #648): add_metrika_counters is the
+        # user-supplied autocomplete-suggestion text
+        # ("{label} • {domain/path} • {id}", one line), while
+        # _read_metrika_counters returns the linked tag's read-back display
+        # text ("{domain} • {id}\n{N} целей", two lines) — comparing those
+        # two formats directly can never match, so every successful add
+        # used to raise a false "did not save as requested" error. Both
+        # formats agree on the counter's numeric id (see
+        # _metrika_counter_identity's own docstring), which is the actual
+        # identity a caller cares about.
+        expected_counters = Counter(
+            _metrika_counter_identity(c) for c in metrika_counters_before
+        )
         for index in remove_metrika_counter_indices or []:
-            expected_counters[metrika_counters_before[index]] -= 1
-        expected_counters += Counter(add_metrika_counters or [])
+            expected_counters[
+                _metrika_counter_identity(metrika_counters_before[index])
+            ] -= 1
+        expected_counters += Counter(
+            _metrika_counter_identity(c) for c in (add_metrika_counters or [])
+        )
 
         def _counter_state_matches(actual_counters: List[str], _expected: Any) -> bool:
-            return Counter(actual_counters) == expected_counters
+            return (
+                Counter(_metrika_counter_identity(c) for c in actual_counters)
+                == expected_counters
+            )
 
         actual_counters = _read_until_matches(
             page,
@@ -6205,7 +6250,7 @@ def _verify_saved(
         )
         if not _counter_state_matches(actual_counters, None):
             mismatches.append(
-                "metrika_counters: expected "
+                "metrika_counters: expected counter ids "
                 f"{sorted(expected_counters.elements())!r}, page now shows "
                 f"{sorted(actual_counters)!r}"
             )

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -4835,18 +4835,35 @@ def _add_metrika_counter(page: "Page", text: str) -> None:
     ``text`` into the counter search input and clicking the suggestion row
     whose FIRST LINE exactly matches it.
 
-    NOT LIVE-VERIFIED (issue #648 recon, 2026-08-06, campaign 713277109):
-    the recon this module is based on confirmed the DOM shape before and
-    immediately after opening the editor, but never actually typed into the
-    input or clicked a suggestion — so the exact text a caller must pass
-    (a domain? a numeric counter id? something else Yandex's own suggestion
-    label shows?) is unconfirmed. This follows ``_add_audience_tag``'s
-    matching convention (first line of the option's full text, not a
-    constructed testid — see that function's docstring and the module
-    comment above ``_METRIKA_COUNTER_LISTBOX_TESTID`` for why) as the most
-    conservative choice available without a live browser, but the semantics
-    of what to pass as ``text`` need live confirmation before this is relied
-    on.
+    ``text`` FORMAT CONFIRMED LIVE (issue #648, 2026-08-06, campaign
+    713277109, via ``mcp__claude-in-chrome`` — real Chrome, not the
+    Playwright session): typing a partial query (e.g. just the counter's
+    label, "Ксамата") still surfaces the SAME suggestion as typing the full
+    string, but the suggestion's accessible text is exactly ONE line —
+    ``"{label} • {domain/path} • {numeric counter id}"`` (confirmed:
+    ``"Ксамата • yandex.ru/maps • 88834924"``), no newline anywhere in it.
+    Since ``_find_matching_option`` below splits on the first ``"\n"`` and
+    compares for EQUALITY against the whole (single-line) result, the
+    caller-supplied ``text`` must be that ENTIRE string verbatim — passing
+    only the label (e.g. ``"Ксамата"``) will NOT match, even though it's
+    enough to surface the right suggestion while typing interactively.
+    ``masters update``'s own help text/docstring should say this plainly
+    rather than describe it as "an autocomplete suggestion's text" in the
+    abstract.
+
+    Still NOT LIVE-VERIFIED: whether ``match.click()`` actually commits the
+    counter into the "tags-wrapper" list and whether that persists through
+    the campaign's save — the recon session closed the popup with Escape
+    and reloaded the page without saving, precisely to avoid mutating this
+    live campaign's counter set. Also unconfirmed: whether ``Escape`` alone
+    (with no fill-clear afterwards) can leave the search input holding
+    stale, non-committed text the way ``_set_target_action_price`` was
+    found to leave its own popup open in issue #796 — the live recon here
+    hit the SAME visual symptom (Escape closed the suggestion list but left
+    the typed text sitting in the input) and had to explicitly clear the
+    field before navigating away. Worth revisiting whether ``_add_metrika_
+    counter``'s error path below needs the same explicit-clear treatment,
+    not just an ``Escape`` press, once this is exercised end to end.
 
     Unlike ``_add_audience_tag``, this clicks the dedicated
     ``_METRIKA_COUNTER_LAUNCHER_TESTID`` button to open the editor rather

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -5959,7 +5959,17 @@ def _verify_saved(
         or add_audience_tags
         or remove_audience_tag_indices
     )
-    if _audience_touched:
+    # cycle-review finding, issue #648: the pre-reload settle wait below was
+    # scoped to `_audience_touched` only, so a metrika-counters-only save
+    # skipped it entirely. The Metrika counters widget shares the exact
+    # same structural pattern as audience tags (same tag-group DOM shape,
+    # same add/remove-by-position mechanics) — no live recon has confirmed
+    # whether it shares the SAME server-side save-commit race issue #681
+    # found for audience tags, but there's no basis to assume it doesn't
+    # either, and this wait is cheap insurance against the identical
+    # false-negative-mismatch failure mode.
+    _metrika_touched = bool(add_metrika_counters or remove_metrika_counter_indices)
+    if _audience_touched or _metrika_touched:
         # Confirmed live (issue #681): reloading immediately after clicking
         # 'Сохранить кампанию' can race the server-side commit for this
         # section specifically — a reload landing too soon reads back the
@@ -5972,8 +5982,8 @@ def _verify_saved(
         # fully closed (see this function's own docstring "false negative"
         # note and issue #681's follow-up). No other field this module
         # verifies has shown this same race, so the delay is scoped to
-        # audience-touching saves only rather than slowing down every
-        # update_master call.
+        # audience/metrika-touching saves only rather than slowing down
+        # every update_master call.
         page.wait_for_timeout(5_000)
 
     url = WIZARD_EDIT_URL.format(campaign_id=campaign_id)

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -1556,13 +1556,16 @@ def audience_get(
     multiple=True,
     help=(
         "Add a Yandex Metrika counter to 'Счетчики Яндекс Метрики' — the "
-        "exact text of one of Yandex's own autocomplete suggestions for "
-        "that text (repeat for multiple). NOT LIVE-VERIFIED: the exact "
-        "expected input (a domain, a numeric counter ID, or something "
-        "else) has not been confirmed against a real Yandex session — see "
-        "`direct_cli/browser/masters.py`'s module comment above "
-        "`_METRIKA_COUNTER_WRAPPER_TESTID`. A value with no matching "
-        "suggestion is refused."
+        "exact, full text of one of Yandex's own autocomplete suggestions "
+        "(repeat for multiple), confirmed live (issue #648, 2026-08-06) to "
+        "be a single line shaped '{label} • {domain/path} • {numeric "
+        "counter id}' (e.g. 'Ксамата • yandex.ru/maps • 88834924') — "
+        "typing just the label is enough to surface the suggestion "
+        "interactively, but this flag needs the WHOLE string, not just "
+        "the label. Adding/removing itself is NOT LIVE-VERIFIED (only the "
+        "suggestion text format was confirmed) — see "
+        "`direct_cli/browser/masters.py`'s `_add_metrika_counter` "
+        "docstring. A value with no matching suggestion is refused."
     ),
 )
 @click.option(

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -893,6 +893,22 @@ def _parse_remove_audience_tag_options(values: "tuple[int, ...]") -> "list[int]"
     return list(values)
 
 
+def _parse_remove_metrika_counter_options(values: "tuple[int, ...]") -> "list[int]":
+    """Parse repeated ``--remove-metrika-counter`` CLI values into a list of
+    0-based positions — mirrors ``_parse_remove_audience_tag_options``
+    exactly, for the same "positions resolve against a single pre-mutation
+    snapshot" reason (``update_master``'s ``metrika_counters_before``)."""
+    seen: "set[int]" = set()
+    for position in values:
+        if position in seen:
+            raise click.UsageError(
+                f"--remove-metrika-counter position {position + 1} was "
+                "specified more than once."
+            )
+        seen.add(position)
+    return list(values)
+
+
 def _validate_image_path(raw_path: str, *, option_name: str, context: str) -> None:
     """Reject one image path that doesn't exist or that Yandex won't accept.
 
@@ -1535,6 +1551,35 @@ def audience_get(
     ),
 )
 @click.option(
+    "--add-metrika-counter",
+    "add_metrika_counters",
+    multiple=True,
+    help=(
+        "Add a Yandex Metrika counter to 'Счетчики Яндекс Метрики' — the "
+        "exact text of one of Yandex's own autocomplete suggestions for "
+        "that text (repeat for multiple). NOT LIVE-VERIFIED: the exact "
+        "expected input (a domain, a numeric counter ID, or something "
+        "else) has not been confirmed against a real Yandex session — see "
+        "`direct_cli/browser/masters.py`'s module comment above "
+        "`_METRIKA_COUNTER_WRAPPER_TESTID`. A value with no matching "
+        "suggestion is refused."
+    ),
+)
+@click.option(
+    "--remove-metrika-counter",
+    "remove_metrika_counters",
+    multiple=True,
+    type=int,
+    help=(
+        "Remove a counter from 'Счетчики Яндекс Метрики' by its CURRENT "
+        "0-based position. There is no dedicated read command for this "
+        "section yet — inspect current positions with --headful. Repeat "
+        "for multiple positions; positions refer to the list as it exists "
+        "BEFORE this command runs, not after earlier removals in the same "
+        "call. NOT LIVE-VERIFIED — see --add-metrika-counter's help text."
+    ),
+)
+@click.option(
     "--launch",
     is_flag=True,
     default=False,
@@ -1572,6 +1617,8 @@ def update(
     devices,
     add_audience_tags,
     remove_audience_tags,
+    add_metrika_counters,
+    remove_metrika_counters,
     launch,
     headful,
     profile_dir,
@@ -1639,9 +1686,9 @@ def update(
     rationale. ``--image`` additionally has NO in-place replacement at all
     on Yandex's side — see its own help text and
     ``direct_cli/browser/masters.py::_set_image`` for why the image set's
-    order changes as a result. Later fields (sitelinks, Metrika
-    counters/goals, budget adaptation) and video (a separate follow-up
-    issue) are tracked separately, see issue #648.
+    order changes as a result. Later fields (sitelinks, budget adaptation)
+    and video (a separate follow-up issue) are tracked separately, see
+    issue #648.
 
     ``--clear-headline``/``--clear-text`` (issue #786) DELETE an existing
     headline/ad-text variant by its 1-based slot number, the counterpart
@@ -1665,6 +1712,18 @@ def update(
     Yandex's own autocomplete suggestions — Yandex decides whether it
     resolves to a search-term keyword or an interest category, and a tag
     with no matching suggestion is refused rather than added as free text.
+
+    ``--add-metrika-counter``/``--remove-metrika-counter`` (issue #648)
+    cover the "Счетчики Яндекс Метрики" section, mirroring
+    ``--add-audience-tag``/``--remove-audience-tag`` above field-for-field:
+    a value must be the exact text of one of Yandex's own autocomplete
+    suggestions, and ``--remove-metrika-counter`` takes 0-based positions
+    into the counter list as it exists BEFORE this command runs. NOT
+    LIVE-VERIFIED — this is an offline implementation following the
+    audience-tags pattern; see ``--add-metrika-counter``'s own help text
+    and ``direct_cli/browser/masters.py``'s module comment above
+    ``_METRIKA_COUNTER_WRAPPER_TESTID`` for what specifically remains
+    unconfirmed.
 
     A DRAFT campaign's edit page has no "Сохранить кампанию" button at all —
     only a save-as-draft/launch pair (issue #668). ``update`` saves it as a
@@ -1697,6 +1756,8 @@ def update(
         and not devices
         and not add_audience_tags
         and not remove_audience_tags
+        and not add_metrika_counters
+        and not remove_metrika_counters
     ):
         raise click.UsageError(
             "Provide at least one of --weekly-budget, --promotion-goal, "
@@ -1704,7 +1765,8 @@ def update(
             "--remove-target-action, --directs-helps/--no-directs-helps, "
             "--name, --landing-url, --tracking-params, --headline, --text, "
             "--clear-headline, --clear-text, --image, --gender, --age-from, "
-            "--age-to, --device, --add-audience-tag, --remove-audience-tag."
+            "--age-to, --device, --add-audience-tag, --remove-audience-tag, "
+            "--add-metrika-counter, --remove-metrika-counter."
         )
 
     if goal_price is not None and promotion_goal == "max-conversions":
@@ -1804,6 +1866,9 @@ def update(
     parsed_remove_audience_tags = _parse_remove_audience_tag_options(
         remove_audience_tags
     )
+    parsed_remove_metrika_counters = _parse_remove_metrika_counter_options(
+        remove_metrika_counters
+    )
 
     result = _with_session(
         ctx,
@@ -1836,6 +1901,8 @@ def update(
             devices=set(devices) if devices else None,
             add_audience_tags=list(add_audience_tags) or None,
             remove_audience_tags=parsed_remove_audience_tags or None,
+            add_metrika_counters=list(add_metrika_counters) or None,
+            remove_metrika_counters=parsed_remove_metrika_counters or None,
             launch=launch,
         ),
     )

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -16666,6 +16666,40 @@ class TestWaitForAudienceSection(unittest.TestCase):
 
         self.assertIn("metrika_counters", str(ctx.exception))
 
+    def test_metrika_only_save_gets_the_same_pre_reload_settle_wait_as_audience(self):
+        """cycle-review finding, issue #648: the pre-reload settle wait
+        (issue #681's confirmed-live save-commit race) was scoped to
+        `_audience_touched` only, so a metrika-counters-only save skipped
+        it entirely -- even though the Metrika counters widget shares the
+        exact same tag-group DOM pattern that race was found on. A
+        metrika-only call (no audience fields touched) must still trigger
+        the 5s wait."""
+        page = FakePage(
+            locators={
+                browser_masters._METRIKA_COUNTER_WRAPPER_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                ),
+                '[data-testid="MetrikaCountersTagGroup.tag.0"]': _FakeLocator(
+                    [_FakeLocatorHandle(text="gc.ksamata.ru • 72112213\n30 целей")]
+                ),
+            }
+        )
+        wait_calls = []
+        page.wait_for_timeout = lambda timeout: wait_calls.append(timeout)
+
+        with patch.object(browser_masters, "_wait_for_edit_form", lambda *a, **k: None):
+            browser_masters._verify_saved(
+                page,
+                42,
+                weekly_budget=None,
+                promotion_goal=None,
+                directs_helps=None,
+                metrika_counters_before=[],
+                add_metrika_counters=["Ксамата • yandex.ru/maps • 72112213"],
+            )
+
+        self.assertIn(5_000, wait_calls)
+
     def test_raises_if_gender_trigger_never_shows_a_label(self):
         page = FakePage(locators={})  # no _GENDER_SELECT_TESTID handle at all
 

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -16608,6 +16608,64 @@ class TestWaitForAudienceSection(unittest.TestCase):
         self.assertEqual(len(page_tags), len(baseline) - 1)
         self.assertIn("audience_tags", str(ctx.exception))
 
+    def test_add_metrika_counter_does_not_false_positive_on_format_mismatch(self):
+        """Cycle-review finding, issue #648: the pre-fix code compared
+        add_metrika_counters' raw suggestion text ("{label} • {domain/path}
+        • {id}", one line) directly against _read_metrika_counters' raw
+        tag-display text ("{domain} • {id}\\n{N} целей", two lines) — two
+        different string formats for the SAME counter, which can never be
+        multiset-equal. Every successful add used to raise a false
+        BrowserSessionError here. The page shows the counter linked, in its
+        own two-line display format that differs from the one-line
+        suggestion text used to add it — this must NOT raise."""
+        page = FakePage(
+            locators={
+                browser_masters._METRIKA_COUNTER_WRAPPER_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                ),
+                '[data-testid="MetrikaCountersTagGroup.tag.0"]': _FakeLocator(
+                    [_FakeLocatorHandle(text="gc.ksamata.ru • 72112213\n30 целей")]
+                ),
+            }
+        )
+
+        with patch.object(browser_masters, "_wait_for_edit_form", lambda *a, **k: None):
+            # Must NOT raise despite the format mismatch between the add
+            # text and the read-back tag text -- both share id "72112213".
+            browser_masters._verify_saved(
+                page,
+                42,
+                weekly_budget=None,
+                promotion_goal=None,
+                directs_helps=None,
+                metrika_counters_before=[],
+                add_metrika_counters=["Ксамата • yandex.ru/maps • 72112213"],
+            )
+
+    def test_add_metrika_counter_still_catches_a_genuinely_missing_counter(self):
+        """The mirror of the test above: if the added counter's id truly
+        never shows up on the page (e.g. the add silently failed), the
+        mismatch must still be reported -- the identity-based comparison
+        must not become a tautology that never fails."""
+        page = FakePage(locators={})  # no wrapper -> _read_metrika_counters returns []
+
+        with (
+            patch.object(browser_masters, "_wait_for_edit_form", lambda *a, **k: None),
+            patch.object(browser_masters, "_METRIKA_COUNTER_SUGGEST_TIMEOUT_MS", 10),
+            self.assertRaises(BrowserSessionError) as ctx,
+        ):
+            browser_masters._verify_saved(
+                page,
+                42,
+                weekly_budget=None,
+                promotion_goal=None,
+                directs_helps=None,
+                metrika_counters_before=[],
+                add_metrika_counters=["Ксамата • yandex.ru/maps • 72112213"],
+            )
+
+        self.assertIn("metrika_counters", str(ctx.exception))
+
     def test_raises_if_gender_trigger_never_shows_a_label(self):
         page = FakePage(locators={})  # no _GENDER_SELECT_TESTID handle at all
 
@@ -17116,6 +17174,34 @@ class TestAddMetrikaCounter(unittest.TestCase):
             self.assertRaises(BrowserSessionError),
         ):
             browser_masters._add_metrika_counter(page, "nomatch.ru")
+
+
+class TestMetrikaCounterIdentity(unittest.TestCase):
+    """``_metrika_counter_identity`` (cycle-review finding, issue #648):
+    extracts the stable numeric counter id shared by both of this widget's
+    text formats, so ``_verify_saved`` can compare an add's suggestion text
+    against a read-back tag's display text without a false mismatch."""
+
+    def test_extracts_id_from_suggestion_format(self):
+        self.assertEqual(
+            browser_masters._metrika_counter_identity(
+                "Ксамата • yandex.ru/maps • 88834924"
+            ),
+            "88834924",
+        )
+
+    def test_extracts_id_from_two_line_tag_display_format(self):
+        self.assertEqual(
+            browser_masters._metrika_counter_identity(
+                "gc.ksamata.ru • 72112213\n30 целей"
+            ),
+            "72112213",
+        )
+
+    def test_returns_text_unchanged_when_no_separator(self):
+        self.assertEqual(
+            browser_masters._metrika_counter_identity("nomatch"), "nomatch"
+        )
 
 
 class TestParseRemoveMetrikaCounterOptions(unittest.TestCase):

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -128,6 +128,7 @@ class _FakeLocatorHandle:
         get_checked=None,
         on_upload=None,
         sub_locators=None,
+        role_options=None,
     ):
         self._text = text
         self._attrs = attrs or {}
@@ -149,10 +150,30 @@ class _FakeLocatorHandle:
         # matched label handle itself, not via a second independent
         # page.locator() call built from the same selector string).
         self._sub_locators = sub_locators or {}
+        # [_FakeLocatorHandle, ...] this handle's own get_by_role() call
+        # enumerates — models Locator.get_by_role() scoped off an
+        # already-matched locator (e.g. ``page.locator(listbox_testid).first
+        # .get_by_role("option")``), used by ``_add_metrika_counter``/
+        # ``_add_audience_tag`` (issue #648/#681) to enumerate an
+        # autocomplete popup's option rows.
+        self._role_options = role_options or []
 
     def locator(self, selector):
         handle = self._sub_locators.get(selector)
         return _FakeLocator([handle] if handle is not None else [])
+
+    def get_by_role(self, role, name=None, exact=False):
+        if name is None:
+            return _FakeGetByTextLocator(list(self._role_options))
+        matched = []
+        for handle in self._role_options:
+            text = handle.inner_text()
+            if exact:
+                if text == name:
+                    matched.append(handle)
+            elif name in text:
+                matched.append(handle)
+        return _FakeGetByTextLocator(matched)
 
     def inner_text(self, timeout=None):
         if self._raises:
@@ -16924,6 +16945,253 @@ class TestMastersAudienceGetCommand(unittest.TestCase):
         mock_fetch.assert_called_once()
         args, _kwargs = mock_fetch.call_args
         self.assertEqual(args[1], 42)
+
+
+class TestReadMetrikaCounters(unittest.TestCase):
+    """``_read_metrika_counters`` (issue #648, Этап C) — mirrors
+    ``_read_audience_tags``, but each "tag" is a whole Metrika counter whose
+    on-page text spans two lines (domain+id, then goal count). NOT
+    LIVE-VERIFIED beyond the DOM shape recon confirmed BEFORE/immediately
+    after opening the editor — see the module comment above
+    ``_METRIKA_COUNTER_WRAPPER_TESTID`` in ``direct_cli/browser/masters.py``.
+    """
+
+    def _tag_testid(self, index):
+        testid = browser_masters._METRIKA_COUNTER_TESTID_TEMPLATE.format(index=index)
+        return f'[data-testid="{testid}"]'
+
+    def test_returns_every_counters_full_two_line_text(self):
+        page = FakePage(
+            locators={
+                browser_masters._METRIKA_COUNTER_WRAPPER_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                ),
+                self._tag_testid(0): _FakeLocator(
+                    [_FakeLocatorHandle(text="gc.ksamata.ru • 72112213\n30 целей")]
+                ),
+                self._tag_testid(1): _FakeLocator(
+                    [_FakeLocatorHandle(text="example.com • 12345678\n5 целей")]
+                ),
+            }
+        )
+
+        self.assertEqual(
+            browser_masters._read_metrika_counters(page),
+            [
+                "gc.ksamata.ru • 72112213\n30 целей",
+                "example.com • 12345678\n5 целей",
+            ],
+        )
+
+    def test_returns_empty_list_when_wrapper_missing(self):
+        page = FakePage(locators={})
+
+        self.assertEqual(browser_masters._read_metrika_counters(page), [])
+
+    def test_stops_at_first_missing_index(self):
+        page = FakePage(
+            locators={
+                browser_masters._METRIKA_COUNTER_WRAPPER_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                ),
+                self._tag_testid(0): _FakeLocator(
+                    [_FakeLocatorHandle(text="a.ru • 1\n1 цель")]
+                ),
+                # No entry for index 1 -> .first raises -> loop stops.
+            }
+        )
+
+        self.assertEqual(
+            browser_masters._read_metrika_counters(page), ["a.ru • 1\n1 цель"]
+        )
+
+
+class TestRemoveMetrikaCounter(unittest.TestCase):
+    """``_remove_metrika_counter`` (issue #648) — mirrors
+    ``_remove_audience_tag``'s position-based close-button click."""
+
+    def _close_testid(self, index):
+        testid = browser_masters._METRIKA_COUNTER_CLOSE_TESTID_TEMPLATE.format(
+            index=index
+        )
+        return f'[data-testid="{testid}"]'
+
+    def test_clicks_close_button_at_position(self):
+        clicked = {"count": 0}
+        handle = _FakeLocatorHandle(
+            on_click=lambda: clicked.__setitem__("count", clicked["count"] + 1)
+        )
+        page = FakePage(locators={self._close_testid(1): _FakeLocator([handle])})
+
+        browser_masters._remove_metrika_counter(page, 1)
+
+        self.assertEqual(clicked["count"], 1)
+
+    def test_raises_when_close_button_missing(self):
+        page = FakePage(locators={})
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters._remove_metrika_counter(page, 0)
+
+
+class TestAddMetrikaCounter(unittest.TestCase):
+    """``_add_metrika_counter`` (issue #648) — mirrors ``_add_audience_tag``,
+    but clicks a dedicated launcher button instead of the tags-wrapper
+    itself (see the module comment above ``_METRIKA_COUNTER_WRAPPER_TESTID``
+    for why). NOT LIVE-VERIFIED: recon never exercised typing into the
+    input or clicking a suggestion, so the exact input semantics (what text
+    a caller must pass) remain unconfirmed."""
+
+    def test_raises_when_launcher_missing(self):
+        page = FakePage(locators={})
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters._add_metrika_counter(page, "gc.ksamata.ru")
+
+    def test_raises_when_input_missing_after_launcher_click(self):
+        launcher = _FakeLocatorHandle()
+        page = FakePage(
+            locators={
+                browser_masters._METRIKA_COUNTER_LAUNCHER_TESTID: _FakeLocator(
+                    [launcher]
+                ),
+                # No entry for the input testid -> .first raises on click().
+            }
+        )
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters._add_metrika_counter(page, "gc.ksamata.ru")
+
+    def test_clicks_launcher_then_matching_option_by_first_line(self):
+        launcher_clicks = {"count": 0}
+        launcher = _FakeLocatorHandle(
+            on_click=lambda: launcher_clicks.__setitem__(
+                "count", launcher_clicks["count"] + 1
+            )
+        )
+        field = _FakeLocatorHandle()
+        option_clicked = {"clicked": False}
+        matching_option = _FakeLocatorHandle(
+            text="gc.ksamata.ru • 72112213\n30 целей",
+            on_click=lambda: option_clicked.__setitem__("clicked", True),
+        )
+        other_option = _FakeLocatorHandle(text="other.ru • 999\n1 цель")
+        listbox = _FakeLocatorHandle(role_options=[other_option, matching_option])
+        page = FakePage(
+            locators={
+                browser_masters._METRIKA_COUNTER_LAUNCHER_TESTID: _FakeLocator(
+                    [launcher]
+                ),
+                browser_masters._METRIKA_COUNTER_INPUT_TESTID: _FakeLocator([field]),
+                browser_masters._METRIKA_COUNTER_LISTBOX_TESTID: _FakeLocator(
+                    [listbox]
+                ),
+            }
+        )
+
+        browser_masters._add_metrika_counter(page, "gc.ksamata.ru • 72112213")
+
+        self.assertEqual(launcher_clicks["count"], 1)
+        self.assertTrue(option_clicked["clicked"])
+
+    def test_raises_when_no_suggestion_matches(self):
+        launcher = _FakeLocatorHandle()
+        field = _FakeLocatorHandle()
+        non_matching = _FakeLocatorHandle(text="other.ru • 999\n1 цель")
+        listbox = _FakeLocatorHandle(role_options=[non_matching])
+        page = FakePage(
+            locators={
+                browser_masters._METRIKA_COUNTER_LAUNCHER_TESTID: _FakeLocator(
+                    [launcher]
+                ),
+                browser_masters._METRIKA_COUNTER_INPUT_TESTID: _FakeLocator([field]),
+                browser_masters._METRIKA_COUNTER_LISTBOX_TESTID: _FakeLocator(
+                    [listbox]
+                ),
+            }
+        )
+
+        with (
+            patch.object(browser_masters, "_METRIKA_COUNTER_SUGGEST_TIMEOUT_MS", 10),
+            self.assertRaises(BrowserSessionError),
+        ):
+            browser_masters._add_metrika_counter(page, "nomatch.ru")
+
+
+class TestParseRemoveMetrikaCounterOptions(unittest.TestCase):
+    """``_parse_remove_metrika_counter_options`` (issue #648) — mirrors
+    ``_parse_remove_audience_tag_options``'s duplicate-position guard."""
+
+    def test_rejects_duplicate_position(self):
+        from direct_cli.commands.masters import _parse_remove_metrika_counter_options
+
+        with self.assertRaises(click.UsageError):
+            _parse_remove_metrika_counter_options((1, 1))
+
+    def test_accepts_distinct_positions_in_order(self):
+        from direct_cli.commands.masters import _parse_remove_metrika_counter_options
+
+        self.assertEqual(_parse_remove_metrika_counter_options((3, 1, 2)), [3, 1, 2])
+
+
+class TestMastersUpdateMetrikaCounterFlags(unittest.TestCase):
+    """CLI wiring for `masters update`'s "Счетчики Яндекс Метрики" flags
+    (issue #648)."""
+
+    def setUp(self):
+        self.runner = CliRunner()
+
+    def test_documents_metrika_counter_flags(self):
+        result = self.runner.invoke(cli, ["masters", "update", "--help"])
+        self.assertIn("--add-metrika-counter", result.output)
+        self.assertIn("--remove-metrika-counter", result.output)
+
+    def test_rejects_duplicate_remove_metrika_counter_position(self):
+        result = self.runner.invoke(
+            cli,
+            [
+                "masters",
+                "update",
+                "42",
+                "--remove-metrika-counter",
+                "1",
+                "--remove-metrika-counter",
+                "1",
+            ],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("more than once", result.output.lower())
+
+    def test_passes_add_and_remove_metrika_counters(self):
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42}
+            result = self.runner.invoke(
+                cli,
+                [
+                    "masters",
+                    "update",
+                    "42",
+                    "--add-metrika-counter",
+                    "gc.ksamata.ru",
+                    "--remove-metrika-counter",
+                    "1",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        mock_update.assert_called_once()
+        _args, kwargs = mock_update.call_args
+        self.assertEqual(kwargs["add_metrika_counters"], ["gc.ksamata.ru"])
+        self.assertEqual(kwargs["remove_metrika_counters"], [1])
+
+    def test_no_fields_still_rejected_with_metrika_counter_flags_absent(self):
+        result = self.runner.invoke(cli, ["masters", "update", "42"])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("--add-metrika-counter", result.output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Implements Yandex Metrika counter linking/unlinking in `direct masters update` — part of issue #648's Этап C (structural sections: sitelinks, audience, Metrika counters/goals). Browser-driven (Мастер кампаний has no API), mirroring the `--add-audience-tag`/`--remove-audience-tag` (#681) add/remove-by-position pattern almost field-for-field, since the "Счетчики Яндекс Метрики" section's DOM shape (`MetrikaCountersTagGroup.*`) turned out to be structurally identical to the audience-tags widget.

- `--add-metrika-counter TEXT` — types into the section's search input, clicks the matching autocomplete suggestion.
- `--remove-metrika-counter POSITION` — removes a counter by its 0-based on-page position.
- `_read_metrika_counters`/`_add_metrika_counter`/`_remove_metrika_counter` in `direct_cli/browser/masters.py`, wired into `update_master` and `_verify_saved` (multiset check), same as audience tags.

## ⚠️ NOT LIVE-VERIFIED (with one exception — see below)

Testid structure was confirmed via live **read-only** recon against campaign 713277109 (Playwright + `mcp claude-in-chrome`, no mutations saved). Actual add/remove/save behavior has **not** been exercised end to end.

**One thing IS live-confirmed** (via `mcp claude-in-chrome` against the real Chrome session, 2026-08-06): the exact text format `--add-metrika-counter` needs. Typing a partial query (e.g. just a counter's label, "Ксамата") surfaces the same suggestion as typing more, but the suggestion's accessible text is a single line shaped `"{label} • {domain/path} • {numeric counter id}"` (confirmed: `"Ксамата • yandex.ru/maps • 88834924"`). Since the exact-match lookup compares against the WHOLE string, callers must pass that full string, not just the label — this is now documented in the CLI help text and the `_add_metrika_counter` docstring.

Still open:

1. **Whether `match.click()` actually commits the counter and whether a save persists it** — the recon session closed the suggestion popup with `Escape` and reloaded the edit page without saving, specifically to avoid mutating this production campaign's counter set.
2. **A possible "leftover text after Escape" gap** — the same recon session that confirmed the text format also observed `Escape` closing the suggestion dropdown but leaving the typed text sitting in the input (the field had to be explicitly cleared before navigating away). This mirrors the class of bug found in issue #796 (`_set_target_action_price`'s price popup not being closed before the terminal click) — worth revisiting whether `_add_metrika_counter`'s error path needs the same explicit-clear treatment once this is exercised end to end, not just an `Escape` press.
3. **Hydration/settle timing** for this section — currently reuses `_AUDIENCE_TAG_SUGGEST_TIMEOUT_MS`'s 5s budget with no independent calibration.
4. **`MetrikaCountersTagGroup.Expander`'s purpose** — left unimplemented/ignored, its function was not determined from recon.

None of the add/remove/save behavior is claimed as working in the docstrings/CLI help. A live mutation-verification pass is planned as a follow-up (browser session currently queued for other in-flight work).

## Test plan

- [x] `pytest tests/test_masters.py -k "Metrika or metrika"` — 15 passed
- [x] Full offline suite `pytest -n auto` — 3392 passed, 23 skipped, no regressions
- [x] `black`/`flake8` clean on all changed files
- [ ] Live verification (add, remove, save-persists) — **pending**, tracked as a follow-up before this is relied upon

Relates to #648 (no dedicated sub-issue for this specific section).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01FF5MKQjSX89UpwHfFG3uBe