### PR TITLE
feat(masters): add --tracking-params to `masters get` (#824)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@
 
 ### Added
 
+**`masters get --tracking-params` — read a campaign's UTM string (#824).**
+
+`masters get` never returned `TrackingParams`, either set or empty: the
+overview page it reads has no such field at all — "UTM-метки и параметры
+URL" only exists on the edit page, behind the "Дополнительные параметры"
+spoiler. This left `masters update --tracking-params`'s own result as the
+only evidence a save had taken effect, with no independent way to audit a
+batch of campaigns afterwards.
+
+A flag on the existing `get`, not a new subcommand — same shape as
+`--moderation-statuses` (#814): one more edit-page navigation, merged into
+the same result rather than paying for it on every `get`.
+
+```
+direct masters get 74736436 --tracking-params
+```
+
+adds `TrackingParams` to the result:
+
+- a UTM string is set → the string itself;
+- the field is mounted and genuinely empty → `""`;
+- the section could not be confirmed readable within the wait budget →
+  `TrackingParams` is omitted, rather than reporting a misleading `""`
+  (mirrors how the DRAFT overview path already omits an unreadable
+  `LandingUrl`).
+
+Reuses `_read_tracking_params`/`_wait_for_utm_section`, the same reader
+`masters update`'s own verify path already relies on (#769/#774), so `get`
+and `update --tracking-params` agree on what "empty" vs "unreadable" means
+for this field. Without the flag, `get`'s output and page loads are
+unchanged.
+
 **`masters get --moderation-statuses` — detect per-element moderation
 rejections in Мастер кампаний (#814).**
 

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -8785,6 +8785,40 @@ def fetch_master_moderation_statuses(page: "Page", campaign_id: int) -> Dict[str
     return result
 
 
+def fetch_master_tracking_params(page: "Page", campaign_id: int) -> Dict[str, Any]:
+    """Navigate to a campaign's edit page and read its "UTM-метки и
+    параметры URL" field (issue #824).
+
+    Read-only, mirroring ``fetch_master_moderation_statuses``: this data
+    lives only on the EDIT page (behind the "Дополнительные параметры"
+    spoiler) — the overview page ``fetch_master`` reads has no such field at
+    all — and nothing here ever clicks Save.
+
+    Reuses ``_wait_for_utm_section``/``_read_tracking_params``, the same
+    reader ``update_master``'s verify path already relies on (issue
+    #769/#774), so ``get`` and ``update --tracking-params`` agree on what
+    "empty" vs "unreadable" means for this field:
+
+    - a UTM string is set → the string itself;
+    - the field is mounted and genuinely empty → ``""``;
+    - the section never became readable within the wait budget →
+      ``TrackingParams`` is OMITTED from the result, rather than emitting a
+      misleading ``""`` for "we couldn't tell" (mirrors how the DRAFT
+      overview path already omits ``LandingUrl`` it could not read).
+    """
+    page.goto(WIZARD_EDIT_URL.format(campaign_id=campaign_id), wait_until="commit")
+    assert_not_captcha(page.content())
+    assert_authenticated(page.content())
+    _wait_for_edit_form(page, campaign_id)
+
+    result: Dict[str, Any] = {"CampaignId": campaign_id}
+    if _wait_for_utm_section(page):
+        tracking_params = _read_tracking_params(page)
+        if tracking_params is not None:
+            result["TrackingParams"] = tracking_params
+    return result
+
+
 def fetch_master_target_actions(page: "Page", campaign_id: int) -> Dict[str, Any]:
     """Read a campaign's current "Целевые действия" (target action / CPA)
     table — see ``_read_target_actions``'s docstring for the row shape.

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -560,6 +560,15 @@ def list_masters(
         "(images). Adds RejectedElements/RejectedCount to each result."
     ),
 )
+@click.option(
+    "--tracking-params",
+    is_flag=True,
+    help=(
+        'Also read the campaign\'s "UTM-метки и параметры URL" field from '
+        "its edit page. Adds TrackingParams to each result; omitted if the "
+        "field could not be confirmed readable (issue #824)."
+    ),
+)
 @_masters_browser_options
 @click.pass_context
 @handle_api_errors
@@ -567,6 +576,7 @@ def get(
     ctx,
     campaign_ids,
     moderation_statuses,
+    tracking_params,
     headful,
     profile_dir,
     chrome_profile,
@@ -581,12 +591,20 @@ def get(
     the campaign-level status). Only images carry such a marker today; see
     UnsupportedTypes in the output.
 
+    With --tracking-params, additionally reads the campaign's UTM field from
+    its edit page (the overview page this command otherwise reads has no
+    such field at all — see issue #824).
+
     Every ID is attempted even if an earlier one fails, and each ID's
     outcome (the row, or its error) is reported — see ``_run_per_id``
     (issue #816: a failure reading one campaign used to discard every
     already-read campaign in the same batch).
     """
-    from ..browser.masters import fetch_master, fetch_master_moderation_statuses
+    from ..browser.masters import (
+        fetch_master,
+        fetch_master_moderation_statuses,
+        fetch_master_tracking_params,
+    )
 
     ids = parse_ids(campaign_ids) or []
 
@@ -601,6 +619,18 @@ def get(
                 {
                     key: value
                     for key, value in fetch_master_moderation_statuses(
+                        page, campaign_id
+                    ).items()
+                    if key != "CampaignId"
+                }
+            )
+        if tracking_params:
+            # Same "merge into this result" shape as --moderation-statuses
+            # above, one more edit-page navigation (issue #824).
+            result.update(
+                {
+                    key: value
+                    for key, value in fetch_master_tracking_params(
                         page, campaign_id
                     ).items()
                     if key != "CampaignId"

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -19998,6 +19998,72 @@ class TestFetchMasterModerationStatuses(unittest.TestCase):
         self.assertIn("/edit/", page.navigated_to[-1])
 
 
+class TestFetchMasterTrackingParams(unittest.TestCase):
+    """``fetch_master_tracking_params`` — the navigating wrapper (issue #824).
+
+    Reuses ``TestUtmSectionReadability``'s page shape (a UTM spoiler that may
+    mount late), since the readability distinction this function must
+    surface is exactly what that class's fake already models.
+    """
+
+    @staticmethod
+    def _page(*, spoiler_appears_after=0, value="utm_source=x"):
+        # TestUtmSectionReadability's fake models the UTM spoiler/field but
+        # not the edit form's own ready markers — fetch_master_tracking_params
+        # navigates via _wait_for_edit_form first, which needs those present
+        # (mirrors _FakeImagesPage's role_elements default).
+        page = TestUtmSectionReadability._page(
+            spoiler_appears_after=spoiler_appears_after, value=value
+        )
+        page._locators.setdefault(
+            f'[data-testid="{browser_masters._EDIT_FORM_READY_TESTID}"]',
+            _FakeLocator([_FakeLocatorHandle()]),
+        )
+        page._role_elements = [
+            (
+                "button",
+                browser_masters._SAVE_BUTTON_TEXT,
+                _FakeTextLocatorHandle(visible=True),
+            )
+        ]
+        return page
+
+    def test_carries_the_campaign_id_into_the_result(self):
+        page = self._page(value="utm_source=x")
+
+        result = browser_masters.fetch_master_tracking_params(page, 42)
+
+        self.assertEqual(result["CampaignId"], 42)
+        self.assertEqual(result["TrackingParams"], "utm_source=x")
+
+    def test_reads_the_edit_page_not_the_overview_page(self):
+        page = self._page(value="utm_source=x")
+
+        browser_masters.fetch_master_tracking_params(page, 42)
+
+        self.assertIn("/edit/", page.navigated_to[-1])
+
+    def test_mounted_and_empty_field_reports_empty_string_not_omitted(self):
+        page = self._page(value="")
+
+        result = browser_masters.fetch_master_tracking_params(page, 42)
+
+        self.assertIn("TrackingParams", result)
+        self.assertEqual(result["TrackingParams"], "")
+
+    def test_unreadable_section_omits_the_key_rather_than_a_misleading_value(self):
+        # A section that never becomes readable within the wait budget must
+        # not be reported as "" (that would be indistinguishable from a
+        # genuinely empty field) — the key is simply absent, mirroring how
+        # the DRAFT overview path already omits an unreadable LandingUrl.
+        page = self._page(spoiler_appears_after=10**9)
+
+        result = browser_masters.fetch_master_tracking_params(page, 42)
+
+        self.assertNotIn("TrackingParams", result)
+        self.assertEqual(result["CampaignId"], 42)
+
+
 def _chromium_available():
     try:
         from playwright.sync_api import sync_playwright
@@ -20242,6 +20308,103 @@ class TestMastersGetModerationStatusesFlag(unittest.TestCase):
         payload = json.loads(result.output)
         self.assertEqual([row["CampaignId"] for row in payload], [42, 43])
         self.assertTrue(all("RejectedCount" in row for row in payload))
+
+
+class TestMastersGetTrackingParamsFlag(unittest.TestCase):
+    """``masters get --tracking-params`` — issue #824's CLI surface."""
+
+    def setUp(self):
+        self.runner = CliRunner()
+
+    def _invoke(self, args):
+        with patch(
+            "direct_cli.commands.masters._with_session",
+            side_effect=lambda ctx, headful, profile_dir, chrome_profile, fn: fn(
+                object()
+            ),
+        ):
+            return self.runner.invoke(cli, args)
+
+    def test_flag_absent_never_reads_tracking_params(self):
+        """The default `get` must not pay for a second page load."""
+        with patch.object(
+            browser_masters, "fetch_master", return_value={"CampaignId": 42}
+        ):
+            with patch.object(
+                browser_masters, "fetch_master_tracking_params"
+            ) as mock_tracking:
+                result = self._invoke(["masters", "get", "42"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        mock_tracking.assert_not_called()
+        self.assertNotIn("TrackingParams", result.output)
+
+    def test_flag_merges_tracking_params_into_the_same_result_object(self):
+        """A slice of `get`'s output, not a separate command's (mirrors
+        --moderation-statuses, issue #814)."""
+        with patch.object(
+            browser_masters,
+            "fetch_master",
+            return_value={"CampaignId": 42, "Name": "campaign"},
+        ):
+            with patch.object(
+                browser_masters,
+                "fetch_master_tracking_params",
+                return_value={
+                    "CampaignId": 42,
+                    "TrackingParams": "utm_source=yandex",
+                },
+            ):
+                result = self._invoke(["masters", "get", "42", "--tracking-params"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["CampaignId"], 42)
+        self.assertEqual(payload["Name"], "campaign")
+        self.assertEqual(payload["TrackingParams"], "utm_source=yandex")
+
+    def test_flag_applies_to_every_id_in_a_comma_separated_list(self):
+        with patch.object(
+            browser_masters,
+            "fetch_master",
+            side_effect=lambda _page, cid: {"CampaignId": cid},
+        ):
+            with patch.object(
+                browser_masters,
+                "fetch_master_tracking_params",
+                side_effect=lambda _page, cid: {
+                    "CampaignId": cid,
+                    "TrackingParams": f"utm_campaign={cid}",
+                },
+            ) as mock_tracking:
+                result = self._invoke(["masters", "get", "42,43", "--tracking-params"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(mock_tracking.call_count, 2)
+        payload = json.loads(result.output)
+        self.assertEqual([row["CampaignId"] for row in payload], [42, 43])
+        self.assertTrue(all("TrackingParams" in row for row in payload))
+
+    def test_unreadable_section_omits_the_key_rather_than_a_misleading_value(self):
+        # fetch_master_tracking_params itself omits the key when the UTM
+        # section never became readable (see
+        # TestFetchMasterTrackingParams) — this asserts the CLI merge
+        # preserves that omission instead of coercing it to "".
+        with patch.object(
+            browser_masters,
+            "fetch_master",
+            return_value={"CampaignId": 42, "Name": "campaign"},
+        ):
+            with patch.object(
+                browser_masters,
+                "fetch_master_tracking_params",
+                return_value={"CampaignId": 42},
+            ):
+                result = self._invoke(["masters", "get", "42", "--tracking-params"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertNotIn("TrackingParams", payload)
 
 
 class TestMastersGetPerCampaignFailureIsolation(unittest.TestCase):


### PR DESCRIPTION
## Summary

`direct masters get <id>` never returned `TrackingParams`, either set or empty — the overview page it reads has no such field at all. "UTM-метки и параметры URL" only exists on the edit page, behind the "Дополнительные параметры" spoiler. This left `masters update --tracking-params`'s own response as the only evidence a save had taken effect, with no independent way to re-check via `get`.

Closes #824

## Changes

- `direct_cli/browser/masters.py`: adds `fetch_master_tracking_params`, a navigating wrapper mirroring `fetch_master_moderation_statuses` (#814) — navigates to the edit page and reuses `_wait_for_utm_section`/`_read_tracking_params`, the exact reader `update_master`'s own verify path already relies on (#769/#774).
- `direct_cli/commands/masters.py`: adds a `--tracking-params` flag to `masters get`, gated the same way as `--moderation-statuses` — merges into the same result object (one more edit-page navigation), no extra cost when the flag is absent.
- `CHANGELOG.md`: documents the new flag under Unreleased.
- `tests/test_masters.py`: unit coverage for `fetch_master_tracking_params` (campaign-id passthrough, edit-page navigation, empty-vs-unreadable distinction) and the CLI flag (absent = no extra read, merges into result, applies per-ID in a batch, omission preserved through the merge).

## Value semantics (per the issue's request)

- UTM string set → the string itself
- field mounted and genuinely empty → `""`
- section could not be confirmed readable within the wait budget → key omitted (never a misleading `""`), mirroring how the DRAFT overview path already omits an unreadable `LandingUrl`

## Testing

```
pytest                                   # 3535 passed, 23 skipped
black --check <touched files>            # clean
flake8 direct_cli/browser/masters.py direct_cli/commands/masters.py tests/test_masters.py  # clean
```

No live browser run was performed for this PR (no `.env`/Chrome session available in this environment) — the new code path reuses `_read_tracking_params`/`_wait_for_utm_section`, which are already live-verified per their own docstrings (issue #769/#774), and `_wait_for_edit_form`/edit-page navigation are shared with `fetch_master_moderation_statuses`, live-verified in #814.

🤖 Generated with [Claude Code](https://claude.com/claude-code)