### PR TITLE
feat(masters): per-campaign progress on batch update

### DIFF
--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -1607,6 +1607,7 @@ def _run_update_file_batch(
     moderation_statuses: bool,
     dry_run: bool,
     pacing_ms: Optional[int] = None,
+    show_progress: bool = True,
 ) -> List[Dict[str, Any]]:
     """Apply a validated update plan to every campaign in ONE browser session.
 
@@ -1650,6 +1651,7 @@ def _run_update_file_batch(
 
     completed: "set[int]" = set()
     outcomes: Dict[int, Dict[str, Any]] = {}
+    total = len(rows)
 
     def operation(page):
         for position, row in enumerate(rows):
@@ -1675,11 +1677,22 @@ def _run_update_file_batch(
                     result["ModerationStatuses"] = fetch_master_moderation_statuses(
                         page, campaign_id
                     )
+                if show_progress:
+                    click.echo(
+                        f"[{position + 1}/{total}] campaign {campaign_id}: saved",
+                        err=True,
+                    )
             except BrowserAuthError:
                 raise
             except (BrowserSessionError, PlaywrightError) as exc:
                 completed.add(campaign_id)
                 outcomes[campaign_id] = {"CampaignId": campaign_id, "Error": str(exc)}
+                if show_progress:
+                    click.echo(
+                        f"[{position + 1}/{total}] campaign {campaign_id}: "
+                        f"failed: {exc}",
+                        err=True,
+                    )
             if pause_ms and position != len(rows) - 1:
                 # Pace after EVERY attempt, including a failed one: the live
                 # failures behind issue #829 tracked how often the profile hit
@@ -2378,6 +2391,15 @@ def audience_get(
     ),
 )
 @click.option(
+    "--no-progress",
+    "no_progress",
+    is_flag=True,
+    help=(
+        "Batch mode only: suppress the per-campaign progress line normally "
+        "printed to stderr as each row is processed (issue #839)."
+    ),
+)
+@click.option(
     "--weekly-budget",
     type=int,
     help="Weekly budget in account currency (Недельный бюджет)",
@@ -2705,6 +2727,7 @@ def update(
     moderation_statuses,
     dry_run,
     pacing_ms,
+    no_progress,
     weekly_budget,
     promotion_goal,
     goal_price,
@@ -2989,6 +3012,7 @@ def update(
             moderation_statuses=moderation_statuses,
             dry_run=dry_run,
             pacing_ms=pacing_ms,
+            show_progress=not no_progress,
         )
         format_output(result, output_format, output)
         errors = [row for row in result if row.get("Error")]
@@ -3009,6 +3033,11 @@ def update(
         raise click.UsageError(
             "--pacing-ms paces the gap BETWEEN campaigns and is supported "
             "only with --from-file/--masters-json batch mode."
+        )
+    if no_progress:
+        raise click.UsageError(
+            "--no-progress suppresses batch progress output and is "
+            "supported only with --from-file/--masters-json batch mode."
         )
 
     if (

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -21424,7 +21424,7 @@ class TestMastersUpdateBatch(unittest.TestCase):
         # 1 is saved once despite the replay; 2 succeeds on the second pass.
         self.assertEqual(saved, [1, 2])
         self.assertEqual(
-            [row["CampaignId"] for row in json.loads(result.output)], [1, 2]
+            [row["CampaignId"] for row in json.loads(result.stdout)], [1, 2]
         )
 
     def test_auth_failure_while_reading_moderation_keeps_saved_row_reported(self):
@@ -21481,7 +21481,7 @@ class TestMastersUpdateBatch(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertEqual(saved, [1, 2])
-        payload = json.loads(result.output)
+        payload = json.loads(result.stdout)
         self.assertEqual([row["CampaignId"] for row in payload], [1, 2])
         # Campaign 1 was saved but its statuses could not be read -- say so
         # explicitly instead of omitting the key.
@@ -21906,6 +21906,55 @@ class TestMastersUpdateBatch(unittest.TestCase):
                 continue
             with self.subTest(key=key):
                 self.assertIn(target, browser_kwargs)
+
+    # --- progress indication (issue #839) -----------------------------------
+
+    def test_batch_prints_per_campaign_progress_to_stderr(self):
+        """Each row must print a stderr progress line as it is processed —
+        the whole point is visibility DURING a long batch, not just a final
+        report. stdout must stay pure JSON (unaffected)."""
+
+        def _update(page, campaign_id, **kwargs):
+            if campaign_id == 2:
+                raise BrowserSessionError("edit page never loaded")
+            return {"CampaignId": campaign_id}
+
+        with self.runner.isolated_filesystem() as tmp:
+            plan = self._plan(
+                tmp,
+                [
+                    {"CampaignId": 1, "Name": "one"},
+                    {"CampaignId": 2, "Name": "two"},
+                    {"CampaignId": 3, "Name": "three"},
+                ],
+            )
+            with self._session(update=_update):
+                result = self.runner.invoke(
+                    cli, ["masters", "update", "--from-file", plan]
+                )
+
+        # stdout stays a clean JSON array — progress must not leak into it.
+        json.loads(result.stdout)
+
+        self.assertIn("1/3", result.stderr)
+        self.assertIn("2/3", result.stderr)
+        self.assertIn("3/3", result.stderr)
+        self.assertIn("campaign 1", result.stderr.lower())
+        self.assertIn("saved", result.stderr.lower())
+        self.assertIn("campaign 2", result.stderr.lower())
+        self.assertIn("failed", result.stderr.lower())
+        self.assertIn("edit page never loaded", result.stderr)
+
+    def test_batch_progress_is_suppressed_by_no_progress_flag(self):
+        with self.runner.isolated_filesystem() as tmp:
+            plan = self._plan(tmp, [{"CampaignId": 1, "Name": "one"}])
+            with self._session():
+                result = self.runner.invoke(
+                    cli,
+                    ["masters", "update", "--from-file", plan, "--no-progress"],
+                )
+
+        self.assertEqual(result.stderr.strip(), "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Проблема

`masters update --from-file/--masters-json` в batch-режиме не выводил ничего до
завершения всей команды — снаружи невозможно было отличить нормальный ход от зависания.

## Фикс

`_run_update_file_batch` теперь печатает построчный прогресс в **stderr** по мере
обработки каждой строки плана:

```
[1/17] campaign 74099856: saved
[2/17] campaign 74099857: failed: edit page never loaded
...
```

- Не буферизуется — `click.echo(..., err=True)` пишет сразу после каждой строки.
- stdout (итоговый JSON-отчёт) не тронут.
- Новый флаг `--no-progress` подавляет вывод (только batch-режим; в single-item режиме
  флаг отклоняется как UsageError, аналогично `--pacing-ms`).

## Тесты (red → green)

- `test_batch_prints_per_campaign_progress_to_stderr` — красный до фикса (нет строк
  прогресса на stderr), зелёный после.
- `test_batch_progress_is_suppressed_by_no_progress_flag` — красный до фикса (нет опции
  `--no-progress`), зелёный после.
- Полный `tests/test_masters.py`: 947 passed.
- `black`/`flake8`: чисто.
- Мутационная проверка вручную: мутант, снимающий проверку `show_progress`, ловится
  тестом `test_batch_progress_is_suppressed_by_no_progress_flag`.

Closes #839