### PR TITLE
fix(masters): require --weekly-budget for masters add (#796)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,46 @@ re-reading it from a separate page (goal 236386933 at price 150).
   delete`, see the "Added" section above), which found and used the
   campaigns grid's own row menu to remove 713337891 for good instead.
 
+**`masters add` now requires `--weekly-budget` (#796).**
+
+Live recon (2026-08-06/07, ksamatadirect account, 5+ repro attempts) found
+the **exact same silent-rejection shape** #777's `--add-target-action`
+requirement above already documents, just for a different field: Yandex's
+create form refuses to submit without a weekly budget, and refuses
+*silently* — no error is visible anywhere in the DOM before the terminal
+button is clicked. Only AFTER the click does a
+`[data-testid="BudgetWithSuggest.ErrorMessage"]` element appear, reading
+"Не задан недельный бюджет". A full network trace of the click confirmed
+the click handler DOES run (its own analytics beacon,
+`yandex.ru/clck/click/.../path=submit.campaign.save`, fires), but no
+create/save request is ever sent to Yandex's backend — so an unset budget
+previously surfaced only as `_wait_for_created_campaign_id`'s opaque
+redirect-timeout error, indistinguishable from a markup change or a
+genuine network problem.
+
+- New required option `masters add --weekly-budget <amount>` (account
+  currency). `create_master`'s `weekly_budget` parameter changes from
+  `Optional[int] = None` to a required `int` — a **breaking change** for
+  any direct API caller, mirroring `target_actions`'s own #777 change.
+- **Migration:** add `--weekly-budget <amount>` to existing `masters add`
+  invocations. The result dict's `WeeklyBudget` key, previously present
+  only when the flag was passed, is now always present.
+
+Live-verified end to end (2026-08-07): with the budget passed, a `--draft`
+create was accepted by Yandex and produced campaign 713359607, confirmed
+via a grid diff (79 rows → 80).
+
+An initially plausible but ultimately **unrelated** finding from the same
+investigation: `_set_target_action_price`'s price-input click leaves a
+separate "Поиск" search/autocomplete combobox open (confirmed live: up to
+24 `[role="option"]` elements stay in the DOM), never closed by
+`_add_target_action`/`create_master` before this fix. Closing it alone
+(via a click on the "Целевые действия" section's own heading —
+`page.keyboard.press("Escape")` does NOT close it, confirmed live) did
+**not** fix the create failure on its own; the popup fix is kept as a real,
+live-confirmed defensive improvement (`_close_target_actions_search_popup`),
+not because it was this issue's root cause.
+
 **Added — `masters update --clear-headline`/`--clear-text` (#786, Этап B follow-up):**
 
 `masters update --headline`/`--text` (#665) can only *replace* an existing

--- a/README.md
+++ b/README.md
@@ -61,14 +61,16 @@ It always reads the logged-in browser session's own account — there is no
 `masters add` creates a new Мастер кампаний. Besides `--headline`/`--text`
 and one of `--region`/`--region-id`, it **requires `--add-target-action`**
 (`"goal_id=price"`, repeatable — the same flag name and syntax as
-`masters update --add-target-action`): Yandex's create form refuses to submit
-without at least one Яндекс Метрика conversion goal, and refuses *silently* —
+`masters update --add-target-action`) **and `--weekly-budget`**: Yandex's
+create form refuses to submit without at least one Яндекс Метрика conversion
+goal, or without a weekly budget, and refuses *silently* in both cases —
 both terminal buttons keep reporting visible/enabled with no `aria-disabled`,
-so a goal-less attempt would otherwise fail as an unexplained timeout after
-the whole form was filled in. The goals on offer come from the Metrika counter
-Yandex auto-discovers from the landing page's domain, so a domain with no
-counter installed cannot be used here. There is no sandbox and no rollback for
-Мастер кампаний — double-check every flag before running it for real.
+so a goal-less or budget-less attempt would otherwise fail as an unexplained
+timeout after the whole form was filled in. The goals on offer come from the
+Metrika counter Yandex auto-discovers from the landing page's domain, so a
+domain with no counter installed cannot be used here. There is no sandbox and
+no rollback for Мастер кампаний — double-check every flag before running it
+for real.
 
 `masters update` edits a single Мастер кампаний's settings page. It currently
 covers the simplest scalar fields (Этап A of a larger, staged rollout — see

--- a/README_ru.md
+++ b/README_ru.md
@@ -48,8 +48,8 @@ direct masters adimages add 72349978 --image-file /path/to/a.png --image-file /p
 direct masters adimages delete 72349978 --position 2
 direct masters adimages delete 72349978 --all
 direct masters adimages set 72349978 --image-file /path/to/a.png --image-file /path/to/b.png
-direct masters add https://example.com/ --headline "Заголовок 1" --headline "Заголовок 2" --text "Текст объявления" --region Москва --weekly-budget 50000 --draft
-direct masters add https://example.com/ --headline "Заголовок 1" --text "Текст объявления" --region-id 213 --weekly-budget 50000 --draft
+direct masters add https://example.com/ --headline "Заголовок 1" --headline "Заголовок 2" --text "Текст объявления" --region Москва --add-target-action "236386933=150" --weekly-budget 50000 --draft
+direct masters add https://example.com/ --headline "Заголовок 1" --text "Текст объявления" --region-id 213 --add-target-action "236386933=150" --weekly-budget 50000 --draft
 direct masters copy 72349978
 direct masters copy 72349978 --launch
 ```

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -3950,11 +3950,29 @@ def _close_target_actions_search_popup(page: "Page") -> None:
     positive signal is the create/save actually succeeding, verified by
     the caller's own post-click checks; swallowing a click failure here
     just means one less mitigation was applied, not a hard error.
+
+    The heading-text match is deliberately unscoped (page-wide, not
+    confined to the "Целевые действия" section's own container — see the
+    module comment above ``_TARGET_ACTIONS_HEADING_TEXT``'s definition for
+    why the section's testid doesn't cover the H2 itself) because live
+    recon confirmed exactly one match on the create page. That is an
+    empirical, not structural, guarantee — cycle-review of #796 raised the
+    risk that a SECOND exact match elsewhere on the page (e.g. a nav item,
+    breadcrumb, or a variant that also has this text) would make ``.first``
+    click the wrong node, and a successful-but-wrong click is not a
+    ``PlaywrightError`` so ``contextlib.suppress`` below would not catch
+    it. Guarding with ``count() == 1`` closes that gap directly: multiple
+    (or zero) matches skip the click outright rather than guessing which
+    one is safe, preserving the same best-effort contract without ever
+    clicking an unverified target. This also covers the edit page (called
+    via ``update_master``'s ``_set_target_action_price`` loop, before its
+    own add/remove baseline snapshot), which was never separately
+    recon'd for this specific invariant.
     """
     with contextlib.suppress(PlaywrightError):
-        page.get_by_text(_TARGET_ACTIONS_HEADING_TEXT, exact=True).first.click(
-            timeout=_POPUP_APPEAR_TIMEOUT_MS
-        )
+        heading = page.get_by_text(_TARGET_ACTIONS_HEADING_TEXT, exact=True)
+        if heading.count() == 1:
+            heading.first.click(timeout=_POPUP_APPEAR_TIMEOUT_MS)
 
 
 def _set_target_action_price(page: "Page", goal_id: int, price: float) -> None:

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -1210,6 +1210,18 @@ _TARGET_ACTION_ADD_BUTTON_EMPTY_TESTID_TEMPLATE = (
 )
 _TARGET_ACTION_ADD_OPTION_TESTID_TEMPLATE = "AddTargetAction.{category}.{goal_id}"
 
+# "Целевые действия" (issue #796): the section's own H2 heading text, used
+# ONLY to close the leftover "Поиск" combobox left open after filling a
+# price input — see _close_target_actions_search_popup for why this is
+# needed and why THIS specific element is the click target. Deliberately a
+# page-wide text match, not scoped inside _TARGET_ACTIONS_SECTION_TESTID:
+# live recon (issue #796) found that testid wraps only the goals TABLE
+# (starts at the "Цель"/"Средняя цена..." column headers), not the H2
+# heading above it — a locator scoped to that container therefore never
+# matches this text at all. Confirmed live exactly one match on both the
+# create and edit pages.
+_TARGET_ACTIONS_HEADING_TEXT = "Целевые действия"
+
 # How many times ``_click_and_wait_for_popup``-style retries are attempted
 # for the add-popup's option to become visible/clickable — same hydration
 # race as every other menu/modal trigger in this module (issues #723/#725),
@@ -3908,6 +3920,43 @@ def _set_goal_price(page: "Page", goal_price: float) -> None:
         ) from exc
 
 
+def _close_target_actions_search_popup(page: "Page") -> None:
+    """Best-effort close of the "Поиск" combobox left open by interacting
+    with a target-action price input (issue #796).
+
+    Live-confirmed 2026-08-06 (campaign creation recon, ksamatadirect
+    account): clicking a ``*.PriceInput`` field (``_set_target_action_price``
+    below) leaves a SEPARATE search/autocomplete combobox open beneath the
+    "Целевые действия" table — up to 24 ``[role="option"]`` elements
+    (other goals from the linked Metrika counter) stay visible in the DOM.
+    Neither ``_set_target_action_price`` nor ``_add_target_action`` ever
+    closed it before this fix — issue #717's own recon comment even notes
+    "[the add popup] list stays open after a click (no auto-close) —
+    irrelevant here", written before it was known that this specific
+    leftover popup is what blocks the create page's terminal click (issue
+    #796: 5/5 live ``masters add --draft`` attempts silently failed to
+    create a campaign, redirect-timing out with no server-side create at
+    all — the same DOM-gives-no-"rejected"-signal shape already documented
+    for issue #777's goal-less-submit case).
+
+    ``page.keyboard.press("Escape")`` does NOT close it (live-confirmed:
+    24 options open before, 24 still open after) — Yandex's combobox
+    apparently doesn't wire the standard close-on-Escape behaviour here.
+    What DOES close it, confirmed live: clicking the section's own H2
+    heading text (``_TARGET_ACTIONS_HEADING_TEXT``) — a plain blur/
+    click-away, not a component-specific close action. This function is
+    best-effort (mirrors ``_scroll_grid_to_row``'s contract) — a failure
+    to close is not itself proof the popup matters here, since the actual
+    positive signal is the create/save actually succeeding, verified by
+    the caller's own post-click checks; swallowing a click failure here
+    just means one less mitigation was applied, not a hard error.
+    """
+    with contextlib.suppress(PlaywrightError):
+        page.get_by_text(_TARGET_ACTIONS_HEADING_TEXT, exact=True).first.click(
+            timeout=_POPUP_APPEAR_TIMEOUT_MS
+        )
+
+
 def _set_target_action_price(page: "Page", goal_id: int, price: float) -> None:
     """Fill the "Целевые действия" table's price input for an EXISTING goal row.
 
@@ -3924,6 +3973,11 @@ def _set_target_action_price(page: "Page", goal_id: int, price: float) -> None:
     reasoning as ``_set_goal_price``: this section sits even lower on the
     edit page and can still be hydrating when ``_wait_for_edit_form``
     returns.
+
+    Closes the search combobox the price-input click leaves open (issue
+    #796, see ``_close_target_actions_search_popup``) before returning —
+    every caller of this function eventually reaches a terminal
+    save/create click, and that leftover popup is what silently blocks it.
     """
     testid = _TARGET_ACTION_PRICE_TESTID_TEMPLATE.format(
         category=_TARGET_ACTIONS_CATEGORY, goal_id=goal_id
@@ -3944,6 +3998,8 @@ def _set_target_action_price(page: "Page", goal_id: int, price: float) -> None:
             "already be there, Yandex may have changed the page's markup — "
             "re-run with --headful to inspect the page."
         ) from exc
+
+    _close_target_actions_search_popup(page)
 
 
 def _add_target_action(page: "Page", goal_id: int, price: float) -> None:
@@ -9490,7 +9546,7 @@ def create_master(
     texts: List[str],
     regions: "Sequence[Union[str, Tuple[str, Optional[int]]]]",
     target_actions: Dict[int, float],
-    weekly_budget: Optional[int] = None,
+    weekly_budget: int,
     launch: bool = True,
 ) -> Dict[str, Any]:
     """Create a new Мастер кампаний ("Конверсии и трафик" type) end to end.
@@ -9532,6 +9588,31 @@ def create_master(
     from ``url``'s domain, so a domain with no counter installed has none
     to pick and cannot be used here at all.
 
+    ``weekly_budget`` is REQUIRED (issue #796) — a **breaking change** from
+    the previous ``Optional[int] = None`` signature. Live recon
+    (2026-08-06/07, campaign 713231614's account, 5+ repro attempts) found
+    the EXACT same silent-rejection shape ``target_actions`` above already
+    documents, just for a different field: leaving the create page's
+    "Недельный бюджет" input empty makes Yandex refuse the submit with
+    **no DOM signal whatsoever before the click** — no error text, no
+    ``aria-invalid``, no disabled button. Only AFTER the terminal button is
+    clicked does a ``[data-testid="BudgetWithSuggest.ErrorMessage"]``
+    element appear, reading "Не задан недельный бюджет" — confirmed live by
+    network-tracing the click: the click's own analytics beacon
+    (``yandex.ru/clck/click/.../path=submit.campaign.save``) fires, proving
+    the click handler DID run, but no create/save POST is ever sent to
+    Yandex's backend. Before this fix, an unset budget could only ever
+    surface as ``_wait_for_created_campaign_id``'s opaque redirect-timeout
+    error — exactly the false "Yandex may have changed the page's markup"
+    diagnosis issue #796's reporter chased for two days before a full
+    network trace isolated the real cause. A leftover "Поиск"
+    search-combobox left open by ``_set_target_action_price`` (see
+    ``_close_target_actions_search_popup``) was an initially plausible but
+    ultimately UNRELATED finding from the same investigation — closing it
+    alone did not fix the create failure; it's kept as a real, live-
+    confirmed defensive improvement, not because it was the root cause
+    here.
+
     Returns the created campaign's ``CampaignId``, read from the post-click
     redirect (``_wait_for_created_campaign_id``), which also gives
     ``_verify_created`` a page to reload for the display-region check.
@@ -9566,6 +9647,12 @@ def create_master(
             "goal): Yandex's create form silently refuses to submit without "
             "one."
         )
+    if weekly_budget is None:
+        raise ValueError(
+            "create_master requires weekly_budget: Yandex's create form "
+            "silently refuses to submit without one (issue #796) — the "
+            "same silent-rejection shape as target_actions above."
+        )
 
     # ``wait_until="commit"``, not ``domcontentloaded`` (issue #685):
     # confirmed live the create page can take long enough to hydrate that
@@ -9597,8 +9684,7 @@ def create_master(
     # default actionability wait covers the ~0.4s gap observed live). No
     # markup change was needed.
     _set_region(page, regions)
-    if weekly_budget is not None:
-        _set_weekly_budget_on_create(page, weekly_budget)
+    _set_weekly_budget_on_create(page, weekly_budget)
 
     # Issue #777: at least one conversion goal, or Yandex silently rejects
     # the terminal click below. Live recon (2026-08-06) confirmed the create
@@ -9673,15 +9759,15 @@ def create_master(
         regions=regions,
     )
 
-    result: Dict[str, Any] = {
+    return {
         "CampaignId": campaign_id,
         "LandingUrl": url,
         "Headlines": headlines,
         "Texts": texts,
         "Regions": regions,
         "TargetActions": target_actions,
+        # weekly_budget is required (issue #796) — always present, unlike
+        # the pre-#796 conditional key this replaced.
+        "WeeklyBudget": weekly_budget,
         "Launched": launch,
     }
-    if weekly_budget is not None:
-        result["WeeklyBudget"] = weekly_budget
-    return result

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -9653,6 +9653,13 @@ def create_master(
             "silently refuses to submit without one (issue #796) — the "
             "same silent-rejection shape as target_actions above."
         )
+    if weekly_budget <= 0:
+        raise ValueError(
+            f"create_master requires a positive weekly_budget, got "
+            f"{weekly_budget!r}. A zero/negative value is not a real "
+            "budget and is not known to be distinguishable from a missing "
+            "one by Yandex's own silent-rejection check (issue #796)."
+        )
 
     # ``wait_until="commit"``, not ``domcontentloaded`` (issue #685):
     # confirmed live the create page can take long enough to hydrate that

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -2284,7 +2284,13 @@ def _resolve_region_ids(
 @click.option(
     "--weekly-budget",
     type=int,
-    help="Weekly budget in account currency (Недельный бюджет)",
+    required=True,
+    help=(
+        "Weekly budget in account currency (Недельный бюджет). REQUIRED "
+        "(issue #796) — Yandex's create form silently refuses to submit "
+        "without one, the same silent-rejection shape as the target-action "
+        "goal requirement above."
+    ),
 )
 @click.option(
     "--draft/--launch",
@@ -2339,6 +2345,14 @@ def add(
     rejected state, so a goal-less run could only ever surface as an
     unexplained timeout. It takes the same "goal_id=price" syntax as
     `masters update --add-target-action`.
+
+    --weekly-budget is required (issue #796): the SAME silent-rejection
+    shape as the goal requirement above — Yandex's create form refuses to
+    submit without a weekly budget, with no visible error until AFTER a
+    submit attempt (a `data-form-error` element reading "Не задан
+    недельный бюджет" only appears in the DOM post-click), so an
+    unset-budget run previously surfaced only as an unexplained redirect
+    timeout with no campaign ever created.
 
     By default the campaign is launched immediately (--launch). Pass
     --draft to save it as a draft instead (Сохранить как черновик) without

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -2349,10 +2349,10 @@ def add(
     --weekly-budget is required (issue #796): the SAME silent-rejection
     shape as the goal requirement above — Yandex's create form refuses to
     submit without a weekly budget, with no visible error until AFTER a
-    submit attempt (a `data-form-error` element reading "Не задан
-    недельный бюджет" only appears in the DOM post-click), so an
-    unset-budget run previously surfaced only as an unexplained redirect
-    timeout with no campaign ever created.
+    submit attempt (a `[data-testid="BudgetWithSuggest.ErrorMessage"]`
+    element reading "Не задан недельный бюджет" only appears in the DOM
+    post-click), so an unset-budget run previously surfaced only as an
+    unexplained redirect timeout with no campaign ever created.
 
     By default the campaign is launched immediately (--launch). Pass
     --draft to save it as a draft instead (Сохранить как черновик) without

--- a/scripts/test_dangerous_commands.sh
+++ b/scripts/test_dangerous_commands.sh
@@ -48,12 +48,14 @@ non-critical campaign, confirming before/after state in the web UI):
   - direct masters launch <campaign_id>
     (publishes a DRAFT campaign -- irreversible, there is no `masters unlaunch`)
   - direct masters add <url> --headline ... --text ... --region ...
-      --add-target-action "<goal_id>=<price>"
+      --add-target-action "<goal_id>=<price>" --weekly-budget ...
     (creates a brand-new campaign -- NOT idempotent, a second run creates a
     second campaign; verify with --draft first, then delete/archive the
     test campaign by hand after checking it in the web UI.
-    --add-target-action is REQUIRED since 0.6.0 -- Yandex's create form
-    silently refuses a campaign with no conversion goal. Note a --draft
+    --add-target-action is REQUIRED (issue #777) -- Yandex's create form
+    silently refuses a campaign with no conversion goal. --weekly-budget is
+    also REQUIRED (issue #796) for the same reason -- the create form
+    silently refuses to submit without a weekly budget too. Note a --draft
     created this way cannot be archived (issue #660) but can be removed
     via `masters delete`, see issue #782)
   - direct masters copy <campaign_id> [--launch/--draft]

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -600,6 +600,19 @@ class _FakeGetByTextLocator:
     def nth(self, i):
         return self._handles[i]
 
+    @property
+    def first(self):
+        # Mirrors real Playwright's Locator.first (and _FakeLocator.first's
+        # own identical fallback) — issue #796's
+        # _close_target_actions_search_popup uses it on a get_by_text()
+        # result the same way every other locator in this module does. An
+        # empty match returns a handle that raises on use, not an
+        # IndexError on attribute access, so callers wrapped in
+        # contextlib.suppress(PlaywrightError) (as that function is) see
+        # the same "best-effort, no-op on absence" behaviour a real empty
+        # Locator's timeout would produce.
+        return self._handles[0] if self._handles else _FakeLocatorHandle(raises=True)
+
 
 class FakePage:
     """A Page whose ``locator(selector)`` result is pre-scripted per selector."""
@@ -5919,6 +5932,46 @@ class TestSetTargetActionPrice(unittest.TestCase):
         browser_masters._set_target_action_price(page, 159614149, 200)
 
         self.assertEqual(state["value"], "200")
+
+    def test_closes_leftover_search_popup_after_filling(self):
+        # issue #796: clicking the price field leaves a separate search
+        # combobox open, which silently blocks the create/save page's
+        # terminal click. This must be closed before returning.
+        field = _FakeLocatorHandle()
+        field.fill = lambda value: None
+        price_testid = browser_masters._TARGET_ACTION_PRICE_TESTID_TEMPLATE.format(
+            category=browser_masters._TARGET_ACTIONS_CATEGORY, goal_id=159614149
+        )
+        heading_clicks = []
+        heading = _FakeLocatorHandle(on_click=lambda: heading_clicks.append(1))
+        page = FakePage(
+            locators={f'[data-testid="{price_testid}"]': _FakeLocator([field])},
+            text_buttons={
+                browser_masters._TARGET_ACTIONS_HEADING_TEXT: _FakeGetByTextLocator(
+                    [heading]
+                )
+            },
+        )
+
+        browser_masters._set_target_action_price(page, 159614149, 200)
+
+        self.assertEqual(heading_clicks, [1])
+
+    def test_missing_heading_does_not_raise(self):
+        # _close_target_actions_search_popup is best-effort (issue #796) --
+        # a page/fixture with no matching heading (e.g. Yandex changed the
+        # markup, or a test that doesn't care about this) must not turn
+        # _set_target_action_price itself into a failure.
+        field = _FakeLocatorHandle()
+        field.fill = lambda value: None
+        price_testid = browser_masters._TARGET_ACTION_PRICE_TESTID_TEMPLATE.format(
+            category=browser_masters._TARGET_ACTIONS_CATEGORY, goal_id=159614149
+        )
+        page = FakePage(
+            locators={f'[data-testid="{price_testid}"]': _FakeLocator([field])}
+        )
+
+        browser_masters._set_target_action_price(page, 159614149, 200)  # must not raise
 
     def test_raises_when_row_not_present(self):
         page = FakePage(locators={})
@@ -15205,6 +15258,7 @@ class TestCreateMaster(unittest.TestCase):
             texts=["Текст объявления"],
             regions=["Москва"],
             target_actions={self.GOAL_ID: self.GOAL_PRICE},
+            weekly_budget=1000,
         )
 
         self.assertEqual(state["url"]["url"], "https://ksamata.ru/")
@@ -15226,6 +15280,8 @@ class TestCreateMaster(unittest.TestCase):
                 # required, echoed back so the caller can see which CPA was
                 # actually published.
                 "TargetActions": {self.GOAL_ID: self.GOAL_PRICE},
+                # Issue #796: weekly_budget is required, always echoed back.
+                "WeeklyBudget": 1000,
                 "Launched": True,
             },
         )
@@ -15251,6 +15307,7 @@ class TestCreateMaster(unittest.TestCase):
             texts=["Текст объявления"],
             regions=["Москва"],
             target_actions={self.GOAL_ID: self.GOAL_PRICE},
+            weekly_budget=1000,
             launch=False,
         )
 
@@ -15274,19 +15331,32 @@ class TestCreateMaster(unittest.TestCase):
         self.assertEqual(state["budget"]["value"], "50000")
         self.assertEqual(result["WeeklyBudget"], 50000)
 
-    def test_omits_weekly_budget_key_when_not_given(self):
-        page, _ = self._full_page()
+    def test_raises_value_error_when_no_weekly_budget(self):
+        """Issue #796: the SAME silent-rejection shape as target_actions
+        above (test_raises_value_error_when_no_target_actions) — Yandex's
+        create form refuses to submit without a weekly budget, and refuses
+        SILENTLY: no error appears in the DOM until AFTER a submit attempt
+        (a data-form-error element reading "Не задан недельный бюджет"),
+        so a budget-less call must be refused outright rather than driven
+        through the whole form and left to fail as an opaque redirect
+        timeout."""
+        page, state = self._full_page()
 
-        result = browser_masters.create_master(
-            page,
-            "https://ksamata.ru/",
-            headlines=["Заголовок"],
-            texts=["Текст объявления"],
-            regions=["Москва"],
-            target_actions={self.GOAL_ID: self.GOAL_PRICE},
-        )
+        with self.assertRaises(ValueError):
+            browser_masters.create_master(
+                page,
+                "https://ksamata.ru/",
+                headlines=["Заголовок"],
+                texts=["Текст объявления"],
+                regions=["Москва"],
+                target_actions={self.GOAL_ID: self.GOAL_PRICE},
+                weekly_budget=None,  # type: ignore[arg-type]
+            )
 
-        self.assertNotIn("WeeklyBudget", result)
+        # Fails fast: nothing was published, and no browser work was done.
+        self.assertEqual(state["launch_clicks"], [])
+        self.assertEqual(state["draft_clicks"], [])
+        self.assertEqual(page.navigated_to, [])
 
     def test_raises_value_error_when_no_target_actions(self):
         """Issue #777: Yandex silently swallows the terminal click when the
@@ -15303,6 +15373,7 @@ class TestCreateMaster(unittest.TestCase):
                 texts=["Текст объявления"],
                 regions=["Москва"],
                 target_actions={},
+                weekly_budget=1000,
             )
 
         # Fails fast: nothing was published, and no browser work was done.
@@ -15324,6 +15395,7 @@ class TestCreateMaster(unittest.TestCase):
             texts=["Текст объявления"],
             regions=["Москва"],
             target_actions={self.GOAL_ID: 250},
+            weekly_budget=1000,
         )
 
         self.assertEqual(state["goal_prices"], {self.GOAL_ID: "250"})
@@ -15340,6 +15412,7 @@ class TestCreateMaster(unittest.TestCase):
             texts=["Текст объявления"],
             regions=["Москва"],
             target_actions={self.GOAL_ID: 250, second_goal: 75},
+            weekly_budget=1000,
         )
 
         self.assertEqual(state["goal_prices"], {self.GOAL_ID: "250", second_goal: "75"})
@@ -15361,6 +15434,7 @@ class TestCreateMaster(unittest.TestCase):
             texts=["Текст объявления"],
             regions=["Москва"],
             target_actions={self.GOAL_ID: self.GOAL_PRICE},
+            weekly_budget=1000,
         )
 
         self.assertEqual(len(state["launch_clicks"]), 1)
@@ -15385,6 +15459,7 @@ class TestCreateMaster(unittest.TestCase):
             texts=["Текст объявления"],
             regions=["Москва"],
             target_actions={self.GOAL_ID: self.GOAL_PRICE},
+            weekly_budget=1000,
         )
 
         self.assertEqual(state["goal_prices"], {self.GOAL_ID: "150"})
@@ -15404,6 +15479,7 @@ class TestCreateMaster(unittest.TestCase):
                 texts=["Текст объявления"],
                 regions=["Москва"],
                 target_actions={self.GOAL_ID: self.GOAL_PRICE},
+                weekly_budget=1000,
             )
 
         self.assertEqual(state["launch_clicks"], [])
@@ -15430,6 +15506,7 @@ class TestCreateMaster(unittest.TestCase):
                 texts=["Текст объявления"],
                 regions=["Москва"],
                 target_actions={self.GOAL_ID: self.GOAL_PRICE},
+                weekly_budget=1000,
             )
 
         self.assertIn("Целевые действия", str(ctx.exception))
@@ -15453,6 +15530,7 @@ class TestCreateMaster(unittest.TestCase):
                 texts=["Текст объявления"],
                 regions=["Москва"],
                 target_actions={self.GOAL_ID: self.GOAL_PRICE},
+                weekly_budget=1000,
             )
 
         self.assertIn(str(self.GOAL_ID), str(ctx.exception))
@@ -15470,6 +15548,7 @@ class TestCreateMaster(unittest.TestCase):
                 texts=["t"],
                 regions=["r"],
                 target_actions={self.GOAL_ID: self.GOAL_PRICE},
+                weekly_budget=1000,
             )
 
     def test_raises_value_error_when_no_texts(self):
@@ -15483,6 +15562,7 @@ class TestCreateMaster(unittest.TestCase):
                 texts=[],
                 regions=["r"],
                 target_actions={self.GOAL_ID: self.GOAL_PRICE},
+                weekly_budget=1000,
             )
 
     def test_raises_value_error_when_no_regions(self):
@@ -15496,6 +15576,7 @@ class TestCreateMaster(unittest.TestCase):
                 texts=["t"],
                 regions=[],
                 target_actions={self.GOAL_ID: self.GOAL_PRICE},
+                weekly_budget=1000,
             )
 
     def test_invalid_url_stops_before_step2(self):
@@ -15512,6 +15593,7 @@ class TestCreateMaster(unittest.TestCase):
                 texts=["t"],
                 regions=["Москва"],
                 target_actions={self.GOAL_ID: self.GOAL_PRICE},
+                weekly_budget=1000,
             )
 
     def test_step1_timeout_raises_when_url_field_never_renders(self):
@@ -15534,6 +15616,7 @@ class TestCreateMaster(unittest.TestCase):
                     texts=["t"],
                     regions=["Москва"],
                     target_actions={self.GOAL_ID: self.GOAL_PRICE},
+                    weekly_budget=1000,
                 )
         self.assertIn("step 1", str(ctx.exception))
 
@@ -15578,6 +15661,7 @@ class TestCreateMaster(unittest.TestCase):
                 texts=["Текст объявления"],
                 regions=["Москва"],
                 target_actions={self.GOAL_ID: self.GOAL_PRICE},
+                weekly_budget=1000,
             )
         # The whole point: caught BEFORE the irreversible click, not after.
         self.assertEqual(len(state["launch_clicks"]), 0)
@@ -15626,6 +15710,7 @@ class TestCreateMaster(unittest.TestCase):
                 texts=["Текст объявления"],
                 regions=["Москва"],
                 target_actions={self.GOAL_ID: self.GOAL_PRICE},
+                weekly_budget=1000,
             )
         self.assertEqual(len(state["launch_clicks"]), 1)  # the click DID happen
         self.assertIn("did not take effect as requested", str(ctx.exception))
@@ -15647,6 +15732,7 @@ class TestCreateMaster(unittest.TestCase):
             texts=["Текст объявления"],
             regions=["Москва"],
             target_actions={self.GOAL_ID: self.GOAL_PRICE},
+            weekly_budget=1000,
         )
 
         self.assertEqual(result["CampaignId"], 713299123)
@@ -15669,6 +15755,7 @@ class TestCreateMaster(unittest.TestCase):
                     texts=["Текст объявления"],
                     regions=["Москва"],
                     target_actions={self.GOAL_ID: self.GOAL_PRICE},
+                    weekly_budget=1000,
                 )
 
         self.assertEqual(len(state["launch_clicks"]), 1)  # the click DID happen
@@ -15699,6 +15786,7 @@ class TestCreateMaster(unittest.TestCase):
                     texts=["Текст объявления"],
                     regions=["Москва"],
                     target_actions={self.GOAL_ID: self.GOAL_PRICE},
+                    weekly_budget=1000,
                 )
 
         self.assertEqual(len(state["launch_clicks"]), 1)  # the click DID happen
@@ -15727,6 +15815,7 @@ class TestCreateMaster(unittest.TestCase):
             texts=["Текст объявления"],
             regions=["Москва"],
             target_actions={self.GOAL_ID: self.GOAL_PRICE},
+            weekly_budget=1000,
         )  # must not raise
 
         self.assertEqual(result["CampaignId"], self.CREATED_ID)
@@ -15748,6 +15837,7 @@ class TestCreateMaster(unittest.TestCase):
             texts=["Текст объявления"],
             regions=[("Москва", 213)],
             target_actions={self.GOAL_ID: self.GOAL_PRICE},
+            weekly_budget=1000,
         )  # must not raise
 
         self.assertEqual(result["Regions"], [("Москва", 213)])
@@ -15826,6 +15916,8 @@ class TestMastersAddCommand(unittest.TestCase):
                     "236386933=150",
                     "--region",
                     "Москва",
+                    "--weekly-budget",
+                    "1000",
                 ],
             )
 
@@ -15862,6 +15954,8 @@ class TestMastersAddCommand(unittest.TestCase):
                     "236386933=150",
                     "--region",
                     "Москва",
+                    "--weekly-budget",
+                    "1000",
                     "--draft",
                 ],
             )
@@ -15913,6 +16007,8 @@ class TestMastersAddCommand(unittest.TestCase):
                 "t",
                 "--add-target-action",
                 "236386933=150",
+                "--weekly-budget",
+                "1000",
             ],
         )
         self.assertNotEqual(result.exit_code, 0)
@@ -15959,6 +16055,8 @@ class TestMastersAddCommand(unittest.TestCase):
                 "Москва",
                 "--add-target-action",
                 "236386933",
+                "--weekly-budget",
+                "1000",
             ],
         )
         self.assertNotEqual(result.exit_code, 0)
@@ -15997,6 +16095,8 @@ class TestMastersAddCommand(unittest.TestCase):
                     "236386933=150",
                     "--region-id",
                     "213",
+                    "--weekly-budget",
+                    "1000",
                 ],
             )
 
@@ -16044,6 +16144,8 @@ class TestMastersAddCommand(unittest.TestCase):
                     "Москва",
                     "--region-id",
                     "2",
+                    "--weekly-budget",
+                    "1000",
                 ],
             )
 
@@ -16077,6 +16179,8 @@ class TestMastersAddCommand(unittest.TestCase):
                     "236386933=150",
                     "--region-id",
                     "999999",
+                    "--weekly-budget",
+                    "1000",
                 ],
             )
 

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -16014,6 +16014,32 @@ class TestMastersAddCommand(unittest.TestCase):
         self.assertNotEqual(result.exit_code, 0)
         self.assertIn("--region/--region-id", result.output)
 
+    def test_weekly_budget_is_required(self):
+        """Issue #796: the SAME silent-rejection shape as #777's
+        --add-target-action requirement — Yandex's create form is silently
+        rejected without a weekly budget, so a budget-less invocation must
+        be refused at the CLI boundary (Click's required=True) rather than
+        driven through a whole browser session that can only end in an
+        unexplained redirect timeout."""
+        result = self.runner.invoke(
+            cli,
+            [
+                "masters",
+                "add",
+                "https://ksamata.ru/",
+                "--headline",
+                "h",
+                "--text",
+                "t",
+                "--region",
+                "Москва",
+                "--add-target-action",
+                "236386933=150",
+            ],
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("--weekly-budget", result.output)
+
     def test_add_target_action_is_required(self):
         """Issue #777: Yandex's create form is silently rejected without a
         conversion goal — both terminal buttons keep reporting

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -5973,6 +5973,38 @@ class TestSetTargetActionPrice(unittest.TestCase):
 
         browser_masters._set_target_action_price(page, 159614149, 200)  # must not raise
 
+    def test_skips_click_when_heading_text_matches_more_than_once(self):
+        # cycle-review of #796: the heading-text match is page-wide, not
+        # scoped to the "Целевые действия" section's own container, on the
+        # empirical (live-recon, not structural) assumption that it's the
+        # ONLY exact match on the page. If that assumption ever breaks
+        # (e.g. a second nav item/breadcrumb/tooltip with the same exact
+        # text), .first would click an unverified — possibly interactive —
+        # element instead of the section heading, and a successful click
+        # on the wrong element is not a PlaywrightError, so
+        # contextlib.suppress would not catch it. Must skip the click
+        # outright on ANY count other than exactly 1, not guess.
+        field = _FakeLocatorHandle()
+        field.fill = lambda value: None
+        price_testid = browser_masters._TARGET_ACTION_PRICE_TESTID_TEMPLATE.format(
+            category=browser_masters._TARGET_ACTIONS_CATEGORY, goal_id=159614149
+        )
+        heading_clicks = []
+        heading_a = _FakeLocatorHandle(on_click=lambda: heading_clicks.append("a"))
+        heading_b = _FakeLocatorHandle(on_click=lambda: heading_clicks.append("b"))
+        page = FakePage(
+            locators={f'[data-testid="{price_testid}"]': _FakeLocator([field])},
+            text_buttons={
+                browser_masters._TARGET_ACTIONS_HEADING_TEXT: _FakeGetByTextLocator(
+                    [heading_a, heading_b]
+                )
+            },
+        )
+
+        browser_masters._set_target_action_price(page, 159614149, 200)  # must not raise
+
+        self.assertEqual(heading_clicks, [])
+
     def test_raises_when_row_not_present(self):
         page = FakePage(locators={})
 

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -15336,10 +15336,10 @@ class TestCreateMaster(unittest.TestCase):
         above (test_raises_value_error_when_no_target_actions) — Yandex's
         create form refuses to submit without a weekly budget, and refuses
         SILENTLY: no error appears in the DOM until AFTER a submit attempt
-        (a data-form-error element reading "Не задан недельный бюджет"),
-        so a budget-less call must be refused outright rather than driven
-        through the whole form and left to fail as an opaque redirect
-        timeout."""
+        (a `[data-testid="BudgetWithSuggest.ErrorMessage"]` element reading
+        "Не задан недельный бюджет"), so a budget-less call must be refused
+        outright rather than driven through the whole form and left to fail
+        as an opaque redirect timeout."""
         page, state = self._full_page()
 
         with self.assertRaises(ValueError):
@@ -15352,6 +15352,33 @@ class TestCreateMaster(unittest.TestCase):
                 target_actions={self.GOAL_ID: self.GOAL_PRICE},
                 weekly_budget=None,  # type: ignore[arg-type]
             )
+
+        # Fails fast: nothing was published, and no browser work was done.
+        self.assertEqual(state["launch_clicks"], [])
+        self.assertEqual(state["draft_clicks"], [])
+        self.assertEqual(page.navigated_to, [])
+
+    def test_raises_value_error_when_weekly_budget_is_not_positive(self):
+        """A zero/negative weekly_budget passes both Click's `required=True`
+        (it only checks presence, not value) and the `is None` check above —
+        the DOM comparison in `_read_created_form_mismatches` reads the
+        field back as the same 0, so it would NOT be caught as a mismatch
+        even if Yandex's own form silently rejected it exactly like a
+        missing budget. Refuse it outright, the same fail-fast shape as the
+        None case."""
+        page, state = self._full_page()
+
+        for bad_value in (0, -1):
+            with self.assertRaises(ValueError):
+                browser_masters.create_master(
+                    page,
+                    "https://ksamata.ru/",
+                    headlines=["Заголовок"],
+                    texts=["Текст объявления"],
+                    regions=["Москва"],
+                    target_actions={self.GOAL_ID: self.GOAL_PRICE},
+                    weekly_budget=bad_value,
+                )
 
         # Fails fast: nothing was published, and no browser work was done.
         self.assertEqual(state["launch_clicks"], [])


### PR DESCRIPTION
## Summary

`masters add --draft` silently failed to create a campaign in 5+ live attempts (redirect-timeout, no campaign ever created — confirmed via `masters list` grid diffs). An initial hypothesis (a leftover target-action search combobox blocking the terminal click, reported in the issue comments) was investigated and **ruled out** as the root cause via a full network trace of the click.

## Root cause (confirmed live, not a hypothesis)

`create_master`'s `weekly_budget` parameter was `Optional[int] = None`, but Yandex's create form **silently refuses to submit without a weekly budget** — the same silent-rejection shape #777 already found and fixed for the target-action goal requirement.

- No DOM signal exists before the click.
- Only AFTER clicking does a `[data-testid="BudgetWithSuggest.ErrorMessage"]` element appear, reading **"Не задан недельный бюджет"**.
- Network tracing confirmed the click handler DOES fire (its own analytics beacon, `yandex.ru/clck/click/.../path=submit.campaign.save`, fires), but **no create/save request is ever sent** to Yandex's backend.

So the failure previously surfaced only as `_wait_for_created_campaign_id`'s opaque redirect-timeout error, indistinguishable from a markup change or genuine network problem.

## BREAKING CHANGE

`create_master`'s `weekly_budget` parameter is now a required `int` (was `Optional[int] = None`). `masters add --weekly-budget` is now a required CLI option, mirroring #777's `--add-target-action` change. See `CHANGELOG.md` for the full entry and migration note.

## Also kept: a real, unrelated defensive improvement

`_set_target_action_price`'s price-input click leaves a separate "Поиск" search/autocomplete combobox open in the DOM (confirmed live: up to 24 `[role="option"]` elements). Never closed before this fix. Closing it (via a click on the "Целевые действия" section's own heading — `Escape` does **not** close it, confirmed live) did **not** fix the create failure on its own — it's kept as defensive hardening (`_close_target_actions_search_popup`), not because it was this issue's root cause.

## Live verification

2026-08-07: with `--weekly-budget` passed, a `--draft` create was accepted by Yandex and produced campaign **713359607**, confirmed via a grid diff (79 rows → 80).

## Testing

- Fixed 25 existing `create_master` test call sites to pass `weekly_budget`.
- Added `test_raises_value_error_when_no_weekly_budget`.
- `pytest` (full offline suite) — 3379 passed, 23 skipped
- `black`/`flake8` clean

Closes #796

🤖 Generated with [Claude Code](https://claude.com/claude-code)