### PR TITLE
fix(masters): preserve counters and target actions on URL/UTM saves (#836)

### DIFF
--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -7490,6 +7490,8 @@ def _verify_saved(
     add_target_actions: Optional[Dict[int, float]] = None,
     remove_target_action_goal_ids: Optional[List[int]] = None,
     target_action_goal_ids_before: Optional[List[int]] = None,
+    target_actions_unchanged_before: Optional[List[int]] = None,
+    target_actions_unchanged_requested: bool = False,
     gender: Optional[str] = None,
     age_from_requested: bool = False,
     age_from: Optional[int] = None,
@@ -8123,6 +8125,64 @@ def _verify_saved(
                         "still be hydrating, or the save did not take effect"
                     )
 
+    if target_actions_unchanged_requested:
+        # Issue #836: this save touched no target action at all (a URL/UTM
+        # -only update), so the block above never ran — yet the whole-form
+        # save still resubmits this section, and the UTM spoiler's
+        # live-confirmed re-render (issue #830) can empty it first. Assert
+        # the untouched set came back UNCHANGED, mirroring what
+        # ``audience_tags_before`` does for a gender/age/device-only save.
+        #
+        # Scoped to a NON-EMPTY baseline, set by ``update_master`` only when
+        # the pre-save read actually saw goal rows. ``_read_target_actions_
+        # or_none`` returns ``None`` both when the table failed to hydrate
+        # AND when the section is simply not visible — which is the normal,
+        # correct state for a campaign that has no target actions at all —
+        # so "unreadable" and "legitimately none" are indistinguishable
+        # here. Treating that ambiguity as a failure would block every
+        # URL/UTM update on every campaign without goals, for no safety
+        # gain: a campaign with nothing to lose cannot silently lose it.
+        #
+        # The protection therefore covers exactly the case that has
+        # something at stake — goals demonstrably present before the save —
+        # and within that case it IS closed: once a non-empty baseline
+        # exists, a post-save read that is empty, partial, or unreadable
+        # all fail the set comparison below rather than passing.
+        expected_unchanged = set(target_actions_unchanged_before or [])
+        if expected_unchanged:
+
+            # Defined locally rather than reusing the identically-shaped
+            # reader in the add/remove block above: that one is nested
+            # inside its own ``if``, so it is unbound on this path (the two
+            # blocks never both run).
+            def _read_unchanged_goal_ids(p: "Page") -> Optional[Set[int]]:
+                rows = _read_target_actions_or_none(p)
+                if rows is None:
+                    return None
+                return {row["GoalId"] for row in rows}
+
+            def _unchanged_matches(actual: Optional[Set[int]], _expected: Any) -> bool:
+                return actual is not None and actual == expected_unchanged
+
+            actual_unchanged = _read_until_matches(
+                page,
+                _read_unchanged_goal_ids,
+                None,
+                matches=_unchanged_matches,
+                timeout_ms=_VERIFY_FIELD_READ_TIMEOUT_MS
+                + _TARGET_ACTION_SETTLE_TIMEOUT_MS,
+            )
+            if not _unchanged_matches(actual_unchanged, None):
+                _shown = (
+                    sorted(actual_unchanged) if actual_unchanged is not None else None
+                )
+                mismatches.append(
+                    "target actions: this update did not request any "
+                    "target-action change, but goal ids "
+                    f"{sorted(expected_unchanged)!r} are no longer intact — "
+                    f"page now shows {_shown!r}"
+                )
+
     mismatches.extend(
         _verify_repeating_value_mismatches(
             page,
@@ -8181,6 +8241,53 @@ def _verify_saved(
             + detail
             + " Verify manually before retrying."
         )
+
+
+def _warn_on_cross_domain_landing_url(
+    page: "Page",
+    landing_url: Optional[str],
+    counters: Optional[List[str]],
+) -> None:
+    """Warn when ``landing_url`` moves the campaign to a different domain
+    while it still has linked Metrika counters (issue #836, point 3).
+
+    Yandex links a Metrika counter and its goals to the landing page's
+    DOMAIN — on the create page the counter is auto-discovered from it (see
+    ``_add_target_action``/``create_master``). The edit page does not appear
+    to re-sync that link when the URL alone changes, so pointing a campaign
+    at a different domain can leave its counters and target actions
+    referring to a site the campaign no longer promotes.
+
+    That desync happens server-side, in Yandex's own data model — this
+    module cannot prevent or repair it, so this is a non-blocking
+    ``print_warning`` rather than a refusal: the update itself is still a
+    legitimate thing to ask for, and the user is the one who can judge
+    whether the new domain is covered by the same counter.
+
+    Only a real domain CHANGE warns — a path/query-only edit keeps the same
+    counter binding and would make this pure noise. A landing URL that
+    cannot be read (``None``) is inconclusive, and a campaign with no
+    counters has nothing to desync; both stay silent.
+    """
+    if landing_url is None or not counters:
+        return
+    current_url = _read_landing_url(page)
+    if not current_url:
+        return
+    current_domain = urlsplit(current_url.strip()).netloc.lower()
+    requested_domain = urlsplit(landing_url.strip()).netloc.lower()
+    if not current_domain or not requested_domain:
+        return
+    if current_domain == requested_domain:
+        return
+    print_warning(
+        f"Landing URL moves from '{current_domain}' to '{requested_domain}', "
+        f"but this campaign has {len(counters)} linked Yandex Metrika "
+        "counter(s). Yandex links counters and their target-action goals to "
+        "the landing page's domain, so they may no longer match the new "
+        "site — check the campaign's 'Счётчики Яндекс Метрики' and "
+        "'Целевые действия' sections after this update."
+    )
 
 
 def update_master(
@@ -8504,6 +8611,51 @@ def update_master(
     # ``_wait_for_draft_status``'s docstring).
     was_draft = _wait_for_draft_status(page, campaign_id)
 
+    # Issue #836: a URL/UTM-only update mutates neither the Metrika-counters
+    # nor the "Целевые действия" section, but still submits the WHOLE form
+    # (see this module's docstring) — and expanding the UTM spoiler is
+    # live-confirmed (issue #830, 4 campaigns, 100% reproduction) to
+    # re-render the surrounding form from server state. Nothing used to
+    # re-check either untouched section afterwards, so a re-render that
+    # dropped a counter or a goal row would be saved and reported as a
+    # success. Same "snapshot the untouched section so _verify_saved can
+    # assert it came back UNCHANGED" fix issue #752 (R2-1) applied to the
+    # audience tags below.
+    #
+    # Taken HERE, before ``_set_tracking_params`` expands that spoiler,
+    # because a snapshot read after the re-render would capture the already
+    # corrupted state and certify the loss as the expected baseline.
+    #
+    # Only for a URL/UTM update: an explicit counters/target-actions
+    # mutation takes its own, later snapshot below, whose position must be
+    # resolved against the state those mutations actually operate on.
+    _url_or_utm_only_save = (
+        landing_url is not None or tracking_params is not None
+    ) and not (
+        add_metrika_counters
+        or remove_metrika_counters
+        or add_target_actions
+        or remove_target_action_goal_ids
+        or target_action_prices
+    )
+    metrika_counters_before: Optional[List[str]] = None
+    target_actions_unchanged_before: Optional[List[int]] = None
+    if _url_or_utm_only_save:
+        metrika_counters_before = _read_metrika_counters(page)
+        # ``_read_target_actions_or_none`` (not ``_read_target_actions``):
+        # the latter flattens "the table never hydrated" into a well-formed
+        # ``[]``, which would certify "this campaign had no goals" as the
+        # baseline and make a genuine wipe unverifiable. ``None`` keeps
+        # "unreadable" distinct, and _verify_saved fails closed on it.
+        _rows_before = (
+            _read_target_actions_or_none(page)
+            if _wait_for_target_actions_ready(page)
+            else None
+        )
+        if _rows_before is not None:
+            target_actions_unchanged_before = [row["GoalId"] for row in _rows_before]
+        _warn_on_cross_domain_landing_url(page, landing_url, metrika_counters_before)
+
     if name is not None:
         _set_campaign_name(page, name)
     # Expand and fill the lazily-mounted UTM section first.  On campaigns
@@ -8621,11 +8773,20 @@ def update_master(
     # counter is linked first (61 options available, stable from t+1s).
     # This is an ordering bug, not a hydration race — waiting longer at the
     # old position never helps, because the counter simply is not linked yet.
-    metrika_counters_before = _apply_metrika_counters(
+    _metrika_baseline = _apply_metrika_counters(
         page,
         add_metrika_counters=add_metrika_counters,
         remove_metrika_counters=remove_metrika_counters,
     )
+    # ``_apply_metrika_counters`` returns ``None`` when no counter mutation
+    # was requested — which is exactly the URL/UTM-only case that already
+    # captured this section above, BEFORE the UTM spoiler's re-render
+    # (issue #836). Assigning its ``None`` unconditionally would discard
+    # that baseline and disable the untouched-section check. The two are
+    # mutually exclusive by ``_url_or_utm_only_save``'s own definition, so
+    # only a real mutation's baseline overwrites it.
+    if _metrika_baseline is not None:
+        metrika_counters_before = _metrika_baseline
 
     for goal_id in remove_target_action_goal_ids or []:
         _remove_target_action(page, goal_id)
@@ -8966,6 +9127,8 @@ def update_master(
             add_target_actions=add_target_actions,
             remove_target_action_goal_ids=remove_target_action_goal_ids,
             target_action_goal_ids_before=target_action_goal_ids_before,
+            target_actions_unchanged_before=target_actions_unchanged_before,
+            target_actions_unchanged_requested=_url_or_utm_only_save,
             gender=gender,
             age_from_requested=age_from_requested,
             age_from=age_from,

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -7145,8 +7145,88 @@ def _read_save_validation_errors(page: "Page") -> List[str]:
     return seen[:_SAVE_VALIDATION_ERROR_LIMIT]
 
 
+def _assert_preserved_sections_before_save(
+    page: "Page",
+    *,
+    metrika_counters_before: Optional[List[str]],
+    metrika_preservation_requested: bool,
+    add_metrika_counters: Optional[List[str]],
+    remove_metrika_counter_indices: Optional[List[int]],
+    target_action_goal_ids_before: Optional[List[int]],
+    target_actions_unchanged_before: Optional[List[int]],
+    target_actions_preservation_requested: bool,
+    add_target_actions: Optional[Dict[int, float]],
+    remove_target_action_goal_ids: Optional[List[int]],
+) -> None:
+    """Abort before Save if URL/UTM hydration changed a protected section.
+
+    Post-save verification is still required for server-side persistence,
+    but it is too late to prevent issue #836's whole-form data loss. This
+    guard compares the stabilized current DOM with each independently
+    derived expected state immediately before the irreversible click.
+    """
+    if metrika_preservation_requested:
+        if metrika_counters_before is None:
+            raise BrowserSessionError(
+                "Refusing to save the URL/UTM update: no readable pre-save "
+                "Metrika-counter baseline is available."
+            )
+        expected_counters = Counter(
+            _metrika_counter_identity(value) for value in metrika_counters_before
+        )
+        for index in remove_metrika_counter_indices or []:
+            expected_counters[
+                _metrika_counter_identity(metrika_counters_before[index])
+            ] -= 1
+        expected_counters += Counter(
+            _metrika_counter_identity(value) for value in (add_metrika_counters or [])
+        )
+        actual_counters = _read_confirmed_metrika_counters_or_none(page)
+        actual_counter_ids = (
+            None
+            if actual_counters is None
+            else Counter(_metrika_counter_identity(value) for value in actual_counters)
+        )
+        if actual_counter_ids != expected_counters:
+            shown = sorted(actual_counters) if actual_counters is not None else None
+            raise BrowserSessionError(
+                "Refusing to save the URL/UTM update because the current "
+                "Metrika counters no longer match their protected pre-save "
+                f"state: expected ids {sorted(expected_counters.elements())!r}, "
+                f"page now shows {shown!r}. No Save button was clicked."
+            )
+
+    if target_actions_preservation_requested:
+        baseline = (
+            target_action_goal_ids_before
+            if target_action_goal_ids_before is not None
+            else target_actions_unchanged_before
+        )
+        if baseline is None:
+            raise BrowserSessionError(
+                "Refusing to save the URL/UTM update: no readable pre-save "
+                "target-action baseline is available."
+            )
+        expected_goal_ids = set(baseline)
+        expected_goal_ids -= set(remove_target_action_goal_ids or [])
+        expected_goal_ids |= set(add_target_actions or {})
+        actual_goal_ids = _read_confirmed_target_action_goal_ids(page)
+        if actual_goal_ids is None or set(actual_goal_ids) != expected_goal_ids:
+            raise BrowserSessionError(
+                "Refusing to save the URL/UTM update because the current "
+                "target-action goal ids no longer match their protected "
+                f"pre-save state: expected {sorted(expected_goal_ids)!r}, "
+                f"page now shows {actual_goal_ids!r}. No Save button was clicked."
+            )
+
+
 def _click_save(
-    page: "Page", campaign_id: int, *, is_draft: bool, launch: bool = False
+    page: "Page",
+    campaign_id: int,
+    *,
+    is_draft: bool,
+    launch: bool = False,
+    before_click: Optional[Callable[[], None]] = None,
 ) -> None:
     """Click the edit page's save button — "Сохранить кампанию" on a
     non-DRAFT campaign, or the DRAFT-specific save-as-draft/launch button.
@@ -7169,8 +7249,15 @@ def _click_save(
     ``is_draft`` before doing any of the mutations that precede this click,
     for the same "read it while the page still reflects what's about to
     happen" reason ``update_master`` documents at its own call site.
+
+    ``before_click`` runs only after the terminal button is available and
+    immediately before each click attempt. Issue #836 uses it for the final
+    protected-section guard so even the scroll needed to mount a non-DRAFT
+    Save button cannot create an unchecked re-render window.
     """
     if is_draft:
+        if before_click is not None:
+            before_click()
         _click_draft_terminal_button(page, campaign_id, launch=launch)
         return
 
@@ -7217,6 +7304,8 @@ def _click_save(
         handle = _find_visible_save_button()
         if handle is not None:
             try:
+                if before_click is not None:
+                    before_click()
                 handle.click()
                 return
             except PlaywrightError:
@@ -8688,6 +8777,7 @@ def update_master(
     metrika_preservation_requested = False
     target_actions_unchanged_before: Optional[List[int]] = None
     target_actions_unchanged_requested = False
+    target_actions_preservation_requested = False
     target_action_goal_ids_before: Optional[List[int]] = None
     if _url_or_utm_save:
         section_present = _metrika_counters_section_present(page)
@@ -8716,6 +8806,7 @@ def update_master(
                     "saved because an unreadable baseline could hide target-"
                     "action loss; retry after the page has fully loaded."
                 )
+            target_actions_preservation_requested = True
             if add_target_actions or remove_target_action_goal_ids:
                 # The existing add/remove verifier derives its full expected
                 # final set from this baseline. Supplying the pre-UTM snapshot
@@ -9144,7 +9235,33 @@ def update_master(
     else:
         clicked_button_label = _SAVE_BUTTON_TEXT
 
-    _click_save(page, campaign_id, is_draft=was_draft, launch=launch)
+    def _validate_preserved_sections_before_click() -> None:
+        _assert_preserved_sections_before_save(
+            page,
+            metrika_counters_before=metrika_counters_before,
+            metrika_preservation_requested=metrika_preservation_requested,
+            add_metrika_counters=add_metrika_counters,
+            remove_metrika_counter_indices=remove_metrika_counters,
+            target_action_goal_ids_before=target_action_goal_ids_before,
+            target_actions_unchanged_before=target_actions_unchanged_before,
+            target_actions_preservation_requested=(
+                target_actions_preservation_requested
+            ),
+            add_target_actions=add_target_actions,
+            remove_target_action_goal_ids=remove_target_action_goal_ids,
+        )
+
+    _click_save(
+        page,
+        campaign_id,
+        is_draft=was_draft,
+        launch=launch,
+        before_click=(
+            _validate_preserved_sections_before_click
+            if (metrika_preservation_requested or target_actions_preservation_requested)
+            else None
+        ),
+    )
 
     # Read Yandex's inline rejection text BEFORE _verify_saved reloads the
     # page away (issue #840) — these messages live only in the still-open

--- a/direct_cli/browser/masters.py
+++ b/direct_cli/browser/masters.py
@@ -1829,7 +1829,7 @@ _METRIKA_COUNTERS_BLOCK_TESTID = '[data-testid="MetrikaCountersBlock"]'
 # The window is now 500ms x 8 = ~3.5s of agreement, which spans the flip with
 # margin. Keep POLL_MS * (STABLE_TICKS - 1) comfortably ABOVE 3000ms if these
 # are ever retuned; raising POLL_MS alone widens it just as well as raising
-# the tick count. The 5s overall budget still bounds the call.
+# the tick count. The 8s overall budget still bounds the call.
 _METRIKA_COUNTERS_SECTION_POLL_MS = 500
 _METRIKA_COUNTERS_SECTION_STABLE_TICKS = 8
 
@@ -1842,6 +1842,16 @@ _METRIKA_COUNTERS_SECTION_STABLE_TICKS = 8
 # their own merits: max-conversions (never flips) at ~3.5s, max-clicks at
 # ~6.5s. Only reached on campaigns whose section is genuinely absent.
 _METRIKA_COUNTERS_SECTION_TIMEOUT_MS = 8_000
+
+# Preservation reads need a wider FULL-LIST stability window than the
+# section-presence probe above. A linked tag's label is known to change at
+# about t+4s (bare id -> hydrated label), so the 3.5s presence window can
+# still certify an early partial/text-incomplete counter list. Twelve 500ms
+# samples span ~5.5s and therefore cross that measured transition with
+# margin; the 12s budget leaves enough room for the streak to restart after
+# such a change instead of turning normal hydration into a false failure.
+_METRIKA_PRESERVATION_STABLE_TICKS = 12
+_METRIKA_PRESERVATION_TIMEOUT_MS = 12_000
 
 # Reuses the same 5s budget ``_AUDIENCE_TAG_SUGGEST_TIMEOUT_MS`` uses for its
 # own autocomplete popup — no live timing recon exists yet for THIS widget's
@@ -5796,6 +5806,41 @@ def _metrika_counter_identity(text: str) -> str:
     return stripped_identity if stripped_identity.isdigit() else text
 
 
+def _read_metrika_counters_or_none(page: "Page") -> Optional[List[str]]:
+    """Failure-aware variant of ``_read_metrika_counters``.
+
+    ``None`` means the tags wrapper could not be read; ``[]`` means the
+    wrapper rendered successfully and genuinely contains no counter tags.
+    The distinction is required for pre-save preservation snapshots: an
+    unreadable wrapper must never be certified as an empty baseline.
+    """
+    try:
+        page.locator(_METRIKA_COUNTER_WRAPPER_TESTID).first.wait_for(
+            state="attached", timeout=_METRIKA_COUNTER_SUGGEST_TIMEOUT_MS
+        )
+    except PlaywrightError:
+        return None
+
+    counters: List[str] = []
+    index = 0
+    while True:
+        selector = (
+            f'[data-testid="{_METRIKA_COUNTER_TESTID_TEMPLATE.format(index=index)}"]'
+        )
+        try:
+            tag = page.locator(selector)
+            if tag.count() == 0:
+                break
+            text = tag.first.inner_text(timeout=1_000).strip()
+        except PlaywrightError:
+            return None
+        if not text:
+            return None
+        counters.append(text)
+        index += 1
+    return counters
+
+
 def _read_metrika_counters(page: "Page") -> List[str]:
     """Read every currently linked Metrika counter's display text in
     "Счетчики Яндекс Метрики" (in on-page order).
@@ -5814,28 +5859,8 @@ def _read_metrika_counters(page: "Page") -> List[str]:
     than raising, since an edit page whose audience section hasn't hydrated
     yet is a normal, retriable state, not a markup-drift signal.
     """
-    try:
-        page.locator(_METRIKA_COUNTER_WRAPPER_TESTID).first.wait_for(
-            state="attached", timeout=_METRIKA_COUNTER_SUGGEST_TIMEOUT_MS
-        )
-    except PlaywrightError:
-        return []
-
-    counters: List[str] = []
-    index = 0
-    while True:
-        selector = (
-            f'[data-testid="{_METRIKA_COUNTER_TESTID_TEMPLATE.format(index=index)}"]'
-        )
-        try:
-            text = page.locator(selector).first.inner_text(timeout=1_000).strip()
-        except PlaywrightError:
-            break
-        if not text:
-            break
-        counters.append(text)
-        index += 1
-    return counters
+    counters = _read_metrika_counters_or_none(page)
+    return [] if counters is None else counters
 
 
 def _metrika_counters_section_present(page: "Page") -> bool:
@@ -6009,6 +6034,39 @@ def _read_settled_metrika_counters(page: "Page") -> List[str]:
         page.wait_for_timeout(_METRIKA_COUNTERS_SECTION_POLL_MS)
 
     return previous if previous is not None else []
+
+
+def _read_confirmed_metrika_counters_or_none(
+    page: "Page",
+) -> Optional[List[str]]:
+    """Return a failure-aware, stabilized full counter snapshot.
+
+    Issue #836's preservation guard cannot trust one readable DOM sample:
+    the widget can hold an early partial render before rehydrating again.
+    Require a consecutive streak of identical FULL-LIST reads wide enough
+    to span the widget's measured ~4s label transition. A changed list
+    restarts the streak; an unreadable attempt clears it. Returning ``None``
+    therefore means no trustworthy baseline/post-save snapshot was obtained,
+    never a fabricated empty list.
+    """
+    deadline = _clock.now() + _METRIKA_PRESERVATION_TIMEOUT_MS / 1000
+    previous: Optional[List[str]] = None
+    stable_ticks = 0
+
+    while _clock.now() < deadline:
+        current = _read_metrika_counters_or_none(page)
+        if current is None:
+            previous = None
+            stable_ticks = 0
+        elif current == previous:
+            stable_ticks += 1
+            if stable_ticks >= _METRIKA_PRESERVATION_STABLE_TICKS:
+                return current
+        else:
+            previous = current
+            stable_ticks = 1
+        page.wait_for_timeout(_METRIKA_COUNTERS_SECTION_POLL_MS)
+    return None
 
 
 def _parse_metrika_counter_tag(text: str) -> Dict[str, Any]:
@@ -6762,6 +6820,39 @@ def _wait_for_target_actions_settled(page: "Page") -> bool:
     )
 
 
+def _read_confirmed_target_action_goal_ids(page: "Page") -> Optional[List[int]]:
+    """Read a stable target-action goal-id set, or ``None`` if inconclusive.
+
+    A stable row *count* does not prove that the same complete rows were
+    present throughout hydration. After waiting out the page-level fallback,
+    require a full streak of successful reads whose exact id sets agree. The
+    identity streak itself subsumes the older count-only settle loop and is
+    used both before and after URL/UTM saves, so neither a partial baseline nor
+    one transient matching post-save render can certify silent row loss.
+    """
+    _wait_for_page_fallback_gone(page)
+
+    deadline = _clock.now() + _TARGET_ACTION_SETTLE_TIMEOUT_MS / 1000
+    previous: Optional[Set[int]] = None
+    stable_streak = 0
+    while _clock.now() < deadline:
+        rows = _read_target_actions_or_none(page)
+        if rows is None:
+            previous = None
+            stable_streak = 0
+        else:
+            current = {row["GoalId"] for row in rows}
+            if current == previous:
+                stable_streak += 1
+                if stable_streak >= _TARGET_ACTION_STABLE_STREAK:
+                    return sorted(current)
+            else:
+                previous = current
+                stable_streak = 1
+        page.wait_for_timeout(_TARGET_ACTION_STABLE_TICK_MS)
+    return None
+
+
 def _parse_target_action_price(raw: str) -> Optional[float]:
     """Parse a target-action price input's raw string value, same
     normalization as ``_goal_price_matches`` (comma decimal separator,
@@ -7502,6 +7593,7 @@ def _verify_saved(
     add_audience_tags: Optional[List[str]] = None,
     remove_audience_tag_indices: Optional[List[int]] = None,
     metrika_counters_before: Optional[List[str]] = None,
+    metrika_preservation_requested: bool = False,
     add_metrika_counters: Optional[List[str]] = None,
     remove_metrika_counter_indices: Optional[List[int]] = None,
     sitelinks_before: Optional[List[Dict[str, str]]] = None,
@@ -7791,18 +7883,11 @@ def _verify_saved(
                 f"page now shows {sorted(actual_tags)!r}"
             )
 
-    if metrika_counters_before is not None:
-        # Mirrors the audience-tags block immediately above verbatim (same
-        # "expected multiset derived from the pre-mutation baseline, so an
-        # untouched save is asserted UNCHANGED rather than left
-        # unverified" reasoning applies here too) — see that block's own
-        # comments for the full rationale. Not live-verified: this section
-        # has no confirmed settle-timing recon of its own (see the module
-        # comment above ``_METRIKA_COUNTER_WRAPPER_TESTID``), so this uses
-        # the shared default read budget rather than inventing an
-        # unconfirmed multiplier the way the audience-tags block's
-        # ``_AUDIENCE_SECTION_READY_TIMEOUT_MS * 3`` does from its own
-        # live-measured settle time.
+    if metrika_counters_before is not None or metrika_preservation_requested:
+        # Same expected-multiset-from-the-pre-mutation-baseline contract as
+        # audience tags above, but using the failure-aware stabilized reader:
+        # an unreadable or transiently partial post-save widget must not turn
+        # into a false empty/successful preservation check (issue #836).
         # Built from _metrika_counter_identity(...), NOT the raw text
         # (cycle-review finding, issue #648): add_metrika_counters is the
         # user-supplied autocomplete-suggestion text
@@ -7814,35 +7899,39 @@ def _verify_saved(
         # formats agree on the counter's numeric id (see
         # _metrika_counter_identity's own docstring), which is the actual
         # identity a caller cares about.
-        expected_counters = Counter(
-            _metrika_counter_identity(c) for c in metrika_counters_before
-        )
-        for index in remove_metrika_counter_indices or []:
-            expected_counters[
-                _metrika_counter_identity(metrika_counters_before[index])
-            ] -= 1
-        expected_counters += Counter(
-            _metrika_counter_identity(c) for c in (add_metrika_counters or [])
-        )
-
-        def _counter_state_matches(actual_counters: List[str], _expected: Any) -> bool:
-            return (
-                Counter(_metrika_counter_identity(c) for c in actual_counters)
-                == expected_counters
-            )
-
-        actual_counters = _read_until_matches(
-            page,
-            _read_metrika_counters,
-            None,
-            matches=_counter_state_matches,
-        )
-        if not _counter_state_matches(actual_counters, None):
+        if metrika_counters_before is None:
             mismatches.append(
-                "metrika_counters: expected counter ids "
-                f"{sorted(expected_counters.elements())!r}, page now shows "
-                f"{sorted(actual_counters)!r}"
+                "metrika_counters: the preservation check was requested, "
+                "but no readable pre-save baseline is available"
             )
+        else:
+            expected_counters = Counter(
+                _metrika_counter_identity(c) for c in metrika_counters_before
+            )
+            for index in remove_metrika_counter_indices or []:
+                expected_counters[
+                    _metrika_counter_identity(metrika_counters_before[index])
+                ] -= 1
+            expected_counters += Counter(
+                _metrika_counter_identity(c) for c in (add_metrika_counters or [])
+            )
+
+            def _counter_state_matches(
+                actual_counters: Optional[List[str]], _expected: Any
+            ) -> bool:
+                return actual_counters is not None and (
+                    Counter(_metrika_counter_identity(c) for c in actual_counters)
+                    == expected_counters
+                )
+
+            actual_counters = _read_confirmed_metrika_counters_or_none(page)
+            if not _counter_state_matches(actual_counters, None):
+                shown = sorted(actual_counters) if actual_counters is not None else None
+                mismatches.append(
+                    "metrika_counters: expected counter ids "
+                    f"{sorted(expected_counters.elements())!r}, page now shows "
+                    f"{shown!r}"
+                )
 
     if sitelinks_before is not None:
         # Same "one expected multiset derived from the pre-mutation
@@ -8126,62 +8215,22 @@ def _verify_saved(
                     )
 
     if target_actions_unchanged_requested:
-        # Issue #836: this save touched no target action at all (a URL/UTM
-        # -only update), so the block above never ran — yet the whole-form
-        # save still resubmits this section, and the UTM spoiler's
-        # live-confirmed re-render (issue #830) can empty it first. Assert
-        # the untouched set came back UNCHANGED, mirroring what
-        # ``audience_tags_before`` does for a gender/age/device-only save.
-        #
-        # Scoped to a NON-EMPTY baseline, set by ``update_master`` only when
-        # the pre-save read actually saw goal rows. ``_read_target_actions_
-        # or_none`` returns ``None`` both when the table failed to hydrate
-        # AND when the section is simply not visible — which is the normal,
-        # correct state for a campaign that has no target actions at all —
-        # so "unreadable" and "legitimately none" are indistinguishable
-        # here. Treating that ambiguity as a failure would block every
-        # URL/UTM update on every campaign without goals, for no safety
-        # gain: a campaign with nothing to lose cannot silently lose it.
-        #
-        # The protection therefore covers exactly the case that has
-        # something at stake — goals demonstrably present before the save —
-        # and within that case it IS closed: once a non-empty baseline
-        # exists, a post-save read that is empty, partial, or unreadable
-        # all fail the set comparison below rather than passing.
+        # Issue #836: this URL/UTM save requested no row add/remove (a price
+        # update may still be present), yet the whole-form save resubmits the
+        # complete table. Compare the exact set from independently stabilized
+        # pre/post-save reads. An empty set is valid when the rendered section
+        # genuinely has no goals; an unreadable baseline is rejected before
+        # Save and an unreadable post-save state is a mismatch here.
         expected_unchanged = set(target_actions_unchanged_before or [])
-        if expected_unchanged:
-
-            # Defined locally rather than reusing the identically-shaped
-            # reader in the add/remove block above: that one is nested
-            # inside its own ``if``, so it is unbound on this path (the two
-            # blocks never both run).
-            def _read_unchanged_goal_ids(p: "Page") -> Optional[Set[int]]:
-                rows = _read_target_actions_or_none(p)
-                if rows is None:
-                    return None
-                return {row["GoalId"] for row in rows}
-
-            def _unchanged_matches(actual: Optional[Set[int]], _expected: Any) -> bool:
-                return actual is not None and actual == expected_unchanged
-
-            actual_unchanged = _read_until_matches(
-                page,
-                _read_unchanged_goal_ids,
-                None,
-                matches=_unchanged_matches,
-                timeout_ms=_VERIFY_FIELD_READ_TIMEOUT_MS
-                + _TARGET_ACTION_SETTLE_TIMEOUT_MS,
+        actual_unchanged = _read_confirmed_target_action_goal_ids(page)
+        actual_set = set(actual_unchanged) if actual_unchanged is not None else None
+        if actual_set != expected_unchanged:
+            mismatches.append(
+                "target actions: this update did not request any "
+                "target-action row change, but goal ids "
+                f"{sorted(expected_unchanged)!r} are no longer intact — "
+                f"page now shows {actual_unchanged!r}"
             )
-            if not _unchanged_matches(actual_unchanged, None):
-                _shown = (
-                    sorted(actual_unchanged) if actual_unchanged is not None else None
-                )
-                mismatches.append(
-                    "target actions: this update did not request any "
-                    "target-action change, but goal ids "
-                    f"{sorted(expected_unchanged)!r} are no longer intact — "
-                    f"page now shows {_shown!r}"
-                )
 
     mismatches.extend(
         _verify_repeating_value_mismatches(
@@ -8611,50 +8660,72 @@ def update_master(
     # ``_wait_for_draft_status``'s docstring).
     was_draft = _wait_for_draft_status(page, campaign_id)
 
-    # Issue #836: a URL/UTM-only update mutates neither the Metrika-counters
-    # nor the "Целевые действия" section, but still submits the WHOLE form
-    # (see this module's docstring) — and expanding the UTM spoiler is
-    # live-confirmed (issue #830, 4 campaigns, 100% reproduction) to
-    # re-render the surrounding form from server state. Nothing used to
-    # re-check either untouched section afterwards, so a re-render that
-    # dropped a counter or a goal row would be saved and reported as a
-    # success. Same "snapshot the untouched section so _verify_saved can
-    # assert it came back UNCHANGED" fix issue #752 (R2-1) applied to the
-    # audience tags below.
+    # Issue #836: a URL/UTM update still submits the WHOLE form (see this
+    # module's docstring) — and expanding the UTM spoiler is live-confirmed
+    # (issue #830, 4 campaigns, 100% reproduction) to re-render the
+    # surrounding form from server state. Nothing used to re-check these
+    # sections afterwards when they were not themselves mutated, so a
+    # re-render that dropped a counter or goal row could be saved and
+    # reported as a success. Snapshot each protected section so verification
+    # can assert the unchanged or explicitly requested final state.
     #
     # Taken HERE, before ``_set_tracking_params`` expands that spoiler,
     # because a snapshot read after the re-render would capture the already
     # corrupted state and certify the loss as the expected baseline.
     #
-    # Only for a URL/UTM update: an explicit counters/target-actions
-    # mutation takes its own, later snapshot below, whose position must be
-    # resolved against the state those mutations actually operate on.
-    _url_or_utm_only_save = (
-        landing_url is not None or tracking_params is not None
-    ) and not (
-        add_metrika_counters
-        or remove_metrika_counters
-        or add_target_actions
-        or remove_target_action_goal_ids
-        or target_action_prices
-    )
+    # The two protections are deliberately independent: mutating target
+    # actions must not disable preservation of Metrika counters, and vice
+    # versa. Switching the promotion goal to max-clicks is the one exception
+    # because that transition legitimately removes both sections.
+    _url_or_utm_save = landing_url is not None or tracking_params is not None
+    # Only max-clicks intentionally removes these widgets. Re-selecting or
+    # switching to max-conversions must keep protection enabled: if the
+    # sections already exist, they still participate in the same whole-form
+    # URL/UTM save and remain vulnerable to the hydration race.
+    _preserve_metrika = _url_or_utm_save and promotion_goal != "max-clicks"
+    _preserve_target_actions = _url_or_utm_save and promotion_goal != "max-clicks"
     metrika_counters_before: Optional[List[str]] = None
+    metrika_preservation_requested = False
     target_actions_unchanged_before: Optional[List[int]] = None
-    if _url_or_utm_only_save:
-        metrika_counters_before = _read_metrika_counters(page)
-        # ``_read_target_actions_or_none`` (not ``_read_target_actions``):
-        # the latter flattens "the table never hydrated" into a well-formed
-        # ``[]``, which would certify "this campaign had no goals" as the
-        # baseline and make a genuine wipe unverifiable. ``None`` keeps
-        # "unreadable" distinct, and _verify_saved fails closed on it.
-        _rows_before = (
-            _read_target_actions_or_none(page)
-            if _wait_for_target_actions_ready(page)
-            else None
-        )
-        if _rows_before is not None:
-            target_actions_unchanged_before = [row["GoalId"] for row in _rows_before]
-        _warn_on_cross_domain_landing_url(page, landing_url, metrika_counters_before)
+    target_actions_unchanged_requested = False
+    target_action_goal_ids_before: Optional[List[int]] = None
+    if _url_or_utm_save:
+        section_present = _metrika_counters_section_present(page)
+        counters_at_load: Optional[List[str]] = None
+        if section_present:
+            counters_at_load = _read_confirmed_metrika_counters_or_none(page)
+            if counters_at_load is None and _preserve_metrika:
+                raise BrowserSessionError(
+                    "Could not obtain a stable pre-save snapshot of the "
+                    "'Счетчики Яндекс Метрики' section. The URL/UTM update "
+                    "was not saved because an unreadable baseline could hide "
+                    "counter loss; retry after the page has fully loaded."
+                )
+        _warn_on_cross_domain_landing_url(page, landing_url, counters_at_load)
+
+        if _preserve_metrika and section_present:
+            metrika_counters_before = counters_at_load
+            metrika_preservation_requested = True
+
+        if _preserve_target_actions and section_present:
+            target_ids = _read_confirmed_target_action_goal_ids(page)
+            if target_ids is None:
+                raise BrowserSessionError(
+                    "Could not obtain a stable pre-save snapshot of the "
+                    "'Целевые действия' section. The URL/UTM update was not "
+                    "saved because an unreadable baseline could hide target-"
+                    "action loss; retry after the page has fully loaded."
+                )
+            if add_target_actions or remove_target_action_goal_ids:
+                # The existing add/remove verifier derives its full expected
+                # final set from this baseline. Supplying the pre-UTM snapshot
+                # prevents a re-rendered partial table from lowering that bar.
+                target_action_goal_ids_before = target_ids
+            else:
+                # Price-only mutations do not change row identity, so the full
+                # id set is still expected to survive unchanged.
+                target_actions_unchanged_before = target_ids
+                target_actions_unchanged_requested = True
 
     if name is not None:
         _set_campaign_name(page, name)
@@ -8736,8 +8807,7 @@ def update_master(
     # streak-only verification, whose `added_ok` check is positive-going
     # (it requires the added goal to be PRESENT) and so is not satisfied by
     # an empty dip in the first place.
-    target_action_goal_ids_before: Optional[List[int]] = None
-    if remove_target_action_goal_ids:
+    if remove_target_action_goal_ids and target_action_goal_ids_before is None:
         _rows_before = (
             _read_target_actions_or_none(page)
             if _wait_for_target_actions_ready(page)
@@ -8778,14 +8848,11 @@ def update_master(
         add_metrika_counters=add_metrika_counters,
         remove_metrika_counters=remove_metrika_counters,
     )
-    # ``_apply_metrika_counters`` returns ``None`` when no counter mutation
-    # was requested — which is exactly the URL/UTM-only case that already
-    # captured this section above, BEFORE the UTM spoiler's re-render
-    # (issue #836). Assigning its ``None`` unconditionally would discard
-    # that baseline and disable the untouched-section check. The two are
-    # mutually exclusive by ``_url_or_utm_only_save``'s own definition, so
-    # only a real mutation's baseline overwrites it.
-    if _metrika_baseline is not None:
+    # Preserve an early pre-UTM baseline whenever one exists. The helper's
+    # later baseline is still needed for ordinary counter-only updates, but
+    # on a combined URL/UTM update it may already reflect the very re-render
+    # loss issue #836 is guarding against.
+    if metrika_counters_before is None and _metrika_baseline is not None:
         metrika_counters_before = _metrika_baseline
 
     for goal_id in remove_target_action_goal_ids or []:
@@ -9128,7 +9195,7 @@ def update_master(
             remove_target_action_goal_ids=remove_target_action_goal_ids,
             target_action_goal_ids_before=target_action_goal_ids_before,
             target_actions_unchanged_before=target_actions_unchanged_before,
-            target_actions_unchanged_requested=_url_or_utm_only_save,
+            target_actions_unchanged_requested=target_actions_unchanged_requested,
             gender=gender,
             age_from_requested=age_from_requested,
             age_from=age_from,
@@ -9139,6 +9206,7 @@ def update_master(
             add_audience_tags=add_audience_tags,
             remove_audience_tag_indices=remove_audience_tags,
             metrika_counters_before=metrika_counters_before,
+            metrika_preservation_requested=metrika_preservation_requested,
             add_metrika_counters=add_metrika_counters,
             remove_metrika_counter_indices=remove_metrika_counters,
             sitelinks_before=sitelinks_before,

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -21908,5 +21908,260 @@ class TestMastersUpdateBatch(unittest.TestCase):
                 self.assertIn(target, browser_kwargs)
 
 
+class TestUrlUtmOnlySavePreservesUntouchedSections(unittest.TestCase):
+    """Issue #836 — a URL/UTM-only ``masters update`` must not silently drop
+    the campaign's Metrika counters or target actions.
+
+    The edit page is a single whole-form save (module docstring), and
+    expanding the UTM spoiler is live-confirmed (issue #830) to re-render
+    the surrounding form from server state. Before this fix, neither
+    section was read on a URL/UTM-only update, so a re-render that emptied
+    one of them was saved and reported as a success.
+
+    These fakes model the sections as they read back AFTER the save (the
+    ``_verify_saved`` reload), which is where the loss becomes observable.
+    """
+
+    GOAL_ID = 159614149
+
+    def _row_prefix_selector(self):
+        return (
+            f'[data-testid^="TargetActions.'
+            f'{browser_masters._TARGET_ACTIONS_CATEGORY}."]'
+        )
+
+    def _target_action_locators(self, goal_ids):
+        """Locators for a rendered 'Целевые действия' table holding
+        ``goal_ids``. An empty list models a section that rendered with no
+        rows at all — the shape a dropped-goals save reads back as."""
+        row_testids = [
+            browser_masters._TARGET_ACTION_ROW_TESTID_TEMPLATE.format(
+                category=browser_masters._TARGET_ACTIONS_CATEGORY, goal_id=goal_id
+            )
+            for goal_id in goal_ids
+        ]
+        locators = {
+            browser_masters._TARGET_ACTIONS_SECTION_TESTID: _FakeLocator(
+                [_FakeLocatorHandle()]
+            ),
+            self._row_prefix_selector(): _FakeLocator(
+                [
+                    _FakeLocatorHandle(attrs={"data-testid": row_testid})
+                    for row_testid in row_testids
+                ]
+            ),
+        }
+        for goal_id, row_testid in zip(goal_ids, row_testids):
+            price_testid = browser_masters._TARGET_ACTION_PRICE_TESTID_TEMPLATE.format(
+                category=browser_masters._TARGET_ACTIONS_CATEGORY, goal_id=goal_id
+            )
+            locators[f'[data-testid="{row_testid}"] [data-testid="Text"]'] = (
+                _FakeLocator([_FakeLocatorHandle(text="Покупка")])
+            )
+            locators[f'[data-testid="{price_testid}"]'] = _FakeLocator(
+                [_FakeLocatorHandle(get_value=lambda: "150")]
+            )
+        return locators
+
+    def _metrika_locators(self, counters):
+        locators = {}
+        if counters:
+            locators[browser_masters._METRIKA_COUNTER_WRAPPER_TESTID] = _FakeLocator(
+                [_FakeLocatorHandle()]
+            )
+            for index, counter in enumerate(counters):
+                locators[f'[data-testid="MetrikaCountersTagGroup.tag.{index}"]'] = (
+                    _FakeLocator([_FakeLocatorHandle(text=counter)])
+                )
+        return locators
+
+    def _page(self, *, goal_ids_after, counters_after, landing_url="https://a.ru/x"):
+        """A fake edit page whose sections read back ``*_after`` state.
+
+        The pre-save baseline and the post-save re-read share these same
+        locators, so a test that wants to model a LOSS passes a smaller
+        ``*_after`` set than the baseline read will see — see
+        ``_LosingPage`` below, which switches state at save time.
+        """
+        save_handle = _FakeTextLocatorHandle(visible=True)
+        locators = {
+            browser_masters._EDIT_URL_INPUT_TESTID: _FakeLocator(
+                [_FakeContentEditableHandle(text=landing_url)]
+            ),
+            f'[data-testid="{browser_masters._EDIT_FORM_READY_TESTID}"]': _FakeLocator(
+                [_FakeLocatorHandle()]
+            ),
+        }
+        locators.update(self._target_action_locators(goal_ids_after))
+        locators.update(self._metrika_locators(counters_after))
+        return FakePage(
+            locators=locators,
+            role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
+        )
+
+    def test_untouched_sections_that_survive_the_save_are_accepted(self):
+        """The baseline case: counters and goals read back intact after a
+        tracking-params-only save, so the update must succeed. Guards
+        against the new check becoming a blanket failure."""
+        page = self._page(
+            goal_ids_after=[self.GOAL_ID],
+            counters_after=["gc.ksamata.ru • 72112213\n30 целей"],
+        )
+
+        result = browser_masters.update_master(
+            page, 42, landing_url="https://a.ru/new-page"
+        )
+
+        self.assertEqual(result["CampaignId"], 42)
+
+    def test_dropped_target_actions_are_reported_not_silently_saved(self):
+        """The core issue #836 failure: goals present before the save are
+        gone from the post-save page. This is exactly the silent data loss
+        the user hit, and it must raise rather than report success."""
+        goal_id = self.GOAL_ID
+        page = self._page(goal_ids_after=[goal_id], counters_after=[])
+        # After the save click, the target-actions table comes back empty —
+        # the whole-form save persisted a re-rendered, emptied section.
+        original_locator = page.locator
+        state = {"saved": False}
+        empty_rows = _FakeLocator([])
+
+        def _locator(selector):
+            if state["saved"] and selector == self._row_prefix_selector():
+                return empty_rows
+            return original_locator(selector)
+
+        page.locator = _locator
+        save_button = page.get_by_role("button", name=browser_masters._SAVE_BUTTON_TEXT)
+        original_click = save_button.first.click
+
+        def _click_then_lose():
+            state["saved"] = True
+            return original_click()
+
+        save_button.first.click = _click_then_lose
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(page, 42, landing_url="https://a.ru/new-page")
+
+        self.assertIn("target actions", str(ctx.exception))
+        self.assertIn(str(goal_id), str(ctx.exception))
+
+    def test_dropped_metrika_counters_are_reported_not_silently_saved(self):
+        """Same failure for the Metrika section: a counter linked before
+        the save is missing afterwards."""
+        page = self._page(
+            goal_ids_after=[],
+            counters_after=["gc.ksamata.ru • 72112213\n30 целей"],
+        )
+        state = {"saved": False}
+        original_locator = page.locator
+        empty = _FakeLocator([])
+
+        def _locator(selector):
+            if state["saved"] and selector.startswith(
+                browser_masters._METRIKA_COUNTER_WRAPPER_TESTID
+            ):
+                return empty
+            return original_locator(selector)
+
+        page.locator = _locator
+        save_button = page.get_by_role("button", name=browser_masters._SAVE_BUTTON_TEXT)
+        original_click = save_button.first.click
+
+        def _click_then_lose():
+            state["saved"] = True
+            return original_click()
+
+        save_button.first.click = _click_then_lose
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(page, 42, landing_url="https://a.ru/new-page")
+
+        self.assertIn("metrika_counters", str(ctx.exception))
+
+    def test_campaign_without_target_actions_is_not_blocked(self):
+        """A campaign with no goals at all reads the section as
+        unavailable, which is indistinguishable from 'failed to hydrate'.
+        That ambiguity must not block a legitimate URL/UTM update — there
+        is nothing to lose, so there is nothing to protect."""
+        page = self._page(goal_ids_after=[], counters_after=[])
+
+        result = browser_masters.update_master(
+            page, 42, landing_url="https://a.ru/new-page"
+        )
+
+        self.assertEqual(result["CampaignId"], 42)
+
+
+class TestCrossDomainLandingUrlWarning(unittest.TestCase):
+    """Issue #836 point 3 — Yandex binds a Metrika counter and its goals to
+    the landing page's DOMAIN, so moving a campaign to a different domain
+    can leave them pointing at a site it no longer promotes. Non-blocking:
+    the update is still legitimate, the user is warned."""
+
+    COUNTER = "gc.ksamata.ru • 72112213\n30 целей"
+
+    def _page(self, current_url):
+        return FakePage(
+            locators={
+                browser_masters._EDIT_URL_INPUT_TESTID: _FakeLocator(
+                    [_FakeContentEditableHandle(text=current_url)]
+                ),
+            }
+        )
+
+    def test_warns_when_the_domain_changes_and_counters_are_linked(self):
+        warnings = []
+        page = self._page("https://old.example.com/landing")
+
+        with patch.object(browser_masters, "print_warning", warnings.append):
+            browser_masters._warn_on_cross_domain_landing_url(
+                page, "https://new.example.org/landing", [self.COUNTER]
+            )
+
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("old.example.com", warnings[0])
+        self.assertIn("new.example.org", warnings[0])
+
+    def test_does_not_warn_when_only_the_path_changes(self):
+        """Same domain keeps the counter binding valid — warning here would
+        be pure noise on the most common kind of URL edit."""
+        warnings = []
+        page = self._page("https://shop.example.com/old-page?a=1")
+
+        with patch.object(browser_masters, "print_warning", warnings.append):
+            browser_masters._warn_on_cross_domain_landing_url(
+                page, "https://shop.example.com/new-page?b=2", [self.COUNTER]
+            )
+
+        self.assertEqual(warnings, [])
+
+    def test_does_not_warn_when_the_campaign_has_no_counters(self):
+        """Nothing is bound to the old domain, so nothing can desync."""
+        warnings = []
+        page = self._page("https://old.example.com/landing")
+
+        with patch.object(browser_masters, "print_warning", warnings.append):
+            browser_masters._warn_on_cross_domain_landing_url(
+                page, "https://new.example.org/landing", []
+            )
+
+        self.assertEqual(warnings, [])
+
+    def test_does_not_warn_when_the_current_url_is_unreadable(self):
+        """An unreadable current URL is inconclusive, not evidence of a
+        domain change — guessing would cry wolf on every such read."""
+        warnings = []
+        page = FakePage(locators={})
+
+        with patch.object(browser_masters, "print_warning", warnings.append):
+            browser_masters._warn_on_cross_domain_landing_url(
+                page, "https://new.example.org/landing", [self.COUNTER]
+            )
+
+        self.assertEqual(warnings, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -7592,6 +7592,29 @@ class TestClickSave(unittest.TestCase):
 
         self.assertEqual(clicks, [True])
 
+    def test_runs_final_guard_immediately_before_non_draft_click(self):
+        events = []
+        page = FakePage(
+            role_elements=[
+                (
+                    "button",
+                    browser_masters._SAVE_BUTTON_TEXT,
+                    _FakeTextLocatorHandle(
+                        visible=True, on_click=lambda: events.append("click")
+                    ),
+                )
+            ]
+        )
+
+        browser_masters._click_save(
+            page,
+            42,
+            is_draft=False,
+            before_click=lambda: events.append("guard"),
+        )
+
+        self.assertEqual(events, ["guard", "click"])
+
 
 class TestDraftEditPageSave(unittest.TestCase):
     """``_is_draft_edit_page``/``_click_save`` DRAFT path (issue #668).
@@ -7637,6 +7660,29 @@ class TestDraftEditPageSave(unittest.TestCase):
         # The publish button must never be touched unless --launch was
         # explicitly requested.
         self.assertEqual(clicks, ["draft"])
+
+    def test_final_guard_can_block_draft_click(self):
+        clicks = []
+        page = FakePage(
+            locators={
+                browser_masters._DRAFT_SAVE_DRAFT_BUTTON_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle(on_click=lambda: clicks.append("draft"))]
+                )
+            }
+        )
+
+        def _block():
+            raise BrowserSessionError("unsafe protected section")
+
+        with self.assertRaisesRegex(BrowserSessionError, "unsafe protected section"):
+            browser_masters._click_save(
+                page,
+                713231614,
+                is_draft=True,
+                before_click=_block,
+            )
+
+        self.assertEqual(clicks, [])
 
     def test_click_save_on_draft_clicks_launch_button_when_requested(self):
         clicks = []
@@ -22019,6 +22065,28 @@ class TestUrlUtmSavePreservesSections(unittest.TestCase):
             role_elements=[("button", browser_masters._SAVE_BUTTON_TEXT, save_handle)],
         )
 
+    def _add_utm_controls(self, page, *, on_expand=None):
+        state = {"expanded": False}
+
+        def _expand():
+            state["expanded"] = True
+            if on_expand is not None:
+                on_expand()
+
+        spoiler = _DynamicAttrsLocatorHandle(
+            get_attrs=lambda: {
+                "aria-expanded": "true" if state["expanded"] else "false"
+            },
+            on_click=_expand,
+        )
+        page._locators[browser_masters._EDIT_UTM_SPOILER_BUTTON_TESTID] = _FakeLocator(
+            [spoiler]
+        )
+        page._locators[browser_masters._EDIT_UTM_INPUT_TESTID] = _FakeLocator(
+            [_FakeContentEditableHandle(text="utm_source=old")]
+        )
+        return state
+
     def test_untouched_sections_that_survive_the_save_are_accepted(self):
         """The baseline case: counters and goals read back intact after a
         tracking-params-only save, so the update must succeed. Guards
@@ -22288,6 +22356,66 @@ class TestUrlUtmSavePreservesSections(unittest.TestCase):
 
         self.assertIn(str(other_goal), str(ctx.exception))
 
+    def test_utm_counter_loss_aborts_before_save_during_combined_update(self):
+        counter = "gc.ksamata.ru • 72112213\n30 целей"
+        page = self._page(goal_ids_after=[self.GOAL_ID], counters_after=[counter])
+        state = {"rerendered": False}
+        original_locator = page.locator
+        counter_tag = '[data-testid="MetrikaCountersTagGroup.tag.0"]'
+        empty = _FakeLocator([])
+
+        def _locator(selector):
+            if state["rerendered"] and selector == counter_tag:
+                return empty
+            return original_locator(selector)
+
+        page.locator = _locator
+        self._add_utm_controls(
+            page, on_expand=lambda: state.__setitem__("rerendered", True)
+        )
+        clicks = []
+        save = page.get_by_role("button", name=browser_masters._SAVE_BUTTON_TEXT).first
+        save._on_click = lambda: clicks.append(True)
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(
+                page,
+                42,
+                tracking_params="utm_source=new",
+                target_action_prices={self.GOAL_ID: 150},
+            )
+
+        self.assertIn("Refusing to save", str(ctx.exception))
+        self.assertIn("Metrika counters", str(ctx.exception))
+        self.assertEqual(clicks, [])
+
+    def test_utm_target_action_loss_aborts_before_save(self):
+        page = self._page(goal_ids_after=[self.GOAL_ID], counters_after=[])
+        state = {"rerendered": False}
+        original_locator = page.locator
+        row_prefix = self._row_prefix_selector()
+        empty = _FakeLocator([])
+
+        def _locator(selector):
+            if state["rerendered"] and selector == row_prefix:
+                return empty
+            return original_locator(selector)
+
+        page.locator = _locator
+        self._add_utm_controls(
+            page, on_expand=lambda: state.__setitem__("rerendered", True)
+        )
+        clicks = []
+        save = page.get_by_role("button", name=browser_masters._SAVE_BUTTON_TEXT).first
+        save._on_click = lambda: clicks.append(True)
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(page, 42, tracking_params="utm_source=new")
+
+        self.assertIn("Refusing to save", str(ctx.exception))
+        self.assertIn("target-action goal ids", str(ctx.exception))
+        self.assertEqual(clicks, [])
+
     def test_target_price_update_does_not_disable_metrika_preservation(self):
         counter = "gc.ksamata.ru • 72112213\n30 целей"
         page = self._page(
@@ -22329,12 +22457,12 @@ class TestUrlUtmSavePreservesSections(unittest.TestCase):
         counter = "gc.ksamata.ru • 72112213\n30 целей"
         counter_tag = '[data-testid="MetrikaCountersTagGroup.tag.0"]'
         page = self._page(goal_ids_after=[self.GOAL_ID], counters_after=[])
-        state = {"saved": False}
+        state = {"saved": False, "counter_added": False}
         original_locator = page.locator
         empty_rows = _FakeLocator([])
 
         def _locator(selector):
-            if state["saved"] and selector == counter_tag:
+            if state["counter_added"] and selector == counter_tag:
                 return _FakeLocator([_FakeLocatorHandle(text=counter)])
             if state["saved"] and selector == self._row_prefix_selector():
                 return empty_rows
@@ -22350,8 +22478,16 @@ class TestUrlUtmSavePreservesSections(unittest.TestCase):
 
         save.click = _click_then_lose_targets
 
+        def _apply_counter(*_args, **_kwargs):
+            state["counter_added"] = True
+            return []
+
         with (
-            patch.object(browser_masters, "_apply_metrika_counters", return_value=[]),
+            patch.object(
+                browser_masters,
+                "_apply_metrika_counters",
+                side_effect=_apply_counter,
+            ),
             self.assertRaises(BrowserSessionError) as ctx,
         ):
             browser_masters.update_master(
@@ -22434,19 +22570,7 @@ class TestUrlUtmSavePreservesSections(unittest.TestCase):
             goal_ids_after=[self.GOAL_ID],
             counters_after=["gc.ksamata.ru • 72112213\n30 целей"],
         )
-        state = {"expanded": False}
-        spoiler = _DynamicAttrsLocatorHandle(
-            get_attrs=lambda: {
-                "aria-expanded": "true" if state["expanded"] else "false"
-            },
-            on_click=lambda: state.__setitem__("expanded", True),
-        )
-        page._locators[browser_masters._EDIT_UTM_SPOILER_BUTTON_TESTID] = _FakeLocator(
-            [spoiler]
-        )
-        page._locators[browser_masters._EDIT_UTM_INPUT_TESTID] = _FakeLocator(
-            [_FakeContentEditableHandle(text="utm_source=old")]
-        )
+        self._add_utm_controls(page)
 
         result = browser_masters.update_master(
             page, 42, tracking_params="utm_source=new"

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -19772,6 +19772,20 @@ class TestReadMetrikaCounters(unittest.TestCase):
 
         self.assertEqual(browser_masters._read_metrika_counters(page), [])
 
+    def test_failure_aware_reader_rejects_an_unreadable_existing_tag(self):
+        page = FakePage(
+            locators={
+                browser_masters._METRIKA_COUNTER_WRAPPER_TESTID: _FakeLocator(
+                    [_FakeLocatorHandle()]
+                ),
+                self._tag_testid(0): _FakeLocator(
+                    [_FakeLocatorHandle(text="ignored", raises=True)]
+                ),
+            }
+        )
+
+        self.assertIsNone(browser_masters._read_metrika_counters_or_none(page))
+
     def test_stops_at_first_missing_index(self):
         page = FakePage(
             locators={
@@ -21908,14 +21922,14 @@ class TestMastersUpdateBatch(unittest.TestCase):
                 self.assertIn(target, browser_kwargs)
 
 
-class TestUrlUtmOnlySavePreservesUntouchedSections(unittest.TestCase):
-    """Issue #836 — a URL/UTM-only ``masters update`` must not silently drop
-    the campaign's Metrika counters or target actions.
+class TestUrlUtmSavePreservesSections(unittest.TestCase):
+    """Issue #836 — a URL/UTM ``masters update`` must not silently drop the
+    campaign's Metrika counters or target actions, including combined calls.
 
     The edit page is a single whole-form save (module docstring), and
     expanding the UTM spoiler is live-confirmed (issue #830) to re-render
     the surrounding form from server state. Before this fix, neither
-    section was read on a URL/UTM-only update, so a re-render that emptied
+    section was read on a URL/UTM update, so a re-render that emptied
     one of them was saved and reported as a success.
 
     These fakes model the sections as they read back AFTER the save (the
@@ -21964,15 +21978,21 @@ class TestUrlUtmOnlySavePreservesUntouchedSections(unittest.TestCase):
         return locators
 
     def _metrika_locators(self, counters):
-        locators = {}
-        if counters:
-            locators[browser_masters._METRIKA_COUNTER_WRAPPER_TESTID] = _FakeLocator(
+        # This class models max-conversions campaigns: the block and wrapper
+        # render even when no counter is linked, making ``[]`` a genuine
+        # readable empty state rather than an absent/unreadable section.
+        locators = {
+            browser_masters._METRIKA_COUNTERS_BLOCK_TESTID: _FakeLocator(
                 [_FakeLocatorHandle()]
+            ),
+            browser_masters._METRIKA_COUNTER_WRAPPER_TESTID: _FakeLocator(
+                [_FakeLocatorHandle()]
+            ),
+        }
+        for index, counter in enumerate(counters):
+            locators[f'[data-testid="MetrikaCountersTagGroup.tag.{index}"]'] = (
+                _FakeLocator([_FakeLocatorHandle(text=counter)])
             )
-            for index, counter in enumerate(counters):
-                locators[f'[data-testid="MetrikaCountersTagGroup.tag.{index}"]'] = (
-                    _FakeLocator([_FakeLocatorHandle(text=counter)])
-                )
         return locators
 
     def _page(self, *, goal_ids_after, counters_after, landing_url="https://a.ru/x"):
@@ -22057,11 +22077,10 @@ class TestUrlUtmOnlySavePreservesUntouchedSections(unittest.TestCase):
         state = {"saved": False}
         original_locator = page.locator
         empty = _FakeLocator([])
+        counter_tag = '[data-testid="MetrikaCountersTagGroup.tag.0"]'
 
         def _locator(selector):
-            if state["saved"] and selector.startswith(
-                browser_masters._METRIKA_COUNTER_WRAPPER_TESTID
-            ):
+            if state["saved"] and selector == counter_tag:
                 return empty
             return original_locator(selector)
 
@@ -22081,10 +22100,8 @@ class TestUrlUtmOnlySavePreservesUntouchedSections(unittest.TestCase):
         self.assertIn("metrika_counters", str(ctx.exception))
 
     def test_campaign_without_target_actions_is_not_blocked(self):
-        """A campaign with no goals at all reads the section as
-        unavailable, which is indistinguishable from 'failed to hydrate'.
-        That ambiguity must not block a legitimate URL/UTM update — there
-        is nothing to lose, so there is nothing to protect."""
+        """A rendered, readable empty table is a legitimate no-goals state
+        and must not block a URL/UTM update."""
         page = self._page(goal_ids_after=[], counters_after=[])
 
         result = browser_masters.update_master(
@@ -22092,6 +22109,350 @@ class TestUrlUtmOnlySavePreservesUntouchedSections(unittest.TestCase):
         )
 
         self.assertEqual(result["CampaignId"], 42)
+
+    def test_unreadable_metrika_baseline_blocks_before_save(self):
+        page = self._page(goal_ids_after=[self.GOAL_ID], counters_after=[])
+        page._locators[browser_masters._METRIKA_COUNTER_WRAPPER_TESTID] = _FakeLocator(
+            []
+        )
+        clicks = []
+        save = page.get_by_role("button", name=browser_masters._SAVE_BUTTON_TEXT).first
+        save._on_click = lambda: clicks.append(True)
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(page, 42, landing_url="https://a.ru/new")
+
+        self.assertIn("stable pre-save snapshot", str(ctx.exception))
+        self.assertIn("Метрики", str(ctx.exception))
+        self.assertEqual(clicks, [])
+
+    def test_unreadable_target_action_baseline_blocks_before_save(self):
+        page = self._page(goal_ids_after=[], counters_after=[])
+        page._locators[browser_masters._TARGET_ACTIONS_SECTION_TESTID] = _FakeLocator(
+            []
+        )
+        clicks = []
+        save = page.get_by_role("button", name=browser_masters._SAVE_BUTTON_TEXT).first
+        save._on_click = lambda: clicks.append(True)
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(page, 42, landing_url="https://a.ru/new")
+
+        self.assertIn("stable pre-save snapshot", str(ctx.exception))
+        self.assertIn("Целевые действия", str(ctx.exception))
+        self.assertEqual(clicks, [])
+
+    def test_transient_matching_post_save_target_read_is_not_trusted(self):
+        """The first post-save read can still show the intact old rows before
+        hydration settles on the persisted empty table."""
+        page = self._page(goal_ids_after=[self.GOAL_ID], counters_after=[])
+        state = {"saved": False, "row_lookups": 0}
+        row_prefix = self._row_prefix_selector()
+        original_locator = page.locator
+        empty_rows = _FakeLocator([])
+
+        def _locator(selector):
+            if state["saved"] and selector == row_prefix:
+                state["row_lookups"] += 1
+                # The first two identity reads still see the old row. Every
+                # later read sees the settled persisted loss.
+                if state["row_lookups"] > 2:
+                    return empty_rows
+            return original_locator(selector)
+
+        page.locator = _locator
+        save = page.get_by_role("button", name=browser_masters._SAVE_BUTTON_TEXT).first
+        original_click = save.click
+
+        def _click_then_hydrate_empty():
+            state["saved"] = True
+            return original_click()
+
+        save.click = _click_then_hydrate_empty
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(page, 42, landing_url="https://a.ru/new")
+
+        self.assertIn("target actions", str(ctx.exception))
+
+    def test_transient_matching_post_save_metrika_read_is_not_trusted(self):
+        """A stale intact render that lasts one ordinary stability window
+        must not hide the empty state that settles immediately afterwards."""
+        counter = "gc.ksamata.ru • 72112213\n30 целей"
+        page = self._page(goal_ids_after=[], counters_after=[counter])
+        state = {"saved": False, "tag_reads": 0}
+        original_locator = page.locator
+        counter_tag = '[data-testid="MetrikaCountersTagGroup.tag.0"]'
+        empty = _FakeLocator([])
+
+        def _locator(selector):
+            if state["saved"] and selector == counter_tag:
+                state["tag_reads"] += 1
+                if state["tag_reads"] > (
+                    browser_masters._METRIKA_COUNTERS_SECTION_STABLE_TICKS
+                ):
+                    return empty
+            return original_locator(selector)
+
+        page.locator = _locator
+        save = page.get_by_role("button", name=browser_masters._SAVE_BUTTON_TEXT).first
+        original_click = save.click
+
+        def _click_then_hydrate_empty():
+            state["saved"] = True
+            return original_click()
+
+        save.click = _click_then_hydrate_empty
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(page, 42, landing_url="https://a.ru/new")
+
+        self.assertIn("metrika_counters", str(ctx.exception))
+
+    def test_partial_pre_save_metrika_baseline_waits_for_complete_state(self):
+        """A partial early list must not lower the expected post-save set.
+
+        The second counter appears while the preservation streak is still
+        running; after Save it is deliberately lost. The stabilized baseline
+        must include it, so post-save verification reports the loss.
+        """
+        first = "a.example • 72112213\n30 целей"
+        second = "b.example • 72112214\n10 целей"
+        page = self._page(goal_ids_after=[], counters_after=[first, second])
+        state = {"saved": False, "second_reads": 0}
+        original_locator = page.locator
+        second_tag = '[data-testid="MetrikaCountersTagGroup.tag.1"]'
+        missing = _FakeLocator([])
+
+        def _locator(selector):
+            if selector != second_tag:
+                return original_locator(selector)
+            if state["saved"]:
+                return missing
+            state["second_reads"] += 1
+            if state["second_reads"] <= (
+                browser_masters._METRIKA_COUNTERS_SECTION_STABLE_TICKS
+            ):
+                return missing
+            return original_locator(selector)
+
+        page.locator = _locator
+        save = page.get_by_role("button", name=browser_masters._SAVE_BUTTON_TEXT).first
+        original_click = save.click
+
+        def _click_then_drop_second():
+            state["saved"] = True
+            return original_click()
+
+        save.click = _click_then_drop_second
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(page, 42, landing_url="https://a.ru/new")
+
+        self.assertIn("72112214", str(ctx.exception))
+
+    def test_partial_pre_save_target_baseline_is_not_certified(self):
+        """A stable count followed by one partial identity read must not set
+        the verification bar below the campaign's real row set."""
+        other_goal = 281285474
+        page = self._page(goal_ids_after=[self.GOAL_ID, other_goal], counters_after=[])
+        state = {"saved": False, "row_lookups": 0}
+        row_prefix = self._row_prefix_selector()
+        partial = self._target_action_locators([self.GOAL_ID])[row_prefix]
+        original_locator = page.locator
+
+        def _locator(selector):
+            if selector != row_prefix:
+                return original_locator(selector)
+            if state["saved"]:
+                return partial  # the omitted row was persisted as lost
+            state["row_lookups"] += 1
+            # The initial count/read is partial; continued identity reads
+            # reveal the complete two-row baseline before Save.
+            if state["row_lookups"] <= 3:
+                return partial
+            return original_locator(selector)
+
+        page.locator = _locator
+        save = page.get_by_role("button", name=browser_masters._SAVE_BUTTON_TEXT).first
+        original_click = save.click
+
+        def _click_then_persist_partial():
+            state["saved"] = True
+            return original_click()
+
+        save.click = _click_then_persist_partial
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(page, 42, landing_url="https://a.ru/new")
+
+        self.assertIn(str(other_goal), str(ctx.exception))
+
+    def test_target_price_update_does_not_disable_metrika_preservation(self):
+        counter = "gc.ksamata.ru • 72112213\n30 целей"
+        page = self._page(
+            goal_ids_after=[self.GOAL_ID],
+            counters_after=[counter],
+            landing_url="https://old.example.com/page",
+        )
+        state = {"saved": False}
+        original_locator = page.locator
+        empty = _FakeLocator([])
+        counter_tag = '[data-testid="MetrikaCountersTagGroup.tag.0"]'
+
+        def _locator(selector):
+            if state["saved"] and selector == counter_tag:
+                return empty
+            return original_locator(selector)
+
+        page.locator = _locator
+        save = page.get_by_role("button", name=browser_masters._SAVE_BUTTON_TEXT).first
+        original_click = save.click
+
+        def _click_then_lose_counter():
+            state["saved"] = True
+            return original_click()
+
+        save.click = _click_then_lose_counter
+
+        with self.assertRaises(BrowserSessionError) as ctx:
+            browser_masters.update_master(
+                page,
+                42,
+                landing_url="https://new.example.org/page",
+                target_action_prices={self.GOAL_ID: 150},
+            )
+
+        self.assertIn("metrika_counters", str(ctx.exception))
+
+    def test_metrika_update_does_not_disable_target_action_preservation(self):
+        counter = "gc.ksamata.ru • 72112213\n30 целей"
+        counter_tag = '[data-testid="MetrikaCountersTagGroup.tag.0"]'
+        page = self._page(goal_ids_after=[self.GOAL_ID], counters_after=[])
+        state = {"saved": False}
+        original_locator = page.locator
+        empty_rows = _FakeLocator([])
+
+        def _locator(selector):
+            if state["saved"] and selector == counter_tag:
+                return _FakeLocator([_FakeLocatorHandle(text=counter)])
+            if state["saved"] and selector == self._row_prefix_selector():
+                return empty_rows
+            return original_locator(selector)
+
+        page.locator = _locator
+        save = page.get_by_role("button", name=browser_masters._SAVE_BUTTON_TEXT).first
+        original_click = save.click
+
+        def _click_then_lose_targets():
+            state["saved"] = True
+            return original_click()
+
+        save.click = _click_then_lose_targets
+
+        with (
+            patch.object(browser_masters, "_apply_metrika_counters", return_value=[]),
+            self.assertRaises(BrowserSessionError) as ctx,
+        ):
+            browser_masters.update_master(
+                page,
+                42,
+                landing_url="https://a.ru/new",
+                add_metrika_counters=["Ксамата • gc.ksamata.ru • 72112213"],
+            )
+
+        self.assertIn("target actions", str(ctx.exception))
+
+    def test_promotion_goal_change_skips_obsolete_section_expectations(self):
+        page = self._page(
+            goal_ids_after=[self.GOAL_ID],
+            counters_after=["gc.ksamata.ru • 72112213\n30 целей"],
+        )
+        expected_label = browser_masters.PROMOTION_GOAL_CHOICES["max-clicks"]
+
+        with (
+            patch.object(browser_masters, "_set_promotion_goal"),
+            patch.object(
+                browser_masters,
+                "_read_promotion_goal_label",
+                return_value=expected_label,
+            ),
+        ):
+            result = browser_masters.update_master(
+                page,
+                42,
+                landing_url="https://a.ru/new",
+                promotion_goal="max-clicks",
+            )
+
+        self.assertEqual(result["CampaignId"], 42)
+
+    def test_reselecting_max_conversions_keeps_section_protection(self):
+        counter = "gc.ksamata.ru • 72112213\n30 целей"
+        page = self._page(goal_ids_after=[self.GOAL_ID], counters_after=[counter])
+        state = {"saved": False}
+        original_locator = page.locator
+        counter_tag = '[data-testid="MetrikaCountersTagGroup.tag.0"]'
+        empty = _FakeLocator([])
+        expected_label = browser_masters.PROMOTION_GOAL_CHOICES["max-conversions"]
+
+        def _locator(selector):
+            if state["saved"] and selector == counter_tag:
+                return empty
+            return original_locator(selector)
+
+        page.locator = _locator
+        save = page.get_by_role("button", name=browser_masters._SAVE_BUTTON_TEXT).first
+        original_click = save.click
+
+        def _click_then_lose_counter():
+            state["saved"] = True
+            return original_click()
+
+        save.click = _click_then_lose_counter
+
+        with (
+            patch.object(browser_masters, "_set_promotion_goal"),
+            patch.object(
+                browser_masters,
+                "_read_promotion_goal_label",
+                return_value=expected_label,
+            ),
+            self.assertRaises(BrowserSessionError) as ctx,
+        ):
+            browser_masters.update_master(
+                page,
+                42,
+                landing_url="https://a.ru/new",
+                promotion_goal="max-conversions",
+            )
+
+        self.assertIn("metrika_counters", str(ctx.exception))
+
+    def test_tracking_params_path_preserves_sections_too(self):
+        page = self._page(
+            goal_ids_after=[self.GOAL_ID],
+            counters_after=["gc.ksamata.ru • 72112213\n30 целей"],
+        )
+        state = {"expanded": False}
+        spoiler = _DynamicAttrsLocatorHandle(
+            get_attrs=lambda: {
+                "aria-expanded": "true" if state["expanded"] else "false"
+            },
+            on_click=lambda: state.__setitem__("expanded", True),
+        )
+        page._locators[browser_masters._EDIT_UTM_SPOILER_BUTTON_TESTID] = _FakeLocator(
+            [spoiler]
+        )
+        page._locators[browser_masters._EDIT_UTM_INPUT_TESTID] = _FakeLocator(
+            [_FakeContentEditableHandle(text="utm_source=old")]
+        )
+
+        result = browser_masters.update_master(
+            page, 42, tracking_params="utm_source=new"
+        )
+
+        self.assertEqual(result["TrackingParams"], "utm_source=new")
 
 
 class TestCrossDomainLandingUrlWarning(unittest.TestCase):
@@ -22161,6 +22522,27 @@ class TestCrossDomainLandingUrlWarning(unittest.TestCase):
             )
 
         self.assertEqual(warnings, [])
+
+    def test_combined_target_action_update_still_warns(self):
+        """A mutation in the other protected section must not disable the
+        landing-domain warning."""
+        fixture = TestUrlUtmSavePreservesSections()
+        page = fixture._page(
+            goal_ids_after=[fixture.GOAL_ID],
+            counters_after=[self.COUNTER],
+            landing_url="https://old.example.com/landing",
+        )
+        warnings = []
+
+        with patch.object(browser_masters, "print_warning", warnings.append):
+            browser_masters.update_master(
+                page,
+                42,
+                landing_url="https://new.example.org/landing",
+                target_action_prices={fixture.GOAL_ID: 150},
+            )
+
+        self.assertEqual(len(warnings), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Проблема

Страница редактирования Мастера кампаний сохраняется целиком. Раскрытие UTM-спойлера live-подтверждённо в #830 ре-рендерит окружающую форму из серверного состояния. Если при обновлении `--landing-url`/`--tracking-params` этот ре-рендер временно опустошал «Счётчики Яндекс Метрики» или «Целевые действия», пустой DOM мог быть сохранён, а команда сообщала об успехе.

## Что сделано

- До любых URL/UTM-мутаций снимаются отдельные baseline-снимки Metrika и target actions.
- Защиты независимы: изменение target actions не выключает проверку Metrika, а изменение Metrika не выключает проверку target actions. Комбинированные вызовы сверяются с ожидаемым состоянием `before - removed + added`; price-only обновления сохраняют полный набор goal id.
- Baseline, pre-save и post-save чтения failure-aware и стабилизированы серией одинаковых полных снимков. Нечитаемый baseline прерывает операцию до Save.
- Сразу после появления terminal Save-кнопки и непосредственно перед её click текущий DOM повторно сравнивается с ожидаемым состоянием обеих защищённых секций. Если UTM re-render уже потерял счётчик/цель, команда останавливается, не нажимая Save — потеря не отправляется на сервер.
- Post-save сверка остаётся вторым барьером против серверного/последующего рассогласования: нечитаемое или частичное состояние даёт `BrowserSessionError`.
- Пустая, но реально отрисованная таблица целей остаётся валидным состоянием и не блокирует обновление.
- При `promotion_goal=max-clicks` проверки старых conversion-секций не запускаются: этот переход легитимно удаляет обе секции. `max-conversions` остаётся защищённым.
- При смене домена лендинга и наличии счётчиков выводится неблокирующий warning.

Фикс не устраняет гонку в интерфейсе Яндекса; он предотвращает отправку уже повреждённой whole-form формы и сохраняет post-save диагностику как дополнительный барьер.

## Проверка

Добавлено 25 офлайн-тестов, включая:

- потерю Metrika/target actions после Save;
- отказ **до Save** при потере любой секции во время UTM re-render (включая combined call);
- порядок final guard → terminal click для non-DRAFT и блокировку DRAFT click;
- нечитаемые baseline-снимки;
- partial baseline и transient stale post-save render для обеих секций;
- URL/UTM вместе с Metrika/target-action мутациями;
- `promotion_goal=max-clicks` и повторный `max-conversions`;
- реальный путь `tracking_params` через UTM-спойлер;
- cross-domain warning, включая комбинированный вызов.

Результаты:

```text
pytest -q -n0: 3655 passed, 23 skipped, 88 deselected, 115 subtests passed
pytest -q -n0 tests/test_masters.py: 970 passed, 85 subtests passed
mypy .: Success (99 source files)
ruff 0.15.7 check .: All checks passed
black + flake8 для изменённых файлов: clean
```

## Ограничения

Живая репродукция из пункта 1 issue не выполнялась: по решению пользователя реальные кампании пока не мутируем. Поэтому также не снимается пометка NOT LIVE-VERIFIED для Metrika-секции. PR использует `Refs`, а не `Closes`.

Refs #836
