### PR TITLE
feat(history): add `direct history get` for «История изменений» (#837)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,48 @@
 
 ### Added
 
+**`direct history get` — read «История изменений» (#837).**
+
+The API has no per-field change journal at all: `changes.checkCampaigns`
+reports only `ChangesIn: SELF|CHILDREN|STAT`, `changes.check` returns bare
+lists of changed IDs, and Live v4's `GetEventsLog` logs system events
+(`BannerModerated`, `MoneyOut`, …). None of them answer "who changed this
+field, when, and from what to what" — the question that arises after a bulk
+edit silently drops a strategy goal or a Metrika counter.
+
+That history exists only in the web interface, so this is a new browser-backed
+group alongside `masters`, sharing its session stack (`--headful`/
+`--profile-dir`/`--chrome-profile`, no `--login`):
+
+```
+direct history get --campaign-ids 77593206 --categories CAMPAIGN_STRATEGY
+direct history get --date-from 2026-07-01 --date-to 2026-08-13 --limit 50
+```
+
+A separate group rather than a `masters` subcommand because the section is
+account-wide: its records cover ordinary ТГО/ЕПК campaigns, ad groups and ads
+as much as Мастера, and `--campaign-ids` is only a filter over that.
+
+Like `masters list` (#639), it does not scrape the DOM — it replays the
+section's own data call, `POST /web-api/user-action-log/api`. Live recon
+established two things that differ from the campaigns grid: `variables.login`
+is required (dropping it returns HTTP 200 with `errors: ["Нет прав"]`, not an
+auth failure), while the URL-level `ulogin` parameter is *not* needed — the
+opposite of `GridCampaigns`, where one's own login as `ulogin` causes HTTP
+401. Filters are applied server-side; results paginate automatically.
+
+Each record carries `Datetime`, `Login`, `ChangeSource`, `Category`,
+`EventType` and `CampaignId`/`CampaignName`, with the event's own fields under
+`Event`, passed through as-is because it is a union with a different shape per
+`EventType`. A dropped strategy goal reads directly off
+`Event.oldStrategy.goalId` → `Event.newStrategy.goalId`.
+
+Pagination de-duplicates on `gtid`: the cursor is a timestamp with one-second
+granularity, so consecutive pages overlap on records sharing a second. Live
+measurement over 2026-07-01..08-13 returned 6877 rows for 3257 distinct
+records — an inflation invisible in a two-page check, since the first overlap
+landed on page 3.
+
 **`masters get --tracking-params` — read a campaign's UTM string (#824).**
 
 `masters get` never returned `TrackingParams`, either set or empty: the

--- a/README.md
+++ b/README.md
@@ -267,6 +267,43 @@ in), so it can't run unattended. Run `direct masters logout` to delete the
 profile and revoke the on-disk session (a no-op warning, not an error, if
 none exists).
 
+### История изменений (change history) — browser-only
+
+The API has **no per-field change journal**: `changes.checkCampaigns` reports
+only `ChangesIn: SELF|CHILDREN|STAT`, `changes.check` returns bare lists of
+changed IDs, and Live v4's `GetEventsLog` logs *system* events
+(`BannerModerated`, `MoneyOut`, …) — none of them can answer "who changed
+this field, when, and from what to what". That history exists only in the web
+interface's «История изменений» section, so `direct history` reads it through
+the same browser session `direct masters` uses (same `--headful`/
+`--profile-dir`/`--chrome-profile` options, same no-`--login` rule):
+
+```bash
+direct history get
+direct history get --limit 50
+direct history get --campaign-ids 77593206
+direct history get --date-from 2026-07-01 --date-to 2026-08-13
+direct history get --categories CAMPAIGN_STRATEGY
+direct history get --logins someone --change-sources WEB
+```
+
+It is a separate group rather than a `masters` subcommand because the section
+is **account-wide**: records cover ordinary ТГО/ЕПК campaigns, ad groups and
+ads just as much as Мастера, and `--campaign-ids` is only a filter over that.
+Every filter is applied server-side, and results paginate automatically.
+
+Each record carries `Datetime`, `Login`, `ChangeSource`, `Category`,
+`EventType`, `CampaignId`/`CampaignName`, plus the event's own fields under
+`Event`. `Event` is passed through as-is: it is a union with a different
+shape per `EventType` (`CampaignStrategyEvent` carries the
+`oldStrategy`/`newStrategy` pair, `CampaignStatusChangeEvent` carries
+neither), so a change that dropped a strategy goal is visible as
+`Event.oldStrategy.goalId` → `Event.newStrategy.goalId`.
+
+A bare `--date-from`/`--date-to` date covers the whole day; pass
+`YYYY-MM-DDTHH:MM:SS` for an exact window. Without them, the period the
+section itself defaults to is used.
+
 ### Configuration
 
 Create a `.env` file in your working directory:

--- a/direct_cli/browser/__init__.py
+++ b/direct_cli/browser/__init__.py
@@ -1,8 +1,10 @@
 """
 Browser automation layer for Yandex Direct features that have no API surface.
 
-Currently used only by ``direct masters`` (Мастер кампаний / Campaign Wizard) —
-see ``direct_cli/browser/session.py`` and ``direct_cli/browser/masters.py``.
+Used by ``direct masters`` (Мастер кампаний / Campaign Wizard) and ``direct
+history`` («История изменений» — the per-field change journal the API does not
+expose at all) — see ``direct_cli/browser/session.py``,
+``direct_cli/browser/masters.py`` and ``direct_cli/browser/change_history.py``.
 ``playwright`` is an optional dependency (``pip install "direct-cli[browser]"``);
 nothing in this package is imported unless a browser-backed command actually runs.
 """

--- a/direct_cli/browser/change_history.py
+++ b/direct_cli/browser/change_history.py
@@ -1,0 +1,360 @@
+"""
+«История изменений» (user action log) — browser-backed reader, issue #837.
+
+Yandex Direct's API has no per-field change journal: ``changes.checkCampaigns``
+returns only ``ChangesIn: SELF|CHILDREN|STAT``, ``changes.check`` only lists
+changed IDs, and Live v4's ``GetEventsLog`` logs *system* events
+(``BannerModerated``, ``MoneyOut``, …) — never "user X set the strategy goal
+from A to B". The only place that history exists is the web interface's
+«История изменений» section, ``https://direct.yandex.ru/dna/log/``.
+
+Like ``masters.py``'s ``list`` (issue #639), this module does NOT scrape the
+section's DOM. Live recon on 2026-08-13 (account ``ksamatadirect``) found the
+page is driven by its own GraphQL call,
+``POST /web-api/user-action-log/api?operationName=userActionLog``
+(``USER_ACTION_LOG_API_URL``), which returns every record as typed JSON —
+including the ``oldStrategy``/``newStrategy`` pair that is the whole point of
+the section. Capturing and replaying that call is strictly better than parsing
+rendered rows: the values arrive already typed and un-truncated, whereas the
+grid renders them as prose inside a virtualized table.
+
+The captured GraphQL ``query`` (~5.7 KB of fragments) is replayed verbatim and
+never hand-assembled — same rationale as ``_capture_grid_campaigns_request``:
+a hand-built query would drift out of sync with Yandex's schema and would be
+missing the CSRF/session headers. Only ``variables`` are varied.
+
+Two facts about this endpoint, both confirmed live, differ from the campaigns
+grid and matter:
+
+* ``variables.login`` is **required**. Dropping it returns HTTP 200 with
+  ``errors: [{message: "Нет прав"}]`` and a null payload, not an auth error.
+  ``_capture_user_action_log_request`` therefore reads the login out of the
+  captured request rather than inventing one.
+* The URL-level ``ulogin`` query parameter is **not** needed — replaying
+  against a bare ``?operationName=userActionLog`` works and returns the same
+  200 records. This is the opposite of ``GridCampaigns``, where passing one's
+  own login as ``ulogin`` produces HTTP 401 «Доступ ограничен» (see
+  ``masters.py``'s module docstring). ``LOG_URL`` below keeps whatever the
+  page itself uses; the replay URL is normalized by
+  ``_strip_ulogin`` so an agency-flavoured captured URL can't leak into it.
+
+Pagination is cursor-based, not offset-based: the response carries
+``nextPageToken``, which is fed back as ``variables.token``. An offset-style
+replay like the grid's would silently re-read page 1 forever.
+
+**Pages overlap, and ``fetch_change_history`` de-duplicates them.** The
+cursor is a timestamp with one-second granularity — ``nextPageToken`` decodes
+to ``{"t": <unix seconds>, …}`` — so every record sharing the last returned
+record's second is served *again* at the head of the next page. This is
+invisible in a two-page check (the first overlap measured live landed on page
+3) and severe over a real range: a 2026-07-01..08-13 query returned 6877 rows
+for 3257 distinct ``gtid``s. Dedup is on ``gtid``, the server's own
+per-record id, not on the record body — the same campaign archived twice is
+legitimately identical apart from ``datetime``.
+"""
+
+import json
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+from ..output import print_warning
+from .session import (
+    BrowserSessionError,
+    assert_authenticated,
+    assert_not_captcha,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from playwright.sync_api import Page
+
+try:  # pragma: no cover - import shape mirrors masters.py
+    from playwright.sync_api import Error as PlaywrightError
+except ImportError:  # pragma: no cover - exercised only when playwright is absent
+    PlaywrightError = Exception  # type: ignore[assignment,misc]
+
+
+LOG_URL = "https://direct.yandex.ru/dna/log/"
+USER_ACTION_LOG_API_URL = "https://direct.yandex.ru/web-api/user-action-log/api"
+
+# The section's data call identifies itself via this query parameter.
+_USER_ACTION_LOG_OPERATION = "userActionLog"
+
+# Server-side page size the UI itself requests (confirmed live: a real
+# response contained exactly this many records and still carried a
+# nextPageToken).
+LOG_PAGE_LIMIT = 200
+
+# Timeout for observing the section's own data call. Mirrors the grid's
+# budget in masters.py — the page is the same class of SPA.
+_LOG_CAPTURE_TIMEOUT_MS = 30_000
+
+# Safety valve for the pagination loop: a server that keeps returning a
+# nextPageToken must not spin forever. 200 pages x 200 records = 40k records,
+# far beyond any realistic «История изменений» query.
+_MAX_PAGES = 200
+
+
+def _is_user_action_log_request(response: Any) -> bool:
+    return (
+        f"operationName={_USER_ACTION_LOG_OPERATION}" in response.url
+        and response.status == 200
+        and bool(response.request.post_data)
+    )
+
+
+def _strip_ulogin(url: str) -> str:
+    """Drop any ``ulogin`` query parameter from a captured request URL.
+
+    ``ulogin`` is Yandex's managed-client (agency) parameter. This module
+    only ever reads the logged-in user's own account, and the endpoint does
+    not need it (confirmed live — see the module docstring), while the
+    *page* URL does carry one. Normalizing here keeps a captured
+    agency-flavoured URL from being replayed as-is.
+    """
+    parts = urlsplit(url)
+    query = [(k, v) for k, v in parse_qsl(parts.query) if k != "ulogin"]
+    return urlunsplit(
+        (parts.scheme, parts.netloc, parts.path, urlencode(query), parts.fragment)
+    )
+
+
+def _capture_user_action_log_request(page: "Page") -> Dict[str, Any]:
+    """Navigate «История изменений» and capture the request it fires.
+
+    Returns ``{"body": dict, "url": str, "headers": dict}`` — the parsed
+    GraphQL body (``operationName``/``variables``/``query``), the replay URL
+    with any ``ulogin`` stripped, and the request headers (which carry the
+    CSRF token and session cookies a hand-built request would lack).
+
+    Uses ``page.expect_response`` started *before* ``goto`` and
+    ``wait_until="commit"`` for the same reasons ``masters.py``'s grid
+    capture does (issues #682/#694): Direct's SPA pages keep long-poll
+    connections open so ``networkidle`` never settles, ``readyState`` never
+    advances past ``"interactive"`` so ``domcontentloaded`` times out, and a
+    ``expect_response`` timeout surfaces from the ``with`` block's own exit
+    rather than from reading ``.value`` afterwards — so the whole block must
+    sit inside the ``try``.
+    """
+    try:
+        with page.expect_response(
+            _is_user_action_log_request, timeout=_LOG_CAPTURE_TIMEOUT_MS
+        ) as response_info:
+            page.goto(LOG_URL, wait_until="commit")
+            assert_not_captcha(page.content())
+            assert_authenticated(page.content())
+        response = response_info.value
+    except BrowserSessionError:
+        # BrowserCaptchaError/BrowserAuthError must propagate as-is rather
+        # than being relabelled as the generic timeout below — and without
+        # this clause the bare-Exception PlaywrightError fallback (used when
+        # playwright isn't installed) would swallow them.
+        raise
+    except PlaywrightError as exc:
+        raise BrowserSessionError(
+            "Could not observe the change-history data request "
+            f"(operationName={_USER_ACTION_LOG_OPERATION}) within "
+            f"{_LOG_CAPTURE_TIMEOUT_MS / 1000:.0f}s. Yandex may have "
+            "changed the section's internal API, or the page is unusually "
+            "slow to load."
+        ) from exc
+
+    post_data = response.request.post_data
+    assert post_data  # guaranteed non-empty by _is_user_action_log_request
+    return {
+        "body": json.loads(post_data),
+        "url": _strip_ulogin(response.url),
+        "headers": dict(response.request.headers),
+    }
+
+
+def _apply_filters(
+    request: Dict[str, Any],
+    *,
+    campaign_ids: Optional[List[int]],
+    date_from: Optional[str],
+    date_to: Optional[str],
+    categories: Optional[List[str]],
+    logins: Optional[List[str]],
+    change_sources: Optional[List[str]],
+) -> None:
+    """Overlay CLI filters onto the captured request's variables, in place.
+
+    Every filter is applied server-side. ``None`` means "leave whatever the
+    page itself sent" — notably for ``categories``, whose default is the
+    44-entry list the UI requests; replacing it with a partial guess would
+    silently drop event kinds.
+    """
+    variables = request["body"].setdefault("variables", {})
+    if campaign_ids is not None:
+        variables["campaignIds"] = campaign_ids
+    if date_from is not None:
+        variables["dateFrom"] = date_from
+    if date_to is not None:
+        variables["dateTo"] = date_to
+    if categories is not None:
+        variables["categories"] = categories
+    if logins is not None:
+        variables["logins"] = logins
+    if change_sources is not None:
+        variables["changeSources"] = change_sources
+    variables["limit"] = LOG_PAGE_LIMIT
+
+
+def _fetch_log_page(
+    page: "Page", request: Dict[str, Any], token: Optional[str]
+) -> Dict[str, Any]:
+    """Replay the captured request at a given pagination cursor.
+
+    ``token=None`` requests the first page; subsequent pages pass the
+    previous response's ``nextPageToken``.
+    """
+    body = request["body"]
+    body["variables"]["token"] = token
+    response = page.request.post(
+        request["url"],
+        data=json.dumps(body),
+        headers=request["headers"],
+    )
+    if not response.ok:
+        raise BrowserSessionError(
+            f"Change-history API returned HTTP {response.status} for "
+            f"{_USER_ACTION_LOG_OPERATION}."
+        )
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise BrowserSessionError(
+            "Change-history API returned a non-JSON response for "
+            f"{_USER_ACTION_LOG_OPERATION}."
+        ) from exc
+
+    # This endpoint reports authorization failures as HTTP 200 + a GraphQL
+    # `errors` array (confirmed live: dropping variables.login yields
+    # "Нет прав" this way), so a status-only check would read the empty
+    # payload as "no history".
+    errors = payload.get("errors") or []
+    if errors:
+        messages = "; ".join(
+            str(e.get("message", e)) for e in errors if isinstance(e, dict)
+        ) or str(errors)
+        raise BrowserSessionError(f"Change-history API returned an error: {messages}")
+
+    try:
+        return payload["data"][_USER_ACTION_LOG_OPERATION]
+    except (KeyError, TypeError) as exc:
+        raise BrowserSessionError(
+            "Change-history API response did not have the expected shape "
+            f"(data.{_USER_ACTION_LOG_OPERATION}) — Yandex may have changed "
+            "its schema."
+        ) from exc
+
+
+def _flatten_record(record: Dict[str, Any]) -> Dict[str, Any]:
+    """Project one raw log record onto the CLI's flat output shape.
+
+    The nested ``event`` object is passed through untouched under
+    ``Event``: it is a GraphQL union with a different field set per
+    ``__typename`` (``CampaignStrategyEvent`` carries
+    ``oldStrategy``/``newStrategy``, ``CampaignStatusChangeEvent`` carries
+    neither, and there are at least five more kinds — all seen live). Only
+    the fields common to *every* record are lifted to the top level; typed
+    per-event diffing is deliberately out of scope here so that a new event
+    kind shows up as data rather than as a parse error.
+    """
+    event = record.get("event") or {}
+    campaign = event.get("campaign") or {}
+    user = record.get("user") or {}
+    return {
+        "Datetime": record.get("datetime"),
+        "Login": user.get("login"),
+        "Uid": user.get("uid"),
+        "ChangeSource": record.get("changeSource"),
+        "Category": event.get("category"),
+        "EventType": event.get("__typename"),
+        "CampaignId": campaign.get("id"),
+        "CampaignName": campaign.get("name"),
+        "Gtid": record.get("gtid"),
+        "Event": event,
+    }
+
+
+def fetch_change_history(
+    page: "Page",
+    *,
+    campaign_ids: Optional[List[int]] = None,
+    date_from: Optional[str] = None,
+    date_to: Optional[str] = None,
+    categories: Optional[List[str]] = None,
+    logins: Optional[List[str]] = None,
+    change_sources: Optional[List[str]] = None,
+    limit: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Return «История изменений» records, newest first.
+
+    Reads the section's own JSON data call (see
+    ``_capture_user_action_log_request``) and follows ``nextPageToken`` until
+    the server stops issuing one, ``limit`` records have been collected, or
+    ``_MAX_PAGES`` is reached.
+
+    ``limit`` bounds the *total* number of records returned, independent of
+    the server's fixed ``LOG_PAGE_LIMIT`` page size.
+    """
+    if limit is not None and limit <= 0:
+        raise ValueError(f"limit must be positive, got {limit!r}")
+
+    request = _capture_user_action_log_request(page)
+    _apply_filters(
+        request,
+        campaign_ids=campaign_ids,
+        date_from=date_from,
+        date_to=date_to,
+        categories=categories,
+        logins=logins,
+        change_sources=change_sources,
+    )
+
+    records: List[Dict[str, Any]] = []
+    seen_gtids: Set[str] = set()
+    token: Optional[str] = None
+    for _ in range(_MAX_PAGES):
+        log = _fetch_log_page(page, request, token)
+        page_records = log.get("logRecords") or []
+        # Consecutive pages overlap: the cursor is a *timestamp* with
+        # one-second granularity (``nextPageToken`` decodes to
+        # ``{"t": <unix seconds>, …}``), so every record sharing the last
+        # record's second is served again at the head of the next page.
+        # Measured live over 2026-07-01..08-13: 6877 rows returned for 3257
+        # distinct ``gtid``s — a >2x inflation that only appears past page 2,
+        # which is why a two-page check reads as clean. ``gtid`` is the
+        # server's own per-record identifier, so dedup on it rather than on
+        # the record body (identical field values recur legitimately — the
+        # same campaign archived twice looks the same apart from datetime).
+        for record in page_records:
+            gtid = record.get("gtid")
+            if gtid is not None:
+                if gtid in seen_gtids:
+                    continue
+                seen_gtids.add(gtid)
+            records.append(record)
+        token = log.get("nextPageToken")
+        if not page_records or not token:
+            break
+        if limit is not None and len(records) >= limit:
+            break
+    else:
+        print_warning(
+            f"Stopped after {_MAX_PAGES} pages of change history; there may "
+            "be more records. Narrow the query with --date-from/--date-to "
+            "or --campaign-ids."
+        )
+
+    if limit is not None:
+        records = records[:limit]
+
+    if not records:
+        print_warning(
+            "No change-history records found. Either nothing matched this "
+            "filter, or Yandex changed the section's API this reads "
+            f"(operationName={_USER_ACTION_LOG_OPERATION})."
+        )
+    return [_flatten_record(record) for record in records]

--- a/direct_cli/cli.py
+++ b/direct_cli/cli.py
@@ -63,6 +63,7 @@ from .commands.v4wordstat import v4wordstat
 from .commands.v4keywords import v4keywords
 from .commands.v4adimage import v4adimage
 from .commands.masters import masters
+from .commands.history import history
 from .commands.browser_session import playwright_group
 
 # Load .env file
@@ -75,9 +76,11 @@ load_env_file()
 # Мастер кампаний for the logged-in browser session's own account only (no
 # agency/managed-client support, see direct_cli/browser/masters.py module
 # docstring -- issue #639 found that passing a login as `?ulogin=` there
-# actually broke access with HTTP 401). None of the three read
+# actually broke access with HTTP 401). `history` is browser-backed the same
+# way (issue #837): «История изменений» has no API surface, and its data call
+# authorizes off the browser session, not off a token. None of the four read
 # ctx.obj["token"] or ctx.obj["login"].
-_NO_CREDENTIALS_GROUPS = ("auth", "playwright", "masters")
+_NO_CREDENTIALS_GROUPS = ("auth", "playwright", "masters", "history")
 
 
 CLI_EPILOG = """\b
@@ -486,6 +489,7 @@ for command in (
     v4meta,
     auth,
     masters,
+    history,
     playwright_group,
 ):
     _register_command(command)

--- a/direct_cli/commands/history.py
+++ b/direct_cli/commands/history.py
@@ -1,0 +1,154 @@
+"""
+``direct history`` — «История изменений» reader (issue #837).
+
+Browser-backed, like ``direct masters``: the Direct API has no per-field
+change journal at all (see ``direct_cli/browser/change_history.py``'s module
+docstring for why ``changes.check``/``GetEventsLog`` cannot answer "who
+changed this field, and to what"). This is a separate command group rather
+than a ``masters`` subcommand because the section is account-wide — its
+records cover ordinary ТГО/ЕПК campaigns, ad groups and ads just as much as
+Мастера, and ``--campaign-ids`` is only a filter over that.
+
+The session-resolution stack (``_open_session``/``_with_session``, the
+``--headful``/``--profile-dir``/``--chrome-profile`` options and the
+saved-session self-heal) is imported from ``commands/masters.py`` rather than
+duplicated: none of it is Мастер-specific, and a second copy would drift.
+"""
+
+from typing import Optional
+
+import click
+
+from ..output import format_output, handle_api_errors
+from ..utils import parse_ids
+from .masters import _masters_browser_options, _with_session
+
+# The API takes naive local datetimes (`2026-08-05T17:00:00`, confirmed
+# live). The CLI accepts a plain calendar date and widens it to cover the
+# whole day, which is what a user asking for "changes on the 5th" means.
+_DAY_START_SUFFIX = "T00:00:00"
+_DAY_END_SUFFIX = "T23:59:59"
+
+
+def _to_datetime(value: Optional[str], suffix: str) -> Optional[str]:
+    """Expand a ``YYYY-MM-DD`` date to the datetime the API expects.
+
+    A value that already carries a time component is passed through
+    unchanged, so an exact window can still be requested.
+    """
+    if value is None:
+        return None
+    return value if "T" in value else f"{value}{suffix}"
+
+
+@click.group()
+def history():
+    """История изменений (change history) — browser-only, no API"""
+
+
+@history.command(name="get")
+@click.option(
+    "--campaign-ids",
+    help="Only records for these campaigns (comma-separated IDs)",
+)
+@click.option(
+    "--date-from",
+    help="Start of the period, YYYY-MM-DD (or YYYY-MM-DDTHH:MM:SS)",
+)
+@click.option(
+    "--date-to",
+    help="End of the period, YYYY-MM-DD (or YYYY-MM-DDTHH:MM:SS)",
+)
+@click.option(
+    "--logins",
+    help="Only changes made by these logins (comma-separated)",
+)
+@click.option(
+    "--change-sources",
+    help=(
+        "Only changes from these sources, comma-separated (e.g. WEB, API, "
+        "OTHER — the section's own vocabulary)"
+    ),
+)
+@click.option(
+    "--categories",
+    help=(
+        "Only these change categories, comma-separated (e.g. "
+        "CAMPAIGN_STRATEGY). Default: every category the web interface "
+        "itself requests."
+    ),
+)
+@click.option(
+    "--limit",
+    type=int,
+    help="Maximum number of records to return (default: all of them)",
+)
+@_masters_browser_options
+@click.pass_context
+@handle_api_errors
+def get(
+    ctx,
+    campaign_ids,
+    date_from,
+    date_to,
+    logins,
+    change_sources,
+    categories,
+    limit,
+    headful,
+    profile_dir,
+    chrome_profile,
+    output_format,
+    output,
+):
+    """Read the account's change history
+
+    Returns one record per logged change, newest first, with the event's own
+    fields under Event — including the oldStrategy/newStrategy pair that
+    shows exactly which strategy goal or Metrika counter a change dropped.
+
+    Without --date-from/--date-to the period the section itself defaults to
+    is used. Every filter is applied server-side.
+    """
+    if limit is not None and limit <= 0:
+        raise click.UsageError("--limit must be a positive integer")
+
+    from ..browser.change_history import fetch_change_history
+
+    parsed_campaign_ids = parse_ids(campaign_ids)
+    parsed_logins = _split_csv(logins)
+    parsed_sources = _split_csv(change_sources)
+    parsed_categories = _split_csv(categories)
+
+    result = _with_session(
+        ctx,
+        headful,
+        profile_dir,
+        chrome_profile,
+        lambda page: fetch_change_history(
+            page,
+            campaign_ids=parsed_campaign_ids,
+            date_from=_to_datetime(date_from, _DAY_START_SUFFIX),
+            date_to=_to_datetime(date_to, _DAY_END_SUFFIX),
+            categories=parsed_categories,
+            logins=parsed_logins,
+            change_sources=parsed_sources,
+            limit=limit,
+        ),
+    )
+
+    format_output(result, output_format, output)
+
+
+def _split_csv(value: Optional[str]) -> Optional[list]:
+    """Parse a comma-separated option into a list, or None if unset.
+
+    ``None`` (option absent) and an explicit empty string differ: the former
+    leaves the captured request's own value in place, which for
+    ``categories`` is the 44-entry list the web interface sends. Returning
+    ``[]`` for an empty string would instead filter everything out.
+    """
+    if value is None:
+        return None
+    items = [part.strip() for part in value.split(",")]
+    return [item for item in items if item]

--- a/direct_cli/smoke_matrix.py
+++ b/direct_cli/smoke_matrix.py
@@ -45,6 +45,11 @@ SMOKE_MATRIX = {
         "dynamicads.get",
         "dynamicfeedadtargets.get",
         "feeds.get",
+        # Read-only: navigates «История изменений» and replays that section's
+        # own data call to read the account's change log (see
+        # fetch_change_history's docstring). No page it touches has a Save
+        # control at all, so this is safe to exercise like any other *.get.
+        "history.get",
         "keywordbids.get",
         "keywords.get",
         "keywordsresearch.deduplicate",

--- a/tests/fixtures/user_action_log.json
+++ b/tests/fixtures/user_action_log.json
@@ -1,0 +1,85 @@
+{
+  "_comment": "Trimmed real response captured live from POST /web-api/user-action-log/api?operationName=userActionLog on 2026-08-13 (issue #837 recon). Record shapes are verbatim; ids/logins/names are scrubbed. Kept deliberately heterogeneous: CampaignStrategyEvent carries oldStrategy/newStrategy (the pair issue #837 needs to see a dropped strategy goal), while CampaignStatusChangeEvent carries neither — the `event` union has at least 7 __typename variants live (CampaignStrategyEvent, CampaignStatusChangeEvent, DemographyMultipliersEvent, AdGroupsRegionsEvent, CampaignValueChangeEvent, CampaignTimeTargetEvent, SingleMultiplierEvent), which is why fetch_change_history passes `event` through untouched instead of parsing per-type.",
+  "data": {
+    "userActionLog": {
+      "nextPageToken": "eyJwYWdlIjoyfQ",
+      "logRecords": [
+        {
+          "datetime": "2026-08-13T16:22:39",
+          "user": {
+            "uid": 1000000001,
+            "login": "example-login"
+          },
+          "changeSource": "WEB",
+          "gtid": "00000000-0000-0000-0000-000000000000:8547615",
+          "event": {
+            "__typename": "CampaignStrategyEvent",
+            "category": "CAMPAIGN_STRATEGY",
+            "clientId": 90000001,
+            "campaign": {
+              "id": 77593206,
+              "name": "Мастер РД (холодный) набор 3",
+              "calcType": "CPC",
+              "source": "UAC"
+            },
+            "currencyCode": "RUB",
+            "oldStrategy": {
+              "__typename": "GdStrategyOptimizeClicks",
+              "strategyType": "OPTIMIZE_CLICKS",
+              "avgBid": null,
+              "attributionModel": "AUTOMATIC",
+              "clicksLimit": null,
+              "bid": null,
+              "platform": "BOTH",
+              "isAutoBudget": true,
+              "budget": {
+                "autoProlongation": null,
+                "start": null,
+                "finish": null,
+                "period": "WEEK",
+                "sum": 10000
+              }
+            },
+            "newStrategy": {
+              "__typename": "GdStrategyOptimizeConversions",
+              "strategyType": "OPTIMIZE_CONVERSIONS",
+              "avgCpa": 150,
+              "goalId": 3000000001,
+              "attributionModel": "AUTOMATIC",
+              "payForConversion": false,
+              "platform": "BOTH",
+              "isAutoBudget": true,
+              "budget": {
+                "period": "WEEK",
+                "sum": 12000
+              }
+            }
+          }
+        },
+        {
+          "datetime": "2026-08-13T14:14:02",
+          "user": {
+            "uid": 1000000001,
+            "login": "example-login"
+          },
+          "changeSource": "OTHER",
+          "gtid": "00000000-0000-0000-0000-000000000000:8547600",
+          "event": {
+            "__typename": "CampaignStatusChangeEvent",
+            "category": "CAMPAIGN_ARCHIVED",
+            "clientId": 90000001,
+            "campaign": {
+              "id": 107706575,
+              "name": "Мастер РД (ретаргет)",
+              "calcType": "CPC",
+              "source": "UAC"
+            }
+          }
+        }
+      ]
+    },
+    "reqId": "1234567890123456789",
+    "telemetryTraceId": "00000000000000000000000000000000"
+  },
+  "errors": []
+}

--- a/tests/test_change_history.py
+++ b/tests/test_change_history.py
@@ -1,0 +1,642 @@
+"""
+Tests for `direct history` — «История изменений» (issue #837).
+
+Like `direct masters`, this group has no API surface at all: it replays the
+web interface's own GraphQL data call
+(``POST /web-api/user-action-log/api?operationName=userActionLog``). These
+tests never launch a browser and never hit the network — they drive
+``fetch_change_history`` against small fakes implementing just the Playwright
+surface it calls (``expect_response``/``goto``/``content``/``request.post``).
+
+See ``tests/fixtures/user_action_log.json`` for the trimmed real response
+these fakes replay.
+
+No fake clock is installed here (unlike tests/test_masters.py, issue #767):
+this module's production code has no ``wait_for_timeout`` poll loop — its
+only wait is ``expect_response``, which blocks on an event rather than
+sampling on an interval.
+"""
+
+import json
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from direct_cli.browser import change_history
+from direct_cli.browser.change_history import (
+    LOG_PAGE_LIMIT,
+    PlaywrightError,
+    fetch_change_history,
+)
+from direct_cli.browser.session import (
+    BrowserAuthError,
+    BrowserCaptchaError,
+    BrowserSessionError,
+)
+from direct_cli.cli import cli
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+def _load_fixture():
+    with open(FIXTURES_DIR / "user_action_log.json", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _captured_request_body(variables=None):
+    """The GraphQL body the live page posts, in the shape recon confirmed."""
+    return {
+        "operationName": "userActionLog",
+        "variables": {
+            "order": "DESC",
+            "dateFrom": "2026-08-05T17:00:00",
+            "dateTo": "2026-08-13T16:59:59",
+            "categories": ["CAMPAIGN_STRATEGY", "CAMPAIGN_ARCHIVED"],
+            "campaignIds": None,
+            "adGroupIds": None,
+            "adIds": None,
+            "logins": None,
+            "changeSources": None,
+            "limit": LOG_PAGE_LIMIT,
+            "token": None,
+            **(variables or {}),
+        },
+        "query": "query userActionLog(...) { ... }",
+    }
+
+
+class _FakeRequest:
+    def __init__(self, post_data, headers=None):
+        self.post_data = post_data
+        self.headers = headers or {"x-csrf-token": "fake-csrf"}
+
+
+class _FakeResponse:
+    """The subset of Playwright's Response the capture reads."""
+
+    def __init__(self, url, status=200, post_data=None, headers=None):
+        self.url = url
+        self.status = status
+        self.request = _FakeRequest(post_data, headers)
+
+
+class _FakeResponseInfo:
+    def __init__(self, page, predicate):
+        self._page = page
+        self._predicate = predicate
+
+    @property
+    def value(self):
+        candidate = self._page._log_response
+        if candidate is not None and self._predicate(candidate):
+            return candidate
+        raise PlaywrightError("Timeout waiting for response")
+
+
+class _FakeExpectResponse:
+    def __init__(self, page, predicate):
+        self._page = page
+        self._predicate = predicate
+
+    def __enter__(self):
+        return _FakeResponseInfo(self._page, self._predicate)
+
+    def __exit__(self, *exc_info):
+        # Mirrors real Playwright: the EventContextManager resolves the
+        # response on exit when the wrapped block did not raise, so a
+        # timeout surfaces from the `with` block's own exit (issue #694).
+        if exc_info[0] is not None:
+            return False
+        candidate = self._page._log_response
+        if candidate is None or not self._predicate(candidate):
+            raise PlaywrightError("Timeout waiting for response")
+        return False
+
+
+class _FakeApiResponse:
+    def __init__(self, ok=True, status=200, payload=None, raw_body=None):
+        self.ok = ok
+        self.status = status
+        self._payload = payload
+        self._raw_body = raw_body
+
+    def json(self):
+        if self._raw_body is not None:
+            return json.loads(self._raw_body)  # may raise, on purpose
+        return self._payload
+
+
+class _FakeApiRequestContext:
+    """Fakes ``page.request`` — the replayed POST used for pagination."""
+
+    def __init__(self, pages=None, ok=True, status=200, raw_body=None):
+        self._pages = pages or []
+        self._call_count = 0
+        self._ok = ok
+        self._status = status
+        self._raw_body = raw_body
+        self.calls = []  # (url, parsed_body, headers) for assertions
+
+    def post(self, url, data=None, headers=None):
+        self.calls.append((url, json.loads(data), headers))
+        idx = min(self._call_count, max(len(self._pages) - 1, 0))
+        self._call_count += 1
+        payload = self._pages[idx] if self._pages else {}
+        return _FakeApiResponse(
+            ok=self._ok, status=self._status, payload=payload, raw_body=self._raw_body
+        )
+
+
+class FakePage:
+    def __init__(self, log_response=None, api_request=None, html="<html></html>"):
+        self._log_response = log_response
+        self.request = api_request or _FakeApiRequestContext()
+        self._html = html
+        self.navigated_to = []
+        self.goto_wait_until = None
+
+    def goto(self, url, wait_until=None, timeout=None):
+        self.navigated_to.append(url)
+        self.goto_wait_until = wait_until
+
+    def content(self):
+        return self._html
+
+    def expect_response(self, predicate, timeout=None):
+        return _FakeExpectResponse(self, predicate)
+
+
+def _page_with(pages, captured_variables=None, url=None):
+    """A FakePage that observes the log request and replays `pages`."""
+    response = _FakeResponse(
+        url
+        or "https://direct.yandex.ru/web-api/user-action-log/api"
+        "?operationName=userActionLog&ulogin=example-login",
+        post_data=json.dumps(_captured_request_body(captured_variables)),
+    )
+    return FakePage(log_response=response, api_request=_FakeApiRequestContext(pages))
+
+
+def _payload(records, next_token=None):
+    return {
+        "data": {"userActionLog": {"logRecords": records, "nextPageToken": next_token}},
+        "errors": [],
+    }
+
+
+class TestFetchChangeHistory(unittest.TestCase):
+    def test_returns_flattened_records_from_live_shaped_fixture(self):
+        fixture = _load_fixture()
+        records = fixture["data"]["userActionLog"]["logRecords"]
+        page = _page_with([_payload(records)])
+
+        result = fetch_change_history(page)
+
+        self.assertEqual(len(result), 2)
+        first = result[0]
+        self.assertEqual(first["Datetime"], "2026-08-13T16:22:39")
+        self.assertEqual(first["Login"], "example-login")
+        self.assertEqual(first["Uid"], 1000000001)
+        self.assertEqual(first["ChangeSource"], "WEB")
+        self.assertEqual(first["Category"], "CAMPAIGN_STRATEGY")
+        self.assertEqual(first["EventType"], "CampaignStrategyEvent")
+        self.assertEqual(first["CampaignId"], 77593206)
+        self.assertEqual(first["CampaignName"], "Мастер РД (холодный) набор 3")
+        self.assertTrue(first["Gtid"])
+
+    def test_raw_event_is_passed_through_untouched(self):
+        """The old->new strategy pair is what issue #837 actually needs."""
+        fixture = _load_fixture()
+        records = fixture["data"]["userActionLog"]["logRecords"]
+        page = _page_with([_payload(records)])
+
+        result = fetch_change_history(page)
+
+        event = result[0]["Event"]
+        self.assertEqual(event["oldStrategy"]["strategyType"], "OPTIMIZE_CLICKS")
+        self.assertEqual(event["newStrategy"]["strategyType"], "OPTIMIZE_CONVERSIONS")
+        # The dropped/changed strategy goal is readable without this module
+        # having to model per-event-type schemas.
+        self.assertEqual(event["newStrategy"]["goalId"], 3000000001)
+
+    def test_event_types_without_a_diff_still_flatten(self):
+        """CampaignStatusChangeEvent carries no old/new pair — not an error."""
+        fixture = _load_fixture()
+        records = fixture["data"]["userActionLog"]["logRecords"]
+        page = _page_with([_payload(records)])
+
+        result = fetch_change_history(page)
+
+        second = result[1]
+        self.assertEqual(second["EventType"], "CampaignStatusChangeEvent")
+        self.assertEqual(second["Category"], "CAMPAIGN_ARCHIVED")
+        self.assertEqual(second["CampaignId"], 107706575)
+        self.assertNotIn("oldStrategy", second["Event"])
+
+    def test_navigates_with_commit_wait_until(self):
+        """Direct's SPA never reaches domcontentloaded (issues #682/#694)."""
+        page = _page_with([_payload([])])
+
+        fetch_change_history(page)
+
+        self.assertEqual(page.navigated_to, [change_history.LOG_URL])
+        self.assertEqual(page.goto_wait_until, "commit")
+
+
+class TestPagination(unittest.TestCase):
+    def _record(self, gtid):
+        return {
+            "datetime": "2026-08-13T10:00:00",
+            "user": {"uid": 1, "login": "example-login"},
+            "changeSource": "WEB",
+            "gtid": gtid,
+            "event": {
+                "__typename": "CampaignStatusChangeEvent",
+                "category": "CAMPAIGN_HIDE",
+                "campaign": {"id": 1, "name": "c"},
+            },
+        }
+
+    def test_follows_next_page_token_until_exhausted(self):
+        page = _page_with(
+            [
+                _payload([self._record("a")], next_token="tok-2"),
+                _payload([self._record("b")], next_token="tok-3"),
+                _payload([self._record("c")], next_token=None),
+            ]
+        )
+
+        result = fetch_change_history(page)
+
+        self.assertEqual([r["Gtid"] for r in result], ["a", "b", "c"])
+
+    def test_cursor_is_threaded_into_the_next_request(self):
+        """Offset-style replay would silently re-read page 1 forever."""
+        page = _page_with(
+            [
+                _payload([self._record("a")], next_token="tok-2"),
+                _payload([self._record("b")], next_token=None),
+            ]
+        )
+
+        fetch_change_history(page)
+
+        tokens = [body["variables"]["token"] for _, body, _ in page.request.calls]
+        self.assertEqual(tokens, [None, "tok-2"])
+
+    def test_stops_when_a_page_comes_back_empty(self):
+        page = _page_with(
+            [
+                _payload([self._record("a")], next_token="tok-2"),
+                _payload([], next_token="tok-3"),
+            ]
+        )
+
+        result = fetch_change_history(page)
+
+        self.assertEqual([r["Gtid"] for r in result], ["a"])
+        self.assertEqual(len(page.request.calls), 2)
+
+    def test_limit_bounds_total_records_and_stops_paginating(self):
+        page = _page_with(
+            [
+                _payload([self._record("a"), self._record("b")], next_token="tok-2"),
+                _payload([self._record("c")], next_token=None),
+            ]
+        )
+
+        result = fetch_change_history(page, limit=2)
+
+        self.assertEqual([r["Gtid"] for r in result], ["a", "b"])
+        self.assertEqual(len(page.request.calls), 1)
+
+    def test_limit_truncates_an_overshooting_page(self):
+        page = _page_with(
+            [_payload([self._record("a"), self._record("b")], next_token=None)]
+        )
+
+        result = fetch_change_history(page, limit=1)
+
+        self.assertEqual([r["Gtid"] for r in result], ["a"])
+
+    def test_non_positive_limit_is_rejected(self):
+        page = _page_with([_payload([])])
+
+        with self.assertRaises(ValueError):
+            fetch_change_history(page, limit=0)
+
+    def test_page_cap_stops_a_server_that_never_stops_paginating(self):
+        # One page repeated forever: without the cap this loops until OOM.
+        page = _page_with([_payload([self._record("a")], next_token="always")])
+
+        with patch.object(change_history, "_MAX_PAGES", 3):
+            result = fetch_change_history(page)
+
+        # Every page after the first is a duplicate, so dedup collapses them
+        # to one record — but the cap is what stops the requests.
+        self.assertEqual([r["Gtid"] for r in result], ["a"])
+        self.assertEqual(len(page.request.calls), 3)
+
+    def test_overlapping_pages_are_deduplicated_by_gtid(self):
+        """The cursor is a 1-second timestamp, so page boundaries overlap.
+
+        Measured live over 2026-07-01..08-13: 6877 rows for 3257 distinct
+        gtids. The first overlap landed on page 3, which is why a two-page
+        check reads as clean.
+        """
+        page = _page_with(
+            [
+                _payload([self._record("a"), self._record("b")], next_token="tok-2"),
+                # "b" repeats: it shares the previous page's last second.
+                _payload([self._record("b"), self._record("c")], next_token="tok-3"),
+                _payload([self._record("c"), self._record("d")], next_token=None),
+            ]
+        )
+
+        result = fetch_change_history(page)
+
+        self.assertEqual([r["Gtid"] for r in result], ["a", "b", "c", "d"])
+
+    def test_limit_counts_deduplicated_records(self):
+        """A limit must not be satisfied by duplicates of the same record."""
+        page = _page_with(
+            [
+                _payload([self._record("a")], next_token="tok-2"),
+                _payload([self._record("a")], next_token="tok-3"),
+                _payload([self._record("b")], next_token=None),
+            ]
+        )
+
+        result = fetch_change_history(page, limit=2)
+
+        self.assertEqual([r["Gtid"] for r in result], ["a", "b"])
+
+    def test_records_without_a_gtid_are_kept(self):
+        """A record the server sends without an id must not be dropped."""
+        record = self._record("a")
+        del record["gtid"]
+        page = _page_with([_payload([record, self._record("b")], next_token=None)])
+
+        result = fetch_change_history(page)
+
+        self.assertEqual([r["Gtid"] for r in result], [None, "b"])
+
+
+class TestFilters(unittest.TestCase):
+    def _body(self, page):
+        return page.request.calls[0][1]["variables"]
+
+    def test_filters_are_applied_server_side(self):
+        page = _page_with([_payload([])])
+
+        fetch_change_history(
+            page,
+            campaign_ids=[1, 2],
+            date_from="2026-08-01T00:00:00",
+            date_to="2026-08-02T23:59:59",
+            categories=["CAMPAIGN_STRATEGY"],
+            logins=["someone"],
+            change_sources=["API"],
+        )
+
+        variables = self._body(page)
+        self.assertEqual(variables["campaignIds"], [1, 2])
+        self.assertEqual(variables["dateFrom"], "2026-08-01T00:00:00")
+        self.assertEqual(variables["dateTo"], "2026-08-02T23:59:59")
+        self.assertEqual(variables["categories"], ["CAMPAIGN_STRATEGY"])
+        self.assertEqual(variables["logins"], ["someone"])
+        self.assertEqual(variables["changeSources"], ["API"])
+
+    def test_unset_filters_keep_the_pages_own_values(self):
+        """Notably `categories`: the UI sends 44 of them, guessing drops kinds."""
+        page = _page_with([_payload([])])
+
+        fetch_change_history(page)
+
+        variables = self._body(page)
+        self.assertEqual(
+            variables["categories"], ["CAMPAIGN_STRATEGY", "CAMPAIGN_ARCHIVED"]
+        )
+        self.assertEqual(variables["dateFrom"], "2026-08-05T17:00:00")
+        self.assertIsNone(variables["campaignIds"])
+
+    def test_login_variable_is_preserved(self):
+        """Dropping variables.login returns HTTP 200 + "Нет прав" (live)."""
+        page = _page_with([_payload([])], captured_variables={"login": "example-login"})
+
+        fetch_change_history(page, campaign_ids=[1])
+
+        self.assertEqual(self._body(page)["login"], "example-login")
+
+    def test_query_is_replayed_verbatim(self):
+        """Hand-assembling the GraphQL query would drift from Yandex's schema."""
+        page = _page_with([_payload([])])
+
+        fetch_change_history(page)
+
+        self.assertEqual(
+            page.request.calls[0][1]["query"],
+            _captured_request_body()["query"],
+        )
+
+    def test_captured_headers_are_replayed(self):
+        page = _page_with([_payload([])])
+
+        fetch_change_history(page)
+
+        self.assertEqual(page.request.calls[0][2]["x-csrf-token"], "fake-csrf")
+
+    def test_ulogin_is_stripped_from_the_replay_url(self):
+        """Unlike GridCampaigns, this endpoint needs no ulogin (live-confirmed)."""
+        page = _page_with([_payload([])])
+
+        fetch_change_history(page)
+
+        url = page.request.calls[0][0]
+        self.assertNotIn("ulogin", url)
+        self.assertIn("operationName=userActionLog", url)
+
+
+class TestErrorHandling(unittest.TestCase):
+    def test_graphql_errors_are_raised_not_read_as_empty(self):
+        """ "Нет прав" arrives as HTTP 200 + errors[] — a status check misses it."""
+        page = _page_with(
+            [
+                {
+                    "data": {"userActionLog": None},
+                    "errors": [{"message": "Нет прав"}],
+                }
+            ]
+        )
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            fetch_change_history(page)
+
+        self.assertIn("Нет прав", str(ctx.exception))
+
+    def test_http_error_is_reported(self):
+        response = _FakeResponse(
+            "https://direct.yandex.ru/web-api/user-action-log/api"
+            "?operationName=userActionLog",
+            post_data=json.dumps(_captured_request_body()),
+        )
+        page = FakePage(
+            log_response=response,
+            api_request=_FakeApiRequestContext(ok=False, status=500),
+        )
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            fetch_change_history(page)
+
+        self.assertIn("500", str(ctx.exception))
+
+    def test_non_json_response_is_reported(self):
+        response = _FakeResponse(
+            "https://direct.yandex.ru/web-api/user-action-log/api"
+            "?operationName=userActionLog",
+            post_data=json.dumps(_captured_request_body()),
+        )
+        page = FakePage(
+            log_response=response,
+            api_request=_FakeApiRequestContext(raw_body="<html>captcha</html>"),
+        )
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            fetch_change_history(page)
+
+        self.assertIn("non-JSON", str(ctx.exception))
+
+    def test_unexpected_schema_is_reported(self):
+        page = _page_with([{"data": {"somethingElse": {}}, "errors": []}])
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            fetch_change_history(page)
+
+        self.assertIn("expected shape", str(ctx.exception))
+
+    def test_capture_timeout_is_reported(self):
+        page = FakePage(log_response=None)
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            fetch_change_history(page)
+
+        self.assertIn("userActionLog", str(ctx.exception))
+
+    def test_captcha_propagates_rather_than_being_relabelled(self):
+        page = FakePage(log_response=None)
+
+        with patch.object(
+            change_history,
+            "assert_not_captcha",
+            side_effect=BrowserCaptchaError("captcha"),
+        ):
+            with self.assertRaises(BrowserCaptchaError):
+                fetch_change_history(page)
+
+    def test_auth_error_propagates_rather_than_being_relabelled(self):
+        """_with_session's self-heal retry depends on seeing this unchanged."""
+        page = FakePage(log_response=None)
+
+        with patch.object(
+            change_history,
+            "assert_authenticated",
+            side_effect=BrowserAuthError("logged out"),
+        ):
+            with self.assertRaises(BrowserAuthError):
+                fetch_change_history(page)
+
+
+class TestHistoryCommand(unittest.TestCase):
+    def setUp(self):
+        self.runner = CliRunner()
+
+    def _invoke(self, *args, records=None):
+        captured = {}
+
+        def _fake_fetch(page, **kwargs):
+            captured.update(kwargs)
+            return records if records is not None else []
+
+        def _fake_with_session(ctx, headful, profile_dir, chrome_profile, operation):
+            return operation(object())
+
+        with patch.object(change_history, "fetch_change_history", _fake_fetch):
+            with patch("direct_cli.commands.history._with_session", _fake_with_session):
+                result = self.runner.invoke(cli, ["history", "get", *args])
+        return result, captured
+
+    def test_outputs_records_as_json(self):
+        records = [{"Datetime": "2026-08-13T16:22:39", "CampaignId": 1}]
+        result, _ = self._invoke(records=records)
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("2026-08-13T16:22:39", result.output)
+
+    def test_campaign_ids_are_parsed_to_ints(self):
+        _, captured = self._invoke("--campaign-ids", "1, 2,3")
+
+        self.assertEqual(captured["campaign_ids"], [1, 2, 3])
+
+    def test_bare_dates_are_widened_to_cover_the_whole_day(self):
+        _, captured = self._invoke(
+            "--date-from", "2026-08-01", "--date-to", "2026-08-02"
+        )
+
+        self.assertEqual(captured["date_from"], "2026-08-01T00:00:00")
+        self.assertEqual(captured["date_to"], "2026-08-02T23:59:59")
+
+    def test_explicit_datetimes_pass_through_unchanged(self):
+        _, captured = self._invoke(
+            "--date-from", "2026-08-01T09:30:00", "--date-to", "2026-08-01T10:00:00"
+        )
+
+        self.assertEqual(captured["date_from"], "2026-08-01T09:30:00")
+        self.assertEqual(captured["date_to"], "2026-08-01T10:00:00")
+
+    def test_csv_options_are_split(self):
+        _, captured = self._invoke(
+            "--categories",
+            "CAMPAIGN_STRATEGY, CAMPAIGN_ARCHIVED",
+            "--logins",
+            "a,b",
+            "--change-sources",
+            "WEB",
+        )
+
+        self.assertEqual(
+            captured["categories"], ["CAMPAIGN_STRATEGY", "CAMPAIGN_ARCHIVED"]
+        )
+        self.assertEqual(captured["logins"], ["a", "b"])
+        self.assertEqual(captured["change_sources"], ["WEB"])
+
+    def test_unset_csv_options_stay_none(self):
+        """None must not collapse to [], which would filter everything out."""
+        _, captured = self._invoke()
+
+        self.assertIsNone(captured["categories"])
+        self.assertIsNone(captured["logins"])
+        self.assertIsNone(captured["change_sources"])
+        self.assertIsNone(captured["campaign_ids"])
+
+    def test_non_positive_limit_is_rejected(self):
+        result, _ = self._invoke("--limit", "0")
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("--limit", result.output)
+
+    def test_invalid_campaign_ids_are_rejected(self):
+        result, _ = self._invoke("--campaign-ids", "abc")
+
+        self.assertNotEqual(result.exit_code, 0)
+
+    def test_group_needs_no_api_credentials(self):
+        """Browser-backed: authorizes off the session, not off a token."""
+        from direct_cli.cli import _NO_CREDENTIALS_GROUPS
+
+        self.assertIn("history", _NO_CREDENTIALS_GROUPS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_comprehensive.py
+++ b/tests/test_comprehensive.py
@@ -65,6 +65,7 @@ class TestCommandsRegistered(unittest.TestCase):
         "v4meta",
         "auth",
         "masters",
+        "history",
         "playwright",
     ]
 


### PR DESCRIPTION
## Проблема

У API Директа нет журнала изменений по полям: `changes.checkCampaigns` отдаёт только `ChangesIn`, `changes.check` — голые списки ID, а `GetEventsLog` (v4) логирует лишь системные события. Ни один не отвечает на вопрос «кто, когда и с какого на какое значение поменял поле» — тот самый вопрос, который возникает, когда массовая правка молча снесла цель стратегии или счётчик Метрики.

## Решение

Новая browser-команда `direct history get`, переиспользующая session-стек `masters` (`--headful`/`--profile-dir`/`--chrome-profile`, без `--login`).

**Отдельная группа, а не подкоманда `masters`** — раздел общеаккаунтный: его записи покрывают обычные ТГО/ЕПК кампании, группы и объявления не меньше, чем Мастеров, а `--campaign-ids` — лишь фильтр поверх этого.

**Playwright-скрапинг DOM не понадобился.** Живая разведка показала, что раздел управляется собственным GraphQL-вызовом `POST /web-api/user-action-log/api?operationName=userActionLog` — как грид в #639. Захваченный запрос воспроизводится дословно (query ~5.7 КБ фрагментов, варьируются только `variables`), значения приходят уже типизированными и необрезанными.

## Что установила живая разведка

Два отличия от грида кампаний, оба подтверждены на реальном аккаунте:

- **`variables.login` обязателен** — без него HTTP 200 + `errors: ["Нет прав"]`, а не ошибка авторизации. Поэтому логин читается из захваченного запроса, а не выдумывается.
- **URL-параметр `ulogin` НЕ нужен** — прямо противоположно `GridCampaigns`, где собственный логин в `ulogin` даёт HTTP 401 «Доступ ограничен».

## Баг пагинации, найденный живой проверкой

Курсор — таймстемп с **секундной** гранулярностью (`nextPageToken` декодируется в `{"t": <unix seconds>, …}`), поэтому соседние страницы перекрываются по записям, попавшим в одну секунду.

На двух страницах это невидимо — первое перекрытие пришлось на страницу 3. На реальном диапазоне 2026-07-01..08-13 отдавалось **6877 строк при 3257 уникальных** записях. Дедуп идёт по `gtid` (собственный ID записи у сервера), а не по телу записи: одна и та же кампания, заархивированная дважды, легитимно выглядит одинаково.

После фикса на том же диапазоне: **3257 / 3257, дублей нет.**

## Формат вывода

Плоские `Datetime`, `Login`, `ChangeSource`, `Category`, `EventType`, `CampaignId`/`CampaignName` + событие как есть под `Event`. `Event` не разбирается по типам намеренно — это union с разной схемой на каждый `__typename` (живьём встречено 7+ видов), так что новый вид события появится как данные, а не как ошибка парсинга.

Исходный кейс issue читается напрямую: `Event.oldStrategy.goalId` → `Event.newStrategy.goalId`.

## Verification

- **Офлайн:** 3581 passed, 23 skipped (весь набор). 36 новых тестов в `tests/test_change_history.py`.
- **Живьём** (аккаунт ksamatadirect):
  - `history get --limit 3` — end-to-end работает;
  - `history get --campaign-ids 77593206 --categories CAMPAIGN_STRATEGY` — серверная фильтрация подтверждена, видно `goalId: 159614149 → None` (снятая цель стратегии) с датой и автором;
  - многостраничный прогон 2026-07-01..08-13 — до фикса 6877/3257, после 3257/3257.
- `black --check` / `flake8` по изменённым файлам чисты.

## Область, оставленная за рамками

Типизированный человекочитаемый diff по каждому виду события — отдельная задача: видов 7+, схемы разные, риск дрейфа схемы Яндекса выше. Сейчас консьюмер разбирает `Event` сам (как `ksamata_sales_2026` парсит JSON из stdout).

Closes #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lb3YNL4EWkmmUgwVNK9Uzh