### PR TITLE
fix(masters): diagnose empty target-actions table on launch redirect timeout (#823)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,8 +109,29 @@ confirmed unchanged before and after.
 
 ### Fixed
 
-**`masters` — `_metrika_counter_identity` now normalizes surrounding
-whitespace around a non-empty counter id (#809).**
+**`masters launch`/`masters update --launch` — diagnose an empty "Целевые
+действия" table instead of a generic redirect timeout (#823).**
+
+Yandex silently refuses to save/launch a DRAFT campaign with no Яндекс
+Метрика conversion goal ("Добавьте хотя бы одну цель для сайта, чтобы
+создать и запустить кампанию") — same failure mode `create_master` already
+diagnoses (#777), but the edit page's launch/save-as-draft click
+(`_click_draft_terminal_button`, shared by `launch_master` and
+`update_master --launch`) previously only reported the generic "Yandex did
+not redirect away from the edit page" message on timeout, with no clue as
+to why. Neither terminal button ever gains a disabled/`aria-disabled`
+marker in this state, so a caller had to rediscover the root cause by hand
+each time (live-reported in #823: a cloned Мастер кампаний whose landing
+URL was then changed via `masters update --landing-url` lost its inherited
+goals, and `masters launch` failed identically on three consecutive
+attempts, including `--headful`).
+
+On timeout, `_click_draft_terminal_button` now re-reads the "Целевые
+действия" table (reusing `_wait_for_target_actions_settled`/
+`_read_target_actions_or_none`, the same reader `create_master`'s pre-click
+gate uses — confirmed to be the identical widget on both pages) and raises
+a specific error naming the empty goals table when that's the cause,
+falling back to the original generic message otherwise.
 
 The suggestion-text format (`"{label} • {domain/path} • {numeric counter
 id}"`) and the read-back tag-display format (`"{domain} • {numeric

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,7 +131,13 @@ On timeout, `_click_draft_terminal_button` now re-reads the "Целевые
 `_read_target_actions_or_none`, the same reader `create_master`'s pre-click
 gate uses — confirmed to be the identical widget on both pages) and raises
 a specific error naming the empty goals table when that's the cause,
-falling back to the original generic message otherwise.
+falling back to the original generic message otherwise. This diagnosis
+itself polls for up to another ~25s after the original redirect deadline
+already elapsed, so a merely-slow (not stuck) Yandex redirect can land
+*during* the diagnosis; `page.url` is re-checked immediately before each
+`raise` so a redirect landing mid-diagnosis is treated as success rather
+than reported as a false failure on an already-successful, no-rollback
+launch/save (cycle-review PR #826, Codex).
 
 The suggestion-text format (`"{label} • {domain/path} • {numeric counter
 id}"`) and the read-back tag-display format (`"{domain} • {numeric

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -6293,6 +6293,37 @@ def _click_draft_terminal_button(
             return
         page.wait_for_timeout(250)
 
+    # Issue #823: a missing "Целевые действия" (Metrika conversion) goal is a
+    # KNOWN cause of exactly this silent no-op — confirmed live on the create
+    # page (issue #777/#744, module docstring's "A required-field marker is
+    # not the list of required fields") and reused verbatim here because the
+    # edit page renders the very same TargetActionsSection widget (module
+    # docstring, "The widget itself is the same one the edit page uses").
+    # Yandex refuses the click with "Добавьте хотя бы одну цель для сайта,
+    # чтобы создать и запустить кампанию" but neither terminal button ever
+    # gains a disabled/aria-disabled marker, so the ONLY way to tell "goal
+    # missing" apart from "still hydrating"/"a different rejection reason" is
+    # to read the table's own row count after the redirect has already timed
+    # out. A landing-url change (this issue's repro) can invalidate goals
+    # inherited from a cloned campaign's original site, silently emptying
+    # this exact table. Reported as a distinct, actionable error rather than
+    # folded into the generic message so a caller doesn't have to rediscover
+    # this root cause by hand every time.
+    if _wait_for_target_actions_settled(page):
+        rows = _read_target_actions_or_none(page)
+        if rows is not None and len(rows) == 0:
+            raise BrowserSessionError(
+                f"Clicked {button_label!r} for DRAFT campaign {campaign_id}, "
+                "but Yandex did not redirect away from the edit page within "
+                f"{_DRAFT_SAVE_REDIRECT_TIMEOUT_MS / 1000:.0f}s — the "
+                "'Целевые действия' (Яндекс.Метрика conversion goals) table "
+                "is empty. Yandex silently refuses to save/launch a campaign "
+                'with no conversion goal ("Добавьте хотя бы одну цель для '
+                'сайта, чтобы создать и запустить кампанию") without ever '
+                "disabling the button — add at least one goal (e.g. via "
+                "'masters update --add-target-action') and retry."
+            )
+
     raise BrowserSessionError(
         f"Clicked {button_label!r} for DRAFT campaign {campaign_id}, but "
         "Yandex did not redirect away from the edit page within "

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -6312,6 +6312,16 @@ def _click_draft_terminal_button(
     if _wait_for_target_actions_settled(page):
         rows = _read_target_actions_or_none(page)
         if rows is not None and len(rows) == 0:
+            # Cycle-review PR #826 (Codex): this diagnosis itself waits up to
+            # _TARGET_ACTION_SETTLE_TIMEOUT_MS (20s) + _TARGET_ACTION_WAIT_
+            # TIMEOUT_MS (5s) AFTER the original redirect deadline already
+            # elapsed — plenty of time for a merely-slow (not stuck) redirect
+            # to complete during the diagnosis itself. Raising unconditionally
+            # here would report failure on an actually-successful, no-
+            # rollback launch/save. Re-check page.url one last time before
+            # concluding the goal really is the cause.
+            if "/edit/" not in page.url:
+                return
             raise BrowserSessionError(
                 f"Clicked {button_label!r} for DRAFT campaign {campaign_id}, "
                 "but Yandex did not redirect away from the edit page within "
@@ -6323,6 +6333,12 @@ def _click_draft_terminal_button(
                 "disabling the button — add at least one goal (e.g. via "
                 "'masters update --add-target-action') and retry."
             )
+
+    # Same late-redirect race as above: the target-actions diagnosis itself
+    # (settle wait + section-visibility wait) can run long enough for an
+    # in-flight (not stuck) redirect to land during it.
+    if "/edit/" not in page.url:
+        return
 
     raise BrowserSessionError(
         f"Clicked {button_label!r} for DRAFT campaign {campaign_id}, but "

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -5222,6 +5222,67 @@ class TestClickDraftTerminalButton(unittest.TestCase):
         self.assertEqual(click_count["n"], 1)
         self.assertIn("did not redirect", str(ctx.exception))
 
+    def test_raises_specific_goal_error_when_target_actions_table_is_empty(self):
+        # Issue #823: an empty "Целевые действия" table is a KNOWN, silent
+        # cause of the click never redirecting (same widget/failure mode as
+        # create_master's #777 finding) — the timeout must surface that
+        # specific diagnosis, not the generic "may not have saved" message.
+        page = _FakeTargetActionsPage(
+            {},
+            locators={
+                browser_masters._DRAFT_LAUNCH_BUTTON_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                )
+            },
+        )
+        page.url = browser_masters.WIZARD_EDIT_URL.format(campaign_id=713469085)
+
+        clock = {"now": 0.0}
+
+        def _wait_for_timeout(timeout):
+            clock["now"] += timeout / 1000
+
+        page.wait_for_timeout = _wait_for_timeout
+
+        with patch.object(_clock, "_clock", lambda: clock["now"]):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters._click_draft_terminal_button(
+                    page, 713469085, launch=True
+                )
+
+        self.assertIn("Целевые действия", str(ctx.exception))
+        self.assertIn("conversion goal", str(ctx.exception))
+
+    def test_generic_error_when_target_actions_table_has_rows(self):
+        # A stuck redirect with goals PRESENT must keep the generic message
+        # — the specific goal diagnosis only fires when the table is
+        # genuinely empty, not for every timeout.
+        page = _FakeTargetActionsPage(
+            {159614149: {"name": "Регистрация", "price": "150"}},
+            locators={
+                browser_masters._DRAFT_LAUNCH_BUTTON_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                )
+            },
+        )
+        page.url = browser_masters.WIZARD_EDIT_URL.format(campaign_id=713469085)
+
+        clock = {"now": 0.0}
+
+        def _wait_for_timeout(timeout):
+            clock["now"] += timeout / 1000
+
+        page.wait_for_timeout = _wait_for_timeout
+
+        with patch.object(_clock, "_clock", lambda: clock["now"]):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                browser_masters._click_draft_terminal_button(
+                    page, 713469085, launch=True
+                )
+
+        self.assertIn("did not redirect", str(ctx.exception))
+        self.assertNotIn("Целевые действия", str(ctx.exception))
+
 
 class TestLaunchMaster(unittest.TestCase):
     """``launch_master`` (issue #704): publish a DRAFT via the edit page's

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -5283,6 +5283,75 @@ class TestClickDraftTerminalButton(unittest.TestCase):
         self.assertIn("did not redirect", str(ctx.exception))
         self.assertNotIn("Целевые действия", str(ctx.exception))
 
+    def test_returns_normally_when_redirect_lands_during_empty_table_diagnosis(self):
+        # Cycle-review PR #826 (Codex, HIGH): the empty-table diagnosis itself
+        # polls for up to _TARGET_ACTION_SETTLE_TIMEOUT_MS after the original
+        # redirect deadline already elapsed — plenty of time for a merely-
+        # slow (not stuck) redirect to land DURING the diagnosis. Raising the
+        # goal-specific error in that case would report failure on an
+        # actually-successful, no-rollback launch/save. The table reads
+        # empty (the settle-poll's row count never moves off 0), but once
+        # the redirect is observed the function must return normally instead
+        # of raising.
+        page = _FakeTargetActionsPage(
+            {},
+            locators={
+                browser_masters._DRAFT_LAUNCH_BUTTON_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                )
+            },
+        )
+        page.url = browser_masters.WIZARD_EDIT_URL.format(campaign_id=713469085)
+
+        clock = {"now": 0.0}
+        ticks = {"n": 0}
+
+        def _wait_for_timeout(timeout):
+            clock["now"] += timeout / 1000
+            ticks["n"] += 1
+            # Let the redirect-deadline loop time out normally (that part
+            # ticks in 250ms steps — well under the settle poll's 400ms
+            # ticks), then land the redirect partway through the settle
+            # poll that follows, exactly like a merely-slow Yandex redirect
+            # completing while this function is busy diagnosing.
+            if ticks["n"] == 90:
+                page.url = "https://direct.yandex.ru/wizard/campaigns/713469085"
+
+        page.wait_for_timeout = _wait_for_timeout
+
+        with patch.object(_clock, "_clock", lambda: clock["now"]):
+            # Must NOT raise — the late redirect means the click actually
+            # succeeded.
+            browser_masters._click_draft_terminal_button(page, 713469085, launch=True)
+
+    def test_returns_normally_when_redirect_lands_during_settle_wait_timeout(self):
+        # Same late-redirect race, but hitting the *second* url re-check
+        # (after a settle-wait timeout / non-empty table) rather than the
+        # one inside the empty-table branch.
+        page = _FakeTargetActionsPage(
+            {159614149: {"name": "Регистрация", "price": "150"}},
+            locators={
+                browser_masters._DRAFT_LAUNCH_BUTTON_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                )
+            },
+        )
+        page.url = browser_masters.WIZARD_EDIT_URL.format(campaign_id=713469085)
+
+        clock = {"now": 0.0}
+        ticks = {"n": 0}
+
+        def _wait_for_timeout(timeout):
+            clock["now"] += timeout / 1000
+            ticks["n"] += 1
+            if ticks["n"] == 90:
+                page.url = "https://direct.yandex.ru/wizard/campaigns/713469085"
+
+        page.wait_for_timeout = _wait_for_timeout
+
+        with patch.object(_clock, "_clock", lambda: clock["now"]):
+            browser_masters._click_draft_terminal_button(page, 713469085, launch=True)
+
 
 class TestLaunchMaster(unittest.TestCase):
     """``launch_master`` (issue #704): publish a DRAFT via the edit page's


### PR DESCRIPTION
## Проблема

`direct masters launch`/`masters update --launch` кликают "Запустить кампанию" на DRAFT-странице редактирования и, если Yandex не делает редирект в течение 20с, репортят только generic-сообщение "Yandex did not redirect away from the edit page" — без указания причины.

Однако **отсутствие цели Яндекс.Метрики** в секции "Целевые действия" — известная, воспроизводимая причина именно такого silent no-op (без каких-либо DOM-сигналов disabled/aria-disabled), уже задокументированная и продиагностированная для `create_master` (#777), но не для `_click_draft_terminal_button` — общего хелпера, которым пользуются и `launch_master`, и `update_master --launch`.

В issue #823 живой репро: кампания 713469085, клонированная через `masters copy`, у которой затем сменили landing URL через `masters update --landing-url` — это, вероятно, инвалидировало унаследованные с клона цели, оставив таблицу "Целевые действия" пустой. `masters launch` затем стабильно фейлился 3 раза подряд (включая `--headful`) с одинаковой generic-ошибкой.

## Решение

При таймауте редиректа `_click_draft_terminal_button` теперь дополнительно перечитывает таблицу "Целевые действия" (переиспользуя существующие `_wait_for_target_actions_settled`/`_read_target_actions_or_none` — тот же виджет, что и на странице создания) и, если таблица пуста, поднимает конкретную ошибку с явным указанием причины и подсказкой (`masters update --add-target-action`). Если таблица не пуста — сохраняется прежнее generic-сообщение.

## Тесты

- `TestClickDraftTerminalButton::test_raises_specific_goal_error_when_target_actions_table_is_empty` — новый
- `TestClickDraftTerminalButton::test_generic_error_when_target_actions_table_has_rows` — новый (regression guard: специфичная ошибка не должна перекрывать generic-случай)
- Полный офлайн-набор: `3529 passed, 23 skipped` (`pytest`)
- `black`/`flake8` чисто

Closes #823

🤖 Generated with [Claude Code](https://claude.com/claude-code)