### PR TITLE
fix(masters): resolve moderation ContentId structurally, not positionally

### DIFF
--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -1051,6 +1051,40 @@ _VIDEOS_EDITOR_TIMEOUT_MS = 60_000
 # answer for the whole campaign (issue #814's central requirement).
 _IMAGE_STATUS_TESTID = "ImageSuggestionsEditor.CampaignContents.ImageStatus"
 _IMAGE_STATUS_SELECTOR = f'[data-testid="{_IMAGE_STATUS_TESTID}"]'
+# Structural link between a status button and its image, resolved via a
+# shared ancestor rather than trusted from DOM order alone (issue #817
+# follow-up to #814/#815). CONFIRMED LIVE 2026-08-09 across 9 campaigns
+# (713277109, 713234204, 713234064, 713231614, 713234162, 713234179,
+# 713234142, 713234150, 75107869 — the 10th sweep target, 713234191, hit an
+# expired session and was skipped): walking up from each ``ImageStatus``
+# button, the nearest ancestor containing EXACTLY ONE
+# ``ContentImage.<contentId>`` descendant was found at the SAME depth (4) on
+# every button on every campaign, and its content ID matched
+# ``_read_image_content_ids``'s Nth entry on every single button checked —
+# no exceptions. That is evidence of a real shared-container relationship,
+# not merely equal list lengths: a reordered DOM would still resolve each
+# button to ITS OWN card's content ID here, because the walk is anchored at
+# the button and reads the ID from whatever card is actually its DOM
+# neighbor, never from a separately-fetched list indexed by position.
+_IMAGE_STATUS_CONTENT_ID_JS = """
+(button) => {
+    let node = button;
+    for (let depth = 0; depth < 12 && node && node !== document.body; depth++) {
+        const imgs = node.querySelectorAll(
+            '[data-testid^="ImageSuggestionsEditor.CampaignContents.ContentImage."]'
+        );
+        if (imgs.length === 1) {
+            const m = imgs[0].getAttribute('data-testid').match(/ContentImage\\.(.+)$/);
+            return m ? m[1] : null;
+        }
+        if (imgs.length > 1) {
+            return null;
+        }
+        node = node.parentElement;
+    }
+    return null;
+}
+"""
 # Present on a NON-rejected (efficiency-badge) status button only. CSS-module
 # class, so the real attribute value is ``ImageStatusIcon_efficiency__pCGiR``
 # with a build-time hash suffix — matched as a substring, never equality,
@@ -8483,64 +8517,45 @@ def _read_image_moderation_rejections(page: "Page") -> List[Dict[str, Any]]:
       rejection.
 
     The status button carries no content ID of its own (one shared testid for
-    every image), so a rejection is mapped back to its image POSITIONALLY:
-    the Nth ``ImageStatus`` belongs to the Nth ``ContentImage``. Confirmed
-    live 2026-08-08 both by bounding-box alignment and by the two lists
-    having equal length on all 38 swept campaigns.
+    every image) — but it IS structurally nested inside the same card as its
+    image. A rejection's ``ContentId`` is resolved via that shared ancestor
+    (``_IMAGE_STATUS_CONTENT_ID_JS``): walk up from the button until an
+    ancestor contains exactly one ``ContentImage.<contentId>`` descendant, and
+    read the ID from there. CONFIRMED LIVE 2026-08-09 across 9 campaigns (see
+    ``_IMAGE_STATUS_CONTENT_ID_JS``'s docstring) — every button's structural
+    resolution landed at the same DOM depth (4) and matched the Nth
+    ``ContentImage`` from ``_read_image_content_ids`` on every single button,
+    no exceptions. This is strictly stronger than the DOM-order correspondence
+    used before #817: it reads the ID from the button's OWN card, so even a
+    hypothetically reordered DOM still resolves each button correctly, and a
+    hydration gap that renders fewer buttons than images no longer shifts
+    later buttons onto the wrong image — each button independently finds its
+    own card, it does not fall back to a positional index into a separately
+    fetched list.
 
-    What the code checks is COUNT equality, which is weaker than the DOM-order
-    correspondence the mapping actually rests on: it catches a missing or
-    surplus status button, not a reordered one. Order itself has only live
-    evidence (bounding-box alignment on campaign 713234064) against markup
-    this module guarantees nothing about, so a count-equal-but-reordered DOM
-    would still map a rejection to the wrong image. No such reordering was
-    observed in the recon; treat ``Position``/``ContentId`` as order-derived
-    rather than structurally verified.
+    ``Position`` is still order-derived (the button's index among
+    ``_IMAGE_STATUS_SELECTOR`` matches), since Yandex's UI itself presents the
+    cards in that order — but ``ContentId``, the field a caller would act on,
+    is now sourced structurally rather than positionally.
 
-    If the two lists disagree in length — in EITHER direction —
-    the positional mapping is no longer trustworthy, so rejections are still
-    reported but with BOTH ``ContentId`` and ``Position`` set to ``None``.
-    "Something is rejected but this reader cannot say which image" is
-    strictly more useful than silently dropping it, and far better than
-    misattributing the rejection to an innocent image. Nulling only the
-    content ID would half-protect: a reader without one falls back to the
-    ordinal, and the ordinal is exactly what a mismatch shifts. The deficit
-    direction matters as much as the surplus one — ``_wait_for_images_editor``
-    settles on ``ContentImage``/``StubN`` presence and never waits for the
-    status buttons, so a hydration gap dropping one button shifts every later
-    button by one, making the button ordinal name the wrong image.
+    If the structural walk cannot resolve a button to exactly one image
+    (no ancestor found within the depth budget, or an ambiguous ancestor
+    containing more than one card), both ``ContentId`` and ``Position`` are
+    set to ``None`` for that rejection. "Something is rejected but this
+    reader cannot say which image" is strictly more useful than silently
+    dropping it, and far better than misattributing the rejection to an
+    innocent image.
 
     Never hovers: the explanatory tooltip is not in the DOM until a real
     mouse hover (confirmed live — synthetic events do not mount it), so its
     copy is attached from the confirmed constants instead. That keeps this a
     pure read over one already-loaded page.
     """
-    content_ids = _read_image_content_ids(page)
-
     try:
         buttons = page.locator(_IMAGE_STATUS_SELECTOR)
         count = buttons.count()
     except PlaywrightError:
         return []
-
-    # Count equality between the status buttons and the image cards. This is
-    # strictly WEAKER than the DOM-order correspondence the mapping actually
-    # relies on — it detects a missing/surplus button, not a reordered one —
-    # and is deliberately named for what it checks rather than for what it
-    # protects, so a future maintainer does not widen trust based on the name.
-    # Order itself is confirmed only live (bounding-box alignment on campaign
-    # 713234064) and rests on Yandex's markup, which this module disclaims any
-    # stability guarantee for; a count-equal-but-reordered DOM would defeat it.
-    #
-    # It is still worth checking, because the failure it DOES catch is the
-    # reachable one: ``_wait_for_images_editor`` settles on
-    # ``ContentImage``/``StubN`` presence and never waits for the status
-    # buttons themselves, so a hydration gap that renders fewer buttons than
-    # images shifts every later button by one — silently reporting image N's
-    # rejection against image N-1. On any count disagreement both identifying
-    # fields are dropped rather than emitting one that may name an innocent
-    # image; the rejection itself is still reported.
-    counts_match = count == len(content_ids)
 
     rejected: List[Dict[str, Any]] = []
     for index in range(count):
@@ -8557,11 +8572,16 @@ def _read_image_moderation_rejections(page: "Page") -> List[Dict[str, Any]]:
         if _IMAGE_STATUS_EFFICIENCY_CLASS in class_attr or not has_negative:
             continue
 
+        try:
+            content_id = button.evaluate(_IMAGE_STATUS_CONTENT_ID_JS)
+        except PlaywrightError:
+            content_id = None
+
         rejected.append(
             {
                 "Type": "image",
-                "Position": (index + 1) if counts_match else None,
-                "ContentId": (content_ids[index] if counts_match else None),
+                "Position": (index + 1) if content_id is not None else None,
+                "ContentId": content_id,
                 "Title": _MODERATION_REJECTED_TITLE,
                 "Hint": _MODERATION_REJECTED_HINT,
             }

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -8526,17 +8526,39 @@ def _read_image_moderation_rejections(page: "Page") -> List[Dict[str, Any]]:
     resolution landed at the same DOM depth (4) and matched the Nth
     ``ContentImage`` from ``_read_image_content_ids`` on every single button,
     no exceptions. This is strictly stronger than the DOM-order correspondence
-    used before #817: it reads the ID from the button's OWN card, so even a
-    hypothetically reordered DOM still resolves each button correctly, and a
-    hydration gap that renders fewer buttons than images no longer shifts
-    later buttons onto the wrong image — each button independently finds its
-    own card, it does not fall back to a positional index into a separately
-    fetched list.
+    used before #817 for the case the count guard below does not cover — a
+    reordered-but-count-equal DOM: it reads the ID from the button's OWN
+    card, so even a hypothetically reordered DOM still resolves each button
+    correctly, and a hydration gap that renders fewer buttons than images no
+    longer shifts later buttons onto the wrong image — each button
+    independently finds its own card, it does not fall back to a positional
+    index into a separately fetched list.
 
     ``Position`` is still order-derived (the button's index among
     ``_IMAGE_STATUS_SELECTOR`` matches), since Yandex's UI itself presents the
     cards in that order — but ``ContentId``, the field a caller would act on,
     is now sourced structurally rather than positionally.
+
+    The structural walk alone does NOT protect the SURPLUS case (more status
+    buttons than image cards): every real card is confirmed to contain
+    EXACTLY ONE ``ContentImage`` (see ``_read_image_content_ids``), so a
+    surplus button — one rendered without a card of its own, e.g. a
+    hydration duplicate — is necessarily nested inside some OTHER button's
+    real, single-image card. Its structural walk would then resolve to that
+    card's real (innocent) content ID rather than ``None``, misattributing a
+    rejection to an image that is not actually the surplus button's own. The
+    ``imgs.length > 1`` ambiguity check in the JS cannot catch this, because
+    the card it lands on legitimately holds exactly one image. So a global
+    count check is still required as a coarse safety net layered on top of
+    structural resolution: whenever the number of status buttons does not
+    equal ``_read_image_content_ids(page)``'s count, in EITHER direction,
+    every rejection's ``ContentId``/``Position`` is nulled instead of trusted
+    — mirroring the pre-#817 ``counts_match`` guard, which the structural
+    walk narrows but does not replace. (For the deficit direction alone, this
+    is more conservative than necessary — the structural walk resolves a
+    missing-middle-button gap correctly — but count mismatches are rare
+    enough live that trading that precision for surplus-case safety is the
+    right default.)
 
     If the structural walk cannot resolve a button to exactly one image
     (no ancestor found within the depth budget, or an ambiguous ancestor
@@ -8557,6 +8579,17 @@ def _read_image_moderation_rejections(page: "Page") -> List[Dict[str, Any]]:
     except PlaywrightError:
         return []
 
+    # Coarse safety net over the structural per-button resolution below: a
+    # surplus status button structurally resolves to whatever real card it
+    # happens to be nested in (every card holds exactly one image), so it
+    # cannot be told apart from that card's own button by the structural walk
+    # alone. Any count disagreement — deficit OR surplus — makes every
+    # ContentId/Position in this pass untrustworthy.
+    try:
+        counts_match = count == len(_read_image_content_ids(page))
+    except PlaywrightError:
+        counts_match = False
+
     rejected: List[Dict[str, Any]] = []
     for index in range(count):
         button = buttons.nth(index)
@@ -8572,10 +8605,12 @@ def _read_image_moderation_rejections(page: "Page") -> List[Dict[str, Any]]:
         if _IMAGE_STATUS_EFFICIENCY_CLASS in class_attr or not has_negative:
             continue
 
-        try:
-            content_id = button.evaluate(_IMAGE_STATUS_CONTENT_ID_JS)
-        except PlaywrightError:
-            content_id = None
+        content_id = None
+        if counts_match:
+            try:
+                content_id = button.evaluate(_IMAGE_STATUS_CONTENT_ID_JS)
+            except PlaywrightError:
+                content_id = None
 
         rejected.append(
             {

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -8534,10 +8534,16 @@ def _read_image_moderation_rejections(page: "Page") -> List[Dict[str, Any]]:
     independently finds its own card, it does not fall back to a positional
     index into a separately fetched list.
 
-    ``Position`` is still order-derived (the button's index among
-    ``_IMAGE_STATUS_SELECTOR`` matches), since Yandex's UI itself presents the
-    cards in that order — but ``ContentId``, the field a caller would act on,
-    is now sourced structurally rather than positionally.
+    ``Position`` is derived from the STRUCTURALLY resolved ``ContentId``'s
+    own index in ``_read_image_content_ids(page)`` — never from the button's
+    raw DOM ordinal. A reordered-but-count-equal DOM (button order != image
+    order) is exactly the case the structural walk exists to survive; sourcing
+    ``Position`` from the button's ordinal there would silently disagree with
+    the correctly-resolved ``ContentId`` right next to it, and a caller would
+    have no way to tell that apart from a genuinely unresolvable button.
+    Deriving both fields from the same resolved ID keeps them unable to
+    contradict each other — ``Position`` is ``None`` exactly when ``ContentId``
+    is.
 
     The structural walk alone does NOT protect the SURPLUS case (more status
     buttons than image cards): every real card is confirmed to contain
@@ -8586,8 +8592,10 @@ def _read_image_moderation_rejections(page: "Page") -> List[Dict[str, Any]]:
     # alone. Any count disagreement — deficit OR surplus — makes every
     # ContentId/Position in this pass untrustworthy.
     try:
-        counts_match = count == len(_read_image_content_ids(page))
+        image_ids = _read_image_content_ids(page)
+        counts_match = count == len(image_ids)
     except PlaywrightError:
+        image_ids = []
         counts_match = False
 
     rejected: List[Dict[str, Any]] = []
@@ -8612,10 +8620,26 @@ def _read_image_moderation_rejections(page: "Page") -> List[Dict[str, Any]]:
             except PlaywrightError:
                 content_id = None
 
+        # Position is derived from the STRUCTURALLY resolved ContentId's own
+        # index in the image list, never from the button's raw DOM ordinal
+        # (``index``): the two can legitimately diverge in a reordered-but-
+        # count-equal DOM (button order != image order, the exact case the
+        # structural walk exists to survive), and reporting the button's
+        # ordinal there would silently disagree with the ContentId right next
+        # to it — a caller has no way to tell the two apart from a genuinely
+        # unresolvable button. Sourcing both from the same resolved ID keeps
+        # them impossible to contradict each other.
+        position = None
+        if content_id is not None:
+            try:
+                position = image_ids.index(content_id) + 1
+            except ValueError:
+                position = None
+
         rejected.append(
             {
                 "Type": "image",
-                "Position": (index + 1) if content_id is not None else None,
+                "Position": position,
                 "ContentId": content_id,
                 "Title": _MODERATION_REJECTED_TITLE,
                 "Hint": _MODERATION_REJECTED_HINT,

--- a/tests/fixtures/masters_wizard_edit_moderation.html
+++ b/tests/fixtures/masters_wizard_edit_moderation.html
@@ -60,12 +60,27 @@ button, on every one of 9 freshly-swept campaigns (713277109, 713234204,
 a 10th target, 713234191, hit an expired session and was skipped), and the
 content ID found there matched the Nth entry from a separate
 _read_image_content_ids() read on EVERY button checked, no exceptions. This
-is what `_IMAGE_STATUS_CONTENT_ID_JS`/`_read_image_moderation_rejections`
-now uses to resolve `ContentId`, replacing the earlier count-equality-only
-guard: a status button's content ID is read from its OWN shared-ancestor
-card, so it no longer relies on the two lists being the same length, and a
-hypothetically reordered DOM would still resolve each button to the card it
-is actually nested inside.
+is what `_IMAGE_STATUS_CONTENT_ID_JS` uses to resolve `ContentId` for each
+button, reading the ID from the button's own shared-ancestor card instead of
+a positional index — so a hypothetically reordered DOM still resolves each
+button to the card it is actually nested inside.
+
+UPDATE 2026-08-09 (issue #817, round 2) — the structural walk above is
+deliberately NOT trusted on its own: every real card is confirmed (see KEY
+FINDING #1's count-alignment sweep) to hold EXACTLY ONE ContentImage, so a
+SURPLUS status button — one with no card of its own, e.g. a hydration
+duplicate — would be nested inside some OTHER button's real card and the
+structural walk would resolve it to that card's real, innocent content ID
+rather than failing safe. No such surplus button was ever observed live, but
+the code cannot tell a genuine surplus button apart from a real one sharing
+its card by structure alone. `_read_image_moderation_rejections` therefore
+keeps the earlier count-equality guard (`_IMAGE_STATUS_SELECTOR` count vs.
+`_read_image_content_ids()` count) as a global safety net layered ON TOP OF
+the structural walk: any mismatch, in either direction, nulls every
+rejection's `ContentId`/`Position` for that pass, exactly as it did before
+the structural walk was introduced. The structural walk only gets to run,
+and only replaces the old positional-index lookup, when the counts already
+agree.
 
 
 KEY FINDING #2 — rejected vs. not is a CSS-CLASS SHAPE, two variants

--- a/tests/fixtures/masters_wizard_edit_moderation.html
+++ b/tests/fixtures/masters_wizard_edit_moderation.html
@@ -82,6 +82,18 @@ the structural walk was introduced. The structural walk only gets to run,
 and only replaces the old positional-index lookup, when the counts already
 agree.
 
+UPDATE 2026-08-09 (issue #817, round 3) — `Position` is now derived from the
+STRUCTURALLY resolved `ContentId`'s own index in `_read_image_content_ids()`,
+never from the button's raw DOM ordinal. A reordered-but-count-equal DOM
+(button order != image order) is exactly the case the structural walk exists
+to survive: sourcing `Position` from the button's own ordinal there would
+silently disagree with the correctly-resolved `ContentId` right next to it —
+confidently wrong output, not a safe null. Deriving both fields from the same
+resolved ID keeps them unable to contradict each other: `Position` is `None`
+exactly when `ContentId` is. No reordered-but-count-equal DOM has been
+observed live (see UPDATE round-1's 9-campaign sweep), but the code no longer
+depends on that never being true.
+
 
 KEY FINDING #2 — rejected vs. not is a CSS-CLASS SHAPE, two variants
 ================================================================================

--- a/tests/fixtures/masters_wizard_edit_moderation.html
+++ b/tests/fixtures/masters_wizard_edit_moderation.html
@@ -51,6 +51,22 @@ ImageStatus buttons equals the number of ContentImage cards on every single
 one (0 images -> 0 buttons, 4 -> 4, 5 -> 5). No campaign was observed where
 the two lists could disagree.
 
+UPDATE 2026-08-09 (issue #817) — the DOM-order correspondence above is now
+ALSO confirmed STRUCTURALLY, not just by count/bounding-box: walking up from
+each ImageStatus button to the nearest ancestor containing exactly ONE
+ContentImage.<contentId> descendant lands at the SAME depth (4) for every
+button, on every one of 9 freshly-swept campaigns (713277109, 713234204,
+713234064, 713231614, 713234162, 713234179, 713234142, 713234150, 75107869 —
+a 10th target, 713234191, hit an expired session and was skipped), and the
+content ID found there matched the Nth entry from a separate
+_read_image_content_ids() read on EVERY button checked, no exceptions. This
+is what `_IMAGE_STATUS_CONTENT_ID_JS`/`_read_image_moderation_rejections`
+now uses to resolve `ContentId`, replacing the earlier count-equality-only
+guard: a status button's content ID is read from its OWN shared-ancestor
+card, so it no longer relies on the two lists being the same length, and a
+hypothetically reordered DOM would still resolve each button to the card it
+is actually nested inside.
+
 
 KEY FINDING #2 — rejected vs. not is a CSS-CLASS SHAPE, two variants
 ================================================================================

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -129,6 +129,7 @@ class _FakeLocatorHandle:
         on_upload=None,
         sub_locators=None,
         role_options=None,
+        evaluate_result=None,
     ):
         self._text = text
         self._attrs = attrs or {}
@@ -141,6 +142,12 @@ class _FakeLocatorHandle:
         self._get_value = get_value
         self._get_checked = get_checked
         self._on_upload = on_upload
+        # Result Locator.evaluate(js) should return for this handle — models
+        # the structural content-ID resolution
+        # ``_IMAGE_STATUS_CONTENT_ID_JS`` performs (issue #817): a fake status
+        # button carries the content ID its structural walk would find,
+        # rather than the reader trusting a positional index.
+        self._evaluate_result = evaluate_result
         # Every `timeout=` this handle's click() was called with, in order
         # (issue #779 review) — see click().
         self.click_timeouts = []
@@ -185,6 +192,11 @@ class _FakeLocatorHandle:
 
     def get_attribute(self, name):
         return self._attrs.get(name)
+
+    def evaluate(self, script, arg=None):
+        if self._raises:
+            raise PlaywrightError("element detached")
+        return self._evaluate_result
 
     def is_visible(self):
         if self._raises:
@@ -19428,14 +19440,44 @@ class _FakeModerationPage(_FakeImagesPage):
     ``extra_statuses`` appends status buttons with NO corresponding image,
     modeling the count-mismatch case ``_read_image_moderation_rejections``
     must survive without misattributing a content ID.
+
+    Each status button's structural content-ID resolution
+    (``_IMAGE_STATUS_CONTENT_ID_JS``, issue #817) is modeled as "the Nth
+    button structurally belongs to the Nth image" by default — i.e. the fake
+    still models the live-confirmed common case where DOM order and the
+    structural walk agree. A test wanting to model the walk failing to
+    resolve (no single-image ancestor found) passes that index in
+    ``unresolvable_structural_indices``; ``extra_statuses`` positions (beyond
+    ``len(ids)``) are unresolvable by construction, since no image exists for
+    them to resolve to — mirroring the real JS walk finding zero or more than
+    one ``ContentImage`` and returning ``null``.
     """
 
-    def __init__(self, ids, *, statuses=None, extra_statuses=(), **kwargs):
+    def __init__(
+        self,
+        ids,
+        *,
+        statuses=None,
+        extra_statuses=(),
+        unresolvable_structural_indices=(),
+        **kwargs,
+    ):
         super().__init__(ids, **kwargs)
         self.statuses = list(statuses if statuses is not None else ["ok"] * len(ids))
         self.statuses.extend(extra_statuses)
+        self._ids = list(ids)
+        self._unresolvable_structural_indices = set(unresolvable_structural_indices)
 
-    def _status_handle(self, status):
+    def _structural_content_id(self, index):
+        if index in self._unresolvable_structural_indices:
+            return None
+        if index < len(self._ids):
+            return self._ids[index]
+        # A status button beyond the image list (extra_statuses): the real
+        # walk finds no single-image ancestor for it either.
+        return None
+
+    def _status_handle(self, status, content_id):
         if status == "rejected":
             # No ImageStatusIcon_efficiency class; a negative-label child.
             return _FakeLocatorHandle(
@@ -19445,6 +19487,7 @@ class _FakeModerationPage(_FakeImagesPage):
                         _FakeLocatorHandle()
                     )
                 },
+                evaluate_result=content_id,
             )
         if status == "ok-with-negative-child":
             # The efficiency badge, but ALSO matching the negative selector.
@@ -19464,6 +19507,7 @@ class _FakeModerationPage(_FakeImagesPage):
                         _FakeLocatorHandle()
                     )
                 },
+                evaluate_result=content_id,
             )
         if status == "unknown":
             # Neither shape: no efficiency class AND no negative child — a
@@ -19479,13 +19523,17 @@ class _FakeModerationPage(_FakeImagesPage):
                     "dc-ClickableIcon ImageStatusIcon_button__sqJGQ "
                     "ImageStatusIcon_efficiency__pCGiR"
                 )
-            }
+            },
+            evaluate_result=content_id,
         )
 
     def locator(self, selector):
         if selector == browser_masters._IMAGE_STATUS_SELECTOR:
             return _FakeLocator(
-                [self._status_handle(status) for status in self.statuses]
+                [
+                    self._status_handle(status, self._structural_content_id(index))
+                    for index, status in enumerate(self.statuses)
+                ]
             )
         return super().locator(selector)
 
@@ -19584,7 +19632,10 @@ class TestReadModerationStatuses(unittest.TestCase):
     def test_extra_status_button_yields_null_content_id_not_a_wrong_one(self):
         """More status buttons than images: the surplus rejection is still
         reported, but must never borrow another image's identity — neither
-        its content ID nor its ordinal."""
+        its content ID nor its ordinal. The surplus button's structural walk
+        finds no image ancestor at all (there is no corresponding image),
+        which is exactly what ``_structural_content_id`` models by returning
+        ``None`` past ``len(ids)``."""
         page = _FakeModerationPage(["a"], statuses=["ok"], extra_statuses=["rejected"])
 
         result = browser_masters.read_moderation_statuses(page)
@@ -19593,17 +19644,20 @@ class TestReadModerationStatuses(unittest.TestCase):
         self.assertIsNone(result["RejectedElements"][0]["Position"])
         self.assertIsNone(result["RejectedElements"][0]["ContentId"])
 
-    def test_missing_status_button_yields_null_content_id_not_a_wrong_one(self):
-        """FEWER status buttons than images: the positional mapping is no
-        longer trustworthy, so no rejection may borrow an unrelated image's
-        content ID.
+    def test_missing_status_button_still_resolves_the_right_content_id(self):
+        """FEWER status buttons than images no longer misattributes a
+        rejection (issue #817): resolution is now STRUCTURAL — each button's
+        content ID comes from walking up to its OWN shared-ancestor image
+        (``_IMAGE_STATUS_CONTENT_ID_JS``, confirmed live on 9 campaigns), not
+        from a positional index into a separately-fetched content-ID list.
 
-        The surplus direction was already guarded; this is the deficit one.
-        ``_wait_for_images_editor`` settles on ``ContentImage``/``StubN``
-        presence and never waits for the status buttons themselves, so a
-        hydration gap that drops one button shifts every later button by one
-        — reporting image N's rejection against image N-1's content ID, i.e.
-        telling the user to replace an innocent element.
+        Before #817 this dropped a hydration gap's rejection to ``None``
+        because the two lists' lengths disagreed (3 buttons vs. 4 images).
+        The gap can still shift PAGE ORDER — the missing button is button #1,
+        so this rejected button is only the page's 3rd ``ImageStatus`` — but
+        each button still structurally belongs to its own card, and the fake
+        models that button as belonging to image "c" regardless of how many
+        buttons rendered before it, exactly like the live DOM would.
         """
         page = _FakeModerationPage(
             ["a", "b", "c", "d"], statuses=["ok", "ok", "rejected"]
@@ -19612,31 +19666,22 @@ class TestReadModerationStatuses(unittest.TestCase):
         result = browser_masters.read_moderation_statuses(page)
 
         self.assertEqual(result["RejectedCount"], 1)
-        self.assertIsNone(result["RejectedElements"][0]["ContentId"])
+        self.assertEqual(result["RejectedElements"][0]["ContentId"], "c")
+        self.assertEqual(result["RejectedElements"][0]["Position"], 3)
 
-    def test_missing_status_button_yields_null_position_too(self):
-        """``Position`` must be nulled alongside ``ContentId`` on a mismatch.
-
-        A reader with no content ID falls back to the ordinal, so leaving a
-        shifted ``Position`` behind only half-protects: with image #1's
-        status button missing, the button ordinal of the rejected 4th image
-        is 3 — pointing the user at the innocent image before it. Neither
-        field may survive a mismatch as something readable as "which image".
-        """
+    def test_unresolvable_structural_walk_yields_null_content_id_and_position(self):
+        """When the structural walk itself cannot resolve a button to exactly
+        one image (the real JS returns ``null`` — no single-image ancestor
+        found within the depth budget, or an ambiguous ancestor), both
+        ``ContentId`` and ``Position`` are dropped rather than guessed.
+        "Something is rejected but this reader cannot say which image" is
+        strictly more useful than silence, and far better than misattributing
+        the rejection to an innocent image."""
         page = _FakeModerationPage(
-            ["a", "b", "c", "d"], statuses=["ok", "ok", "rejected"]
+            ["a", "b"],
+            statuses=["rejected"],
+            unresolvable_structural_indices={0},
         )
-
-        result = browser_masters.read_moderation_statuses(page)
-
-        self.assertEqual(result["RejectedCount"], 1)
-        self.assertIsNone(result["RejectedElements"][0]["Position"])
-
-    def test_missing_status_button_still_reports_the_rejection(self):
-        """Dropping the content ID must not drop the rejection itself —
-        "something is rejected but this reader cannot say which image" is
-        strictly more useful than silence."""
-        page = _FakeModerationPage(["a", "b"], statuses=["rejected"])
 
         result = browser_masters.read_moderation_statuses(page)
 
@@ -19646,8 +19691,9 @@ class TestReadModerationStatuses(unittest.TestCase):
         self.assertIsNone(result["RejectedElements"][0]["ContentId"])
 
     def test_aligned_counts_still_resolve_the_content_id(self):
-        """The guard must only fire on a real mismatch — an aligned page
-        keeps reporting the content ID it always did."""
+        """The common case — button count matches image count and the
+        structural walk resolves cleanly — keeps reporting the content ID it
+        always did."""
         page = _FakeModerationPage(["a", "b", "c"], statuses=["ok", "rejected", "ok"])
 
         result = browser_masters.read_moderation_statuses(page)

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -19750,6 +19750,29 @@ class TestReadModerationStatuses(unittest.TestCase):
 
         self.assertEqual(result["RejectedElements"][0]["ContentId"], "b")
 
+    def test_reordered_but_count_equal_dom_keeps_position_and_content_id_consistent(
+        self,
+    ):
+        """A reordered-but-count-equal DOM (button order != image order) is
+        exactly the case the structural walk exists to survive (issue #817).
+        The 2nd button (DOM index 1) structurally belongs to image "c" (the
+        3rd image in ``_read_image_content_ids`` order), not to the 2nd
+        image "b" — modeled via ``button_content_ids``. ``Position`` must be
+        derived from where "c" actually sits in the image list (3), NEVER
+        from the button's own DOM ordinal (2), so it cannot contradict the
+        correctly-resolved ``ContentId``."""
+        page = _FakeModerationPage(
+            ["a", "b", "c"],
+            statuses=["ok", "rejected", "ok"],
+            button_content_ids=["a", "c", "b"],
+        )
+
+        result = browser_masters.read_moderation_statuses(page)
+
+        self.assertEqual(result["RejectedCount"], 1)
+        self.assertEqual(result["RejectedElements"][0]["ContentId"], "c")
+        self.assertEqual(result["RejectedElements"][0]["Position"], 3)
+
     def test_declares_which_element_types_were_actually_checked(self):
         """An empty result must not be readable as "no video/headline/text is
         rejected" — only images have a live-confirmed marker."""

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -19450,7 +19450,12 @@ class _FakeModerationPage(_FakeImagesPage):
     ``unresolvable_structural_indices``; ``extra_statuses`` positions (beyond
     ``len(ids)``) are unresolvable by construction, since no image exists for
     them to resolve to — mirroring the real JS walk finding zero or more than
-    one ``ContentImage`` and returning ``null``.
+    one ``ContentImage`` and returning ``null``. A test wanting to model a
+    genuine hydration gap — a button MISSING from the middle of the list, so
+    a later button's DOM-order index no longer equals its image's position —
+    passes the images each *rendered* button structurally belongs to via
+    ``button_content_ids`` (positionally aligned with ``statuses``, distinct
+    from ``ids``/``_ids`` which lists every image on the page).
     """
 
     def __init__(
@@ -19460,6 +19465,7 @@ class _FakeModerationPage(_FakeImagesPage):
         statuses=None,
         extra_statuses=(),
         unresolvable_structural_indices=(),
+        button_content_ids=None,
         **kwargs,
     ):
         super().__init__(ids, **kwargs)
@@ -19467,9 +19473,16 @@ class _FakeModerationPage(_FakeImagesPage):
         self.statuses.extend(extra_statuses)
         self._ids = list(ids)
         self._unresolvable_structural_indices = set(unresolvable_structural_indices)
+        self._button_content_ids = (
+            list(button_content_ids) if button_content_ids is not None else None
+        )
 
     def _structural_content_id(self, index):
         if index in self._unresolvable_structural_indices:
+            return None
+        if self._button_content_ids is not None:
+            if index < len(self._button_content_ids):
+                return self._button_content_ids[index]
             return None
         if index < len(self._ids):
             return self._ids[index]
@@ -19651,22 +19664,29 @@ class TestReadModerationStatuses(unittest.TestCase):
         (``_IMAGE_STATUS_CONTENT_ID_JS``, confirmed live on 9 campaigns), not
         from a positional index into a separately-fetched content-ID list.
 
-        Before #817 this dropped a hydration gap's rejection to ``None``
-        because the two lists' lengths disagreed (3 buttons vs. 4 images).
-        The gap can still shift PAGE ORDER — the missing button is button #1,
-        so this rejected button is only the page's 3rd ``ImageStatus`` — but
-        each button still structurally belongs to its own card, and the fake
-        models that button as belonging to image "c" regardless of how many
-        buttons rendered before it, exactly like the live DOM would.
+        Models a genuine hydration gap: image "b"'s status button never
+        rendered, so only 3 buttons exist on the page, structurally
+        belonging to "a", "c", "d" in that DOM order (``button_content_ids``)
+        — NOT the first 3 of the 4 images. Before #817 this dropped the
+        rejection to ``None`` because the two lists' lengths disagreed (3
+        buttons vs. 4 images). The gap also shifts PAGE ORDER: the rejected
+        button ("d"'s) is only the page's 3rd ``ImageStatus``, so
+        ``Position`` (the button's own ordinal) is 3 even though "d" is the
+        4th image — each button still structurally resolves to its own card
+        regardless of how many buttons rendered before it, exactly like the
+        live DOM would; ``Position`` and image ordinal are NOT the same
+        thing once a button is missing (see the module docstring).
         """
         page = _FakeModerationPage(
-            ["a", "b", "c", "d"], statuses=["ok", "ok", "rejected"]
+            ["a", "b", "c", "d"],
+            statuses=["ok", "ok", "rejected"],
+            button_content_ids=["a", "c", "d"],
         )
 
         result = browser_masters.read_moderation_statuses(page)
 
         self.assertEqual(result["RejectedCount"], 1)
-        self.assertEqual(result["RejectedElements"][0]["ContentId"], "c")
+        self.assertEqual(result["RejectedElements"][0]["ContentId"], "d")
         self.assertEqual(result["RejectedElements"][0]["Position"], 3)
 
     def test_unresolvable_structural_walk_yields_null_content_id_and_position(self):

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -19645,10 +19645,10 @@ class TestReadModerationStatuses(unittest.TestCase):
     def test_extra_status_button_yields_null_content_id_not_a_wrong_one(self):
         """More status buttons than images: the surplus rejection is still
         reported, but must never borrow another image's identity — neither
-        its content ID nor its ordinal. The surplus button's structural walk
-        finds no image ancestor at all (there is no corresponding image),
-        which is exactly what ``_structural_content_id`` models by returning
-        ``None`` past ``len(ids)``."""
+        its content ID nor its ordinal. Nulled by the GLOBAL count guard
+        (button count != image count), not by the per-button structural
+        walk — see ``test_surplus_status_button_is_nulled_not_misattributed``
+        for why the walk alone cannot be trusted for this case."""
         page = _FakeModerationPage(["a"], statuses=["ok"], extra_statuses=["rejected"])
 
         result = browser_masters.read_moderation_statuses(page)
@@ -19657,25 +19657,27 @@ class TestReadModerationStatuses(unittest.TestCase):
         self.assertIsNone(result["RejectedElements"][0]["Position"])
         self.assertIsNone(result["RejectedElements"][0]["ContentId"])
 
-    def test_missing_status_button_still_resolves_the_right_content_id(self):
-        """FEWER status buttons than images no longer misattributes a
-        rejection (issue #817): resolution is now STRUCTURAL — each button's
-        content ID comes from walking up to its OWN shared-ancestor image
-        (``_IMAGE_STATUS_CONTENT_ID_JS``, confirmed live on 9 campaigns), not
-        from a positional index into a separately-fetched content-ID list.
+    def test_missing_status_button_still_nulls_rather_than_trusts_the_structural_walk(
+        self,
+    ):
+        """FEWER status buttons than images (issue #817's original deficit
+        scenario) is now caught by the SAME global count guard that protects
+        the surplus case (issue #817 round-2 follow-up): the structural walk
+        alone cannot tell a surplus button apart from a real one sharing its
+        card (see ``test_surplus_status_button_is_nulled_not_misattributed``
+        below), so any count mismatch — deficit included — nulls every
+        rejection's ``ContentId``/``Position`` rather than trusting the
+        per-button walk. This is more conservative than the walk alone would
+        need to be for a pure deficit, but it is the only guard that also
+        covers surplus, so both directions share it.
 
         Models a genuine hydration gap: image "b"'s status button never
-        rendered, so only 3 buttons exist on the page, structurally
-        belonging to "a", "c", "d" in that DOM order (``button_content_ids``)
-        — NOT the first 3 of the 4 images. Before #817 this dropped the
-        rejection to ``None`` because the two lists' lengths disagreed (3
-        buttons vs. 4 images). The gap also shifts PAGE ORDER: the rejected
-        button ("d"'s) is only the page's 3rd ``ImageStatus``, so
-        ``Position`` (the button's own ordinal) is 3 even though "d" is the
-        4th image — each button still structurally resolves to its own card
-        regardless of how many buttons rendered before it, exactly like the
-        live DOM would; ``Position`` and image ordinal are NOT the same
-        thing once a button is missing (see the module docstring).
+        rendered, so only 3 buttons exist on the page (button count 3 !=
+        image count 4), structurally belonging to "a", "c", "d" in DOM order
+        (``button_content_ids``) — NOT the first 3 of the 4 images. Even
+        though the rejected button ("d"'s) would resolve correctly via the
+        structural walk alone, the count mismatch nulls it, matching
+        pre-#817 behavior for this direction too.
         """
         page = _FakeModerationPage(
             ["a", "b", "c", "d"],
@@ -19686,8 +19688,33 @@ class TestReadModerationStatuses(unittest.TestCase):
         result = browser_masters.read_moderation_statuses(page)
 
         self.assertEqual(result["RejectedCount"], 1)
-        self.assertEqual(result["RejectedElements"][0]["ContentId"], "d")
-        self.assertEqual(result["RejectedElements"][0]["Position"], 3)
+        self.assertIsNone(result["RejectedElements"][0]["ContentId"])
+        self.assertIsNone(result["RejectedElements"][0]["Position"])
+
+    def test_surplus_status_button_is_nulled_not_misattributed(self):
+        """MORE status buttons than images: a surplus button (e.g. a
+        hydration duplicate) is necessarily nested inside some OTHER
+        button's real, single-image card — every real card holds exactly
+        one image (see ``_read_image_content_ids``) — so the structural walk
+        alone would resolve it to that card's real, innocent content ID
+        rather than ``None``, misattributing the rejection (round-2 finding
+        on issue #817). ``button_content_ids`` models this realistically: the
+        surplus (3rd) button structurally resolves to "b", the SAME card as
+        the 2nd (real) button, rather than to nothing. The global count
+        guard (3 buttons vs 2 images) is what actually protects this case,
+        nulling every rejection in the pass — not the per-button walk, which
+        would have happily returned "b" twice."""
+        page = _FakeModerationPage(
+            ["a", "b"],
+            statuses=["ok", "ok", "rejected"],
+            button_content_ids=["a", "b", "b"],
+        )
+
+        result = browser_masters.read_moderation_statuses(page)
+
+        self.assertEqual(result["RejectedCount"], 1)
+        self.assertIsNone(result["RejectedElements"][0]["ContentId"])
+        self.assertIsNone(result["RejectedElements"][0]["Position"])
 
     def test_unresolvable_structural_walk_yields_null_content_id_and_position(self):
         """When the structural walk itself cannot resolve a button to exactly
@@ -19696,10 +19723,13 @@ class TestReadModerationStatuses(unittest.TestCase):
         ``ContentId`` and ``Position`` are dropped rather than guessed.
         "Something is rejected but this reader cannot say which image" is
         strictly more useful than silence, and far better than misattributing
-        the rejection to an innocent image."""
+        the rejection to an innocent image. Counts are kept ALIGNED (2
+        buttons, 2 images) so the global count guard passes and this
+        specifically exercises the per-button structural-walk fallback, not
+        the count guard from the surplus/deficit tests below."""
         page = _FakeModerationPage(
             ["a", "b"],
-            statuses=["rejected"],
+            statuses=["rejected", "ok"],
             unresolvable_structural_indices={0},
         )
 


### PR DESCRIPTION
## Summary

- `_read_image_moderation_rejections` used to map a rejected `ImageStatus` button to its image purely by DOM order (Nth button -> Nth `ContentImage`), guarded only by a count-equality check that is strictly weaker than the correspondence it relies on: it catches a missing/surplus button, not a reordered one.
- Live recon on 9 freshly-swept campaigns (713277109, 713234204, 713234064, 713231614, 713234162, 713234179, 713234142, 713234150, 75107869 — a 10th, 713234191, hit an expired session and was skipped) confirms a genuine structural link: walking up from each `ImageStatus` button, the nearest ancestor containing exactly one `ContentImage.<contentId>` lands at the same DOM depth (4) on every button, on every campaign, and its content ID always matches the button's DOM-order index — no exceptions.
- `ContentId` is now resolved via that shared-ancestor walk (`_IMAGE_STATUS_CONTENT_ID_JS`) instead of a positional index into a separately-fetched content-ID list. This is strictly stronger: each button now resolves to its own card directly, so a hydration gap rendering fewer buttons than images no longer shifts a rejection onto an innocent image, and a hypothetically reordered DOM would still resolve correctly.
- `tests/fixtures/masters_wizard_edit_moderation.html` updated with the new live evidence, per the issue's ask to record confirmed structural facts rather than leave them as an unverified assumption.

Closes #817

## Test plan
- [x] `pytest tests/test_masters.py -k Moderation -v` (26 passed)
- [x] `pytest tests/test_masters.py` (865 passed)
- [x] `pytest` full offline suite (3514 passed, 23 skipped)
- [x] `flake8 direct_cli/browser/masters.py tests/test_masters.py` (clean)
- [x] `black` (already formatted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYTSZBwtJTmKUenxPSS7CS