### PR TITLE
fix(masters): preserve landing URL in combined updates

### DIFF
--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -7891,10 +7891,15 @@ def update_master(
 
     if name is not None:
         _set_campaign_name(page, name)
-    if landing_url is not None:
-        _set_landing_url(page, landing_url)
+    # Expand and fill the lazily-mounted UTM section first.  On campaigns
+    # with a long existing landing URL, expanding that section can re-render
+    # the surrounding form and restore the landing URL from server state.
+    # Filling the landing URL last keeps that re-render from discarding it
+    # before the single whole-form save (issue #830).
     if tracking_params is not None:
         _set_tracking_params(page, tracking_params)
+    if landing_url is not None:
+        _set_landing_url(page, landing_url)
     if weekly_budget is not None:
         _set_weekly_budget(page, weekly_budget)
     if promotion_goal is not None:

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -9532,6 +9532,42 @@ class TestUpdateMaster(unittest.TestCase):
             },
         )
 
+    def test_sets_tracking_params_before_landing_url_when_combined(self):
+        """Issue #830: UTM expansion must not invalidate the URL edit."""
+        page, _save_clicks = self._page_with_save_button(
+            landing_url_state={"value": "https://lp.example.ru/old"},
+            utm_input_state={"value": "utm_source=old"},
+        )
+        calls = []
+        original_set_tracking_params = browser_masters._set_tracking_params
+        original_set_landing_url = browser_masters._set_landing_url
+
+        def set_tracking_params(_page, value):
+            calls.append(("tracking_params", value))
+            original_set_tracking_params(_page, value)
+
+        def set_landing_url(_page, value):
+            calls.append(("landing_url", value))
+            original_set_landing_url(_page, value)
+
+        with patch.object(
+            browser_masters, "_set_tracking_params", set_tracking_params
+        ), patch.object(browser_masters, "_set_landing_url", set_landing_url):
+            browser_masters.update_master(
+                page,
+                42,
+                landing_url="https://lp.example.ru/new",
+                tracking_params="utm_source=new",
+            )
+
+        self.assertEqual(
+            calls,
+            [
+                ("tracking_params", "utm_source=new"),
+                ("landing_url", "https://lp.example.ru/new"),
+            ],
+        )
+
     def test_raises_when_landing_url_field_is_read_only_archived(self):
         # cycle-review round 2 (issue #761 fixup, Codex-confirmed):
         # _set_landing_url no longer pre-checks the Clear button's disabled


### PR DESCRIPTION
## Summary
- apply tracking parameters before landing URL in combined masters updates
- add regression coverage for issue #830 ordering

Fixes #830

## Tests
- `pytest -q -n0 tests/test_masters.py` (892 passed, 9 subtests passed)