### PR TITLE
fix(masters): return LandingUrl for DRAFT campaigns in `masters get`

### DIFF
--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -2355,12 +2355,20 @@ def _is_draft_overview_page(page: "Page") -> bool:
 
 
 def _fetch_draft_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
-    """Read name/status/weekly budget from a DRAFT campaign's overview page.
+    """Read name/status/weekly budget/landing URL from a DRAFT campaign's
+    overview page.
 
-    No stat tiles, no landing-URL link with the confirmed ``utm_source=``
-    marker the non-DRAFT extractor keys off (the form's landing-URL field is
-    a plain input, not a rendered link) — DRAFT results simply omit
-    ``LandingUrl``/``Stats`` rather than guessing at a different selector.
+    No stat tiles — nothing has run yet for a campaign that was never
+    launched. No landing-URL link with the confirmed ``utm_source=`` marker
+    the non-DRAFT extractor keys off either (the form's landing-URL field is
+    a plain contenteditable input, not a rendered link) — but per the live
+    recon in ``masters_wizard_draft_overview.html``, a DRAFT campaign's
+    overview page IS the same single-page wizard form ``update_master``'s
+    edit-page path reads/writes (issue #660), so the edit form's own
+    ``_read_landing_url`` (``CampaignLinkEditorLite.LinkInput.Textinput``)
+    works here unchanged (issue #822: ``masters get`` on a DRAFT campaign
+    used to omit ``LandingUrl`` entirely, with no way to verify
+    ``masters update --landing-url`` short of ``--headful``).
     """
     result: Dict[str, Any] = {"CampaignId": campaign_id, "Status": "DRAFT"}
 
@@ -2379,6 +2387,12 @@ def _fetch_draft_master(page: "Page", campaign_id: int) -> Dict[str, Any]:
         )
     except PlaywrightError:
         print_warning(f"Could not read weekly budget for {campaign_id}.")
+
+    landing_url = _read_landing_url(page)
+    if landing_url is not None:
+        result["LandingUrl"] = landing_url
+    else:
+        print_warning(f"Could not read landing URL for {campaign_id}.")
 
     return result
 

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -2832,21 +2832,27 @@ class TestFetchMasterDraft(unittest.TestCase):
     """
 
     def _draft_page(
-        self, title="Мастер ИЖ-1 Сосуды и вены (холодный)", budget="80 000"
+        self,
+        title="Мастер ИЖ-1 Сосуды и вены (холодный)",
+        budget="80 000",
+        landing_url="https://lp.ksamata.ru/",
     ):
-        return FakePage(
-            locators={
-                browser_masters._CAMPAIGN_HEADER_STATUS_SELECTOR: _FakeLocator(
-                    [_FakeLocatorHandle(text=browser_masters._DRAFT_STATUS_TEXT)]
-                ),
-                browser_masters._CAMPAIGN_HEADER_TITLE_NAME_SELECTOR: _FakeLocator(
-                    [_FakeLocatorHandle(text=title)]
-                ),
-                browser_masters._BUDGET_INPUT_SELECTOR: _FakeLocator(
-                    [_FakeLocatorHandle(text=budget)]
-                ),
-            },
-        )
+        locators = {
+            browser_masters._CAMPAIGN_HEADER_STATUS_SELECTOR: _FakeLocator(
+                [_FakeLocatorHandle(text=browser_masters._DRAFT_STATUS_TEXT)]
+            ),
+            browser_masters._CAMPAIGN_HEADER_TITLE_NAME_SELECTOR: _FakeLocator(
+                [_FakeLocatorHandle(text=title)]
+            ),
+            browser_masters._BUDGET_INPUT_SELECTOR: _FakeLocator(
+                [_FakeLocatorHandle(text=budget)]
+            ),
+        }
+        if landing_url is not None:
+            locators[browser_masters._EDIT_URL_INPUT_TESTID] = _FakeLocator(
+                [_FakeLocatorHandle(text=landing_url)]
+            )
+        return FakePage(locators=locators)
 
     def test_parses_draft_overview(self):
         page = self._draft_page()
@@ -2860,14 +2866,24 @@ class TestFetchMasterDraft(unittest.TestCase):
                 "Status": "DRAFT",
                 "Name": "Мастер ИЖ-1 Сосуды и вены (холодный)",
                 "WeeklyBudget": "80 000",
+                "LandingUrl": "https://lp.ksamata.ru/",
             },
         )
 
-    def test_draft_result_has_no_landing_url_or_stats(self):
+    def test_draft_result_has_no_stats(self):
         result = browser_masters.fetch_master(self._draft_page(), 1)
 
-        self.assertNotIn("LandingUrl", result)
         self.assertNotIn("Stats", result)
+
+    def test_draft_result_omits_landing_url_when_field_unreadable(self):
+        # issue #822: the field genuinely missing/unreadable is reported via
+        # print_warning and simply omitted, same convention as name/budget —
+        # not a hard failure of the whole `masters get` call.
+        with patch("direct_cli.browser.masters.print_warning") as warn:
+            result = browser_masters.fetch_master(self._draft_page(landing_url=None), 1)
+
+        self.assertNotIn("LandingUrl", result)
+        warn.assert_any_call("Could not read landing URL for 1.")
 
     def test_draft_partial_result_on_missing_name_and_budget(self):
         page = FakePage(
@@ -2882,7 +2898,7 @@ class TestFetchMasterDraft(unittest.TestCase):
             result = browser_masters.fetch_master(page, 1)
 
         self.assertEqual(result, {"CampaignId": 1, "Status": "DRAFT"})
-        self.assertEqual(warn.call_count, 2)  # name, budget
+        self.assertEqual(warn.call_count, 3)  # name, budget, landing URL
 
     def test_non_draft_page_unaffected(self):
         # A page whose CampaignHeader.Status reads something other than


### PR DESCRIPTION
## Проблема

`direct masters get <CAMPAIGN_ID>` не включал `LandingUrl` в вывод для кампаний в статусе DRAFT, хотя это поле управляется `masters update --landing-url`. Не было способа сверить актуальный `LandingUrl` черновика без `--headful`.

## Причина

`fetch_master`'s DRAFT-ветка (`_fetch_draft_master`) была реализована так, что читает только `Name`/`WeeklyBudget` и **намеренно** пропускает `LandingUrl` — по докстрингу, предполагалось, что оверлей-страница черновика не содержит подходящего селектора (только ссылка `a[href*=utm_source=]`, которой у DRAFT нет — там простое поле ввода).

Но живой recon (`tests/fixtures/masters_wizard_draft_overview.html`) подтверждает: страница обзора DRAFT-кампании — это **та же самая** форма мастера, что и `/edit/`-страница (`_is_draft_edit_page`/`update_master`'s verify step уже используют её для чтения `LandingUrl` через `_read_landing_url`/`_EDIT_URL_INPUT_TESTID`). Этот же селектор работает и на странице обзора DRAFT-кампании.

## Исправление

`_fetch_draft_master` теперь дополнительно вызывает `_read_landing_url(page)` — тот же геттер, что уже используется `update_master`'s верификацией после сохранения. Если поле нечитаемо (селектор отсутствует), поведение остаётся best-effort — `print_warning` + поле опускается, как и для `Name`/`WeeklyBudget`.

## Тесты

- `TestFetchMasterDraft::test_parses_draft_overview` — теперь ожидает `LandingUrl` в полном результате.
- `TestFetchMasterDraft::test_draft_result_has_no_stats` (переименован из `test_draft_result_has_no_landing_url_or_stats`) — Stats по-прежнему отсутствует.
- Новый `TestFetchMasterDraft::test_draft_result_omits_landing_url_when_field_unreadable` — best-effort пропуск при нечитаемом поле.
- `test_draft_partial_result_on_missing_name_and_budget` — обновлён счётчик предупреждений (2 → 3).

`pytest` (полный офлайн-сьют): 3528 passed, 23 skipped.

Closes #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)