### PR TITLE
fix(tests): isolate TestWithSessionRetry/TestMastersRegistered from real persistent Chrome profile

### DIFF
--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -987,6 +987,23 @@ class TestMastersRegistered(unittest.TestCase):
                     "direct_cli.browser.store.session_status",
                     return_value={"exists": False, "error": None, "expired": None},
                 ),
+                # Same isolation as TestOpenSessionTiers.setUp: without
+                # this, _open_session's Tier 1.5 check
+                # (persistent_profile_is_usable) reads the real
+                # ~/.direct-cli/chrome-profile/Default/Cookies. On a
+                # machine that has ever run `direct masters
+                # login`/`direct playwright login` for real, that file
+                # exists, Tier 1.5 wins over the patched
+                # open_chrome_session above, and this test then exercises
+                # a real Chromium session instead of the injected error.
+                patch(
+                    "direct_cli.browser.session.DEFAULT_PERSISTENT_PROFILE_DIR",
+                    Path("/nonexistent/chrome-profile"),
+                ),
+                patch(
+                    "direct_cli.browser.session.PROFILE_POINTER_PATH",
+                    Path("/nonexistent/chrome-profile-path"),
+                ),
             ):
                 with self.assertRaises(click.ClickException) as cm:
                     with _open_session(
@@ -1990,6 +2007,31 @@ class TestWithSessionRetry(unittest.TestCase):
     yield a second time from the same _open_session generator invocation
     (which raises RuntimeError: generator didn't stop after throw()).
     """
+
+    def setUp(self):
+        # Same isolation as TestOpenSessionTiers.setUp: every test here
+        # exercises tiers below 1.5 (persistent CLI profile) via a patched
+        # open_chrome_session/open_saved_session, but _open_session's Tier
+        # 1.5 check (persistent_profile_is_usable) reads the real
+        # filesystem regardless of those patches. On a machine that has
+        # ever run `direct masters login`/`direct playwright login` for
+        # real, ~/.direct-cli/chrome-profile/Default/Cookies exists, Tier
+        # 1.5 wins over the intended tier, and the *real*
+        # open_persistent_session launches an actual Chromium instead of
+        # hitting either patched fake — the test then asserts against a
+        # real Page object instead of "fresh-page"/the injected exception.
+        patcher = patch(
+            "direct_cli.browser.session.DEFAULT_PERSISTENT_PROFILE_DIR",
+            Path("/nonexistent/chrome-profile"),
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        pointer = patch(
+            "direct_cli.browser.session.PROFILE_POINTER_PATH",
+            Path("/nonexistent/chrome-profile-path"),
+        )
+        pointer.start()
+        self.addCleanup(pointer.stop)
 
     def _list_ctx(self, args=None):
         from direct_cli.commands.masters import masters


### PR DESCRIPTION
## Проблема

3 теста падали на этой машине, но не в CI:
- `TestMastersRegistered::test_open_session_catches_errors_raised_inside_the_with_block`
- `TestWithSessionRetry::test_no_saved_session_runs_operation_once`
- `TestWithSessionRetry::test_auth_error_raised_inside_operation_retries_via_fresh_session`

## Причина

Тесты мокают `direct_cli.browser.session.open_chrome_session` (и `open_saved_session`/`session_status`), чтобы подставить фейковую сессию, но `_open_session`'s Tier 1.5 проверка (`persistent_profile_is_usable` в `direct_cli/commands/masters.py`) читает реальную файловую систему (`~/.direct-cli/chrome-profile/Default/Cookies`) вне зависимости от этих патчей. На машине, где хоть раз выполнялся `direct masters login`/`direct playwright login` по-настоящему, этот файл существует, Tier 1.5 побеждает над предполагаемым тестом уровнем, и **настоящий** `open_persistent_session` запускает реальный Chromium вместо любого из замоканных путей — тест затем сравнивает с реальным `Page`-объектом (`"<Page url='about:blank'>"`) вместо ожидаемого `"fresh-page"`/инжектированного исключения.

`TestOpenSessionTiers.setUp` уже документирует и решает именно эту проблему (патчит `DEFAULT_PERSISTENT_PROFILE_DIR` и `PROFILE_POINTER_PATH` на несуществующие пути) — `TestWithSessionRetry` и один затронутый тест в `TestMastersRegistered` просто не получили того же обращения. Применён идентичный паттерн.

## Тесты

**Red → green** (воспроизведено на машине с реальным `~/.direct-cli/chrome-profile`):
- `tests/test_masters.py::TestMastersRegistered::test_open_session_catches_errors_raised_inside_the_with_block`
- `tests/test_masters.py::TestWithSessionRetry::test_no_saved_session_runs_operation_once`
- `tests/test_masters.py::TestWithSessionRetry::test_auth_error_raised_inside_operation_retries_via_fresh_session`

Полный набор: **3679 passed, 23 skipped, 117 subtests passed — 0 падений** (было 3 падения на этой машине). `black`/`flake8` чисто.

## Mutation-проверка

Не прогнана — mutmut 3.7.0 в этом окружении падает на баге в собственном коде (`NameError: name 'exit' is not defined` в `mutmut/__main__.py::run_stats_collection`), воспроизведено ранее в этой же сессии независимо от кода проекта. Явно отмечаю как не прогнанную, не пропускаю молча.

Не мержу.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YG39FbugFn94w9BjbUutCi