### PR TITLE
fix(masters): normalize whitespace around a non-empty Metrika counter id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ save-mismatch for an `--add-metrika-counter` that actually succeeded. The
 existing empty/whitespace-only fallback behavior (return the original
 text unchanged when there's no real id) is unchanged.
 
+Cycle-review round 2 (Codex): stripping is only applied when the result
+is a genuine numeric id (`.isdigit()`) — real counter ids are numeric.
+A stripped non-numeric token falls back to the unstripped original, so
+two malformed non-numeric inputs that differ only by surrounding
+whitespace (e.g. `"Label A •  foo "` vs `"Label B • foo "`) still don't
+collapse to the same identity, preserving the function's documented
+"malformed inputs must not silently match" invariant.
+
 ### Added
 
 **`masters update --add-metrika-counter`/`--remove-metrika-counter` —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+### Fixed
+
+**`masters` — `_metrika_counter_identity` now normalizes surrounding
+whitespace around a non-empty counter id (#809).**
+
+The suggestion-text format (`"{label} • {domain/path} • {numeric counter
+id}"`) and the read-back tag-display format (`"{domain} • {numeric
+counter id}\n{N} целей"`) aren't guaranteed to have identical whitespace
+around the id token on both sides — e.g. a trailing space before the
+newline in the tag-display format. The extracted identity is now
+`.strip()`-ed when non-empty before being returned, so
+`_verify_saved`'s `Counter` comparison no longer reports a false
+save-mismatch for an `--add-metrika-counter` that actually succeeded. The
+existing empty/whitespace-only fallback behavior (return the original
+text unchanged when there's no real id) is unchanged.
+
 ### Added
 
 **`masters update --add-metrika-counter`/`--remove-metrika-counter` —

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -5334,13 +5334,23 @@ def _metrika_counter_identity(text: str) -> str:
     format (``"...• 12345 \\n30 целей"``) aren't guaranteed to have identical
     whitespace around the id token on both sides, and an unstripped identity
     would make ``_verify_saved``'s ``Counter`` comparison report a false
-    save-mismatch for an add that actually succeeded.
+    save-mismatch for an add that actually succeeded. The stripped token is
+    only used as the identity when it's a genuine numeric id (``.isdigit()``
+    — real counter ids are numeric, confirmed live, see above); a stripped
+    NON-numeric token falls back to the unstripped original (cycle-review
+    finding, PR #810 round 2: without this guard, two malformed inputs that
+    differ only by surrounding whitespace around non-numeric text — e.g.
+    ``"Label A •  foo "`` vs ``"Label B • foo "`` — would both collapse to
+    ``"foo"`` and silently match each other, the exact "no false positive
+    for malformed input" failure mode the empty/whitespace-only guard above
+    already exists to prevent).
     """
     first_line = text.split("\n", 1)[0]
     if " • " not in first_line:
         return text
-    identity = first_line.rsplit(" • ", 1)[1].strip()
-    return identity if identity else text
+    raw_identity = first_line.rsplit(" • ", 1)[1]
+    stripped_identity = raw_identity.strip()
+    return stripped_identity if stripped_identity.isdigit() else text
 
 
 def _read_metrika_counters(page: "Page") -> List[str]:

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -5328,12 +5328,19 @@ def _metrika_counter_identity(text: str) -> str:
     this, two malformed/unexpected inputs would both collapse to the same
     identity and silently match each other, masking a real mismatch instead
     of failing to match anything (the intended, safe failure mode).
+
+    A non-empty id is also stripped of surrounding whitespace (issue #809):
+    the suggestion format (``"...• 88834924"``) and the two-line tag-display
+    format (``"...• 12345 \\n30 целей"``) aren't guaranteed to have identical
+    whitespace around the id token on both sides, and an unstripped identity
+    would make ``_verify_saved``'s ``Counter`` comparison report a false
+    save-mismatch for an add that actually succeeded.
     """
     first_line = text.split("\n", 1)[0]
     if " • " not in first_line:
         return text
-    identity = first_line.rsplit(" • ", 1)[1]
-    return identity if identity.strip() else text
+    identity = first_line.rsplit(" • ", 1)[1].strip()
+    return identity if identity else text
 
 
 def _read_metrika_counters(page: "Page") -> List[str]:

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -19313,6 +19313,30 @@ class TestMetrikaCounterIdentity(unittest.TestCase):
         )
         self.assertEqual(suggestion, tag_display)
 
+    def test_non_numeric_whitespace_padded_malformed_tokens_stay_distinct(self):
+        """cycle-review finding (PR #810 round 2): stripping whitespace
+        around a non-empty token must NOT extend to non-numeric malformed
+        tokens -- only a genuine numeric id (real counter ids are numeric)
+        is normalized. Without an .isdigit() guard, "Label A •  foo " and
+        "Label B • foo " would both collapse to "foo" and silently match
+        each other in _verify_saved's Counter comparison, the exact
+        "malformed inputs must not silently match" failure mode the
+        empty/whitespace-only guard already exists to prevent -- just for
+        a narrower, non-numeric class of malformed input."""
+        a = browser_masters._metrika_counter_identity("Label A •  foo ")
+        b = browser_masters._metrika_counter_identity("Label B • foo ")
+        self.assertNotEqual(a, b)
+        self.assertEqual(a, "Label A •  foo ")
+        self.assertEqual(b, "Label B • foo ")
+
+    def test_numeric_id_still_stripped_when_padded(self):
+        """Sanity check that the .isdigit() guard doesn't regress the
+        original issue #809 fix for genuine numeric ids."""
+        self.assertEqual(
+            browser_masters._metrika_counter_identity("domain •  88834924 "),
+            "88834924",
+        )
+
 
 class TestParseRemoveMetrikaCounterOptions(unittest.TestCase):
     """``_parse_remove_metrika_counter_options`` (issue #648) — mirrors

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -19284,6 +19284,35 @@ class TestMetrikaCounterIdentity(unittest.TestCase):
         b = browser_masters._metrika_counter_identity("Label B •  ")
         self.assertNotEqual(a, b)
 
+    def test_strips_trailing_whitespace_around_a_real_id(self):
+        """issue #809: a real id with incidental trailing whitespace (e.g.
+        from the two-line tag-display format's first line) must normalize
+        to the same identity as the same id with no surrounding
+        whitespace, or _verify_saved's Counter comparison false-mismatches
+        an add that actually succeeded."""
+        self.assertEqual(
+            browser_masters._metrika_counter_identity("domain • 12345 "),
+            "12345",
+        )
+
+    def test_strips_leading_whitespace_around_a_real_id(self):
+        self.assertEqual(
+            browser_masters._metrika_counter_identity("domain •  12345"),
+            "12345",
+        )
+
+    def test_suggestion_and_whitespace_padded_tag_display_share_identity(self):
+        """The exact scenario from issue #809: suggestion text has no
+        padding, read-back tag-display text has incidental whitespace
+        around the same id -- both must normalize to the same identity."""
+        suggestion = browser_masters._metrika_counter_identity(
+            "label • domain/path • 12345"
+        )
+        tag_display = browser_masters._metrika_counter_identity(
+            "domain • 12345 \n30 целей"
+        )
+        self.assertEqual(suggestion, tag_display)
+
 
 class TestParseRemoveMetrikaCounterOptions(unittest.TestCase):
     """``_parse_remove_metrika_counter_options`` (issue #648) — mirrors


### PR DESCRIPTION
## Summary

`_metrika_counter_identity` (`direct_cli/browser/masters.py`, added in PR #801) extracts the numeric counter id shared by the suggestion-text and read-back tag-display formats so `_verify_saved` can compare them for equality. The non-empty branch returned the identity **unstripped**:

```python
identity = first_line.rsplit(" • ", 1)[1]
return identity if identity.strip() else text
```

If a real (non-empty) id has surrounding whitespace on one side but not the other — e.g. read-back `"domain • 12345 \n30 целей"` (trailing space before the newline) vs. suggestion `"label • domain/path • 12345"` (no trailing space) — the two identities (`"12345 "` vs `"12345"`) wouldn't compare equal, and `_verify_saved`'s `Counter` comparison would report a false save-mismatch even though the add actually succeeded.

## Fix

```python
identity = first_line.rsplit(" • ", 1)[1].strip()
return identity if identity else text
```

The existing empty/whitespace-only fallback behavior (PR #808's guard: return the original text unchanged when there's no real id after the last `" • "` separator) is unchanged — only the non-empty branch now normalizes whitespace.

## Testing

- Added `test_strips_trailing_whitespace_around_a_real_id`, `test_strips_leading_whitespace_around_a_real_id`, and `test_suggestion_and_whitespace_padded_tag_display_share_identity` (the exact scenario from the issue: suggestion text with no padding vs. read-back tag-display text with incidental whitespace, both must normalize to the same identity) to `TestMetrikaCounterIdentity` in `tests/test_masters.py`.
- `pytest tests/test_masters.py -k MetrikaCounterIdentity` — 10 passed
- `pytest tests/test_masters.py` — 843 passed
- Full offline suite `pytest` — 3492 passed, 23 skipped, no regressions
- `black`/`flake8` clean on all changed files

Closes #809

🤖 Generated with [Claude Code](https://claude.com/claude-code)
