### PR TITLE
feat(masters): add --add-sitelink/--remove-sitelink to `masters update`

### DIFF
--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -7770,6 +7770,22 @@ def update_master(
                 f"{_running_sitelink_count} — the click may not have "
                 "committed. Verify manually before retrying."
             )
+    # Populated with the ACTUALLY-OBSERVED card for each successful add
+    # (read back via _read_sitelinks right after its own commit-confirmation
+    # below), not the raw CLI input — cycle-review finding (Codex): Yandex's
+    # displayed Title/Href is NOT LIVE-VERIFIED to equal the raw input
+    # byte-for-byte (protocol stripping, trailing slash, host casing are
+    # all plausible normalizations a real page could apply). Building
+    # _verify_saved's expected multiset from the raw input meant ANY such
+    # normalization would make an already-successful add report a false
+    # "did not save as requested" AFTER the irreversible save — and because
+    # update_master's own retry re-reads the (now-updated) baseline and
+    # re-applies the same add_sitelinks, a naive retry would then create a
+    # DUPLICATE sitelink. Comparing against what the page itself reports
+    # right after the add succeeds sidesteps the whole class of mismatch —
+    # mirrors _metrika_counter_identity's identical "compare what actually
+    # got read back, not the raw request" fix for the same failure shape.
+    add_sitelinks_observed: "list[dict[str, str]]" = []
     for sitelink in add_sitelinks or []:
         _add_sitelink(
             page,
@@ -7782,18 +7798,22 @@ def update_master(
         # sitelink list is a hard error here too, not a silent no-op.
         _running_sitelink_count += 1
         deadline = _clock.now() + _SITELINK_ROW_TIMEOUT_MS / 1000
-        actual_count = len(_read_sitelinks(page))
-        while actual_count != _running_sitelink_count and _clock.now() < deadline:
+        current_sitelinks = _read_sitelinks(page)
+        while (
+            len(current_sitelinks) != _running_sitelink_count
+            and _clock.now() < deadline
+        ):
             page.wait_for_timeout(250)
-            actual_count = len(_read_sitelinks(page))
-        if actual_count != _running_sitelink_count:
+            current_sitelinks = _read_sitelinks(page)
+        if len(current_sitelinks) != _running_sitelink_count:
             raise BrowserSessionError(
                 f"Added a sitelink titled {sitelink['Title']!r}, but the "
-                f"sitelink list still shows {actual_count} sitelink(s) "
-                f"instead of the expected {_running_sitelink_count} — the "
-                "add may not have committed. Verify manually before "
-                "retrying."
+                f"sitelink list still shows {len(current_sitelinks)} "
+                f"sitelink(s) instead of the expected "
+                f"{_running_sitelink_count} — the add may not have "
+                "committed. Verify manually before retrying."
             )
+        add_sitelinks_observed.append(current_sitelinks[-1])
 
     # Mirrors the audience-tags block immediately above, field-for-field —
     # same pre-mutation-baseline-snapshot rationale (needed both for
@@ -7965,7 +7985,7 @@ def update_master(
             add_metrika_counters=add_metrika_counters,
             remove_metrika_counter_indices=remove_metrika_counters,
             sitelinks_before=sitelinks_before,
-            add_sitelinks=add_sitelinks,
+            add_sitelinks=add_sitelinks_observed,
             remove_sitelink_indices=remove_sitelinks,
             clicked_button_label=clicked_button_label,
         )

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -6634,7 +6634,15 @@ def _verify_saved(
     # either, and this wait is cheap insurance against the identical
     # false-negative-mismatch failure mode.
     _metrika_touched = bool(add_metrika_counters or remove_metrika_counter_indices)
-    if _audience_touched or _metrika_touched:
+    # Same reasoning as `_metrika_touched` immediately above — sitelinks
+    # share the same "no live recon confirming/denying issue #681's race,
+    # so no basis to assume it doesn't apply" position, and this wait is
+    # cheap insurance either way. (cycle-review finding, this PR: `_verify_
+    # saved` already gained `sitelinks_before`/`add_sitelinks`/`remove_
+    # sitelink_indices` params and a full post-save verify block, but this
+    # settle-wait guard was left scoped to audience/metrika only.)
+    _sitelinks_touched = bool(add_sitelinks or remove_sitelink_indices)
+    if _audience_touched or _metrika_touched or _sitelinks_touched:
         # Confirmed live (issue #681): reloading immediately after clicking
         # 'Сохранить кампанию' can race the server-side commit for this
         # section specifically — a reload landing too soon reads back the
@@ -7731,6 +7739,7 @@ def update_master(
     _sitelinks_requested = bool(add_sitelinks or remove_sitelinks)
     sitelinks_before = _read_sitelinks(page) if _sitelinks_requested else None
     _sitelinks_before_list = sitelinks_before or []
+    _running_sitelink_count = len(_sitelinks_before_list)  # noqa: SIM113
     for index in sorted(remove_sitelinks or [], reverse=True):
         if index >= len(_sitelinks_before_list):
             raise BrowserSessionError(
@@ -7739,6 +7748,28 @@ def update_master(
                 f"sitelink(s) (positions 1-{len(_sitelinks_before_list)})."
             )
         _remove_sitelink(page, index)
+        # Same "click alone isn't proof" guard as the audience-tag/Metrika-
+        # counter loops above — confirmed live (issue #681) a save
+        # immediately after a click that hadn't actually committed to the
+        # DOM yet reloaded with the change missing (there, a still-present
+        # tag; here, symmetrically, a still-present or wrongly-shifted
+        # card). Without this, removing multiple sitelinks high-to-low
+        # could target a stale DOM if an earlier click hasn't committed
+        # yet, removing the WRONG card.
+        _running_sitelink_count -= 1
+        deadline = _clock.now() + _SITELINK_ROW_TIMEOUT_MS / 1000
+        actual_count = len(_read_sitelinks(page))
+        while actual_count != _running_sitelink_count and _clock.now() < deadline:
+            page.wait_for_timeout(250)
+            actual_count = len(_read_sitelinks(page))
+        if actual_count != _running_sitelink_count:
+            raise BrowserSessionError(
+                f"Clicked the remove button for the sitelink at position "
+                f"{index + 1}, but the sitelink list still shows "
+                f"{actual_count} sitelink(s) instead of the expected "
+                f"{_running_sitelink_count} — the click may not have "
+                "committed. Verify manually before retrying."
+            )
     for sitelink in add_sitelinks or []:
         _add_sitelink(
             page,
@@ -7746,6 +7777,23 @@ def update_master(
             sitelink["Href"],
             sitelink.get("Description", ""),
         )
+        # Mirrors the removal guard immediately above and the audience-tag
+        # add loop's own guard — a click that doesn't visibly grow the
+        # sitelink list is a hard error here too, not a silent no-op.
+        _running_sitelink_count += 1
+        deadline = _clock.now() + _SITELINK_ROW_TIMEOUT_MS / 1000
+        actual_count = len(_read_sitelinks(page))
+        while actual_count != _running_sitelink_count and _clock.now() < deadline:
+            page.wait_for_timeout(250)
+            actual_count = len(_read_sitelinks(page))
+        if actual_count != _running_sitelink_count:
+            raise BrowserSessionError(
+                f"Added a sitelink titled {sitelink['Title']!r}, but the "
+                f"sitelink list still shows {actual_count} sitelink(s) "
+                f"instead of the expected {_running_sitelink_count} — the "
+                "add may not have committed. Verify manually before "
+                "retrying."
+            )
 
     # Mirrors the audience-tags block immediately above, field-for-field —
     # same pre-mutation-baseline-snapshot rationale (needed both for

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -1556,6 +1556,91 @@ _METRIKA_COUNTER_CLOSE_TESTID_TEMPLATE = "MetrikaCountersTagGroup.tag.{index}.cl
 # value is a more defensible default than inventing an unverified number.
 _METRIKA_COUNTER_SUGGEST_TIMEOUT_MS = _AUDIENCE_TAG_SUGGEST_TIMEOUT_MS
 
+# "Быстрые ссылки" (sitelinks) section, issue #648 Этап C. Confirmed live
+# 2026-08-06 against campaign 713277109 (an ACTIVE campaign on a real ad
+# account — see this module's own recon notes below for what was and was
+# NOT verified) via two READ-ONLY Playwright/claude-in-chrome recon passes.
+#
+# Recon #1 (Playwright, before opening any card): the section container, the
+# "Добавить" button that creates a new card, and per-card testids — but the
+# per-card testids (``Sitelink.overlay``/``CampaignSitelink``/
+# ``CampaignSitelink.title``/``Sitelink.remove``) are confirmed NOT
+# parameterized by index — the campaign's 4 existing sitelinks at recon time
+# each rendered the SAME four testid strings once per card, distinguishable
+# only by DOM ORDER (the Nth match of the selector = the Nth card), not by a
+# number embedded in the testid itself. This mirrors
+# ``_AUDIENCE_TAG_TESTID_TEMPLATE``'s "read/remove by position" convention,
+# except audience tags DO get an ``{index}``-parameterized testid — sitelinks
+# do not, so every reader/mutator below locates cards via ``.nth(position)``
+# rather than formatting an index into the selector (see
+# ``_SITELINK_REMOVE_TESTID``'s docstring for why removal in particular
+# differs from ``_AUDIENCE_TAG_CLOSE_TESTID_TEMPLATE``).
+#
+# Recon #2 (claude-in-chrome, after clicking the FIRST card's ``Sitelink.
+# overlay``): clicking a card mounts an INLINE edit form directly in the
+# card (not a modal) with its own three ``SitelinkRow.*`` field testids for
+# title/href/description. These are confirmed to belong to only the ONE
+# currently-open card, not parameterized by position either — there is
+# exactly one such triple in the DOM at a time (the currently-open card),
+# mirroring ``_AUDIENCE_TAG_INPUT_TESTID``'s "mounts on click, one instance
+# at a time" shape.
+#
+# NOT LIVE-VERIFIED (recon #2 stopped here deliberately, to avoid mutating a
+# real, live campaign):
+# * How the inline form CLOSES/commits after typing — no dedicated "Готово"/
+#   save testid appeared in the recon's accessibility-tree/DOM dump, so this
+#   module assumes closing happens via clicking away from the card (Escape
+#   is tried first, then a click on the section's own container) — same
+#   "best-effort, then verify by re-reading" posture as this module takes
+#   for every field with no confirmed native save action.
+# * Whether ``SitelinkRow.*.textarea`` is a plain ``<textarea>`` (``.fill()``
+#   works) or a ``contenteditable`` div like the headline/text slots
+#   (``.fill()`` does NOT work, ``_clear_text_field`` + ``.type()`` are
+#   required instead, see ``_add_repeating_values``'s docstring). This
+#   module conservatively assumes the WORSE case (contenteditable) and reuses
+#   ``_clear_text_field``, exactly as instructed by issue #648's Этап C task
+#   — if it turns out to be a plain textarea, ``.fill("")`` would have
+#   worked too and ``_clear_text_field`` degrades to a harmless no-op
+#   equivalent (select-all + Backspace clears a plain textarea just as well).
+# * Whether "Добавить" opens a new card with the SAME empty ``SitelinkRow.*``
+#   triple (assumed, by analogy with every other "click Добавить, fill,
+#   commit" flow in this module — target actions, audience tags — but not
+#   itself clicked in recon).
+# * The real maximum sitelink count. ``_SITELINKS_SLOT_COUNT`` below is
+#   taken from UI copy ("добавить до 5 штук", seen alongside the video
+#   section in the same recon) — nobody actually tried adding a 5th sitelink
+#   past the 4 the recon campaign already had.
+_SITELINKS_EDITOR_TESTID = '[data-testid="CampaignFormSitelinks.editor"]'
+_SITELINKS_ADD_BUTTON_TESTID = '[data-testid="CampaignFormSitelinks.button"]'
+_SITELINK_OVERLAY_TESTID = '[data-testid="Sitelink.overlay"]'
+_SITELINK_CARD_TESTID = '[data-testid="CampaignSitelink"]'
+_SITELINK_TITLE_TESTID = '[data-testid="CampaignSitelink.title"]'
+# NOT parameterized by index, unlike ``_AUDIENCE_TAG_CLOSE_TESTID_TEMPLATE``
+# (which embeds ``{index}`` directly in the testid string) — every card's
+# remove button shares this exact selector, so ``_remove_sitelink`` below
+# resolves a specific card via ``.nth(index)`` on this locator instead of
+# formatting a position into the selector. Confirmed live: no confirmation
+# modal appears, the click removes the card directly.
+_SITELINK_REMOVE_TESTID = '[data-testid="Sitelink.remove"]'
+# Also not parameterized — see the module comment above these constants.
+# Belongs to whichever ONE card is currently open for inline editing.
+_SITELINK_ROW_NAME_TESTID = '[data-testid="SitelinkRow.name.textarea"]'
+_SITELINK_ROW_HREF_TESTID = '[data-testid="SitelinkRow.href.textarea"]'
+_SITELINK_ROW_DESCRIPTION_TESTID = '[data-testid="SitelinkRow.description.textarea"]'
+# NOT LIVE-VERIFIED — see module comment above. UI copy says "до 5 штук" but
+# no attempt was made to add a 5th sitelink to the 4 the recon campaign
+# already had.
+_SITELINKS_SLOT_COUNT = 5
+
+# How long to wait for the inline sitelink-row form to mount after clicking
+# a card's overlay (or the section's "Добавить" button) — mirrors
+# ``_AUDIENCE_TAG_SUGGEST_TIMEOUT_MS``'s "give the SPA time to hydrate"
+# rationale for the sibling "click to mount an editor" flow. NOT tuned
+# against a live timing measurement (unlike the audience-tag constant,
+# which cites a specific observed popup latency) — this is a conservative
+# default pending live confirmation.
+_SITELINK_ROW_TIMEOUT_MS = 5_000
+
 # "Устройства пользователей" (DeviceEditor): a multi-select popup with
 # exactly three checkboxes, confirmed live all pre-checked by default
 # ("Любые" = all three checked, not a fourth distinct value) — mobile,
@@ -5380,6 +5465,216 @@ def _remove_metrika_counter(page: "Page", index: int) -> None:
         ) from exc
 
 
+def _read_sitelinks(page: "Page") -> List[Dict[str, str]]:
+    """Read every current "Быстрые ссылки" card's title/URL, in on-page order.
+
+    Returns ``[{"Title": str, "Href": str}, ...]`` — NOT description: the
+    card list only renders each card's TITLE and a combined "title\\nurl"
+    text (confirmed live, recon #1 — see the module comment above
+    ``_SITELINKS_EDITOR_TESTID``), the description is only visible once a
+    card is opened for inline editing via ``Sitelink.overlay``, and this
+    reader deliberately does not open every card just to read its
+    description (that would mutate on-page focus/scroll state for a
+    read-only call, and NOT LIVE-VERIFIED whether opening a card has other
+    side effects). Callers that need a card's description must open it
+    individually — there is no bulk read for it.
+
+    Like ``_read_audience_tags``, walks cards by POSITION (the Nth match of
+    ``_SITELINK_CARD_TESTID``) rather than a per-card testid, since sitelink
+    card testids are not parameterized by index (see the module comment
+    above ``_SITELINKS_EDITOR_TESTID``). Unlike ``_read_audience_tags``,
+    the card COUNT is known ahead of time via ``.count()`` (Playwright can
+    report how many elements matched a selector without an index-by-index
+    probe), so this does not need a per-index existence check to know when
+    to stop.
+
+    The card's own ``inner_text()`` is documented (recon #1) to read as
+    ``"{title}\\n{url}"`` — this splits on the first newline to recover
+    both fields independently, rather than only reading the separate
+    ``CampaignSitelink.title`` sub-testid for the title and leaving the URL
+    unavailable from a bulk read. A card whose text has no newline (e.g. a
+    href-less card, if that is even a state Yandex allows — NOT
+    LIVE-VERIFIED) reports the whole text as ``Title`` and an empty
+    ``Href``, rather than raising, mirroring ``_read_repeating_values``'
+    "treat an unreadable/unexpected slot as an empty value, not a fatal
+    error" convention for a bulk read.
+
+    Returns ``[]`` both when the section can't be found (mirrors
+    ``_read_target_actions``' "absent/inconclusive" convention) and when the
+    campaign genuinely has zero sitelinks.
+    """
+    try:
+        page.locator(_SITELINKS_EDITOR_TESTID).first.wait_for(
+            state="attached", timeout=_SITELINK_ROW_TIMEOUT_MS
+        )
+    except PlaywrightError:
+        return []
+
+    cards = page.locator(_SITELINK_CARD_TESTID)
+    try:
+        count = cards.count()
+    except PlaywrightError:
+        return []
+
+    sitelinks: List[Dict[str, str]] = []
+    for i in range(count):
+        try:
+            text = cards.nth(i).inner_text(timeout=1_000)
+        except PlaywrightError:
+            continue
+        title, _, href = text.partition("\n")
+        sitelinks.append({"Title": title.strip(), "Href": href.strip()})
+    return sitelinks
+
+
+def _add_sitelink(page: "Page", title: str, href: str, description: str) -> None:
+    """Add ONE new sitelink card via the section's "Добавить" button.
+
+    Refuses up front if the section already has ``_SITELINKS_SLOT_COUNT``
+    cards — NOT LIVE-VERIFIED as the real Yandex-enforced maximum (see the
+    module comment above ``_SITELINKS_EDITOR_TESTID``), but a conservative
+    client-side guard matching the CLI's general "fail before touching the
+    page when a limit is already known to be exceeded" posture
+    (``_add_repeating_values``'s ``slot_count`` guard is the same shape).
+
+    NOT LIVE-VERIFIED: whether clicking "Добавить" mounts a new card whose
+    ``SitelinkRow.*`` fields are immediately present, or whether (like
+    ``_AUDIENCE_TAG_INPUT_TESTID``) there is a further click needed to
+    mount the actual input. This assumes the simpler case — the add button
+    itself opens the new card's inline form directly — since recon #2 only
+    observed the form appearing after clicking an EXISTING card's overlay,
+    not the add button (recon deliberately did not click "Добавить" to
+    avoid creating an unreviewed card on a live campaign).
+
+    Each of the three fields is treated as a ``contenteditable`` div, the
+    conservative assumption issue #648's task instructions call for (see
+    the module comment above ``_SITELINKS_EDITOR_TESTID``): clicked,
+    cleared via ``_clear_text_field``, then typed into via ``.type()`` —
+    exactly ``_add_repeating_values``' per-slot sequence. ``description``
+    may be an empty string (a sitelink with no description is a
+    legitimate, common shape — see ``direct_cli/commands/sitelinks.py``'s
+    WSDL sitelinks command, which treats description as optional); an
+    empty ``description`` still clears the field (in case "Добавить"
+    pre-fills it with something) but skips the ``.type()`` call.
+
+    The inline form's close/commit action is NOT LIVE-VERIFIED (see module
+    comment) — this presses Escape first, then clicks the section's own
+    editor container as a fallback, mirroring the "best-effort dismiss,
+    then let the caller's own re-read verification be the real proof of
+    success" posture the rest of this module takes whenever no confirmed
+    native save control exists for a field.
+    """
+    existing = page.locator(_SITELINK_CARD_TESTID)
+    try:
+        existing_count = existing.count()
+    except PlaywrightError:
+        existing_count = 0
+    if existing_count >= _SITELINKS_SLOT_COUNT:
+        raise BrowserSessionError(
+            f"Cannot add another sitelink — the campaign already has "
+            f"{existing_count} of the (UI-stated, not live-confirmed) "
+            f"maximum {_SITELINKS_SLOT_COUNT}. Remove one first with "
+            "--remove-sitelink, or edit the campaign with --headful."
+        )
+
+    try:
+        page.locator(_SITELINKS_ADD_BUTTON_TESTID).first.click()
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            "Could not click the 'Добавить' button in the 'Быстрые "
+            "ссылки' section on the campaign edit page — Yandex may have "
+            "changed the page's markup. Re-run with --headful to inspect "
+            "the page."
+        ) from exc
+
+    def _fill_row_field(testid: str, value: str, field_label: str) -> None:
+        field = page.locator(testid).first
+        try:
+            field.wait_for(state="visible", timeout=_SITELINK_ROW_TIMEOUT_MS)
+            field.click()
+            cleared = _clear_text_field(field)
+        except PlaywrightError as exc:
+            raise BrowserSessionError(
+                f"Could not open the new sitelink's {field_label} field "
+                f"via {testid!r} on the campaign edit page — Yandex may "
+                "have changed the page's markup, or the new card did not "
+                "mount as expected (NOT LIVE-VERIFIED: this module assumes "
+                "'Добавить' opens the new card's inline form directly). "
+                "Re-run with --headful to inspect the page."
+            ) from exc
+        if not cleared:
+            raise BrowserSessionError(
+                f"Could not clear the new sitelink's {field_label} field "
+                "before typing. This usually means Playwright is older "
+                "than 1.44 (the version that added the 'ControlOrMeta' "
+                "modifier) — upgrade with 'pip install -U playwright'."
+            )
+        if not value:
+            return
+        try:
+            field.type(value)
+        except PlaywrightError as exc:
+            raise BrowserSessionError(
+                f"Could not type into the new sitelink's {field_label} "
+                f"field via {testid!r} — Yandex may have changed the "
+                "page's markup. Re-run with --headful to inspect the page."
+            ) from exc
+
+    _fill_row_field(_SITELINK_ROW_NAME_TESTID, title, "title")
+    _fill_row_field(_SITELINK_ROW_HREF_TESTID, href, "URL")
+    _fill_row_field(_SITELINK_ROW_DESCRIPTION_TESTID, description, "description")
+
+    # NOT LIVE-VERIFIED close/commit action — see this function's own
+    # docstring. Escape first (the least likely to have an unwanted side
+    # effect if it does nothing), then a click on the section's own
+    # container as a fallback dismiss. Both are best-effort: neither
+    # raising is treated as fatal here, since the caller (``update_master``)
+    # always re-reads the sitelink list afterward to confirm the add
+    # actually took effect, mirroring ``_add_audience_tag``'s "the click
+    # alone is not proof" posture.
+    with contextlib.suppress(PlaywrightError):
+        page.keyboard.press("Escape")
+    with contextlib.suppress(PlaywrightError):
+        page.locator(_SITELINKS_EDITOR_TESTID).first.click()
+
+
+def _remove_sitelink(page: "Page", index: int) -> None:
+    """Remove the sitelink card currently at position ``index``.
+
+    Unlike ``_remove_audience_tag`` (whose close-button testid embeds
+    ``{index}`` directly, ``_AUDIENCE_TAG_CLOSE_TESTID_TEMPLATE``), sitelink
+    remove buttons all share the exact same ``_SITELINK_REMOVE_TESTID``
+    selector — confirmed live, recon #1 (see the module comment above
+    ``_SITELINKS_EDITOR_TESTID``) — so this resolves the button for a
+    specific card via ``.nth(index)`` on that shared selector instead of
+    formatting a position into the testid string. ``index`` must reference
+    an EXISTING card (see ``_read_sitelinks``) — positions shift after each
+    removal, exactly like audience tags, so callers removing multiple
+    sitelinks in one ``update_master`` call must go high-to-low.
+
+    Confirmed live (recon #1): no confirmation modal appears — the click
+    removes the card directly.
+    """
+    try:
+        # ``IndexError`` is caught alongside ``PlaywrightError``: real
+        # Playwright's ``.nth()`` is lazy and never raises for an
+        # out-of-bounds index by itself (the failure only surfaces once an
+        # action like ``.click()`` is attempted against no matching
+        # element) — but this module's offline fake locator resolves
+        # ``.nth()`` eagerly against a plain Python list, so an
+        # out-of-range index raises ``IndexError`` immediately instead.
+        # Treating both as the same "could not remove" outcome keeps this
+        # function's contract identical against the fake and the real page.
+        page.locator(_SITELINK_REMOVE_TESTID).nth(index).click()
+    except (PlaywrightError, IndexError) as exc:
+        raise BrowserSessionError(
+            f"Could not remove the sitelink at position {index + 1} via "
+            f"{_SITELINK_REMOVE_TESTID!r} on the campaign edit page — "
+            "Yandex may have changed the page's markup, or that position "
+            "no longer exists. Re-run with --headful to inspect the page."
+        ) from exc
+
+
 def _read_target_actions(page: "Page") -> List[Dict[str, Any]]:
     """Read the "Целевые действия" table's current rows.
 
@@ -6304,6 +6599,9 @@ def _verify_saved(
     metrika_counters_before: Optional[List[str]] = None,
     add_metrika_counters: Optional[List[str]] = None,
     remove_metrika_counter_indices: Optional[List[int]] = None,
+    sitelinks_before: Optional[List[Dict[str, str]]] = None,
+    add_sitelinks: Optional[List[Dict[str, str]]] = None,
+    remove_sitelink_indices: Optional[List[int]] = None,
     clicked_button_label: str = _SAVE_BUTTON_TEXT,
 ) -> None:
     """Reload the edit page and confirm every requested field actually saved.
@@ -6632,6 +6930,44 @@ def _verify_saved(
                 f"{sorted(actual_counters)!r}"
             )
 
+    if sitelinks_before is not None:
+        # Same "one expected multiset derived from the pre-mutation
+        # baseline" shape as ``audience_tags_before`` above, adapted for
+        # ``_read_sitelinks``' dict-per-card return value: dicts aren't
+        # hashable, so the multiset is keyed on ``(Title, Href)`` tuples —
+        # ``_read_sitelinks`` does not expose ``Description`` at all (see
+        # its own docstring for why), so a mismatch confined to
+        # ``Description`` alone cannot be detected by this check, only
+        # title/href presence and count.
+        def _sitelink_key(entry: Dict[str, str]) -> Tuple[str, str]:
+            return (entry.get("Title", ""), entry.get("Href", ""))
+
+        expected_sitelinks = Counter(_sitelink_key(s) for s in sitelinks_before)
+        for index in remove_sitelink_indices or []:
+            expected_sitelinks[_sitelink_key(sitelinks_before[index])] -= 1
+        expected_sitelinks += Counter(_sitelink_key(s) for s in (add_sitelinks or []))
+
+        def _sitelink_state_matches(
+            actual_sitelinks: List[Dict[str, str]], _expected: Any
+        ) -> bool:
+            return Counter(_sitelink_key(s) for s in actual_sitelinks) == (
+                expected_sitelinks
+            )
+
+        actual_sitelinks = _read_until_matches(
+            page,
+            _read_sitelinks,
+            None,
+            matches=_sitelink_state_matches,
+            timeout_ms=_SITELINK_ROW_TIMEOUT_MS * 3,
+        )
+        if not _sitelink_state_matches(actual_sitelinks, None):
+            mismatches.append(
+                "sitelinks: expected "
+                f"{sorted(expected_sitelinks.elements())!r}, page now shows "
+                f"{sorted(_sitelink_key(s) for s in actual_sitelinks)!r}"
+            )
+
     if goal_price is not None:
         actual_goal_price = _read_until_matches(
             page,
@@ -6940,6 +7276,8 @@ def update_master(
     remove_audience_tags: Optional[List[int]] = None,
     add_metrika_counters: Optional[List[str]] = None,
     remove_metrika_counters: Optional[List[int]] = None,
+    add_sitelinks: Optional[List[Dict[str, str]]] = None,
+    remove_sitelinks: Optional[List[int]] = None,
     launch: bool = False,
 ) -> Dict[str, Any]:
     """Update one or more Этап A/B/D fields (plus the campaign name) and save.
@@ -7059,9 +7397,25 @@ def update_master(
     high-to-low internally for the same "don't shift a later pending
     position" reason as ``remove_audience_tags``.
 
-    Later Этап C fields — sitelinks, goals, budget adaptation — plus video
-    (a separate follow-up issue, different upload control/pipeline) are out
-    of scope for this function; see issue #648.
+    ``add_sitelinks``/``remove_sitelinks`` (issue #648, Этап C) cover the
+    "Быстрые ссылки" section — see ``_add_sitelink``/``_remove_sitelink``
+    for the per-field mechanics, and the module comment above
+    ``_SITELINKS_EDITOR_TESTID`` for what is and is NOT live-verified about
+    this section (in particular: the inline form's close/commit action, and
+    whether its fields are plain textareas or contenteditable divs, are
+    both unconfirmed). ``add_sitelinks`` is a list of
+    ``{"Title": str, "Href": str, "Description": str}`` dicts, each
+    appended as a new card via the section's "Добавить" button —
+    ``Description`` may be an empty string (sitelinks without a
+    description are a normal shape, see ``direct_cli/commands/
+    sitelinks.py``). ``remove_sitelinks`` takes 0-based POSITIONS into the
+    card list as it exists BEFORE this call (see ``masters sitelinks get``,
+    if/when added, or re-read via ``_read_sitelinks``) — removed
+    high-to-low internally, same reasoning as ``remove_audience_tags``.
+
+    Later Этап C fields — goals, budget adaptation — plus video (a separate
+    follow-up issue, different upload control/pipeline) are out of scope
+    for this function; see issue #648.
 
     ``launch`` (issue #668) matters only when ``campaign_id`` is currently a
     DRAFT: that edit page has no "Сохранить кампанию" button at all, only a
@@ -7136,6 +7490,8 @@ def update_master(
         and not remove_audience_tags
         and not add_metrika_counters
         and not remove_metrika_counters
+        and not add_sitelinks
+        and not remove_sitelinks
     ):
         raise ValueError(
             "update_master requires at least one field to update "
@@ -7146,7 +7502,8 @@ def update_master(
             "clear_headlines, clear_texts, images, "
             "gender, age_from, age_to, devices, "
             "add_audience_tags, remove_audience_tags, "
-            "add_metrika_counters, remove_metrika_counters)."
+            "add_metrika_counters, remove_metrika_counters, "
+            "add_sitelinks, remove_sitelinks)."
         )
 
     url = WIZARD_EDIT_URL.format(campaign_id=campaign_id)
@@ -7366,6 +7723,30 @@ def update_master(
                 "Verify manually before retrying."
             )
 
+    # Snapshotted BEFORE any sitelink mutation, same reasoning as
+    # ``audience_tags_before`` above — ``_verify_saved`` needs the
+    # pre-mutation list to compute the expected post-save state, and the
+    # removal loop below needs it to remove high-to-low without an earlier
+    # removal shifting a later requested position.
+    _sitelinks_requested = bool(add_sitelinks or remove_sitelinks)
+    sitelinks_before = _read_sitelinks(page) if _sitelinks_requested else None
+    _sitelinks_before_list = sitelinks_before or []
+    for index in sorted(remove_sitelinks or [], reverse=True):
+        if index >= len(_sitelinks_before_list):
+            raise BrowserSessionError(
+                f"Sitelink position {index + 1} is out of range — this "
+                f"campaign currently has {len(_sitelinks_before_list)} "
+                f"sitelink(s) (positions 1-{len(_sitelinks_before_list)})."
+            )
+        _remove_sitelink(page, index)
+    for sitelink in add_sitelinks or []:
+        _add_sitelink(
+            page,
+            sitelink["Title"],
+            sitelink["Href"],
+            sitelink.get("Description", ""),
+        )
+
     # Mirrors the audience-tags block immediately above, field-for-field —
     # same pre-mutation-baseline-snapshot rationale (needed both for
     # _verify_saved's expected multiset and so remove_metrika_counters below
@@ -7535,6 +7916,9 @@ def update_master(
             metrika_counters_before=metrika_counters_before,
             add_metrika_counters=add_metrika_counters,
             remove_metrika_counter_indices=remove_metrika_counters,
+            sitelinks_before=sitelinks_before,
+            add_sitelinks=add_sitelinks,
+            remove_sitelink_indices=remove_sitelinks,
             clicked_button_label=clicked_button_label,
         )
     except BrowserAuthError as exc:
@@ -7593,6 +7977,10 @@ def update_master(
         result["AddedMetrikaCounters"] = add_metrika_counters
     if remove_metrika_counters:
         result["RemovedMetrikaCounterPositions"] = sorted(remove_metrika_counters)
+    if add_sitelinks:
+        result["AddedSitelinks"] = add_sitelinks
+    if remove_sitelinks:
+        result["RemovedSitelinkPositions"] = sorted(remove_sitelinks)
     if was_draft and launch:
         # Issue #721: the DRAFT edit page's launch click redirects away from
         # /edit/ (already awaited by _click_draft_terminal_button inside

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -909,6 +909,77 @@ def _parse_remove_metrika_counter_options(values: "tuple[int, ...]") -> "list[in
     return list(values)
 
 
+def _parse_add_sitelink_options(
+    values: "tuple[str, ...]",
+) -> "list[dict[str, str]]":
+    """Parse repeated ``--add-sitelink "Title|Href|Description"`` CLI values.
+
+    Requires exactly 3 pipe-separated parts (2 pipes) — unlike the WSDL-API
+    ``direct sitelinks add --sitelink`` command's ``parse_sitelink_specs``
+    (``direct_cli/utils.py``), which accepts 2-4 parts and treats
+    Description/TurboPageId as optional. This is a DIFFERENT feature (see
+    module docstring: browser-driven Мастер кампаний sitelinks, not the WSDL
+    ``SitelinksSet`` resource) with no live confirmation that the edit
+    page's inline form tolerates an omitted field the way the WSDL request
+    does, so the format is deliberately stricter here: all three parts —
+    Title, Href, AND Description — must be non-empty. This may be loosened
+    once the inline form's actual behaviour with a blank description is
+    live-verified (see ``direct_cli/browser/masters.py``'s
+    ``_SITELINKS_EDITOR_TESTID`` module comment).
+
+    No escape syntax for a literal ``|`` (unlike ``parse_sitelink_specs``'s
+    ``\\|``) — added only if a real need for one shows up, to keep this
+    format as simple as possible for now.
+    """
+    parsed: "list[dict[str, str]]" = []
+    for raw in values:
+        parts = raw.split("|")
+        if len(parts) != 3:
+            raise click.UsageError(
+                f"--add-sitelink value {raw!r} must be in the form "
+                "\"Title|Href|Description\" (exactly 2 '|' separators, e.g. "
+                '"Об авторе|https://example.com/about|Узнайте больше").'
+            )
+        title, href, description = (part.strip() for part in parts)
+        if not title:
+            raise click.UsageError(
+                f"--add-sitelink value {raw!r} has an empty Title — Title "
+                "is required."
+            )
+        if not href:
+            raise click.UsageError(
+                f"--add-sitelink value {raw!r} has an empty Href — Href is " "required."
+            )
+        if not description:
+            raise click.UsageError(
+                f"--add-sitelink value {raw!r} has an empty Description — "
+                "Description is required (this may be relaxed once the "
+                "edit page's actual behaviour with a blank description is "
+                "confirmed; for now pass some text)."
+            )
+        parsed.append({"Title": title, "Href": href, "Description": description})
+    return parsed
+
+
+def _parse_remove_sitelink_options(values: "tuple[int, ...]") -> "list[int]":
+    """Parse repeated ``--remove-sitelink`` CLI values into a list of 0-based
+    positions, rejecting a duplicate — mirrors
+    ``_parse_remove_audience_tag_options``: positions are resolved against a
+    single pre-mutation snapshot (``update_master``'s ``sitelinks_before``),
+    so a repeated position would silently remove two DIFFERENT sitelinks
+    (the one originally at that position, then whatever shifted into it
+    after the first removal) instead of raising."""
+    seen: "set[int]" = set()
+    for position in values:
+        if position in seen:
+            raise click.UsageError(
+                f"--remove-sitelink position {position + 1} was specified "
+                "more than once."
+            )
+        seen.add(position)
+    return list(values)
+
+
 def _validate_image_path(raw_path: str, *, option_name: str, context: str) -> None:
     """Reject one image path that doesn't exist or that Yandex won't accept.
 
@@ -1583,6 +1654,32 @@ def audience_get(
     ),
 )
 @click.option(
+    "--add-sitelink",
+    "add_sitelinks",
+    multiple=True,
+    help=(
+        'Add a quick link to "Быстрые ссылки": "Title|Href|Description" '
+        "(repeat for multiple), e.g. "
+        '"Об авторе|https://example.com/about|Узнайте больше о нас". All '
+        "three parts are required and non-empty (NOT LIVE-VERIFIED whether "
+        "Yandex's inline form actually requires a non-empty description — "
+        "this CLI is conservative pending confirmation). Refused once the "
+        "campaign already has the UI-stated maximum of 5 sitelinks."
+    ),
+)
+@click.option(
+    "--remove-sitelink",
+    "remove_sitelinks",
+    multiple=True,
+    type=int,
+    help=(
+        "Remove a sitelink from 'Быстрые ссылки' by its CURRENT 0-based "
+        "position. Repeat for multiple positions; positions refer to the "
+        "list as it exists BEFORE this command runs, not after earlier "
+        "removals in the same call."
+    ),
+)
+@click.option(
     "--launch",
     is_flag=True,
     default=False,
@@ -1622,6 +1719,8 @@ def update(
     remove_audience_tags,
     add_metrika_counters,
     remove_metrika_counters,
+    add_sitelinks,
+    remove_sitelinks,
     launch,
     headful,
     profile_dir,
@@ -1728,6 +1827,20 @@ def update(
     ``_METRIKA_COUNTER_WRAPPER_TESTID`` for what specifically remains
     unconfirmed.
 
+    ``--add-sitelink``/``--remove-sitelink`` (issue #648, Этап C) cover the
+    "Быстрые ссылки" section. ``--add-sitelink "Title|Href|Description"``
+    appends a new card (repeat for multiple) — all three parts are
+    required and non-empty, see the option's own help text for why this is
+    stricter than the WSDL-API ``direct sitelinks add --sitelink`` command
+    (a different feature entirely — see
+    ``direct_cli/browser/masters.py`` module docstring). A significant
+    part of this section's behaviour is NOT LIVE-VERIFIED — see
+    ``direct_cli/browser/masters.py``'s ``_SITELINKS_EDITOR_TESTID`` module
+    comment for specifics (in particular: how the inline edit form closes,
+    and whether the real maximum is genuinely 5). ``--remove-sitelink``
+    takes a 0-based position into the card list as it exists BEFORE this
+    command runs, same convention as ``--remove-audience-tag``.
+
     A DRAFT campaign's edit page has no "Сохранить кампанию" button at all —
     only a save-as-draft/launch pair (issue #668). ``update`` saves it as a
     draft by default (keeping DRAFT status); pass ``--launch`` to publish it
@@ -1761,6 +1874,8 @@ def update(
         and not remove_audience_tags
         and not add_metrika_counters
         and not remove_metrika_counters
+        and not add_sitelinks
+        and not remove_sitelinks
     ):
         raise click.UsageError(
             "Provide at least one of --weekly-budget, --promotion-goal, "
@@ -1769,7 +1884,8 @@ def update(
             "--name, --landing-url, --tracking-params, --headline, --text, "
             "--clear-headline, --clear-text, --image, --gender, --age-from, "
             "--age-to, --device, --add-audience-tag, --remove-audience-tag, "
-            "--add-metrika-counter, --remove-metrika-counter."
+            "--add-metrika-counter, --remove-metrika-counter, "
+            "--add-sitelink, --remove-sitelink."
         )
 
     if goal_price is not None and promotion_goal == "max-conversions":
@@ -1872,6 +1988,8 @@ def update(
     parsed_remove_metrika_counters = _parse_remove_metrika_counter_options(
         remove_metrika_counters
     )
+    parsed_add_sitelinks = _parse_add_sitelink_options(add_sitelinks)
+    parsed_remove_sitelinks = _parse_remove_sitelink_options(remove_sitelinks)
 
     result = _with_session(
         ctx,
@@ -1906,6 +2024,8 @@ def update(
             remove_audience_tags=parsed_remove_audience_tags or None,
             add_metrika_counters=list(add_metrika_counters) or None,
             remove_metrika_counters=parsed_remove_metrika_counters or None,
+            add_sitelinks=parsed_add_sitelinks or None,
+            remove_sitelinks=parsed_remove_sitelinks or None,
             launch=launch,
         ),
     )

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -17727,6 +17727,472 @@ class TestMastersAudienceGetCommand(unittest.TestCase):
         self.assertEqual(args[1], 42)
 
 
+class TestReadSitelinks(unittest.TestCase):
+    """``_read_sitelinks`` (issue #648, Этап C) — reads "Быстрые ссылки"
+    cards by DOM position, since the card testids are not parameterized by
+    index (see the module comment above ``_SITELINKS_EDITOR_TESTID``)."""
+
+    def test_reads_title_and_href_from_each_card(self):
+        page = FakePage(
+            locators={
+                browser_masters._SITELINKS_EDITOR_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                ),
+                browser_masters._SITELINK_CARD_TESTID: _FakeLocator(
+                    [
+                        _FakeLocatorHandle(text="Об Авторе\nhttps://example.com/about"),
+                        _FakeLocatorHandle(text="Бесплатно\nhttps://example.com/free"),
+                    ]
+                ),
+            }
+        )
+
+        result = browser_masters._read_sitelinks(page)
+
+        self.assertEqual(
+            result,
+            [
+                {"Title": "Об Авторе", "Href": "https://example.com/about"},
+                {"Title": "Бесплатно", "Href": "https://example.com/free"},
+            ],
+        )
+
+    def test_returns_empty_list_when_section_never_renders(self):
+        page = FakePage(locators={})
+
+        with patch.object(browser_masters, "_SITELINK_ROW_TIMEOUT_MS", 1):
+            result = browser_masters._read_sitelinks(page)
+
+        self.assertEqual(result, [])
+
+    def test_returns_empty_list_for_zero_sitelinks(self):
+        page = FakePage(
+            locators={
+                browser_masters._SITELINKS_EDITOR_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                ),
+                browser_masters._SITELINK_CARD_TESTID: _FakeLocator([]),
+            }
+        )
+
+        self.assertEqual(browser_masters._read_sitelinks(page), [])
+
+    def test_card_with_no_newline_reports_empty_href(self):
+        """A card whose text has no newline (title only) reports the whole
+        text as Title and an empty Href, rather than raising — mirrors
+        ``_read_repeating_values``'s "unreadable slot -> empty value"
+        convention for a bulk read."""
+        page = FakePage(
+            locators={
+                browser_masters._SITELINKS_EDITOR_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                ),
+                browser_masters._SITELINK_CARD_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle(text="Только заголовок")]
+                ),
+            }
+        )
+
+        result = browser_masters._read_sitelinks(page)
+
+        self.assertEqual(result, [{"Title": "Только заголовок", "Href": ""}])
+
+
+class TestAddSitelink(unittest.TestCase):
+    """``_add_sitelink`` (issue #648, Этап C)."""
+
+    def _page_with_new_card_form(self, existing_count=0):
+        row_handles = {
+            browser_masters._SITELINK_ROW_NAME_TESTID: _FakeContentEditableHandle(),
+            browser_masters._SITELINK_ROW_HREF_TESTID: _FakeContentEditableHandle(),
+            browser_masters._SITELINK_ROW_DESCRIPTION_TESTID: (
+                _FakeContentEditableHandle()
+            ),
+        }
+        locators = {
+            browser_masters._SITELINKS_ADD_BUTTON_TESTID: _FakeLocator(
+                [_FakeLocatorHandle()]
+            ),
+            browser_masters._SITELINK_CARD_TESTID: _FakeLocator(
+                [_FakeLocatorHandle() for _ in range(existing_count)]
+            ),
+            browser_masters._SITELINKS_EDITOR_TESTID: _FakeLocator(
+                [_FakeLocatorHandle()]
+            ),
+        }
+        for testid, handle in row_handles.items():
+            locators[testid] = _FakeLocator([handle])
+        return FakePage(locators=locators), row_handles
+
+    def test_fills_all_three_fields(self):
+        page, row_handles = self._page_with_new_card_form()
+
+        browser_masters._add_sitelink(
+            page, "Об авторе", "https://example.com/about", "Узнайте больше"
+        )
+
+        self.assertEqual(
+            row_handles[browser_masters._SITELINK_ROW_NAME_TESTID]._text,
+            "Об авторе",
+        )
+        self.assertEqual(
+            row_handles[browser_masters._SITELINK_ROW_HREF_TESTID]._text,
+            "https://example.com/about",
+        )
+        self.assertEqual(
+            row_handles[browser_masters._SITELINK_ROW_DESCRIPTION_TESTID]._text,
+            "Узнайте больше",
+        )
+
+    def test_empty_description_still_clears_but_does_not_type(self):
+        page, row_handles = self._page_with_new_card_form()
+        # Pre-fill the description field the way a "Добавить" click might
+        # (NOT LIVE-VERIFIED whether it does) — an empty description
+        # request must still clear it.
+        row_handles[browser_masters._SITELINK_ROW_DESCRIPTION_TESTID]._text = "leftover"
+
+        browser_masters._add_sitelink(page, "Title", "https://example.com", "")
+
+        self.assertEqual(
+            row_handles[browser_masters._SITELINK_ROW_DESCRIPTION_TESTID]._text, ""
+        )
+
+    def test_refuses_when_slot_count_already_at_limit(self):
+        page, _ = self._page_with_new_card_form(
+            existing_count=browser_masters._SITELINKS_SLOT_COUNT
+        )
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._add_sitelink(
+                page, "Title", "https://example.com", "Description"
+            )
+
+        self.assertIn("already has", str(ctx.exception))
+
+    def test_raises_when_add_button_missing(self):
+        page = FakePage(locators={})
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters._add_sitelink(
+                page, "Title", "https://example.com", "Description"
+            )
+
+    def test_raises_when_row_field_never_mounts(self):
+        page, _ = self._page_with_new_card_form()
+        page._locators[browser_masters._SITELINK_ROW_NAME_TESTID] = _FakeLocator(
+            [_FakeLocatorHandle(raises=True)]
+        )
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._add_sitelink(
+                page, "Title", "https://example.com", "Description"
+            )
+
+        self.assertIn("title", str(ctx.exception))
+
+
+class TestRemoveSitelink(unittest.TestCase):
+    """``_remove_sitelink`` (issue #648, Этап C) — unlike
+    ``_remove_audience_tag``, the remove-button testid is NOT
+    parameterized by index, so this resolves the button via ``.nth(index)``
+    on the shared selector."""
+
+    def test_clicks_the_nth_remove_button(self):
+        handles = [_FakeLocatorHandle() for _ in range(3)]
+        page = FakePage(
+            locators={
+                browser_masters._SITELINK_REMOVE_TESTID: _FakeLocator(handles),
+            }
+        )
+
+        browser_masters._remove_sitelink(page, 1)
+
+        self.assertEqual(handles[1].click_timeouts, [None])
+        self.assertEqual(handles[0].click_timeouts, [])
+        self.assertEqual(handles[2].click_timeouts, [])
+
+    def test_raises_when_position_out_of_range(self):
+        page = FakePage(
+            locators={
+                browser_masters._SITELINK_REMOVE_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                ),
+            }
+        )
+
+        with self.assertRaises(BrowserSessionError):
+            browser_masters._remove_sitelink(page, 5)
+
+
+class TestVerifySavedSitelinks(unittest.TestCase):
+    """``_verify_saved``'s sitelinks check (issue #648, Этап C) — mirrors
+    the audience-tags multiset-derived-from-baseline verification
+    (``TestWaitForAudienceSection``'s removal/untouched tests)."""
+
+    def _page_with_sitelinks(self, sitelinks):
+        cards = [
+            _FakeLocatorHandle(text=f"{s['Title']}\n{s['Href']}") for s in sitelinks
+        ]
+        return FakePage(
+            locators={
+                browser_masters._SITELINKS_EDITOR_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                ),
+                browser_masters._SITELINK_CARD_TESTID: _FakeLocator(cards),
+            }
+        )
+
+    def test_untouched_list_verifies_when_unchanged(self):
+        sitelinks = [
+            {"Title": "Об Авторе", "Href": "https://example.com/about"},
+            {"Title": "Бесплатно", "Href": "https://example.com/free"},
+        ]
+        page = self._page_with_sitelinks(sitelinks)
+
+        with patch.object(browser_masters, "_wait_for_edit_form", lambda *a, **k: None):
+            # Must not raise: the page still shows exactly the baseline.
+            browser_masters._verify_saved(
+                page,
+                42,
+                weekly_budget=None,
+                promotion_goal=None,
+                directs_helps=None,
+                sitelinks_before=sitelinks,
+            )
+
+    def test_removal_verified_by_identity_not_just_count(self):
+        """Baseline [a, b, c], remove position 0 (=a). The page comes back
+        with the right COUNT (2) but the WRONG sitelinks — 'a' survived and
+        'b' is gone instead. A count-only check would pass; the multiset
+        check derived from the baseline must not."""
+        baseline = [
+            {"Title": "a", "Href": "https://example.com/a"},
+            {"Title": "b", "Href": "https://example.com/b"},
+            {"Title": "c", "Href": "https://example.com/c"},
+        ]
+        # Page after "save": a survived, b vanished instead of a.
+        page = self._page_with_sitelinks([baseline[0], baseline[2]])
+
+        with (
+            patch.object(browser_masters, "_wait_for_edit_form", lambda *a, **k: None),
+            patch.object(browser_masters, "_SITELINK_ROW_TIMEOUT_MS", 1),
+            self.assertRaises(BrowserSessionError) as ctx,
+        ):
+            browser_masters._verify_saved(
+                page,
+                42,
+                weekly_budget=None,
+                promotion_goal=None,
+                directs_helps=None,
+                sitelinks_before=baseline,
+                remove_sitelink_indices=[0],
+            )
+
+        self.assertIn("sitelinks", str(ctx.exception))
+
+    def test_add_is_verified_present(self):
+        baseline = [{"Title": "a", "Href": "https://example.com/a"}]
+        added = [{"Title": "new", "Href": "https://example.com/new"}]
+        page = self._page_with_sitelinks(baseline + added)
+
+        with patch.object(browser_masters, "_wait_for_edit_form", lambda *a, **k: None):
+            browser_masters._verify_saved(
+                page,
+                42,
+                weekly_budget=None,
+                promotion_goal=None,
+                directs_helps=None,
+                sitelinks_before=baseline,
+                add_sitelinks=[{**added[0], "Description": "desc"}],
+            )
+
+    def test_add_not_actually_saved_raises(self):
+        baseline = [{"Title": "a", "Href": "https://example.com/a"}]
+        page = self._page_with_sitelinks(baseline)  # add never took effect
+
+        with (
+            patch.object(browser_masters, "_wait_for_edit_form", lambda *a, **k: None),
+            patch.object(browser_masters, "_SITELINK_ROW_TIMEOUT_MS", 1),
+            self.assertRaises(BrowserSessionError) as ctx,
+        ):
+            browser_masters._verify_saved(
+                page,
+                42,
+                weekly_budget=None,
+                promotion_goal=None,
+                directs_helps=None,
+                sitelinks_before=baseline,
+                add_sitelinks=[
+                    {
+                        "Title": "new",
+                        "Href": "https://example.com/new",
+                        "Description": "desc",
+                    }
+                ],
+            )
+
+        self.assertIn("sitelinks", str(ctx.exception))
+
+
+class TestParseAddSitelinkOptions(unittest.TestCase):
+    """``_parse_add_sitelink_options`` (issue #648, Этап C CLI layer)."""
+
+    def test_parses_title_href_description(self):
+        from direct_cli.commands.masters import _parse_add_sitelink_options
+
+        result = _parse_add_sitelink_options(
+            ("Об авторе|https://example.com/about|Узнайте больше",)
+        )
+
+        self.assertEqual(
+            result,
+            [
+                {
+                    "Title": "Об авторе",
+                    "Href": "https://example.com/about",
+                    "Description": "Узнайте больше",
+                }
+            ],
+        )
+
+    def test_strips_whitespace_around_parts(self):
+        from direct_cli.commands.masters import _parse_add_sitelink_options
+
+        result = _parse_add_sitelink_options(
+            (" Title | https://example.com | Description ",)
+        )
+
+        self.assertEqual(
+            result[0],
+            {
+                "Title": "Title",
+                "Href": "https://example.com",
+                "Description": "Description",
+            },
+        )
+
+    def test_rejects_wrong_number_of_parts(self):
+        from direct_cli.commands.masters import _parse_add_sitelink_options
+
+        with self.assertRaises(click.UsageError):
+            _parse_add_sitelink_options(("Title|https://example.com",))
+
+        with self.assertRaises(click.UsageError):
+            _parse_add_sitelink_options(
+                ("Title|https://example.com|Description|Extra",)
+            )
+
+    def test_rejects_empty_title(self):
+        from direct_cli.commands.masters import _parse_add_sitelink_options
+
+        with self.assertRaises(click.UsageError):
+            _parse_add_sitelink_options(("|https://example.com|Description",))
+
+    def test_rejects_empty_href(self):
+        from direct_cli.commands.masters import _parse_add_sitelink_options
+
+        with self.assertRaises(click.UsageError):
+            _parse_add_sitelink_options(("Title||Description",))
+
+    def test_rejects_empty_description(self):
+        from direct_cli.commands.masters import _parse_add_sitelink_options
+
+        with self.assertRaises(click.UsageError):
+            _parse_add_sitelink_options(("Title|https://example.com|",))
+
+
+class TestParseRemoveSitelinkOptions(unittest.TestCase):
+    """``_parse_remove_sitelink_options`` (issue #648, Этап C CLI layer) —
+    mirrors ``_parse_remove_audience_tag_options``."""
+
+    def test_rejects_duplicate_position(self):
+        from direct_cli.commands.masters import _parse_remove_sitelink_options
+
+        with self.assertRaises(click.UsageError):
+            _parse_remove_sitelink_options((1, 1))
+
+    def test_accepts_distinct_positions_in_order(self):
+        from direct_cli.commands.masters import _parse_remove_sitelink_options
+
+        self.assertEqual(_parse_remove_sitelink_options((3, 1, 2)), [3, 1, 2])
+
+
+class TestMastersUpdateSitelinkFlags(unittest.TestCase):
+    """CLI wiring for `masters update`'s "Быстрые ссылки" flags (issue #648,
+    Этап C)."""
+
+    def setUp(self):
+        self.runner = CliRunner()
+
+    def test_documents_sitelink_flags(self):
+        result = self.runner.invoke(cli, ["masters", "update", "--help"])
+        self.assertIn("--add-sitelink", result.output)
+        self.assertIn("--remove-sitelink", result.output)
+
+    def test_rejects_duplicate_remove_sitelink_position(self):
+        result = self.runner.invoke(
+            cli,
+            [
+                "masters",
+                "update",
+                "42",
+                "--remove-sitelink",
+                "1",
+                "--remove-sitelink",
+                "1",
+            ],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("more than once", result.output.lower())
+
+    def test_rejects_malformed_add_sitelink(self):
+        result = self.runner.invoke(
+            cli,
+            ["masters", "update", "42", "--add-sitelink", "OnlyTitle"],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+
+    def test_passes_add_and_remove_sitelinks(self):
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42}
+            result = self.runner.invoke(
+                cli,
+                [
+                    "masters",
+                    "update",
+                    "42",
+                    "--add-sitelink",
+                    "Об авторе|https://example.com/about|Узнайте больше",
+                    "--remove-sitelink",
+                    "3",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        mock_update.assert_called_once()
+        _args, kwargs = mock_update.call_args
+        self.assertEqual(
+            kwargs["add_sitelinks"],
+            [
+                {
+                    "Title": "Об авторе",
+                    "Href": "https://example.com/about",
+                    "Description": "Узнайте больше",
+                }
+            ],
+        )
+        self.assertEqual(kwargs["remove_sitelinks"], [3])
+
+    def test_no_fields_still_rejected_with_sitelink_flags_absent(self):
+        result = self.runner.invoke(cli, ["masters", "update", "42"])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("--add-sitelink", result.output)
+
+
 class TestReadMetrikaCounters(unittest.TestCase):
     """``_read_metrika_counters`` (issue #648, Этап C) — mirrors
     ``_read_audience_tags``, but each "tag" is a whole Metrika counter whose

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -18061,6 +18061,60 @@ class TestUpdateMasterSitelinkCommitConfirmation(unittest.TestCase):
 
         self.assertEqual(save_clicks, [True])
 
+    def test_verifies_against_the_displayed_card_not_the_raw_cli_input(self):
+        # cycle-review finding (Codex, cycle 2): Yandex's displayed Href is
+        # NOT LIVE-VERIFIED to equal the raw CLI input byte-for-byte (e.g.
+        # a trailing slash could be added/stripped on display). Comparing
+        # _verify_saved's expected multiset against the raw input would
+        # make this successful add report a false "did not save as
+        # requested" -- add_sitelinks_observed must carry the DISPLAYED
+        # Href ("https://example.com/new/", with a trailing slash) forward
+        # to _verify_saved, not the raw CLI Href ("https://example.com/new",
+        # without one).
+        raw_href = "https://example.com/new"
+        displayed_href = "https://example.com/new/"  # Yandex added a slash
+        edit_form_ready_selector = (
+            f'[data-testid="{browser_masters._EDIT_FORM_READY_TESTID}"]'
+        )
+        save_clicks = []
+        save_handle = _FakeTextLocatorHandle(
+            visible=True, on_click=lambda: save_clicks.append(True)
+        )
+        page = FakePage(
+            locators={edit_form_ready_selector: _FakeLocator([_FakeLocatorHandle()])},
+            role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
+        )
+        # Empty BEFORE the add, one card (with the DISPLAYED href) after --
+        # models the real "add committed" state transition, since
+        # sitelinks_before is also read via this same mocked function.
+        cards = {"count": 0}
+
+        def _read_sitelinks_stub(_page):
+            if cards["count"] == 0:
+                return []
+            return [{"Title": "New", "Href": displayed_href}]
+
+        def _add_sitelink_stub(_page, _title, _href, _desc):
+            cards["count"] = 1
+
+        with (
+            patch.object(browser_masters, "_SITELINK_ROW_TIMEOUT_MS", 5_000),
+            patch.object(browser_masters, "_read_sitelinks", _read_sitelinks_stub),
+            patch.object(browser_masters, "_add_sitelink", _add_sitelink_stub),
+        ):
+            # Must NOT raise: the multiset is built from the DISPLAYED
+            # value (with the slash), which is exactly what the final
+            # _verify_saved re-read also reports -- so it matches.
+            browser_masters.update_master(
+                page,
+                42,
+                add_sitelinks=[
+                    {"Title": "New", "Href": raw_href, "Description": "Desc"}
+                ],
+            )
+
+        self.assertEqual(save_clicks, [True])
+
 
 class TestRemoveSitelink(unittest.TestCase):
     """``_remove_sitelink`` (issue #648, Этап C) — unlike

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -17388,6 +17388,46 @@ class TestWaitForAudienceSection(unittest.TestCase):
 
         self.assertIn(5_000, wait_calls)
 
+    def test_sitelinks_only_save_gets_the_same_pre_reload_settle_wait(self):
+        """cycle-review finding (this PR): the pre-reload settle wait
+        (issue #681's confirmed-live save-commit race) was extended to
+        `_metrika_touched` above but `_sitelinks_touched` was left out of
+        the same guard, even though this same PR wires up sitelinks_before/
+        add_sitelinks/remove_sitelink_indices as _verify_saved params right
+        next to it. A sitelinks-only call (no audience/metrika fields
+        touched) must still trigger the 5s wait."""
+        page = FakePage(
+            locators={
+                browser_masters._SITELINKS_EDITOR_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                ),
+                browser_masters._SITELINK_CARD_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle(text="Title\nhttps://example.com")]
+                ),
+            }
+        )
+        wait_calls = []
+        page.wait_for_timeout = lambda timeout: wait_calls.append(timeout)
+
+        with patch.object(browser_masters, "_wait_for_edit_form", lambda *a, **k: None):
+            browser_masters._verify_saved(
+                page,
+                42,
+                weekly_budget=None,
+                promotion_goal=None,
+                directs_helps=None,
+                sitelinks_before=[],
+                add_sitelinks=[
+                    {
+                        "Title": "Title",
+                        "Href": "https://example.com",
+                        "Description": "Desc",
+                    }
+                ],
+            )
+
+        self.assertIn(5_000, wait_calls)
+
     def test_raises_if_gender_trigger_never_shows_a_label(self):
         page = FakePage(locators={})  # no _GENDER_SELECT_TESTID handle at all
 
@@ -17889,6 +17929,137 @@ class TestAddSitelink(unittest.TestCase):
             )
 
         self.assertIn("title", str(ctx.exception))
+
+
+class TestUpdateMasterSitelinkCommitConfirmation(unittest.TestCase):
+    """``update_master``'s sitelink add/remove loop (cycle-review finding,
+    Codex, this PR) — mirrors the audience-tag/Metrika-counter loops in the
+    same function: after each click, poll ``_read_sitelinks`` until the
+    on-page count reflects the change, raising BEFORE the save click if it
+    never does (issue #681: a save immediately after a non-committed click
+    reloaded with the change missing). Unlike ``TestRemoveSitelink``/
+    ``TestAddSitelink`` (which test ``_remove_sitelink``/``_add_sitelink``
+    in isolation), this exercises the polling loop that wraps them inside
+    ``update_master`` itself."""
+
+    def setUp(self):
+        self._patches = [
+            patch.object(browser_masters, "_wait_for_edit_form", lambda *a, **k: None),
+            patch.object(
+                browser_masters, "_wait_for_draft_status", lambda *a, **k: False
+            ),
+            patch.object(browser_masters, "_SITELINK_ROW_TIMEOUT_MS", 1),
+        ]
+        for p in self._patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+    def test_raises_before_save_when_removal_click_never_commits(self):
+        # _read_sitelinks always reports the ORIGINAL 2 cards -- models a
+        # remove-button click that fires with no error but never actually
+        # shrinks the on-page list (the exact issue #681 failure mode).
+        baseline = [
+            {"Title": "a", "Href": "https://example.com/a"},
+            {"Title": "b", "Href": "https://example.com/b"},
+        ]
+        save_clicks = []
+        save_handle = _FakeTextLocatorHandle(
+            visible=True, on_click=lambda: save_clicks.append(True)
+        )
+        page = FakePage(
+            locators={},
+            role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
+        )
+
+        with (
+            patch.object(browser_masters, "_read_sitelinks", lambda p: list(baseline)),
+            patch.object(browser_masters, "_remove_sitelink", lambda p, i: None),
+            self.assertRaises(BrowserSessionError) as ctx,
+        ):
+            browser_masters.update_master(page, 42, remove_sitelinks=[0])
+
+        self.assertIn("may not have committed", str(ctx.exception).lower())
+        # The save click must NOT have fired -- the whole point of this
+        # guard is to catch the problem BEFORE the irreversible save.
+        self.assertEqual(save_clicks, [])
+
+    def test_raises_before_save_when_add_click_never_commits(self):
+        # _read_sitelinks always reports the ORIGINAL empty list -- models
+        # an add that fires with no error but never actually grows the
+        # on-page list.
+        save_clicks = []
+        save_handle = _FakeTextLocatorHandle(
+            visible=True, on_click=lambda: save_clicks.append(True)
+        )
+        page = FakePage(
+            locators={},
+            role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
+        )
+
+        with (
+            patch.object(browser_masters, "_read_sitelinks", lambda p: []),
+            patch.object(
+                browser_masters, "_add_sitelink", lambda p, title, href, desc: None
+            ),
+            self.assertRaises(BrowserSessionError) as ctx,
+        ):
+            browser_masters.update_master(
+                page,
+                42,
+                add_sitelinks=[
+                    {
+                        "Title": "New",
+                        "Href": "https://example.com/new",
+                        "Description": "Desc",
+                    }
+                ],
+            )
+
+        self.assertIn("may not have committed", str(ctx.exception).lower())
+        self.assertEqual(save_clicks, [])
+
+    def test_does_not_raise_when_removal_commits_after_a_few_ticks(self):
+        # The commit check must tolerate a DOM update landing a beat after
+        # the click resolves (the normal case), not just an instantaneous
+        # change -- mirrors _clear_repeating_value's own equivalent test.
+        # The reader keeps returning the post-removal state once the
+        # scripted reads are exhausted (mirrors _read_until_matches'
+        # callers elsewhere in this file) since _verify_saved re-reads
+        # again after this loop's own commit-confirmation succeeds.
+        baseline = [
+            {"Title": "a", "Href": "https://example.com/a"},
+            {"Title": "b", "Href": "https://example.com/b"},
+        ]
+        reads = iter([list(baseline), list(baseline)])
+        after_removal = [baseline[0]]
+
+        def _next_read(_page):
+            try:
+                return next(reads)
+            except StopIteration:
+                return list(after_removal)
+
+        save_clicks = []
+        save_handle = _FakeTextLocatorHandle(
+            visible=True, on_click=lambda: save_clicks.append(True)
+        )
+        edit_form_ready_selector = (
+            f'[data-testid="{browser_masters._EDIT_FORM_READY_TESTID}"]'
+        )
+        page = FakePage(
+            locators={edit_form_ready_selector: _FakeLocator([_FakeLocatorHandle()])},
+            role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
+        )
+
+        with (
+            patch.object(browser_masters, "_SITELINK_ROW_TIMEOUT_MS", 5_000),
+            patch.object(browser_masters, "_read_sitelinks", _next_read),
+            patch.object(browser_masters, "_remove_sitelink", lambda p, i: None),
+        ):
+            # Does not raise -- the second read shows the removal committed.
+            browser_masters.update_master(page, 42, remove_sitelinks=[1])
+
+        self.assertEqual(save_clicks, [True])
 
 
 class TestRemoveSitelink(unittest.TestCase):


### PR DESCRIPTION
## Summary

Implements быстрые ссылки (sitelinks) support in `direct masters update` — part of issue #648's Этап C (structural sections: sitelinks, audience, Metrika counters/goals). This is a browser-driven feature (Мастер кампаний has no API), following the same add/remove-by-position pattern already established for `--add-audience-tag`/`--remove-audience-tag` (#681), adapted for sitelinks' 3-field card structure (Title/Href/Description) instead of a plain text tag.

- `--add-sitelink "Title|Href|Description"` — pipe-delimited, adds a new card via the "Добавить" button.
- `--remove-sitelink POSITION` — removes a card by its 0-based on-page position.
- `_read_sitelinks`/`_add_sitelink`/`_remove_sitelink` in `direct_cli/browser/masters.py`, wired into `update_master` (snapshot-before + high-to-low removal, mirroring the audience-tags convention) and `_verify_saved` (multiset check on `(Title, Href)` — `Description` is not bulk-readable, see below).

## ⚠️ NOT LIVE-VERIFIED

Testid structure was confirmed via two live **read-only** recon passes against campaign 713277109 (Playwright + `mcp claude-in-chrome`, no mutations saved) — but the actual add/remove/save behavior has **not** been exercised end to end against a real Yandex session. Specifically open questions:

1. **How the inline `SitelinkRow.*` edit form closes/commits** — no dedicated "Готово"/save testid appeared in recon. The code presses `Escape` then clicks the section container as a best-effort dismiss, relying on `update_master`'s own re-read (`_verify_saved`) as the real proof of success rather than trusting the close action itself.
2. **`contenteditable` vs plain `<textarea>`** for `SitelinkRow.name/href/description.textarea` — conservatively assumed `contenteditable` (same class as headline/text slots), reusing `_clear_text_field` + `.type()`. If it turns out to be a plain textarea, this degrades to a harmless no-op equivalent, not a functional bug.
3. **Whether "Добавить" opens a new card with the `SitelinkRow.*` triple immediately available** — assumed by analogy with every other "click Добавить, fill, commit" flow in this module (target actions, audience tags), never itself clicked in recon.
4. **The real maximum sitelink count** — `_SITELINKS_SLOT_COUNT = 5` comes from UI copy ("добавить до 5 штук"), not from actually adding a 5th sitelink past the 4 the recon campaign already had.

None of this is claimed as working in the docstrings/CLI help — see the module comment above `_SITELINKS_EDITOR_TESTID` in `direct_cli/browser/masters.py` for the full recon writeup. A live mutation-verification pass is planned as a follow-up (browser session currently queued for other in-flight work) before this is considered safe to rely on in production.

## Test plan

- [x] `pytest tests/test_masters.py -k "sitelink or Sitelink"` — 28 passed
- [x] Full offline suite `pytest -n auto` — 3405 passed, 23 skipped, no regressions
- [x] `black`/`flake8` clean on all changed files
- [ ] Live verification (add, remove, save-persists) — **pending**, tracked as a follow-up before this is relied upon

Relates to #648 (no dedicated sub-issue for this specific section).

Supersedes #800 and #802 (both closed — CI got permanently stuck queued on the original branch, even after an empty-commit push and a close/reopen cycle on #800→#802; recreating on a fresh branch name to rule out a branch-scoped webhook/Actions issue).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01FF5MKQjSX89UpwHfFG3uBe