### PR TITLE
fix(browser): recognize DirectGrid testid after Sidebar marker rot (#859)

### DIFF
--- a/direct_cli/browser/session.py
+++ b/direct_cli/browser/session.py
@@ -150,16 +150,28 @@ _LOGIN_PAGE_MARKERS = (
 # any single step's own markup.
 _PASSPORT_PAGE_MARKERS = ('[data-testid="auth-logo"]',)
 
-# ``Sidebar`` confirmed live 2026-08-03 against a real, authenticated
-# ``https://direct.yandex.ru/dna/grid/campaigns/`` response — Direct's own
-# left navigation shell, present on every authenticated Direct page
-# regardless of the grid's own virtualized content (issue #639: the grid
-# never renders a stable content marker of its own, only its
-# ``GridCampaigns`` data call does — see ``direct_cli/browser/masters.py``'s
-# ``_capture_grid_campaigns_request``). Waiting on the general Direct shell
-# is sufficient here: both call sites only need ``page.content()`` to be
-# real markup for the captcha/auth checks, not the grid's own data.
-_DIRECT_PAGE_MARKERS = ('[data-testid="Sidebar"]',)
+# issue #859: Yandex dropped the ``Sidebar`` testid from the campaigns grid's
+# left navigation shell entirely — live-confirmed 2026-08-29 against a real,
+# authenticated ``https://direct.yandex.ru/dna/grid/campaigns/`` response
+# (611 KB of real markup, no login/captcha marker, but no ``Sidebar`` testid
+# either) that made ``direct playwright login`` time out and fail closed even
+# though the underlying Chrome session was valid — the same failure mode
+# #666's login-page marker rot hit, just on the authenticated side this time.
+# ``DirectGrid`` replaces it: the grid's own outer shell (confirmed unique,
+# single occurrence, present regardless of the grid's own virtualized row
+# content — issue #639: the grid never renders a stable content marker of
+# its own, only its ``GridCampaigns`` data call does, see
+# ``direct_cli/browser/masters.py``'s ``_capture_grid_campaigns_request``).
+# The old ``Sidebar`` marker is kept alongside the new one rather than
+# replaced outright, same rationale as ``_LOGIN_PAGE_MARKERS`` above — Yandex
+# could reintroduce it, and a marker that's merely unused costs nothing.
+# Waiting on either is sufficient here: both call sites only need
+# ``page.content()`` to be real markup for the captcha/auth checks, not the
+# grid's own data.
+_DIRECT_PAGE_MARKERS = (
+    '[data-testid="DirectGrid"]',
+    '[data-testid="Sidebar"]',
+)
 
 # Union of both marker sets — for a navigation that can legitimately land on
 # either page (see ``_wait_for_marker``'s "Accepts multiple selectors"

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -1554,6 +1554,45 @@ class TestCaptureStorageState(unittest.TestCase):
 
         self.assertEqual(page.goto_wait_until, "commit")
 
+    def test_verify_succeeds_when_only_the_directgrid_marker_is_present(self):
+        """Issue #859: Yandex dropped the ``Sidebar`` testid from the grid's
+        left navigation shell entirely — live-confirmed 2026-08-29 against a
+        real, authenticated grid response that had no ``Sidebar`` testid
+        anywhere in 611 KB of real markup, causing `direct playwright login`
+        to time out and fail closed even though the underlying Chrome
+        session was valid (same failure shape as #666's login-page marker
+        rot, just on the authenticated side). `_DIRECT_PAGE_MARKERS` must
+        keep matching on the newer `DirectGrid` marker alone, without the
+        older `Sidebar` marker also being present."""
+        pytest.importorskip("playwright")
+        from direct_cli.browser import session as session_module
+
+        page = _direct_page(
+            locators={
+                '[data-testid="DirectGrid"]': _FakeLocator([_FakeLocatorHandle()]),
+                '[data-testid="Sidebar"]': _FakeLocator([]),
+            }
+        )
+        fake_browser = _FakeBrowser()
+        fake_context = _FakeVerifyContext(page, storage_state={"cookies": []})
+        fake_browser.new_context = lambda **kwargs: fake_context
+        fake_chromium = _FakeChromium(fake_browser)
+        fake_playwright = _FakePlaywright(fake_chromium)
+
+        with (
+            patch("playwright.sync_api.sync_playwright", return_value=fake_playwright),
+            self._patch_decrypt(),
+            patch.object(
+                session_module,
+                "default_chrome_profile_dir",
+                return_value=Path("/fake/chrome/profile"),
+            ),
+            patch.object(Path, "exists", return_value=True),
+        ):
+            storage_state, _source_meta = session_module.capture_storage_state()
+
+        self.assertEqual(storage_state, {"cookies": []})
+
     def test_verify_fails_closed_when_grid_marker_never_appears(self):
         """Issue #692 cycle-review: `_wait_for_marker`'s `False` return must
         not be discarded here either — a blank/unrendered grid response


### PR DESCRIPTION
## Проблема

`direct playwright login` падал с `Timed out waiting for https://direct.yandex.ru/dna/grid/campaigns/ to render while verifying the session`, хотя реальная Chrome-сессия пользователя была валидна (страница грида открывалась вручную без проблем).

## Причина

Живая проверка (headless Chromium, декрипт куков из Chrome Keychain, навигация на `GRID_URL`) показала: страница рендерится нормально (611 KB реальной разметки, без маркеров логина/капчи), но `[data-testid="Sidebar"]` — маркер, на который поллит `_wait_for_marker` — больше не встречается в разметке. Yandex убрал этот testid из левой навигации грида кампаний. `_wait_for_marker` честно ждал 30 секунд и падал по таймауту, хотя страница давно отрендерилась.

## Фикс

`_DIRECT_PAGE_MARKERS` в `direct_cli/browser/session.py` теперь дополнительно принимает `[data-testid="DirectGrid"]` — внешнюю оболочку самого грида (подтверждено уникальным, единственным вхождением в живом ответе, присутствует независимо от виртуализированного содержимого строк — issue #639). Старый маркер `Sidebar` оставлен рядом (тот же паттерн, что и фикс #666 для маркеров страницы логина) — Yandex может его вернуть, а неиспользуемый маркер ничего не стоит.

## Тесты

- Новый regression-тест `test_verify_succeeds_when_only_the_directgrid_marker_is_present` в `tests/test_masters.py` — воспроизводит ровно сценарий issue #859 (маркер `DirectGrid` присутствует, `Sidebar` — нет).
- Полный офлайн-набор (`pytest`) прогнан: 3673 passed, 23 skipped; 3 упавших теста (`TestWithSessionRetry`/`TestMastersRegistered::test_open_session_catches_errors_raised_inside_the_with_block`) — подтверждено как pre-existing на `main`, не связаны с этим изменением.
- `black --check` / `flake8` чисто на изменённых файлах.

Closes #859

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YG39FbugFn94w9BjbUutCi