### PR TITLE
feat(masters): add status command for session state (#862)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,12 @@ path/usability and the saved session's existence/expiry (reusing
 doctor` already does). Never launches a browser or touches Yandex; unlike
 every other `masters` subcommand, `status` is pure on-disk inspection.
 Defaults to `text` output like other local reference/diagnostic commands
-(`direct playwright doctor`, `trackingparams`).
+(`direct playwright doctor`, `trackingparams`). An explicit `--profile-dir`
+on the `status` call itself reports tier 1 ("explicit --profile-dir"),
+matching `_open_session`'s real precedence: a real `masters` read command
+given the same flag always decrypts fresh from that profile, bypassing
+tier 1.5/2 entirely — `status` models that override instead of reporting a
+tier the real command would not actually use (cycle-review of #864).
 
 **`masters update --add-video-url` — select an already-uploaded video (#812).**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ### Added
 
+**`masters status` — inspect the active browser session with no network call (#862).**
+
+Reports which of `_open_session`'s tiers `masters` commands would currently
+use — the CLI's own persistent profile from `masters login` (tier 1.5), a
+saved `direct playwright login` session (tier 2), or neither (tier 3,
+fresh Chrome-cookie decrypt on every call) — plus the persistent profile's
+path/usability and the saved session's existence/expiry (reusing
+`direct_cli.browser.store.session_status`, the same read `direct playwright
+doctor` already does). Never launches a browser or touches Yandex; unlike
+every other `masters` subcommand, `status` is pure on-disk inspection.
+Defaults to `text` output like other local reference/diagnostic commands
+(`direct playwright doctor`, `trackingparams`).
+
 **`masters update --add-video-url` — select an already-uploaded video (#812).**
 
 Adds a video to a campaign's "Варианты видео" section by selecting one the

--- a/README.md
+++ b/README.md
@@ -303,6 +303,11 @@ in), so it can't run unattended. Run `direct masters logout` to delete the
 profile and revoke the on-disk session (a no-op warning, not an error, if
 none exists).
 
+Run `direct masters status` to check which of these two sessions `masters`
+commands would currently use — which tier is active, the persistent
+profile's path, and the saved session's expiry — without any network call
+or side effect (no browser launch, unlike every other `masters` command).
+
 ### История изменений (change history) — browser-only
 
 The API has **no per-field change journal**: `changes.checkCampaigns` reports

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -82,7 +82,7 @@ from ..output import (
     print_info,
     print_warning,
 )
-from ..utils import parse_ids
+from ..utils import parse_ids, reference_output_options
 
 _BROWSER_INSTALL_HINT = (
     'pip install "direct-cli[browser]" && playwright install chromium'
@@ -523,6 +523,88 @@ def logout(profile_dir):
     if pointer_target and Path(pointer_target) == resolved_profile_dir.resolve():
         PROFILE_POINTER_PATH.unlink(missing_ok=True)
     print_info(f"Deleted persistent browser profile at {resolved_profile_dir}")
+
+
+@masters.command(name="status")
+@click.option(
+    "--profile-dir",
+    help="Directory for the CLI's own persistent Chrome profile "
+    "(default: ~/.direct-cli/chrome-profile/)",
+)
+@reference_output_options
+def status(profile_dir, output_format, output):
+    """Show which session `masters` commands would use, no network call
+
+    Read-only inspection of the same on-disk state `_open_session` consults
+    to pick a tier (issue #862) — never launches a browser, never touches
+    Yandex. Reports which tier is currently active (the CLI's own persistent
+    profile from `masters login`, tier 1.5; or a saved `direct playwright
+    login` session, tier 2; or neither, meaning every `masters` call falls
+    back to a fresh Keychain decrypt, tier 3) plus what is known about that
+    session's freshness.
+
+    The persistent profile (tier 1.5) has no expiry to report — Chromium
+    manages that cookie store's own on-disk format, unlike the Playwright
+    `storage_state` JSON tier 2 saves, whose cookie expiry timestamps
+    `direct_cli.browser.store.session_status` already reads for `direct
+    playwright doctor`. "usable" for tier 1.5 means only "a session was
+    ever captured" (`persistent_profile_is_usable`) -- whether it is still
+    valid server-side is unknown until the next real `masters` call.
+    """
+    from ..browser import store
+    from ..browser.session import (
+        configured_persistent_profile_dir,
+        persistent_profile_is_usable,
+    )
+
+    resolved_persistent_dir = (
+        Path(profile_dir) if profile_dir else configured_persistent_profile_dir()
+    )
+    persistent_usable = persistent_profile_is_usable(resolved_persistent_dir)
+    saved_status = store.session_status()
+
+    if persistent_usable:
+        active_tier = "1.5"
+        active_source = "masters login"
+    elif (
+        saved_status["exists"]
+        and not saved_status["error"]
+        and saved_status["expired"] is not True
+    ):
+        active_tier = "2"
+        active_source = "playwright login"
+    else:
+        active_tier = "3"
+        active_source = "chrome-cookie-injection"
+
+    payload = {
+        "active_tier": active_tier,
+        "active_source": active_source,
+        "persistent_profile": {
+            "path": str(resolved_persistent_dir),
+            "usable": persistent_usable,
+        },
+        "saved_session": saved_status,
+    }
+
+    if output_format == "text":
+        click.echo(f"active_tier={active_tier} ({active_source})")
+        click.echo(
+            "persistent_profile: "
+            f"path={resolved_persistent_dir} usable={persistent_usable}"
+        )
+        click.echo(
+            "saved_session: "
+            f"exists={saved_status['exists']} "
+            f"expired={saved_status['expired']} "
+            f"cookie_count={saved_status['cookie_count']} "
+            f"path={saved_status['path']}"
+        )
+        if saved_status["error"]:
+            click.echo(f"  error: {saved_status['error']}")
+        return
+
+    format_output(payload, output_format, output)
 
 
 _STATUS_CHOICES = ("not-archived", "active", "stopped", "archived", "all")

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -529,19 +529,25 @@ def logout(profile_dir):
 @click.option(
     "--profile-dir",
     help="Directory for the CLI's own persistent Chrome profile "
-    "(default: ~/.direct-cli/chrome-profile/)",
+    "(default: ~/.direct-cli/chrome-profile/). Passing this explicitly "
+    "mirrors `_open_session`'s tier-1 override: a real `masters` read "
+    "command given the same flag always decrypts fresh from that profile, "
+    "bypassing tier 1.5/2 entirely -- so `status` reports tier 1 too.",
 )
+@click.pass_context
 @reference_output_options
-def status(profile_dir, output_format, output):
+def status(ctx, profile_dir, output_format, output):
     """Show which session `masters` commands would use, no network call
 
     Read-only inspection of the same on-disk state `_open_session` consults
     to pick a tier (issue #862) — never launches a browser, never touches
-    Yandex. Reports which tier is currently active (the CLI's own persistent
-    profile from `masters login`, tier 1.5; or a saved `direct playwright
-    login` session, tier 2; or neither, meaning every `masters` call falls
-    back to a fresh Keychain decrypt, tier 3) plus what is known about that
-    session's freshness.
+    Yandex. Reports which tier is currently active: an explicit
+    `--profile-dir` on this call, tier 1 (matches `_open_session`'s own
+    precedence -- see `_profile_options_explicit`); else the CLI's own
+    persistent profile from `masters login`, tier 1.5; or a saved `direct
+    playwright login` session, tier 2; or neither, meaning every `masters`
+    call falls back to a fresh Keychain decrypt, tier 3 — plus what is
+    known about that session's freshness.
 
     The persistent profile (tier 1.5) has no expiry to report — Chromium
     manages that cookie store's own on-disk format, unlike the Playwright
@@ -551,6 +557,8 @@ def status(profile_dir, output_format, output):
     ever captured" (`persistent_profile_is_usable`) -- whether it is still
     valid server-side is unknown until the next real `masters` call.
     """
+    from click.core import ParameterSource
+
     from ..browser import store
     from ..browser.session import (
         configured_persistent_profile_dir,
@@ -562,8 +570,19 @@ def status(profile_dir, output_format, output):
     )
     persistent_usable = persistent_profile_is_usable(resolved_persistent_dir)
     saved_status = store.session_status()
+    profile_dir_explicit = (
+        ctx.get_parameter_source("profile_dir") is ParameterSource.COMMANDLINE
+    )
 
-    if persistent_usable:
+    if profile_dir_explicit:
+        # Tier 1 (see `_open_session`/`_profile_options_explicit`): an
+        # explicit --profile-dir on a real `masters` read command always
+        # forces a fresh decrypt from that profile, ignoring tier 1.5/2
+        # entirely -- `status` must model that same precedence or it
+        # reports a tier the real command would not actually use.
+        active_tier = "1"
+        active_source = "explicit --profile-dir"
+    elif persistent_usable:
         active_tier = "1.5"
         active_source = "masters login"
     elif (

--- a/direct_cli/smoke_matrix.py
+++ b/direct_cli/smoke_matrix.py
@@ -72,6 +72,11 @@ SMOKE_MATRIX = {
         "masters.counters.get",
         "masters.get",
         "masters.list",
+        # No network call at all -- pure on-disk inspection of which browser
+        # session tier `masters` would use (see status's own docstring,
+        # issue #862). Safer than every other masters.* entry here, none of
+        # which even launches a browser.
+        "masters.status",
         # Read-only: navigates to the edit page and reads the "Целевые
         # действия" table, never clicks Save (see
         # fetch_master_target_actions's docstring) — same "opens the edit

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -13032,19 +13032,24 @@ class TestMastersStatusCommand(unittest.TestCase):
 
     def test_status_never_imports_playwright(self):
         # Read-only inspection of on-disk state only -- no browser, ever.
-        with patch.dict(
-            "sys.modules", {"playwright": None, "playwright.sync_api": None}
+        with (
+            patch.dict(
+                "sys.modules", {"playwright": None, "playwright.sync_api": None}
+            ),
+            patch(
+                "direct_cli.browser.session.configured_persistent_profile_dir",
+                return_value=self.persistent_dir,
+            ),
         ):
-            result = self.runner.invoke(
-                cli,
-                ["masters", "status", "--profile-dir", str(self.persistent_dir)],
-            )
+            result = self.runner.invoke(cli, ["masters", "status"])
         self.assertEqual(result.exit_code, 0, result.output)
 
     def test_status_reports_tier_3_when_nothing_saved(self):
-        result = self.runner.invoke(
-            cli, ["masters", "status", "--profile-dir", str(self.persistent_dir)]
-        )
+        with patch(
+            "direct_cli.browser.session.configured_persistent_profile_dir",
+            return_value=self.persistent_dir,
+        ):
+            result = self.runner.invoke(cli, ["masters", "status"])
 
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertIn("active_tier=3", result.output)
@@ -13052,9 +13057,11 @@ class TestMastersStatusCommand(unittest.TestCase):
     def test_status_reports_tier_1_5_when_persistent_profile_usable(self):
         self._make_usable_persistent_profile()
 
-        result = self.runner.invoke(
-            cli, ["masters", "status", "--profile-dir", str(self.persistent_dir)]
-        )
+        with patch(
+            "direct_cli.browser.session.configured_persistent_profile_dir",
+            return_value=self.persistent_dir,
+        ):
+            result = self.runner.invoke(cli, ["masters", "status"])
 
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertIn("active_tier=1.5", result.output)
@@ -13065,9 +13072,11 @@ class TestMastersStatusCommand(unittest.TestCase):
 
         store.save_session({"cookies": [{"domain": "direct.yandex.ru"}]})
 
-        result = self.runner.invoke(
-            cli, ["masters", "status", "--profile-dir", str(self.persistent_dir)]
-        )
+        with patch(
+            "direct_cli.browser.session.configured_persistent_profile_dir",
+            return_value=self.persistent_dir,
+        ):
+            result = self.runner.invoke(cli, ["masters", "status"])
 
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertIn("active_tier=2", result.output)
@@ -13079,29 +13088,30 @@ class TestMastersStatusCommand(unittest.TestCase):
         self._make_usable_persistent_profile()
         store.save_session({"cookies": [{"domain": "direct.yandex.ru"}]})
 
-        result = self.runner.invoke(
-            cli, ["masters", "status", "--profile-dir", str(self.persistent_dir)]
-        )
+        with patch(
+            "direct_cli.browser.session.configured_persistent_profile_dir",
+            return_value=self.persistent_dir,
+        ):
+            result = self.runner.invoke(cli, ["masters", "status"])
 
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertIn("active_tier=1.5", result.output)
 
     def test_status_json_output_reports_saved_session_details(self):
+        # No --profile-dir on the CLI invocation here (the option below is
+        # consumed by the runner's own args list, not passed through as a
+        # user-supplied --profile-dir -- see setUp: persistent_dir is only
+        # the *default* lookup target, not an explicit CLI flag) -- so tier
+        # precedence is unaffected and tier 2 (saved session) applies.
         from direct_cli.browser import store
 
         store.save_session({"cookies": [{"domain": "direct.yandex.ru"}]})
 
-        result = self.runner.invoke(
-            cli,
-            [
-                "masters",
-                "status",
-                "--profile-dir",
-                str(self.persistent_dir),
-                "--format",
-                "json",
-            ],
-        )
+        with patch(
+            "direct_cli.browser.session.configured_persistent_profile_dir",
+            return_value=self.persistent_dir,
+        ):
+            result = self.runner.invoke(cli, ["masters", "status", "--format", "json"])
 
         self.assertEqual(result.exit_code, 0, result.output)
         payload = json.loads(result.output)
@@ -13118,6 +13128,44 @@ class TestMastersStatusCommand(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, result.output)
         with self.assertRaises(json.JSONDecodeError):
             json.loads(result.output)
+
+    def test_status_reports_tier_1_when_profile_dir_explicit_even_with_saved_session(
+        self,
+    ):
+        # `_open_session`'s own tier-1 rule (masters.py's
+        # `_profile_options_explicit`): an explicit --profile-dir always
+        # forces a fresh decrypt from that profile, bypassing tier 1.5/2
+        # entirely -- regardless of a saved session or a usable persistent
+        # profile existing elsewhere. `status` must model that same
+        # precedence, or it reports a tier that a real `masters list
+        # --profile-dir <path>` call would not actually use.
+        from direct_cli.browser import store
+
+        self._make_usable_persistent_profile()
+        store.save_session({"cookies": [{"domain": "direct.yandex.ru"}]})
+
+        result = self.runner.invoke(
+            cli, ["masters", "status", "--profile-dir", str(self.persistent_dir)]
+        )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("active_tier=1 ", result.output)
+
+    def test_status_reports_tier_1_5_when_profile_dir_not_explicit(self):
+        # Without an explicit --profile-dir on the command line, tier
+        # precedence is unaffected -- confirms the fix does not regress the
+        # default (no-flag) path, which still prefers the configured
+        # persistent profile.
+        self._make_usable_persistent_profile()
+
+        with patch(
+            "direct_cli.browser.session.configured_persistent_profile_dir",
+            return_value=self.persistent_dir,
+        ):
+            result = self.runner.invoke(cli, ["masters", "status"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("active_tier=1.5", result.output)
 
 
 class TestCaptchaDetection(unittest.TestCase):

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -891,6 +891,7 @@ class TestMastersRegistered(unittest.TestCase):
         self.assertIn("get", result.output)
         self.assertIn("login", result.output)
         self.assertIn("logout", result.output)
+        self.assertIn("status", result.output)
 
     def test_masters_list_help(self):
         result = self.runner.invoke(cli, ["masters", "list", "--help"])
@@ -12994,6 +12995,129 @@ class TestMastersLogoutCommand(unittest.TestCase):
             live_profile.resolve(),
             "logout on an unrelated profile cleared the pointer to the live one",
         )
+
+
+class TestMastersStatusCommand(unittest.TestCase):
+    """CLI wiring for `masters status` (issue #862) -- must never touch the network."""
+
+    def setUp(self):
+        self.runner = CliRunner()
+        import tempfile
+
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.persistent_dir = Path(self._tmpdir.name) / "chrome-profile"
+        self.session_path = Path(self._tmpdir.name) / "session.json"
+
+        pointer = patch(
+            "direct_cli.browser.session.PROFILE_POINTER_PATH",
+            Path(self._tmpdir.name) / "chrome-profile-path",
+        )
+        pointer.start()
+        self.addCleanup(pointer.stop)
+
+        saved_path = patch(
+            "direct_cli.browser.store.PLAYWRIGHT_SESSION_PATH", self.session_path
+        )
+        saved_path.start()
+        self.addCleanup(saved_path.stop)
+
+    def _make_usable_persistent_profile(self):
+        (self.persistent_dir / "Default").mkdir(parents=True)
+        (self.persistent_dir / "Default" / "Cookies").write_text("fake")
+
+    def test_status_registered(self):
+        result = self.runner.invoke(cli, ["masters", "status", "--help"])
+        self.assertEqual(result.exit_code, 0)
+
+    def test_status_never_imports_playwright(self):
+        # Read-only inspection of on-disk state only -- no browser, ever.
+        with patch.dict(
+            "sys.modules", {"playwright": None, "playwright.sync_api": None}
+        ):
+            result = self.runner.invoke(
+                cli,
+                ["masters", "status", "--profile-dir", str(self.persistent_dir)],
+            )
+        self.assertEqual(result.exit_code, 0, result.output)
+
+    def test_status_reports_tier_3_when_nothing_saved(self):
+        result = self.runner.invoke(
+            cli, ["masters", "status", "--profile-dir", str(self.persistent_dir)]
+        )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("active_tier=3", result.output)
+
+    def test_status_reports_tier_1_5_when_persistent_profile_usable(self):
+        self._make_usable_persistent_profile()
+
+        result = self.runner.invoke(
+            cli, ["masters", "status", "--profile-dir", str(self.persistent_dir)]
+        )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("active_tier=1.5", result.output)
+        self.assertIn("masters login", result.output)
+
+    def test_status_reports_tier_2_when_saved_session_fresh(self):
+        from direct_cli.browser import store
+
+        store.save_session({"cookies": [{"domain": "direct.yandex.ru"}]})
+
+        result = self.runner.invoke(
+            cli, ["masters", "status", "--profile-dir", str(self.persistent_dir)]
+        )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("active_tier=2", result.output)
+        self.assertIn("playwright login", result.output)
+
+    def test_status_prefers_tier_1_5_over_tier_2(self):
+        from direct_cli.browser import store
+
+        self._make_usable_persistent_profile()
+        store.save_session({"cookies": [{"domain": "direct.yandex.ru"}]})
+
+        result = self.runner.invoke(
+            cli, ["masters", "status", "--profile-dir", str(self.persistent_dir)]
+        )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("active_tier=1.5", result.output)
+
+    def test_status_json_output_reports_saved_session_details(self):
+        from direct_cli.browser import store
+
+        store.save_session({"cookies": [{"domain": "direct.yandex.ru"}]})
+
+        result = self.runner.invoke(
+            cli,
+            [
+                "masters",
+                "status",
+                "--profile-dir",
+                str(self.persistent_dir),
+                "--format",
+                "json",
+            ],
+        )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["active_tier"], "2")
+        self.assertTrue(payload["saved_session"]["exists"])
+        self.assertFalse(payload["persistent_profile"]["usable"])
+
+    def test_status_default_format_is_text_not_json(self):
+        # Reference/diagnostic command convention (CLAUDE.md): text default.
+        result = self.runner.invoke(
+            cli, ["masters", "status", "--profile-dir", str(self.persistent_dir)]
+        )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        with self.assertRaises(json.JSONDecodeError):
+            json.loads(result.output)
 
 
 class TestCaptchaDetection(unittest.TestCase):


### PR DESCRIPTION
## Summary

Adds `direct masters status` — a read-only diagnostic that reports which
browser session tier `_open_session` would currently use, with no network
call and no browser launch.

- Tier 1.5 (`masters login` persistent Chromium profile) vs tier 2 (saved
  `direct playwright login` session) vs tier 3 (fresh Chrome-cookie
  decrypt, zero-config fallback) — same tier logic `_open_session` already
  implements, just surfaced read-only.
- Reports the persistent profile's path and whether it's "usable"
  (`persistent_profile_is_usable`), and the saved session's
  existence/cookie-count/expiry via the existing
  `direct_cli.browser.store.session_status()` (already used internally by
  `direct playwright doctor`).
- Defaults to `text` output (reference/diagnostic command convention),
  supports `--format json/table/csv/tsv` via `reference_output_options`.
- Classified `masters.status` as `SAFE` in `smoke_matrix.py` (safer than
  every other `masters.*` entry — it never even launches a browser).

Closes #862

## Tests

- New `TestMastersStatusCommand` in `tests/test_masters.py`: registration,
  no-playwright-import guard, tier detection (3 / 1.5 / 2, and 1.5
  preferred over 2), JSON payload shape, text-is-default.
- `tests/test_masters.py::TestMastersRegistered` extended to assert
  `status` is listed in `masters --help`.
- Full offline suite: 3684 passed, 23 skipped. 3 pre-existing failures in
  `test_masters.py` (`TestMastersRegistered::test_open_session_catches_errors_raised_inside_the_with_block`,
  `TestWithSessionRetry::test_no_saved_session_runs_operation_once`,
  `TestWithSessionRetry::test_auth_error_raised_inside_operation_retries_via_fresh_session`)
  reproduce identically on a clean `main` checkout on this machine (an
  already-usable real `~/.direct-cli/chrome-profile` leaks into those
  tests) — unrelated to this change.
- `black`/`flake8` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5DdFJmA8QqZQ4uXDwcvmZ