### PR TITLE
fix(masters): read the counter suggestion popup, accept a bare counter id (#846)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,6 +260,78 @@ Both are handled by polling for a *stable* reading, mirroring
 
 ### Fixed
 
+**`masters update --add-metrika-counter` — read the suggestion popup at all,
+and accept a bare counter id (#846).**
+
+The counter autocomplete could never match anything, for any input. The option
+search was scoped to `[data-testid="MetrikaCountersTagGroup.editor.listBox"]`,
+but no element carries that testid: live recon (campaign 74099856) found the
+suggestions are portalled into a `dc-Popup` under `<body>` — outside the editor
+subtree entirely — and the `…editor.listBox` string appears only as the *prefix*
+of each option's own testid, `…editor.listBox.{counter id}`. The locator
+resolved to zero elements, `get_by_role("option")` under it always counted 0,
+and every add timed out.
+
+The timeout was reported as "No suggestion exactly matching {text} appeared",
+which blamed the caller's text for a selector bug — the operator in #846 spent
+three attempts (bare id, domain, full `label • domain • id` line) trying to
+respell a value that was never being compared against anything.
+
+Options are now located directly by that testid prefix, and because the testid
+carries the counter id, `--add-metrika-counter` accepts the **bare numeric id**:
+
+```
+direct masters update <id> --promotion-goal max-conversions \
+  --add-metrika-counter 72112213
+```
+
+The id is matched against the option's own id, never as a substring of the
+display text, so a short id cannot silently select a counter whose label or
+domain merely contains those digits. The full suggestion line still works. This
+closes the round trip with `masters counters get`, whose `CounterId` can now be
+passed straight back in — its tag text (`gc.ksamata.ru • 72112213`) has a
+different shape from the suggestion (`Ксамата Директ • gc.ksamata.ru •
+72112213`) and never could be.
+
+Both failure messages now diagnose rather than accuse: a non-match lists what
+Yandex actually offered, and an empty list points at account access to the
+counter, since the search runs server-side on partial input (typing `7211`
+surfaces the full suggestion).
+
+Live-verified end to end on campaign 74099856: the counter links, its tag
+renders, and the "Счетчик отсутствует" warning under «Целевые действия» clears.
+That recon was deliberately not saved.
+
+**`masters counters get` — stop reporting an unstable `SectionPresent` (#846).**
+
+The same campaign could report `SectionPresent: true` in one run and `false` in
+the next with no update in between. `_metrika_counters_section_present` already
+polled for a *stable* answer rather than trusting one sample — the block is
+briefly rendered at t+0 on a max-clicks campaign and unmounted once the form
+settles (~t+3000ms live) — but its stability window was calibrated shorter than
+the transient it guards against.
+
+At 500ms × 3 ticks the loop settles after 3 samples spanning 2 gaps, ~1.0s: it
+certified "stably present" a full 2 seconds *before* the unmount. Whether a run
+saw `true` or `false` came down to how the poll ticks happened to line up
+against the flip.
+
+The window is now 500ms × 8 (~3.5s of agreement) against its own 8s budget,
+rather than borrowing the autocomplete's 5s. The budget must exceed *flip +
+window*, not just the window, because the run of agreement only starts after
+the flip — at 5s the max-clicks case never settled at all and reached the right
+answer only through the "report the last read" fallback, which is not a
+property worth depending on. Both outcomes now settle deliberately:
+max-conversions at ~3.5s, max-clicks at ~6.5s.
+
+The presence locator is also re-resolved per sample instead of once before the
+loop. Playwright locators are lazy and re-query on each `count()`, so this was
+not itself the live bug, but a loop whose entire purpose is watching the DOM
+change should not depend on that implicitly.
+
+Regression tests model the live timeline against the fake clock and fail on the
+old constants.
+
 **`masters update` — apply Metrika counters BEFORE target actions (#844).**
 
 `update_master` linked counters ~200 lines *after* it added target actions, so

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -1783,8 +1783,20 @@ _METRIKA_COUNTER_LAUNCHER_TESTID = '[data-testid="MetrikaCountersTagGroup.launch
 _METRIKA_COUNTER_INPUT_TESTID = (
     '[data-testid="MetrikaCountersTagGroup.editor.Textinput"]'
 )
-_METRIKA_COUNTER_LISTBOX_TESTID = (
-    '[data-testid="MetrikaCountersTagGroup.editor.listBox"]'
+# The suggestion popup is NOT a descendant of the editor: it is portalled to
+# a `dc-Popup` directly under <body> (live recon, issue #846, campaign
+# 74099856). Scoping the option search to the editor subtree — or to an
+# element whose data-testid EQUALS "...editor.listBox" — matches nothing,
+# because no element carries that exact testid: it exists only as the PREFIX
+# of each option's own testid, "...editor.listBox.{counter id}". The previous
+# `[data-testid="...editor.listBox"]` locator therefore resolved to zero
+# elements on every campaign, so `get_by_role("option")` under it always
+# counted 0 and every add timed out — reported as "no suggestion matching
+# {text}", which blamed the caller's text for a selector bug and cost the
+# operator three wrong guesses at the spelling before this recon.
+_METRIKA_COUNTER_OPTION_TESTID_PREFIX = "MetrikaCountersTagGroup.editor.listBox."
+_METRIKA_COUNTER_OPTION_SELECTOR = (
+    f'[data-testid^="{_METRIKA_COUNTER_OPTION_TESTID_PREFIX}"]'
 )
 _METRIKA_COUNTER_TESTID_TEMPLATE = "MetrikaCountersTagGroup.tag.{index}"
 _METRIKA_COUNTER_CLOSE_TESTID_TEMPLATE = "MetrikaCountersTagGroup.tag.{index}.close"
@@ -1802,8 +1814,31 @@ _METRIKA_COUNTERS_BLOCK_TESTID = '[data-testid="MetrikaCountersBlock"]'
 # _metrika_counters_section_present polls for a STABLE presence reading
 # rather than trusting one sample — see its docstring for the measured
 # t+0/t+3s flip that makes a single read confidently wrong.
+#
+# THE STABILITY WINDOW MUST OUTLAST THE TRANSIENT IT GUARDS AGAINST (#846).
+# These were 500ms x 3 ticks, which settles after 3 samples spanning only 2
+# gaps — ~1.0s — while the measured unmount lands at t+3000ms. The poller
+# therefore certified "stably present" a full 2s BEFORE the block went away,
+# and `masters counters get` returned SectionPresent: true on a max-clicks
+# campaign that has no counters section at all — the intermittent true/false
+# between consecutive reads reported in #846, with no update in between.
+#
+# The window is now 500ms x 8 = ~3.5s of agreement, which spans the flip with
+# margin. Keep POLL_MS * (STABLE_TICKS - 1) comfortably ABOVE 3000ms if these
+# are ever retuned; raising POLL_MS alone widens it just as well as raising
+# the tick count. The 5s overall budget still bounds the call.
 _METRIKA_COUNTERS_SECTION_POLL_MS = 500
-_METRIKA_COUNTERS_SECTION_STABLE_TICKS = 3
+_METRIKA_COUNTERS_SECTION_STABLE_TICKS = 8
+
+# This poller needs its OWN budget rather than borrowing the autocomplete's
+# 5s: a ~3.5s stability window cannot also settle a flip that happens at
+# t+3000ms inside 5s, because the run of agreement only STARTS after the
+# flip. At 5s the max-clicks case never settled and fell through to the
+# "report the last read" fallback — it returned the right answer by accident,
+# which is not a property worth depending on. At 8s both cases settle on
+# their own merits: max-conversions (never flips) at ~3.5s, max-clicks at
+# ~6.5s. Only reached on campaigns whose section is genuinely absent.
+_METRIKA_COUNTERS_SECTION_TIMEOUT_MS = 8_000
 
 # Reuses the same 5s budget ``_AUDIENCE_TAG_SUGGEST_TIMEOUT_MS`` uses for its
 # own autocomplete popup — no live timing recon exists yet for THIS widget's
@@ -5740,13 +5775,33 @@ def _metrika_counters_section_present(page: "Page") -> bool:
     So this polls for a STABLE answer instead: the block's presence must
     read the same on consecutive ticks before it is believed, mirroring
     ``_wait_for_target_actions_settled``'s "settled snapshot" convention.
+
+    THE WINDOW MUST OUTLAST THE FLIP (#846). The original 500ms x 3 ticks
+    settles after 3 samples spanning 2 gaps — ~1.0s — i.e. it certified
+    "stably present" ~2s BEFORE the t+3000ms unmount, which is exactly the
+    bug it was written to prevent: ``masters counters get`` reported
+    ``SectionPresent: true`` on a max-clicks campaign in one run and
+    ``false`` in the next, with no update in between, and the true/false
+    split tracked nothing but how the poll ticks happened to line up
+    against the unmount.
+
+    Now 500ms x 8 ticks (~3.5s of agreement) against an 8s budget, so both
+    outcomes settle deliberately rather than via the fallback: a
+    max-conversions campaign (never flips) settles ``True`` at ~3.5s, a
+    max-clicks one settles ``False`` at ~6.5s, having watched the block go
+    away and stay away. Note the run of agreement only STARTS after the
+    flip, which is why the budget must exceed flip + window, not just the
+    window.
     """
-    deadline = _clock.now() + _METRIKA_COUNTER_SUGGEST_TIMEOUT_MS / 1000
-    locator = page.locator(_METRIKA_COUNTERS_BLOCK_TESTID)
+    deadline = _clock.now() + _METRIKA_COUNTERS_SECTION_TIMEOUT_MS / 1000
 
     def _present() -> bool:
+        # Re-resolve the locator on every sample. A Playwright locator is
+        # lazy and would re-query on each `count()`, but relying on that
+        # makes the poll silently depend on it — and this loop exists
+        # precisely to observe the DOM CHANGING under it.
         try:
-            return locator.count() > 0
+            return page.locator(_METRIKA_COUNTERS_BLOCK_TESTID).count() > 0
         except PlaywrightError:
             return False
 
@@ -5903,40 +5958,83 @@ def _parse_metrika_counter_tag(text: str) -> Dict[str, Any]:
     }
 
 
+def _read_metrika_counter_suggestions(page: "Page") -> List[str]:
+    """Read the suggestion lines currently in the counter autocomplete.
+
+    Used only to build the failure message: naming what Yandex DID offer
+    turns "no match" into something the operator can act on, instead of the
+    guess-the-spelling loop that issue #846 documents (three wrong spellings
+    tried against a popup that, as it turned out, was never being read at
+    all).
+
+    Best-effort: returns ``[]`` rather than raising, so a read failure here
+    can never mask the real "no match" error being raised by the caller.
+    """
+    lines: List[str] = []
+    try:
+        options = page.locator(_METRIKA_COUNTER_OPTION_SELECTOR)
+        for i in range(options.count()):
+            raw = options.nth(i).inner_text(timeout=500)
+            collapsed = " ".join(str(raw).split())
+            if collapsed and collapsed not in lines:
+                lines.append(collapsed)
+    except PlaywrightError:
+        return lines
+    return lines
+
+
+def _suggestion_matches_counter(first_line: str, option_id: str, text: str) -> bool:
+    """Decide whether one autocomplete suggestion is the counter the caller
+    asked for.
+
+    ``option_id`` is the counter id Yandex itself puts in the option's
+    ``data-testid`` suffix (``...editor.listBox.72112213``) — an exact,
+    unambiguous identity that needs no parsing of display text. Accepted
+    spellings of ``text`` (issue #846):
+
+    * the bare numeric counter id — ``"72112213"``;
+    * the whole suggestion line verbatim, as before —
+      ``"Ксамата Директ • gc.ksamata.ru • 72112213"``.
+
+    The bare id is the spelling operators actually have: it is what Metrika
+    displays and what ``masters counters get`` reads back off a LINKED tag
+    (``_parse_metrika_counter_tag``), whose text — ``"gc.ksamata.ru •
+    72112213"`` — is a DIFFERENT shape from the suggestion's (no label), so
+    a value read back could never be pasted into ``--add-metrika-counter``
+    before this. Matching on the id closes that round trip.
+
+    The id is compared against ``option_id`` only, never as a substring of
+    the display text: a bare ``"123"`` must not select ``"Магазин 123 •
+    shop.ru • 99999999"``. Linking the WRONG counter silently is the failure
+    this guards against — a counter set is not re-read after every run.
+    """
+    query = text.strip()
+    if query.isdigit():
+        return option_id == query
+    return first_line == query
+
+
 def _add_metrika_counter(page: "Page", text: str) -> None:
     """Add one Metrika counter to "Счетчики Яндекс Метрики" by typing
-    ``text`` into the counter search input and clicking the suggestion row
-    whose FIRST LINE exactly matches it.
+    ``text`` into the counter search input and clicking the matching
+    suggestion (see ``_suggestion_matches_counter``).
 
-    ``text`` FORMAT CONFIRMED LIVE (issue #648, 2026-08-06, campaign
-    713277109, via ``mcp__claude-in-chrome`` — real Chrome, not the
-    Playwright session): typing a partial query (e.g. just the counter's
-    label, "Ксамата") still surfaces the SAME suggestion as typing the full
-    string, but the suggestion's accessible text is exactly ONE line —
-    ``"{label} • {domain/path} • {numeric counter id}"`` (confirmed:
-    ``"Ксамата • yandex.ru/maps • 88834924"``), no newline anywhere in it.
-    Since ``_find_matching_option`` below splits on the first ``"\n"`` and
-    compares for EQUALITY against the whole (single-line) result, the
-    caller-supplied ``text`` must be that ENTIRE string verbatim — passing
-    only the label (e.g. ``"Ксамата"``) will NOT match, even though it's
-    enough to surface the right suggestion while typing interactively.
-    ``masters update``'s own help text/docstring should say this plainly
-    rather than describe it as "an autocomplete suggestion's text" in the
-    abstract.
+    ``text`` may be the counter's BARE NUMERIC ID — the spelling operators
+    actually have — or the full suggestion line. LIVE-CONFIRMED (issue #846,
+    2026-08-14, campaign 74099856, ksamatadirect, via
+    ``mcp__claude-in-chrome``): the search runs SERVER-SIDE on partial input
+    — typing ``"7211"`` surfaces ``"Ксамата Директ • gc.ksamata.ru •
+    72112213"`` — and each option carries its own counter id in
+    ``data-testid`` (``MetrikaCountersTagGroup.editor.listBox.72112213``),
+    which is what the id match compares against.
 
-    Still NOT LIVE-VERIFIED: whether ``match.click()`` actually commits the
-    counter into the "tags-wrapper" list and whether that persists through
-    the campaign's save — the recon session closed the popup with Escape
-    and reloaded the page without saving, precisely to avoid mutating this
-    live campaign's counter set. Also unconfirmed: whether ``Escape`` alone
-    (with no fill-clear afterwards) can leave the search input holding
-    stale, non-committed text the way ``_set_target_action_price`` was
-    found to leave its own popup open in issue #796 — the live recon here
-    hit the SAME visual symptom (Escape closed the suggestion list but left
-    the typed text sitting in the input) and had to explicitly clear the
-    field before navigating away. Worth revisiting whether ``_add_metrika_
-    counter``'s error path below needs the same explicit-clear treatment,
-    not just an ``Escape`` press, once this is exercised end to end.
+    The whole add path is now LIVE-VERIFIED end to end: clicking the
+    suggestion commits the counter into the tags-wrapper (it renders as
+    ``"gc.ksamata.ru • 72112213\\n30 целей"``) and the "Счетчик отсутствует"
+    warning under "Целевые действия" clears, replaced by its "Добавить"
+    button. That recon was deliberately NOT saved — the page was reloaded
+    through the "Leave site?" dialog — so persistence through save is still
+    the one unconfirmed step.
 
     Unlike ``_add_audience_tag``, this clicks the dedicated
     ``_METRIKA_COUNTER_LAUNCHER_TESTID`` button to open the editor rather
@@ -6005,8 +6103,7 @@ def _add_metrika_counter(page: "Page", text: str) -> None:
             "the page."
         ) from exc
 
-    listbox = page.locator(_METRIKA_COUNTER_LISTBOX_TESTID).first
-    options = listbox.get_by_role("option")
+    options = page.locator(_METRIKA_COUNTER_OPTION_SELECTOR)
 
     def _find_matching_option():
         try:
@@ -6016,10 +6113,12 @@ def _add_metrika_counter(page: "Page", text: str) -> None:
         for i in range(count):
             option = options.nth(i)
             try:
+                testid = option.get_attribute("data-testid") or ""
                 first_line = option.inner_text(timeout=500).split("\n", 1)[0]
             except PlaywrightError:
                 continue
-            if first_line == text:
+            option_id = testid[len(_METRIKA_COUNTER_OPTION_TESTID_PREFIX) :]
+            if _suggestion_matches_counter(first_line, option_id, text):
                 return option
         return None
 
@@ -6034,13 +6133,25 @@ def _add_metrika_counter(page: "Page", text: str) -> None:
     if match is None:
         with contextlib.suppress(PlaywrightError):
             page.keyboard.press("Escape")
+        seen = _read_metrika_counter_suggestions(page)
+        if seen:
+            offered = "; ".join(repr(item) for item in seen)
+            raise BrowserSessionError(
+                f"No suggestion matching {text!r} appeared in the 'Счетчики "
+                "Яндекс Метрики' autocomplete within "
+                f"{_METRIKA_COUNTER_SUGGEST_TIMEOUT_MS / 1000:.0f}s. Yandex "
+                f"offered: {offered}. Pass the counter's numeric id (the "
+                "trailing number) — that is matched exactly."
+            )
         raise BrowserSessionError(
-            f"No suggestion exactly matching {text!r} appeared in the "
-            "'Счетчики Яндекс Метрики' autocomplete within "
-            f"{_METRIKA_COUNTER_SUGGEST_TIMEOUT_MS / 1000:.0f}s — this may "
-            "not be a valid Metrika counter on Yandex's side, or its "
-            "suggestion label differs from the exact text passed. Re-run "
-            "with --headful to see the actual suggestion list."
+            f"Yandex's 'Счетчики Яндекс Метрики' autocomplete returned no "
+            f"suggestions at all for {text!r} within "
+            f"{_METRIKA_COUNTER_SUGGEST_TIMEOUT_MS / 1000:.0f}s. The search "
+            "runs server-side and matches partial input, so this usually "
+            "means the counter is not accessible to this Yandex account "
+            "rather than that the text was spelled wrong — verify the "
+            "account has access to it in Metrika. Re-run with --headful to "
+            "watch the suggestion list."
         )
 
     try:

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -2267,9 +2267,10 @@ def counters_get(
     counter-less case.
 
     Each entry carries the raw two-line tag ``Text`` plus the ``CounterId``
-    and ``Domain`` parsed from it. Note ``Text`` is NOT the same shape as
-    the autocomplete value ``--add-metrika-counter`` expects (the linked
-    tag carries no label) — compare on ``CounterId``.
+    and ``Domain`` parsed from it. ``Text`` is NOT the same shape as the
+    autocomplete suggestion (the linked tag carries no label), so compare
+    on ``CounterId`` — and pass that same ``CounterId`` straight to
+    ``--add-metrika-counter``, which matches numeric ids exactly (#846).
     """
     from ..browser.masters import fetch_master_metrika_counters
 
@@ -2630,17 +2631,16 @@ def audience_get(
     "add_metrika_counters",
     multiple=True,
     help=(
-        "Add a Yandex Metrika counter to 'Счетчики Яндекс Метрики' — the "
-        "exact, full text of one of Yandex's own autocomplete suggestions "
-        "(repeat for multiple), confirmed live (issue #648, 2026-08-06) to "
-        "be a single line shaped '{label} • {domain/path} • {numeric "
-        "counter id}' (e.g. 'Ксамата • yandex.ru/maps • 88834924') — "
-        "typing just the label is enough to surface the suggestion "
-        "interactively, but this flag needs the WHOLE string, not just "
-        "the label. Adding/removing itself is NOT LIVE-VERIFIED (only the "
-        "suggestion text format was confirmed) — see "
-        "`direct_cli/browser/masters.py`'s `_add_metrika_counter` "
-        "docstring. A value with no matching suggestion is refused."
+        "Add a Yandex Metrika counter to 'Счетчики Яндекс Метрики' by its "
+        "NUMERIC COUNTER ID, e.g. --add-metrika-counter 72112213 (repeat "
+        "for multiple). The id is matched exactly against Yandex's own "
+        "suggestion, so it is the spelling to prefer: it is what Metrika "
+        "shows and what `masters counters get` reports as `CounterId`. The "
+        "full suggestion line ('{label} • {domain/path} • {numeric counter "
+        "id}') is also accepted verbatim. The section exists only under "
+        "--promotion-goal max-conversions — pass that in the SAME call if "
+        "the campaign is on max-clicks. A value with no matching "
+        "suggestion is refused, and the error lists what Yandex offered."
     ),
 )
 @click.option(
@@ -2873,15 +2873,15 @@ def update(
 
     ``--add-metrika-counter``/``--remove-metrika-counter`` (issue #648)
     cover the "Счетчики Яндекс Метрики" section, mirroring
-    ``--add-audience-tag``/``--remove-audience-tag`` above field-for-field:
-    a value must be the exact text of one of Yandex's own autocomplete
-    suggestions, and ``--remove-metrika-counter`` takes 0-based positions
-    into the counter list as it exists BEFORE this command runs. NOT
-    LIVE-VERIFIED — this is an offline implementation following the
-    audience-tags pattern; see ``--add-metrika-counter``'s own help text
-    and ``direct_cli/browser/masters.py``'s module comment above
-    ``_METRIKA_COUNTER_WRAPPER_TESTID`` for what specifically remains
-    unconfirmed.
+    ``--add-audience-tag``/``--remove-audience-tag`` above field-for-field.
+    ``--add-metrika-counter`` takes the counter's NUMERIC ID (matched
+    exactly against Yandex's own suggestion) or the full suggestion line;
+    ``--remove-metrika-counter`` takes 0-based positions into the counter
+    list as it exists BEFORE this command runs. The section only exists
+    under ``--promotion-goal max-conversions``, and counters are applied
+    BEFORE target actions (#844) so both can be set in one call.
+    LIVE-VERIFIED through linking the counter on the page (#846); see
+    ``direct_cli/browser/masters.py``'s ``_add_metrika_counter``.
 
     ``--add-sitelink``/``--remove-sitelink`` (issue #648, Этап C) cover the
     "Быстрые ссылки" section. ``--add-sitelink "Title|Href|Description"``

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -19682,7 +19682,32 @@ class TestAddMetrikaCounter(unittest.TestCase):
         with self.assertRaises(BrowserSessionError):
             browser_masters._add_metrika_counter(page, "gc.ksamata.ru")
 
-    def test_clicks_launcher_then_matching_option_by_first_line(self):
+    @staticmethod
+    def _suggestion(counter_id, text, on_click=None):
+        """One autocomplete row, shaped as the LIVE page renders it (#846):
+        the counter id lives in the option's own ``data-testid`` suffix, and
+        the row is matched directly by that prefix — there is no wrapping
+        element carrying a bare ``...editor.listBox`` testid to scope to.
+        """
+        prefix = browser_masters._METRIKA_COUNTER_OPTION_TESTID_PREFIX
+        return _FakeLocatorHandle(
+            text=text,
+            attrs={"data-testid": f"{prefix}{counter_id}"},
+            on_click=on_click,
+        )
+
+    def _page(self, launcher, field, options):
+        return FakePage(
+            locators={
+                browser_masters._METRIKA_COUNTER_LAUNCHER_TESTID: _FakeLocator(
+                    [launcher]
+                ),
+                browser_masters._METRIKA_COUNTER_INPUT_TESTID: _FakeLocator([field]),
+                browser_masters._METRIKA_COUNTER_OPTION_SELECTOR: _FakeLocator(options),
+            }
+        )
+
+    def test_clicks_launcher_then_matching_option_by_full_line(self):
         launcher_clicks = {"count": 0}
         launcher = _FakeLocatorHandle(
             on_click=lambda: launcher_clicks.__setitem__(
@@ -19691,51 +19716,83 @@ class TestAddMetrikaCounter(unittest.TestCase):
         )
         field = _FakeLocatorHandle()
         option_clicked = {"clicked": False}
-        matching_option = _FakeLocatorHandle(
-            text="gc.ksamata.ru • 72112213\n30 целей",
+        matching = self._suggestion(
+            "72112213",
+            "Ксамата Директ • gc.ksamata.ru • 72112213",
             on_click=lambda: option_clicked.__setitem__("clicked", True),
         )
-        other_option = _FakeLocatorHandle(text="other.ru • 999\n1 цель")
-        listbox = _FakeLocatorHandle(role_options=[other_option, matching_option])
-        page = FakePage(
-            locators={
-                browser_masters._METRIKA_COUNTER_LAUNCHER_TESTID: _FakeLocator(
-                    [launcher]
-                ),
-                browser_masters._METRIKA_COUNTER_INPUT_TESTID: _FakeLocator([field]),
-                browser_masters._METRIKA_COUNTER_LISTBOX_TESTID: _FakeLocator(
-                    [listbox]
-                ),
-            }
-        )
+        other = self._suggestion("999", "Другой • other.ru • 999")
+        page = self._page(launcher, field, [other, matching])
 
-        browser_masters._add_metrika_counter(page, "gc.ksamata.ru • 72112213")
+        browser_masters._add_metrika_counter(
+            page, "Ксамата Директ • gc.ksamata.ru • 72112213"
+        )
 
         self.assertEqual(launcher_clicks["count"], 1)
         self.assertTrue(option_clicked["clicked"])
 
-    def test_raises_when_no_suggestion_matches(self):
-        launcher = _FakeLocatorHandle()
-        field = _FakeLocatorHandle()
-        non_matching = _FakeLocatorHandle(text="other.ru • 999\n1 цель")
-        listbox = _FakeLocatorHandle(role_options=[non_matching])
-        page = FakePage(
-            locators={
-                browser_masters._METRIKA_COUNTER_LAUNCHER_TESTID: _FakeLocator(
-                    [launcher]
-                ),
-                browser_masters._METRIKA_COUNTER_INPUT_TESTID: _FakeLocator([field]),
-                browser_masters._METRIKA_COUNTER_LISTBOX_TESTID: _FakeLocator(
-                    [listbox]
-                ),
-            }
+    def test_bare_numeric_id_selects_the_counter(self):
+        """Issue #846: the bare id is the spelling operators have — it is
+        what Metrika shows and what ``counters get`` reads back."""
+        option_clicked = {"clicked": False}
+        matching = self._suggestion(
+            "72112213",
+            "Ксамата Директ • gc.ksamata.ru • 72112213",
+            on_click=lambda: option_clicked.__setitem__("clicked", True),
         )
+        other = self._suggestion("999", "Другой • other.ru • 999")
+        page = self._page(_FakeLocatorHandle(), _FakeLocatorHandle(), [other, matching])
+
+        browser_masters._add_metrika_counter(page, "72112213")
+
+        self.assertTrue(option_clicked["clicked"])
+
+    def test_bare_id_does_not_match_digits_in_label_or_domain(self):
+        """A bare id must match the option's OWN id, never a substring of
+        the display text — linking the wrong counter would be silent."""
+        wrong_clicked = {"clicked": False}
+        decoy = self._suggestion(
+            "99999999",
+            "Магазин 123 • shop.ru • 99999999",
+            on_click=lambda: wrong_clicked.__setitem__("clicked", True),
+        )
+        page = self._page(_FakeLocatorHandle(), _FakeLocatorHandle(), [decoy])
 
         with (
             patch.object(browser_masters, "_METRIKA_COUNTER_SUGGEST_TIMEOUT_MS", 10),
             self.assertRaises(BrowserSessionError),
         ):
+            browser_masters._add_metrika_counter(page, "123")
+
+        self.assertFalse(wrong_clicked["clicked"])
+
+    def test_raises_when_no_suggestion_matches(self):
+        non_matching = self._suggestion("999", "Другой • other.ru • 999")
+        page = self._page(_FakeLocatorHandle(), _FakeLocatorHandle(), [non_matching])
+
+        with (
+            patch.object(browser_masters, "_METRIKA_COUNTER_SUGGEST_TIMEOUT_MS", 10),
+            self.assertRaises(BrowserSessionError) as ctx,
+        ):
             browser_masters._add_metrika_counter(page, "nomatch.ru")
+
+        # The message must name what Yandex DID offer — issue #846's operator
+        # burned three attempts guessing spellings against an empty read.
+        self.assertIn("Другой • other.ru • 999", str(ctx.exception))
+
+    def test_empty_suggestion_list_blames_access_not_spelling(self):
+        """No suggestions at all is a different diagnosis from "no match":
+        the search is server-side and partial, so an empty list points at
+        account access, not at the text."""
+        page = self._page(_FakeLocatorHandle(), _FakeLocatorHandle(), [])
+
+        with (
+            patch.object(browser_masters, "_METRIKA_COUNTER_SUGGEST_TIMEOUT_MS", 10),
+            self.assertRaises(BrowserSessionError) as ctx,
+        ):
+            browser_masters._add_metrika_counter(page, "72112213")
+
+        self.assertIn("no suggestions at all", str(ctx.exception))
 
 
 class TestMetrikaCounterIdentity(unittest.TestCase):
@@ -19763,6 +19820,58 @@ class TestMetrikaCounterIdentity(unittest.TestCase):
     def test_returns_text_unchanged_when_no_separator(self):
         self.assertEqual(
             browser_masters._metrika_counter_identity("nomatch"), "nomatch"
+        )
+
+
+class TestMetrikaCountersSectionPresent(unittest.TestCase):
+    """``_metrika_counters_section_present`` must outlast the block's
+    measured mount-then-unmount transient (issue #846).
+
+    On a max-clicks campaign the block renders at t+0 and is unmounted once
+    the form settles (~t+3000ms live). A stability window shorter than that
+    certifies "stably present" before the unmount, which is how ``masters
+    counters get`` returned SectionPresent: true and false on consecutive
+    reads of the same unchanged campaign.
+    """
+
+    class _FlippingPage(FakePage):
+        """Reports the block present until ``flip_ms`` of FAKE-clock time has
+        elapsed, then absent forever — the live max-clicks timeline."""
+
+        def __init__(self, flip_ms):
+            super().__init__()
+            self._flip_s = flip_ms / 1000
+            self._start = browser_masters._clock.now()
+
+        def locator(self, selector, *args, **kwargs):
+            if selector == browser_masters._METRIKA_COUNTERS_BLOCK_TESTID:
+                elapsed = browser_masters._clock.now() - self._start
+                present = elapsed < self._flip_s
+                return _FakeLocator([_FakeLocatorHandle()] if present else [])
+            return super().locator(selector, *args, **kwargs)
+
+    def test_transient_presence_does_not_read_as_present(self):
+        page = self._FlippingPage(flip_ms=3000)
+
+        self.assertFalse(browser_masters._metrika_counters_section_present(page))
+
+    def test_genuinely_present_section_reads_as_present(self):
+        page = self._FlippingPage(flip_ms=10**9)
+
+        self.assertTrue(browser_masters._metrika_counters_section_present(page))
+
+    def test_budget_exceeds_flip_plus_stability_window(self):
+        """The run of agreement only STARTS after the flip, so the budget
+        must cover flip + window — not merely the window. At the original
+        5s budget the max-clicks case never settled and reached the right
+        answer only via the "report the last read" fallback."""
+        window_ms = browser_masters._METRIKA_COUNTERS_SECTION_POLL_MS * (
+            browser_masters._METRIKA_COUNTERS_SECTION_STABLE_TICKS - 1
+        )
+        self.assertGreater(window_ms, 3000)
+        self.assertGreater(
+            browser_masters._METRIKA_COUNTERS_SECTION_TIMEOUT_MS,
+            3000 + window_ms,
         )
 
     def test_returns_text_unchanged_when_trailing_separator_has_no_id(self):


### PR DESCRIPTION
## Problem

The "Счетчики Яндекс Метрики" autocomplete **could never match anything, for any input.**

Options were searched under `[data-testid="MetrikaCountersTagGroup.editor.listBox"]`, but no element carries that testid. Live recon (campaign 74099856, real Chrome) found:

- the suggestions are portalled into a `dc-Popup` directly under `<body>` — **outside the editor subtree entirely**;
- `…editor.listBox` exists only as the **prefix** of each option's own testid: `…editor.listBox.72112213`.

So the locator resolved to zero elements, `get_by_role("option")` under it always counted 0, and every add timed out.

The timeout was reported as `No suggestion exactly matching '…' appeared`, which **blamed the caller's text for a selector bug**. The operator in #846 burned three attempts — bare id, domain, full `label • domain • id` line — respelling a value that was never being compared against anything.

## Fix

**Locate options by the testid prefix**, where they actually are in the DOM.

**Accept the bare numeric counter id** — the spelling operators actually have:

```
direct masters update <id> --promotion-goal max-conversions \
  --add-metrika-counter 72112213
```

The id is matched against the option's **own** id from its testid, never as a substring of the display text, so `--add-metrika-counter 123` cannot silently select `Магазин 123 • shop.ru • 99999999`. Linking the wrong counter is not a failure that gets noticed — a counter set is not re-read after every run. The full suggestion line still works.

This closes the round trip with `masters counters get`: its `CounterId` can now be passed straight back in. Its tag text (`gc.ksamata.ru • 72112213`) has a different shape from the suggestion (`Ксамата Директ • gc.ksamata.ru • 72112213`) and never could be.

**Both failure messages now diagnose rather than accuse:** a non-match lists what Yandex actually offered; an empty list points at the account's access to the counter, since the search is server-side and partial (typing `7211` surfaces the full suggestion).

## Also fixes: unstable `SectionPresent`

Reported in the same issue — the same campaign read `true` in one run and `false` in the next, with no update in between.

`_metrika_counters_section_present` already polled for a *stable* answer, but **its window was calibrated shorter than the transient it guards against.** The block renders at t+0 on a max-clicks campaign and unmounts once the form settles (~t+3000ms live). At `500ms × 3` the loop settles after 3 samples spanning 2 gaps — ~1.0s — certifying "stably present" a full 2s *before* the unmount. Whether a run saw `true` or `false` tracked nothing but how the ticks lined up against the flip.

Now `500ms × 8` (~3.5s of agreement) against **its own 8s budget** rather than borrowing the autocomplete's 5s. The budget must exceed *flip + window*, not just the window, because the run of agreement only **starts** after the flip — at 5s the max-clicks case never settled and reached the right answer only through the "report the last read" fallback, which is not a property worth depending on. Both outcomes now settle deliberately: max-conversions ~3.5s, max-clicks ~6.5s.

The presence locator is also re-resolved per sample instead of captured once before the loop. Playwright locators are lazy and re-query on each `count()`, so this was not itself the live bug — but a loop whose entire purpose is watching the DOM change should not depend on that implicitly.

## Verification

**Live** (campaign 74099856, `ksamatadirect`): typing `72112213` surfaces `Ксамата Директ • gc.ksamata.ru • 72112213`; the counter links, its tag renders, and the "Счетчик отсутствует" warning under «Целевые действия» clears. **That recon was deliberately not saved** — the page was reloaded through the "Leave site?" dialog, leaving the campaign untouched. `masters counters get` then returns a consistent `SectionPresent: false` across three consecutive runs.

**Offline:** 3619 passed, 23 skipped. `black` / `flake8` clean outside `_vendor`.

Two pre-existing tests were rewritten: they supplied a listbox the real page never has, so they passed green against the broken code. New tests cover the bare id, the digits-in-label/domain decoy, both error messages, and the section-presence timeline against the fake clock — **verified to fail on the old constants**, so they pin real behaviour.

Closes #846

🤖 Generated with [Claude Code](https://claude.com/claude-code)