### PR TITLE
fix(masters): harden moderation ContentId resolution — issue #820

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -23,6 +23,15 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
+      - name: Install browser dependencies
+        # `playwright` lives under the separate `browser` extra (not `dev`).
+        # Without this, TestImageStatusContentIdJsAgainstRealDom (issue #820
+        # finding #4) silently skips via `_chromium_available()`, and the
+        # real-DOM coverage it exists to provide never actually executes.
+        run: |
+          pip install -e ".[browser]"
+          playwright install --with-deps chromium
+
       - name: Lint
         run: ruff check .
 

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -8612,21 +8612,47 @@ def _read_image_moderation_rejections(page: "Page") -> List[Dict[str, Any]]:
         image_ids = []
         counts_match = False
 
-    # Per-button structural resolution, done for EVERY button up front (not
-    # only the rejected ones) so the multiset cross-check below has the full
-    # picture. A balanced surplus+deficit (issue #820) keeps ``counts_match``
-    # true while a duplicate button's walk still lands on some other card's
-    # real content ID — the only way to catch that is to look at every
-    # resolved ID together, not one button at a time.
+    # Per-button structural resolution AND rejection-state read, done in ONE
+    # pass per button — not two separate passes over the same live ``Locator``
+    # indices. ``Locator.nth(index)`` re-resolves against the LIVE DOM on
+    # every access (it is not a snapshot/handle); reading a button's resolved
+    # content ID in one pass and its class/rejection state in a later, separate
+    # pass leaves a window where a hydration re-render can swap which button
+    # sits at that index between the two reads, silently pairing a stale
+    # content ID with a fresh rejection read (or vice versa) — issue #820
+    # finding #4 (Codex round-4 review of PR #821). Resolving both from the
+    # SAME ``buttons.nth(index)`` access closes that window: there is no
+    # second live re-query to race against.
+    #
+    # Every button is still resolved up front (not only the rejected ones)
+    # so the multiset cross-check below has the full picture. A balanced
+    # surplus+deficit (issue #820 finding #1) keeps ``counts_match`` true
+    # while a duplicate button's walk still lands on some other card's real
+    # content ID — the only way to catch that is to look at every resolved
+    # ID together, not one button at a time.
     resolved: List[Optional[str]] = [None] * count
-    if counts_match:
-        for index in range(count):
-            button = buttons.nth(index)
-            try:
-                content_id = button.evaluate(_IMAGE_STATUS_CONTENT_ID_JS)
-            except PlaywrightError:
-                content_id = None
-            resolved[index] = content_id
+    class_attrs: List[str] = [""] * count
+    has_negatives: List[bool] = [False] * count
+    readable: List[bool] = [False] * count
+    for index in range(count):
+        button = buttons.nth(index)
+        try:
+            class_attrs[index] = button.get_attribute("class") or ""
+            has_negatives[index] = (
+                button.locator(_IMAGE_STATUS_REJECTED_SELECTOR).count() > 0
+            )
+            readable[index] = True
+            # The structural walk is only worth running when the count
+            # guard already holds — a mismatch nulls every ContentId below
+            # regardless (``resolution_trusted``), so skip the extra
+            # ``evaluate()`` call in that case.
+            if counts_match:
+                resolved[index] = button.evaluate(_IMAGE_STATUS_CONTENT_ID_JS)
+        except PlaywrightError:
+            # A status button that cannot be read is not evidence of a
+            # rejection — skip it rather than guess (mirrors
+            # ``_read_testid_suffixes``'s tolerance of a locator failure).
+            continue
 
     seen_ids: Set[str] = set()
     duplicate_ids: Set[str] = set()
@@ -8647,15 +8673,11 @@ def _read_image_moderation_rejections(page: "Page") -> List[Dict[str, Any]]:
 
     rejected: List[Dict[str, Any]] = []
     for index in range(count):
-        button = buttons.nth(index)
-        try:
-            class_attr = button.get_attribute("class") or ""
-            has_negative = button.locator(_IMAGE_STATUS_REJECTED_SELECTOR).count() > 0
-        except PlaywrightError:
-            # A status button that cannot be read is not evidence of a
-            # rejection — skip it rather than guess (mirrors
-            # ``_read_testid_suffixes``'s tolerance of a locator failure).
+        if not readable[index]:
             continue
+
+        class_attr = class_attrs[index]
+        has_negative = has_negatives[index]
 
         if _IMAGE_STATUS_EFFICIENCY_CLASS in class_attr or not has_negative:
             continue

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -8566,6 +8566,20 @@ def _read_image_moderation_rejections(page: "Page") -> List[Dict[str, Any]]:
     enough live that trading that precision for surplus-case safety is the
     right default.)
 
+    The count guard alone is still not sufficient for a BALANCED
+    surplus+deficit — one image's button missing from the DOM while a
+    DIFFERENT image's button simultaneously duplicates (two independent
+    hydration glitches landing at once, issue #820). Totals stay equal, so
+    ``counts_match`` passes, yet the duplicate button's structural walk still
+    resolves to its host card's real content ID — the same failure mode as
+    the pure-surplus case above, just hidden behind an unchanged total. This
+    is caught by a MULTISET check layered on top of the count guard: every
+    button on the page (not only the rejected ones) is structurally resolved,
+    and if any two buttons resolve to the same non-``None`` content ID, the
+    whole pass is untrusted — a real DOM never nests two status buttons in
+    the same single-image card. Never observed live; requires two
+    simultaneous hydration pathologies to coincide numerically.
+
     If the structural walk cannot resolve a button to exactly one image
     (no ancestor found within the depth budget, or an ambiguous ancestor
     containing more than one card), both ``ContentId`` and ``Position`` are
@@ -8598,6 +8612,39 @@ def _read_image_moderation_rejections(page: "Page") -> List[Dict[str, Any]]:
         image_ids = []
         counts_match = False
 
+    # Per-button structural resolution, done for EVERY button up front (not
+    # only the rejected ones) so the multiset cross-check below has the full
+    # picture. A balanced surplus+deficit (issue #820) keeps ``counts_match``
+    # true while a duplicate button's walk still lands on some other card's
+    # real content ID — the only way to catch that is to look at every
+    # resolved ID together, not one button at a time.
+    resolved: List[Optional[str]] = [None] * count
+    if counts_match:
+        for index in range(count):
+            button = buttons.nth(index)
+            try:
+                content_id = button.evaluate(_IMAGE_STATUS_CONTENT_ID_JS)
+            except PlaywrightError:
+                content_id = None
+            resolved[index] = content_id
+
+    seen_ids: Set[str] = set()
+    duplicate_ids: Set[str] = set()
+    for content_id in resolved:
+        if content_id is None:
+            continue
+        if content_id in seen_ids:
+            duplicate_ids.add(content_id)
+        seen_ids.add(content_id)
+
+    # Any resolved ID repeating across buttons means at least two buttons
+    # structurally landed on the same single-image card — a real DOM never
+    # does that, so the whole pass (not just the duplicated entries) is
+    # untrustworthy. This is what catches the balanced surplus+deficit case
+    # ``counts_match`` alone cannot: the total stays equal, but the multiset
+    # of resolved IDs does not.
+    resolution_trusted = counts_match and not duplicate_ids
+
     rejected: List[Dict[str, Any]] = []
     for index in range(count):
         button = buttons.nth(index)
@@ -8613,12 +8660,7 @@ def _read_image_moderation_rejections(page: "Page") -> List[Dict[str, Any]]:
         if _IMAGE_STATUS_EFFICIENCY_CLASS in class_attr or not has_negative:
             continue
 
-        content_id = None
-        if counts_match:
-            try:
-                content_id = button.evaluate(_IMAGE_STATUS_CONTENT_ID_JS)
-            except PlaywrightError:
-                content_id = None
+        content_id = resolved[index] if resolution_trusted else None
 
         # Position is derived from the STRUCTURALLY resolved ContentId's own
         # index in the image list, never from the button's raw DOM ordinal

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -1066,23 +1066,43 @@ _IMAGE_STATUS_SELECTOR = f'[data-testid="{_IMAGE_STATUS_TESTID}"]'
 # button to ITS OWN card's content ID here, because the walk is anchored at
 # the button and reads the ID from whatever card is actually its DOM
 # neighbor, never from a separately-fetched list indexed by position.
-_IMAGE_STATUS_CONTENT_ID_JS = """
+#
+# The class attribute (efficiency-badge check) and the rejection-marker
+# match are read in the SAME script, alongside the ContentId, rather than as
+# separate ``get_attribute()``/scoped-``.locator().count()`` Playwright calls
+# (issue #820, Codex round-4 follow-up review of PR #821). Playwright
+# ``Locator``s are a lazy, re-evaluated query, not a handle to one fixed
+# element: even calling different methods on what looks like "the same
+# button object" in Python re-resolves that Locator's full selector chain
+# (including its ``.nth()`` positional filter) on EVERY individual call, so
+# a hydration reorder landing between any two SEPARATE calls could still
+# pair one button's rejection state with a different button's structural
+# ContentId. Reading all three off ONE already-resolved ``button`` argument
+# inside ONE script closes that window: there is exactly one live DOM access
+# per button.
+_IMAGE_STATUS_COMBINED_JS = """
 (button) => {
+    const classAttr = button.getAttribute('class') || '';
+    const isRejected = !!button.querySelector(
+        '.dc-Label_color_black-negative, svg.dc-Icon_color_red'
+    );
     let node = button;
+    let contentId = null;
     for (let depth = 0; depth < 12 && node && node !== document.body; depth++) {
         const imgs = node.querySelectorAll(
             '[data-testid^="ImageSuggestionsEditor.CampaignContents.ContentImage."]'
         );
         if (imgs.length === 1) {
             const m = imgs[0].getAttribute('data-testid').match(/ContentImage\\.(.+)$/);
-            return m ? m[1] : null;
+            contentId = m ? m[1] : null;
+            break;
         }
         if (imgs.length > 1) {
-            return null;
+            break;
         }
         node = node.parentElement;
     }
-    return null;
+    return {classAttr, isRejected, contentId};
 }
 """
 # Present on a NON-rejected (efficiency-badge) status button only. CSS-module
@@ -8510,19 +8530,20 @@ def _read_image_moderation_rejections(page: "Page") -> List[Dict[str, Any]]:
     * the negative-class check alone is not sufficient: the very same classes
       render inside a video thumbnail's ``MediaControl`` player chrome (see
       ``_IMAGE_STATUS_REJECTED_SELECTOR``'s comment), which is why the check
-      is scoped to a sub-locator off the status button rather than run
-      page-wide;
+      is scoped to a ``querySelector`` off the status button itself (inside
+      ``_IMAGE_STATUS_COMBINED_JS``) rather than run page-wide;
     * the missing-``efficiency`` check alone is not sufficient either — it
       would classify any future third button variant Yandex introduces as a
       rejection.
 
     The status button carries no content ID of its own (one shared testid for
     every image) — but it IS structurally nested inside the same card as its
-    image. A rejection's ``ContentId`` is resolved via that shared ancestor
-    (``_IMAGE_STATUS_CONTENT_ID_JS``): walk up from the button until an
-    ancestor contains exactly one ``ContentImage.<contentId>`` descendant, and
-    read the ID from there. CONFIRMED LIVE 2026-08-09 across 9 campaigns (see
-    ``_IMAGE_STATUS_CONTENT_ID_JS``'s docstring) — every button's structural
+    image. A rejection's ``ContentId``, its class attribute, and its
+    rejection-marker match are all resolved together via
+    ``_IMAGE_STATUS_COMBINED_JS``: walk up from the button until an ancestor
+    contains exactly one ``ContentImage.<contentId>`` descendant, and read
+    the ID from there. CONFIRMED LIVE 2026-08-09 across 9 campaigns (see
+    ``_IMAGE_STATUS_COMBINED_JS``'s comment) — every button's structural
     resolution landed at the same DOM depth (4) and matched the Nth
     ``ContentImage`` from ``_read_image_content_ids`` on every single button,
     no exceptions. This is strictly stronger than the DOM-order correspondence
@@ -8612,17 +8633,22 @@ def _read_image_moderation_rejections(page: "Page") -> List[Dict[str, Any]]:
         image_ids = []
         counts_match = False
 
-    # Per-button structural resolution AND rejection-state read, done in ONE
-    # pass per button — not two separate passes over the same live ``Locator``
-    # indices. ``Locator.nth(index)`` re-resolves against the LIVE DOM on
-    # every access (it is not a snapshot/handle); reading a button's resolved
-    # content ID in one pass and its class/rejection state in a later, separate
-    # pass leaves a window where a hydration re-render can swap which button
-    # sits at that index between the two reads, silently pairing a stale
-    # content ID with a fresh rejection read (or vice versa) — issue #820
-    # finding #4 (Codex round-4 review of PR #821). Resolving both from the
-    # SAME ``buttons.nth(index)`` access closes that window: there is no
-    # second live re-query to race against.
+    # Per-button structural resolution AND rejection-state read, done via a
+    # SINGLE ``evaluate()`` call per button (``_IMAGE_STATUS_COMBINED_JS``) —
+    # not as separate ``get_attribute``/``.locator().count()``/``evaluate()``
+    # calls on the same ``Locator``. Playwright ``Locator``s are a lazy,
+    # re-evaluated query: even calling three different methods on what looks
+    # like "the same button object" in Python re-resolves that Locator's full
+    # selector chain (including its ``.nth()`` positional filter) on EVERY
+    # individual call. A hydration reorder landing between any two of those
+    # calls could still pair one button's rejection state with a different
+    # button's structural ContentId (issue #820, Codex round-4 follow-up
+    # review of PR #821 — a narrower residual of the same finding #4 class
+    # already closed once for the two-full-loop case). Reading the class
+    # attribute, the rejection-marker match, and the structural ContentId
+    # all inside ONE script closes the remaining window: there is exactly one
+    # live DOM access per button, and everything is read from that single
+    # resolved element.
     #
     # Every button is still resolved up front (not only the rejected ones)
     # so the multiset cross-check below has the full picture. A balanced
@@ -8637,17 +8663,17 @@ def _read_image_moderation_rejections(page: "Page") -> List[Dict[str, Any]]:
     for index in range(count):
         button = buttons.nth(index)
         try:
-            class_attrs[index] = button.get_attribute("class") or ""
-            has_negatives[index] = (
-                button.locator(_IMAGE_STATUS_REJECTED_SELECTOR).count() > 0
-            )
+            combined = button.evaluate(_IMAGE_STATUS_COMBINED_JS)
+            class_attrs[index] = combined.get("classAttr") or ""
+            has_negatives[index] = bool(combined.get("isRejected"))
             readable[index] = True
-            # The structural walk is only worth running when the count
-            # guard already holds — a mismatch nulls every ContentId below
-            # regardless (``resolution_trusted``), so skip the extra
-            # ``evaluate()`` call in that case.
+            # The structural ContentId is only trustworthy when the count
+            # guard already holds — a mismatch nulls it below regardless
+            # (``resolution_trusted``) — but it was already resolved as part
+            # of the same combined call above, so there is no separate
+            # ``evaluate()`` to skip; only whether to KEEP the value matters.
             if counts_match:
-                resolved[index] = button.evaluate(_IMAGE_STATUS_CONTENT_ID_JS)
+                resolved[index] = combined.get("contentId")
         except PlaywrightError:
             # A status button that cannot be read is not evidence of a
             # rejection — skip it rather than guess (mirrors

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -1080,6 +1080,17 @@ _IMAGE_STATUS_SELECTOR = f'[data-testid="{_IMAGE_STATUS_TESTID}"]'
 # ContentId. Reading all three off ONE already-resolved ``button`` argument
 # inside ONE script closes that window: there is exactly one live DOM access
 # per button.
+#
+# The rejection-marker match (``.dc-Label_color_black-negative,
+# svg.dc-Icon_color_red``) MUST stay scoped to the button itself via
+# ``querySelector`` — these two classes are NOT unique to moderation.
+# Confirmed live 2026-08-08 that a video thumbnail's player chrome
+# (``MediaControl`` inside ``VideoSuggestionsEditor.CampaignContents.
+# VideoThumb.<url>.Content``) renders the very same pair: campaign 713234162
+# has SIX such elements and ZERO rejected images. A page-wide
+# ``.dc-Icon_color_red`` scan reported 5 of 38 swept campaigns as "rejected"
+# purely off video controls. Hence scoping the match to the button handle,
+# never a page-wide selector.
 _IMAGE_STATUS_COMBINED_JS = """
 (button) => {
     const classAttr = button.getAttribute('class') || '';
@@ -1110,19 +1121,6 @@ _IMAGE_STATUS_COMBINED_JS = """
 # with a build-time hash suffix — matched as a substring, never equality,
 # since that hash changes on every Yandex frontend build.
 _IMAGE_STATUS_EFFICIENCY_CLASS = "ImageStatusIcon_efficiency"
-# Present INSIDE a rejected status button. MUST stay scoped to an
-# ``ImageStatus`` button — these two classes are NOT unique to moderation.
-# Confirmed live 2026-08-08 that a video thumbnail's player chrome
-# (``MediaControl`` inside ``VideoSuggestionsEditor.CampaignContents.
-# VideoThumb.<url>.Content``) renders the very same
-# ``dc-Label_color_black-negative`` + ``svg.dc-Icon_color_red`` pair: campaign
-# 713234162 has SIX such elements and ZERO rejected images. A page-wide
-# ``.dc-Icon_color_red`` scan reported 5 of 38 swept campaigns as "rejected"
-# purely off video controls. Hence a sub-locator off the button handle, never
-# a ``page.locator`` of these classes.
-_IMAGE_STATUS_REJECTED_SELECTOR = (
-    ".dc-Label_color_black-negative, svg.dc-Icon_color_red"
-)
 # The rejection tooltip's own testid and copy. NOT used for detection (see
 # above) — kept because it is the marker a human re-verifying this live will
 # actually look for, and because it names the exact strings that were
@@ -8529,9 +8527,9 @@ def _read_image_moderation_rejections(page: "Page") -> List[Dict[str, Any]]:
 
     * the negative-class check alone is not sufficient: the very same classes
       render inside a video thumbnail's ``MediaControl`` player chrome (see
-      ``_IMAGE_STATUS_REJECTED_SELECTOR``'s comment), which is why the check
-      is scoped to a ``querySelector`` off the status button itself (inside
-      ``_IMAGE_STATUS_COMBINED_JS``) rather than run page-wide;
+      ``_IMAGE_STATUS_COMBINED_JS``'s comment), which is why the check is
+      scoped to a ``querySelector`` off the status button itself rather than
+      run page-wide;
     * the missing-``efficiency`` check alone is not sufficient either — it
       would classify any future third button variant Yandex introduces as a
       rejection.

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -19844,6 +19844,65 @@ class TestReadModerationStatuses(unittest.TestCase):
             with self.assertRaises(BrowserSessionError):
                 browser_masters.read_moderation_statuses(page)
 
+    def test_id_resolution_and_status_read_use_a_single_live_access_per_button(
+        self,
+    ):
+        """issue #820 finding #4 (Codex round-4 review of PR #821): real
+        Playwright ``Locator.nth(index)`` re-resolves against the LIVE DOM on
+        every access — it is not a snapshot/handle. If a reader calls
+        ``buttons.nth(index)`` TWICE for the same index (once to resolve the
+        structural content ID, once — in a separate later pass — to read
+        class/rejection state), a hydration re-render between those two
+        calls can swap which button physically sits at that index, silently
+        pairing a stale content ID with a fresh rejection read (or vice
+        versa) — a confident misattribution. The fix must call
+        ``buttons.nth(index)`` at most ONCE per index and read both the
+        content ID and the class/rejection state off that SAME access, so
+        there is no second live re-query for a reorder to race against.
+
+        Modeled by making the button-1 handle explode on a second
+        ``buttons.nth(1)`` call: the fake ``Locator.nth()`` returns a
+        *tracking* wrapper around the real handle that raises if the same
+        index is fetched more than once. A single-pass reader (one
+        ``nth(index)`` call, both operations off that result) never trips
+        this; any reader that re-fetches ``nth(1)`` in a second pass does.
+        """
+
+        class _SingleFetchLocator(_FakeLocator):
+            """Wraps a real ``_FakeLocator`` but raises if ``.nth()`` is
+            called more than once for the same index — the fake's stand-in
+            for "a second live re-query could return a different button".
+            """
+
+            def __init__(self, handles):
+                super().__init__(handles)
+                self._fetch_counts = [0] * len(handles)
+
+            def nth(self, i):
+                self._fetch_counts[i] += 1
+                if self._fetch_counts[i] > 1:
+                    raise browser_masters.PlaywrightError(
+                        f"button at index {i} re-fetched from the live DOM "
+                        "a second time — the DOM may have changed between "
+                        "the two accesses"
+                    )
+                return super().nth(i)
+
+        class _SingleFetchPage(_FakeModerationPage):
+            def locator(self, selector):
+                if selector == browser_masters._IMAGE_STATUS_SELECTOR:
+                    real = super().locator(selector)
+                    return _SingleFetchLocator(real._handles)
+                return super().locator(selector)
+
+        page = _SingleFetchPage(["a", "b", "c"], statuses=["ok", "rejected", "ok"])
+
+        result = browser_masters.read_moderation_statuses(page)
+
+        self.assertEqual(result["RejectedCount"], 1)
+        self.assertEqual(result["RejectedElements"][0]["ContentId"], "b")
+        self.assertEqual(result["RejectedElements"][0]["Position"], 2)
+
 
 class TestFetchMasterModerationStatuses(unittest.TestCase):
     """``fetch_master_moderation_statuses`` — the navigating wrapper."""

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -19491,6 +19491,13 @@ class _FakeModerationPage(_FakeImagesPage):
         return None
 
     def _status_handle(self, status, content_id):
+        # ``evaluate_result`` models ``_IMAGE_STATUS_COMBINED_JS``'s return
+        # shape (issue #820, Codex round-4 follow-up review of PR #821): the
+        # reader now reads ``classAttr``/``isRejected``/``contentId`` from a
+        # SINGLE ``evaluate()`` call, not from separate ``get_attribute()``/
+        # ``.locator().count()`` reads — ``attrs``/``sub_locators`` are kept
+        # here only as documentation of the modeled markup shape, they are no
+        # longer read by production code.
         if status == "rejected":
             # No ImageStatusIcon_efficiency class; a negative-label child.
             return _FakeLocatorHandle(
@@ -19500,7 +19507,11 @@ class _FakeModerationPage(_FakeImagesPage):
                         _FakeLocatorHandle()
                     )
                 },
-                evaluate_result=content_id,
+                evaluate_result={
+                    "classAttr": "dc-ClickableIcon dc-ClickableIcon_color_gray",
+                    "isRejected": True,
+                    "contentId": content_id,
+                },
             )
         if status == "ok-with-negative-child":
             # The efficiency badge, but ALSO matching the negative selector.
@@ -19508,36 +19519,48 @@ class _FakeModerationPage(_FakeImagesPage):
             # not unique to moderation (a video thumbnail's MediaControl
             # renders them too — campaign 713234162, 6 of them, 0 rejected
             # images), so the efficiency class must veto.
+            class_attr = (
+                "dc-ClickableIcon ImageStatusIcon_button__sqJGQ "
+                "ImageStatusIcon_efficiency__pCGiR"
+            )
             return _FakeLocatorHandle(
-                attrs={
-                    "class": (
-                        "dc-ClickableIcon ImageStatusIcon_button__sqJGQ "
-                        "ImageStatusIcon_efficiency__pCGiR"
-                    )
-                },
+                attrs={"class": class_attr},
                 sub_locators={
                     browser_masters._IMAGE_STATUS_REJECTED_SELECTOR: (
                         _FakeLocatorHandle()
                     )
                 },
-                evaluate_result=content_id,
+                evaluate_result={
+                    "classAttr": class_attr,
+                    "isRejected": True,
+                    "contentId": content_id,
+                },
             )
         if status == "unknown":
             # Neither shape: no efficiency class AND no negative child — a
             # hypothetical third variant, which must NOT count as rejected.
+            class_attr = "dc-ClickableIcon dc-ClickableIcon_color_gray"
             return _FakeLocatorHandle(
-                attrs={"class": "dc-ClickableIcon dc-ClickableIcon_color_gray"}
+                attrs={"class": class_attr},
+                evaluate_result={
+                    "classAttr": class_attr,
+                    "isRejected": False,
+                    "contentId": content_id,
+                },
             )
         # "ok": the efficiency badge. Note the real class carries a
         # build-time hash suffix, which the reader must match as a substring.
+        class_attr = (
+            "dc-ClickableIcon ImageStatusIcon_button__sqJGQ "
+            "ImageStatusIcon_efficiency__pCGiR"
+        )
         return _FakeLocatorHandle(
-            attrs={
-                "class": (
-                    "dc-ClickableIcon ImageStatusIcon_button__sqJGQ "
-                    "ImageStatusIcon_efficiency__pCGiR"
-                )
+            attrs={"class": class_attr},
+            evaluate_result={
+                "classAttr": class_attr,
+                "isRejected": False,
+                "contentId": content_id,
             },
-            evaluate_result=content_id,
         )
 
     def locator(self, selector):
@@ -19903,6 +19926,69 @@ class TestReadModerationStatuses(unittest.TestCase):
         self.assertEqual(result["RejectedElements"][0]["ContentId"], "b")
         self.assertEqual(result["RejectedElements"][0]["Position"], 2)
 
+    def test_content_id_and_rejection_state_read_from_one_evaluate_call(self):
+        """issue #820 finding #4, Codex round-4 follow-up review of PR #821:
+        a single ``buttons.nth(index)`` access is not enough on its own —
+        calling THREE separate Playwright methods on that one Locator
+        (``get_attribute``, a scoped ``.locator().count()``, and
+        ``evaluate()``) still re-resolves the Locator's full selector chain
+        on EACH call, since a Playwright ``Locator`` is a lazy, re-evaluated
+        query rather than a handle to one fixed element. A hydration reorder
+        landing between any two of those three calls could still pair one
+        button's rejection state with a different button's structural
+        ContentId. The fix reads the class attribute, the rejection marker,
+        and the structural ContentId all from ONE ``evaluate()`` call
+        (``_IMAGE_STATUS_COMBINED_JS``), so there is exactly one live access
+        per button — not three.
+
+        Modeled by a handle that raises if ``get_attribute`` or the scoped
+        rejection-selector ``.locator()`` is ever called at all: a reader
+        satisfying the invariant never touches either, since it gets
+        everything from the combined ``evaluate()`` result.
+        """
+
+        class _EvaluateOnlyHandle:
+            """Wraps a real handle; raises if anything OTHER than
+            ``evaluate()`` is called — the fake's stand-in for "a second (or
+            third) live re-query could return a different button"."""
+
+            def __init__(self, real_handle):
+                self._real = real_handle
+
+            def evaluate(self, script):
+                return self._real.evaluate(script)
+
+            def get_attribute(self, name):
+                raise browser_masters.PlaywrightError(
+                    "get_attribute() called separately from evaluate() — "
+                    "the DOM may have changed between the two live accesses"
+                )
+
+            def locator(self, selector):
+                raise browser_masters.PlaywrightError(
+                    "locator() called separately from evaluate() — the DOM "
+                    "may have changed between the two live accesses"
+                )
+
+        class _EvaluateOnlyLocator(_FakeLocator):
+            def nth(self, i):
+                return _EvaluateOnlyHandle(super().nth(i))
+
+        class _EvaluateOnlyPage(_FakeModerationPage):
+            def locator(self, selector):
+                if selector == browser_masters._IMAGE_STATUS_SELECTOR:
+                    real = super().locator(selector)
+                    return _EvaluateOnlyLocator(real._handles)
+                return super().locator(selector)
+
+        page = _EvaluateOnlyPage(["a", "b", "c"], statuses=["ok", "rejected", "ok"])
+
+        result = browser_masters.read_moderation_statuses(page)
+
+        self.assertEqual(result["RejectedCount"], 1)
+        self.assertEqual(result["RejectedElements"][0]["ContentId"], "b")
+        self.assertEqual(result["RejectedElements"][0]["Position"], 2)
+
 
 class TestFetchMasterModerationStatuses(unittest.TestCase):
     """``fetch_master_moderation_statuses`` — the navigating wrapper."""
@@ -19938,9 +20024,9 @@ def _chromium_available():
     "Playwright Chromium not downloaded (run: playwright install chromium)",
 )
 class TestImageStatusContentIdJsAgainstRealDom(unittest.TestCase):
-    """Executes the REAL ``_IMAGE_STATUS_CONTENT_ID_JS`` string against a
-    real, constructed nested DOM via a real Chromium page (issue #820
-    finding #4).
+    """Executes the REAL ``_IMAGE_STATUS_COMBINED_JS`` string's structural
+    ContentId walk against a real, constructed nested DOM via a real
+    Chromium page (issue #820 finding #4).
 
     Every other test in this module drives ``_read_image_moderation_rejections``
     through ``_FakeModerationPage``, whose ``evaluate()`` ignores the script
@@ -19951,10 +20037,16 @@ class TestImageStatusContentIdJsAgainstRealDom(unittest.TestCase):
     had no executed coverage: a future markup change breaking any of those
     would silently degrade every rejection's ``ContentId``/``Position`` to
     ``None`` with all tests green. This class closes that gap by loading a
-    real page and calling ``element_handle.evaluate(_IMAGE_STATUS_CONTENT_ID_JS)``
-    for real, exercising the exact production code path
+    real page and calling
+    ``element_handle.evaluate(_IMAGE_STATUS_COMBINED_JS)`` for real,
+    exercising the exact production code path
     (``_read_image_moderation_rejections`` calls
-    ``button.evaluate(_IMAGE_STATUS_CONTENT_ID_JS)`` the same way).
+    ``button.evaluate(_IMAGE_STATUS_COMBINED_JS)`` the same way), reading
+    just the returned ``contentId`` field — the class-attribute/rejection
+    halves of the combined script are exercised by the ordinary
+    ``_FakeModerationPage``-driven tests above via ``_status_handle``'s
+    modeled markup, so this class stays scoped to the ONE half those fakes
+    cannot exercise: the real structural walk.
 
     A single module-scoped browser/page is reused across test methods (each
     test sets fresh ``page.content()``) to keep this fast — a full Chromium
@@ -19982,7 +20074,8 @@ class TestImageStatusContentIdJsAgainstRealDom(unittest.TestCase):
     def _evaluate(self, html, button_selector="#status"):
         self._page.set_content(html)
         handle = self._page.query_selector(button_selector)
-        return handle.evaluate(browser_masters._IMAGE_STATUS_CONTENT_ID_JS)
+        result = handle.evaluate(browser_masters._IMAGE_STATUS_COMBINED_JS)
+        return result["contentId"]
 
     def test_common_aligned_case_resolves_the_sibling_content_image(self):
         """The button and the ``ContentImage`` sit inside the SAME immediate

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -19493,20 +19493,14 @@ class _FakeModerationPage(_FakeImagesPage):
     def _status_handle(self, status, content_id):
         # ``evaluate_result`` models ``_IMAGE_STATUS_COMBINED_JS``'s return
         # shape (issue #820, Codex round-4 follow-up review of PR #821): the
-        # reader now reads ``classAttr``/``isRejected``/``contentId`` from a
-        # SINGLE ``evaluate()`` call, not from separate ``get_attribute()``/
-        # ``.locator().count()`` reads — ``attrs``/``sub_locators`` are kept
-        # here only as documentation of the modeled markup shape, they are no
-        # longer read by production code.
+        # reader reads ``classAttr``/``isRejected``/``contentId`` from a
+        # SINGLE ``evaluate()`` call — ``attrs`` is kept only as
+        # documentation of the modeled markup's class attribute, it is not
+        # read by production code.
         if status == "rejected":
             # No ImageStatusIcon_efficiency class; a negative-label child.
             return _FakeLocatorHandle(
                 attrs={"class": "dc-ClickableIcon dc-ClickableIcon_color_gray"},
-                sub_locators={
-                    browser_masters._IMAGE_STATUS_REJECTED_SELECTOR: (
-                        _FakeLocatorHandle()
-                    )
-                },
                 evaluate_result={
                     "classAttr": "dc-ClickableIcon dc-ClickableIcon_color_gray",
                     "isRejected": True,
@@ -19525,11 +19519,6 @@ class _FakeModerationPage(_FakeImagesPage):
             )
             return _FakeLocatorHandle(
                 attrs={"class": class_attr},
-                sub_locators={
-                    browser_masters._IMAGE_STATUS_REJECTED_SELECTOR: (
-                        _FakeLocatorHandle()
-                    )
-                },
                 evaluate_result={
                     "classAttr": class_attr,
                     "isRejected": True,

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -19716,6 +19716,36 @@ class TestReadModerationStatuses(unittest.TestCase):
         self.assertIsNone(result["RejectedElements"][0]["ContentId"])
         self.assertIsNone(result["RejectedElements"][0]["Position"])
 
+    def test_balanced_surplus_and_deficit_is_nulled_not_misattributed(self):
+        """issue #820 finding #1: a BALANCED drift — one image's status
+        button missing while a DIFFERENT button duplicates — keeps the total
+        button count equal to the image count, so the global ``counts_match``
+        guard alone would pass. The duplicate ("b"'s second button)
+        structurally resolves to "b" — the same card as the first "b" button
+        — which is exactly what the multiset cross-check exists to catch:
+        two buttons resolving to the same content ID can never happen on a
+        real DOM (every card holds exactly one image), so the whole pass is
+        untrusted rather than reporting the duplicate's rejection against
+        "b" and silently dropping the real rejection on the missing button's
+        own image ("c", never rendered at all).
+
+        3 buttons (counts_match: True against 3 images), but the multiset of
+        resolved IDs is {"a", "b", "b"} — "b" appears twice, "c" never
+        appears — instead of {"a", "b", "c"}.
+        """
+        page = _FakeModerationPage(
+            ["a", "b", "c"],
+            statuses=["ok", "rejected", "rejected"],
+            button_content_ids=["a", "b", "b"],
+        )
+
+        result = browser_masters.read_moderation_statuses(page)
+
+        self.assertEqual(result["RejectedCount"], 2)
+        for element in result["RejectedElements"]:
+            self.assertIsNone(element["ContentId"])
+            self.assertIsNone(element["Position"])
+
     def test_unresolvable_structural_walk_yields_null_content_id_and_position(self):
         """When the structural walk itself cannot resolve a button to exactly
         one image (the real JS returns ``null`` — no single-image ancestor
@@ -19832,6 +19862,161 @@ class TestFetchMasterModerationStatuses(unittest.TestCase):
         browser_masters.fetch_master_moderation_statuses(page, 42)
 
         self.assertIn("/edit/", page.navigated_to[-1])
+
+
+def _chromium_available():
+    try:
+        from playwright.sync_api import sync_playwright
+
+        with sync_playwright() as p:
+            return Path(p.chromium.executable_path).exists()
+    except Exception:  # noqa: PIE786 - any import/launch failure means "unavailable"
+        return False
+
+
+@unittest.skipUnless(
+    _chromium_available(),
+    "Playwright Chromium not downloaded (run: playwright install chromium)",
+)
+class TestImageStatusContentIdJsAgainstRealDom(unittest.TestCase):
+    """Executes the REAL ``_IMAGE_STATUS_CONTENT_ID_JS`` string against a
+    real, constructed nested DOM via a real Chromium page (issue #820
+    finding #4).
+
+    Every other test in this module drives ``_read_image_moderation_rejections``
+    through ``_FakeModerationPage``, whose ``evaluate()`` ignores the script
+    argument entirely and returns a precomputed value
+    (``_structural_content_id``/``button_content_ids``) — so the JS string's
+    own logic (the depth-12 walk, the ``ContentImage.`` prefix selector, the
+    ``/ContentImage\\.(.+)$/`` regex, the ``imgs.length > 1`` ambiguity guard)
+    had no executed coverage: a future markup change breaking any of those
+    would silently degrade every rejection's ``ContentId``/``Position`` to
+    ``None`` with all tests green. This class closes that gap by loading a
+    real page and calling ``element_handle.evaluate(_IMAGE_STATUS_CONTENT_ID_JS)``
+    for real, exercising the exact production code path
+    (``_read_image_moderation_rejections`` calls
+    ``button.evaluate(_IMAGE_STATUS_CONTENT_ID_JS)`` the same way).
+
+    A single module-scoped browser/page is reused across test methods (each
+    test sets fresh ``page.content()``) to keep this fast — a full Chromium
+    launch per test would multiply the ~1s startup cost across every case.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        from playwright.sync_api import sync_playwright
+
+        cls._playwright_cm = sync_playwright()
+        cls._playwright = cls._playwright_cm.__enter__()
+        cls._browser = cls._playwright.chromium.launch()
+        cls._page = cls._browser.new_page()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._browser.close()
+        cls._playwright_cm.__exit__(None, None, None)
+
+    # Shorthand for the (long) real testid prefix, kept as one constant so
+    # the fixture HTML below stays under the repo's line-length limit.
+    _CI = "ImageSuggestionsEditor.CampaignContents.ContentImage"
+
+    def _evaluate(self, html, button_selector="#status"):
+        self._page.set_content(html)
+        handle = self._page.query_selector(button_selector)
+        return handle.evaluate(browser_masters._IMAGE_STATUS_CONTENT_ID_JS)
+
+    def test_common_aligned_case_resolves_the_sibling_content_image(self):
+        """The button and the ``ContentImage`` sit inside the SAME immediate
+        card — the live-confirmed depth-4 shape's simplest instance."""
+        html = f"""
+        <div id="card">
+          <div><div>
+            <div data-testid="{self._CI}.abc123"></div>
+            <button id="status"></button>
+          </div></div>
+        </div>
+        """
+        self.assertEqual(self._evaluate(html), "abc123")
+
+    def test_reordered_dom_still_resolves_to_the_buttons_own_card(self):
+        """A card whose ``ContentImage`` is declared AFTER a DIFFERENT
+        card's button in raw document order — the walk is anchored at the
+        button and reads whatever is nested under ITS OWN ancestor, so a
+        reordered DOM cannot make it drift onto the wrong image."""
+        html = f"""
+        <div>
+          <div id="card-x">
+            <div><div>
+              <button id="other-status"></button>
+              <div data-testid="{self._CI}.xxx"></div>
+            </div></div>
+          </div>
+          <div id="card-y">
+            <div><div>
+              <div data-testid="{self._CI}.yyy"></div>
+              <button id="status"></button>
+            </div></div>
+          </div>
+        </div>
+        """
+        self.assertEqual(self._evaluate(html), "yyy")
+
+    def test_card_nested_deeper_than_the_depth_budget_resolves_to_null(self):
+        """The walk checks the button itself (depth 0) plus 11 ancestor hops
+        (depth < 12), so the shared ancestor containing the ``ContentImage``
+        must be found within 12 nodes up from the button. Nesting the button
+        13 levels below that shared ancestor puts it just outside the
+        budget, so the walk must give up and resolve to ``None`` rather than
+        hang or walk past ``document.body``."""
+        wrappers_open = "<div>" * 13
+        wrappers_close = "</div>" * 13
+        html = f"""
+        <div>
+          <div data-testid="{self._CI}.deep"></div>
+          {wrappers_open}
+            <button id="status"></button>
+          {wrappers_close}
+        </div>
+        """
+        self.assertIsNone(self._evaluate(html))
+
+    def test_card_within_depth_budget_still_resolves(self):
+        """Sanity check paired with the depth-budget test above: a card at
+        exactly the live-confirmed depth (4) resolves normally, proving the
+        ``None`` result above is really the depth budget firing and not an
+        unrelated selector/regex break."""
+        html = f"""
+        <div><div><div><div>
+          <div data-testid="{self._CI}.near"></div>
+          <button id="status"></button>
+        </div></div></div></div>
+        """
+        self.assertEqual(self._evaluate(html), "near")
+
+    def test_sibling_element_sharing_the_contentimage_prefix_yields_null(self):
+        """Two elements sharing the ``ContentImage.`` testid PREFIX under the
+        same ancestor (e.g. a thumbnail AND a hidden duplicate/preview using
+        a related testid) must trip the ``imgs.length > 1`` ambiguity guard
+        and resolve to ``None`` rather than picking one arbitrarily."""
+        html = f"""
+        <div>
+          <div data-testid="{self._CI}.one"></div>
+          <div data-testid="{self._CI}.two"></div>
+          <button id="status"></button>
+        </div>
+        """
+        self.assertIsNone(self._evaluate(html))
+
+    def test_no_content_image_anywhere_up_to_body_resolves_to_null(self):
+        """A button with no ``ContentImage`` ancestor at all (e.g. a surplus
+        hydration-duplicate button rendered outside any real card) must
+        resolve to ``None``, not throw or return a stale value."""
+        html = """
+        <div><div>
+          <button id="status"></button>
+        </div></div>
+        """
+        self.assertIsNone(self._evaluate(html))
 
 
 class TestMastersGetModerationStatusesFlag(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Fixes finding #1 from #820 (round-3 Codex finding, confidence 0.5): the count-equality guard in `_read_image_moderation_rejections` only catches a pure surplus or deficit of image status buttons, not a *balanced* drift (one image's button missing while a different image's button duplicates). Added a multiset cross-check over every button's structurally resolved content ID — any repeated ID makes the whole pass untrusted, since a real DOM never nests two status buttons in the same single-image card.
- Fixes finding #4 from #820 (round-1 Codex finding, confidence 0.6): `_IMAGE_STATUS_CONTENT_ID_JS` had no executed test coverage — the fake page's `evaluate()` always returned a precomputed value. Added `TestImageStatusContentIdJsAgainstRealDom`, which loads real Chromium (skipped automatically if not downloaded) and drives the actual JS string against constructed nested DOM, covering: the common aligned case, a reordered DOM, the depth-12 budget boundary (both sides), and the ambiguous-sibling (`imgs.length > 1`) guard.
- Findings #2 and #3 in the issue were already fixed in #819 (historical record only, no action needed).

## Test plan
- [x] `pytest tests/test_masters.py -k Moderation` — 29 passed (incl. new balanced-drift test)
- [x] `pytest tests/test_masters.py -k ImageStatusContentIdJs` — 6 passed (real Chromium DOM execution)
- [x] `pytest tests/test_masters.py` — 876 passed
- [x] `pytest` (full offline suite) — 3525 passed, 23 skipped
- [x] `black --check` / `flake8` clean

Closes #820