### PR TITLE
feat(masters): add --add-video/--remove-video to `masters update`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,18 @@ the module comments above `_VIDEOS_SLOT_COUNT` in
 `direct_cli/browser/masters.py` for the full confirmed-vs-assumed
 breakdown before relying on this against a real account.
 
+**Preflight fix (cycle-review round 1):** because `--remove-video`'s close
+button commits directly on the edit page with no Save gate of its own —
+unlike images, where remove+add both happen inside a modal and an
+abandoned modal means nothing was mutated — a multiple `--remove-video`
+batch now validates every URL (duplicates and unknown URLs alike) against
+the pre-mutation snapshot up front, before clicking anything. A single
+invalid or repeated URL used to let earlier, valid removals in the same
+batch already execute before the error was raised. `_add_video`'s failure
+messages no longer unconditionally claim "the video set has NOT been
+changed" when one or more `--remove-video` removals already ran earlier in
+the same `masters update` call.
+
 **`masters delete` — remove a DRAFT Мастер кампаний campaign (#782).**
 
 A DRAFT campaign was previously a one-way door: its overview page has no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,20 @@ messages no longer unconditionally claim "the video set has NOT been
 changed" when one or more `--remove-video` removals already ran earlier in
 the same `masters update` call.
 
+**Wording fix (cycle-review round 2):** the round-1 message above still
+overclaimed certainty it did not have — it asserted prior removals
+"already ran and are NOT affected by this failure", but whether
+`--remove-video`'s close-button click actually commits without the page's
+own Save is itself unverified (see the honesty note above). The message
+now says the removals ran but their commit status is unconfirmed, and
+tells the user to verify manually. The upload-landing timeout message is
+similarly softened: it polls the same page-level video list
+`--remove-video` uses, not a modal-internal list (unlike images, which
+have a confirmed-live modal-internal list precisely because the page-level
+one only updates on Save) — if videos behave the same way, this poll can
+never succeed, and the error message now says so instead of implying only
+"processing" was slow.
+
 **`masters delete` — remove a DRAFT Мастер кампаний campaign (#782).**
 
 A DRAFT campaign was previously a one-way door: its overview page has no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,41 @@ issue #796's target-action price popup). Treat add/remove itself as an
 implementation-by-pattern pending a later live mutation verification pass,
 not a confirmed-working feature.
 
+**`masters update --add-video`/`--remove-video` — manage a campaign's video
+variants (#648, Этап D).**
+
+The "Варианты видео" section's add/remove is a materially different shape
+from `--image`'s point-replacement: a 2026-08-06 recon (a byproduct of an
+unrelated sitelinks recon pass, campaign 713277109) found the per-video
+remove control (`VideoSuggestionsEditor.CampaignContents.CloseButton.
+<video_url>`) rendered OUTSIDE any modal, directly on the edit page —
+unlike images, where both add and remove only happen inside
+`ImageSuggestionsEditorModal`. `--add-video`/`--remove-video` are therefore
+a plain add/remove pair (by video URL, not by position), not a synthetic
+point-replacement:
+
+- `--add-video PATH` uploads a local video file, appending it to the set.
+  Refused once the campaign already has 2 videos (Yandex's own UI states
+  "Максимум 2 видео" — NOT independently verified by exceeding it).
+- `--remove-video URL` removes one video by its exact URL (repeat for
+  multiple). There is no CLI command yet to list a campaign's current
+  video URLs.
+- New browser-layer primitives: `_read_videos`, `_wait_for_videos_editor`,
+  `_open_videos_modal`, `_add_video`, `_remove_video`,
+  `_verify_video_mismatches` (`direct_cli/browser/masters.py`).
+
+**Honesty note on live verification:** only the section itself
+(`VideoSuggestionsEditor`), its open button, and the per-video close
+button's presence outside the modal are confirmed live. The (assumed)
+upload modal's own markup — including whether it is really called
+`VideoSuggestionsEditorModal`, its file input, and its Save button — is
+**pure analogy with the images modal, with zero live confirmation**. The
+close button's CLICK EFFECT (does it really remove the video immediately?)
+is likewise unverified — only its presence in the DOM was observed. See
+the module comments above `_VIDEOS_SLOT_COUNT` in
+`direct_cli/browser/masters.py` for the full confirmed-vs-assumed
+breakdown before relying on this against a real account.
+
 **`masters delete` — remove a DRAFT Мастер кампаний campaign (#782).**
 
 A DRAFT campaign was previously a one-way door: its overview page has no

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -10283,12 +10283,24 @@ def _add_video(page: "Page", path: str, *, prior_removals: int = 0) -> None:
 
     ``prior_removals`` (issue #648 cycle-review round 1 of PR #806): the
     caller passes the count of ``--remove-video`` calls that already ran in
-    this same ``update_master`` invocation, since removal happens directly
-    on the edit page (no modal, no Save gate — see ``_remove_video``'s
-    docstring) and is therefore already committed by the time this function
-    runs. Every error message below is worded accordingly — it must never
-    claim "the video set has NOT been changed" when a prior removal may
-    already have taken effect.
+    this same ``update_master`` invocation. Every error message below is
+    worded accordingly — it must never claim "the video set has NOT been
+    changed" when a prior removal may already have taken effect.
+
+    NOT LIVE-VERIFIED (cycle-review round 2 of PR #806): whether
+    ``_remove_video``'s click actually commits without the page's Save is
+    itself unverified (see that function's docstring), so when
+    ``prior_removals`` is nonzero this function cannot assert the removals
+    are safely committed — only that they already ran and their outcome is
+    unconfirmed. Likewise the upload-landing poll below reads
+    ``_read_videos``, the same page-level list ``_remove_video`` polls —
+    unlike images, where the modal has its own confirmed-live
+    modal-internal list (``_read_modal_selected_thumb_urls``) precisely
+    because the page-level list only updates on Save. No modal-internal
+    video list has been found or confirmed, so this poll's assumption that
+    an uploaded video shows up in the page-level list before Save is
+    unverified and, if wrong, ``--add-video`` fails after every real
+    upload.
     """
     _wait_for_videos_editor(page)
     before_urls = _read_videos(page)
@@ -10308,9 +10320,11 @@ def _add_video(page: "Page", path: str, *, prior_removals: int = 0) -> None:
         if not prior_removals
         else (
             f"NOTE: {prior_removals} --remove-video removal(s) requested "
-            "earlier in this same command already ran and are NOT "
-            "affected by this failure — removal happens directly on the "
-            "edit page, with no Save gate of its own. Verify the "
+            "earlier in this same command already ran, but this add "
+            "failure happened before the modal's Save — whether those "
+            "removals are actually committed on Yandex's side is NOT "
+            "LIVE-VERIFIED (they may require the page's own Save like "
+            "every other field, or may already be final). Verify the "
             "campaign's current video set manually before retrying."
         )
     )
@@ -10332,10 +10346,12 @@ def _add_video(page: "Page", path: str, *, prior_removals: int = 0) -> None:
     ):
         raise BrowserSessionError(
             f"Uploaded {path!r} inside the video manager modal, but no new "
-            f"video appeared there within {_VIDEO_UPLOAD_TIMEOUT_MS / 1000:.0f}s "
-            "— Yandex's asynchronous processing may have failed or be "
-            "unusually slow, or this command's assumptions about the "
-            f"modal's markup may simply be wrong (NOT LIVE-VERIFIED). "
+            f"video appeared within {_VIDEO_UPLOAD_TIMEOUT_MS / 1000:.0f}s "
+            "in the page-level video list this command polls — Yandex's "
+            "asynchronous processing may have failed or be unusually "
+            "slow, or (NOT LIVE-VERIFIED) the uploaded video may only be "
+            "staged inside the modal and never promoted to that list "
+            "until Save, in which case this poll can never succeed. "
             f"{no_change_note}"
         )
 

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -934,6 +934,70 @@ _IMAGES_EDITOR_TIMEOUT_MS = 60_000
 # pays this as fixed latency once per edit-page visit.
 _IMAGES_GHOST_GRACE_S = 20.0
 
+# Video variants ("Варианты видео", issue #648 Этап D). CONFIRMED LIVE
+# 2026-08-06 (campaign 713277109, one existing video at recon time) — but
+# ONLY the testids OUTSIDE the modal, in a general page-wide testid dump that
+# never clicked ``VideoSuggestionsEditor.Open``:
+#
+#   VideoSuggestionsEditor                                    (section, DIV)
+#   VideoSuggestionsEditor.Open                                (open button)
+#   VideoSuggestionsEditor.CampaignContents                    (list container)
+#   VideoSuggestionsEditor.CampaignContents.<video_url>        (one video's
+#       card — the testid's suffix is the FULL video URL, e.g.
+#       "https://storage.mds.yandex.net/get-bstor/.../foo.mp4", not a
+#       Yandex-assigned short id the way images use a content id)
+#   VideoSuggestionsEditor.CampaignContents.VideoThumb.<video_url>
+#   VideoSuggestionsEditor.CampaignContents.VideoThumb.<video_url>.Content
+#   VideoSuggestionsEditor.CampaignContents.VideoThumb.<video_url>.VideoElement
+#   VideoSuggestionsEditor.CampaignContents.VideoThumb.<video_url>.PlayButton
+#   VideoSuggestionsEditor.CampaignContents.CloseButton.<video_url>
+#
+# The recon dump showed ``CloseButton.<video_url>`` present OUTSIDE the modal,
+# directly on the edit page — unlike images, where both add AND remove only
+# exist inside ``ImageSuggestionsEditorModal``. This module therefore models
+# removal as a direct click on the page, no modal — see ``_remove_video``.
+# NOT LIVE-VERIFIED: the click itself was never exercised (recon only
+# enumerated testids), so this is "the button exists" confirmed, not "the
+# button works as expected" confirmed.
+_VIDEOS_EDITOR_SELECTOR = '[data-testid="VideoSuggestionsEditor"]'
+_VIDEOS_CONTENT_TESTID_PREFIX = "VideoSuggestionsEditor.CampaignContents."
+_VIDEOS_OPEN_MODAL_SELECTOR = '[data-testid="VideoSuggestionsEditor.Open"]'
+_VIDEOS_CLOSE_BUTTON_TESTID_TEMPLATE = (
+    "VideoSuggestionsEditor.CampaignContents.CloseButton.{video_url}"
+)
+# UI copy next to the section reads "Максимум 2 видео" — an upper bound
+# stated in the page's own text, NOT live-verified by actually attempting a
+# 3rd upload. Mirrors ``_HEADLINES_SLOT_COUNT``/``_TEXTS_SLOT_COUNT`` in
+# spirit (a fixed cap used for a fail-fast CLI/browser-layer check) but,
+# like ``_IMAGES_MAX_COUNT``, only bounds "attempt to add more than this" —
+# the real per-campaign state is always ``len(_read_videos(page))``, read
+# fresh from the page.
+_VIDEOS_SLOT_COUNT = 2
+#
+# EVERYTHING BELOW THIS POINT IS ZERO-LIVE-CONFIRMATION, ASSUMED PURELY BY
+# ANALOGY WITH THE IMAGES MODAL (``ImageSuggestionsEditorModal`` and its
+# constants above). The 2026-08-06 recon that found the testids above was a
+# byproduct of an unrelated sitelinks recon pass and never clicked
+# ``VideoSuggestionsEditor.Open`` — so none of the modal's own markup,
+# including whether it is even called ``VideoSuggestionsEditorModal``, has
+# ever been observed. Treat every name below as a best-effort guess that
+# code review / a future live pass may need to correct outright.
+_VIDEOS_MODAL_SELECTOR = '[data-testid="VideoSuggestionsEditorModal"]'
+_VIDEOS_MODAL_FILE_INPUT_SELECTOR = (
+    '[data-testid="VideoSuggestionsEditorModal.UploadZone.filePicker"]'
+)
+_VIDEOS_MODAL_SAVE_SELECTOR = '[data-testid="VideoSuggestionsEditorModal.Save"]'
+# Yandex's own docs for video creatives commonly cite MP4/MOV/AVI; picked as
+# a conservative, documented-elsewhere starting point, but the modal file
+# input's real ``accept=`` attribute has never been observed live (unlike
+# ``_IMAGE_UPLOAD_SUFFIXES``, which IS a confirmed-live reading of the
+# images modal's file input). Re-verify against the real input before
+# relying on this list to reject anything Yandex would actually accept.
+_VIDEO_UPLOAD_SUFFIXES = frozenset({".mp4", ".mov", ".avi"})
+_VIDEO_MODAL_OPEN_TIMEOUT_MS = 10_000
+_VIDEO_UPLOAD_TIMEOUT_MS = 60_000
+_VIDEOS_EDITOR_TIMEOUT_MS = 60_000
+
 # Region picker (issue #653 re-recon, 2026-08-02): Yandex replaced the old
 # text-combobox-with-suggestions flow with a tree/tag-group widget
 # (``data-testid="RegionsTreeEditor"``). Confirmed live: the tag group's
@@ -6589,6 +6653,9 @@ def _verify_saved(
     texts: Optional[Dict[int, str]] = None,
     images_before_ids: Optional[List[str]] = None,
     images_replaced_ids: Optional[Set[str]] = None,
+    videos_before_urls: Optional[List[str]] = None,
+    video_added: bool = False,
+    videos_removed: Optional[List[str]] = None,
     goal_price: Optional[float] = None,
     target_action_prices: Optional[Dict[int, float]] = None,
     add_target_actions: Optional[Dict[int, float]] = None,
@@ -7251,6 +7318,14 @@ def _verify_saved(
             replaced_ids=images_replaced_ids or set(),
         )
     )
+    mismatches.extend(
+        _verify_video_mismatches(
+            page,
+            before_urls=videos_before_urls or [],
+            added=video_added,
+            removed_urls=videos_removed or [],
+        )
+    )
 
     if mismatches:
         raise BrowserSessionError(
@@ -7281,6 +7356,8 @@ def update_master(
     clear_headlines: Optional[List[int]] = None,
     clear_texts: Optional[List[int]] = None,
     images: Optional[Dict[int, str]] = None,
+    add_video: Optional[str] = None,
+    remove_videos: Optional[List[str]] = None,
     gender: Optional[str] = None,
     age_from: Optional[int] = None,
     age_from_requested: bool = False,
@@ -7371,6 +7448,31 @@ def update_master(
     empty set, or to a position beyond the campaign's actual image count,
     raises ``BrowserSessionError``.
 
+    ``add_video``/``remove_videos`` (issue #648, Этап D) cover the
+    "Варианты видео" section — the UI's own copy states a cap of
+    ``_VIDEOS_SLOT_COUNT`` (2) videos per campaign, NOT independently
+    live-verified by exceeding it. Unlike ``images``, this is deliberately
+    a SIMPLE add/remove pair, not a positional point-replacement:
+    2026-08-06 recon (see the module comment above ``_VIDEOS_SLOT_COUNT``)
+    found the per-video close button lives OUTSIDE the (assumed) video
+    manager modal, directly on the edit page — a materially different
+    shape from images, where both remove and add only happen inside
+    ``ImageSuggestionsEditorModal``. With a hard cap of 2 and remove being
+    a plain identity-based operation (by video URL, via `masters update`'s
+    own read of the set, no position resolution needed), a synthetic
+    remove+add point-replacement composed the way ``_set_image`` composes
+    it would only be adding complexity images needed and videos have not
+    been shown to. ``add_video`` is a single local file path — Yandex
+    processes uploads asynchronously (same pattern as images), and this
+    refuses up front if the set is already at the cap. ``remove_videos``
+    lists video URLs to remove (see `masters update`'s own read via
+    ``_read_videos``, exposed by no CLI reader command yet — retrieving
+    the current set today means inspecting the edit page directly, e.g.
+    ``--headful``). **NOT LIVE-VERIFIED beyond the section/open-button
+    testids** — see ``_add_video``/``_remove_video``/module comments for
+    exactly which pieces are confirmed live vs. assumed by analogy with
+    images.
+
     ``gender``/``age_from``/``age_to``/``devices``/``add_audience_tags``/
     ``remove_audience_tags`` (issue #681, Этап C) cover the "Аудитория"
     section's manual-targeting fields — see ``_set_gender``/
@@ -7428,8 +7530,14 @@ def update_master(
     if/when added, or re-read via ``_read_sitelinks``) — removed
     high-to-low internally, same reasoning as ``remove_audience_tags``.
 
-    Later Этап C fields — goals, budget adaptation — plus video (a separate
-    follow-up issue, different upload control/pipeline) are out of scope
+    ``add_video``/``remove_videos`` (issue #648, Этап D) manage the campaign's
+    video variants in the "Варианты видео" section. ``add_video`` takes a
+    local file PATH and uploads it; ``remove_videos`` takes a list of video
+    URLs to remove. See ``_add_video``, ``_remove_video``, ``_verify_video_mismatches``
+    for implementation details. Not fully live-verified (see the module comment
+    above ``_VIDEOS_SLOT_COUNT`` for the confirmed-vs-assumed breakdown).
+
+    Later Этап C fields — goals, budget adaptation — remain out of scope
     for this function; see issue #648.
 
     ``launch`` (issue #668) matters only when ``campaign_id`` is currently a
@@ -7497,6 +7605,8 @@ def update_master(
         and not clear_headlines
         and not clear_texts
         and not images
+        and add_video is None
+        and not remove_videos
         and gender is None
         and not age_from_requested
         and not age_to_requested
@@ -7514,8 +7624,8 @@ def update_master(
             "target_action_prices, add_target_actions, "
             "remove_target_action_goal_ids, directs_helps, name, "
             "landing_url, tracking_params, headlines, texts, "
-            "clear_headlines, clear_texts, images, "
-            "gender, age_from, age_to, devices, "
+            "clear_headlines, clear_texts, images, add_video, "
+            "remove_videos, gender, age_from, age_to, devices, "
             "add_audience_tags, remove_audience_tags, "
             "add_metrika_counters, remove_metrika_counters, "
             "add_sitelinks, remove_sitelinks)."
@@ -7927,6 +8037,27 @@ def update_master(
         images_replaced_ids.add(target_content_id)
         _set_image(page, index, path, target_content_id=target_content_id)
 
+    # Snapshotted BEFORE any video mutation, same reasoning as
+    # ``images_before_ids`` above — ``_verify_saved`` needs the pre-mutation
+    # set to derive the expected post-save state. Unlike images, there is no
+    # per-item resolution step here (add/remove are both identity-based by
+    # URL, not position — see ``update_master``'s own docstring for why),
+    # so this is a simple snapshot rather than an index->id map.
+    if add_video is not None or remove_videos:
+        _wait_for_videos_editor(page)
+    videos_before_urls = (
+        _read_videos(page) if (add_video is not None or remove_videos) else []
+    )
+    for video_url in remove_videos or []:
+        if video_url not in videos_before_urls:
+            raise BrowserSessionError(
+                f"Video {video_url!r} is not present in this campaign's "
+                "current video set — nothing to remove."
+            )
+        _remove_video(page, video_url)
+    if add_video is not None:
+        _add_video(page, add_video)
+
     # was_draft was captured right after _wait_for_edit_form, above — reused
     # here rather than re-derived, for the same reason _click_save takes it
     # as an explicit argument instead of re-querying the DOM itself.
@@ -7974,6 +8105,9 @@ def update_master(
             texts=verify_texts or None,
             images_before_ids=images_before_ids,
             images_replaced_ids=images_replaced_ids,
+            videos_before_urls=videos_before_urls,
+            video_added=add_video is not None,
+            videos_removed=remove_videos,
             goal_price=goal_price,
             target_action_prices=target_action_prices,
             add_target_actions=add_target_actions,
@@ -8002,7 +8136,7 @@ def update_master(
             "but the session was invalidated while verifying the save — "
             "the requested changes were likely already applied; check "
             f"campaign {campaign_id} manually rather than retrying "
-            "(image replacements are not idempotent)."
+            "(image/video replacements are not idempotent)."
         ) from exc
 
     result: Dict[str, Any] = {"CampaignId": campaign_id}
@@ -8036,6 +8170,10 @@ def update_master(
         result["ClearedTexts"] = sorted(clear_texts)
     if images:
         result["Images"] = images
+    if add_video is not None:
+        result["AddedVideo"] = add_video
+    if remove_videos:
+        result["RemovedVideos"] = list(remove_videos)
     if gender is not None:
         result["Gender"] = gender
     if age_from_requested:
@@ -9989,6 +10127,291 @@ def _verify_image_set_mismatches(
     if len(actual_ids) != expected_size:
         mismatches.append(
             f"image set now has {len(actual_ids)} image(s), expected "
+            f"{expected_size}"
+        )
+    return mismatches
+
+
+def _wait_for_videos_editor(page: "Page") -> None:
+    """Block until the "Варианты видео" section has actually rendered.
+
+    Modeled directly on ``_wait_for_images_editor`` — same SPA-hydration
+    hazard (an empty read before the section mounts is indistinguishable
+    from a campaign that genuinely has zero videos) — but WITHOUT that
+    function's stub/ghost-render handling: the multi-stage render sequence
+    ``_wait_for_images_editor`` guards against was only ever observed for
+    the images section specifically (issue #687), and there is no live
+    evidence the videos section behaves the same way. This only waits for
+    ``_VIDEOS_EDITOR_SELECTOR`` itself to appear — a strictly weaker
+    guarantee than the images function provides. If the videos section
+    turns out to have its own stub/ghost render stages, this will need the
+    same fix ``_wait_for_images_editor`` already went through; nothing here
+    rules that out, it simply has not been observed yet.
+    """
+    if _poll_until(
+        page,
+        lambda: page.locator(_VIDEOS_EDITOR_SELECTOR).first.count() > 0,
+        _VIDEOS_EDITOR_TIMEOUT_MS,
+    ):
+        return
+
+    raise BrowserSessionError(
+        "The edit page's 'Варианты видео' section did not finish rendering "
+        f"within {_VIDEOS_EDITOR_TIMEOUT_MS / 1000:.0f}s, so this command "
+        "cannot tell whether the campaign has videos or not. Yandex may "
+        "have changed the page's markup, or the page may still be loading. "
+        "Re-run with --headful to inspect the page."
+    )
+
+
+def _read_videos(page: "Page") -> List[str]:
+    """Read the campaign's current video set as an ordered list of video
+    URLs.
+
+    Confirmed live 2026-08-06 (campaign 713277109, recon dump, NOT a
+    targeted video recon — see the module comment above
+    ``_VIDEOS_SLOT_COUNT``) that each video renders FOUR testids sharing the
+    same ``<video_url>`` suffix under ``VideoSuggestionsEditor.
+    CampaignContents.``: the bare card
+    (``VideoSuggestionsEditor.CampaignContents.<video_url>``), plus
+    ``VideoThumb.<video_url>``, ``VideoThumb.<video_url>.Content``, and
+    ``VideoThumb.<video_url>.VideoElement``/``.PlayButton`` nested under
+    that, and a sibling ``CloseButton.<video_url>``. Only the bare card
+    (no further ``.`` after the URL... except the URL itself contains no
+    ``.`` -delimited testid segments beyond its own scheme/host/path, which
+    ``_read_testid_suffixes`` cannot tell apart from a deliberate suffix) —
+    so, mirroring ``_read_modal_selected_thumb_urls``'s skip-list approach
+    for images, every suffix that STARTS WITH one of the known nested-testid
+    prefixes (``VideoThumb.`` or ``CloseButton.``) is treated as a
+    sub-element of a card already counted via its own bare-URL entry, not a
+    distinct video.
+    """
+    suffixes = _read_testid_suffixes(page, _VIDEOS_CONTENT_TESTID_PREFIX)
+    return [
+        suffix
+        for suffix in suffixes
+        if not suffix.startswith("VideoThumb.")
+        and not suffix.startswith("CloseButton.")
+    ]
+
+
+def _open_videos_modal(page: "Page") -> None:
+    """Click the video section's "Open" button and wait for the video
+    manager modal to render.
+
+    NOT LIVE-VERIFIED. Modeled directly on ``_open_images_modal`` — the only
+    confirmed-live piece here is that ``_VIDEOS_OPEN_MODAL_SELECTOR``
+    (``VideoSuggestionsEditor.Open``) exists on the page before any click
+    (2026-08-06 recon). Whether clicking it opens a modal at all, and
+    whether that modal is really called ``VideoSuggestionsEditorModal``, is
+    a pure analogy with images — see the module comment above
+    ``_VIDEOS_MODAL_SELECTOR``.
+    """
+    open_button = page.locator(_VIDEOS_OPEN_MODAL_SELECTOR).first
+    try:
+        open_button.click()
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            "Could not find/click the video section's 'Open' button — "
+            "Yandex may have changed the page's markup. Re-run with "
+            "--headful to inspect the page."
+        ) from exc
+
+    if _poll_until(
+        page,
+        lambda: page.locator(_VIDEOS_MODAL_SELECTOR).first.count() > 0,
+        _VIDEO_MODAL_OPEN_TIMEOUT_MS,
+    ):
+        return
+
+    raise BrowserSessionError(
+        "Clicked the video section's 'Open' button but the video manager "
+        f"modal (assumed testid, NOT live-verified) did not appear within "
+        f"{_VIDEO_MODAL_OPEN_TIMEOUT_MS / 1000:.0f}s — Yandex may have "
+        "changed the page's markup, or this command's assumption about the "
+        "modal's testid is simply wrong. Re-run with --headful to inspect "
+        "the page."
+    )
+
+
+def _add_video(page: "Page", path: str) -> None:
+    """Upload a new video file, appending it to the campaign's video set.
+
+    NOT LIVE-VERIFIED beyond the section/open-button testids confirmed by
+    the 2026-08-06 recon (see module comments above ``_VIDEOS_SLOT_COUNT``/
+    ``_VIDEOS_MODAL_SELECTOR``). Modeled directly on ``_set_image``'s
+    upload half (open modal, upload via hidden file input, poll for the new
+    card, click Save) — but WITHOUT the remove step, since videos have no
+    point-replacement here: the caller (``update_master``) treats video as
+    simple add/remove-by-URL, not position-indexed replacement (see
+    ``update_master``'s docstring for why: the confirmed-live recon found
+    ``CloseButton.<video_url>`` OUTSIDE the modal, on the edit page itself,
+    which is a materially different shape from images' remove-only-inside-
+    the-modal behaviour — a synthetic remove+add point-replacement would be
+    inventing complexity images needed and videos have not been shown to).
+
+    Refuses up front if the set is already at ``_VIDEOS_SLOT_COUNT`` — a
+    real cap enforced ahead of any upload attempt, though the number itself
+    is only sourced from the page's own "Максимум 2 видео" copy, not from
+    actually trying to exceed it live.
+    """
+    _wait_for_videos_editor(page)
+    before_urls = _read_videos(page)
+
+    if len(before_urls) >= _VIDEOS_SLOT_COUNT:
+        raise BrowserSessionError(
+            f"This campaign already has {len(before_urls)} video(s) — "
+            f"Yandex's own UI states a maximum of {_VIDEOS_SLOT_COUNT} "
+            "per campaign. Remove one first with --remove-video."
+        )
+
+    _open_videos_modal(page)
+
+    try:
+        page.locator(_VIDEOS_MODAL_FILE_INPUT_SELECTOR).first.set_input_files(path)
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            f"Could not upload {path!r} inside the video manager modal "
+            "(assumed testid, NOT live-verified) — Yandex may have changed "
+            "the page's markup. Re-run with --headful to inspect the page. "
+            "The campaign's saved video set has NOT been changed (the "
+            "modal was never saved)."
+        ) from exc
+
+    if not _poll_until(
+        page,
+        lambda: len(_read_videos(page)) > len(before_urls),
+        _VIDEO_UPLOAD_TIMEOUT_MS,
+    ):
+        raise BrowserSessionError(
+            f"Uploaded {path!r} inside the video manager modal, but no new "
+            f"video appeared there within {_VIDEO_UPLOAD_TIMEOUT_MS / 1000:.0f}s "
+            "— Yandex's asynchronous processing may have failed or be "
+            "unusually slow, or this command's assumptions about the "
+            "modal's markup may simply be wrong (NOT LIVE-VERIFIED). The "
+            "campaign's saved video set has NOT been changed (the modal "
+            "was never saved) — close the browser and retry."
+        )
+
+    try:
+        page.locator(_VIDEOS_MODAL_SAVE_SELECTOR).first.click()
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            "Could not find/click the video manager modal's Save button "
+            "(assumed testid, NOT live-verified) — Yandex may have changed "
+            "the page's markup. Re-run with --headful to inspect the page. "
+            "The campaign's saved video set has NOT been changed (the "
+            "modal was never saved)."
+        ) from exc
+
+    if _poll_until(
+        page,
+        lambda: page.locator(_VIDEOS_MODAL_SELECTOR).first.count() == 0,
+        _VIDEO_MODAL_OPEN_TIMEOUT_MS,
+    ):
+        return
+
+    raise BrowserSessionError(
+        "Clicked the video manager modal's Save button but it did not "
+        f"close within {_VIDEO_MODAL_OPEN_TIMEOUT_MS / 1000:.0f}s — the "
+        "commit may not have completed. Verify manually before retrying."
+    )
+
+
+def _remove_video(page: "Page", video_url: str) -> None:
+    """Remove one video by its URL, directly on the edit page — NO modal.
+
+    Confirmed live 2026-08-06 (recon dump, campaign 713277109): the close
+    button (``VideoSuggestionsEditor.CampaignContents.CloseButton.
+    <video_url>``) is present OUTSIDE the modal, on the edit page itself,
+    unlike images where removal only happens inside
+    ``ImageSuggestionsEditorModal``. This is the one part of the video
+    surface simpler than images as a direct consequence of that recon
+    finding.
+
+    NOT LIVE-VERIFIED: the click itself, and whether it actually removes
+    the video (as opposed to, say, opening a confirmation dialog first, or
+    doing nothing until some other action commits it) — the recon only
+    enumerated testids present in the DOM, it never clicked anything video-
+    related. This function assumes a direct click removes the video
+    immediately, mirroring the confirmed-live click-and-poll shape used
+    throughout this module (e.g. ``_clear_repeating_value``), but that
+    assumption itself is unverified for this specific button.
+    """
+    close_selector = (
+        f'[data-testid="'
+        f"{_VIDEOS_CLOSE_BUTTON_TESTID_TEMPLATE.format(video_url=video_url)}"
+        f'"]'
+    )
+    try:
+        page.locator(close_selector).first.click()
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            f"Could not find/click the close button for video {video_url!r} "
+            "— it may already have been removed, or Yandex may have "
+            "changed the page's markup. Re-run with --headful to inspect "
+            "the page."
+        ) from exc
+
+    if _poll_until(
+        page,
+        lambda: video_url not in _read_videos(page),
+        _VIDEO_MODAL_OPEN_TIMEOUT_MS,
+    ):
+        return
+
+    raise BrowserSessionError(
+        f"Clicked the close button for video {video_url!r}, but it is "
+        f"still shown on the page after "
+        f"{_VIDEO_MODAL_OPEN_TIMEOUT_MS / 1000:.0f}s. Yandex may have "
+        "rejected the removal, or this command's assumption that the "
+        "click removes it immediately (NOT LIVE-VERIFIED) may be wrong."
+    )
+
+
+def _verify_video_mismatches(
+    page: "Page",
+    *,
+    before_urls: List[str],
+    added: bool,
+    removed_urls: "Sequence[str]",
+) -> List[str]:
+    """Re-read the campaign's saved video set and confirm it matches the
+    expected end state after ``update_master``'s add/remove.
+
+    Modeled on ``_verify_image_set_mismatches``'s absolute-end-state check
+    (removed URLs gone, kept URLs still present, size matches), adapted for
+    video's simple add/remove-by-URL semantics (no positional replacement —
+    see ``_add_video``'s docstring for why). A newly added video's URL is
+    not known ahead of time (Yandex assigns it during upload, same
+    limitation ``_verify_image_set_mismatches`` already documents for
+    images' content ids), so ``added`` only asserts a COUNT increase of
+    exactly one, never identity.
+    """
+    if not added and not removed_urls:
+        return []
+
+    _wait_for_videos_editor(page)
+    actual_urls = _read_videos(page)
+
+    mismatches = []
+    still_present = [url for url in removed_urls if url in actual_urls]
+    if still_present:
+        mismatches.append(
+            "video(s) that should have been removed are still present: "
+            + ", ".join(still_present)
+        )
+    expected_kept = [url for url in before_urls if url not in removed_urls]
+    missing_kept = [url for url in expected_kept if url not in actual_urls]
+    if missing_kept:
+        mismatches.append(
+            "video(s) that should have been left untouched are now "
+            "missing: " + ", ".join(missing_kept)
+        )
+    expected_size = len(expected_kept) + (1 if added else 0)
+    if len(actual_urls) != expected_size:
+        mismatches.append(
+            f"video set now has {len(actual_urls)} video(s), expected "
             f"{expected_size}"
         )
     return mismatches

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -8048,15 +8048,38 @@ def update_master(
     videos_before_urls = (
         _read_videos(page) if (add_video is not None or remove_videos) else []
     )
-    for video_url in remove_videos or []:
-        if video_url not in videos_before_urls:
+    # Preflight ALL --remove-video URLs against the pre-mutation snapshot
+    # before clicking anything — mirrors _set_image's "resolve every target
+    # up front" rule for identity-based (not position-based) removal. A
+    # duplicate URL, or a valid URL followed by an invalid one, must never
+    # let an earlier _remove_video click go through before the batch is
+    # known to be entirely valid: unlike sitelinks/metrika-counters/
+    # audience-tags (position-based, removed high-to-low against a fixed-
+    # length list), a video's identity is its URL, and only one close
+    # button exists for it — re-checking mid-loop against a snapshot that
+    # is never updated would let a duplicate URL wrongly appear "still
+    # present" after its first removal already ran.
+    if remove_videos:
+        seen: Set[str] = set()
+        duplicates = sorted(
+            {url for url in remove_videos if url in seen or seen.add(url)}
+        )
+        if duplicates:
             raise BrowserSessionError(
-                f"Video {video_url!r} is not present in this campaign's "
-                "current video set — nothing to remove."
+                "Duplicate URL(s) in --remove-video: "
+                f"{', '.join(repr(url) for url in duplicates)} — each video "
+                "can only be removed once per command."
             )
+        missing = [url for url in remove_videos if url not in videos_before_urls]
+        if missing:
+            raise BrowserSessionError(
+                "Video(s) not present in this campaign's current video "
+                f"set — nothing to remove: {', '.join(repr(url) for url in missing)}."
+            )
+    for video_url in remove_videos or []:
         _remove_video(page, video_url)
     if add_video is not None:
-        _add_video(page, add_video)
+        _add_video(page, add_video, prior_removals=len(remove_videos or []))
 
     # was_draft was captured right after _wait_for_edit_form, above — reused
     # here rather than re-derived, for the same reason _click_save takes it
@@ -10234,7 +10257,7 @@ def _open_videos_modal(page: "Page") -> None:
     )
 
 
-def _add_video(page: "Page", path: str) -> None:
+def _add_video(page: "Page", path: str, *, prior_removals: int = 0) -> None:
     """Upload a new video file, appending it to the campaign's video set.
 
     NOT LIVE-VERIFIED beyond the section/open-button testids confirmed by
@@ -10254,6 +10277,15 @@ def _add_video(page: "Page", path: str) -> None:
     real cap enforced ahead of any upload attempt, though the number itself
     is only sourced from the page's own "Максимум 2 видео" copy, not from
     actually trying to exceed it live.
+
+    ``prior_removals`` (issue #648 cycle-review round 1 of PR #806): the
+    caller passes the count of ``--remove-video`` calls that already ran in
+    this same ``update_master`` invocation, since removal happens directly
+    on the edit page (no modal, no Save gate — see ``_remove_video``'s
+    docstring) and is therefore already committed by the time this function
+    runs. Every error message below is worded accordingly — it must never
+    claim "the video set has NOT been changed" when a prior removal may
+    already have taken effect.
     """
     _wait_for_videos_editor(page)
     before_urls = _read_videos(page)
@@ -10267,15 +10299,27 @@ def _add_video(page: "Page", path: str) -> None:
 
     _open_videos_modal(page)
 
+    no_change_note = (
+        "The campaign's saved video set has NOT been changed (the "
+        "modal was never saved)."
+        if not prior_removals
+        else (
+            f"NOTE: {prior_removals} --remove-video removal(s) requested "
+            "earlier in this same command already ran and are NOT "
+            "affected by this failure — removal happens directly on the "
+            "edit page, with no Save gate of its own. Verify the "
+            "campaign's current video set manually before retrying."
+        )
+    )
+
     try:
         page.locator(_VIDEOS_MODAL_FILE_INPUT_SELECTOR).first.set_input_files(path)
     except PlaywrightError as exc:
         raise BrowserSessionError(
             f"Could not upload {path!r} inside the video manager modal "
             "(assumed testid, NOT live-verified) — Yandex may have changed "
-            "the page's markup. Re-run with --headful to inspect the page. "
-            "The campaign's saved video set has NOT been changed (the "
-            "modal was never saved)."
+            f"the page's markup. Re-run with --headful to inspect the page. "
+            f"{no_change_note}"
         ) from exc
 
     if not _poll_until(
@@ -10288,9 +10332,8 @@ def _add_video(page: "Page", path: str) -> None:
             f"video appeared there within {_VIDEO_UPLOAD_TIMEOUT_MS / 1000:.0f}s "
             "— Yandex's asynchronous processing may have failed or be "
             "unusually slow, or this command's assumptions about the "
-            "modal's markup may simply be wrong (NOT LIVE-VERIFIED). The "
-            "campaign's saved video set has NOT been changed (the modal "
-            "was never saved) — close the browser and retry."
+            f"modal's markup may simply be wrong (NOT LIVE-VERIFIED). "
+            f"{no_change_note}"
         )
 
     try:
@@ -10299,9 +10342,8 @@ def _add_video(page: "Page", path: str) -> None:
         raise BrowserSessionError(
             "Could not find/click the video manager modal's Save button "
             "(assumed testid, NOT live-verified) — Yandex may have changed "
-            "the page's markup. Re-run with --headful to inspect the page. "
-            "The campaign's saved video set has NOT been changed (the "
-            "modal was never saved)."
+            f"the page's markup. Re-run with --headful to inspect the page. "
+            f"{no_change_note}"
         ) from exc
 
     if _poll_until(

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -8061,13 +8061,16 @@ def update_master(
     # present" after its first removal already ran.
     if remove_videos:
         seen: Set[str] = set()
-        duplicates = sorted(
-            {url for url in remove_videos if url in seen or seen.add(url)}
-        )
+        duplicates: Set[str] = set()
+        for url in remove_videos:
+            if url in seen:
+                duplicates.add(url)
+            else:
+                seen.add(url)
         if duplicates:
             raise BrowserSessionError(
                 "Duplicate URL(s) in --remove-video: "
-                f"{', '.join(repr(url) for url in duplicates)} — each video "
+                f"{', '.join(repr(url) for url in sorted(duplicates))} — each video "
                 "can only be removed once per command."
             )
         missing = [url for url in remove_videos if url not in videos_before_urls]

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -1026,6 +1026,37 @@ def _validate_image_files(paths: "tuple[str, ...]") -> None:
         _validate_image_path(raw_path, option_name="--image-file", context="")
 
 
+def _validate_video_path(raw_path: str) -> None:
+    """Reject an ``--add-video`` path that doesn't exist or that this
+    command doesn't recognize as a video file.
+
+    Mirrors ``_validate_image_path``, but the extension allowlist
+    (``_VIDEO_UPLOAD_SUFFIXES``) is NOT a confirmed-live reading of the
+    video modal's file input the way ``_IMAGE_UPLOAD_SUFFIXES`` is for
+    images — see that constant's module comment in
+    ``direct_cli/browser/masters.py``. It is a conservative guess (common
+    Yandex video-creative formats), so this check may reject a file Yandex
+    would actually accept, or (less likely) accept one it would reject.
+    """
+    from ..browser.masters import _VIDEO_UPLOAD_SUFFIXES
+
+    path = Path(raw_path)
+    if not path.is_file():
+        raise click.UsageError(
+            f"--add-video path {raw_path!r} does not exist or is not a file."
+        )
+    if path.suffix.lower() not in _VIDEO_UPLOAD_SUFFIXES:
+        raise click.UsageError(
+            f"--add-video path {raw_path!r} has an unsupported extension "
+            f"{path.suffix!r}. This command expects one of "
+            f"{sorted(_VIDEO_UPLOAD_SUFFIXES)} — NOTE this list is not "
+            "live-confirmed against Yandex's actual upload widget (see "
+            "direct_cli/browser/masters.py's _VIDEO_UPLOAD_SUFFIXES "
+            "comment), so a genuinely valid video file may still be "
+            "rejected here."
+        )
+
+
 @masters.group("adimages")
 def adimages():
     """Manage a Мастер кампаний campaign's image set (browser-driven, no API)
@@ -1566,6 +1597,34 @@ def audience_get(
     ),
 )
 @click.option(
+    "--add-video",
+    help=(
+        "Upload a local video file, appending it to the 'Варианты видео' "
+        "section (Yandex's own UI states a maximum of 2 videos per "
+        "campaign — NOT independently verified by exceeding it). Refused "
+        "if the campaign already has 2 videos. UNLIKE --image, this is a "
+        "plain add, not a positional replacement — Yandex assigns the new "
+        "video's URL, which is not known ahead of time. NOTE: this "
+        "command's video-upload flow (the modal it opens, the fields "
+        "inside it) has NOT been confirmed against the real Yandex UI — "
+        "only the section itself and its open button were observed live; "
+        "see direct_cli/browser/masters.py's module comments above "
+        "_VIDEOS_SLOT_COUNT for exactly what is/isn't confirmed."
+    ),
+)
+@click.option(
+    "--remove-video",
+    "remove_videos",
+    multiple=True,
+    help=(
+        "Remove a video by its exact URL as shown on the edit page (repeat "
+        "for multiple). There is no CLI command yet to list a campaign's "
+        "current video URLs — inspect the edit page directly (e.g. "
+        "--headful) to find them. Refused if the URL is not currently in "
+        "the campaign's video set."
+    ),
+)
+@click.option(
     "--gender",
     type=click.Choice(sorted(_GENDER_CHOICES)),
     help="Target gender (Пол)",
@@ -1711,6 +1770,8 @@ def update(
     clear_headlines,
     clear_texts,
     images,
+    add_video,
+    remove_videos,
     gender,
     age_from,
     age_to,
@@ -1788,9 +1849,26 @@ def update(
     rationale. ``--image`` additionally has NO in-place replacement at all
     on Yandex's side — see its own help text and
     ``direct_cli/browser/masters.py::_set_image`` for why the image set's
-    order changes as a result. Later fields (sitelinks, budget adaptation)
-    and video (a separate follow-up issue) are tracked separately, see
-    issue #648.
+    order changes as a result. Later fields (sitelinks, Metrika
+    counters/goals, budget adaptation) are tracked separately, see issue
+    #648.
+
+    ``--add-video``/``--remove-video`` (issue #648, Этап D) manage the
+    "Варианты видео" section — UNLIKE ``--image``, this is a plain
+    add/remove pair rather than a positional point-replacement (Yandex's
+    own UI caps this at 2 videos per campaign, and 2026-08-06 recon found
+    the remove control lives outside any modal, directly on the edit
+    page — see ``direct_cli/browser/masters.py::update_master``'s
+    docstring for the full reasoning). ``--add-video`` takes a local file
+    path and is refused once the campaign already has 2 videos.
+    ``--remove-video`` takes the video's exact URL (repeat for multiple);
+    there is no CLI command yet to list a campaign's current video URLs.
+    **Large parts of this flag's implementation are NOT LIVE-VERIFIED** —
+    only the section and its open button were confirmed against a real
+    campaign; the upload modal itself is assumed by analogy with
+    ``--image``'s modal and could be wrong. See
+    ``direct_cli/browser/masters.py``'s module comments above
+    ``_VIDEOS_SLOT_COUNT`` for the exact confirmed-vs-assumed breakdown.
 
     ``--clear-headline``/``--clear-text`` (issue #786) DELETE an existing
     headline/ad-text variant by its 1-based slot number, the counterpart
@@ -1866,6 +1944,8 @@ def update(
         and not clear_headlines
         and not clear_texts
         and not images
+        and add_video is None
+        and not remove_videos
         and gender is None
         and age_from is None
         and age_to is None
@@ -1882,8 +1962,9 @@ def update(
             "--goal-price, --target-action-price, --add-target-action, "
             "--remove-target-action, --directs-helps/--no-directs-helps, "
             "--name, --landing-url, --tracking-params, --headline, --text, "
-            "--clear-headline, --clear-text, --image, --gender, --age-from, "
-            "--age-to, --device, --add-audience-tag, --remove-audience-tag, "
+            "--clear-headline, --clear-text, --image, --add-video, "
+            "--remove-video, --gender, --age-from, --age-to, --device, "
+            "--add-audience-tag, --remove-audience-tag, "
             "--add-metrika-counter, --remove-metrika-counter, "
             "--add-sitelink, --remove-sitelink."
         )
@@ -1977,6 +2058,8 @@ def update(
         ),
     )
     _validate_image_paths(parsed_images)
+    if add_video is not None:
+        _validate_video_path(add_video)
 
     parsed_age_from = int(age_from) if age_from is not None else None
     parsed_age_to = (
@@ -2014,6 +2097,8 @@ def update(
             clear_headlines=parsed_clear_headlines or None,
             clear_texts=parsed_clear_texts or None,
             images=parsed_images,
+            add_video=add_video,
+            remove_videos=list(remove_videos) or None,
             gender=gender,
             age_from=parsed_age_from,
             age_from_requested=age_from is not None,

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -10037,6 +10037,75 @@ class TestUpdateMaster(unittest.TestCase):
 
         self.assertIn("not present", str(ctx.exception).lower())
 
+    def test_update_master_raises_before_mutating_when_a_later_remove_url_is_invalid(
+        self,
+    ):
+        # Preflight: with two --remove-video URLs where the first is valid
+        # and the second is not, nothing on the page should be clicked —
+        # the whole batch is validated against the pre-mutation snapshot
+        # before any _remove_video call, mirroring _set_image's "resolve
+        # every target up front" pattern for identity-based (not
+        # position-based) removal.
+        page = _FakeVideosPage(["https://a.test/1.mp4", "https://a.test/2.mp4"])
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(
+                page,
+                42,
+                remove_videos=[
+                    "https://a.test/1.mp4",
+                    "https://nonexistent.test/x.mp4",
+                ],
+            )
+
+        self.assertIn("not present", str(ctx.exception).lower())
+        self.assertEqual(page.urls, ["https://a.test/1.mp4", "https://a.test/2.mp4"])
+
+    def test_update_master_raises_when_remove_videos_has_a_duplicate_url(self):
+        # A duplicate URL in --remove-video must not be treated as "still
+        # present" by a stale snapshot re-check — it must be rejected
+        # up front as a caller error, the same way _set_image treats a
+        # content ID that already disappeared earlier in the same batch.
+        page = _FakeVideosPage(["https://a.test/1.mp4", "https://a.test/2.mp4"])
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(
+                page,
+                42,
+                remove_videos=["https://a.test/1.mp4", "https://a.test/1.mp4"],
+            )
+
+        self.assertIn("duplicate", str(ctx.exception).lower())
+        self.assertEqual(page.urls, ["https://a.test/1.mp4", "https://a.test/2.mp4"])
+
+    def test_add_video_failure_after_a_prior_remove_does_not_claim_no_change(self):
+        # A --remove-video is committed directly on the page, with no Save
+        # gate of its own (see _remove_video's docstring) — so if a
+        # following --add-video then fails, the error must not claim "the
+        # video set has NOT been changed": the removal already ran.
+        page = _FakeVideosPage(["https://a.test/1.mp4", "https://a.test/2.mp4"])
+        original_locator = page.locator
+
+        def _locator(selector):
+            if selector == browser_masters._VIDEOS_MODAL_FILE_INPUT_SELECTOR:
+                return _FakeLocator([_FakeLocatorHandle(raises=True)])
+            return original_locator(selector)
+
+        page.locator = _locator
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(
+                page,
+                42,
+                remove_videos=["https://a.test/1.mp4"],
+                add_video="/tmp/fake.mp4",
+            )
+
+        message = str(ctx.exception)
+        self.assertNotIn("has NOT been changed", message)
+        self.assertIn("1 --remove-video removal(s)", message)
+        self.assertEqual(page.urls, ["https://a.test/2.mp4"])
+
     def test_update_master_raises_when_saved_video_set_does_not_match(self):
         page_save_clicks = []
         save_handle = _FakeTextLocatorHandle(

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -9983,6 +9983,114 @@ class TestUpdateMaster(unittest.TestCase):
         # implying nothing happened.
         self.assertIn("42", str(ctx.exception))
 
+    def test_raises_value_error_when_only_empty_remove_videos_list_provided(self):
+        page = FakePage()
+
+        with self.assertRaises(ValueError):
+            browser_masters.update_master(page, 42, remove_videos=[])
+
+    def test_update_master_adds_a_video(self):
+        page_save_clicks = []
+        save_handle = _FakeTextLocatorHandle(
+            visible=True, on_click=lambda: page_save_clicks.append(True)
+        )
+        page = _FakeVideosPage(
+            ["https://a.test/1.mp4"],
+            upload_urls=["https://a.test/new.mp4"],
+            role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
+        )
+
+        result = browser_masters.update_master(page, 42, add_video="/tmp/fake.mp4")
+
+        self.assertEqual(page.urls, ["https://a.test/1.mp4", "https://a.test/new.mp4"])
+        self.assertEqual(len(page_save_clicks), 1)
+        self.assertEqual(result, {"CampaignId": 42, "AddedVideo": "/tmp/fake.mp4"})
+
+    def test_update_master_removes_a_video(self):
+        page_save_clicks = []
+        save_handle = _FakeTextLocatorHandle(
+            visible=True, on_click=lambda: page_save_clicks.append(True)
+        )
+        page = _FakeVideosPage(
+            ["https://a.test/1.mp4", "https://a.test/2.mp4"],
+            role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
+        )
+
+        result = browser_masters.update_master(
+            page, 42, remove_videos=["https://a.test/1.mp4"]
+        )
+
+        self.assertEqual(page.urls, ["https://a.test/2.mp4"])
+        self.assertEqual(len(page_save_clicks), 1)
+        self.assertEqual(
+            result,
+            {"CampaignId": 42, "RemovedVideos": ["https://a.test/1.mp4"]},
+        )
+
+    def test_update_master_raises_when_removing_a_video_not_present(self):
+        page = _FakeVideosPage(["https://a.test/1.mp4"])
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(
+                page, 42, remove_videos=["https://nonexistent.test/x.mp4"]
+            )
+
+        self.assertIn("not present", str(ctx.exception).lower())
+
+    def test_update_master_raises_when_saved_video_set_does_not_match(self):
+        page_save_clicks = []
+        save_handle = _FakeTextLocatorHandle(
+            visible=True, on_click=lambda: page_save_clicks.append(True)
+        )
+        page = _FakeVideosPage(
+            ["https://a.test/1.mp4"],
+            upload_urls=["https://a.test/new.mp4"],
+            role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
+        )
+        original_click = save_handle._on_click
+
+        def _click():
+            original_click()
+            page.urls = ["https://a.test/1.mp4"]  # revert, as if not saved
+
+        save_handle._on_click = _click
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(page, 42, add_video="/tmp/fake.mp4")
+
+        self.assertEqual(len(page_save_clicks), 1)
+        self.assertIn("did not save as requested", str(ctx.exception))
+
+    def test_auth_error_during_post_save_video_verification_is_not_retried(self):
+        page_save_clicks = []
+        save_handle = _FakeTextLocatorHandle(
+            visible=True, on_click=lambda: page_save_clicks.append(True)
+        )
+        page = _FakeVideosPage(
+            ["https://a.test/1.mp4"],
+            upload_urls=["https://a.test/new.mp4"],
+            role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
+        )
+
+        original_assert_authenticated = browser_masters.assert_authenticated
+
+        def _assert_authenticated(content):
+            if page_save_clicks:
+                raise BrowserAuthError("stale session, detected mid-body")
+            return original_assert_authenticated(content)
+
+        with patch.object(
+            browser_masters,
+            "assert_authenticated",
+            side_effect=_assert_authenticated,
+        ):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters.update_master(page, 42, add_video="/tmp/fake.mp4")
+
+        self.assertNotIsInstance(ctx.exception, BrowserAuthError)
+        self.assertEqual(len(page_save_clicks), 1)
+        self.assertIn("42", str(ctx.exception))
+
 
 class TestMastersUpdateCommand(unittest.TestCase):
     """CLI wiring for `masters update` (issue #631, Этап A)."""
@@ -11195,6 +11303,117 @@ class TestMastersUpdateCommand(unittest.TestCase):
 
                 self.assertEqual(result.exit_code, 0, result.output)
                 self.assertEqual(mock_update.call_args.kwargs["images"], {1: f.name})
+
+    def test_documents_add_video_and_remove_video_flags(self):
+        result = self.runner.invoke(cli, ["masters", "update", "--help"])
+        self.assertIn("--add-video", result.output)
+        self.assertIn("--remove-video", result.output)
+
+    def test_rejects_a_nonexistent_video_path(self):
+        result = self.runner.invoke(
+            cli, ["masters", "update", "42", "--add-video", "/no/such/file.mp4"]
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("does not exist", result.output.lower())
+
+    def test_rejects_an_unsupported_video_extension(self):
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".txt") as f:
+            result = self.runner.invoke(
+                cli, ["masters", "update", "42", "--add-video", f.name]
+            )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("unsupported extension", result.output.lower())
+
+    def test_video_format_errors_do_not_open_a_browser_session(self):
+        with patch("direct_cli.commands.masters._with_session") as mock_with_session:
+            result = self.runner.invoke(
+                cli, ["masters", "update", "42", "--add-video", "/no/such/file.mp4"]
+            )
+        self.assertNotEqual(result.exit_code, 0)
+        mock_with_session.assert_not_called()
+
+    def test_add_video_flag_alone_satisfies_the_at_least_one_field_guard(self):
+        import tempfile
+
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42}
+            with tempfile.NamedTemporaryFile(suffix=".mp4") as f:
+                result = self.runner.invoke(
+                    cli, ["masters", "update", "42", "--add-video", f.name]
+                )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+
+    def test_remove_video_flag_alone_satisfies_the_at_least_one_field_guard(self):
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42}
+            result = self.runner.invoke(
+                cli,
+                [
+                    "masters",
+                    "update",
+                    "42",
+                    "--remove-video",
+                    "https://a.test/1.mp4",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+
+    def test_calls_update_master_with_add_video_path(self):
+        import tempfile
+
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42}
+            with tempfile.NamedTemporaryFile(suffix=".mov") as f:
+                result = self.runner.invoke(
+                    cli, ["masters", "update", "42", "--add-video", f.name]
+                )
+
+                self.assertEqual(result.exit_code, 0, result.output)
+                self.assertEqual(mock_update.call_args.kwargs["add_video"], f.name)
+                self.assertIsNone(mock_update.call_args.kwargs["remove_videos"])
+
+    def test_calls_update_master_with_remove_video_urls(self):
+        with (
+            patch("direct_cli.browser.masters.update_master") as mock_update,
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            mock_update.return_value = {"CampaignId": 42}
+            result = self.runner.invoke(
+                cli,
+                [
+                    "masters",
+                    "update",
+                    "42",
+                    "--remove-video",
+                    "https://a.test/1.mp4",
+                    "--remove-video",
+                    "https://a.test/2.mp4",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(
+            mock_update.call_args.kwargs["remove_videos"],
+            ["https://a.test/1.mp4", "https://a.test/2.mp4"],
+        )
+        self.assertIsNone(mock_update.call_args.kwargs["add_video"])
 
 
 class TestMastersAdimagesCommand(unittest.TestCase):
@@ -13116,6 +13335,353 @@ class _FakeImagesPage(FakePage):
             new_id = f"uploaded-{self._upload_call}"
         self._upload_call += 1
         self.ids.append(new_id)
+
+
+class _FakeVideosPage(FakePage):
+    """Models the "Варианты видео" section + its (assumed) modal (issue
+    #648, Этап D).
+
+    Modeled directly on ``_FakeImagesPage``, with the same caveat the
+    production code carries: only the section/open-button/close-button
+    shape is grounded in a live recon (2026-08-06, campaign 713277109); the
+    modal internals (file input, Save button) are pure analogy with
+    images' fake, not a confirmed shape. ``urls`` doubles as both the
+    page-level video list AND (once open) the modal's own state — real
+    Playwright behaviour for the modal was never observed, so there is
+    nothing to model differently there yet.
+
+    Unlike ``_FakeImagesPage``, the close button lives on ``page`` itself,
+    not gated behind ``modal_open`` — mirrors the recon finding that
+    removal needs no modal at all.
+    """
+
+    def __init__(self, urls, *, save_clicks=None, upload_urls=None, **kwargs):
+        kwargs.setdefault(
+            "role_elements",
+            [
+                (
+                    "button",
+                    browser_masters._SAVE_BUTTON_TEXT,
+                    _FakeTextLocatorHandle(visible=True),
+                )
+            ],
+        )
+        super().__init__(**kwargs)
+        self.urls = list(urls)
+        self.modal_open = False
+        self.save_clicks = save_clicks if save_clicks is not None else []
+        # URLs assigned to successive set_input_files() uploads, one per
+        # call, in order.
+        self._upload_urls = list(upload_urls or [])
+        self._upload_call = 0
+        self.upload_paths = []
+
+    def locator(self, selector):
+        edit_form_ready_selector = (
+            f'[data-testid="{browser_masters._EDIT_FORM_READY_TESTID}"]'
+        )
+        if selector == edit_form_ready_selector:
+            return _FakeLocator([_FakeLocatorHandle()])
+        if selector == browser_masters._VIDEOS_EDITOR_SELECTOR:
+            return _FakeLocator([_FakeLocatorHandle()])
+        if not self.modal_open and selector == browser_masters._VIDEOS_MODAL_SELECTOR:
+            return _FakeLocator([])
+        if self.modal_open and selector == browser_masters._VIDEOS_MODAL_SELECTOR:
+            return _FakeLocator([_FakeLocatorHandle()])
+        if selector == browser_masters._VIDEOS_OPEN_MODAL_SELECTOR:
+            return _FakeLocator(
+                [_FakeLocatorHandle(on_click=lambda: setattr(self, "modal_open", True))]
+            )
+        if selector == browser_masters._VIDEOS_MODAL_FILE_INPUT_SELECTOR:
+            return _FakeLocator([_FakeLocatorHandle(on_upload=self._upload)])
+        if selector == browser_masters._VIDEOS_MODAL_SAVE_SELECTOR:
+            return _FakeLocator(
+                [
+                    _FakeLocatorHandle(
+                        on_click=lambda: (
+                            self.save_clicks.append(True),
+                            setattr(self, "modal_open", False),
+                        )
+                    )
+                ]
+            )
+        content_prefix = (
+            f'[data-testid^="{browser_masters._VIDEOS_CONTENT_TESTID_PREFIX}"]'
+        )
+        if selector == content_prefix:
+            return _FakeLocator(
+                [
+                    _FakeLocatorHandle(attrs={"data-testid": self._content_testid(url)})
+                    for url in self.urls
+                ]
+            )
+        for url in self.urls:
+            close_testid = browser_masters._VIDEOS_CLOSE_BUTTON_TESTID_TEMPLATE.format(
+                video_url=url
+            )
+            close_selector = f'[data-testid="{close_testid}"]'
+            if selector == close_selector:
+                bound_url = url
+                return _FakeLocator(
+                    [
+                        _FakeLocatorHandle(
+                            on_click=lambda bound_url=bound_url: self.urls.remove(
+                                bound_url
+                            )
+                        )
+                    ]
+                )
+        return super().locator(selector)
+
+    def _content_testid(self, url):
+        return f"{browser_masters._VIDEOS_CONTENT_TESTID_PREFIX}{url}"
+
+    def _upload(self, path):
+        self.upload_paths.append(path)
+        if self._upload_call < len(self._upload_urls):
+            new_url = self._upload_urls[self._upload_call]
+        else:
+            new_url = f"https://example.test/uploaded-{self._upload_call}.mp4"
+        self._upload_call += 1
+        self.urls.append(new_url)
+
+
+class TestReadVideos(unittest.TestCase):
+    """``_read_videos`` (issue #648, Этап D)."""
+
+    def test_reads_urls_in_dom_order(self):
+        page = _FakeVideosPage(["https://a.test/1.mp4", "https://a.test/2.mp4"])
+
+        self.assertEqual(
+            browser_masters._read_videos(page),
+            ["https://a.test/1.mp4", "https://a.test/2.mp4"],
+        )
+
+    def test_empty_set_reads_as_empty_list(self):
+        page = _FakeVideosPage([])
+
+        self.assertEqual(browser_masters._read_videos(page), [])
+
+    def test_ignores_nested_videothumb_and_closebutton_suffixes(self):
+        """A real page also renders VideoThumb.<url>[.Content/.VideoElement/
+        .PlayButton] and CloseButton.<url> under the same prefix — only the
+        bare <url> entry should count as one video (see _read_videos'
+        docstring)."""
+        url = "https://a.test/1.mp4"
+        page = FakePage()
+        prefix = browser_masters._VIDEOS_CONTENT_TESTID_PREFIX
+
+        def _locator(selector):
+            if selector == f'[data-testid^="{prefix}"]':
+                testids = [
+                    f"{prefix}{url}",
+                    f"{prefix}VideoThumb.{url}",
+                    f"{prefix}VideoThumb.{url}.Content",
+                    f"{prefix}VideoThumb.{url}.VideoElement",
+                    f"{prefix}VideoThumb.{url}.PlayButton",
+                    f"{prefix}CloseButton.{url}",
+                ]
+                return _FakeLocator(
+                    [_FakeLocatorHandle(attrs={"data-testid": t}) for t in testids]
+                )
+            return _FakeLocator([])
+
+        page.locator = _locator
+
+        self.assertEqual(browser_masters._read_videos(page), [url])
+
+
+class TestWaitForVideosEditor(unittest.TestCase):
+    """``_wait_for_videos_editor`` (issue #648, Этап D)."""
+
+    def test_returns_once_section_present(self):
+        page = _FakeVideosPage([])
+        browser_masters._wait_for_videos_editor(page)  # must not raise
+
+    def test_raises_when_section_never_appears(self):
+        page = FakePage()  # no _VIDEOS_EDITOR_SELECTOR registered
+        with patch.object(browser_masters, "_VIDEOS_EDITOR_TIMEOUT_MS", 1):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters._wait_for_videos_editor(page)
+        self.assertIn("варианты видео", str(ctx.exception).lower())
+
+
+class TestOpenVideosModal(unittest.TestCase):
+    """``_open_videos_modal`` (issue #648, Этап D) — NOT LIVE-VERIFIED, see
+    its own docstring."""
+
+    def test_opens_modal_on_click(self):
+        page = _FakeVideosPage([])
+        browser_masters._open_videos_modal(page)
+        self.assertTrue(page.modal_open)
+
+    def test_raises_when_modal_never_appears(self):
+        page = _FakeVideosPage([])
+        # Sabotage: clicking Open never actually sets modal_open.
+        original_locator = page.locator
+
+        def _locator(selector):
+            if selector == browser_masters._VIDEOS_OPEN_MODAL_SELECTOR:
+                return _FakeLocator([_FakeLocatorHandle(on_click=lambda: None)])
+            return original_locator(selector)
+
+        page.locator = _locator
+        with patch.object(browser_masters, "_VIDEO_MODAL_OPEN_TIMEOUT_MS", 1):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters._open_videos_modal(page)
+        self.assertIn("did not appear", str(ctx.exception))
+
+
+class TestAddVideo(unittest.TestCase):
+    """``_add_video`` (issue #648, Этап D) — NOT LIVE-VERIFIED, see module
+    comments above ``_VIDEOS_SLOT_COUNT``."""
+
+    def test_uploads_and_appends_to_the_set(self):
+        page = _FakeVideosPage(
+            ["https://a.test/1.mp4"], upload_urls=["https://a.test/new.mp4"]
+        )
+
+        browser_masters._add_video(page, "/tmp/fake.mp4")
+
+        self.assertEqual(page.urls, ["https://a.test/1.mp4", "https://a.test/new.mp4"])
+        self.assertEqual(len(page.save_clicks), 1)
+        self.assertFalse(page.modal_open)
+        self.assertEqual(page.upload_paths, ["/tmp/fake.mp4"])
+
+    def test_refuses_when_already_at_slot_count(self):
+        page = _FakeVideosPage(["https://a.test/1.mp4", "https://a.test/2.mp4"])
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._add_video(page, "/tmp/fake.mp4")
+
+        self.assertIn("already has 2", str(ctx.exception).lower())
+        self.assertEqual(page.save_clicks, [])
+        self.assertFalse(page.modal_open)
+
+    def test_does_not_save_when_upload_never_appears(self):
+        page = _FakeVideosPage([], upload_urls=[])
+        original_locator = page.locator
+
+        def _locator(selector):
+            if selector == browser_masters._VIDEOS_MODAL_FILE_INPUT_SELECTOR:
+                return _FakeLocator([_FakeLocatorHandle(on_upload=lambda path: None)])
+            return original_locator(selector)
+
+        page.locator = _locator
+        with patch.object(browser_masters, "_VIDEO_UPLOAD_TIMEOUT_MS", 1):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters._add_video(page, "/tmp/fake.mp4")
+
+        self.assertIn("no new", str(ctx.exception).lower())
+        self.assertEqual(page.save_clicks, [])
+
+
+class TestRemoveVideo(unittest.TestCase):
+    """``_remove_video`` (issue #648, Этап D) — the close-button-testid
+    presence is confirmed live; the click's EFFECT is NOT (see
+    ``_remove_video``'s docstring)."""
+
+    def test_removes_the_named_video(self):
+        page = _FakeVideosPage(["https://a.test/1.mp4", "https://a.test/2.mp4"])
+
+        browser_masters._remove_video(page, "https://a.test/1.mp4")
+
+        self.assertEqual(page.urls, ["https://a.test/2.mp4"])
+
+    def test_does_not_open_a_modal(self):
+        page = _FakeVideosPage(["https://a.test/1.mp4"])
+
+        browser_masters._remove_video(page, "https://a.test/1.mp4")
+
+        self.assertFalse(page.modal_open)
+        self.assertEqual(page.save_clicks, [])
+
+    def test_raises_when_close_button_missing(self):
+        page = _FakeVideosPage(["https://a.test/1.mp4"])
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters._remove_video(page, "https://nonexistent.test/x.mp4")
+
+        self.assertIn("could not find", str(ctx.exception).lower())
+
+    def test_raises_when_click_does_not_actually_remove_it(self):
+        page = _FakeVideosPage(["https://a.test/1.mp4"])
+        original_locator = page.locator
+
+        def _locator(selector):
+            close_testid = browser_masters._VIDEOS_CLOSE_BUTTON_TESTID_TEMPLATE.format(
+                video_url="https://a.test/1.mp4"
+            )
+            close_selector = f'[data-testid="{close_testid}"]'
+            if selector == close_selector:
+                return _FakeLocator([_FakeLocatorHandle(on_click=lambda: None)])
+            return original_locator(selector)
+
+        page.locator = _locator
+        with patch.object(browser_masters, "_VIDEO_MODAL_OPEN_TIMEOUT_MS", 1):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters._remove_video(page, "https://a.test/1.mp4")
+
+        self.assertIn("still shown", str(ctx.exception).lower())
+
+
+class TestVerifyVideoMismatches(unittest.TestCase):
+    """``_verify_video_mismatches`` (issue #648, Этап D)."""
+
+    def test_no_op_when_nothing_touched(self):
+        page = _FakeVideosPage(["https://a.test/1.mp4"])
+
+        result = browser_masters._verify_video_mismatches(
+            page, before_urls=["https://a.test/1.mp4"], added=False, removed_urls=[]
+        )
+
+        self.assertEqual(result, [])
+
+    def test_flags_a_still_present_removed_video(self):
+        page = _FakeVideosPage(["https://a.test/1.mp4"])  # removal didn't take
+
+        result = browser_masters._verify_video_mismatches(
+            page,
+            before_urls=["https://a.test/1.mp4"],
+            added=False,
+            removed_urls=["https://a.test/1.mp4"],
+        )
+
+        self.assertTrue(any("still present" in m for m in result))
+
+    def test_flags_a_missing_kept_video(self):
+        # An untouched video (position 0) vanished even though only
+        # position 1 was requested for removal.
+        page = _FakeVideosPage([])
+        result = browser_masters._verify_video_mismatches(
+            page,
+            before_urls=["https://a.test/1.mp4", "https://a.test/2.mp4"],
+            added=False,
+            removed_urls=["https://a.test/2.mp4"],
+        )
+
+        self.assertTrue(any("missing" in m for m in result))
+
+    def test_flags_a_size_mismatch_when_add_did_not_take(self):
+        page = _FakeVideosPage(["https://a.test/1.mp4"])  # no new video appeared
+
+        result = browser_masters._verify_video_mismatches(
+            page, before_urls=["https://a.test/1.mp4"], added=True, removed_urls=[]
+        )
+
+        self.assertTrue(any("expected 2" in m for m in result))
+
+    def test_passes_when_add_and_remove_both_took_effect(self):
+        page = _FakeVideosPage(["https://a.test/2.mp4", "https://a.test/new.mp4"])
+
+        result = browser_masters._verify_video_mismatches(
+            page,
+            before_urls=["https://a.test/1.mp4", "https://a.test/2.mp4"],
+            added=True,
+            removed_urls=["https://a.test/1.mp4"],
+        )
+
+        self.assertEqual(result, [])
 
 
 class TestReadImageContentIds(unittest.TestCase):


### PR DESCRIPTION
## Summary

Implements видео (video) support in `direct masters update` — part of issue #648's Этап D (media: images and video). Browser-driven (Мастер кампаний has no API). Unlike `--image`'s point-replacement (remove+add inside a shared modal), this uses simple add-by-file / remove-by-URL semantics — reasoning below.

- `--add-video PATH` — uploads a local video file via the section's upload modal.
- `--remove-video URL` (repeat) — removes a video by its full URL, via a close button found directly on the edit page (outside any modal).
- `_read_videos`/`_open_videos_modal`/`_add_video`/`_remove_video` in `direct_cli/browser/masters.py`, wired into `update_master` (`add_video`/`remove_videos` params) and `_verify_saved` (`_verify_video_mismatches`).

## Design decision: simple add/remove, not point-replacement

`--image` composes remove+add inside `ImageSuggestionsEditorModal` because Yandex has no "replace in place" primitive for images and the caller-facing "replace position N" surface is a synthetic construction on top of that. Video's DOM shape looks structurally different: the 2026-08-06 recon (a byproduct of an unrelated sitelinks recon pass, campaign 713277109) found `VideoSuggestionsEditor.CampaignContents.CloseButton.<video_url>` living directly on the edit page, **outside** any modal — not inside a shared manager UI the way images' close buttons are. Combined with the hard cap of 2 videos (vs. images' larger set), a synthetic point-replacement would add complexity this section hasn't been shown to need. If live verification proves this wrong, it can be revisited.

## ⚠️ NOT LIVE-VERIFIED — with an important confidence gap vs. the sitelinks/Metrika-counters PRs

This PR has **less** live confirmation than #801/#803: recon only covered the DOM **outside** the upload modal (it was a byproduct of a different recon session, not a dedicated video pass). Specifically:

**Confirmed live** (2026-08-06 recon, campaign 713277109, testid *presence* only — not click *effect*): `VideoSuggestionsEditor`, `.Open`, `.CampaignContents`, `.CampaignContents.<video_url>` (+ nested `VideoThumb`/`PlayButton`/`VideoElement`), `.CampaignContents.CloseButton.<video_url>`.

**Zero live confirmation, pure analogy with `--image`'s modal**: the entire upload modal — its name (`VideoSuggestionsEditorModal`, assumed), its file input testid (`UploadZone.filePicker`, assumed), its Save button testid (assumed) — none of this was ever clicked into or observed. Also unverified: `_VIDEOS_SLOT_COUNT = 2` as a real enforced limit (from UI copy "Максимум 2 видео", never tested by exceeding it), and the accepted file extensions (`_VIDEO_UPLOAD_SUFFIXES` is a guess, not read from the real file input's `accept=` attribute).

All of this is documented with explicit "NOT LIVE-VERIFIED" markers in the module comments, function docstrings, CLI help text, and CHANGELOG — nothing is claimed as working anywhere it hasn't been confirmed. A live mutation-verification pass — including actually opening the upload modal — is a required follow-up before this is relied upon, more so than for the other two Этап C/D PRs.

## Test plan

- [x] `pytest tests/test_masters.py -k "video or Video"` — 33 passed
- [x] Full offline suite `pytest -n auto` — 3410 passed, 23 skipped, no regressions
- [x] `black`/`flake8` clean on all changed files
- [ ] Live verification (open modal, upload, remove, save-persists) — **pending**, higher priority than #801/#803's follow-up given the larger unverified surface (the modal itself)

Relates to #648 (no dedicated sub-issue for this specific section).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01FF5MKQjSX89UpwHfFG3uBe