### PR TITLE
feat(masters): batch update campaigns from JSONL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,52 @@ measurement over 2026-07-01..08-13 returned 6877 rows for 3257 distinct
 records — an inflation invisible in a two-page check, since the first overlap
 landed on page 3.
 
+**`masters update --from-file` / `--masters-json` — update many campaigns in
+one browser session (#834).**
+
+`masters update` took exactly one campaign id, so editing 10–20 Мастеров
+кампаний meant 10–20 separate CLI processes, each launching its own Chromium
+and re-entering Yandex. A live run of 17 campaigns (#829) showed that it is
+the repeated re-entry — not the editing — that fails.
+
+Batch mode follows the existing API-command convention (`keywords add`,
+#562): a JSONL plan via `--from-file`, or the same array inline via
+`--masters-json`, mutually exclusive with each other and with a positional
+`CAMPAIGN_ID`, and supported only with `--format json`.
+
+```
+direct masters update --from-file plan.jsonl --moderation-statuses
+```
+
+```jsonl
+{"CampaignId": 713234064, "Headlines": {"1": "Новый заголовок"}}
+{"CampaignId": 713231614, "LandingUrl": "https://lp.example.ru/x"}
+```
+
+Each row is one campaign: PascalCase keys that mirror this command's own
+flags 1:1, with slot numbers and positions **1-based exactly as in
+`--headline "2=..."`**. Rows are fully typed-checked before the first save
+(the same bounds, enum values and duplicate rules Click enforces for the
+flags), so a typo in the last row cannot leave earlier campaigns already
+mutated. An unknown key is an error naming the row and the allowed set,
+never a silent skip.
+
+Execution notes:
+
+- the whole plan runs over **one** browser session, paced between campaigns
+  (`--pacing-ms`, default 1000);
+- a campaign that fails is reported with an `Error` and does not stop the
+  rest; the command exits non-zero afterwards (#816/#831 semantics);
+- if the session goes stale mid-plan it is re-opened once and the run
+  resumes from the first campaign that was never saved — **an
+  already-saved campaign is never saved twice**;
+- `--moderation-statuses` reads each campaign's current statuses after its
+  save. Moderation usually has not run yet at that point, so this is a
+  snapshot, not a final verdict;
+- `--dry-run` validates the plan (including that local image/video files
+  exist) and prints what would be applied without opening a browser. It now
+  works for a single `CAMPAIGN_ID` too, printing the same report shape.
+
 **`masters get --tracking-params` — read a campaign's UTM string (#824).**
 
 `masters get` never returned `TrackingParams`, either set or empty: the

--- a/README.md
+++ b/README.md
@@ -164,6 +164,42 @@ A DRAFT campaign's edit page has no "Сохранить кампанию" button
 default, keeping it a DRAFT; pass `--launch` to publish it while saving
 instead ("Запустить кампанию"). Has no effect on a non-DRAFT campaign.
 
+**Updating many campaigns at once.** `masters update` also takes a whole plan
+instead of a single `CAMPAIGN_ID`, so a batch of campaigns is edited over
+**one** browser session rather than one Chromium launch per campaign (what
+actually failed in a live 17-campaign run was the repeated re-entry into
+Yandex, not the editing itself):
+
+```bash
+direct masters update --from-file plan.jsonl
+direct masters update --masters-json '[{"CampaignId": 713234064, "Name": "x"}]'
+```
+
+```jsonl
+{"CampaignId": 713234064, "Headlines": {"1": "Новый заголовок"}, "Texts": {"1": "Текст"}}
+{"CampaignId": 713231614, "LandingUrl": "https://lp.example.ru/x", "TrackingParams": "utm_source=direct"}
+```
+
+Same convention as `keywords add`: `--from-file` (JSONL, one campaign per
+line) and `--masters-json` (the same array inline) are mutually exclusive
+with each other and with a positional `CAMPAIGN_ID`, field flags belong in
+the plan rather than alongside it, and batch mode supports only
+`--format json`. Keys are the PascalCase form of this command's own flags,
+with **1-based** slot numbers and positions — `{"Headlines": {"2": "..."}}`
+is exactly `--headline "2=..."`. An unknown key is an error naming the row,
+never a silent skip, and the whole plan (including that local image/video
+files exist) is validated before the first save.
+
+A campaign that fails is reported with an `Error` and does not stop the rest;
+the command exits non-zero afterwards. If the browser session goes stale
+mid-plan it is re-opened once and the run continues from the first campaign
+that was never saved — an already-saved campaign is never saved twice.
+`--pacing-ms` (default 1000) controls the pause between campaigns,
+`--moderation-statuses` additionally reads each campaign's current moderation
+statuses after its save (a snapshot — moderation usually has not run yet at
+that point, so a rejection can still appear later), and `--dry-run` prints
+what would be applied without opening a browser.
+
 If you see "Found no Yandex cookies", open https://direct.yandex.ru in Chrome
 and log in first. If you use a non-default Chrome profile, pass
 `--chrome-profile "Profile 1"`.

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -877,6 +877,9 @@ _TEXTS_CLEAR_TESTID_TEMPLATE = _TEXTS_TESTID_TEMPLATE.replace(".textarea", ".cle
 # "DRAFT support" note).
 _EDIT_FORM_READY_TESTID = _HEADLINES_TESTID_TEMPLATE.format(index=0)
 _EDIT_FORM_READY_TIMEOUT_MS = 30_000
+# Deliberate pause between mutating edit-page navigations in a JSONL batch.
+# Kept in the browser layer so live pacing and its test seam remain together.
+_BATCH_UPDATE_PACING_MS = 1_000
 
 # Images (issue #670, Этап D). Confirmed live 2026-08-02 against DRAFT clone
 # 713234191 that images are a COMPLETELY different shape from headlines/texts

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -69,6 +69,7 @@ import click
 from click.core import ParameterSource
 
 from ..api import create_client
+from ..browser.masters import _BATCH_UPDATE_PACING_MS as _BATCH_UPDATE_PACING_MS_DEFAULT
 from ..browser.masters import AGE_FROM_CHOICES as _AGE_FROM_CHOICES
 from ..browser.masters import AGE_TO_CHOICES as _AGE_TO_CHOICES
 from ..browser.masters import DEVICE_OPTION_VALUES as _DEVICE_OPTION_VALUES
@@ -933,6 +934,10 @@ def _parse_add_target_action_options(
     return parsed
 
 
+#: PascalCase batch key -> ``update_master`` keyword. The batch surface is a
+#: strict 1:1 mirror of the single-campaign flags (issue #834): every key here
+#: has exactly one ``--flag`` counterpart, and adding a flag without adding its
+#: key would silently drop the field from a JSONL plan.
 _UPDATE_FILE_FIELDS = {
     "CampaignId": "campaign_id",
     "WeeklyBudget": "weekly_budget",
@@ -965,13 +970,318 @@ _UPDATE_FILE_FIELDS = {
     "Launch": "launch",
 }
 
+#: The CLI flag each batch key mirrors, used to keep an error message pointing
+#: at something the reader can act on in either mode.
+_UPDATE_FILE_FIELD_FLAGS = {
+    "WeeklyBudget": "--weekly-budget",
+    "PromotionGoal": "--promotion-goal",
+    "GoalPrice": "--goal-price",
+    "TargetActionPrices": "--target-action-price",
+    "AddTargetActions": "--add-target-action",
+    "RemoveTargetActionGoalIds": "--remove-target-action",
+    "DirectsHelps": "--directs-helps",
+    "Name": "--name",
+    "LandingUrl": "--landing-url",
+    "TrackingParams": "--tracking-params",
+    "Headlines": "--headline",
+    "Texts": "--text",
+    "ClearHeadlines": "--clear-headline",
+    "ClearTexts": "--clear-text",
+    "Images": "--image",
+    "AddVideo": "--add-video",
+    "RemoveVideos": "--remove-video",
+    "Gender": "--gender",
+    "AgeFrom": "--age-from",
+    "AgeTo": "--age-to",
+    "Devices": "--device",
+    "AddAudienceTags": "--add-audience-tag",
+    "RemoveAudienceTags": "--remove-audience-tag",
+    "AddMetrikaCounters": "--add-metrika-counter",
+    "RemoveMetrikaCounters": "--remove-metrika-counter",
+    "AddSitelinks": "--add-sitelink",
+    "RemoveSitelinks": "--remove-sitelink",
+    "Launch": "--launch",
+}
+
+
+def _row_error(row_index: int, message: str) -> click.UsageError:
+    """Build the batch's one and only error shape: row number, then cause.
+
+    Every batch validation failure names its row — a plan is edited as a file,
+    so "which line" is the first thing the reader needs (mirrors ``keywords
+    add``'s ``Row {row_index}: ...`` wording).
+    """
+    return click.UsageError(f"Row {row_index}: {message}")
+
+
+def _require_type(
+    value: Any,
+    expected: type,
+    *,
+    key: str,
+    row_index: int,
+    expected_label: str,
+) -> Any:
+    """Reject a JSON value whose type can't be what ``update_master`` expects.
+
+    ``bool`` is excluded from the ``int`` check on purpose: Python's ``bool``
+    is an ``int`` subclass, so ``{"WeeklyBudget": true}`` would otherwise pass
+    a type check and reach the browser as the budget ``1``.
+    """
+    if expected is int and isinstance(value, bool):
+        raise _row_error(row_index, f"{key} must be {expected_label}, got a boolean")
+    if expected is float and isinstance(value, bool):
+        raise _row_error(row_index, f"{key} must be {expected_label}, got a boolean")
+    if expected is float and isinstance(value, int):
+        return float(value)
+    if not isinstance(value, expected):
+        raise _row_error(
+            row_index,
+            f"{key} must be {expected_label}, got {type(value).__name__}",
+        )
+    return value
+
+
+def _coerce_slot_map(
+    value: Any,
+    *,
+    key: str,
+    row_index: int,
+    slot_count: int,
+    value_label: str,
+) -> "dict[int, str]":
+    """Convert a ``{"1": "value"}`` slot object into the 0-based index map the
+    browser layer takes, enforcing the SAME bounds as the single-campaign
+    ``--headline``/``--text``/``--image`` flags.
+
+    Slot numbers are 1-based in both modes, deliberately: a JSONL plan is
+    usually written by transcribing the equivalent ``--headline "2=..."``
+    invocation, and letting the same number mean slot 2 in one mode and slot 3
+    in the other is exactly the silent mis-write the CLAUDE.md "no divergent
+    forms" rule exists to prevent. JSON object keys are always strings, so the
+    digits are parsed here rather than by Click's ``type=int``.
+    """
+    if not isinstance(value, dict):
+        raise _row_error(
+            row_index,
+            f"{key} must be a JSON object keyed by 1-based slot number "
+            f'(e.g. {{"1": "{value_label}"}}), got {type(value).__name__}',
+        )
+    parsed: "dict[int, str]" = {}
+    for raw_slot, raw_value in value.items():
+        try:
+            slot_number = int(str(raw_slot).strip())
+        except ValueError:
+            raise _row_error(
+                row_index, f"{key} slot key {raw_slot!r} must be an integer"
+            )
+        if slot_number < 1 or slot_number > slot_count:
+            raise _row_error(
+                row_index,
+                f"{key} slot number {slot_number} is out of range — this "
+                f"field has slots (1-{slot_count}).",
+            )
+        if not isinstance(raw_value, str) or not raw_value.strip():
+            raise _row_error(
+                row_index,
+                f"{key} slot {slot_number} must be a non-empty string — "
+                "removing a variant is not supported here, pass the "
+                "replacement value instead.",
+            )
+        parsed[slot_number - 1] = raw_value
+    return parsed
+
+
+def _coerce_slot_list(
+    value: Any, *, key: str, row_index: int, slot_count: int
+) -> "list[int]":
+    """Convert a ``ClearHeadlines``/``ClearTexts`` array of 1-based slot
+    numbers into the 0-based index list the browser layer takes, rejecting a
+    duplicate exactly like ``_parse_clear_slot_options`` does."""
+    if not isinstance(value, list):
+        raise _row_error(
+            row_index,
+            f"{key} must be a JSON array of 1-based slot numbers, got "
+            f"{type(value).__name__}",
+        )
+    parsed: "list[int]" = []
+    seen: "set[int]" = set()
+    for raw_slot in value:
+        slot_number = _require_type(
+            raw_slot, int, key=key, row_index=row_index, expected_label="an integer"
+        )
+        if slot_number < 1 or slot_number > slot_count:
+            raise _row_error(
+                row_index,
+                f"{key} slot number {slot_number} is out of range — this "
+                f"field has slots (1-{slot_count}).",
+            )
+        if slot_number in seen:
+            raise _row_error(
+                row_index, f"{key} slot {slot_number} was specified more than once."
+            )
+        seen.add(slot_number)
+        parsed.append(slot_number - 1)
+    return parsed
+
+
+def _coerce_position_list(value: Any, *, key: str, row_index: int) -> "list[int]":
+    """Convert a ``Remove*`` array of 1-based positions into the 0-based list
+    the browser layer takes.
+
+    Duplicates are rejected for the reason spelled out in
+    ``_parse_remove_audience_tag_options``: positions resolve against a single
+    pre-mutation snapshot, so a repeated position would silently remove two
+    DIFFERENT items rather than being a harmless no-op.
+    """
+    if not isinstance(value, list):
+        raise _row_error(
+            row_index,
+            f"{key} must be a JSON array of 1-based positions, got "
+            f"{type(value).__name__}",
+        )
+    parsed: "list[int]" = []
+    seen: "set[int]" = set()
+    for raw_position in value:
+        position = _require_type(
+            raw_position, int, key=key, row_index=row_index, expected_label="an integer"
+        )
+        if position < 1:
+            raise _row_error(
+                row_index, f"{key} position {position} must be 1 or greater."
+            )
+        if position in seen:
+            raise _row_error(
+                row_index, f"{key} position {position} was specified more than once."
+            )
+        seen.add(position)
+        parsed.append(position - 1)
+    return parsed
+
+
+def _coerce_goal_price_map(
+    value: Any, *, key: str, row_index: int
+) -> "dict[int, float]":
+    """Convert a ``{"<goal id>": price}`` object into the goal-id-keyed price
+    map ``update_master`` takes, mirroring
+    ``_parse_target_action_price_options``' checks."""
+    if not isinstance(value, dict):
+        raise _row_error(
+            row_index,
+            f"{key} must be a JSON object keyed by Metrika goal id, got "
+            f"{type(value).__name__}",
+        )
+    parsed: "dict[int, float]" = {}
+    for raw_goal, raw_price in value.items():
+        try:
+            goal_id = int(str(raw_goal).strip())
+        except ValueError:
+            raise _row_error(
+                row_index, f"{key} goal id {raw_goal!r} must be an integer"
+            )
+        price = _require_type(
+            raw_price, float, key=key, row_index=row_index, expected_label="a number"
+        )
+        if price <= 0:
+            raise _row_error(
+                row_index, f"{key} price for goal {goal_id} must be greater than 0."
+            )
+        parsed[goal_id] = price
+    return parsed
+
+
+def _coerce_string_list(value: Any, *, key: str, row_index: int) -> "list[str]":
+    if not isinstance(value, list):
+        raise _row_error(
+            row_index,
+            f"{key} must be a JSON array of strings, got {type(value).__name__}",
+        )
+    for entry in value:
+        if not isinstance(entry, str) or not entry.strip():
+            raise _row_error(row_index, f"{key} entries must be non-empty strings")
+    return list(value)
+
+
+def _coerce_sitelink_list(
+    value: Any, *, key: str, row_index: int
+) -> "list[dict[str, str]]":
+    """Validate ``AddSitelinks`` — the typed JSON form of ``--add-sitelink
+    "Title|Href|Description"``.
+
+    All three parts stay mandatory here for the same not-live-confirmed reason
+    documented on ``_parse_add_sitelink_options``; only the surface differs
+    (named keys instead of a pipe-separated string).
+    """
+    if not isinstance(value, list):
+        raise _row_error(
+            row_index,
+            f"{key} must be a JSON array of sitelink objects, got "
+            f"{type(value).__name__}",
+        )
+    required = ("Title", "Href", "Description")
+    parsed: "list[dict[str, str]]" = []
+    for entry in value:
+        if not isinstance(entry, dict):
+            raise _row_error(
+                row_index,
+                f"{key} entries must be JSON objects with keys "
+                f"{', '.join(required)}",
+            )
+        unknown = sorted(set(entry) - set(required))
+        if unknown:
+            raise _row_error(
+                row_index,
+                f"{key} entry has unknown key {unknown[0]!r}; allowed: "
+                f"{', '.join(required)}",
+            )
+        for part in required:
+            if part not in entry:
+                raise _row_error(
+                    row_index, f"{key} entry is missing required key {part!r}"
+                )
+            if not isinstance(entry[part], str) or not entry[part].strip():
+                raise _row_error(
+                    row_index, f"{key} entry key {part!r} must be a non-empty string"
+                )
+        parsed.append({part: entry[part] for part in required})
+    return parsed
+
+
+def _coerce_choice(
+    value: Any, *, key: str, row_index: int, choices: "tuple[Any, ...]"
+) -> Any:
+    """Enforce the same value set the single-campaign flag's ``click.Choice``
+    enforces, so a typo fails at the CLI boundary instead of mid-session."""
+    if value not in choices:
+        rendered = ", ".join(repr(choice) for choice in choices)
+        raise _row_error(row_index, f"{key} must be one of: {rendered} (got {value!r})")
+    return value
+
 
 def _normalize_master_update_row(row: Any, row_index: int) -> Dict[str, Any]:
-    """Normalize one PascalCase batch row, matching ``keywords add``."""
+    """Normalize and fully validate one PascalCase batch row.
+
+    Mirrors ``keywords add``'s ``_normalize_keyword_row``: a whitelist of
+    allowed keys (an unknown key is an error naming the row and the allowed
+    set, never a silent skip), then a per-field coercion into exactly the
+    shapes ``update_master`` takes.
+
+    Every check the single-campaign flags get from Click's own types
+    (``type=int``, ``click.Choice``, the ``_parse_*_options`` helpers) is
+    re-applied here by hand, because a JSONL value never passes through Click.
+    Without that, ``{"AgeFrom": "999"}`` or ``{"WeeklyBudget": "abc"}`` would
+    reach the browser as-is and fail mid-mutation — the batch surface would be
+    strictly less safe than the flags it mirrors.
+    """
+    from ..browser.masters import (
+        _HEADLINES_SLOT_COUNT,
+        _IMAGES_MAX_COUNT,
+        _TEXTS_SLOT_COUNT,
+    )
+
     if not isinstance(row, dict):
-        raise click.UsageError(
-            f"Row {row_index}: expected JSON object, got {type(row).__name__}"
-        )
+        raise _row_error(row_index, f"expected JSON object, got {type(row).__name__}")
+
     unknown = sorted(set(row) - set(_UPDATE_FILE_FIELDS))
     if unknown:
         allowed = ", ".join(_UPDATE_FILE_FIELDS)
@@ -979,27 +1289,283 @@ def _normalize_master_update_row(row: Any, row_index: int) -> Dict[str, Any]:
             f"Unknown field {unknown[0]!r} in masters row {row_index}; "
             f"allowed: {allowed}"
         )
-    if "CampaignId" not in row or not isinstance(row["CampaignId"], int):
-        raise click.UsageError(f"Row {row_index}: CampaignId must be an integer")
-    item = {
-        _UPDATE_FILE_FIELDS[key]: value
-        for key, value in row.items()
-        if key != "CampaignId"
-    }
-    item["campaign_id"] = row["CampaignId"]
-    if len(item) == 1:
-        raise click.UsageError(f"Row {row_index}: provide at least one update field")
-    return _normalize_update_file_item(item)
+
+    if "CampaignId" not in row:
+        raise _row_error(row_index, "missing required field 'CampaignId'")
+    campaign_id = _require_type(
+        row["CampaignId"],
+        int,
+        key="CampaignId",
+        row_index=row_index,
+        expected_label="an integer",
+    )
+
+    update_keys = [key for key in row if key != "CampaignId"]
+    if not update_keys:
+        raise _row_error(
+            row_index,
+            "provide at least one update field besides CampaignId; allowed: "
+            + ", ".join(key for key in _UPDATE_FILE_FIELDS if key != "CampaignId"),
+        )
+
+    item: Dict[str, Any] = {"campaign_id": campaign_id}
+    for key in update_keys:
+        value = row[key]
+        target = _UPDATE_FILE_FIELDS[key]
+        if key in ("Name", "LandingUrl", "TrackingParams", "AddVideo"):
+            item[target] = _require_type(
+                value,
+                str,
+                key=key,
+                row_index=row_index,
+                expected_label="a string",
+            )
+        elif key == "WeeklyBudget":
+            item[target] = _require_type(
+                value, int, key=key, row_index=row_index, expected_label="an integer"
+            )
+        elif key == "GoalPrice":
+            item[target] = _require_type(
+                value, float, key=key, row_index=row_index, expected_label="a number"
+            )
+        elif key in ("DirectsHelps", "Launch"):
+            item[target] = _require_type(
+                value, bool, key=key, row_index=row_index, expected_label="a boolean"
+            )
+        elif key in ("TargetActionPrices", "AddTargetActions"):
+            item[target] = _coerce_goal_price_map(value, key=key, row_index=row_index)
+        elif key == "RemoveTargetActionGoalIds":
+            goal_ids: "list[int]" = []
+            if not isinstance(value, list):
+                raise _row_error(
+                    row_index,
+                    f"{key} must be a JSON array of Metrika goal ids, got "
+                    f"{type(value).__name__}",
+                )
+            for raw_goal in value:
+                goal_id = _require_type(
+                    raw_goal,
+                    int,
+                    key=key,
+                    row_index=row_index,
+                    expected_label="an integer",
+                )
+                if goal_id in goal_ids:
+                    raise _row_error(
+                        row_index, f"{key} goal {goal_id} was specified more than once."
+                    )
+                goal_ids.append(goal_id)
+            item[target] = goal_ids
+        elif key in ("Headlines", "Texts"):
+            item[target] = _coerce_slot_map(
+                value,
+                key=key,
+                row_index=row_index,
+                slot_count=(
+                    _HEADLINES_SLOT_COUNT if key == "Headlines" else _TEXTS_SLOT_COUNT
+                ),
+                value_label="New headline" if key == "Headlines" else "New text",
+            )
+        elif key == "Images":
+            item[target] = _coerce_slot_map(
+                value,
+                key=key,
+                row_index=row_index,
+                slot_count=_IMAGES_MAX_COUNT,
+                value_label="/path/to/image.jpg",
+            )
+        elif key in ("ClearHeadlines", "ClearTexts"):
+            item[target] = _coerce_slot_list(
+                value,
+                key=key,
+                row_index=row_index,
+                slot_count=(
+                    _HEADLINES_SLOT_COUNT
+                    if key == "ClearHeadlines"
+                    else _TEXTS_SLOT_COUNT
+                ),
+            )
+        elif key in (
+            "RemoveAudienceTags",
+            "RemoveMetrikaCounters",
+            "RemoveSitelinks",
+        ):
+            item[target] = _coerce_position_list(value, key=key, row_index=row_index)
+        elif key in ("RemoveVideos", "AddAudienceTags", "AddMetrikaCounters"):
+            item[target] = _coerce_string_list(value, key=key, row_index=row_index)
+        elif key == "AddSitelinks":
+            item[target] = _coerce_sitelink_list(value, key=key, row_index=row_index)
+        elif key == "PromotionGoal":
+            item[target] = _coerce_choice(
+                value,
+                key=key,
+                row_index=row_index,
+                choices=tuple(_PROMOTION_GOAL_CHOICES),
+            )
+        elif key == "Gender":
+            item[target] = _coerce_choice(
+                value, key=key, row_index=row_index, choices=tuple(_GENDER_CHOICES)
+            )
+        elif key == "Devices":
+            devices = _coerce_string_list(value, key=key, row_index=row_index)
+            for device in devices:
+                _coerce_choice(
+                    device,
+                    key=key,
+                    row_index=row_index,
+                    choices=tuple(_DEVICE_OPTION_VALUES),
+                )
+            item[target] = set(devices)
+        elif key == "AgeFrom":
+            item[target] = _coerce_choice(
+                value,
+                key=key,
+                row_index=row_index,
+                choices=tuple(_AGE_FROM_CHOICES),
+            )
+            # ``update_master`` distinguishes "not requested" from an
+            # explicitly requested bound, exactly as the flag path does via
+            # ``age_from is not None``.
+            item["age_from_requested"] = True
+        elif key == "AgeTo":
+            # "unlimited" is the flag's spelling of AgeTo=None ("55+"); the
+            # browser layer takes None, so translate at this boundary rather
+            # than teaching it a second spelling.
+            choices = tuple(
+                "unlimited" if choice is None else choice for choice in _AGE_TO_CHOICES
+            )
+            chosen = _coerce_choice(
+                value, key=key, row_index=row_index, choices=choices
+            )
+            item[target] = None if chosen == "unlimited" else chosen
+            item["age_to_requested"] = True
+        else:  # pragma: no cover - defensive, every key is handled above
+            raise _row_error(row_index, f"{key} is not supported in batch mode")
+
+    _reject_conflicting_row_fields(item, row_index)
+    return item
+
+
+def _reject_conflicting_row_fields(item: Dict[str, Any], row_index: int) -> None:
+    """Re-apply the single-campaign cross-field guards to one batch row.
+
+    These are the checks the flag path performs after parsing (goal/price
+    compatibility, a goal targeted twice, a slot both set and cleared). They
+    are duplicated per row rather than skipped because the underlying page
+    behaviour is identical in either mode — a conflict that is ambiguous
+    enough to refuse from the CLI is just as ambiguous inside a plan file.
+    """
+    promotion_goal = item.get("promotion_goal")
+    if item.get("goal_price") is not None and promotion_goal == "max-conversions":
+        raise _row_error(
+            row_index,
+            "GoalPrice has no effect under PromotionGoal 'max-conversions' — "
+            "that goal's price is set per-target-action via "
+            "TargetActionPrices instead.",
+        )
+    if promotion_goal == "max-clicks" and (
+        item.get("target_action_prices")
+        or item.get("add_target_actions")
+        or item.get("remove_target_action_goal_ids")
+    ):
+        raise _row_error(
+            row_index,
+            "TargetActionPrices/AddTargetActions/RemoveTargetActionGoalIds "
+            "have no effect under PromotionGoal 'max-clicks' — that goal's "
+            "price is set once for the whole campaign via GoalPrice instead.",
+        )
+
+    seen_goals: "dict[int, str]" = {}
+    for field, goals in (
+        ("TargetActionPrices", item.get("target_action_prices") or {}),
+        ("AddTargetActions", item.get("add_target_actions") or {}),
+        ("RemoveTargetActionGoalIds", item.get("remove_target_action_goal_ids") or []),
+    ):
+        for goal_id in goals:
+            if goal_id in seen_goals:
+                raise _row_error(
+                    row_index,
+                    f"Goal {goal_id} was passed to both {seen_goals[goal_id]} "
+                    f"and {field} — a goal can only be targeted by one of "
+                    "TargetActionPrices/AddTargetActions/"
+                    "RemoveTargetActionGoalIds in the same row.",
+                )
+            seen_goals[goal_id] = field
+
+    for set_field, clear_field, set_key, clear_key in (
+        ("Headlines", "ClearHeadlines", "headlines", "clear_headlines"),
+        ("Texts", "ClearTexts", "texts", "clear_texts"),
+    ):
+        overlap = sorted(set(item.get(set_key) or {}) & set(item.get(clear_key) or []))
+        if overlap:
+            raise _row_error(
+                row_index,
+                f"slot {overlap[0] + 1} was passed to both {set_field} and "
+                f"{clear_field} — set it or clear it, not both.",
+            )
+
+
+def _reject_duplicate_campaign_ids(rows: List[Dict[str, Any]]) -> None:
+    """Refuse a plan naming the same campaign twice.
+
+    Two rows for one campaign would mean two full edit-page saves, and the
+    retry bookkeeping in :func:`_run_update_file_batch` keys completion by
+    campaign id — so a duplicate is also the one input that could make a
+    replay skip a row that never ran. Merge the rows instead.
+    """
+    seen: "dict[int, int]" = {}
+    for index, row in enumerate(rows, start=1):
+        campaign_id = row["campaign_id"]
+        if campaign_id in seen:
+            raise click.UsageError(
+                f"Campaign {campaign_id} appears in more than one row "
+                f"(rows {seen[campaign_id]} and {index}) — merge them into a "
+                "single row: each campaign is saved once per batch."
+            )
+        seen[campaign_id] = index
+
+
+def _batch_row_report(row: Dict[str, Any]) -> Dict[str, Any]:
+    """Render one normalized row back into the PascalCase report shape.
+
+    The report is the plan's own vocabulary, not the browser layer's: internal
+    snake_case keys, 0-based indices and the ``*_requested`` bookkeeping flags
+    are implementation detail that must not leak into ``--dry-run`` output.
+    """
+    report: Dict[str, Any] = {"CampaignId": row["campaign_id"]}
+    for key, target in _UPDATE_FILE_FIELDS.items():
+        if key == "CampaignId" or target not in row:
+            continue
+        value = row[target]
+        if key in ("Headlines", "Texts", "Images"):
+            value = {str(index + 1): slot_value for index, slot_value in value.items()}
+        elif key in ("ClearHeadlines", "ClearTexts"):
+            value = [index + 1 for index in value]
+        elif key in ("RemoveAudienceTags", "RemoveMetrikaCounters", "RemoveSitelinks"):
+            value = [position + 1 for position in value]
+        elif key in ("TargetActionPrices", "AddTargetActions"):
+            value = {str(goal_id): price for goal_id, price in value.items()}
+        elif key == "Devices":
+            value = sorted(value)
+        elif key == "AgeTo" and value is None:
+            value = "unlimited"
+        report[key] = value
+    return report
 
 
 def _parse_update_file_rows(path: str) -> List[Dict[str, Any]]:
     """Decode and validate JSONL rows using the shared batch loader."""
     from . import _batch
 
-    return [
+    rows = _batch.load_jsonl_rows(path)
+    if not rows:
+        raise click.UsageError(f"--from-file {path!r} contains no campaign rows.")
+    parsed = [
         _normalize_master_update_row(row, index)
-        for index, row in enumerate(_batch.load_jsonl_rows(path), start=1)
+        for index, row in enumerate(rows, start=1)
     ]
+    _reject_duplicate_campaign_ids(parsed)
+    return parsed
 
 
 def _parse_update_inline_rows(value: str) -> List[Dict[str, Any]]:
@@ -1012,49 +1578,23 @@ def _parse_update_inline_rows(value: str) -> List[Dict[str, Any]]:
     )
     if not rows:
         raise click.UsageError("Input contains no campaign rows.")
-    return [
+    parsed = [
         _normalize_master_update_row(row, index)
         for index, row in enumerate(rows, start=1)
     ]
+    _reject_duplicate_campaign_ids(parsed)
+    return parsed
 
 
-def _normalize_update_file_item(item: Dict[str, Any]) -> Dict[str, Any]:
-    """Convert JSONL values to the same shapes used by the single update."""
-    result = dict(item)
-    for key in ("target_action_prices", "add_target_actions"):
-        if key in result:
-            if not isinstance(result[key], dict):
-                raise click.UsageError(f"{key} must be a JSON object keyed by goal id")
-            try:
-                result[key] = {int(goal): price for goal, price in result[key].items()}
-            except (TypeError, ValueError) as exc:
-                raise click.UsageError(f"{key} keys must be integer goal ids") from exc
-    for key in ("headlines", "texts", "images"):
-        if key in result:
-            if not isinstance(result[key], dict):
-                raise click.UsageError(f"{key} must be a JSON object keyed by slot")
-            try:
-                result[key] = {int(slot): value for slot, value in result[key].items()}
-            except (TypeError, ValueError) as exc:
-                raise click.UsageError(f"{key} keys must be integer slots") from exc
-    for key in (
-        "clear_headlines",
-        "clear_texts",
-        "remove_audience_tags",
-        "remove_metrika_counters",
-        "remove_sitelinks",
-    ):
-        if key in result and not isinstance(result[key], list):
-            raise click.UsageError(f"{key} must be a JSON array")
-    if "devices" in result:
-        if not isinstance(result["devices"], list):
-            raise click.UsageError("Devices must be a JSON array")
-        result["devices"] = set(result["devices"])
-    if "age_from" in result:
-        result["age_from_requested"] = True
-    if "age_to" in result:
-        result["age_to_requested"] = True
-    return result
+#: Placeholder left in a row's report when the campaign WAS saved but the
+#: follow-up ``--moderation-statuses`` read could not complete (the session
+#: went stale mid-read, and the save is not replayed on retry). Reporting the
+#: save with an explicit "not read" beats omitting the key, which reads as
+#: "nothing to report" for a campaign that was in fact mutated.
+_MODERATION_READ_INTERRUPTED = (
+    "not read — session expired after this campaign was saved; "
+    "re-read with `masters get --moderation-statuses`"
+)
 
 
 def _run_update_file_batch(
@@ -1066,12 +1606,22 @@ def _run_update_file_batch(
     chrome_profile: str,
     moderation_statuses: bool,
     dry_run: bool,
+    pacing_ms: Optional[int] = None,
 ) -> List[Dict[str, Any]]:
-    """Apply a JSONL update plan in one browser session.
+    """Apply a validated update plan to every campaign in ONE browser session.
 
-    ``completed`` intentionally lives outside the operation passed to
-    ``_with_session``: its retry is operation-wide, and replaying a completed
-    save would be an unsafe duplicate mutation.
+    One session for the whole plan is the point of the command (issue #834):
+    the live failures it exists to avoid correlated with how often a profile
+    re-entered Yandex, not with how many campaigns were edited.
+
+    ``completed``/``outcomes`` deliberately live OUTSIDE the operation handed
+    to ``_with_session``, whose ``BrowserAuthError`` retry re-runs the whole
+    operation under a fresh session. For a read-only fetch that replay is
+    free; here every replayed row is a second real save of a campaign already
+    saved in production. Keeping both maps across the retry lets the replay
+    skip finished campaigns and, just as importantly, keeps their results in
+    the report — a mutation that happened but goes unreported is the failure
+    mode issue #816 was filed for.
     """
     from ..browser.masters import (
         PlaywrightError,
@@ -1081,50 +1631,60 @@ def _run_update_file_batch(
     )
     from ..browser.session import BrowserAuthError, BrowserSessionError
 
-    rows = [_normalize_update_file_item(row) for row in rows]
-    for row in rows:
-        _validate_image_paths(row.get("images") or {})
-        if row.get("add_video") is not None:
-            _validate_video_path(row["add_video"])
-    if dry_run:
-        return [
-            {
-                "CampaignId": row["campaign_id"],
-                **{
-                    key: sorted(value) if isinstance(value, set) else value
-                    for key, value in row.items()
-                    if key != "campaign_id"
-                },
-            }
-            for row in rows
-        ]
+    pause_ms = _BATCH_UPDATE_PACING_MS if pacing_ms is None else pacing_ms
 
-    completed = set()
+    for index, row in enumerate(rows, start=1):
+        try:
+            _validate_image_paths(row.get("images") or {})
+            if row.get("add_video") is not None:
+                _validate_video_path(row["add_video"])
+        except click.UsageError as exc:
+            # Local-file checks run for the WHOLE plan before the first save,
+            # so a typo in the last row cannot leave the first ones already
+            # mutated (the flag path gets this for free -- it only ever has
+            # one campaign to validate).
+            raise _row_error(index, exc.format_message()) from exc
+
+    if dry_run:
+        return [_batch_row_report(row) for row in rows]
+
+    completed: "set[int]" = set()
     outcomes: Dict[int, Dict[str, Any]] = {}
 
     def operation(page):
-        for row in rows:
+        for position, row in enumerate(rows):
             campaign_id = row["campaign_id"]
             if campaign_id in completed:
                 continue
-            kwargs = dict(row)
-            kwargs.pop("campaign_id")
+            kwargs = {key: value for key, value in row.items() if key != "campaign_id"}
             try:
                 result = update_master(page, campaign_id, **kwargs)
-                # Mark completion before the optional read-only moderation
-                # navigation: auth failure there must not replay the save.
+                # Record the save as both done AND reportable before the
+                # optional moderation read: that read navigates again and can
+                # raise BrowserAuthError, and a save already applied in
+                # production must neither be replayed nor vanish from the
+                # report just because the follow-up read failed.
                 completed.add(campaign_id)
+                outcomes[campaign_id] = result
                 if moderation_statuses:
+                    # Marked pending first so that if this read is what raises
+                    # BrowserAuthError, the retry (which skips the completed
+                    # save) still reports WHY the statuses are missing rather
+                    # than silently omitting the key.
+                    result["ModerationStatuses"] = _MODERATION_READ_INTERRUPTED
                     result["ModerationStatuses"] = fetch_master_moderation_statuses(
                         page, campaign_id
                     )
-                outcomes[campaign_id] = result
-                if campaign_id != rows[-1]["campaign_id"]:
-                    page.wait_for_timeout(_BATCH_UPDATE_PACING_MS)
             except BrowserAuthError:
                 raise
             except (BrowserSessionError, PlaywrightError) as exc:
+                completed.add(campaign_id)
                 outcomes[campaign_id] = {"CampaignId": campaign_id, "Error": str(exc)}
+            if pause_ms and position != len(rows) - 1:
+                # Pace after EVERY attempt, including a failed one: the live
+                # failures behind issue #829 tracked how often the profile hit
+                # Yandex, and a row that failed still navigated there.
+                page.wait_for_timeout(pause_ms)
         return [
             outcomes[row["campaign_id"]]
             for row in rows
@@ -1721,20 +2281,46 @@ def audience_get(
     "--from-file",
     "from_file",
     type=click.Path(exists=True, dir_okay=False, readable=True),
-    help="JSONL file with one typed update object per campaign.",
+    help=(
+        "JSONL plan file: one campaign to update per line, with the same "
+        "typed fields as this command's own flags (PascalCase names). Every "
+        "campaign is updated in ONE browser session. Batch mode requires "
+        "--format json."
+    ),
 )
-@click.option("--masters-json", help="Inline JSON array of campaign update objects.")
+@click.option(
+    "--masters-json",
+    help=(
+        "Same plan as --from-file, inline as a JSON array of campaign "
+        "objects. Mutually exclusive with --from-file and CAMPAIGN_ID."
+    ),
+)
 @click.option(
     "--moderation-statuses",
     is_flag=True,
-    help="Read current moderation statuses after each save (not a final verdict).",
+    help=(
+        "After each save, also read that campaign's CURRENT moderation "
+        "statuses (batch mode only). Right after a save moderation has "
+        "usually not run yet — a rejection can appear later, so this is a "
+        "snapshot, NOT a final verdict."
+    ),
 )
 @click.option(
     "--dry-run",
     is_flag=True,
     help=(
-        "Validate a JSONL plan and print its intended changes without opening "
-        "a browser."
+        "Validate the plan (including that local image/video files exist) and "
+        "print what would be applied, without opening a browser."
+    ),
+)
+@click.option(
+    "--pacing-ms",
+    type=click.IntRange(min=0),
+    default=None,
+    help=(
+        "Pause between campaigns in a batch, in milliseconds (default: "
+        f"{_BATCH_UPDATE_PACING_MS_DEFAULT}). Raise it if a long plan starts "
+        "hitting session failures; 0 disables the pause."
     ),
 )
 @click.option(
@@ -2065,6 +2651,7 @@ def update(
     masters_json,
     moderation_statuses,
     dry_run,
+    pacing_ms,
     weekly_budget,
     promotion_goal,
     goal_price,
@@ -2099,7 +2686,31 @@ def update(
     output_format,
     output,
 ):
-    """Update settings of one Мастер кампаний (Этап A/B/D fields, plus name)
+    """Update settings of one or many Мастер кампаний campaigns
+
+    Takes either a single CAMPAIGN_ID with typed flags, or a whole plan via
+    ``--from-file``/``--masters-json`` (issue #834).
+
+    \b
+    Batch mode — one browser session for the WHOLE plan:
+      direct masters update --from-file plan.jsonl
+      direct masters update --masters-json '[{"CampaignId": 1, "Name": "x"}]'
+
+    Each plan row is one campaign: a ``CampaignId`` plus at least one field,
+    keyed in PascalCase (``Name``, ``LandingUrl``, ``Headlines``, ...) — the
+    1:1 counterpart of this command's own flags, with slot numbers and
+    positions 1-based exactly as in ``--headline "2=..."``. An unknown key is
+    an error naming the row, never a silent skip. Every row is validated
+    before the first save, so a typo in the last row cannot leave earlier
+    campaigns already mutated; ``--dry-run`` stops there and prints the plan.
+
+    Campaigns are updated one after another over a single browser session
+    (that is the point — repeated re-entry, not the edit itself, is what
+    failed live in issue #829), with a short pause between them. A campaign
+    that fails is reported with an ``Error`` and does NOT stop the rest; the
+    command exits non-zero afterwards. If the session goes stale mid-plan it
+    is re-opened once and the run continues from the first campaign that was
+    never saved — already-saved campaigns are never saved twice.
 
     Covers weekly budget, promotion goal (plus its target price), the
     "Директ помогает" auto-recommendations toggle, the campaign name,
@@ -2258,74 +2869,53 @@ def update(
 
     batch_mode = from_file is not None or masters_json is not None
     if batch_mode:
-        direct_values = (
-            weekly_budget,
-            promotion_goal,
-            goal_price,
-            target_action_prices,
-            add_target_actions,
-            remove_target_actions,
-            directs_helps,
-            name,
-            landing_url,
-            tracking_params,
-            headlines,
-            texts,
-            clear_headlines,
-            clear_texts,
-            images,
-            add_video,
-            remove_videos,
-            gender,
-            age_from,
-            age_to,
-            devices,
-            add_audience_tags,
-            remove_audience_tags,
-            add_metrika_counters,
-            remove_metrika_counters,
-            add_sitelinks,
-            remove_sitelinks,
-            launch,
-        )
-        if any(value not in (None, False, (), "") for value in direct_values):
+        # Keyed by the batch field name, so this stays in lockstep with
+        # _UPDATE_FILE_FIELDS/_UPDATE_FILE_FIELD_FLAGS by NAME rather than by
+        # argument order (a positional pairing would mislabel every flag after
+        # an inserted field, and still look correct).
+        direct_values = {
+            "WeeklyBudget": weekly_budget,
+            "PromotionGoal": promotion_goal,
+            "GoalPrice": goal_price,
+            "TargetActionPrices": target_action_prices,
+            "AddTargetActions": add_target_actions,
+            "RemoveTargetActionGoalIds": remove_target_actions,
+            "DirectsHelps": directs_helps,
+            "Name": name,
+            "LandingUrl": landing_url,
+            "TrackingParams": tracking_params,
+            "Headlines": headlines,
+            "Texts": texts,
+            "ClearHeadlines": clear_headlines,
+            "ClearTexts": clear_texts,
+            "Images": images,
+            "AddVideo": add_video,
+            "RemoveVideos": remove_videos,
+            "Gender": gender,
+            "AgeFrom": age_from,
+            "AgeTo": age_to,
+            "Devices": devices,
+            "AddAudienceTags": add_audience_tags,
+            "RemoveAudienceTags": remove_audience_tags,
+            "AddMetrikaCounters": add_metrika_counters,
+            "RemoveMetrikaCounters": remove_metrika_counters,
+            "AddSitelinks": add_sitelinks,
+            "RemoveSitelinks": remove_sitelinks,
+            "Launch": launch,
+        }
+        if any(value not in (None, False, (), "") for value in direct_values.values()):
+            # Field values belong in the plan, not alongside it: a flag here
+            # would apply to every row or to none, and both readings are
+            # defensible -- so refuse instead of picking one silently.
             unsupported = ", ".join(
-                flag
-                for flag, value in {
-                    "--weekly-budget": weekly_budget,
-                    "--promotion-goal": promotion_goal,
-                    "--goal-price": goal_price,
-                    "--target-action-price": target_action_prices,
-                    "--add-target-action": add_target_actions,
-                    "--remove-target-action": remove_target_actions,
-                    "--directs-helps": directs_helps,
-                    "--name": name,
-                    "--landing-url": landing_url,
-                    "--tracking-params": tracking_params,
-                    "--headline": headlines,
-                    "--text": texts,
-                    "--clear-headline": clear_headlines,
-                    "--clear-text": clear_texts,
-                    "--image": images,
-                    "--add-video": add_video,
-                    "--remove-video": remove_videos,
-                    "--gender": gender,
-                    "--age-from": age_from,
-                    "--age-to": age_to,
-                    "--device": devices,
-                    "--add-audience-tag": add_audience_tags,
-                    "--remove-audience-tag": remove_audience_tags,
-                    "--add-metrika-counter": add_metrika_counters,
-                    "--remove-metrika-counter": remove_metrika_counters,
-                    "--add-sitelink": add_sitelinks,
-                    "--remove-sitelink": remove_sitelinks,
-                    "--launch": launch,
-                }.items()
+                _UPDATE_FILE_FIELD_FLAGS[key]
+                for key, value in direct_values.items()
                 if value not in (None, False, (), "")
             )
             raise click.UsageError(
-                f"{unsupported} supported only with --from-file/--masters-json "
-                "batch mode"
+                f"{unsupported} supported only with CAMPAIGN_ID single-item "
+                "mode; put the field in the --from-file/--masters-json plan "
+                "instead."
             )
         if output_format != "json":
             raise click.UsageError(
@@ -2345,6 +2935,7 @@ def update(
             chrome_profile=chrome_profile,
             moderation_statuses=moderation_statuses,
             dry_run=dry_run,
+            pacing_ms=pacing_ms,
         )
         format_output(result, output_format, output)
         errors = [row for row in result if row.get("Error")]
@@ -2355,9 +2946,16 @@ def update(
             )
         return
 
-    if moderation_statuses or dry_run:
+    if moderation_statuses:
         raise click.UsageError(
-            "--moderation-statuses and --dry-run are only supported with --from-file"
+            "--moderation-statuses is supported only with --from-file/"
+            "--masters-json batch mode; use `masters get "
+            "--moderation-statuses` for a single campaign."
+        )
+    if pacing_ms is not None:
+        raise click.UsageError(
+            "--pacing-ms paces the gap BETWEEN campaigns and is supported "
+            "only with --from-file/--masters-json batch mode."
         )
 
     if (
@@ -2505,6 +3103,55 @@ def update(
     )
     parsed_add_sitelinks = _parse_add_sitelink_options(add_sitelinks)
     parsed_remove_sitelinks = _parse_remove_sitelink_options(remove_sitelinks)
+
+    if dry_run:
+        # Same report shape as a batch plan of one, so a caller can preview a
+        # single command and a plan file with one reader (and so the batch
+        # renderer stays the only place the PascalCase mapping lives).
+        single_row = {
+            "campaign_id": campaign_id,
+            **{
+                key: value
+                for key, value in {
+                    "weekly_budget": weekly_budget,
+                    "promotion_goal": promotion_goal,
+                    "goal_price": goal_price,
+                    "target_action_prices": parsed_target_action_prices or None,
+                    "add_target_actions": parsed_add_target_actions or None,
+                    "remove_target_action_goal_ids": parsed_remove_target_actions
+                    or None,
+                    "directs_helps": directs_helps,
+                    "name": name,
+                    "landing_url": landing_url,
+                    "tracking_params": tracking_params,
+                    "headlines": parsed_headlines or None,
+                    "texts": parsed_texts or None,
+                    "clear_headlines": parsed_clear_headlines or None,
+                    "clear_texts": parsed_clear_texts or None,
+                    "images": parsed_images or None,
+                    "add_video": add_video,
+                    "remove_videos": list(remove_videos) or None,
+                    "gender": gender,
+                    "devices": set(devices) if devices else None,
+                    "add_audience_tags": list(add_audience_tags) or None,
+                    "remove_audience_tags": parsed_remove_audience_tags or None,
+                    "add_metrika_counters": list(add_metrika_counters) or None,
+                    "remove_metrika_counters": parsed_remove_metrika_counters or None,
+                    "add_sitelinks": parsed_add_sitelinks or None,
+                    "remove_sitelinks": parsed_remove_sitelinks or None,
+                    "launch": launch or None,
+                }.items()
+                if value is not None
+            },
+        }
+        # An explicitly requested bound is reported even when it resolves to
+        # None ("unlimited"), matching what update_master would be told.
+        if age_from is not None:
+            single_row["age_from"] = parsed_age_from
+        if age_to is not None:
+            single_row["age_to"] = parsed_age_to
+        format_output(_batch_row_report(single_row), output_format, output)
+        return
 
     result = _with_session(
         ctx,

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -933,14 +933,14 @@ def _parse_add_target_action_options(
     return parsed
 
 
-_UPDATE_FILE_KEYS = {
+_UPDATE_FILE_FIELDS = {
     "CampaignId": "campaign_id",
     "WeeklyBudget": "weekly_budget",
     "PromotionGoal": "promotion_goal",
     "GoalPrice": "goal_price",
     "TargetActionPrices": "target_action_prices",
     "AddTargetActions": "add_target_actions",
-    "RemoveTargetActions": "remove_target_actions",
+    "RemoveTargetActionGoalIds": "remove_target_action_goal_ids",
     "DirectsHelps": "directs_helps",
     "Name": "name",
     "LandingUrl": "landing_url",
@@ -966,37 +966,61 @@ _UPDATE_FILE_KEYS = {
 }
 
 
-def _parse_update_file_rows(path: str) -> List[Dict[str, Any]]:
-    """Decode and validate the typed JSONL projection for ``masters update``."""
-    from ._batch import load_jsonl_rows
+def _normalize_master_update_row(row: Any, row_index: int) -> Dict[str, Any]:
+    """Normalize one PascalCase batch row, matching ``keywords add``."""
+    if not isinstance(row, dict):
+        raise click.UsageError(
+            f"Row {row_index}: expected JSON object, got {type(row).__name__}"
+        )
+    unknown = sorted(set(row) - set(_UPDATE_FILE_FIELDS))
+    if unknown:
+        allowed = ", ".join(_UPDATE_FILE_FIELDS)
+        raise click.UsageError(
+            f"Unknown field {unknown[0]!r} in masters row {row_index}; "
+            f"allowed: {allowed}"
+        )
+    if "CampaignId" not in row or not isinstance(row["CampaignId"], int):
+        raise click.UsageError(f"Row {row_index}: CampaignId must be an integer")
+    item = {
+        _UPDATE_FILE_FIELDS[key]: value
+        for key, value in row.items()
+        if key != "CampaignId"
+    }
+    item["campaign_id"] = row["CampaignId"]
+    if len(item) == 1:
+        raise click.UsageError(f"Row {row_index}: provide at least one update field")
+    return _normalize_update_file_item(item)
 
-    rows = load_jsonl_rows(path)
-    parsed = []
-    for index, row in enumerate(rows, start=1):
-        if not isinstance(row, dict):
-            raise click.UsageError(f"Row {index}: expected a JSON object")
-        unknown = sorted(set(row) - set(_UPDATE_FILE_KEYS))
-        if unknown:
-            raise click.UsageError(f"Row {index}: unknown key(s): {', '.join(unknown)}")
-        if "CampaignId" not in row or not isinstance(row["CampaignId"], int):
-            raise click.UsageError(f"Row {index}: CampaignId must be an integer")
-        item = {"campaign_id": row["CampaignId"]}
-        for key, value in row.items():
-            if key != "CampaignId":
-                item[_UPDATE_FILE_KEYS[key]] = value
-        if len(item) == 1:
-            raise click.UsageError(f"Row {index}: provide at least one update field")
-        parsed.append(item)
-    if not parsed:
-        raise click.UsageError("--from-file contains no campaign rows")
-    return parsed
+
+def _parse_update_file_rows(path: str) -> List[Dict[str, Any]]:
+    """Decode and validate JSONL rows using the shared batch loader."""
+    from . import _batch
+
+    return [
+        _normalize_master_update_row(row, index)
+        for index, row in enumerate(_batch.load_jsonl_rows(path), start=1)
+    ]
+
+
+def _parse_update_inline_rows(value: str) -> List[Dict[str, Any]]:
+    from . import _batch
+
+    rows = _batch.load_inline_rows(
+        value,
+        invalid_json_key="--masters-json: invalid JSON: {arg0}",
+        not_array_key="--masters-json must be a JSON array of campaign objects",
+    )
+    if not rows:
+        raise click.UsageError("Input contains no campaign rows.")
+    return [
+        _normalize_master_update_row(row, index)
+        for index, row in enumerate(rows, start=1)
+    ]
 
 
 def _normalize_update_file_item(item: Dict[str, Any]) -> Dict[str, Any]:
     """Convert JSONL values to the same shapes used by the single update."""
     result = dict(item)
-    if "remove_target_actions" in result:
-        result["remove_target_action_goal_ids"] = result.pop("remove_target_actions")
     for key in ("target_action_prices", "add_target_actions"):
         if key in result:
             if not isinstance(result[key], dict):
@@ -1066,7 +1090,11 @@ def _run_update_file_batch(
         return [
             {
                 "CampaignId": row["campaign_id"],
-                **{key: value for key, value in row.items() if key != "campaign_id"},
+                **{
+                    key: sorted(value) if isinstance(value, set) else value
+                    for key, value in row.items()
+                    if key != "campaign_id"
+                },
             }
             for row in rows
         ]
@@ -1692,9 +1720,10 @@ def audience_get(
 @click.option(
     "--from-file",
     "from_file",
-    type=click.Path(exists=True, dir_okay=False),
+    type=click.Path(exists=True, dir_okay=False, readable=True),
     help="JSONL file with one typed update object per campaign.",
 )
+@click.option("--masters-json", help="Inline JSON array of campaign update objects.")
 @click.option(
     "--moderation-statuses",
     is_flag=True,
@@ -2033,6 +2062,7 @@ def update(
     ctx,
     campaign_id,
     from_file,
+    masters_json,
     moderation_statuses,
     dry_run,
     weekly_budget,
@@ -2212,9 +2242,23 @@ def update(
     """
     from ..browser.masters import update_master
 
-    if from_file is not None:
+    modes_used = sum(
+        value is not None for value in (campaign_id, from_file, masters_json)
+    )
+    if modes_used == 0:
+        raise click.UsageError(
+            "Provide exactly one of: CAMPAIGN_ID (single), --from-file (JSONL), "
+            "or --masters-json (inline JSON array)."
+        )
+    if modes_used > 1:
+        raise click.UsageError(
+            "Provide exactly one of: CAMPAIGN_ID, --from-file, or "
+            "--masters-json — they are mutually exclusive."
+        )
+
+    batch_mode = from_file is not None or masters_json is not None
+    if batch_mode:
         direct_values = (
-            campaign_id,
             weekly_budget,
             promotion_goal,
             goal_price,
@@ -2245,11 +2289,54 @@ def update(
             launch,
         )
         if any(value not in (None, False, (), "") for value in direct_values):
-            raise click.UsageError(
-                "--from-file is mutually exclusive with CAMPAIGN_ID and "
-                "update field flags"
+            unsupported = ", ".join(
+                flag
+                for flag, value in {
+                    "--weekly-budget": weekly_budget,
+                    "--promotion-goal": promotion_goal,
+                    "--goal-price": goal_price,
+                    "--target-action-price": target_action_prices,
+                    "--add-target-action": add_target_actions,
+                    "--remove-target-action": remove_target_actions,
+                    "--directs-helps": directs_helps,
+                    "--name": name,
+                    "--landing-url": landing_url,
+                    "--tracking-params": tracking_params,
+                    "--headline": headlines,
+                    "--text": texts,
+                    "--clear-headline": clear_headlines,
+                    "--clear-text": clear_texts,
+                    "--image": images,
+                    "--add-video": add_video,
+                    "--remove-video": remove_videos,
+                    "--gender": gender,
+                    "--age-from": age_from,
+                    "--age-to": age_to,
+                    "--device": devices,
+                    "--add-audience-tag": add_audience_tags,
+                    "--remove-audience-tag": remove_audience_tags,
+                    "--add-metrika-counter": add_metrika_counters,
+                    "--remove-metrika-counter": remove_metrika_counters,
+                    "--add-sitelink": add_sitelinks,
+                    "--remove-sitelink": remove_sitelinks,
+                    "--launch": launch,
+                }.items()
+                if value not in (None, False, (), "")
             )
-        rows = _parse_update_file_rows(from_file)
+            raise click.UsageError(
+                f"{unsupported} supported only with --from-file/--masters-json "
+                "batch mode"
+            )
+        if output_format != "json":
+            raise click.UsageError(
+                "--format other than 'json' is not supported in batch mode "
+                "(item-level results may include per-row Errors)."
+            )
+        rows = (
+            _parse_update_file_rows(from_file)
+            if from_file is not None
+            else _parse_update_inline_rows(masters_json or "")
+        )
         result = _run_update_file_batch(
             ctx,
             rows,
@@ -2268,8 +2355,6 @@ def update(
             )
         return
 
-    if campaign_id is None:
-        raise click.UsageError("CAMPAIGN_ID is required unless --from-file is used")
     if moderation_statuses or dry_run:
         raise click.UsageError(
             "--moderation-statuses and --dry-run are only supported with --from-file"

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -63,7 +63,7 @@ fallback rather than trying to yield twice from one generator call.
 import contextlib
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Any, Dict, List, Optional
 
 import click
 from click.core import ParameterSource
@@ -933,6 +933,179 @@ def _parse_add_target_action_options(
     return parsed
 
 
+_UPDATE_FILE_KEYS = {
+    "CampaignId": "campaign_id",
+    "WeeklyBudget": "weekly_budget",
+    "PromotionGoal": "promotion_goal",
+    "GoalPrice": "goal_price",
+    "TargetActionPrices": "target_action_prices",
+    "AddTargetActions": "add_target_actions",
+    "RemoveTargetActions": "remove_target_actions",
+    "DirectsHelps": "directs_helps",
+    "Name": "name",
+    "LandingUrl": "landing_url",
+    "TrackingParams": "tracking_params",
+    "Headlines": "headlines",
+    "Texts": "texts",
+    "ClearHeadlines": "clear_headlines",
+    "ClearTexts": "clear_texts",
+    "Images": "images",
+    "AddVideo": "add_video",
+    "RemoveVideos": "remove_videos",
+    "Gender": "gender",
+    "AgeFrom": "age_from",
+    "AgeTo": "age_to",
+    "Devices": "devices",
+    "AddAudienceTags": "add_audience_tags",
+    "RemoveAudienceTags": "remove_audience_tags",
+    "AddMetrikaCounters": "add_metrika_counters",
+    "RemoveMetrikaCounters": "remove_metrika_counters",
+    "AddSitelinks": "add_sitelinks",
+    "RemoveSitelinks": "remove_sitelinks",
+    "Launch": "launch",
+}
+
+
+def _parse_update_file_rows(path: str) -> List[Dict[str, Any]]:
+    """Decode and validate the typed JSONL projection for ``masters update``."""
+    from ._batch import load_jsonl_rows
+
+    rows = load_jsonl_rows(path)
+    parsed = []
+    for index, row in enumerate(rows, start=1):
+        if not isinstance(row, dict):
+            raise click.UsageError(f"Row {index}: expected a JSON object")
+        unknown = sorted(set(row) - set(_UPDATE_FILE_KEYS))
+        if unknown:
+            raise click.UsageError(f"Row {index}: unknown key(s): {', '.join(unknown)}")
+        if "CampaignId" not in row or not isinstance(row["CampaignId"], int):
+            raise click.UsageError(f"Row {index}: CampaignId must be an integer")
+        item = {"campaign_id": row["CampaignId"]}
+        for key, value in row.items():
+            if key != "CampaignId":
+                item[_UPDATE_FILE_KEYS[key]] = value
+        if len(item) == 1:
+            raise click.UsageError(f"Row {index}: provide at least one update field")
+        parsed.append(item)
+    if not parsed:
+        raise click.UsageError("--from-file contains no campaign rows")
+    return parsed
+
+
+def _normalize_update_file_item(item: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert JSONL values to the same shapes used by the single update."""
+    result = dict(item)
+    if "remove_target_actions" in result:
+        result["remove_target_action_goal_ids"] = result.pop("remove_target_actions")
+    for key in ("target_action_prices", "add_target_actions"):
+        if key in result:
+            if not isinstance(result[key], dict):
+                raise click.UsageError(f"{key} must be a JSON object keyed by goal id")
+            try:
+                result[key] = {int(goal): price for goal, price in result[key].items()}
+            except (TypeError, ValueError) as exc:
+                raise click.UsageError(f"{key} keys must be integer goal ids") from exc
+    for key in ("headlines", "texts", "images"):
+        if key in result:
+            if not isinstance(result[key], dict):
+                raise click.UsageError(f"{key} must be a JSON object keyed by slot")
+            try:
+                result[key] = {int(slot): value for slot, value in result[key].items()}
+            except (TypeError, ValueError) as exc:
+                raise click.UsageError(f"{key} keys must be integer slots") from exc
+    for key in (
+        "clear_headlines",
+        "clear_texts",
+        "remove_audience_tags",
+        "remove_metrika_counters",
+        "remove_sitelinks",
+    ):
+        if key in result and not isinstance(result[key], list):
+            raise click.UsageError(f"{key} must be a JSON array")
+    if "devices" in result:
+        if not isinstance(result["devices"], list):
+            raise click.UsageError("Devices must be a JSON array")
+        result["devices"] = set(result["devices"])
+    if "age_from" in result:
+        result["age_from_requested"] = True
+    if "age_to" in result:
+        result["age_to_requested"] = True
+    return result
+
+
+def _run_update_file_batch(
+    ctx,
+    rows: List[Dict[str, Any]],
+    *,
+    headful: bool,
+    profile_dir: Optional[str],
+    chrome_profile: str,
+    moderation_statuses: bool,
+    dry_run: bool,
+) -> List[Dict[str, Any]]:
+    """Apply a JSONL update plan in one browser session.
+
+    ``completed`` intentionally lives outside the operation passed to
+    ``_with_session``: its retry is operation-wide, and replaying a completed
+    save would be an unsafe duplicate mutation.
+    """
+    from ..browser.masters import (
+        PlaywrightError,
+        _BATCH_UPDATE_PACING_MS,
+        fetch_master_moderation_statuses,
+        update_master,
+    )
+    from ..browser.session import BrowserAuthError, BrowserSessionError
+
+    rows = [_normalize_update_file_item(row) for row in rows]
+    for row in rows:
+        _validate_image_paths(row.get("images") or {})
+        if row.get("add_video") is not None:
+            _validate_video_path(row["add_video"])
+    if dry_run:
+        return [
+            {
+                "CampaignId": row["campaign_id"],
+                **{key: value for key, value in row.items() if key != "campaign_id"},
+            }
+            for row in rows
+        ]
+
+    completed = set()
+    outcomes: Dict[int, Dict[str, Any]] = {}
+
+    def operation(page):
+        for row in rows:
+            campaign_id = row["campaign_id"]
+            if campaign_id in completed:
+                continue
+            kwargs = dict(row)
+            kwargs.pop("campaign_id")
+            try:
+                result = update_master(page, campaign_id, **kwargs)
+                # Mark completion before the optional read-only moderation
+                # navigation: auth failure there must not replay the save.
+                completed.add(campaign_id)
+                if moderation_statuses:
+                    result["ModerationStatuses"] = fetch_master_moderation_statuses(
+                        page, campaign_id
+                    )
+                outcomes[campaign_id] = result
+                if campaign_id != rows[-1]["campaign_id"]:
+                    page.wait_for_timeout(_BATCH_UPDATE_PACING_MS)
+            except BrowserAuthError:
+                raise
+            except (BrowserSessionError, PlaywrightError) as exc:
+                outcomes[campaign_id] = {"CampaignId": campaign_id, "Error": str(exc)}
+        return [
+            outcomes[row["campaign_id"]]
+            for row in rows
+            if row["campaign_id"] in outcomes
+        ]
+
+    return _with_session(ctx, headful, profile_dir, chrome_profile, operation)
+
+
 def _parse_remove_target_action_options(values: "tuple[str, ...]") -> "list[int]":
     """Parse repeated ``--remove-target-action "goal_id"`` CLI values into a
     list of goal ids, identified the same way as every other target-action
@@ -1515,7 +1688,26 @@ def audience_get(
 
 
 @masters.command()
-@click.argument("campaign_id", type=int)
+@click.argument("campaign_id", type=int, required=False)
+@click.option(
+    "--from-file",
+    "from_file",
+    type=click.Path(exists=True, dir_okay=False),
+    help="JSONL file with one typed update object per campaign.",
+)
+@click.option(
+    "--moderation-statuses",
+    is_flag=True,
+    help="Read current moderation statuses after each save (not a final verdict).",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help=(
+        "Validate a JSONL plan and print its intended changes without opening "
+        "a browser."
+    ),
+)
 @click.option(
     "--weekly-budget",
     type=int,
@@ -1840,6 +2032,9 @@ def audience_get(
 def update(
     ctx,
     campaign_id,
+    from_file,
+    moderation_statuses,
+    dry_run,
     weekly_budget,
     promotion_goal,
     goal_price,
@@ -2016,6 +2211,69 @@ def update(
     instead of passing ``--launch`` here with an unchanged field value.
     """
     from ..browser.masters import update_master
+
+    if from_file is not None:
+        direct_values = (
+            campaign_id,
+            weekly_budget,
+            promotion_goal,
+            goal_price,
+            target_action_prices,
+            add_target_actions,
+            remove_target_actions,
+            directs_helps,
+            name,
+            landing_url,
+            tracking_params,
+            headlines,
+            texts,
+            clear_headlines,
+            clear_texts,
+            images,
+            add_video,
+            remove_videos,
+            gender,
+            age_from,
+            age_to,
+            devices,
+            add_audience_tags,
+            remove_audience_tags,
+            add_metrika_counters,
+            remove_metrika_counters,
+            add_sitelinks,
+            remove_sitelinks,
+            launch,
+        )
+        if any(value not in (None, False, (), "") for value in direct_values):
+            raise click.UsageError(
+                "--from-file is mutually exclusive with CAMPAIGN_ID and "
+                "update field flags"
+            )
+        rows = _parse_update_file_rows(from_file)
+        result = _run_update_file_batch(
+            ctx,
+            rows,
+            headful=headful,
+            profile_dir=profile_dir,
+            chrome_profile=chrome_profile,
+            moderation_statuses=moderation_statuses,
+            dry_run=dry_run,
+        )
+        format_output(result, output_format, output)
+        errors = [row for row in result if row.get("Error")]
+        if errors:
+            raise click.ClickException(
+                f"Failed to update {len(errors)} of {len(rows)} campaign(s); "
+                "see per-campaign results above."
+            )
+        return
+
+    if campaign_id is None:
+        raise click.UsageError("CAMPAIGN_ID is required unless --from-file is used")
+    if moderation_statuses or dry_run:
+        raise click.UsageError(
+            "--moderation-statuses and --dry-run are only supported with --from-file"
+        )
 
     if (
         weekly_budget is None

--- a/tests/api_coverage_payloads.py
+++ b/tests/api_coverage_payloads.py
@@ -74,6 +74,10 @@ DRY_RUN_PAYLOAD_EXCLUSIONS = {
         "Read-path SelectionCriteria dry-run is covered by WSDL selection criteria "
         "tests."
     ),
+    "masters.update": (
+        "Browser-only campaign wizard mutation has no Yandex Direct WSDL operation "
+        "or API payload schema."
+    ),
     "negativekeywordsharedsets.get": (
         "Read path omits optional SelectionCriteria when --ids is absent."
     ),

--- a/tests/api_coverage_payloads.py
+++ b/tests/api_coverage_payloads.py
@@ -75,8 +75,10 @@ DRY_RUN_PAYLOAD_EXCLUSIONS = {
         "tests."
     ),
     "masters.update": (
-        "Browser-only campaign wizard mutation has no Yandex Direct WSDL operation "
-        "or API payload schema."
+        "Мастер кампаний is browser-only and has no WSDL operation at all (see "
+        "direct_cli/browser/masters.py) — its --dry-run previews a validated "
+        "update plan, not an API request. Batch/plan validation is covered by "
+        "tests/test_masters.py::TestMastersUpdateBatch."
     ),
     "negativekeywordsharedsets.get": (
         "Read path omits optional SelectionCriteria when --ids is absent."

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -20,6 +20,7 @@ additions below for how that replay is faked.
 
 import ast
 import contextlib
+import inspect
 import json
 import time
 import unittest
@@ -20767,6 +20768,643 @@ class TestMastersGetPerCampaignFailureIsolation(unittest.TestCase):
         self.assertEqual([row["CampaignId"] for row in payload], [1, 2, 3])
         for row in payload:
             self.assertNotIn("Error", row)
+
+
+class _BatchPacingPage:
+    """Minimal stand-in page for `masters update`'s batch loop.
+
+    The batch never touches the DOM itself (each campaign's editing happens
+    inside the patched `update_master`), so the only Playwright surface it
+    needs is the pacing sleep -- which must still advance the module-wide fake
+    clock, per `_advance_fake_clock`'s contract.
+    """
+
+    def __init__(self):
+        self.waits = []
+
+    def wait_for_timeout(self, timeout):
+        self.waits.append(timeout)
+        _advance_fake_clock(timeout)
+
+
+class TestMastersUpdateBatch(unittest.TestCase):
+    """`masters update --from-file/--masters-json` — issue #834.
+
+    The plan is applied over ONE browser session, so these tests drive
+    `_with_session` itself rather than a fake Playwright page: what matters is
+    which campaigns were saved, in what order, exactly once, and what the
+    report says about each of them.
+    """
+
+    def setUp(self):
+        self.runner = CliRunner()
+
+    @staticmethod
+    def _plan(tmpdir, rows):
+        path = Path(tmpdir) / "plan.jsonl"
+        path.write_text(
+            "".join(json.dumps(row, ensure_ascii=False) + "\n" for row in rows),
+            encoding="utf-8",
+        )
+        return str(path)
+
+    @staticmethod
+    @contextlib.contextmanager
+    def _session(update=None, moderation=None, page=None):
+        """Patch the batch's three collaborators: the session wrapper, the
+        save, and the optional moderation read."""
+
+        def _with_session(ctx, headful, profile_dir, chrome_profile, fn):
+            # The batch paces between campaigns, so even a stand-in page must
+            # offer `wait_for_timeout` -- and it must advance the module fake
+            # clock like every other page here (issue #767).
+            return fn(page if page is not None else _BatchPacingPage())
+
+        patches = [
+            patch(
+                "direct_cli.commands.masters._with_session",
+                side_effect=_with_session,
+            ),
+            patch.object(
+                browser_masters,
+                "update_master",
+                side_effect=update or (lambda p, cid, **kw: {"CampaignId": cid}),
+            ),
+        ]
+        if moderation is not None:
+            patches.append(
+                patch.object(
+                    browser_masters,
+                    "fetch_master_moderation_statuses",
+                    side_effect=moderation,
+                )
+            )
+        with contextlib.ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            yield
+
+    # --- the issue's headline scenario -------------------------------------
+
+    def test_middle_row_fails_others_still_applied(self):
+        """A failing campaign is isolated: the rows around it still save, its
+        own row carries an Error, and the command still exits non-zero."""
+        saved = []
+
+        def _update(page, campaign_id, **kwargs):
+            if campaign_id == 2:
+                raise BrowserSessionError("edit page never loaded")
+            saved.append(campaign_id)
+            return {"CampaignId": campaign_id, "Name": kwargs.get("name")}
+
+        with self.runner.isolated_filesystem() as tmp:
+            plan = self._plan(
+                tmp,
+                [
+                    {"CampaignId": 1, "Name": "one"},
+                    {"CampaignId": 2, "Name": "two"},
+                    {"CampaignId": 3, "Name": "three"},
+                ],
+            )
+            with self._session(update=_update):
+                result = self.runner.invoke(
+                    cli, ["masters", "update", "--from-file", plan]
+                )
+
+        self.assertEqual(saved, [1, 3])
+        self.assertNotEqual(result.exit_code, 0)
+        # The report goes to stdout; the non-zero summary goes to stderr.
+        payload = json.loads(result.stdout)
+        self.assertEqual([row["CampaignId"] for row in payload], [1, 2, 3])
+        self.assertNotIn("Error", payload[0])
+        self.assertIn("edit page never loaded", payload[1]["Error"])
+        self.assertNotIn("Error", payload[2])
+
+    def test_stale_session_retry_does_not_resave_completed_campaign(self):
+        """The critical mutation-safety requirement: `_with_session` replays
+        the WHOLE operation on BrowserAuthError, so a campaign already saved
+        must be skipped rather than saved a second time."""
+        saved = []
+        raised = {"done": False}
+
+        def _update(page, campaign_id, **kwargs):
+            if campaign_id == 2 and not raised["done"]:
+                raised["done"] = True
+                raise BrowserAuthError("saved session went stale")
+            saved.append(campaign_id)
+            return {"CampaignId": campaign_id}
+
+        def _with_session(ctx, headful, profile_dir, chrome_profile, fn):
+            try:
+                return fn(_BatchPacingPage())
+            except BrowserAuthError:
+                # Same self-heal `_with_session` performs: re-run the WHOLE
+                # operation under a fresh session.
+                return fn(_BatchPacingPage())
+
+        with self.runner.isolated_filesystem() as tmp:
+            plan = self._plan(
+                tmp,
+                [{"CampaignId": 1, "Name": "a"}, {"CampaignId": 2, "Name": "b"}],
+            )
+            with (
+                patch(
+                    "direct_cli.commands.masters._with_session",
+                    side_effect=_with_session,
+                ),
+                patch.object(browser_masters, "update_master", side_effect=_update),
+            ):
+                result = self.runner.invoke(
+                    cli, ["masters", "update", "--from-file", plan]
+                )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertTrue(raised["done"])
+        # 1 is saved once despite the replay; 2 succeeds on the second pass.
+        self.assertEqual(saved, [1, 2])
+        self.assertEqual(
+            [row["CampaignId"] for row in json.loads(result.output)], [1, 2]
+        )
+
+    def test_auth_failure_while_reading_moderation_keeps_saved_row_reported(self):
+        """A save that succeeded must never vanish from the report because the
+        OPTIONAL moderation read afterwards hit a stale session."""
+        saved = []
+        reads = {"n": 0}
+
+        def _update(page, campaign_id, **kwargs):
+            saved.append(campaign_id)
+            return {"CampaignId": campaign_id}
+
+        def _moderation(page, campaign_id):
+            reads["n"] += 1
+            if reads["n"] == 1:
+                raise BrowserAuthError("stale while reading statuses")
+            return {"Statuses": ["MODERATION"]}
+
+        def _with_session(ctx, headful, profile_dir, chrome_profile, fn):
+            try:
+                return fn(_BatchPacingPage())
+            except BrowserAuthError:
+                # Same self-heal `_with_session` performs: re-run the WHOLE
+                # operation under a fresh session.
+                return fn(_BatchPacingPage())
+
+        with self.runner.isolated_filesystem() as tmp:
+            plan = self._plan(
+                tmp,
+                [{"CampaignId": 1, "Name": "a"}, {"CampaignId": 2, "Name": "b"}],
+            )
+            with (
+                patch(
+                    "direct_cli.commands.masters._with_session",
+                    side_effect=_with_session,
+                ),
+                patch.object(browser_masters, "update_master", side_effect=_update),
+                patch.object(
+                    browser_masters,
+                    "fetch_master_moderation_statuses",
+                    side_effect=_moderation,
+                ),
+            ):
+                result = self.runner.invoke(
+                    cli,
+                    [
+                        "masters",
+                        "update",
+                        "--from-file",
+                        plan,
+                        "--moderation-statuses",
+                    ],
+                )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(saved, [1, 2])
+        payload = json.loads(result.output)
+        self.assertEqual([row["CampaignId"] for row in payload], [1, 2])
+        # Campaign 1 was saved but its statuses could not be read -- say so
+        # explicitly instead of omitting the key.
+        self.assertIn("not read", payload[0]["ModerationStatuses"])
+        self.assertEqual(payload[1]["ModerationStatuses"], {"Statuses": ["MODERATION"]})
+
+    # --- one session, paced ------------------------------------------------
+
+    def test_whole_plan_runs_in_one_session_paced_between_campaigns(self):
+        sessions = {"n": 0}
+
+        page = _BatchPacingPage()
+
+        def _with_session(ctx, headful, profile_dir, chrome_profile, fn):
+            sessions["n"] += 1
+            return fn(page)
+
+        with self.runner.isolated_filesystem() as tmp:
+            plan = self._plan(
+                tmp, [{"CampaignId": cid, "Name": "x"} for cid in (1, 2, 3)]
+            )
+            with (
+                patch(
+                    "direct_cli.commands.masters._with_session",
+                    side_effect=_with_session,
+                ),
+                patch.object(
+                    browser_masters,
+                    "update_master",
+                    side_effect=lambda p, cid, **kw: {"CampaignId": cid},
+                ),
+            ):
+                result = self.runner.invoke(
+                    cli,
+                    ["masters", "update", "--from-file", plan, "--pacing-ms", "250"],
+                )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(sessions["n"], 1)
+        # Paced BETWEEN campaigns only -- no trailing pause after the last one.
+        self.assertEqual(page.waits, [250, 250])
+
+    def test_pacing_still_applied_after_a_failed_campaign(self):
+        """Issue #829's lesson is about how often the profile hits Yandex; a
+        row that failed still navigated there, so it must be paced too."""
+
+        page = _BatchPacingPage()
+
+        def _update(page_, campaign_id, **kwargs):
+            if campaign_id == 2:
+                raise PlaywrightError("boom")
+            return {"CampaignId": campaign_id}
+
+        with self.runner.isolated_filesystem() as tmp:
+            plan = self._plan(
+                tmp, [{"CampaignId": cid, "Name": "x"} for cid in (1, 2, 3)]
+            )
+            with self._session(update=_update, page=page):
+                self.runner.invoke(
+                    cli,
+                    ["masters", "update", "--from-file", plan, "--pacing-ms", "100"],
+                )
+
+        self.assertEqual(page.waits, [100, 100])
+
+    # --- dry-run -----------------------------------------------------------
+
+    def test_dry_run_reports_plan_without_opening_a_browser(self):
+        with self.runner.isolated_filesystem() as tmp:
+            plan = self._plan(
+                tmp,
+                [
+                    {
+                        "CampaignId": 713234064,
+                        "Headlines": {"1": "Новый заголовок"},
+                        "ClearTexts": [2],
+                        "Devices": ["mobile", "desktop"],
+                        "AgeTo": "unlimited",
+                    }
+                ],
+            )
+            with patch(
+                "direct_cli.commands.masters._with_session",
+                side_effect=AssertionError("dry-run must not open a session"),
+            ):
+                result = self.runner.invoke(
+                    cli, ["masters", "update", "--from-file", plan, "--dry-run"]
+                )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        # Reported in the PLAN's vocabulary: PascalCase keys, 1-based slots,
+        # no internal snake_case or *_requested bookkeeping.
+        self.assertEqual(
+            payload,
+            [
+                {
+                    "CampaignId": 713234064,
+                    "Headlines": {"1": "Новый заголовок"},
+                    "ClearTexts": [2],
+                    "Devices": ["desktop", "mobile"],
+                    "AgeTo": "unlimited",
+                }
+            ],
+        )
+
+    def test_dry_run_validates_local_image_paths_before_any_save(self):
+        with self.runner.isolated_filesystem() as tmp:
+            plan = self._plan(
+                tmp, [{"CampaignId": 1, "Images": {"1": "/nope/missing.jpg"}}]
+            )
+            result = self.runner.invoke(
+                cli, ["masters", "update", "--from-file", plan, "--dry-run"]
+            )
+
+        self.assertEqual(result.exit_code, 2)
+        self.assertIn("Row 1", result.output)
+        self.assertIn("missing.jpg", result.output)
+
+    def test_a_bad_last_row_blocks_the_whole_plan_before_the_first_save(self):
+        """Validation is plan-wide and up-front, so a typo in the last row
+        cannot leave earlier campaigns already mutated."""
+        saved = []
+
+        with self.runner.isolated_filesystem() as tmp:
+            plan = self._plan(
+                tmp,
+                [
+                    {"CampaignId": 1, "Name": "fine"},
+                    {"CampaignId": 2, "Images": {"1": "/nope/missing.jpg"}},
+                ],
+            )
+            with self._session(
+                update=lambda p, cid, **kw: saved.append(cid) or {"CampaignId": cid}
+            ):
+                result = self.runner.invoke(
+                    cli, ["masters", "update", "--from-file", plan]
+                )
+
+        self.assertEqual(result.exit_code, 2)
+        self.assertEqual(saved, [])
+
+    def test_single_campaign_dry_run_matches_the_batch_report_shape(self):
+        with patch(
+            "direct_cli.commands.masters._with_session",
+            side_effect=AssertionError("dry-run must not open a session"),
+        ):
+            result = self.runner.invoke(
+                cli,
+                [
+                    "masters",
+                    "update",
+                    "713234064",
+                    "--headline",
+                    "1=Новый заголовок",
+                    "--clear-text",
+                    "2",
+                    "--device",
+                    "mobile",
+                    "--device",
+                    "desktop",
+                    "--age-to",
+                    "unlimited",
+                    "--dry-run",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(
+            json.loads(result.output),
+            {
+                "CampaignId": 713234064,
+                "Headlines": {"1": "Новый заголовок"},
+                "ClearTexts": [2],
+                "Devices": ["desktop", "mobile"],
+                "AgeTo": "unlimited",
+            },
+        )
+
+    # --- input validation --------------------------------------------------
+
+    def test_malformed_jsonl_line_names_its_row(self):
+        with self.runner.isolated_filesystem() as tmp:
+            path = Path(tmp) / "plan.jsonl"
+            path.write_text(
+                '{"CampaignId": 1, "Name": "ok"}\nnot json at all\n', encoding="utf-8"
+            )
+            result = self.runner.invoke(
+                cli, ["masters", "update", "--from-file", str(path), "--dry-run"]
+            )
+
+        self.assertEqual(result.exit_code, 2)
+        self.assertIn("Row 2", result.output)
+
+    def test_unknown_key_names_the_row_and_lists_allowed_keys(self):
+        with self.runner.isolated_filesystem() as tmp:
+            plan = self._plan(
+                tmp,
+                [
+                    {"CampaignId": 1, "Name": "ok"},
+                    {"CampaignId": 2, "Headline": "typo, singular"},
+                ],
+            )
+            result = self.runner.invoke(
+                cli, ["masters", "update", "--from-file", plan, "--dry-run"]
+            )
+
+        self.assertEqual(result.exit_code, 2)
+        self.assertIn("Unknown field 'Headline'", result.output)
+        self.assertIn("row 2", result.output)
+        self.assertIn("Headlines", result.output)
+
+    def test_typed_values_are_validated_exactly_like_the_single_flags(self):
+        """Every check Click gives the flag path (`type=int`, `click.Choice`,
+        the slot/position parsers) is re-applied to a JSON value -- otherwise
+        the batch surface would be strictly less safe than the flags."""
+        cases = [
+            ({"CampaignId": 1, "WeeklyBudget": "не-число"}, "WeeklyBudget"),
+            ({"CampaignId": 1, "WeeklyBudget": True}, "boolean"),
+            ({"CampaignId": 1, "AgeFrom": 999}, "AgeFrom"),
+            ({"CampaignId": 1, "Gender": "ZZZ"}, "Gender"),
+            ({"CampaignId": 1, "Devices": ["NOPE"]}, "Devices"),
+            ({"CampaignId": 1, "Launch": "yes-please"}, "Launch"),
+            ({"CampaignId": 1, "AddSitelinks": "garbage"}, "AddSitelinks"),
+            ({"CampaignId": 1, "Headlines": {"99": "x"}}, "out of range"),
+            ({"CampaignId": 1, "Headlines": {"1": "   "}}, "non-empty"),
+            ({"CampaignId": 1, "RemoveSitelinks": [1, 1]}, "more than once"),
+            ({"CampaignId": "713", "Name": "x"}, "CampaignId"),
+            ({"CampaignId": 1}, "at least one update field"),
+        ]
+        for row, expected in cases:
+            with self.subTest(row=row):
+                result = self.runner.invoke(
+                    cli,
+                    [
+                        "masters",
+                        "update",
+                        "--masters-json",
+                        json.dumps([row]),
+                        "--dry-run",
+                    ],
+                )
+                self.assertEqual(result.exit_code, 2, result.output)
+                self.assertIn("Row 1", result.output)
+                self.assertIn(expected, result.output)
+
+    def test_slot_numbers_are_1_based_in_both_modes(self):
+        """A plan is usually written by transcribing the equivalent flags, so
+        the same number must mean the same slot in either mode."""
+        with self.runner.isolated_filesystem() as tmp:
+            plan = self._plan(tmp, [{"CampaignId": 1, "Headlines": {"1": "first"}}])
+            captured = {}
+            with self._session(
+                update=lambda p, cid, **kw: captured.update(kw) or {"CampaignId": cid}
+            ):
+                result = self.runner.invoke(
+                    cli, ["masters", "update", "--from-file", plan]
+                )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        # Slot 1 in the plan is index 0 for the browser layer -- the same
+        # translation `--headline "1=first"` performs.
+        self.assertEqual(captured["headlines"], {0: "first"})
+
+    def test_cross_field_conflicts_are_rejected_per_row(self):
+        cases = [
+            (
+                {"CampaignId": 1, "Headlines": {"1": "a"}, "ClearHeadlines": [1]},
+                "not both",
+            ),
+            (
+                {
+                    "CampaignId": 1,
+                    "PromotionGoal": "max-clicks",
+                    "AddTargetActions": {"5": 1.0},
+                },
+                "max-clicks",
+            ),
+            (
+                {
+                    "CampaignId": 1,
+                    "PromotionGoal": "max-conversions",
+                    "GoalPrice": 10.0,
+                },
+                "max-conversions",
+            ),
+            (
+                {
+                    "CampaignId": 1,
+                    "TargetActionPrices": {"5": 1.0},
+                    "RemoveTargetActionGoalIds": [5],
+                },
+                "Goal 5",
+            ),
+        ]
+        for row, expected in cases:
+            with self.subTest(row=row):
+                result = self.runner.invoke(
+                    cli,
+                    [
+                        "masters",
+                        "update",
+                        "--masters-json",
+                        json.dumps([row]),
+                        "--dry-run",
+                    ],
+                )
+                self.assertEqual(result.exit_code, 2, result.output)
+                self.assertIn(expected, result.output)
+
+    def test_duplicate_campaign_id_is_rejected(self):
+        """Two rows for one campaign would mean two saves, and completion is
+        tracked per campaign id -- so it is also the one input that could make
+        a retry skip a row that never ran."""
+        with self.runner.isolated_filesystem() as tmp:
+            plan = self._plan(
+                tmp, [{"CampaignId": 1, "Name": "a"}, {"CampaignId": 1, "Name": "b"}]
+            )
+            result = self.runner.invoke(
+                cli, ["masters", "update", "--from-file", plan, "--dry-run"]
+            )
+
+        self.assertEqual(result.exit_code, 2)
+        self.assertIn("rows 1 and 2", result.output)
+
+    def test_empty_plan_is_rejected_in_both_batch_forms(self):
+        with self.runner.isolated_filesystem() as tmp:
+            path = Path(tmp) / "plan.jsonl"
+            path.write_text("\n\n", encoding="utf-8")
+            from_file = self.runner.invoke(
+                cli, ["masters", "update", "--from-file", str(path), "--dry-run"]
+            )
+        inline = self.runner.invoke(
+            cli, ["masters", "update", "--masters-json", "[]", "--dry-run"]
+        )
+
+        self.assertEqual(from_file.exit_code, 2)
+        self.assertIn("no campaign rows", from_file.output)
+        self.assertEqual(inline.exit_code, 2)
+        self.assertIn("no campaign rows", inline.output)
+
+    # --- mode exclusivity, mirroring `keywords add` -------------------------
+
+    def test_modes_are_mutually_exclusive(self):
+        with self.runner.isolated_filesystem() as tmp:
+            plan = self._plan(tmp, [{"CampaignId": 1, "Name": "a"}])
+            both_batch = self.runner.invoke(
+                cli,
+                [
+                    "masters",
+                    "update",
+                    "--from-file",
+                    plan,
+                    "--masters-json",
+                    '[{"CampaignId": 2, "Name": "b"}]',
+                ],
+            )
+            id_and_file = self.runner.invoke(
+                cli, ["masters", "update", "1", "--from-file", plan]
+            )
+        neither = self.runner.invoke(cli, ["masters", "update"])
+
+        for result in (both_batch, id_and_file):
+            self.assertEqual(result.exit_code, 2, result.output)
+            self.assertIn("mutually exclusive", result.output)
+        self.assertEqual(neither.exit_code, 2)
+        self.assertIn("Provide exactly one of", neither.output)
+
+    def test_single_item_flags_are_refused_in_batch_mode(self):
+        with self.runner.isolated_filesystem() as tmp:
+            plan = self._plan(tmp, [{"CampaignId": 1, "Name": "a"}])
+            result = self.runner.invoke(
+                cli, ["masters", "update", "--from-file", plan, "--name", "x"]
+            )
+
+        self.assertEqual(result.exit_code, 2)
+        self.assertIn("--name", result.output)
+        self.assertIn("single-item mode", result.output)
+
+    def test_batch_mode_requires_json_format(self):
+        with self.runner.isolated_filesystem() as tmp:
+            plan = self._plan(tmp, [{"CampaignId": 1, "Name": "a"}])
+            result = self.runner.invoke(
+                cli, ["masters", "update", "--from-file", plan, "--format", "table"]
+            )
+
+        self.assertEqual(result.exit_code, 2)
+        self.assertIn("batch mode", result.output)
+
+    def test_batch_only_flags_are_refused_in_single_mode(self):
+        for flag in (["--moderation-statuses"], ["--pacing-ms", "500"]):
+            with self.subTest(flag=flag):
+                result = self.runner.invoke(
+                    cli, ["masters", "update", "1", "--name", "x", *flag]
+                )
+                self.assertEqual(result.exit_code, 2, result.output)
+                self.assertIn("batch mode", result.output)
+
+    def test_every_batch_key_mirrors_a_single_campaign_flag(self):
+        """Guard against the two surfaces drifting: a field added to one mode
+        and not the other is silent data loss in a plan file."""
+        from direct_cli.commands.masters import (
+            _UPDATE_FILE_FIELD_FLAGS,
+            _UPDATE_FILE_FIELDS,
+        )
+
+        batch_keys = set(_UPDATE_FILE_FIELDS) - {"CampaignId"}
+        self.assertEqual(batch_keys, set(_UPDATE_FILE_FIELD_FLAGS))
+
+        update_command = cli.commands["masters"].commands["update"]
+        declared = {opt for param in update_command.params for opt in param.opts}
+        for key, flag in _UPDATE_FILE_FIELD_FLAGS.items():
+            with self.subTest(key=key):
+                self.assertIn(flag, declared)
+
+        # ...and every mirrored key must actually reach `update_master`.
+        browser_kwargs = set(
+            inspect.signature(browser_masters.update_master).parameters
+        )
+        for key, target in _UPDATE_FILE_FIELDS.items():
+            if key == "CampaignId":
+                continue
+            with self.subTest(key=key):
+                self.assertIn(target, browser_kwargs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #834

`masters update` now takes a whole plan instead of a single campaign id, so a
batch of Мастеров кампаний is edited over **one** browser session — what
failed in the live 17-campaign run (#829) was the repeated re-entry into
Yandex, not the editing itself.

Batch mode follows the `keywords add` convention (#562): `--from-file` (JSONL)
and `--masters-json` (same array inline), mutually exclusive with each other
and with a positional `CAMPAIGN_ID`, field flags refused alongside a plan,
`--format json` only, and PascalCase keys that mirror this command's own flags
1:1 (unknown key → `UsageError` naming the row and the allowed set).

## Correctness work in the second pass

The first pass shipped without a single test for the new surface, so CI was
green while the feature was broken. Each defect below was reproduced first,
then fixed, and now has a regression test:

- **`--from-file` with `Devices` failed every time.** Rows were normalized
  twice and the conversion is not idempotent (a `set` then hit an
  is-a-list check). `--dry-run` returned before the second pass, which is
  exactly why it looked like it worked.
- **A saved campaign could vanish from the report.** `outcomes` was written
  only *after* the optional moderation read, so a `BrowserAuthError` from
  that read lost the row that the retry (correctly) skips — the #816 failure
  mode: a mutation that happened but goes unreported.
- **Batch input bypassed every type check the flags get from Click.**
  `{"AgeFrom": 999}`, `{"Gender": "ZZZ"}`, `{"WeeklyBudget": "не-число"}`,
  `{"Launch": "yes"}` were accepted and forwarded to the browser.
- **`--dry-run` leaked internal snake_case keys** and the
  `age_from_requested` bookkeeping flag instead of the plan's vocabulary.

Also fixed: slot numbers/positions are **1-based in a plan exactly as in
`--headline "2=..."`** (they were passed through as 0-based, so the same
number meant a different slot in each mode — silent mis-write when
transcribing a command into a file); pacing now applies after a failed row
too; duplicate `CampaignId` and an empty JSONL file are rejected; all
local-file validation runs before the first save, so a typo in the last row
cannot leave earlier campaigns already mutated; a campaign whose statuses
could not be read says so instead of omitting the key; `--pacing-ms` makes
the pause configurable as the issue requires; `--dry-run` works for a single
`CAMPAIGN_ID` too (CLAUDE.md describes it as the shared test seam), printing
the same report shape as a one-row plan.

## Mutation safety

`_with_session` replays the whole operation on `BrowserAuthError`, which is
free for a read but would be a second real save here. Completion and results
are tracked outside that closure, so a replay resumes from the first campaign
never saved and keeps the finished ones in the report.

## Tests

21 offline cases (`TestMastersUpdateBatch`): the four scenarios the issue
requires — mid-plan failure isolation with partial-success exit code, the
retry not re-saving a completed campaign, `--dry-run` without a browser,
malformed JSONL and unknown-key errors naming their row — plus a regression
for each defect above and a drift guard tying every batch key to its CLI flag
and to an `update_master` parameter.

`3561 passed`, flake8 + black clean, CI green.

Known risk: live verification against a real account was **not** run — the
author will verify manually before merge.