### PR TITLE
fix(masters): guard against an empty Metrika counter identity

### DIFF
--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -5122,18 +5122,18 @@ def _metrika_counter_identity(text: str) -> str:
     input text unchanged if it doesn't contain a `` • `` separator at all
     (defensive: an id-less string just fails to match anything, the same
     "no false positive" outcome as before this existed). Also returns the
-    input unchanged if the last `` • ``-delimited token is EMPTY (a
-    trailing separator with nothing after it, e.g. ``"Label • "``) —
-    cycle-review finding: without this, two malformed/unexpected inputs
-    would both collapse to the same empty-string identity and silently
-    match each other, masking a real mismatch instead of failing to match
-    anything (the intended, safe failure mode).
+    input unchanged if the last `` • ``-delimited token is EMPTY or
+    whitespace-only (a trailing separator with nothing meaningful after it,
+    e.g. ``"Label • "`` or ``"Label •  "``) — cycle-review finding: without
+    this, two malformed/unexpected inputs would both collapse to the same
+    identity and silently match each other, masking a real mismatch instead
+    of failing to match anything (the intended, safe failure mode).
     """
     first_line = text.split("\n", 1)[0]
     if " • " not in first_line:
         return text
     identity = first_line.rsplit(" • ", 1)[1]
-    return identity if identity else text
+    return identity if identity.strip() else text
 
 
 def _read_metrika_counters(page: "Page") -> List[str]:

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -5121,12 +5121,19 @@ def _metrika_counter_identity(text: str) -> str:
     suggestion and the tag display for the exact same counter. Returns the
     input text unchanged if it doesn't contain a `` • `` separator at all
     (defensive: an id-less string just fails to match anything, the same
-    "no false positive" outcome as before this existed).
+    "no false positive" outcome as before this existed). Also returns the
+    input unchanged if the last `` • ``-delimited token is EMPTY (a
+    trailing separator with nothing after it, e.g. ``"Label • "``) —
+    cycle-review finding: without this, two malformed/unexpected inputs
+    would both collapse to the same empty-string identity and silently
+    match each other, masking a real mismatch instead of failing to match
+    anything (the intended, safe failure mode).
     """
     first_line = text.split("\n", 1)[0]
     if " • " not in first_line:
         return text
-    return first_line.rsplit(" • ", 1)[1]
+    identity = first_line.rsplit(" • ", 1)[1]
+    return identity if identity else text
 
 
 def _read_metrika_counters(page: "Page") -> List[str]:

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -17827,6 +17827,21 @@ class TestMetrikaCounterIdentity(unittest.TestCase):
             browser_masters._metrika_counter_identity("nomatch"), "nomatch"
         )
 
+    def test_returns_text_unchanged_when_trailing_separator_has_no_id(self):
+        """cycle-review finding: a trailing " • " with nothing after it
+        (e.g. malformed/unexpected markup) must NOT collapse to an empty
+        identity -- two different malformed inputs would otherwise both
+        become "" and falsely match each other in _verify_saved's Counter
+        comparison, masking a real mismatch."""
+        self.assertEqual(
+            browser_masters._metrika_counter_identity("Label • "), "Label • "
+        )
+
+    def test_two_malformed_inputs_do_not_collapse_to_the_same_identity(self):
+        a = browser_masters._metrika_counter_identity("Label A • ")
+        b = browser_masters._metrika_counter_identity("Label B • ")
+        self.assertNotEqual(a, b)
+
 
 class TestParseRemoveMetrikaCounterOptions(unittest.TestCase):
     """``_parse_remove_metrika_counter_options`` (issue #648) — mirrors

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -17842,6 +17842,24 @@ class TestMetrikaCounterIdentity(unittest.TestCase):
         b = browser_masters._metrika_counter_identity("Label B • ")
         self.assertNotEqual(a, b)
 
+    def test_returns_text_unchanged_when_trailing_separator_has_only_whitespace(self):
+        """cycle-review finding (PR #808 round 2): a trailing " • " followed
+        only by whitespace (e.g. "Label •  ") is truthy in Python, so the
+        bare `if identity` guard let it through as an identity instead of
+        falling back to `text` -- the same collapse-to-one-identity bug the
+        exactly-empty guard above already fixed, one whitespace-only
+        character class narrower."""
+        self.assertEqual(
+            browser_masters._metrika_counter_identity("Label •  "), "Label •  "
+        )
+
+    def test_two_whitespace_only_malformed_inputs_do_not_collapse_to_the_same_identity(
+        self,
+    ):
+        a = browser_masters._metrika_counter_identity("Label A •  ")
+        b = browser_masters._metrika_counter_identity("Label B •  ")
+        self.assertNotEqual(a, b)
+
 
 class TestParseRemoveMetrikaCounterOptions(unittest.TestCase):
     """``_parse_remove_metrika_counter_options`` (issue #648) — mirrors


### PR DESCRIPTION
## Summary

Follow-up to PR #801 (Metrika counters in `masters update`) — a fix that was pushed to that PR's branch *after* it had already been merged, so it never landed in `main`. Cherry-picked here as its own PR against current `main`.

`_metrika_counter_identity` (added in #801's cycle-review to compare a counter's autocomplete-suggestion text against its read-back tag-display text by numeric id) returned an empty string when a counter's first line ended with a trailing `" • "` and nothing after it — a malformed/unexpected markup shape. Two different malformed inputs would both collapse to the same empty identity and falsely match each other in `_verify_saved`'s `Counter` comparison, masking a real save mismatch instead of failing to match anything (the safe fallback this function already documented for the no-separator case).

Now returns the input text unchanged (instead of `""`) when the last `" • "`-delimited token is empty.

## Test plan

- [x] `pytest tests/test_masters.py -k "TestMetrikaCounterIdentity"` — 5 passed
- [x] Full offline suite `pytest -n auto` — 3416 passed, 23 skipped, no regressions
- [x] `black`/`flake8` clean on all changed files

Found via cycle-review (local `/review`, delayed report — round completed after PR #801 had already merged).

Relates to #648.

🤖 Generated with [Claude Code](https://claude.com/claude-code)