### PR TITLE
fix(output): surface API Warnings (10251/10252) on stderr

### DIFF
--- a/direct_cli/output.py
+++ b/direct_cli/output.py
@@ -11,6 +11,8 @@ from typing import Any, Iterator, List, Optional
 
 import click
 
+from .i18n import t
+
 try:
     from tabulate import tabulate
 except ImportError:
@@ -40,6 +42,7 @@ def format_output(
         Formatted string
     """
     raise_for_api_result_errors(data)
+    warn_for_api_result_warnings(data)
 
     if format_type == "json":
         output = format_json(data)
@@ -114,6 +117,65 @@ def _iter_api_result_errors(data: Any) -> Iterator[dict]:
     elif isinstance(data, list):
         for item in data:
             yield from _iter_api_result_errors(item)
+
+
+# Yandex Direct Warning codes that get a human-readable explanation appended
+# to the raw ``Code``/``Message`` pair (issue #850). Both are emitted by
+# ``ads add``/``ads update`` when text-ad creation is closed and Yandex
+# silently substitutes/edits a combinatorial banner instead.
+_KNOWN_API_WARNINGS = {
+    10251: (
+        "Ad created as a combinatorial banner, not TEXT_AD as requested "
+        "(Yandex has closed text-banner creation). Layout and limits differ "
+        "from a text ad; `ads get` will still report Type: TEXT_AD."
+    ),
+    10252: (
+        "This ad is a combinatorial banner and was just edited through the "
+        "legacy text-ad update API. This path may stop working once Yandex "
+        "retires it."
+    ),
+}
+
+
+def warn_for_api_result_warnings(data: Any) -> None:
+    """Print embedded Direct API action ``Warnings`` to stderr.
+
+    Mirrors :func:`raise_for_api_result_errors`'s tree walk, but warnings
+    don't block the result (unlike ``Errors``) — they're only surfaced so a
+    silent type/behavior substitution (e.g. #850's TEXT_AD-to-combinatorial
+    swap) isn't visible only by reading the JSON result body.
+    """
+    for warning in _iter_api_result_warnings(data):
+        code = _error_code(warning)
+        message = warning.get("Message", "")
+        known = _KNOWN_API_WARNINGS.get(code) if code is not None else None
+        if known:
+            print_warning_stderr(
+                t("Warning {code}: {message} — {known}").format(
+                    code=code, message=message, known=t(known)
+                )
+            )
+        else:
+            print_warning_stderr(
+                t("Warning {code}: {message}").format(code=code, message=message)
+            )
+
+
+def _iter_api_result_warnings(data: Any) -> Iterator[dict]:
+    if isinstance(data, dict):
+        warnings = data.get("Warnings")
+        if isinstance(warnings, list):
+            for warning in warnings:
+                if isinstance(warning, dict):
+                    yield warning
+                else:
+                    yield {"Message": str(warning)}
+        for key, value in data.items():
+            if key != "Warnings":
+                yield from _iter_api_result_warnings(value)
+    elif isinstance(data, list):
+        for item in data:
+            yield from _iter_api_result_warnings(item)
 
 
 def _format_api_result_error(error: dict) -> str:
@@ -257,6 +319,17 @@ def print_error(message: str) -> None:
 def print_warning(message: str) -> None:
     """Print warning message"""
     print(f"\033[33m⚠ {message}\033[0m")
+
+
+def print_warning_stderr(message: str) -> None:
+    """Print warning message to stderr.
+
+    Unlike :func:`print_warning` (stdout, same stream as JSON results),
+    this keeps the machine-readable stdout payload clean for scripted/batch
+    callers while still surfacing the warning to a human running the command
+    interactively (#850).
+    """
+    print(f"\033[33m⚠ {message}\033[0m", file=sys.stderr)
 
 
 def print_info(message: str) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -759,6 +759,81 @@ class TestCLI(unittest.TestCase):
         self.assertIn("current Client-Login/account", result.output)
         self.assertIn("YANDEX_DIRECT_LOGIN", result.output)
 
+    def test_ads_add_surfaces_combinatorial_banner_warning(self):
+        """Warning 10251 (silent TEXT_AD-to-combinatorial substitution, #850)
+        must be surfaced on stderr, not only visible in the JSON body."""
+
+        class FakeResponse:
+            def __call__(self):
+                return self
+
+            def extract(self):
+                return {
+                    "AddResults": [
+                        {
+                            "Id": 1918459304756685779,
+                            "Warnings": [
+                                {
+                                    "Code": 10165,
+                                    "Message": "Parameter will not be applied",
+                                },
+                                {
+                                    "Code": 10251,
+                                    "Message": (
+                                        "Создание " "текстовых " "баннеров " "закрыто"
+                                    ),
+                                },
+                            ],
+                            "Errors": [],
+                        }
+                    ]
+                }
+
+        class FakeClient:
+            def ads(self):
+                return self
+
+            def post(self, data):
+                return FakeResponse()
+
+        ads_module = import_module("direct_cli.commands.ads._cli")
+        with patch.object(ads_module, "create_client", return_value=FakeClient()):
+            result = self.runner.invoke(
+                cli,
+                [
+                    "ads",
+                    "add",
+                    "--adgroup-id",
+                    "5786702368",
+                    "--title",
+                    "Test",
+                    "--text",
+                    "Test text",
+                    "--href",
+                    "https://example.com",
+                ],
+                env={
+                    "YANDEX_DIRECT_TOKEN": "test-token",
+                    "YANDEX_DIRECT_LOGIN": "axisrow",
+                },
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        # The JSON result body (stdout) is unaffected — still parses cleanly
+        # once the stderr-only warning banner is excluded.
+        json_body = "\n".join(
+            line
+            for line in result.output.splitlines()
+            if not line.startswith("\x1b[33m")
+        )
+        parsed = json.loads(json_body)
+        self.assertEqual(parsed["AddResults"][0]["Warnings"][1]["Code"], 10251)
+        # A human-readable explanation is printed via the stderr-only helper.
+        self.assertIn("10251", result.stderr)
+        self.assertIn("combinatorial banner", result.stderr)
+        # The unexplained code (10165) still gets a raw pass-through line.
+        self.assertIn("10165", result.stderr)
+
     def test_keywords_bulk_add_surfaces_item_errors(self):
         """Bulk-add path must not bypass the item-level error renderer. See #211."""
 


### PR DESCRIPTION
## Summary

`ads add`/`ads update` responses can carry Yandex Direct API `Warnings` alongside a successful result — silently. Most notably:

- **Warning 10251** — a requested `TEXT_AD` is silently created as a combinatorial banner, because Yandex has closed text-banner creation.
- **Warning 10252** — that combinatorial banner is edited through the legacy text-ad update API.

Previously these were only visible by reading the full JSON result body — invisible in a piped/scripted batch workflow.

This implements point 1 from the issue ("Распознавать 10251/10252 и печатать человекочитаемое предупреждение в stderr") — the cheap, immediate fix. Points 2 (first-class combinatorial-banner type) and 3 (surfacing `Details` on Warning 10165) are left as follow-ups per the issue's own prioritization.

## Change

- `direct_cli/output.py::format_output()` now walks the result tree for embedded `Warnings` (mirroring the existing `Errors`-tree walk used for `raise_for_api_result_errors`).
- Warning 10251/10252 get a human-readable explanation; any other code gets a generic `Code: Message` line.
- A new `print_warning_stderr()` helper prints to **stderr**, keeping stdout JSON clean for scripted/batch callers — the exact scenario the issue calls out ("Warnings не видны в обычном режиме... в скриптовом сценарии... расхождение вскрывается уже на модерации").
- Since this lives in the shared `format_output()` tail used by `execute_request()` (24 command modules), the fix applies uniformly to every `add`/`update`/`suspend`/etc. command, not just `ads`.

## Tests

- New test `test_ads_add_surfaces_combinatorial_banner_warning` in `tests/test_cli.py`, mirroring the existing `test_embedded_api_errors_are_reported_as_cli_errors` pattern: fakes the exact `AddResults[0].Warnings` shape from the issue's live repro and asserts the JSON stdout body is untouched while stderr carries the human-readable + raw warning lines.
- Full offline suite: `3631 passed, 23 skipped`.
- `black`/`flake8` clean.

Closes #850

🤖 Generated with [Claude Code](https://claude.com/claude-code)