### PR TITLE
fix(masters): distinguish partial batch failures

### DIFF
--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -379,10 +379,14 @@ def _run_per_id(
     if errors:
         for campaign_id, exc in errors:
             print_error(f"Campaign {campaign_id}: {exc}")
-        raise click.ClickException(
+        error = click.ClickException(
             f"Failed to {verb} {len(errors)} of {len(ids)} campaign(s); "
             "see per-ID results above."
         )
+        # Keep exit 1 for a completely failed batch, while giving consumers a
+        # distinct status for output that contains both successes and errors.
+        error.exit_code = 2 if len(errors) < len(ids) else 1
+        raise error
     return results
 
 

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -20577,7 +20577,7 @@ class TestMastersGetPerCampaignFailureIsolation(unittest.TestCase):
         with patch.object(browser_masters, "fetch_master", side_effect=_fetch):
             result = self._invoke(["masters", "get", "1,2,3"])
 
-        self.assertNotEqual(result.exit_code, 0)
+        self.assertEqual(result.exit_code, 2)
         json_start = result.output.index("[\n")
         json_end = result.output.rindex("]") + 1
         payload = json.loads(result.output[json_start:json_end])
@@ -20585,6 +20585,19 @@ class TestMastersGetPerCampaignFailureIsolation(unittest.TestCase):
         self.assertNotIn("Error", payload[0])
         self.assertIn("overview timeout", payload[1]["Error"])
         self.assertNotIn("Error", payload[2])
+
+    def test_all_campaign_failures_keep_exit_one(self):
+        with patch.object(
+            browser_masters,
+            "fetch_master",
+            side_effect=browser_masters.PlaywrightError("overview timeout"),
+        ):
+            result = self._invoke(["masters", "get", "1,2"])
+
+        self.assertEqual(result.exit_code, 1)
+        payload = json.loads(result.output[result.output.index("[\n") :])
+        self.assertEqual([row["CampaignId"] for row in payload], [1, 2])
+        self.assertTrue(all("Error" in row for row in payload))
 
     def test_mid_batch_auth_error_triggers_with_session_retry(self):
         """Issue #816 follow-up (Codex, cycle-review PR #818): BrowserAuthError


### PR DESCRIPTION
Fixes #828

## Summary
- return exit code 2 when a masters per-ID batch has both successes and failures
- retain exit code 1 when every ID fails
- add regression coverage while preserving all per-ID JSON output

## Tests
- pytest -q tests/test_masters.py -k "TestMastersGetPerCampaignFailureIsolation or TestMastersGetTrackingParamsFlag"
- black --check direct_cli/commands/masters.py tests/test_masters.py
- git diff --check