### PR TITLE
docs(masters): live-verify images testids and batched upload (#648)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 ## Unreleased
 
+### Docs
+
+**`masters` images (Мастер кампаний) — live-verify testids and the batched
+multi-file upload primitive (#648, Этап D follow-up).**
+
+Live re-recon (2026-08-08, DRAFT campaign 713234191) against everything
+`masters update --image` / `masters adimages get/add/delete/set` (#670,
+#672, #673, #675-#677) depends on:
+
+- Every `ImageSuggestionsEditor*`/`ImageSuggestionsEditorModal*` testid
+  constant in `direct_cli/browser/masters.py` matched the live DOM exactly
+  — no corrections needed. Unlike `--add-video`/`--remove-video` (#806),
+  whose testids were pure by-analogy guesses later found wrong live
+  (#811), images' testids were already live-confirmed at #670's original
+  recon and remain accurate.
+- `_apply_image_operations`'s previously "not live-verified" risk —
+  uploading multiple files via a single `set_input_files([path1, path2])`
+  call — now IS confirmed live: Yandex's modal panel grew from 3 to 5
+  selected images after one such call with two valid images. The function
+  still issues one `set_input_files` call per path (kept for per-file
+  error attribution), not because batching was found broken.
+- Also observed live: Yandex's upload endpoint (`POST /web-api/uac/content`)
+  rejects a too-small synthetic image with a plain HTTP 400 and no
+  distinguishing toast text — a genuine per-image server-side validation,
+  not a selector/testid problem.
+- No "add a new slot" affordance exists beyond what `masters adimages
+  add`/`set` already implement (#675-#677) — a genuine variable-length
+  add/remove for images already ships as that dedicated command group
+  rather than `masters update --add-image`/`--remove-image` flags, a
+  deliberate design split made when #670 scoped point-replacement only
+  (`--image`) and #675-#677 later filled in add/delete/set as their own
+  vocabulary — see those issues' own scope sections. No new CLI flags
+  were added by this change.
+
+All real-page interactions in this recon pass were abandoned via the
+modal's Cancel button (never Save) — the campaign's saved image set is
+confirmed unchanged before and after.
+
 ### Fixed
 
 **`masters` — `_metrika_counter_identity` now normalizes surrounding

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -9949,10 +9949,23 @@ def _apply_image_operations(
     previously-unverified risk, exercised via ``masters adimages delete
     --all`` and ``masters adimages set --allow-empty``.
 
-    **Not live-verified:** uploading via a single ``set_input_files([path1,
-    path2, ...])`` call with multiple paths — real Playwright accepts a
-    list, but PR #672's recon never exercised it, so this uploads strictly
-    one path per call, sequentially, to stay on already-confirmed ground.
+    **Confirmed live 2026-08-08 (issue #648 Этап D follow-up), DRAFT campaign
+    713234191:** a single ``set_input_files([path1, path2])`` call with
+    MULTIPLE paths does work against Yandex's real file input — the panel
+    grew from 3 to 5 after one such call (2 valid ~1200x1200 JPEGs), closing
+    PR #672's originally-unverified risk. Yandex still processes each file
+    sequentially server-side (each landed as its own
+    ``POST /web-api/uac/content`` call, observed one after another, not a
+    single multipart request) — so this function still uploads one path per
+    ``set_input_files`` call rather than batching the whole list into one,
+    since a single-path call already gives per-file error attribution
+    (a rejected file surfaces against its own path, not "one of N failed").
+    Also confirmed live in the same pass: Yandex's upload endpoint rejects a
+    too-small synthetic image with a plain HTTP 400 (no distinguishing toast
+    text was observed) — this is a real per-image server-side validation,
+    not a testid/selector problem, so a caller seeing an upload silently not
+    appear should suspect the source file's dimensions/format before the
+    DOM markup.
 
     Removals are located by the target's thumb URL, captured from the
     modal's panel BEFORE any removal in this call runs — exactly the


### PR DESCRIPTION
## Summary

Part of #648, Этап D (изображения) follow-up — same discipline video's #806→#811 correction required: re-verify guessed/previously-confirmed testids live before trusting them, don't assume a shipped feature's DOM assumptions still hold.

## What was checked

Live re-recon (2026-08-08, DRAFT test campaign 713234191, the same campaign #670's original recon used) against everything `masters update --image` / `masters adimages get/add/delete/set` (#670, #672, #673, #675-#677) depend on:

1. **Testid parity** — every `ImageSuggestionsEditor*`/`ImageSuggestionsEditorModal*` constant in `direct_cli/browser/masters.py` was dumped fresh from the live DOM (both outside and inside the modal) and diffed against the existing constants. **No mismatches found** — unlike video (#806), whose testids were pure by-analogy guesses later found wrong live in #811, images' testids were already live-confirmed at #670's original recon and remain accurate today.

2. **Batched multi-file upload** — `_apply_image_operations`'s one remaining "not live-verified" risk (PR #672 left it explicitly open): does a single `set_input_files([path1, path2])` call actually work against Yandex's real file input? **Confirmed live**: the modal panel grew from 3 → 5 selected images after removing 2 and uploading 2 valid images via one such call. The function still issues one `set_input_files` call per path (kept intentionally, for per-file error attribution — a rejected file surfaces against its own path rather than "one of N failed"), not because batching turned out broken.

3. **Add/remove-slot affordance** — confirmed no separate capability exists beyond what `masters adimages add`/`delete`/`set` already implement. Images already have a full variable-length add/remove surface, shipped as its own command group (#675-#677) rather than `masters update` flags — a deliberate split made when #670 scoped `--image` as point-replacement-only and #675-#677 later filled in add/delete/set with their own vocabulary (`adimages get/add/delete/set`, mirroring the API-side `direct adimages` group). Adding `--add-image`/`--remove-image` to `update` on top of that would just create two competing APIs for the same operation, so no new flags were added.

## Side finding

Yandex's upload endpoint (`POST /web-api/uac/content`) rejects a too-small synthetic test image with a plain HTTP 400 and no distinguishing toast text — a genuine per-image server-side validation (min dimensions), not a testid/selector problem. Documented in the updated docstring so a future "upload silently doesn't appear" report isn't mis-diagnosed as a DOM regression.

## Safety

All live interactions were abandoned via the modal's **Cancel** button — Save was never clicked. Verified the campaign's saved image content-id set is byte-identical before and after every recon pass.

## Changes

- `direct_cli/browser/masters.py`: updated `_apply_image_operations`'s docstring from "not live-verified" to the confirmed-live finding above.
- `CHANGELOG.md`: Docs entry documenting the re-verification.
- Issue #648's own checklist updated (Этап D image line struck through with the honest verification status), matching the style of its other resolved sub-bullets.

## Tests

- `black --check` / `flake8`: clean.
- Full offline `pytest`: 3494 passed, 23 skipped, 39 subtests passed.
- No new unit tests added — the code path itself (`_apply_image_operations`'s per-path `set_input_files` loop) is unchanged; only its docstring's verification claim changed to match what was actually observed live.

Closes nothing on its own (docs/verification only) — Part of #648.

🤖 Generated with [Claude Code](https://claude.com/claude-code)