### PR TITLE
fix(masters): isolate per-campaign failures in `masters get`

### DIFF
--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -573,6 +573,11 @@ def get(
     running on its remaining approved elements, so this does not show up in
     the campaign-level status). Only images carry such a marker today; see
     UnsupportedTypes in the output.
+
+    Every ID is attempted even if an earlier one fails, and each ID's
+    outcome (the row, or its error) is reported — see ``_run_per_id``
+    (issue #816: a failure reading one campaign used to discard every
+    already-read campaign in the same batch).
     """
     from ..browser.masters import fetch_master, fetch_master_moderation_statuses
 
@@ -596,12 +601,17 @@ def get(
             )
         return result
 
-    def _fetch_all(page):
-        return [_fetch_one(page, campaign_id) for campaign_id in ids]
-
-    results = _with_session(ctx, headful, profile_dir, chrome_profile, _fetch_all)
-
-    format_output(results if len(results) != 1 else results[0], output_format, output)
+    _run_per_id(
+        ctx,
+        ids,
+        _fetch_one,
+        headful=headful,
+        profile_dir=profile_dir,
+        chrome_profile=chrome_profile,
+        output_format=output_format,
+        output=output,
+        verb="read",
+    )
 
 
 @masters.command()

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -352,7 +352,7 @@ def _run_per_id(
     """
 
     def _all(page):
-        from ..browser.session import BrowserSessionError
+        from ..browser.session import BrowserAuthError, BrowserSessionError
         from ..browser.masters import PlaywrightError
 
         results = []
@@ -360,6 +360,13 @@ def _run_per_id(
         for campaign_id in ids:
             try:
                 results.append(action(page, campaign_id))
+            except BrowserAuthError:
+                # A stale saved session must keep propagating to
+                # _with_session's whole-operation retry (issue #816
+                # follow-up) -- BrowserAuthError is a BrowserSessionError
+                # subclass, so a bare `except BrowserSessionError` below
+                # would swallow it per-campaign and defeat the self-heal.
+                raise
             except (BrowserSessionError, PlaywrightError) as exc:
                 errors.append((campaign_id, exc))
                 results.append({"CampaignId": campaign_id, "Error": str(exc)})

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -19799,5 +19799,41 @@ class TestMastersGetModerationStatusesFlag(unittest.TestCase):
         self.assertTrue(all("RejectedCount" in row for row in payload))
 
 
+class TestMastersGetPerCampaignFailureIsolation(unittest.TestCase):
+    """Issue #816: one campaign's read failure must not discard the batch."""
+
+    def setUp(self):
+        self.runner = CliRunner()
+
+    def _invoke(self, args):
+        with patch(
+            "direct_cli.commands.masters._with_session",
+            side_effect=lambda ctx, headful, profile_dir, chrome_profile, fn: fn(
+                object()
+            ),
+        ):
+            return self.runner.invoke(cli, args)
+
+    def test_middle_campaign_failure_keeps_the_others_in_the_output(self):
+        from playwright.sync_api import Error as PlaywrightError
+
+        def _fetch(_page, cid):
+            if cid == 2:
+                raise PlaywrightError("overview timeout")
+            return {"CampaignId": cid}
+
+        with patch.object(browser_masters, "fetch_master", side_effect=_fetch):
+            result = self._invoke(["masters", "get", "1,2,3"])
+
+        self.assertNotEqual(result.exit_code, 0)
+        json_start = result.output.index("[\n")
+        json_end = result.output.rindex("]") + 1
+        payload = json.loads(result.output[json_start:json_end])
+        self.assertEqual([row["CampaignId"] for row in payload], [1, 2, 3])
+        self.assertNotIn("Error", payload[0])
+        self.assertIn("overview timeout", payload[1]["Error"])
+        self.assertNotIn("Error", payload[2])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -19832,6 +19832,48 @@ class TestMastersGetPerCampaignFailureIsolation(unittest.TestCase):
         self.assertIn("overview timeout", payload[1]["Error"])
         self.assertNotIn("Error", payload[2])
 
+    def test_mid_batch_auth_error_triggers_with_session_retry(self):
+        """Issue #816 follow-up (Codex, cycle-review PR #818): BrowserAuthError
+        must propagate to ``_with_session``'s stale-session self-heal retry,
+        not be swallowed as a per-campaign error -- ``BrowserAuthError`` is a
+        ``BrowserSessionError`` subclass, so a bare ``except
+        (BrowserSessionError, PlaywrightError)`` in ``_all`` catches it too
+        and defeats the retry ``_with_session`` is built around.
+        """
+        call_count = {"n": 0}
+        auth_error_raised = {"done": False}
+
+        def _fake_with_session(ctx, headful, profile_dir, chrome_profile, fn):
+            call_count["n"] += 1
+            try:
+                return fn(object())
+            except BrowserAuthError:
+                if call_count["n"] > 1:
+                    raise
+                return fn(object())
+
+        def _fetch(_page, cid):
+            if cid == 2 and not auth_error_raised["done"]:
+                auth_error_raised["done"] = True
+                raise BrowserAuthError("stale session")
+            return {"CampaignId": cid}
+
+        with (
+            patch(
+                "direct_cli.commands.masters._with_session",
+                side_effect=_fake_with_session,
+            ),
+            patch.object(browser_masters, "fetch_master", side_effect=_fetch),
+        ):
+            result = self.runner.invoke(cli, ["masters", "get", "1,2,3"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertTrue(auth_error_raised["done"])
+        payload = json.loads(result.output)
+        self.assertEqual([row["CampaignId"] for row in payload], [1, 2, 3])
+        for row in payload:
+            self.assertNotIn("Error", row)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -19815,11 +19815,9 @@ class TestMastersGetPerCampaignFailureIsolation(unittest.TestCase):
             return self.runner.invoke(cli, args)
 
     def test_middle_campaign_failure_keeps_the_others_in_the_output(self):
-        from playwright.sync_api import Error as PlaywrightError
-
         def _fetch(_page, cid):
             if cid == 2:
-                raise PlaywrightError("overview timeout")
+                raise browser_masters.PlaywrightError("overview timeout")
             return {"CampaignId": cid}
 
         with patch.object(browser_masters, "fetch_master", side_effect=_fetch):


### PR DESCRIPTION
## Summary
- `masters get` collected results via a bare list comprehension, so a failure reading campaign N discarded every already-read campaign 1..N-1 in the same batch.
- Routes `get` through the existing `_run_per_id` helper (already used by `suspend`/`resume`/`launch`/`archive`): every ID is attempted regardless of earlier failures, each ID's outcome (row or `Error` field) is reported, and the command exits non-zero if any ID failed.

Closes #816

## Test plan
- [x] Added `TestMastersGetPerCampaignFailureIsolation`: a batch of three IDs where the middle one raises a `playwright` error — asserts the first and third campaigns still appear in the output and the second carries an `Error` field, with a non-zero exit code.
- [x] `pytest tests/test_masters.py` (867 passed)
- [x] `pytest` full offline suite (3516 passed, 23 skipped)
- [x] `black --check` / `flake8` clean