### PR TITLE
feat(masters): add --moderation-statuses to `masters get` (#814)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,70 @@
 
 ## Unreleased
 
+### Added
+
+**`masters get --moderation-statuses` — detect per-element moderation
+rejections in Мастер кампаний (#814).**
+
+Individual ad elements inside a Мастер кампаний can be rejected on
+moderation while the campaign keeps running on its remaining approved
+elements — so this shows up in neither `campaigns.get`'s nor `ads.get`'s
+`StatusModerate`, and `ads get --image-moderation-statuses` cannot express
+it either (that filter is per finished ad, not per element in the wizard's
+element pool). Browser-only, like the rest of `masters`.
+
+A flag on the existing `get`, not a new subcommand: it is another slice of
+the same campaign read, so filtering by element type is left to the ordinary
+`--format`/downstream tooling rather than per-type flags.
+
+```
+direct masters get 713234064 --moderation-statuses
+```
+
+adds to each result:
+
+```json
+"RejectedElements": [
+  {"Type": "image", "Position": 2, "ContentId": "2513371652347967553",
+   "Title": "Элемент объявления отклонен",
+   "Hint": "Пожалуйста, создайте новый элемент объявления и отправьте его на модерацию"}
+],
+"RejectedCount": 1,
+"CheckedTypes": ["image"],
+"UnsupportedTypes": ["video", "headline", "text"]
+```
+
+Without the flag `get`'s output and page loads are unchanged.
+
+LIVE-VERIFIED end to end (2026-08-08): campaigns 713234064 (image at
+position 2) and 713231614 (position 4) each report exactly the rejection
+their DOM shows, and 713234162 correctly reports none.
+
+Detection notes, from the recon in
+`tests/fixtures/masters_wizard_edit_moderation.html`:
+
+- The marker is a per-image status button
+  (`ImageSuggestionsEditor.CampaignContents.ImageStatus`) carrying ONE
+  testid shared by every image, so a rejection is mapped to its image
+  positionally; a rejected button drops the `ImageStatusIcon_efficiency`
+  class and gains a `dc-Label_color_black-negative`/`svg.dc-Icon_color_red`
+  child.
+- The explanatory tooltip is not in the DOM until a real mouse hover
+  (synthetic events do not mount it), so detection uses the class shape and
+  never hovers — which is what lets one page load answer for the whole
+  campaign.
+- `dc-Icon_color_red` is NOT unique to moderation: a video thumbnail's
+  `MediaControl` renders the same classes. A page-wide scan reported 5 of
+  38 swept campaigns as rejected purely off video controls, so the check is
+  scoped inside a status button.
+- **NOT LIVE-VERIFIED for video/headlines/texts** — a sweep of all 38
+  non-archived Мастер кампаний (~62 videos; every campaign has headlines
+  and texts) found 2 rejected images and zero rejected
+  videos/headlines/texts, and no status affordance exists in those
+  sections' markup at all. That cannot distinguish "Yandex renders no such
+  marker" from "nothing of that type is rejected right now", so those types
+  are reported in `UnsupportedTypes` rather than implied clean.
+
 ### Docs
 
 **`masters` images (Мастер кампаний) — live-verify testids and the batched

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,9 @@ Detection notes, from the recon in
   testid shared by every image, so a rejection is mapped to its image
   positionally; a rejected button drops the `ImageStatusIcon_efficiency`
   class and gains a `dc-Label_color_black-negative`/`svg.dc-Icon_color_red`
-  child.
+  child. That mapping is only trusted while the status-button count matches
+  the image count — on any disagreement the rejection is still reported but
+  with `ContentId: null`, never an adjacent image's ID.
 - The explanatory tooltip is not in the DOM until a real mouse hover
   (synthetic events do not mount it), so detection uses the class shape and
   never hovers — which is what lets one page load answer for the whole

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,8 @@ Detection notes, from the recon in
   class and gains a `dc-Label_color_black-negative`/`svg.dc-Icon_color_red`
   child. That mapping is only trusted while the status-button count matches
   the image count — on any disagreement the rejection is still reported but
-  with `ContentId: null`, never an adjacent image's ID.
+  with both `ContentId` and `Position` set to `null`, so no field can name
+  an adjacent, innocent image.
 - The explanatory tooltip is not in the DOM until a real mouse hover
   (synthetic events do not mount it), so detection uses the class shape and
   never hovers — which is what lets one page load answer for the whole

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -8488,7 +8488,16 @@ def _read_image_moderation_rejections(page: "Page") -> List[Dict[str, Any]]:
     live 2026-08-08 both by bounding-box alignment and by the two lists
     having equal length on all 38 swept campaigns.
 
-    If the two lists nonetheless disagree in length — in EITHER direction —
+    What the code checks is COUNT equality, which is weaker than the DOM-order
+    correspondence the mapping actually rests on: it catches a missing or
+    surplus status button, not a reordered one. Order itself has only live
+    evidence (bounding-box alignment on campaign 713234064) against markup
+    this module guarantees nothing about, so a count-equal-but-reordered DOM
+    would still map a rejection to the wrong image. No such reordering was
+    observed in the recon; treat ``Position``/``ContentId`` as order-derived
+    rather than structurally verified.
+
+    If the two lists disagree in length — in EITHER direction —
     the positional mapping is no longer trustworthy, so rejections are still
     reported but with BOTH ``ContentId`` and ``Position`` set to ``None``.
     "Something is rejected but this reader cannot say which image" is
@@ -8514,15 +8523,24 @@ def _read_image_moderation_rejections(page: "Page") -> List[Dict[str, Any]]:
     except PlaywrightError:
         return []
 
-    # The positional mapping is only trustworthy while the two lists line up.
-    # ``_wait_for_images_editor`` settles on ``ContentImage``/``StubN``
-    # presence and never waits for the status buttons themselves, so a
-    # hydration gap that renders fewer buttons than images shifts every later
-    # button by one — silently reporting image N's rejection against image
-    # N-1's content ID. Any count disagreement therefore drops the content ID
-    # for the whole read (``ContentId: None``) rather than emitting one that
-    # may name an innocent image; the rejection itself is still reported.
-    aligned = count == len(content_ids)
+    # Count equality between the status buttons and the image cards. This is
+    # strictly WEAKER than the DOM-order correspondence the mapping actually
+    # relies on — it detects a missing/surplus button, not a reordered one —
+    # and is deliberately named for what it checks rather than for what it
+    # protects, so a future maintainer does not widen trust based on the name.
+    # Order itself is confirmed only live (bounding-box alignment on campaign
+    # 713234064) and rests on Yandex's markup, which this module disclaims any
+    # stability guarantee for; a count-equal-but-reordered DOM would defeat it.
+    #
+    # It is still worth checking, because the failure it DOES catch is the
+    # reachable one: ``_wait_for_images_editor`` settles on
+    # ``ContentImage``/``StubN`` presence and never waits for the status
+    # buttons themselves, so a hydration gap that renders fewer buttons than
+    # images shifts every later button by one — silently reporting image N's
+    # rejection against image N-1. On any count disagreement both identifying
+    # fields are dropped rather than emitting one that may name an innocent
+    # image; the rejection itself is still reported.
+    counts_match = count == len(content_ids)
 
     rejected: List[Dict[str, Any]] = []
     for index in range(count):
@@ -8542,8 +8560,8 @@ def _read_image_moderation_rejections(page: "Page") -> List[Dict[str, Any]]:
         rejected.append(
             {
                 "Type": "image",
-                "Position": (index + 1) if aligned else None,
-                "ContentId": (content_ids[index] if aligned else None),
+                "Position": (index + 1) if counts_match else None,
+                "ContentId": (content_ids[index] if counts_match else None),
                 "Title": _MODERATION_REJECTED_TITLE,
                 "Hint": _MODERATION_REJECTED_HINT,
             }

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -8490,14 +8490,16 @@ def _read_image_moderation_rejections(page: "Page") -> List[Dict[str, Any]]:
 
     If the two lists nonetheless disagree in length — in EITHER direction —
     the positional mapping is no longer trustworthy, so rejections are still
-    reported but with ``ContentId: None`` rather than a wrong content ID.
+    reported but with BOTH ``ContentId`` and ``Position`` set to ``None``.
     "Something is rejected but this reader cannot say which image" is
     strictly more useful than silently dropping it, and far better than
-    misattributing the rejection to an innocent image. The deficit direction
-    matters as much as the surplus one: ``_wait_for_images_editor`` settles
-    on ``ContentImage``/``StubN`` presence and never waits for the status
-    buttons, so a hydration gap dropping one button would otherwise shift
-    every later button by one and name the wrong image.
+    misattributing the rejection to an innocent image. Nulling only the
+    content ID would half-protect: a reader without one falls back to the
+    ordinal, and the ordinal is exactly what a mismatch shifts. The deficit
+    direction matters as much as the surplus one — ``_wait_for_images_editor``
+    settles on ``ContentImage``/``StubN`` presence and never waits for the
+    status buttons, so a hydration gap dropping one button shifts every later
+    button by one, making the button ordinal name the wrong image.
 
     Never hovers: the explanatory tooltip is not in the DOM until a real
     mouse hover (confirmed live — synthetic events do not mount it), so its
@@ -8540,7 +8542,7 @@ def _read_image_moderation_rejections(page: "Page") -> List[Dict[str, Any]]:
         rejected.append(
             {
                 "Type": "image",
-                "Position": index + 1,
+                "Position": (index + 1) if aligned else None,
                 "ContentId": (content_ids[index] if aligned else None),
                 "Title": _MODERATION_REJECTED_TITLE,
                 "Hint": _MODERATION_REJECTED_HINT,

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -8488,11 +8488,16 @@ def _read_image_moderation_rejections(page: "Page") -> List[Dict[str, Any]]:
     live 2026-08-08 both by bounding-box alignment and by the two lists
     having equal length on all 38 swept campaigns.
 
-    If the two lists nonetheless disagree in length, the extra status buttons
-    are still reported — with ``ContentId: None`` rather than a wrong content
-    ID — since "something is rejected but this reader cannot say which image"
-    is strictly more useful than silently dropping it, and far better than
-    misattributing the rejection to an innocent image.
+    If the two lists nonetheless disagree in length — in EITHER direction —
+    the positional mapping is no longer trustworthy, so rejections are still
+    reported but with ``ContentId: None`` rather than a wrong content ID.
+    "Something is rejected but this reader cannot say which image" is
+    strictly more useful than silently dropping it, and far better than
+    misattributing the rejection to an innocent image. The deficit direction
+    matters as much as the surplus one: ``_wait_for_images_editor`` settles
+    on ``ContentImage``/``StubN`` presence and never waits for the status
+    buttons, so a hydration gap dropping one button would otherwise shift
+    every later button by one and name the wrong image.
 
     Never hovers: the explanatory tooltip is not in the DOM until a real
     mouse hover (confirmed live — synthetic events do not mount it), so its
@@ -8506,6 +8511,16 @@ def _read_image_moderation_rejections(page: "Page") -> List[Dict[str, Any]]:
         count = buttons.count()
     except PlaywrightError:
         return []
+
+    # The positional mapping is only trustworthy while the two lists line up.
+    # ``_wait_for_images_editor`` settles on ``ContentImage``/``StubN``
+    # presence and never waits for the status buttons themselves, so a
+    # hydration gap that renders fewer buttons than images shifts every later
+    # button by one — silently reporting image N's rejection against image
+    # N-1's content ID. Any count disagreement therefore drops the content ID
+    # for the whole read (``ContentId: None``) rather than emitting one that
+    # may name an innocent image; the rejection itself is still reported.
+    aligned = count == len(content_ids)
 
     rejected: List[Dict[str, Any]] = []
     for index in range(count):
@@ -8526,7 +8541,7 @@ def _read_image_moderation_rejections(page: "Page") -> List[Dict[str, Any]]:
             {
                 "Type": "image",
                 "Position": index + 1,
-                "ContentId": (content_ids[index] if index < len(content_ids) else None),
+                "ContentId": (content_ids[index] if aligned else None),
                 "Title": _MODERATION_REJECTED_TITLE,
                 "Hint": _MODERATION_REJECTED_HINT,
             }

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -1010,6 +1010,95 @@ _VIDEO_MODAL_OPEN_TIMEOUT_MS = 10_000
 _VIDEO_UPLOAD_TIMEOUT_MS = 60_000
 _VIDEOS_EDITOR_TIMEOUT_MS = 60_000
 
+# Per-element moderation rejection (issue #814, `masters get
+# --moderation-statuses`).
+#
+# CONFIRMED LIVE 2026-08-08 (campaign 713234064, read-only DOM recon: navigate
+# + read + one hover, no click that mutates, never Saved). The rejected
+# element the issue reported is real and its markup is:
+#
+#   Every image card renders a sibling status button
+#   ``ImageSuggestionsEditor.CampaignContents.ImageStatus`` — a SINGLE testid
+#   shared by every image (NOT suffixed with the content ID), so a status
+#   button is tied to its image ONLY by DOM order: the Nth ImageStatus
+#   belongs to the Nth ``ContentImage.<contentId>``. Confirmed live on
+#   713234064 (4 images, 4 status buttons, positionally aligned by
+#   bounding box: image x-offsets 201/335/469/603 vs status x-offsets
+#   205/339/473/607).
+#
+#   The button comes in TWO shapes, and this is what discriminates a
+#   rejection from a normal card:
+#     * NOT rejected — the "efficiency" badge: the button carries a
+#       ``ImageStatusIcon_efficiency__*`` CSS-module class and contains a
+#       ``dc-Badge`` span (no svg icon).
+#     * REJECTED — no ``ImageStatusIcon_efficiency`` class; the button
+#       instead contains ``dc-Label_color_black-negative`` and an
+#       ``svg.dc-Icon_color_red``.
+#
+#   Hovering the rejected button (real mouse hover — synthetic
+#   mouseover/mouseenter events do NOT trigger it) mounts a tooltip
+#   ``ImageSuggestionsEditor.CampaignContents.StateTooltip`` in a portal at
+#   the end of <body>, whose two text nodes are exactly the strings the
+#   issue quoted: ``Text.Content`` = "Элемент объявления отклонен" and
+#   ``Text.Caption`` = "Пожалуйста, создайте новый элемент объявления и
+#   отправьте его на модерацию".
+#
+# Detection therefore uses the CSS-class shape, NOT the tooltip: the tooltip
+# does not exist in the DOM until hover, so reading it would require one
+# real hover per candidate element — slow, and a mouse interaction on a page
+# this command must keep strictly read-only. The class shape is present in
+# the static DOM for every card at once, which is what lets ONE page load
+# answer for the whole campaign (issue #814's central requirement).
+_IMAGE_STATUS_TESTID = "ImageSuggestionsEditor.CampaignContents.ImageStatus"
+_IMAGE_STATUS_SELECTOR = f'[data-testid="{_IMAGE_STATUS_TESTID}"]'
+# Present on a NON-rejected (efficiency-badge) status button only. CSS-module
+# class, so the real attribute value is ``ImageStatusIcon_efficiency__pCGiR``
+# with a build-time hash suffix — matched as a substring, never equality,
+# since that hash changes on every Yandex frontend build.
+_IMAGE_STATUS_EFFICIENCY_CLASS = "ImageStatusIcon_efficiency"
+# Present INSIDE a rejected status button. MUST stay scoped to an
+# ``ImageStatus`` button — these two classes are NOT unique to moderation.
+# Confirmed live 2026-08-08 that a video thumbnail's player chrome
+# (``MediaControl`` inside ``VideoSuggestionsEditor.CampaignContents.
+# VideoThumb.<url>.Content``) renders the very same
+# ``dc-Label_color_black-negative`` + ``svg.dc-Icon_color_red`` pair: campaign
+# 713234162 has SIX such elements and ZERO rejected images. A page-wide
+# ``.dc-Icon_color_red`` scan reported 5 of 38 swept campaigns as "rejected"
+# purely off video controls. Hence a sub-locator off the button handle, never
+# a ``page.locator`` of these classes.
+_IMAGE_STATUS_REJECTED_SELECTOR = (
+    ".dc-Label_color_black-negative, svg.dc-Icon_color_red"
+)
+# The rejection tooltip's own testid and copy. NOT used for detection (see
+# above) — kept because it is the marker a human re-verifying this live will
+# actually look for, and because it names the exact strings that were
+# confirmed rather than leaving them only in a commit message.
+_MODERATION_TOOLTIP_TESTID = "ImageSuggestionsEditor.CampaignContents.StateTooltip"
+_MODERATION_REJECTED_TITLE = "Элемент объявления отклонен"
+_MODERATION_REJECTED_HINT = (
+    "Пожалуйста, создайте новый элемент объявления и отправьте его на " "модерацию"
+)
+# Element types this reader reports on, and whether a per-element rejection
+# marker is KNOWN to exist for each.
+#
+# Only "image" is supported. Recon 2026-08-08 swept all 38 non-archived
+# Мастер кампаний on the account (~62 video variants; every campaign carries
+# headlines and texts) and found 2 rejected images and ZERO rejected
+# videos/headlines/texts. Structurally the affordance does not exist outside
+# images either: a full page-wide ``[data-testid]`` dump shows the video
+# section rendering only card/VideoThumb/CloseButton testids and the
+# headline/text sections only ``CampaignTitles<N>``/``CampaignTexts<N>``
+# (+``.textarea``/``.clear``) — no ``*Status``, no ``*StateTooltip``.
+#
+# That evidence CANNOT distinguish "Yandex renders no per-element status for
+# these types" from "no element of these types happens to be rejected right
+# now". So rather than reporting them as verified-clean (which would be a
+# claim this recon does not support), they are reported as checked-but-
+# unsupported — see ``read_moderation_statuses``'s ``UnsupportedTypes``.
+MODERATION_SUPPORTED_TYPES = ("image",)
+MODERATION_UNSUPPORTED_TYPES = ("video", "headline", "text")
+MODERATION_ELEMENT_TYPES = MODERATION_SUPPORTED_TYPES + MODERATION_UNSUPPORTED_TYPES
+
 # Region picker (issue #653 re-recon, 2026-08-02): Yandex replaced the old
 # text-combobox-with-suggestions flow with a tree/tag-group widget
 # (``data-testid="RegionsTreeEditor"``). Confirmed live: the tag group's
@@ -8371,6 +8460,127 @@ def fetch_master_images(page: "Page", campaign_id: int) -> Dict[str, Any]:
         "Count": len(content_ids),
         "MaxCount": _IMAGES_MAX_COUNT,
     }
+
+
+def _read_image_moderation_rejections(page: "Page") -> List[Dict[str, Any]]:
+    """Read which of the campaign's images are individually rejected on
+    moderation, as a list of rejected-element records in page order.
+
+    Detection is the CSS-class shape documented at
+    ``_IMAGE_STATUS_TESTID`` and in
+    ``tests/fixtures/masters_wizard_edit_moderation.html``: a status button
+    that lacks ``ImageStatusIcon_efficiency`` AND contains a
+    ``dc-Label_color_black-negative``/``svg.dc-Icon_color_red`` child is a
+    rejection. BOTH halves are required —
+
+    * the negative-class check alone is not sufficient: the very same classes
+      render inside a video thumbnail's ``MediaControl`` player chrome (see
+      ``_IMAGE_STATUS_REJECTED_SELECTOR``'s comment), which is why the check
+      is scoped to a sub-locator off the status button rather than run
+      page-wide;
+    * the missing-``efficiency`` check alone is not sufficient either — it
+      would classify any future third button variant Yandex introduces as a
+      rejection.
+
+    The status button carries no content ID of its own (one shared testid for
+    every image), so a rejection is mapped back to its image POSITIONALLY:
+    the Nth ``ImageStatus`` belongs to the Nth ``ContentImage``. Confirmed
+    live 2026-08-08 both by bounding-box alignment and by the two lists
+    having equal length on all 38 swept campaigns.
+
+    If the two lists nonetheless disagree in length, the extra status buttons
+    are still reported — with ``ContentId: None`` rather than a wrong content
+    ID — since "something is rejected but this reader cannot say which image"
+    is strictly more useful than silently dropping it, and far better than
+    misattributing the rejection to an innocent image.
+
+    Never hovers: the explanatory tooltip is not in the DOM until a real
+    mouse hover (confirmed live — synthetic events do not mount it), so its
+    copy is attached from the confirmed constants instead. That keeps this a
+    pure read over one already-loaded page.
+    """
+    content_ids = _read_image_content_ids(page)
+
+    try:
+        buttons = page.locator(_IMAGE_STATUS_SELECTOR)
+        count = buttons.count()
+    except PlaywrightError:
+        return []
+
+    rejected: List[Dict[str, Any]] = []
+    for index in range(count):
+        button = buttons.nth(index)
+        try:
+            class_attr = button.get_attribute("class") or ""
+            has_negative = button.locator(_IMAGE_STATUS_REJECTED_SELECTOR).count() > 0
+        except PlaywrightError:
+            # A status button that cannot be read is not evidence of a
+            # rejection — skip it rather than guess (mirrors
+            # ``_read_testid_suffixes``'s tolerance of a locator failure).
+            continue
+
+        if _IMAGE_STATUS_EFFICIENCY_CLASS in class_attr or not has_negative:
+            continue
+
+        rejected.append(
+            {
+                "Type": "image",
+                "Position": index + 1,
+                "ContentId": (content_ids[index] if index < len(content_ids) else None),
+                "Title": _MODERATION_REJECTED_TITLE,
+                "Hint": _MODERATION_REJECTED_HINT,
+            }
+        )
+    return rejected
+
+
+def read_moderation_statuses(page: "Page") -> Dict[str, Any]:
+    """Read per-element moderation rejections across the edit page's element
+    sections, from a page whose edit form has ALREADY been waited for.
+
+    Takes an already-open page rather than navigating itself, because issue
+    #814's whole point is that ``--moderation-statuses`` is a second slice of
+    the SAME DOM snapshot ``masters get`` already loads — not a second visit.
+    ``fetch_master_moderation_statuses`` is the navigating wrapper.
+
+    ``RejectedElements`` is a flat list so that every entry carries its own
+    ``Type``, letting a caller filter by element type with the CLI's ordinary
+    ``--format``/downstream tooling rather than this command growing per-type
+    flags (again issue #814).
+
+    ``UnsupportedTypes`` is deliberately part of the result: only ``image``
+    has a live-confirmed rejection marker, and an empty ``RejectedElements``
+    must not be read as "no video/headline/text is rejected" — see
+    ``MODERATION_SUPPORTED_TYPES``.
+    """
+    _wait_for_images_editor(page)
+
+    rejected = _read_image_moderation_rejections(page)
+
+    return {
+        "RejectedElements": rejected,
+        "RejectedCount": len(rejected),
+        "CheckedTypes": list(MODERATION_SUPPORTED_TYPES),
+        "UnsupportedTypes": list(MODERATION_UNSUPPORTED_TYPES),
+    }
+
+
+def fetch_master_moderation_statuses(page: "Page", campaign_id: int) -> Dict[str, Any]:
+    """Navigate to a campaign's edit page and read its per-element moderation
+    rejections (issue #814).
+
+    Read-only, mirroring ``fetch_master_target_actions``: this data lives on
+    the EDIT page, not the overview page ``fetch_master`` reads, and nothing
+    here ever clicks Save.
+    """
+    page.goto(WIZARD_EDIT_URL.format(campaign_id=campaign_id), wait_until="commit")
+    assert_not_captcha(page.content())
+    assert_authenticated(page.content())
+    _wait_for_edit_form(page, campaign_id)
+
+    result = read_moderation_statuses(page)
+    result["CampaignId"] = campaign_id
+    return result
 
 
 def fetch_master_target_actions(page: "Page", campaign_id: int) -> Dict[str, Any]:

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -545,25 +545,59 @@ def list_masters(
 
 @masters.command()
 @click.argument("campaign_ids")
+@click.option(
+    "--moderation-statuses",
+    is_flag=True,
+    help=(
+        "Also report ad elements individually rejected on moderation "
+        "(images). Adds RejectedElements/RejectedCount to each result."
+    ),
+)
 @_masters_browser_options
 @click.pass_context
 @handle_api_errors
 def get(
     ctx,
     campaign_ids,
+    moderation_statuses,
     headful,
     profile_dir,
     chrome_profile,
     output_format,
     output,
 ):
-    """Get one or more Мастер кампаний by ID (comma-separated)"""
-    from ..browser.masters import fetch_master
+    """Get one or more Мастер кампаний by ID (comma-separated)
+
+    With --moderation-statuses, additionally reads each campaign's edit page
+    for ad elements that moderation rejected individually (the campaign keeps
+    running on its remaining approved elements, so this does not show up in
+    the campaign-level status). Only images carry such a marker today; see
+    UnsupportedTypes in the output.
+    """
+    from ..browser.masters import fetch_master, fetch_master_moderation_statuses
 
     ids = parse_ids(campaign_ids) or []
 
+    def _fetch_one(page, campaign_id):
+        result = fetch_master(page, campaign_id)
+        if moderation_statuses:
+            # A second navigation on purpose: the rejection markers live on
+            # the edit page, while fetch_master reads the overview page.
+            # Merged into the SAME result object so the flag stays a slice of
+            # `get`'s output rather than a separate command (issue #814).
+            result.update(
+                {
+                    key: value
+                    for key, value in fetch_master_moderation_statuses(
+                        page, campaign_id
+                    ).items()
+                    if key != "CampaignId"
+                }
+            )
+        return result
+
     def _fetch_all(page):
-        return [fetch_master(page, campaign_id) for campaign_id in ids]
+        return [_fetch_one(page, campaign_id) for campaign_id in ids]
 
     results = _with_session(ctx, headful, profile_dir, chrome_profile, _fetch_all)
 

--- a/tests/fixtures/masters_wizard_edit_moderation.html
+++ b/tests/fixtures/masters_wizard_edit_moderation.html
@@ -1,0 +1,196 @@
+<!--
+Fixture: DOM findings for PER-ELEMENT MODERATION REJECTION on the Yandex
+Direct "Мастер кампаний" (Campaign Wizard) edit page — issue #814
+(`direct masters get <id> --moderation-statuses`), part of the #648 umbrella.
+
+Captured 2026-08-08 via claude-in-chrome (targeted recon on two campaigns)
+plus a scripted read-only sweep over every non-archived Мастер кампаний on
+the account (38 campaigns).
+
+READ-ONLY. Every observation below came from `page.goto` + DOM reads, plus
+exactly ONE real mouse hover per rejected marker to make its tooltip mount.
+No field was typed into, no Save/Launch button was ever clicked, no campaign
+was mutated.
+
+Source URL:
+  https://direct.yandex.ru/wizard/campaigns/{id}/edit/?ulogin={login}
+
+Campaigns carrying a confirmed rejected element:
+  713234064 — 4 images, the 2nd (0-based index 1, content ID
+              2513371652347967553) rejected
+  713231614 — 5 images, the 4th (0-based index 3, content ID
+              2539115717674655622) rejected
+
+Note on the issue's wording: #814 described the 713234064 case as
+"[Image #5] rejected". At recon time that campaign has only FOUR images and
+the rejected one sits at position 2. The rejection itself reproduced exactly
+as described; only the ordinal differs, presumably because the image set
+changed between the issue's screenshot and this recon. Positions here are
+what the page actually rendered on 2026-08-08.
+
+
+KEY FINDING #1 — the marker is a per-image STATUS BUTTON, keyed by DOM order
+================================================================================
+
+Each image card renders a sibling status button:
+
+  data-testid="ImageSuggestionsEditor.CampaignContents.ImageStatus"
+
+This is a SINGLE testid shared by every image — it is NOT suffixed with the
+content ID (unlike `...CampaignContents.ContentImage.<contentId>`). So a
+status button is tied to its image ONLY by DOM order: the Nth ImageStatus
+belongs to the Nth ContentImage.
+
+Positional alignment confirmed live on 713234064 by bounding box —
+  ContentImage x-offsets: 201 / 335 / 469 / 603
+  ImageStatus  x-offsets: 205 / 339 / 473 / 607
+i.e. each status button sits directly under its own card.
+
+Count alignment confirmed across ALL 38 swept campaigns: the number of
+ImageStatus buttons equals the number of ContentImage cards on every single
+one (0 images -> 0 buttons, 4 -> 4, 5 -> 5). No campaign was observed where
+the two lists could disagree.
+
+
+KEY FINDING #2 — rejected vs. not is a CSS-CLASS SHAPE, two variants
+================================================================================
+
+The status button comes in exactly two shapes:
+
+  NOT rejected ("efficiency" badge) — the button's own class list contains
+    ImageStatusIcon_efficiency__<hash>
+  and it holds a `span.dc-Badge` (no svg icon):
+
+    <button type="button"
+            data-testid="ImageSuggestionsEditor.CampaignContents.ImageStatus"
+            class="dc-ClickableIcon dc-ClickableIcon_color_gray
+                   dc-ClickableIcon_role_supplementary
+                   ImageStatusIcon_button__sqJGQ
+                   ImageStatusIcon_efficiency__pCGiR">
+      <div class="dc-Stack ...">
+        <span class="dc-Badge dc-Badge_color_gray dc-Badge_size_8
+                     dc-Badge_empty ..."></span>
+        ...
+      </div>
+    </button>
+
+  REJECTED — NO ImageStatusIcon_efficiency class at all; the button instead
+  contains a negative label and a red icon:
+
+    <button type="button"
+            data-testid="ImageSuggestionsEditor.CampaignContents.ImageStatus"
+            class="dc-ClickableIcon dc-ClickableIcon_color_gray
+                   dc-ClickableIcon_role_supplementary">
+      <div class="dc-Label dc-Label_withIconOnly
+                  dc-Label_color_black-negative dc-Label_size_3xs ...">
+        <div class="... dc-Label__icon ...">
+          <svg width="12" height="12" viewBox="0 0 12 12"
+               class="dc-Icon dc-Icon_role_main dc-Icon_color_red"
+               focusable="false" aria-hidden="true">
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M2.048 1.323..."/>
+          </svg>
+        </div>
+      </div>
+    </button>
+
+Note `ImageStatusIcon_efficiency__pCGiR` is a CSS-module class: the `__pCGiR`
+suffix is a build-time hash that changes on every Yandex frontend build. The
+reader matches it as a SUBSTRING (`ImageStatusIcon_efficiency`), never by
+equality.
+
+The button carries NO aria-label and NO title attribute — there is no
+accessible-name shortcut; the class shape is the signal.
+
+Confirmed identical on both rejected campaigns (713234064 index 1, 713231614
+index 3), i.e. the shape is not a one-off.
+
+
+KEY FINDING #3 — the tooltip exists ONLY after a real hover
+================================================================================
+
+Hovering a REJECTED status button mounts, in a portal at the end of <body>:
+
+  data-testid="ImageSuggestionsEditor.CampaignContents.StateTooltip"
+    └ data-testid="ImageSuggestionsEditor.CampaignContents.StateTooltip
+                   .TooltipContent"   (class "dc-Tooltip dc-Tooltip_color_inverted")
+        └ data-testid="Text.Content"  -> "Элемент объявления отклонен"
+        └ data-testid="Text.Caption"  -> "Пожалуйста, создайте новый элемент
+                                          объявления и отправьте его на
+                                          модерацию"
+
+Both strings match issue #814's quoted copy verbatim. Confirmed on BOTH
+rejected campaigns independently.
+
+Two facts that decided the implementation:
+
+  * The tooltip is NOT in the DOM before hover. Nothing anywhere on the page
+    contains the string "отклонен" until the marker is hovered.
+  * A SYNTHETIC event does not mount it. Dispatching
+    mouseover/mouseenter/mousemove via `dispatchEvent` produced nothing; only
+    a real CDP-driven mouse hover worked.
+
+So `read_moderation_statuses` detects via the CSS-class shape (Finding #2),
+which is present in the static DOM for every card simultaneously, and does
+NOT hover. That is what lets ONE page load answer for the whole campaign,
+which is issue #814's central requirement — and it keeps the command free of
+mouse interaction on a page it must not mutate.
+
+
+KEY FINDING #4 — a page-wide class scan is a FALSE-POSITIVE TRAP
+================================================================================
+
+`.dc-Label_color_black-negative` and `svg.dc-Icon_color_red` are NOT unique to
+moderation. On campaigns with video variants they also appear inside the video
+thumbnail's player chrome:
+
+  VideoSuggestionsEditor.CampaignContents.<url>
+    └ VideoSuggestionsEditor.CampaignContents.VideoThumb.<url>
+        └ ....VideoThumb.<url>.Content
+            └ data-testid="MediaControl"
+                └ ClickableIcon
+                    └ div.dc-Label_color_black-negative
+                        └ svg.dc-Icon_color_red
+
+Observed on 5 swept campaigns (713234162, 713234179, 713234142, 713234150,
+75107869) — e.g. 713234162 has 6 such MediaControl elements and ZERO rejected
+images. A naive page-wide `querySelectorAll('.dc-Icon_color_red')` would have
+reported all five as rejections.
+
+The reader therefore scopes the class check to a sub-locator INSIDE an
+`ImageStatus` button, never a page-wide selector.
+
+
+KEY FINDING #5 — no rejection marker exists for video / headlines / texts
+================================================================================
+
+Issue #814 asked whether the marker/tooltip shape is uniform across element
+types. On the evidence available it could not be confirmed uniform, because
+NO non-image rejection was found to compare against:
+
+  * Swept all 38 non-archived Мастер кампаний on the account. Aggregate:
+    ~62 video variants, and every campaign carries headlines and texts
+    (CampaignTitles0..4 / CampaignTexts0..2).
+  * Rejected images found: 2 (the campaigns named at the top).
+  * Rejected videos / headlines / texts found: 0.
+  * Structurally, the status affordance does not even EXIST outside images.
+    A full `[data-testid]` dump on 713234064 yields these status-ish testids:
+        CampaignHeader.Status
+        CampaignFormStatusInput.efficiency.{ONE,TWO,...}   (campaign-level)
+        ImageSuggestionsEditor.CampaignContents.ImageStatus
+        ImageSuggestionsEditor.CampaignContents.StateTooltip
+    The video section renders only card / VideoThumb / CloseButton testids —
+    no `*Status`, no `*StateTooltip`. The headline and text sections render
+    only `CampaignTitles<N>[.textarea|.clear]` /
+    `CampaignTexts<N>[.textarea|.clear]` — likewise no status affordance.
+
+CONCLUSION (and the honest limit of this recon): for IMAGES the marker is
+confirmed on two independent campaigns. For video/headlines/texts there is no
+observed marker at all — which is consistent with either "Yandex renders no
+per-element status for these types" or "no element of these types happens to
+be rejected on this account right now". THIS RECON CANNOT DISTINGUISH THE
+TWO. `read_moderation_statuses` reports images as a checked-and-supported
+type, and reports video/headline/text as checked-but-unsupported, rather than
+silently implying they were verified clean. Should a rejected video/headline/
+text ever be observed live, this fixture and the reader's element-type table
+are what need updating.
+-->

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -19592,6 +19592,48 @@ class TestReadModerationStatuses(unittest.TestCase):
         self.assertEqual(result["RejectedElements"][0]["Position"], 2)
         self.assertIsNone(result["RejectedElements"][0]["ContentId"])
 
+    def test_missing_status_button_yields_null_content_id_not_a_wrong_one(self):
+        """FEWER status buttons than images: the positional mapping is no
+        longer trustworthy, so no rejection may borrow an unrelated image's
+        content ID.
+
+        The surplus direction was already guarded; this is the deficit one.
+        ``_wait_for_images_editor`` settles on ``ContentImage``/``StubN``
+        presence and never waits for the status buttons themselves, so a
+        hydration gap that drops one button shifts every later button by one
+        — reporting image N's rejection against image N-1's content ID, i.e.
+        telling the user to replace an innocent element.
+        """
+        page = _FakeModerationPage(
+            ["a", "b", "c", "d"], statuses=["ok", "ok", "rejected"]
+        )
+
+        result = browser_masters.read_moderation_statuses(page)
+
+        self.assertEqual(result["RejectedCount"], 1)
+        self.assertIsNone(result["RejectedElements"][0]["ContentId"])
+
+    def test_missing_status_button_still_reports_the_rejection(self):
+        """Dropping the content ID must not drop the rejection itself —
+        "something is rejected but this reader cannot say which image" is
+        strictly more useful than silence."""
+        page = _FakeModerationPage(["a", "b"], statuses=["rejected"])
+
+        result = browser_masters.read_moderation_statuses(page)
+
+        self.assertEqual(result["RejectedCount"], 1)
+        self.assertEqual(result["RejectedElements"][0]["Position"], 1)
+        self.assertIsNone(result["RejectedElements"][0]["ContentId"])
+
+    def test_aligned_counts_still_resolve_the_content_id(self):
+        """The guard must only fire on a real mismatch — an aligned page
+        keeps reporting the content ID it always did."""
+        page = _FakeModerationPage(["a", "b", "c"], statuses=["ok", "rejected", "ok"])
+
+        result = browser_masters.read_moderation_statuses(page)
+
+        self.assertEqual(result["RejectedElements"][0]["ContentId"], "b")
+
     def test_declares_which_element_types_were_actually_checked(self):
         """An empty result must not be readable as "no video/headline/text is
         rejected" — only images have a live-confirmed marker."""

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -19414,5 +19414,328 @@ class TestMastersUpdateMetrikaCounterFlags(unittest.TestCase):
         self.assertIn("--add-metrika-counter", result.output)
 
 
+class _FakeModerationPage(_FakeImagesPage):
+    """Models the images section plus its per-image moderation status buttons
+    (issue #814).
+
+    ``statuses`` is one entry per image, positionally aligned with ``ids``,
+    each either ``"ok"`` (the efficiency-badge variant) or ``"rejected"`` —
+    exactly the two live-confirmed shapes (see
+    ``tests/fixtures/masters_wizard_edit_moderation.html``). Defaults to all
+    ``"ok"``, so an existing images test that subclasses this gets a clean
+    campaign.
+
+    ``extra_statuses`` appends status buttons with NO corresponding image,
+    modeling the count-mismatch case ``_read_image_moderation_rejections``
+    must survive without misattributing a content ID.
+    """
+
+    def __init__(self, ids, *, statuses=None, extra_statuses=(), **kwargs):
+        super().__init__(ids, **kwargs)
+        self.statuses = list(statuses if statuses is not None else ["ok"] * len(ids))
+        self.statuses.extend(extra_statuses)
+
+    def _status_handle(self, status):
+        if status == "rejected":
+            # No ImageStatusIcon_efficiency class; a negative-label child.
+            return _FakeLocatorHandle(
+                attrs={"class": "dc-ClickableIcon dc-ClickableIcon_color_gray"},
+                sub_locators={
+                    browser_masters._IMAGE_STATUS_REJECTED_SELECTOR: (
+                        _FakeLocatorHandle()
+                    )
+                },
+            )
+        if status == "ok-with-negative-child":
+            # The efficiency badge, but ALSO matching the negative selector.
+            # Models the live false-positive class of bug: those classes are
+            # not unique to moderation (a video thumbnail's MediaControl
+            # renders them too — campaign 713234162, 6 of them, 0 rejected
+            # images), so the efficiency class must veto.
+            return _FakeLocatorHandle(
+                attrs={
+                    "class": (
+                        "dc-ClickableIcon ImageStatusIcon_button__sqJGQ "
+                        "ImageStatusIcon_efficiency__pCGiR"
+                    )
+                },
+                sub_locators={
+                    browser_masters._IMAGE_STATUS_REJECTED_SELECTOR: (
+                        _FakeLocatorHandle()
+                    )
+                },
+            )
+        if status == "unknown":
+            # Neither shape: no efficiency class AND no negative child — a
+            # hypothetical third variant, which must NOT count as rejected.
+            return _FakeLocatorHandle(
+                attrs={"class": "dc-ClickableIcon dc-ClickableIcon_color_gray"}
+            )
+        # "ok": the efficiency badge. Note the real class carries a
+        # build-time hash suffix, which the reader must match as a substring.
+        return _FakeLocatorHandle(
+            attrs={
+                "class": (
+                    "dc-ClickableIcon ImageStatusIcon_button__sqJGQ "
+                    "ImageStatusIcon_efficiency__pCGiR"
+                )
+            }
+        )
+
+    def locator(self, selector):
+        if selector == browser_masters._IMAGE_STATUS_SELECTOR:
+            return _FakeLocator(
+                [self._status_handle(status) for status in self.statuses]
+            )
+        return super().locator(selector)
+
+
+class TestReadModerationStatuses(unittest.TestCase):
+    """``read_moderation_statuses`` — issue #814's per-element rejection read.
+
+    Marker shape confirmed live 2026-08-08 on campaigns 713234064 and
+    713231614; see ``tests/fixtures/masters_wizard_edit_moderation.html``.
+    """
+
+    def test_reports_a_rejected_image_with_position_and_content_id(self):
+        page = _FakeModerationPage(
+            ["a", "b", "c", "d"], statuses=["ok", "rejected", "ok", "ok"]
+        )
+
+        result = browser_masters.read_moderation_statuses(page)
+
+        self.assertEqual(result["RejectedCount"], 1)
+        self.assertEqual(
+            result["RejectedElements"],
+            [
+                {
+                    "Type": "image",
+                    "Position": 2,
+                    "ContentId": "b",
+                    "Title": browser_masters._MODERATION_REJECTED_TITLE,
+                    "Hint": browser_masters._MODERATION_REJECTED_HINT,
+                }
+            ],
+        )
+
+    def test_clean_campaign_reports_no_rejections(self):
+        page = _FakeModerationPage(["a", "b", "c"])
+
+        result = browser_masters.read_moderation_statuses(page)
+
+        self.assertEqual(result["RejectedCount"], 0)
+        self.assertEqual(result["RejectedElements"], [])
+
+    def test_campaign_without_images_reports_no_rejections(self):
+        page = _FakeModerationPage([])
+
+        result = browser_masters.read_moderation_statuses(page)
+
+        self.assertEqual(result["RejectedCount"], 0)
+
+    def test_reports_every_rejected_image_in_page_order(self):
+        page = _FakeModerationPage(
+            ["a", "b", "c", "d", "e"],
+            statuses=["rejected", "ok", "rejected", "ok", "rejected"],
+        )
+
+        result = browser_masters.read_moderation_statuses(page)
+
+        self.assertEqual(
+            [(e["Position"], e["ContentId"]) for e in result["RejectedElements"]],
+            [(1, "a"), (3, "c"), (5, "e")],
+        )
+
+    def test_efficiency_badge_is_never_a_rejection_despite_hash_suffix(self):
+        """The live class is ``ImageStatusIcon_efficiency__<buildhash>`` — the
+        reader must match it as a substring, not by equality."""
+        page = _FakeModerationPage(["a"], statuses=["ok"])
+
+        result = browser_masters.read_moderation_statuses(page)
+
+        self.assertEqual(result["RejectedElements"], [])
+
+    def test_efficiency_badge_wins_even_if_a_negative_class_is_also_present(self):
+        """The negative-class check alone is NOT sufficient: those classes are
+        not unique to moderation (confirmed live — a video thumbnail's
+        ``MediaControl`` renders the same pair). An efficiency badge is never
+        a rejection, whatever else it contains."""
+        page = _FakeModerationPage(
+            ["a", "b"], statuses=["ok-with-negative-child", "rejected"]
+        )
+
+        result = browser_masters.read_moderation_statuses(page)
+
+        self.assertEqual(
+            [(e["Position"], e["ContentId"]) for e in result["RejectedElements"]],
+            [(2, "b")],
+        )
+
+    def test_negative_child_without_efficiency_check_is_not_enough(self):
+        """A third button variant (no efficiency class, no negative child) is
+        NOT reported — guards against classifying anything unfamiliar as a
+        rejection."""
+        page = _FakeModerationPage(["a", "b"], statuses=["unknown", "unknown"])
+
+        result = browser_masters.read_moderation_statuses(page)
+
+        self.assertEqual(result["RejectedElements"], [])
+
+    def test_extra_status_button_yields_null_content_id_not_a_wrong_one(self):
+        """More status buttons than images: the surplus rejection is still
+        reported, but must never borrow another image's content ID."""
+        page = _FakeModerationPage(["a"], statuses=["ok"], extra_statuses=["rejected"])
+
+        result = browser_masters.read_moderation_statuses(page)
+
+        self.assertEqual(result["RejectedCount"], 1)
+        self.assertEqual(result["RejectedElements"][0]["Position"], 2)
+        self.assertIsNone(result["RejectedElements"][0]["ContentId"])
+
+    def test_declares_which_element_types_were_actually_checked(self):
+        """An empty result must not be readable as "no video/headline/text is
+        rejected" — only images have a live-confirmed marker."""
+        page = _FakeModerationPage(["a"])
+
+        result = browser_masters.read_moderation_statuses(page)
+
+        self.assertEqual(result["CheckedTypes"], ["image"])
+        self.assertEqual(result["UnsupportedTypes"], ["video", "headline", "text"])
+
+    def test_never_clicks_save(self):
+        page = _FakeModerationPage(["a", "b"], statuses=["ok", "rejected"])
+
+        browser_masters.read_moderation_statuses(page)
+
+        self.assertEqual(page.save_clicks, [])
+
+    def test_never_opens_the_images_modal(self):
+        """Unlike ``fetch_master_images`` there is no thumb URL to read, so
+        this reader must stay a pure page-level read."""
+        page = _FakeModerationPage(["a"], statuses=["rejected"])
+
+        browser_masters.read_moderation_statuses(page)
+
+        self.assertFalse(page.modal_open)
+
+    def test_unrendered_images_section_raises_rather_than_reporting_clean(self):
+        """Same invariant as ``fetch_master_images``: an unsettled section
+        must not be reported as "nothing rejected"."""
+
+        class _NoEditorPage(_FakeModerationPage):
+            def locator(self, selector):
+                if selector == browser_masters._IMAGES_EDITOR_SELECTOR:
+                    return _FakeLocator([])
+                return super().locator(selector)
+
+        page = _NoEditorPage([])
+        with patch.object(browser_masters, "_IMAGES_EDITOR_TIMEOUT_MS", 1):
+            with self.assertRaises(BrowserSessionError):
+                browser_masters.read_moderation_statuses(page)
+
+
+class TestFetchMasterModerationStatuses(unittest.TestCase):
+    """``fetch_master_moderation_statuses`` — the navigating wrapper."""
+
+    def test_carries_the_campaign_id_into_the_result(self):
+        page = _FakeModerationPage(["a"], statuses=["rejected"])
+
+        result = browser_masters.fetch_master_moderation_statuses(page, 42)
+
+        self.assertEqual(result["CampaignId"], 42)
+        self.assertEqual(result["RejectedCount"], 1)
+
+    def test_reads_the_edit_page_not_the_overview_page(self):
+        page = _FakeModerationPage(["a"])
+
+        browser_masters.fetch_master_moderation_statuses(page, 42)
+
+        self.assertIn("/edit/", page.navigated_to[-1])
+
+
+class TestMastersGetModerationStatusesFlag(unittest.TestCase):
+    """``masters get --moderation-statuses`` — issue #814's CLI surface."""
+
+    def setUp(self):
+        self.runner = CliRunner()
+
+    def _invoke(self, args):
+        with patch(
+            "direct_cli.commands.masters._with_session",
+            side_effect=lambda ctx, headful, profile_dir, chrome_profile, fn: fn(
+                object()
+            ),
+        ):
+            return self.runner.invoke(cli, args)
+
+    def test_flag_absent_never_reads_moderation_statuses(self):
+        """The default `get` must not pay for a second page load."""
+        with patch.object(
+            browser_masters, "fetch_master", return_value={"CampaignId": 42}
+        ):
+            with patch.object(
+                browser_masters, "fetch_master_moderation_statuses"
+            ) as mock_moderation:
+                result = self._invoke(["masters", "get", "42"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        mock_moderation.assert_not_called()
+        self.assertNotIn("RejectedElements", result.output)
+
+    def test_flag_merges_rejections_into_the_same_result_object(self):
+        """Issue #814: a slice of `get`'s output, not a separate command's."""
+        with patch.object(
+            browser_masters,
+            "fetch_master",
+            return_value={"CampaignId": 42, "Name": "campaign"},
+        ):
+            with patch.object(
+                browser_masters,
+                "fetch_master_moderation_statuses",
+                return_value={
+                    "CampaignId": 42,
+                    "RejectedElements": [{"Type": "image", "Position": 2}],
+                    "RejectedCount": 1,
+                    "CheckedTypes": ["image"],
+                    "UnsupportedTypes": ["video", "headline", "text"],
+                },
+            ):
+                result = self._invoke(["masters", "get", "42", "--moderation-statuses"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["CampaignId"], 42)
+        self.assertEqual(payload["Name"], "campaign")
+        self.assertEqual(payload["RejectedCount"], 1)
+        self.assertEqual(payload["RejectedElements"][0]["Position"], 2)
+
+    def test_flag_applies_to_every_id_in_a_comma_separated_list(self):
+        with patch.object(
+            browser_masters,
+            "fetch_master",
+            side_effect=lambda _page, cid: {"CampaignId": cid},
+        ):
+            with patch.object(
+                browser_masters,
+                "fetch_master_moderation_statuses",
+                side_effect=lambda _page, cid: {
+                    "CampaignId": cid,
+                    "RejectedElements": [],
+                    "RejectedCount": 0,
+                    "CheckedTypes": ["image"],
+                    "UnsupportedTypes": ["video", "headline", "text"],
+                },
+            ) as mock_moderation:
+                result = self._invoke(
+                    ["masters", "get", "42,43", "--moderation-statuses"]
+                )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(mock_moderation.call_count, 2)
+        payload = json.loads(result.output)
+        self.assertEqual([row["CampaignId"] for row in payload], [42, 43])
+        self.assertTrue(all("RejectedCount" in row for row in payload))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -19583,13 +19583,14 @@ class TestReadModerationStatuses(unittest.TestCase):
 
     def test_extra_status_button_yields_null_content_id_not_a_wrong_one(self):
         """More status buttons than images: the surplus rejection is still
-        reported, but must never borrow another image's content ID."""
+        reported, but must never borrow another image's identity — neither
+        its content ID nor its ordinal."""
         page = _FakeModerationPage(["a"], statuses=["ok"], extra_statuses=["rejected"])
 
         result = browser_masters.read_moderation_statuses(page)
 
         self.assertEqual(result["RejectedCount"], 1)
-        self.assertEqual(result["RejectedElements"][0]["Position"], 2)
+        self.assertIsNone(result["RejectedElements"][0]["Position"])
         self.assertIsNone(result["RejectedElements"][0]["ContentId"])
 
     def test_missing_status_button_yields_null_content_id_not_a_wrong_one(self):
@@ -19613,6 +19614,24 @@ class TestReadModerationStatuses(unittest.TestCase):
         self.assertEqual(result["RejectedCount"], 1)
         self.assertIsNone(result["RejectedElements"][0]["ContentId"])
 
+    def test_missing_status_button_yields_null_position_too(self):
+        """``Position`` must be nulled alongside ``ContentId`` on a mismatch.
+
+        A reader with no content ID falls back to the ordinal, so leaving a
+        shifted ``Position`` behind only half-protects: with image #1's
+        status button missing, the button ordinal of the rejected 4th image
+        is 3 — pointing the user at the innocent image before it. Neither
+        field may survive a mismatch as something readable as "which image".
+        """
+        page = _FakeModerationPage(
+            ["a", "b", "c", "d"], statuses=["ok", "ok", "rejected"]
+        )
+
+        result = browser_masters.read_moderation_statuses(page)
+
+        self.assertEqual(result["RejectedCount"], 1)
+        self.assertIsNone(result["RejectedElements"][0]["Position"])
+
     def test_missing_status_button_still_reports_the_rejection(self):
         """Dropping the content ID must not drop the rejection itself —
         "something is rejected but this reader cannot say which image" is
@@ -19622,7 +19641,8 @@ class TestReadModerationStatuses(unittest.TestCase):
         result = browser_masters.read_moderation_statuses(page)
 
         self.assertEqual(result["RejectedCount"], 1)
-        self.assertEqual(result["RejectedElements"][0]["Position"], 1)
+        self.assertEqual(result["RejectedElements"][0]["Type"], "image")
+        self.assertIsNone(result["RejectedElements"][0]["Position"])
         self.assertIsNone(result["RejectedElements"][0]["ContentId"])
 
     def test_aligned_counts_still_resolve_the_content_id(self):


### PR DESCRIPTION
## Что

`direct masters get <id> --moderation-statuses` — детекция элементов объявления, отклонённых модерацией по отдельности внутри Мастера кампаний.

Кампания при этом продолжает крутиться на оставшихся допущенных элементах, поэтому это не видно ни в `campaigns.get`/`ads.get` `StatusModerate`, ни через `ads get --image-moderation-statuses` (тот фильтр — на уровне готового объявления, а не элемента в пуле Мастера). Browser-only, как и весь `masters`.

Флаг у существующей `get`, а не отдельная подкоманда — это ещё один срез того же чтения кампании; фильтрация по типу элемента остаётся за `--format`/внешними средствами, без per-type флагов.

```console
$ direct masters get 713234064 --moderation-statuses
```
```json
"RejectedElements": [
  {"Type": "image", "Position": 2, "ContentId": "2513371652347967553",
   "Title": "Элемент объявления отклонен",
   "Hint": "Пожалуйста, создайте новый элемент объявления и отправьте его на модерацию"}
],
"RejectedCount": 1,
"CheckedTypes": ["image"],
"UnsupportedTypes": ["video", "headline", "text"]
```

Без флага вывод и число загрузок страницы у `get` не меняются.

## Что нашла живая рекогносцировка

Read-only: `goto` + чтение DOM, плюс ровно один настоящий hover на маркер, чтобы поднять тултип. Ничего не сохранялось, ни одна кампания не мутировалась. Полностью задокументировано в `tests/fixtures/masters_wizard_edit_moderation.html`.

- **Маркер — кнопка статуса у каждой картинки** `ImageSuggestionsEditor.CampaignContents.ImageStatus`. Это ОДИН testid на все картинки (без суффикса content ID), поэтому отклонение привязывается к картинке позиционно: N-я кнопка — к N-й `ContentImage`. Подтверждено и выравниванием bounding box, и равенством длин обоих списков на всех 38 просмотренных кампаниях.
- **Две формы кнопки.** Не отклонена — класс `ImageStatusIcon_efficiency__<hash>` + `dc-Badge`. Отклонена — этого класса нет, внутри `dc-Label_color_black-negative` и `svg.dc-Icon_color_red`. Хеш в классе меняется от сборки к сборке, поэтому матчинг подстрокой, не равенством.
- **Тултип появляется только после настоящего hover.** До наведения строки «отклонен» на странице нет вообще; синтетические `mouseover`/`mouseenter` его не монтируют — только реальный hover. Поэтому детекция идёт по классам и не наводит мышь: именно это позволяет одной загрузке страницы ответить за всю кампанию (центральное требование #814) и оставляет команду строго read-only.
- **Ловушка ложных срабатываний.** `dc-Icon_color_red`/`dc-Label_color_black-negative` НЕ уникальны для модерации: те же классы рендерит `MediaControl` внутри превью видео. Page-wide скан отметил 5 кампаний из 38 как «отклонённые» чисто по видео-контролам (напр. 713234162 — 6 таких элементов и 0 отклонённых картинок). Поэтому проверка scoped внутрь кнопки статуса.

## Статус верификации — честно

**LIVE-VERIFIED (2026-08-08), картинки:**

| Кампания | Ожидалось по DOM | Вернула команда |
|---|---|---|
| 713234064 | картинка на позиции 2, `2513371652347967553` | ✅ то же |
| 713231614 | картинка на позиции 4, `2539115717674655622` | ✅ то же |
| 713234162 | нет отклонённых (6 видео-MediaControl) | ✅ `RejectedCount: 0` |

Оба отклонённых случая независимо подтверждены и по маркеру, и по тултипу (текст совпадает с #814 дословно).

**NOT LIVE-VERIFIED — видео / заголовки / тексты.** Просмотрены все 38 неархивных Мастеров кампаний аккаунта (~62 видео; заголовки и тексты есть у каждой): найдено 2 отклонённых картинки и НОЛЬ отклонённых видео/заголовков/текстов. Структурно affordance статуса в этих секциях тоже отсутствует — полный дамп `[data-testid]` показывает у видео только card/VideoThumb/CloseButton, у заголовков/текстов только `CampaignTitles<N>`/`CampaignTexts<N>`, без `*Status`/`*StateTooltip`.

Эти данные **не позволяют отличить** «Яндекс не рендерит такой маркер для этих типов» от «сейчас просто нет отклонённого элемента такого типа». Поэтому вопрос #814 про единообразие маркера между типами **остаётся открытым**, а типы отдаются в `UnsupportedTypes`, а не выдаются за проверенно-чистые. Если отклонённое видео/заголовок/текст когда-нибудь встретится живьём — обновлять надо фикстуру и таблицу типов в `MODERATION_SUPPORTED_TYPES`.

## Тесты

- 24 новых юнит-теста (fake Page/Locator), полный офлайн-прогон: **3511 passed, 23 skipped**.
- `black --check` чисто, `flake8` по затронутым файлам чисто.
- Оба guard'а детекции проверены мутационно: снятие проверки на `efficiency`-класс, снятие проверки на negative-child и подстановка чужого content ID при рассогласовании длин — каждая мутация роняет ровно свой тест. Первый прогон мутаций выявил дырку в покрытии (efficiency-кнопка с negative-child внутри — та самая форма ложного срабатывания), тест добавлен.

Closes #814

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7X2ut3CYWem4Yy6zPeHjE