### PR TITLE
fix(masters): promotion-goal dropdown race, counters section diagnosis, counters get (#840, #842, #843)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,6 +229,35 @@ confirmed unchanged before and after.
 
 ### Fixed
 
+**`masters update --promotion-goal` — retry a swallowed dropdown click, and
+report Yandex's own rejection text (#840).**
+
+`--promotion-goal max-conversions` failed with "Could not find the 'Максимум
+целевых действий' option in the 'Цель продвижения' dropdown — Yandex may have
+changed the page's markup" on campaigns whose markup had not changed at all.
+Live recon (campaign 74736436) confirmed the heading, the trigger XPath and
+the `CampaignTargetSelect.TargetSelect.ListBox.INVOLVED_CONVERSION` testid all
+still match; instrumenting a failing run found the real cause — the same
+menu-trigger hydration race as #723/#725. The trigger already matched
+(`count=1`) while un-hydrated (`aria-expanded=None`, empty `inner_text()`), so
+Playwright's actionability check passed, the click landed on a node with no
+React handler attached, and nothing opened. Because the option rows exist in
+the DOM only while the dropdown is open, the follow-up `option.click()` then
+misreported a hydration race as a markup change. `_set_promotion_goal` now
+opens the dropdown through `_click_and_wait_for_popup` (retrying the open),
+like the other menu/modal triggers in this module.
+
+Saves refused by Yandex's client-side validation are also no longer reported
+with a generic "Yandex may have rejected the value". `update_master` now reads
+the inline error text before `_verify_saved`'s reload discards it and quotes it
+back — closing the follow-up the module docstring's "Save verification"
+paragraph had left open. On a campaign with no Metrika goals, switching to
+`max-conversions` is refused outright (the save request is never sent), and the
+error now names why: "Добавьте хотя бы одну цель для сайта, чтобы создать и
+запустить кампанию." Note that the "Счетчики Яндекс Метрики" section itself
+only renders once the promotion goal is `max-conversions`, so a campaign that
+lost both needs the counter, the goal and the promotion goal set in one call.
+
 **`masters launch`/`masters update --launch` — diagnose an empty "Целевые
 действия" table instead of a generic redirect timeout (#823).**
 

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -186,9 +186,14 @@ was requested after a real reload, it raises ``BrowserSessionError`` rather
 than reporting false success. This mirrors ``_suspend_or_resume``'s
 "a click that doesn't visibly change the state is a hard error, not a
 silent success" convention, applied to the whole-form save instead of a
-single status field. Not yet covered: an inline validation-error TEXT is
-not itself surfaced to the caller (only the resulting mismatch is) — a
-follow-up could read and report Yandex's actual rejection reason.
+single status field. Since issue #840 the inline validation-error TEXT is
+also surfaced: ``update_master`` calls ``_read_save_validation_errors``
+right after the save click (before ``_verify_saved``'s reload discards it)
+and the resulting mismatch error quotes Yandex's own wording — e.g.
+"Добавьте хотя бы одну цель для сайта…" for a ``--promotion-goal
+max-conversions`` save on a campaign with no Metrika goals. That read is
+best-effort and never changes control flow: the mismatch itself remains
+the thing that decides success or failure.
 
 ``create_master`` (issue #632) — **live-verified end to end for the DRAFT
 leg** (#777, 2026-08-06): a full ``--draft`` create was accepted by Yandex
@@ -1981,6 +1986,24 @@ _VERIFY_RELOAD_BACKOFF_MS = 5_000
 _SAVE_BUTTON_TEXT = "Сохранить кампанию"
 _LAUNCH_BUTTON_TEXT = "Запустить кампанию"
 _SAVE_DRAFT_BUTTON_TEXT = "Сохранить как черновик"
+
+# Inline validation-error text rendered into the still-open edit form when
+# Yandex's client-side validation refuses a save (issue #840). Matched by
+# class substring / role rather than a data-testid: unlike the option rows
+# and terminal buttons this module targets, these messages carry no stable
+# testid of their own, and this selector only ever ENRICHES an error that
+# is already being raised (see _read_save_validation_errors) — a miss
+# degrades the message, it never changes control flow. Confirmed live on
+# campaign 74736436, which reports both a pre-existing keyword-count
+# warning and the goal-required rejection that blocks the save itself.
+_SAVE_VALIDATION_ERROR_SELECTOR = '[class*="error"], [class*="Error"], [role="alert"]'
+
+# Cap on how many distinct validation messages are quoted back. The page
+# can carry unrelated pre-existing warnings (e.g. the keyword-count notice
+# above) alongside the one that actually blocked the save, and this module
+# has no reliable way to tell them apart — report a bounded list and let
+# the operator judge, rather than guessing wrong or dumping the whole form.
+_SAVE_VALIDATION_ERROR_LIMIT = 5
 
 # DRAFT edit page's terminal buttons (issue #668, live-confirmed 2026-08-02
 # against campaign 713231614 — see the module docstring's "DRAFT support"
@@ -4598,6 +4621,25 @@ def _set_promotion_goal(page: "Page", goal: str) -> None:
     mirrors ``_suspend_or_resume``'s "never trust the click alone"
     convention.
 
+    The dropdown is opened via ``_click_and_wait_for_popup``, not a bare
+    ``trigger.click()`` (issue #840, live-confirmed on campaign 74736436):
+    this trigger is subject to the same menu-trigger hydration race as
+    issues #723/#725. Instrumenting a real failing run showed the trigger
+    ALREADY matched (``count=1``) while still un-hydrated —
+    ``aria-expanded=None`` and an empty ``inner_text()`` — so Playwright's
+    actionability check passed and the click landed on a node whose React
+    handler was not attached yet. Nothing raised, but the listbox never
+    mounted; 2s later the trigger had hydrated to ``aria-expanded='false'``,
+    confirming the click had been swallowed rather than the dropdown having
+    opened and closed. Because the option rows exist in the DOM *only* while
+    the dropdown is open, the old code's unconditional ``option.click()``
+    then failed with "Could not find the ... option ... Yandex may have
+    changed the page's markup" — a misdiagnosis, since the markup was
+    verified byte-identical to what this module expects (heading, trigger
+    XPath and ``ListBox.<value>`` testids all matched live). Retrying the
+    open is safe here for the same reason ``_click_and_wait_for_popup``
+    documents: opening a dropdown has no side effect on the campaign.
+
     Matched by data-testid, not accessible-name text (issue #696
     re-investigation, 2026-08-04): Yandex now appends a description sentence
     and, for some rows, a "Рекомендуем" badge to each option's accessible
@@ -4615,30 +4657,23 @@ def _set_promotion_goal(page: "Page", goal: str) -> None:
         )
 
     trigger = page.locator(_PROMOTION_GOAL_BUTTON_XPATH).first
-    try:
-        trigger.click()
-    except PlaywrightError as exc:
-        raise BrowserSessionError(
-            "Could not find or open the 'Цель продвижения' dropdown on the "
-            "campaign edit page — Yandex may have changed the page's "
-            "markup. Re-run with --headful to inspect the page."
-        ) from exc
-
     option_testid = _PROMOTION_GOAL_OPTION_TESTID_TEMPLATE.format(value=internal_value)
-    option = page.locator(f'[data-testid="{option_testid}"]').first
-    clicked = False
+    option_selector = f'[data-testid="{option_testid}"]'
+    _click_and_wait_for_popup(
+        page,
+        trigger_selector=_PROMOTION_GOAL_BUTTON_XPATH,
+        popup_selector=option_selector,
+        description="the 'Цель продвижения' dropdown",
+    )
+
+    option = page.locator(option_selector).first
     try:
         option.click()
-        clicked = True
-    except PlaywrightError:
-        clicked = False
-
-    if not clicked:
+    except PlaywrightError as exc:
         raise BrowserSessionError(
-            f"Could not find the {label!r} option in the 'Цель продвижения' "
-            "dropdown on the campaign edit page — Yandex may have changed "
-            "the page's markup. Re-run with --headful to inspect the page."
-        )
+            f"Opened the 'Цель продвижения' dropdown but could not click the "
+            f"{label!r} option — verify manually before retrying."
+        ) from exc
 
     if not _trigger_shows_selection(trigger, label):
         try:
@@ -6556,6 +6591,44 @@ def _wait_for_draft_status(page: "Page", campaign_id: int) -> bool:
     return state == "draft"
 
 
+def _read_save_validation_errors(page: "Page") -> List[str]:
+    """Read Yandex's inline validation-error text from the edit page.
+
+    Closes the follow-up the module docstring's "Save verification"
+    paragraph left open (issue #840): until now a save that Yandex's
+    client-side validation refused surfaced only as a post-reload field
+    mismatch, so the caller was told the value "did not save" with no hint
+    as to why. These messages ARE readable — confirmed live on campaign
+    74736436, whose ``--promotion-goal max-conversions`` save is rejected
+    with "Добавьте хотя бы одну цель для сайта, чтобы создать и запустить
+    кампанию." because the campaign has no Metrika goals (the same
+    goal-required rule ``create_master`` hits).
+
+    Must be called BEFORE ``_verify_saved`` re-navigates: the messages are
+    rendered into the still-open form by the save click and do not survive
+    the reload. Best-effort by design — this only enriches an error message
+    that is already being raised, so any failure to read returns an empty
+    list rather than masking the real mismatch error.
+    """
+    try:
+        texts = page.eval_on_selector_all(
+            _SAVE_VALIDATION_ERROR_SELECTOR,
+            "els => els.map(e => e.innerText.trim()).filter(Boolean)",
+        )
+    except PlaywrightError:
+        return []
+
+    seen: List[str] = []
+    for raw in texts or []:
+        # NBSP is used liberally in these strings (confirmed live); collapse
+        # it along with the rest of the whitespace so the reported text is
+        # greppable and matches what the user sees.
+        text = " ".join(str(raw).split())
+        if text and text not in seen:
+            seen.append(text)
+    return seen[:_SAVE_VALIDATION_ERROR_LIMIT]
+
+
 def _click_save(
     page: "Page", campaign_id: int, *, is_draft: bool, launch: bool = False
 ) -> None:
@@ -7008,6 +7081,7 @@ def _verify_saved(
     add_sitelinks: Optional[List[Dict[str, str]]] = None,
     remove_sitelink_indices: Optional[List[int]] = None,
     clicked_button_label: str = _SAVE_BUTTON_TEXT,
+    validation_errors: Optional[List[str]] = None,
 ) -> None:
     """Reload the edit page and confirm every requested field actually saved.
 
@@ -7659,12 +7733,28 @@ def _verify_saved(
     )
 
     if mismatches:
+        # Quote Yandex's own rejection text when the caller captured it at
+        # save time (issue #840) — without it the operator is told only
+        # THAT the value did not save, and the actual reason (e.g. "add at
+        # least one goal") is invisible. Falls back to the original generic
+        # wording when nothing was readable, so a selector miss degrades
+        # the message rather than hiding the mismatch.
+        detail = (
+            " Yandex reported: " + " | ".join(validation_errors) + "."
+            if validation_errors
+            else (
+                " Yandex may have rejected the value (client-side "
+                "validation) or the save did not complete."
+            )
+        )
         raise BrowserSessionError(
             f"Clicked '{clicked_button_label}' for campaign {campaign_id}, "
             "but re-reading the edit page after reload shows it did not "
-            "save as requested: " + "; ".join(mismatches) + ". Yandex may "
-            "have rejected the value (client-side validation) or the save "
-            "did not complete — verify manually before retrying."
+            "save as requested: "
+            + "; ".join(mismatches)
+            + "."
+            + detail
+            + " Verify manually before retrying."
         )
 
 
@@ -8438,6 +8528,11 @@ def update_master(
 
     _click_save(page, campaign_id, is_draft=was_draft, launch=launch)
 
+    # Read Yandex's inline rejection text BEFORE _verify_saved reloads the
+    # page away (issue #840) — these messages live only in the still-open
+    # form. Best-effort: used purely to enrich a failure message.
+    save_validation_errors = _read_save_validation_errors(page)
+
     # The terminal-button click above already happened — irreversible, and
     # for images NOT idempotent (a retry would re-snapshot the
     # already-mutated set and replace DIFFERENT images than the ones the
@@ -8497,6 +8592,7 @@ def update_master(
             add_sitelinks=add_sitelinks_observed,
             remove_sitelink_indices=remove_sitelinks,
             clicked_button_label=clicked_button_label,
+            validation_errors=save_validation_errors,
         )
     except BrowserAuthError as exc:
         raise BrowserSessionError(

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -6403,6 +6403,110 @@ class TestSetPromotionGoal(unittest.TestCase):
             browser_masters._set_promotion_goal(page, "max-clicks")
         self.assertIn("does not show it", str(ctx.exception))
 
+    def test_retries_open_when_first_trigger_click_is_swallowed(self):
+        # Regression test for issue #840, reproduced live on campaign
+        # 74736436: the trigger matches (count=1) while React has not yet
+        # attached its click handler, so Playwright's actionability check
+        # passes, the click lands on the un-hydrated node and NOTHING
+        # happens — instrumenting a real failing run showed the trigger
+        # still reporting aria-expanded=None with an empty inner_text() at
+        # click time, hydrating to 'false' 2s later. Because the option
+        # rows only exist in the DOM while the dropdown is open, the old
+        # single-click code then reported "Could not find the ... option
+        # ... Yandex may have changed the page's markup" — a misdiagnosis,
+        # since the markup was verified byte-identical. The open must
+        # therefore be retried (via _click_and_wait_for_popup) rather than
+        # trusted once.
+        state = {"selected_line": "Максимум переходов", "trigger_clicks": 0}
+
+        def _select():
+            state["selected_line"] = "Максимум целевых действий"
+
+        option = _FakeLocatorHandle(visible=False, on_click=_select)
+        option_selector = f'[data-testid="{self._option_testid("max-conversions")}"]'
+
+        def _on_trigger_click():
+            # The FIRST click is swallowed by the hydration race and leaves
+            # the listbox unmounted; only a later one actually opens it.
+            state["trigger_clicks"] += 1
+            if state["trigger_clicks"] > 1:
+                option._visible = True
+
+        trigger = _FakeLocatorHandle(
+            text=self._TRIGGER_LABEL, on_click=_on_trigger_click
+        )
+        trigger.inner_text = lambda: f"{self._TRIGGER_LABEL}\n{state['selected_line']}"
+
+        page = FakePage(
+            locators={
+                browser_masters._PROMOTION_GOAL_BUTTON_XPATH: _FakeLocator([trigger]),
+                option_selector: _FakeLocator([option]),
+            },
+        )
+
+        browser_masters._set_promotion_goal(page, "max-conversions")
+
+        self.assertGreater(state["trigger_clicks"], 1)
+        self.assertEqual(state["selected_line"], "Максимум целевых действий")
+
+
+class TestReadSaveValidationErrors(unittest.TestCase):
+    """``_read_save_validation_errors`` (issue #840).
+
+    Yandex's client-side validation can refuse a save outright — confirmed
+    live on campaign 74736436, where ``--promotion-goal max-conversions``
+    never reaches the server because the campaign has no Metrika goals.
+    Before this the operator only saw "it did not save"; the reason is now
+    quoted back.
+    """
+
+    def test_reads_and_normalises_messages(self):
+        goal_required_raw = (
+            "Добавьте хотя\xa0бы одну цель для сайта,\n"
+            "чтобы создать и\xa0запустить кампанию."
+        )
+        goal_required = (
+            "Добавьте хотя бы одну цель для сайта, "
+            "чтобы создать и запустить кампанию."
+        )
+        page = FakePage()
+        page.eval_on_selector_all = lambda selector, script: [
+            # NBSP + newlines, exactly as the live page renders them.
+            "Вы\xa0добавили 200 ключевых фраз\xa0— это пока максимум",
+            goal_required_raw,
+        ]
+
+        self.assertEqual(
+            browser_masters._read_save_validation_errors(page),
+            [
+                "Вы добавили 200 ключевых фраз — это пока максимум",
+                goal_required,
+            ],
+        )
+
+    def test_deduplicates_and_caps(self):
+        page = FakePage()
+        page.eval_on_selector_all = lambda selector, script: ["же самое"] * 3 + [
+            f"ошибка {i}" for i in range(10)
+        ]
+
+        result = browser_masters._read_save_validation_errors(page)
+
+        self.assertEqual(result[0], "же самое")
+        self.assertEqual(len(result), browser_masters._SAVE_VALIDATION_ERROR_LIMIT)
+
+    def test_returns_empty_on_read_failure(self):
+        # Best-effort by design: this only enriches an error that is already
+        # being raised, so a selector miss must never mask the real mismatch.
+        page = FakePage()
+
+        def _raise(selector, script):
+            raise PlaywrightError("no such selector")
+
+        page.eval_on_selector_all = _raise
+
+        self.assertEqual(browser_masters._read_save_validation_errors(page), [])
+
 
 class TestSetGoalPrice(unittest.TestCase):
     """``_set_goal_price``/``_read_goal_price`` (issue #696).
@@ -9627,9 +9731,10 @@ class TestUpdateMaster(unittest.TestCase):
             calls.append(("landing_url", value))
             original_set_landing_url(_page, value)
 
-        with patch.object(
-            browser_masters, "_set_tracking_params", set_tracking_params
-        ), patch.object(browser_masters, "_set_landing_url", set_landing_url):
+        with (
+            patch.object(browser_masters, "_set_tracking_params", set_tracking_params),
+            patch.object(browser_masters, "_set_landing_url", set_landing_url),
+        ):
             browser_masters.update_master(
                 page,
                 42,


### PR DESCRIPTION
Три связанные проблемы вокруг секций «Цель продвижения» / «Счетчики Яндекс Метрики» на edit-странице Мастера. Всё найдено живой разведкой на реальном аккаунте, ничего в продакшене не изменено.

## #840 — дропдаун «Цель продвижения»

Падало с «Could not find the 'Максимум целевых действий' option … Yandex may have changed the page's markup» при **неизменной** разметке.

Все три гипотезы из issue опровергнуты: текст пункта тот же, гонки рендера опции нет (<100 мс, стабильно), промо-цель была `max-clicks`, а не «уже выбрана». Заголовок, XPath триггера и testid `…ListBox.INVOLVED_CONVERSION` совпадают с кодом 1:1.

Настоящая причина — **гонка гидратации триггера** (тот же класс, что #723/#725):

```
before-click: count=1  aria-expanded=None   text=''
after-click:  count=1  aria-expanded='false' text='Цель продвижения | Максимум переходов'
option count: 0
```

Триггер уже сматчен, но React-обработчик не навешен → actionability-проверка проходит, клик уходит в никуда. Опции живут в DOM **только при открытом дропдауне**, поэтому безусловный `option.click()` рапортовал гонку как дрейф разметки.

Фикс: открытие через `_click_and_wait_for_popup` (с ретраями) — безопасно ровно по причине, задокументированной в самом хелпере.

Плюс закрыт follow-up, который docstring модуля отмечал как непокрытый: `update_master` читает инлайн-текст валидации **до** релоада и цитирует его. Живо подтверждено, что кампания без целей Метрики получает отказ клиентской валидации (save-запрос вообще не уходит):

> Yandex reported: … | Добавьте хотя бы одну цель для сайта, чтобы создать и запустить кампанию.

## #843 — launcher секции счётчиков

Падало с «Could not click the 'Счетчики Яндекс Метрики' launcher button — Yandex may have changed the page's markup», отправляя искать несуществующий дрейф testid.

Селектор верный — секции просто нет:

```
74736436 (max-clicks):       block=1 launcher=1  @ t+0
                             block=0 launcher=0  @ t+3s, t+6s, t+10s
713234204 (max-conversions): block=1 launcher=1
```

Блок присутствует в первом рендере и **демонтируется**, когда форма устаканивается на `max-clicks`. Ошибка теперь называет предусловие и способ починки.

## #842 — `masters counters get`

Новая read-only команда, сиблинг `masters targetactions get`/`masters audience get`. Цель добавляется только из целей **привязанного** счётчика, поэтому «`--add-target-action` не находит цель» и «счётчик вообще не привязан» раньше выглядели из CLI одинаково.

```
$ direct masters counters get 713234204
{"CampaignId": 713234204, "SectionPresent": true,
 "Counters": [{"CounterId": 72112213, "Domain": "gc.ksamata.ru",
               "Text": "gc.ksamata.ru • 72112213\n30 целей"}], "Count": 1}

$ direct masters counters get 74736436
{"CampaignId": 74736436, "SectionPresent": false, "Counters": [], "Count": 0}
```

Две живо измеренные ловушки чтения — обе делают одиночный сэмпл **уверенно неверным**, а не просто ранним:

1. блок демонтируется под `max-clicks` (см. выше) — зеркало обычных гонок модуля, где транзиентно именно *отсутствие*;
2. текст тега гидратируется в два этапа: `"72112213"` на t+0 → `"gc.ksamata.ru • 72112213\n30 целей"` с t+4s. Ранний вид без разделителя парсится в `CounterId: null`, хотя id прямо там.

Обе решены поллингом до **стабильного** чтения (конвенция `_wait_for_target_actions_settled`).

## #844 — порядок мутаций (найдено по ходу)

`update_master` привязывал счётчики на ~200 строк ПОЗЖЕ, чем добавлял цели, поэтому
`--add-metrika-counter` вместе с `--add-target-action` в одном вызове был невозможен
by construction: цель искалась по набору счётчиков, каким он был ДО привязки.

Это ошибка порядка, а не гонка — ожидание в старой позиции не помогает никогда.
С привязанным первым счётчиком popup отдаёт 61 опцию, стабильно с t+1s до t+20s.

Живо проверено end-to-end на 74736436: кампания сохраняет промо-цель, счётчик и цель
одним вызовом (`counters get` → CounterId 72112213; `targetactions get` → 226332091 @ 150).
Регресс-тест на порядок вызовов подтверждён падающим на старом порядке.

## Тесты

Регресс-тесты: проглоченный клик по триггеру; `_read_save_validation_errors` (NBSP-нормализация, дедуп/лимит, best-effort); `_parse_metrika_counter_tag` (живая форма, догидратационный bare id, autocomplete-форма); CLI-обвязка `counters get`. Команда добавлена в `smoke_matrix` как SAFE. `black`/`flake8` чисто, офлайн-сюита **3612 passed**.

Closes #840
Closes #842
Closes #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yah1788NPNXovBV8hFqe2

Closes #844
