### PR TITLE
fix(browser): name stale-marker hypothesis in marker-timeout errors (#859 follow-up)

### DIFF
--- a/direct_cli/browser/session.py
+++ b/direct_cli/browser/session.py
@@ -213,8 +213,10 @@ def _stale_marker_hint() -> str:
         "This can mean either your session is expired/slow, or the page's "
         "markup changed and the marker this tool looks for is now outdated "
         "(this has happened before, see issue #859). If the page opens fine "
-        f"in your own Chrome, please report this at {_ISSUE_TRACKER_URL} "
-        "with the page's HTML or a screenshot."
+        f"in your own Chrome, please report this at {_ISSUE_TRACKER_URL} — "
+        "the tracker is public, so first redact any account-identifying "
+        "details (campaign names/IDs, account login, tokens) before "
+        "attaching the page's HTML or a screenshot."
     )
 
 

--- a/direct_cli/browser/session.py
+++ b/direct_cli/browser/session.py
@@ -184,6 +184,39 @@ _DIRECT_OR_PASSPORT_PAGE_MARKERS = _DIRECT_PAGE_MARKERS + _PASSPORT_PAGE_MARKERS
 _PAGE_MARKER_TIMEOUT_MS = 30_000
 _PAGE_MARKER_POLL_MS = 250
 
+#: GitHub issue tracker URL for reporting a stale/renamed DOM marker — kept
+#: as a single literal here rather than repeated in each timeout message
+#: (CLAUDE.md "No URL literals outside the registry" spirit, even though this
+#: one isn't a Yandex docs URL: a second copy would drift the same way #426's
+#: duplicated captcha URL did).
+_ISSUE_TRACKER_URL = "https://github.com/axisrow/direct-cli/issues"
+
+
+def _stale_marker_hint() -> str:
+    """Diagnostic addendum for a "timed out waiting for ... to render"
+    message — appended when the first navigation to a page (Passport or the
+    Direct grid) never shows a marker `_wait_for_marker` recognizes.
+
+    A bare "timed out" reads as a session/network problem, but issue #859
+    showed a second, systemic cause: Yandex silently renamed or removed the
+    specific DOM marker(s) this module polls for (``[data-testid="Sidebar"]``
+    disappeared from the grid entirely, even though the grid itself rendered
+    611 KB of real, authenticated markup) — the two markers this file polls
+    for today (``_PASSPORT_PAGE_MARKERS``, ``_DIRECT_PAGE_MARKERS``) are just
+    as vulnerable to Yandex renaming them again tomorrow. Without this hint a
+    user whose session is actually fine (the page opens normally in their own
+    Chrome) has no way to tell "retry" from "report a bug" apart, and would
+    just keep retrying a timeout that can never succeed until the marker
+    itself is fixed in code.
+    """
+    return (
+        "This can mean either your session is expired/slow, or the page's "
+        "markup changed and the marker this tool looks for is now outdated "
+        "(this has happened before, see issue #859). If the page opens fine "
+        f"in your own Chrome, please report this at {_ISSUE_TRACKER_URL} "
+        "with the page's HTML or a screenshot."
+    )
+
 
 def _wait_for_marker(
     page: "Page",
@@ -479,8 +512,7 @@ def login_persistent_session(
             # were a real one (issue #692 cycle-review).
             raise BrowserSessionError(
                 f"Timed out waiting for {_PASSPORT_LOGIN_URL} to render. "
-                "This can happen on a slow connection — retry `direct "
-                "masters login`."
+                f"{_stale_marker_hint()}"
             )
 
         # Poll on a second page, never on `page`: the human is typing into
@@ -626,7 +658,7 @@ def capture_storage_state(
                 # verified, authenticated grid (issue #692 cycle-review).
                 raise BrowserAuthError(
                     f"Timed out waiting for {GRID_URL} to render while "
-                    "verifying the session. Retry `direct playwright login`."
+                    f"verifying the session. {_stale_marker_hint()}"
                 )
             html = page.content()
             assert_not_captcha(html)

--- a/direct_cli/browser/session.py
+++ b/direct_cli/browser/session.py
@@ -514,7 +514,7 @@ def login_persistent_session(
             # were a real one (issue #692 cycle-review).
             raise BrowserSessionError(
                 f"Timed out waiting for {_PASSPORT_LOGIN_URL} to render. "
-                f"{_stale_marker_hint()}"
+                f"Retry `direct masters login`. {_stale_marker_hint()}"
             )
 
         # Poll on a second page, never on `page`: the human is typing into
@@ -660,7 +660,8 @@ def capture_storage_state(
                 # verified, authenticated grid (issue #692 cycle-review).
                 raise BrowserAuthError(
                     f"Timed out waiting for {GRID_URL} to render while "
-                    f"verifying the session. {_stale_marker_hint()}"
+                    "verifying the session. Retry `direct playwright login`. "
+                    f"{_stale_marker_hint()}"
                 )
             html = page.content()
             assert_not_captcha(html)

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -1671,6 +1671,21 @@ class TestCaptureStorageState(unittest.TestCase):
         self.assertIn("outdated", message.lower())
         self.assertIn("github", message.lower())
 
+    def test_stale_marker_hint_warns_before_asking_for_page_evidence(self):
+        """Codex adversarial review of PR #861: the timeout hint asked users
+        to attach the page's raw HTML or a screenshot to a *public* GitHub
+        issue with no redaction warning. For the authenticated Direct grid
+        path that page can contain account/campaign identifiers and other
+        account data — a user following the message literally could paste
+        that into a public tracker. The hint must warn to redact
+        account-identifying details before attaching evidence, not just ask
+        for "the page's HTML or a screenshot" unconditionally."""
+        from direct_cli.browser.session import _stale_marker_hint
+
+        message = _stale_marker_hint().lower()
+        self.assertIn("redact", message)
+        self.assertIn("account", message)
+
 
 class TestOpenSessionTiers(unittest.TestCase):
     """_open_session's tiered resolution: explicit profile / persistent CLI

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -1437,6 +1437,14 @@ class TestPersistentSession(unittest.TestCase):
         self.assertIn("Timed out", message)
         self.assertIn("outdated", message.lower())
         self.assertIn("github", message.lower())
+        self.assertIn(
+            "direct masters login",
+            message,
+            "cycle-review round 2: the retry instruction present before the "
+            "#859 diagnostic-hint refactor must not be dropped — a genuinely "
+            "expired/slow session (the common, non-marker-rot case) still "
+            "needs an actionable retry command, not just the report-a-bug hint",
+        )
         self.assertFalse(
             session_module.PROFILE_POINTER_PATH.exists(),
             "an unrendered login must not be recorded as a usable profile",
@@ -1596,6 +1604,43 @@ class TestCaptureStorageState(unittest.TestCase):
 
         self.assertEqual(storage_state, {"cookies": []})
 
+    def test_verify_succeeds_when_only_the_older_sidebar_marker_is_present(self):
+        """cycle-review round 2 (/review deferred finding): the reverse of
+        `test_verify_succeeds_when_only_the_directgrid_marker_is_present`.
+        `_DIRECT_PAGE_MARKERS`'s OR-union must still match on the older
+        `Sidebar` marker alone (kept deliberately in case Yandex reintroduces
+        it, see #859) — not just on the newer `DirectGrid` marker. Both
+        directions of the union need coverage, not only the one #859's own
+        regression test exercised."""
+        pytest.importorskip("playwright")
+        from direct_cli.browser import session as session_module
+
+        page = _direct_page(
+            locators={
+                '[data-testid="DirectGrid"]': _FakeLocator([]),
+                '[data-testid="Sidebar"]': _FakeLocator([_FakeLocatorHandle()]),
+            }
+        )
+        fake_browser = _FakeBrowser()
+        fake_context = _FakeVerifyContext(page, storage_state={"cookies": []})
+        fake_browser.new_context = lambda **kwargs: fake_context
+        fake_chromium = _FakeChromium(fake_browser)
+        fake_playwright = _FakePlaywright(fake_chromium)
+
+        with (
+            patch("playwright.sync_api.sync_playwright", return_value=fake_playwright),
+            self._patch_decrypt(),
+            patch.object(
+                session_module,
+                "default_chrome_profile_dir",
+                return_value=Path("/fake/chrome/profile"),
+            ),
+            patch.object(Path, "exists", return_value=True),
+        ):
+            storage_state, _source_meta = session_module.capture_storage_state()
+
+        self.assertEqual(storage_state, {"cookies": []})
+
     def test_verify_fails_closed_when_grid_marker_never_appears(self):
         """Issue #692 cycle-review: `_wait_for_marker`'s `False` return must
         not be discarded here either — a blank/unrendered grid response
@@ -1628,7 +1673,16 @@ class TestCaptureStorageState(unittest.TestCase):
             with self.assertRaises(BrowserAuthError) as ctx:
                 session_module.capture_storage_state()
 
-        self.assertIn("Timed out", str(ctx.exception))
+        message = str(ctx.exception)
+        self.assertIn("Timed out", message)
+        self.assertIn(
+            "direct playwright login",
+            message,
+            "cycle-review round 2: the retry instruction present before the "
+            "#859 diagnostic-hint refactor must not be dropped — a genuinely "
+            "expired/slow session (the common, non-marker-rot case) still "
+            "needs an actionable retry command, not just the report-a-bug hint",
+        )
 
     def test_verify_timeout_message_hints_at_a_stale_dom_marker(self):
         """Issue #859 follow-up: a marker timeout here is ambiguous between

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -1433,7 +1433,10 @@ class TestPersistentSession(unittest.TestCase):
                 session_module.login_persistent_session(
                     profile_dir=self.profile_dir, timeout_ms=5_000
                 )
-        self.assertIn("Timed out", str(ctx.exception))
+        message = str(ctx.exception)
+        self.assertIn("Timed out", message)
+        self.assertIn("outdated", message.lower())
+        self.assertIn("github", message.lower())
         self.assertFalse(
             session_module.PROFILE_POINTER_PATH.exists(),
             "an unrendered login must not be recorded as a usable profile",
@@ -1626,6 +1629,47 @@ class TestCaptureStorageState(unittest.TestCase):
                 session_module.capture_storage_state()
 
         self.assertIn("Timed out", str(ctx.exception))
+
+    def test_verify_timeout_message_hints_at_a_stale_dom_marker(self):
+        """Issue #859 follow-up: a marker timeout here is ambiguous between
+        two different causes — a genuinely expired/slow session, or Yandex
+        having changed the grid's markup so the specific DOM marker(s)
+        `_wait_for_marker` polls for (`_DIRECT_PAGE_MARKERS`) no longer
+        exist, even though the page renders fine (this is exactly what
+        happened to `[data-testid="Sidebar"]`, see #859). Yandex can rename
+        any of these markers again at any time, so the timeout message must
+        name this hypothesis explicitly — rather than reading like a plain
+        session/network failure — so a user whose session is actually valid
+        (page opens fine in their own Chrome) knows to report a stale
+        selector instead of just retrying forever."""
+        pytest.importorskip("playwright")
+        from direct_cli.browser import session as session_module
+        from direct_cli.browser.session import BrowserAuthError
+
+        blank_page = FakePage(locators={}, html="<html></html>")
+        fake_browser = _FakeBrowser()
+        fake_context = _FakeVerifyContext(blank_page, storage_state={"cookies": []})
+        fake_browser.new_context = lambda **kwargs: fake_context
+        fake_chromium = _FakeChromium(fake_browser)
+        fake_playwright = _FakePlaywright(fake_chromium)
+
+        with (
+            patch("playwright.sync_api.sync_playwright", return_value=fake_playwright),
+            self._patch_decrypt(),
+            patch.object(
+                session_module,
+                "default_chrome_profile_dir",
+                return_value=Path("/fake/chrome/profile"),
+            ),
+            patch.object(Path, "exists", return_value=True),
+            patch.object(session_module, "_PAGE_MARKER_TIMEOUT_MS", 10),
+        ):
+            with self.assertRaises(BrowserAuthError) as ctx:
+                session_module.capture_storage_state()
+
+        message = str(ctx.exception)
+        self.assertIn("outdated", message.lower())
+        self.assertIn("github", message.lower())
 
 
 class TestOpenSessionTiers(unittest.TestCase):


### PR DESCRIPTION
Стек на PR #860.

## Проблема

Ошибки таймаута DOM-маркера в `direct_cli/browser/session.py` (`login_persistent_session` — маркер страницы Passport, `capture_storage_state` — маркер грида кампаний) читаются как обычный сбой сессии/сети: *«Timed out waiting for <url> to render»*. Но issue #859 показал вторую, системную причину: Yandex может молча переименовать/убрать конкретный DOM-маркер (`[data-testid="Sidebar"]` полностью исчез из грида, хотя страница рендерилась нормально — 611 KB реальной аутентифицированной разметки). Оба маркера, на которые сейчас поллит модуль, так же уязвимы к переименованию завтра.

Пользователь с реально валидной сессией не мог отличить «просто ретрай» от «баг в коде, нужно репортить» — и заходил в бесконечный цикл ретраев таймаута, который в принципе не мог завершиться успехом, пока кто-то не поправит маркер в коде.

## Фикс

Добавлен `_stale_marker_hint()` — общий диагностический довесок к сообщению об ошибке, называющий обе гипотезы явно (протухшая сессия/медленная сеть ИЛИ устаревший маркер) и указывающий на GitHub issues для репорта. Применён в двух местах, где таймаут маркера возникает после обычной навигации (не в исходящем 5-минутном таймауте ручного логина внутри `login_persistent_session` — там другая, самостоятельная причина: человек просто не успел залогиниться).

## TDD

- **Красный:** `test_verify_timeout_message_hints_at_a_stale_dom_marker` (новый) + расширенный `test_login_fails_closed_when_passport_marker_never_appears` — оба падали до фикса (сообщение не содержало 'outdated'/'github').
- **Зелёный:** оба теста проходят после фикса.
- **Полный набор:** `tests/test_masters.py` + `tests/test_playwright_session.py` — 1007 passed (+87 subtests); те же 3 pre-existing падения (`TestWithSessionRetry`/`test_open_session_catches_errors_raised_inside_the_with_block`), подтверждённые как несвязанные ранее (воспроизводятся на чистом `main`).
- **black/flake8:** чисто.
- **mutation (mutmut):** попытка предпринята, но заблокирована независимым багом в самом mutmut 3.7.0 — его stage сбора статистики падает с `NameError: name 'exit' is not defined` внутри `mutmut/__main__.py::run_stats_collection`, воспроизводится вне зависимости от этого изменения. Явно не прогнано, а не пропущено молча.

Follow-up к #859 / PR #860.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YG39FbugFn94w9BjbUutCi