### PR TITLE
feat(dictionaries): add get-retargeting-goals for domain -> ExternalId (#852)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,25 @@ opening the modal when the video is already there, and correctly reports
 no change was made (no `AddedVideoUrl` in the JSON output, no false "did
 not save as requested" from the post-save verification pass).
 
+**`direct dictionaries get-retargeting-goals` — domain/app → `ExternalId` (#852).**
+
+Direct Commander can resolve a site address or app name into the
+`ExternalId` used by `RetargetingList(Type=AUDIENCE) -> Rules[].Arguments[].ExternalId`,
+but `direct-cli` had no equivalent. It calls `getRetargetingGoals`, an
+**undocumented/internal v5 method** not declared in the `dictionaries` WSDL
+(confirmed live: it is absent from the cached WSDL, no `X-Direct-Commander`
+header is required or wanted, and Yandex gives no stability guarantees for
+it). `--name` and `--ids` are mutually exclusive and one is required:
+
+```
+direct dictionaries get-retargeting-goals --name exist.ru
+direct dictionaries get-retargeting-goals --ids 19000000660,19000001592
+```
+
+A `--name` search can return more than one goal `Type` for similar names
+(e.g. `HOST` and `APPLICATION`) — pick the entry with the `Type` your use
+case needs. Unblocks `axisrow/yandex-direct-mcp-plugin#168`.
+
 **`direct history get` — read «История изменений» (#837).**
 
 The API has no per-field change journal at all: `changes.checkCampaigns`

--- a/README.md
+++ b/README.md
@@ -994,6 +994,19 @@ direct changes check-dictionaries
 direct keywordsresearch has-search-volume --keywords "buy laptop,buy desktop"
 direct retargeting add --name "List A" --description "High intent users" --type AUDIENCE --rule "ALL:12345:30|67890:7" --dry-run
 direct retargeting update --id 55 --name "Renamed" --description "Updated note" --rule "ANY:12345:30" --dry-run
+direct dictionaries get-retargeting-goals --name exist.ru
+direct dictionaries get-retargeting-goals --ids 19000000660,19000001592
+```
+
+> ⚠ `dictionaries get-retargeting-goals` calls `getRetargetingGoals`, an
+> **undocumented/internal v5 method** (not declared in the `dictionaries`
+> WSDL). Direct Commander uses it to resolve a site/app into the `ExternalId`
+> used by `RetargetingList(Type=AUDIENCE) -> Rules[].Arguments[].ExternalId`.
+> Yandex gives no stability guarantees for it. A `--name` search can match
+> more than one goal `Type` (e.g. `HOST` and `APPLICATION`) for similar names
+> — pick the entry with the `Type` your use case needs.
+
+```bash
 
 # Bids and modifiers
 direct bids get --campaign-ids 123 --fields CampaignId,AdGroupId,KeywordId,Bid

--- a/README.md
+++ b/README.md
@@ -1007,7 +1007,6 @@ direct dictionaries get-retargeting-goals --ids 19000000660,19000001592
 > — pick the entry with the `Type` your use case needs.
 
 ```bash
-
 # Bids and modifiers
 direct bids get --campaign-ids 123 --fields CampaignId,AdGroupId,KeywordId,Bid
 direct bids set --keyword-id 123 --bid 15000000

--- a/direct_cli/commands/dictionaries.py
+++ b/direct_cli/commands/dictionaries.py
@@ -5,7 +5,7 @@ Dictionaries commands
 import click
 
 from ..api import client_from_ctx, create_client
-from ..i18n import resolve_locale
+from ..i18n import resolve_locale, t
 from ..output import format_output, handle_api_errors
 from ..utils import parse_csv_strings, parse_ids, reference_output_options
 
@@ -80,6 +80,58 @@ def get_geo_regions(ctx, name, region_ids, exact_names, fields, output_format, o
         params["SelectionCriteria"] = selection_criteria
 
     body = {"method": "getGeoRegions", "params": params}
+
+    result = client.dictionaries().post(data=body)
+    format_output(result.data, output_format, output)
+
+
+RETARGETING_GOALS_FIELDS = [
+    "Id",
+    "Name",
+    "Type",
+    "Description",
+    "CoverageType",
+    "SuggestionSource",
+    "StoreLink",
+]
+
+
+@dictionaries.command(name="get-retargeting-goals")
+@click.option("--name", help="Retargeting goal name to search for (e.g. a domain)")
+@click.option("--ids", help="Comma-separated retargeting goal IDs to look up")
+@click.option("--format", "output_format", default="json", help="Output format")
+@click.option("--output", help="Output file")
+@click.pass_context
+@handle_api_errors
+def get_retargeting_goals(ctx, name, ids, output_format, output):
+    """Get RetargetingGoals dictionary entries (undocumented/internal v5 method)
+
+    Resolves a site address or app name into the ExternalId used by
+    RetargetingList(Type=AUDIENCE) -> Rules[].Arguments[].ExternalId. Yandex
+    does not document this method and gives no stability guarantees for it.
+
+    A search by --name can return multiple goal types with similar names
+    (e.g. Type=HOST and Type=APPLICATION) -- pick the entry with the Type
+    your use case needs.
+    """
+    if bool(name) == bool(ids):
+        raise click.UsageError(t("Exactly one of --name or --ids is required"))
+
+    client = client_from_ctx(ctx, create_client)
+
+    selection_criteria = {}
+    if name:
+        selection_criteria["Name"] = name
+    else:
+        selection_criteria["Ids"] = {"Items": parse_ids(ids)}
+
+    body = {
+        "method": "getRetargetingGoals",
+        "params": {
+            "FieldNames": RETARGETING_GOALS_FIELDS,
+            "SelectionCriteria": selection_criteria,
+        },
+    }
 
     result = client.dictionaries().post(data=body)
     format_output(result.data, output_format, output)

--- a/direct_cli/smoke_matrix.py
+++ b/direct_cli/smoke_matrix.py
@@ -41,6 +41,7 @@ SMOKE_MATRIX = {
         "creatives.get",
         "dictionaries.get",
         "dictionaries.get-geo-regions",
+        "dictionaries.get-retargeting-goals",
         "dictionaries.list-names",
         "dynamicads.get",
         "dynamicfeedadtargets.get",

--- a/direct_cli/translations/dictionaries.json
+++ b/direct_cli/translations/dictionaries.json
@@ -6,5 +6,9 @@
   "Geo region name contains this value": "Имя географического региона содержит это значение",
   "Comma-separated geo region IDs": "ID географических регионов через запятую",
   "Comma-separated exact geo region names": "Точные имена географических регионов через запятую",
-  "List available dictionary names": "Список доступных имён справочников"
+  "List available dictionary names": "Список доступных имён справочников",
+  "Retargeting goal name to search for (e.g. a domain)": "Имя цели ретаргетинга для поиска (например, домен)",
+  "Comma-separated retargeting goal IDs to look up": "ID целей ретаргетинга через запятую для поиска",
+  "Get RetargetingGoals dictionary entries (undocumented/internal v5 method)\n\n    Resolves a site address or app name into the ExternalId used by\n    RetargetingList(Type=AUDIENCE) -> Rules[].Arguments[].ExternalId. Yandex\n    does not document this method and gives no stability guarantees for it.\n\n    A search by --name can return multiple goal types with similar names\n    (e.g. Type=HOST and Type=APPLICATION) -- pick the entry with the Type\n    your use case needs.\n    ": "Получить записи справочника RetargetingGoals (недокументированный/внутренний метод v5)\n\n    Преобразует адрес сайта или имя приложения в ExternalId, который\n    используется в RetargetingList(Type=AUDIENCE) -> Rules[].Arguments[].ExternalId.\n    Яндекс не документирует этот метод и не даёт гарантий стабильности.\n\n    Поиск по --name может вернуть несколько типов целей с похожими именами\n    (например, Type=HOST и Type=APPLICATION) — выбирайте запись с нужным Type.\n    ",
+  "Exactly one of --name or --ids is required": "Требуется указать ровно один из параметров: --name или --ids"
 }

--- a/direct_cli/wsdl_coverage.py
+++ b/direct_cli/wsdl_coverage.py
@@ -148,6 +148,13 @@ INTENTIONAL_EXTRA_METHODS = {
         "emulates 'resume the group' via ads.get + ads.resume; see its "
         "--help for the resulting resume-everything limitation."
     ),
+    ("dictionaries", "getRetargetingGoals"): (
+        "Issue #852: undocumented/internal v5 method (not declared in the "
+        "dictionaries WSDL) that Direct Commander uses to resolve a site/app "
+        "into the ExternalId used by RetargetingList(Type=AUDIENCE) -> "
+        "Rules[].Arguments[].ExternalId. Confirmed live against production; "
+        "Yandex gives no stability guarantees for it."
+    ),
 }
 
 RUNTIME_DEPRECATED_METHODS = {
@@ -167,6 +174,7 @@ METHOD_NAME_OVERRIDES = {
     "check-campaigns": "checkCampaigns",
     "check-dictionaries": "checkDictionaries",
     "get-geo-regions": "getGeoRegions",
+    "get-retargeting-goals": "getRetargetingGoals",
     "has-search-volume": "hasSearchVolume",
     "list-names": "get",
     "list-types": "get",

--- a/tests/test_low_coverage_payloads.py
+++ b/tests/test_low_coverage_payloads.py
@@ -301,6 +301,63 @@ def test_dictionaries_get_geo_regions_defaults_locale_to_ru():
     assert mock_create_client.call_args.kwargs["language"] == "ru"
 
 
+def test_dictionaries_get_retargeting_goals_by_name_payload():
+    """#852: --name reaches getRetargetingGoals as SelectionCriteria.Name."""
+    body = _mock_service_command(
+        "direct_cli.commands.dictionaries",
+        "dictionaries",
+        ["dictionaries", "get-retargeting-goals", "--name", "exist.ru"],
+    )
+    assert body["method"] == "getRetargetingGoals"
+    assert body["params"]["SelectionCriteria"] == {"Name": "exist.ru"}
+    assert body["params"]["FieldNames"] == [
+        "Id",
+        "Name",
+        "Type",
+        "Description",
+        "CoverageType",
+        "SuggestionSource",
+        "StoreLink",
+    ]
+
+
+def test_dictionaries_get_retargeting_goals_by_ids_payload():
+    """#852: --ids reaches getRetargetingGoals as SelectionCriteria.Ids.Items."""
+    body = _mock_service_command(
+        "direct_cli.commands.dictionaries",
+        "dictionaries",
+        [
+            "dictionaries",
+            "get-retargeting-goals",
+            "--ids",
+            "19000000660,19000001592",
+        ],
+    )
+    assert body["method"] == "getRetargetingGoals"
+    assert body["params"]["SelectionCriteria"] == {
+        "Ids": {"Items": [19000000660, 19000001592]}
+    }
+
+
+def test_dictionaries_get_retargeting_goals_requires_name_or_ids():
+    result = _failing_run("dictionaries", "get-retargeting-goals")
+    assert result.exit_code != 0
+    assert "Exactly one of --name or --ids" in result.output
+
+
+def test_dictionaries_get_retargeting_goals_rejects_both_name_and_ids():
+    result = _failing_run(
+        "dictionaries",
+        "get-retargeting-goals",
+        "--name",
+        "exist.ru",
+        "--ids",
+        "19000000660",
+    )
+    assert result.exit_code != 0
+    assert "Exactly one of --name or --ids" in result.output
+
+
 def test_strategies_add_typed_fields_payload():
     body = _dry_run(
         "strategies",


### PR DESCRIPTION
## Summary

Adds `direct dictionaries get-retargeting-goals`, wrapping the undocumented v5 method `getRetargetingGoals` (not declared in the `dictionaries` WSDL) that Direct Commander uses to resolve a site/app into the `ExternalId` used by `RetargetingList(Type=AUDIENCE) -> Rules[].Arguments[].ExternalId`. Unblocks `axisrow/yandex-direct-mcp-plugin#168`.

```bash
direct dictionaries get-retargeting-goals --name exist.ru
direct dictionaries get-retargeting-goals --ids 19000000660,19000001592
```

- `--name` and `--ids` are mutually exclusive; exactly one is required.
- `--name` → `SelectionCriteria.Name`; `--ids` → `SelectionCriteria.Ids.Items`.
- Requests all seven fields from the wire contract: `Id`, `Name`, `Type`, `Description`, `CoverageType`, `SuggestionSource`, `StoreLink`.
- Registered `("dictionaries", "getRetargetingGoals")` in `INTENTIONAL_EXTRA_METHODS` (it has no WSDL declaration) and `get-retargeting-goals` → `getRetargetingGoals` in `METHOD_NAME_OVERRIDES`.
- Added to the `SAFE` smoke matrix (read-only).
- README/CHANGELOG document the undocumented/internal status and no-stability-guarantee caveat explicitly.
- i18n: docstring + option help + error message translated (ru).

## Live verification (production, 2026-08-26)

```
$ direct dictionaries get-retargeting-goals --name exist.ru
{
  "result": {
    "RetargetingGoals": [
      {"Id": 19000000660, "Name": "exist.ru", "Type": "HOST", ...},
      {"Id": 19900005830, "Name": "Exist", "Type": "APPLICATION", ...}
    ]
  }
}

$ direct dictionaries get-retargeting-goals --ids 19000000660
{"result": {"RetargetingGoals": [{"Id": 19000000660, "Name": "exist.ru", "Type": "HOST", ...}]}}
```

Matches the issue's acceptance criteria: `--name exist.ru` returns the `HOST` object with `Id=19000000660`, and looking that ID back up returns `Name=exist.ru`.

Also verified: `--name` and `--ids` together, and neither, both fail with `Exactly one of --name or --ids is required`.

## Tests

- `pytest -q` — 3634 passed, 23 skipped (full offline suite)
- New payload tests in `tests/test_low_coverage_payloads.py`: wire shape for `--name` and `--ids`, and the mutual-exclusivity `UsageError` in both directions.
- `black --check` / `flake8` clean on touched files.

Closes #852

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVgkPM7jAeEsQfCdfGDVnZ