### PR TITLE
fix(browser): retry net::ERR_* goto aborts in masters login

### DIFF
--- a/direct_cli/browser/session.py
+++ b/direct_cli/browser/session.py
@@ -50,8 +50,20 @@ if TYPE_CHECKING:
 
 try:
     from playwright.sync_api import Error as PlaywrightError
+    from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 except ImportError:  # pragma: no cover - exercised only when playwright is absent
     PlaywrightError = Exception  # type: ignore[assignment,misc]
+
+    # A fallback that can never match a real raised exception: with
+    # playwright absent no navigation — and hence no goto timeout — can
+    # happen at all, so the isinstance() check in
+    # `_is_network_navigation_error` must simply never be true. Aliasing
+    # this to ``Exception`` (PlaywrightError's own fallback shape) would
+    # instead classify *every* error as a navigation timeout.
+    class _AbsentPlaywrightTimeout(Exception):
+        pass
+
+    PlaywrightTimeoutError = _AbsentPlaywrightTimeout  # type: ignore[misc]
 
 _BROWSER_INSTALL_HINT = (
     'pip install "direct-cli[browser]" && playwright install chromium'
@@ -83,7 +95,9 @@ _LOGIN_POLL_INTERVAL_MS = 1_000
 # a not-yet-authenticated tick), so the default rides out a ~30s VPN blip
 # without killing a login the user may be mid-way through, while still
 # failing well inside the 5-minute window when the connection is properly
-# down. A single successful navigation resets the count.
+# down. A single successful navigation resets the count. Capped by the
+# caller's ``timeout_ms`` budget inside the poll loop — see
+# ``network_failure_limit`` there.
 _LOGIN_NETWORK_FAILURE_LIMIT = 30
 
 
@@ -315,12 +329,25 @@ def _is_network_navigation_error(exc: BaseException) -> bool:
     """True if ``exc`` is a Playwright navigation failure from the network layer.
 
     Issue #857: an unstable VPN/proxy aborts ``Page.goto`` before Playwright
-    ever sees a response — ``net::ERR_ABORTED`` in the live report. Such an
-    error says nothing about the session's validity, so it must be retried
-    and reported as a connectivity problem, never folded into the
-    expired/wrong-account story :class:`BrowserAuthError` tells.
+    ever sees a response — ``net::ERR_ABORTED`` in the live report — or, on
+    a merely *slow* connection, lets the navigation hit Playwright's own
+    timeout first (``Page.goto: Timeout 30000ms exceeded``, no ``net::ERR_``
+    code in sight — #865 review flagged it as the more frequent companion
+    of a flaky VPN). Either way the failure says nothing about the session's
+    validity, so it must be retried and reported as a connectivity problem,
+    never folded into the expired/wrong-account story
+    :class:`BrowserAuthError` tells.
+
+    Scoped by call site, not by message alone: this helper is only ever
+    asked about exceptions raised by a ``goto`` navigation, so matching
+    Playwright's :class:`TimeoutError` by class here cannot misclassify a
+    timeout from some unrelated ``wait_for_*`` call.
     """
-    return isinstance(exc, PlaywrightError) and _NETWORK_NAVIGATION_MARKER in str(exc)
+    if not isinstance(exc, PlaywrightError):
+        return False
+    return _NETWORK_NAVIGATION_MARKER in str(exc) or isinstance(
+        exc, PlaywrightTimeoutError
+    )
 
 
 def _goto_with_network_retry(page: "Page", url: str) -> None:
@@ -628,6 +655,21 @@ def login_persistent_session(
             # the command uncaught). Any successful navigation resets the
             # count: only *consecutive* failures mean the connection is down.
             consecutive_network_failures = 0
+            # Cap the failure limit by the caller's timeout budget: every
+            # failed tick spends one poll interval of ``elapsed_ms``, so a
+            # budget shorter than the limit in ticks — e.g. ``masters login
+            # --timeout 10`` — would expire the loop first and report the
+            # dead connection as the misleading "timed out waiting for
+            # login" below, the exact framing this block exists to remove
+            # (#865 review). The floor of 1 keeps a single network failure
+            # diagnosable as network whatever the budget.
+            network_failure_limit = max(
+                1,
+                min(
+                    _LOGIN_NETWORK_FAILURE_LIMIT,
+                    timeout_ms // _LOGIN_POLL_INTERVAL_MS - 1,
+                ),
+            )
             while elapsed_ms < timeout_ms:
                 try:
                     probe.goto(GRID_URL, wait_until="commit")
@@ -635,7 +677,7 @@ def login_persistent_session(
                     if not _is_network_navigation_error(exc):
                         raise
                     consecutive_network_failures += 1
-                    if consecutive_network_failures >= _LOGIN_NETWORK_FAILURE_LIMIT:
+                    if consecutive_network_failures >= network_failure_limit:
                         raise BrowserNetworkError(
                             f"Navigation to {GRID_URL} kept failing at the "
                             f"network level ({exc}) for "

--- a/direct_cli/browser/session.py
+++ b/direct_cli/browser/session.py
@@ -76,6 +76,16 @@ _PASSPORT_LOGIN_URL = "https://passport.yandex.ru/auth"
 _LOGIN_WAIT_TIMEOUT_MS = 5 * 60 * 1000
 _LOGIN_POLL_INTERVAL_MS = 1_000
 
+# issue #857: how many *consecutive* network-layer failures of the grid probe
+# the login poll loop tolerates before giving up with a
+# :class:`BrowserNetworkError`. Each failed tick costs one
+# ``_LOGIN_POLL_INTERVAL_MS`` of the login timeout budget (same accounting as
+# a not-yet-authenticated tick), so the default rides out a ~30s VPN blip
+# without killing a login the user may be mid-way through, while still
+# failing well inside the 5-minute window when the connection is properly
+# down. A single successful navigation resets the count.
+_LOGIN_NETWORK_FAILURE_LIMIT = 30
+
 
 class BrowserSessionError(RuntimeError):
     """Raised when a Playwright/Chrome session cannot be established."""
@@ -92,6 +102,21 @@ class BrowserAuthError(BrowserSessionError):
     this means the cookies decrypted fine but the session they represent is
     no longer valid (expired, or belongs to a different account) — see
     ``assert_authenticated``.
+    """
+
+
+class BrowserNetworkError(BrowserSessionError):
+    """Raised when a navigation is aborted at the network layer (issue #857).
+
+    An unstable VPN/proxy/connection can kill ``Page.goto`` before Playwright
+    receives any response (``net::ERR_ABORTED``, ``net::ERR_CONNECTION_*``,
+    …) — which says nothing about whether the Yandex session is valid.
+    Deliberately distinct from :class:`BrowserAuthError` (expired or
+    wrong-account cookies) so an error message can tell "restore the
+    connection and retry" apart from "re-login": before this class existed
+    the raw Playwright traceback escaped ``direct masters login`` uncaught,
+    and the natural reading — an auth problem — sent the user chasing a
+    session that was fine (the live #857 report blamed exactly that).
     """
 
 
@@ -263,6 +288,68 @@ def _wait_for_marker(
                 return True
         page.wait_for_timeout(_PAGE_MARKER_POLL_MS)
     return False
+
+
+# Every network-layer failure Chromium reports for a navigation surfaces from
+# Playwright as an error whose message carries the Chromium network error
+# code — ``net::ERR_ABORTED``, ``net::ERR_CONNECTION_RESET``,
+# ``net::ERR_NAME_NOT_RESOLVED``, ``net::ERR_TIMED_OUT``, … (Chromium's
+# ``net_error_list.h`` is the full family). This package only ever drives
+# ``playwright.chromium``, so the Firefox ``NS_ERROR_*`` family cannot appear
+# here, and one prefix covers the whole family — no per-code denylist to
+# drift out of sync with Chromium (same "declare the marker once" spirit as
+# ``_LOGIN_PAGE_MARKERS`` above).
+_NETWORK_NAVIGATION_MARKER = "net::ERR_"
+
+# Retry budget for :func:`_goto_with_network_retry` — enough attempts to ride
+# out a flaky-VPN blip on a navigation the flow cannot continue without (the
+# Passport login page, ``playwright login``'s verification probe), while still
+# failing fast with a clear network-level message when the connection is
+# genuinely down. The login poll loop has its own, longer tolerance
+# (:data:`_LOGIN_NETWORK_FAILURE_LIMIT`) because the user may be mid-login.
+_GOTO_NETWORK_ATTEMPTS = 3
+_GOTO_NETWORK_RETRY_INTERVAL_MS = 1_000
+
+
+def _is_network_navigation_error(exc: BaseException) -> bool:
+    """True if ``exc`` is a Playwright navigation failure from the network layer.
+
+    Issue #857: an unstable VPN/proxy aborts ``Page.goto`` before Playwright
+    ever sees a response — ``net::ERR_ABORTED`` in the live report. Such an
+    error says nothing about the session's validity, so it must be retried
+    and reported as a connectivity problem, never folded into the
+    expired/wrong-account story :class:`BrowserAuthError` tells.
+    """
+    return isinstance(exc, PlaywrightError) and _NETWORK_NAVIGATION_MARKER in str(exc)
+
+
+def _goto_with_network_retry(page: "Page", url: str) -> None:
+    """``page.goto(url, wait_until="commit")``, retrying network-layer aborts.
+
+    Transient ``net::ERR_*`` failures (flaky VPN/proxy — issue #857) are
+    retried up to :data:`_GOTO_NETWORK_ATTEMPTS` times, waiting
+    :data:`_GOTO_NETWORK_RETRY_INTERVAL_MS` between attempts via
+    ``page.wait_for_timeout`` — the #767 tick primitive, never a raw sleep the
+    offline harness cannot advance. Any other Playwright failure is re-raised
+    untouched: only the network layer is ours to retry. Exhaustion raises
+    :class:`BrowserNetworkError`, which names the connectivity cause
+    explicitly so the user is not sent chasing a session that isn't expired.
+    """
+    for attempt in range(1, _GOTO_NETWORK_ATTEMPTS + 1):
+        try:
+            page.goto(url, wait_until="commit")
+            return
+        except PlaywrightError as exc:
+            if not _is_network_navigation_error(exc):
+                raise
+            if attempt == _GOTO_NETWORK_ATTEMPTS:
+                raise BrowserNetworkError(
+                    f"Navigation to {url} failed at the network level "
+                    f"({exc}). This is a connectivity problem (VPN, proxy or "
+                    "unstable network), not an expired or wrong-account "
+                    "session. Restore the connection and retry."
+                ) from exc
+            page.wait_for_timeout(_GOTO_NETWORK_RETRY_INTERVAL_MS)
 
 
 def default_chrome_profile_dir() -> Optional[Path]:
@@ -484,7 +571,11 @@ def login_persistent_session(
     :data:`_LOGIN_POLL_INTERVAL_MS`) until :func:`assert_authenticated` no
     longer raises against ``direct.yandex.ru`` — i.e. until the user has
     finished logging in by hand in the visible window. Raises
-    :class:`BrowserAuthError` if ``timeout_ms`` elapses first.
+    :class:`BrowserAuthError` if ``timeout_ms`` elapses first. Navigation
+    aborts at the network layer (unstable VPN/proxy, issue #857) are
+    retried, never mistaken for an auth problem: transient ones are
+    tolerated inside the poll budget, persistent ones raise
+    :class:`BrowserNetworkError`.
 
     Deliberately defaults ``headless=False``: a headless window cannot be
     logged into by a human, so ``direct masters login`` always shows the
@@ -504,7 +595,7 @@ def login_persistent_session(
         sync_playwright, resolved_dir, headless=headless
     ) as context:
         page = context.new_page()
-        page.goto(_PASSPORT_LOGIN_URL, wait_until="commit")
+        _goto_with_network_retry(page, _PASSPORT_LOGIN_URL)
         if not _wait_for_marker(page, _PASSPORT_PAGE_MARKERS):
             # Fail closed: a timed-out marker means the page never rendered
             # far enough to trust `page.content()` — an in-progress/blank
@@ -525,8 +616,39 @@ def login_persistent_session(
         probe = context.new_page()
         try:
             elapsed_ms = 0
+            # issue #857: a network-layer abort of the grid probe (flaky
+            # VPN/proxy) says nothing about the login's progress, so it must
+            # not crash the flow the user may be mid-way through. Tolerate
+            # consecutive aborts up to _LOGIN_NETWORK_FAILURE_LIMIT — each
+            # consuming one poll interval of the timeout budget, exactly like
+            # a not-yet-authenticated tick — and only then fail with the
+            # distinct BrowserNetworkError, so a dead connection is not
+            # reported as the misleading "timed out waiting for login" below
+            # (or worse, as the raw Playwright traceback that used to escape
+            # the command uncaught). Any successful navigation resets the
+            # count: only *consecutive* failures mean the connection is down.
+            consecutive_network_failures = 0
             while elapsed_ms < timeout_ms:
-                probe.goto(GRID_URL, wait_until="commit")
+                try:
+                    probe.goto(GRID_URL, wait_until="commit")
+                except PlaywrightError as exc:
+                    if not _is_network_navigation_error(exc):
+                        raise
+                    consecutive_network_failures += 1
+                    if consecutive_network_failures >= _LOGIN_NETWORK_FAILURE_LIMIT:
+                        raise BrowserNetworkError(
+                            f"Navigation to {GRID_URL} kept failing at the "
+                            f"network level ({exc}) for "
+                            f"{consecutive_network_failures} consecutive "
+                            "attempts. This is a connectivity problem (VPN, "
+                            "proxy or unstable network), not an expired or "
+                            "wrong-account session. Restore the connection "
+                            "and run `direct masters login` again."
+                        ) from exc
+                    probe.wait_for_timeout(_LOGIN_POLL_INTERVAL_MS)
+                    elapsed_ms += _LOGIN_POLL_INTERVAL_MS
+                    continue
+                consecutive_network_failures = 0
                 # Either marker is a valid landing spot here: an unfinished
                 # login redirects the grid URL right back to Passport, so
                 # waiting on the grid's own marker alone would burn the full
@@ -647,7 +769,12 @@ def capture_storage_state(
             from .masters import GRID_URL
 
             page = context.new_page()
-            page.goto(GRID_URL, wait_until="commit")
+            # Same retry-and-classify treatment as the login flow's
+            # navigations (issue #857): a network-layer abort here used to
+            # escape `direct playwright login` as a raw Playwright traceback,
+            # reading like a session problem when the connection was the
+            # culprit.
+            _goto_with_network_retry(page, GRID_URL)
             # Either marker is a valid landing spot: a bad/expired cookie
             # jar redirects the grid URL to Passport instead of rendering
             # the grid, and `assert_authenticated` below is what turns that

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -878,6 +878,70 @@ def _direct_page(html="<body>Кампания остановлена</body>", **
     return FakePage(locators=locators, html=html, **kwargs)
 
 
+def _marker_locators(markers):
+    """Locator map with every given page-marker present.
+
+    The seeding ``_passport_page``/``_direct_page`` do, split out so the
+    network-flaky factory below can reuse it for either page flavour.
+    """
+    return {selector: _FakeLocator([_FakeLocatorHandle()]) for selector in markers}
+
+
+class _NetworkFlakyPage(FakePage):
+    """A ``FakePage`` whose ``goto()`` raises a Chromium navigation error.
+
+    Models issue #857: an unstable VPN/proxy aborts the navigation at the
+    network layer before Playwright ever sees a response. The first
+    ``failures`` ``goto()`` calls raise a ``Page.goto: <message> at <url>``
+    error shaped like Playwright's own (``net::ERR_ABORTED`` in the live
+    report); ``always=True`` makes every call fail. Once the failure budget
+    is spent the page behaves like a normal ``FakePage`` — so a test can
+    model both a transient blip and a properly dead connection.
+
+    Raises the same ``PlaywrightError`` class the production code catches
+    (module-top import — identical to ``session.py``'s own), so the
+    ``except`` clauses match by identity; a differently-sourced exception
+    class would silently not be caught and the test would pass vacuously.
+    """
+
+    def __init__(self, failures, *, always=False, message="net::ERR_ABORTED", **kwargs):
+        super().__init__(**kwargs)
+        self._failures_remaining = failures
+        self._always = always
+        self._message = message
+        self.goto_attempts = 0
+
+    def goto(self, url, wait_until=None):
+        self.goto_attempts += 1
+        if self._always or self._failures_remaining > 0:
+            self._failures_remaining -= 1
+            raise PlaywrightError(
+                f"Page.goto: {self._message} at {url}\n"
+                "Call log:\n"
+                f'  - navigating to "{url}", waiting until "commit"'
+            )
+        super().goto(url, wait_until=wait_until)
+
+
+def _flaky_network_page(
+    failures, *, markers, html, always=False, message="net::ERR_ABORTED", **kwargs
+):
+    """A ``_NetworkFlakyPage`` carrying the given page markers once navigated.
+
+    ``markers`` is ``session_module._PASSPORT_PAGE_MARKERS`` or
+    ``_DIRECT_PAGE_MARKERS`` — the page only needs its marker set for the
+    ticks where ``goto()`` actually succeeds.
+    """
+    return _NetworkFlakyPage(
+        failures,
+        always=always,
+        message=message,
+        locators=_marker_locators(markers),
+        html=html,
+        **kwargs,
+    )
+
+
 class TestMastersRegistered(unittest.TestCase):
     """The group and its subcommands must be wired into the root CLI."""
 
@@ -1495,6 +1559,180 @@ class TestPersistentSession(unittest.TestCase):
         # The unfinished login must never be recorded as a usable profile.
         self.assertFalse(session_module.PROFILE_POINTER_PATH.exists())
 
+    def test_login_rides_out_a_transient_network_abort_of_the_grid_probe(self):
+        """Issue #857: a flaky VPN aborts the grid probe's `goto` with
+        net::ERR_ABORTED before the login screen flow finishes — that says
+        nothing about the login's progress, so the poll loop must tolerate
+        the blip instead of crashing with the raw Playwright traceback the
+        live report showed."""
+        pytest.importorskip("playwright")
+        from direct_cli.browser import session as session_module
+
+        # The probe fails once (network blip), then navigates fine and sees
+        # an authenticated grid.
+        login_page = _passport_page()
+        probe_page = _flaky_network_page(
+            1,
+            markers=session_module._DIRECT_PAGE_MARKERS,
+            html="<body>Кампания остановлена</body>",
+        )
+        persistent_ctx = _FakePersistentContext(pages=[login_page, probe_page])
+        fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
+        fake_playwright = _FakePlaywright(fake_chromium)
+
+        with patch("playwright.sync_api.sync_playwright", return_value=fake_playwright):
+            session_module.login_persistent_session(
+                profile_dir=self.profile_dir, timeout_ms=5_000
+            )
+
+        self.assertEqual(
+            probe_page.goto_attempts, 2, "probe was not retried after the network abort"
+        )
+        self.assertTrue(
+            session_module.PROFILE_POINTER_PATH.exists(),
+            "a login that survived a transient network blip was not recorded",
+        )
+        self.assertTrue(probe_page.closed)
+
+    def test_login_reports_a_dead_connection_as_network_error_not_auth(self):
+        """Issue #857: when the probe never gets through at all, the error
+        must name the network as the cause — the pre-fix raw traceback (and
+        its natural 'your session expired' reading) sent the user re-logging
+        in over a VPN when the session was fine."""
+        pytest.importorskip("playwright")
+        from direct_cli.browser import session as session_module
+
+        login_page = _passport_page()
+        probe_page = _flaky_network_page(
+            0,
+            markers=session_module._DIRECT_PAGE_MARKERS,
+            html="<body>never rendered</body>",
+            always=True,
+        )
+        persistent_ctx = _FakePersistentContext(pages=[login_page, probe_page])
+        fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
+        fake_playwright = _FakePlaywright(fake_chromium)
+
+        with (
+            patch("playwright.sync_api.sync_playwright", return_value=fake_playwright),
+            patch.object(session_module, "_LOGIN_NETWORK_FAILURE_LIMIT", 3),
+        ):
+            with self.assertRaises(session_module.BrowserNetworkError) as ctx:
+                session_module.login_persistent_session(
+                    profile_dir=self.profile_dir, timeout_ms=30_000
+                )
+
+        message = str(ctx.exception)
+        self.assertNotIsInstance(
+            ctx.exception,
+            BrowserAuthError,
+            "a dead connection was reported as an auth failure",
+        )
+        self.assertIn("network level", message)
+        self.assertIn("VPN", message)
+        self.assertIn("not an expired or wrong-account session", message)
+        self.assertTrue(probe_page.closed, "poll probe page was left open")
+        self.assertFalse(
+            session_module.PROFILE_POINTER_PATH.exists(),
+            "an unfinished login must not be recorded as a usable profile",
+        )
+
+    def test_login_retries_a_transient_network_abort_of_the_passport_page(self):
+        """Issue #857, first navigation: the Passport `goto` itself gets the
+        same bounded retry — a blip that clears within the attempt budget
+        must not kill `direct masters login` before any window opens."""
+        pytest.importorskip("playwright")
+        from direct_cli.browser import session as session_module
+
+        # Two aborts, then the login page renders on the third attempt
+        # (_GOTO_NETWORK_ATTEMPTS default).
+        login_page = _flaky_network_page(
+            2,
+            markers=session_module._PASSPORT_PAGE_MARKERS,
+            html="<body>Войдите с Яндекс ID</body>",
+        )
+        probe_page = _direct_page()
+        persistent_ctx = _FakePersistentContext(pages=[login_page, probe_page])
+        fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
+        fake_playwright = _FakePlaywright(fake_chromium)
+
+        with patch("playwright.sync_api.sync_playwright", return_value=fake_playwright):
+            session_module.login_persistent_session(
+                profile_dir=self.profile_dir, timeout_ms=5_000
+            )
+
+        self.assertEqual(
+            login_page.goto_attempts,
+            session_module._GOTO_NETWORK_ATTEMPTS,
+            "passport navigation was not retried up to the attempt budget",
+        )
+        self.assertTrue(session_module.PROFILE_POINTER_PATH.exists())
+
+    def test_login_raises_network_error_when_passport_is_unreachable(self):
+        """Issue #857, first navigation: a connection that stays dead past
+        the retry budget fails with the explicit network-level message, not
+        the marker-timeout/auth story — and not the raw Playwright error."""
+        pytest.importorskip("playwright")
+        from direct_cli.browser import session as session_module
+
+        login_page = _flaky_network_page(
+            0,
+            markers=session_module._PASSPORT_PAGE_MARKERS,
+            html="<body>never rendered</body>",
+            always=True,
+        )
+        persistent_ctx = _FakePersistentContext(pages=[login_page])
+        fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
+        fake_playwright = _FakePlaywright(fake_chromium)
+
+        with patch("playwright.sync_api.sync_playwright", return_value=fake_playwright):
+            with self.assertRaises(session_module.BrowserNetworkError) as ctx:
+                session_module.login_persistent_session(
+                    profile_dir=self.profile_dir, timeout_ms=5_000
+                )
+
+        message = str(ctx.exception)
+        self.assertIn("network level", message)
+        self.assertIn("not an expired or wrong-account session", message)
+        self.assertEqual(
+            login_page.goto_attempts,
+            session_module._GOTO_NETWORK_ATTEMPTS,
+            "more attempts were made than the retry budget allows",
+        )
+        self.assertFalse(session_module.PROFILE_POINTER_PATH.exists())
+
+    def test_login_does_not_reclassify_non_network_goto_errors(self):
+        """Only the network layer is ours to retry (issue #857 scope): a
+        Playwright failure without a net::ERR_* code — here, the page being
+        closed mid-navigation — must propagate untouched, not be swallowed
+        into a misleading 'connectivity' message."""
+        pytest.importorskip("playwright")
+        from direct_cli.browser import session as session_module
+
+        login_page = _flaky_network_page(
+            0,
+            markers=session_module._PASSPORT_PAGE_MARKERS,
+            html="<body>never rendered</body>",
+            always=True,
+            message="Target page, context or browser has been closed",
+        )
+        persistent_ctx = _FakePersistentContext(pages=[login_page])
+        fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
+        fake_playwright = _FakePlaywright(fake_chromium)
+
+        with patch("playwright.sync_api.sync_playwright", return_value=fake_playwright):
+            with self.assertRaises(PlaywrightError) as ctx:
+                session_module.login_persistent_session(
+                    profile_dir=self.profile_dir, timeout_ms=5_000
+                )
+
+        self.assertNotIsInstance(
+            ctx.exception,
+            session_module.BrowserSessionError,
+            "a non-network Playwright failure was reclassified as a session problem",
+        )
+        self.assertEqual(login_page.goto_attempts, 1, "a non-network error was retried")
+
 
 class _FakeVerifyContext(_FakeContext):
     """A ``_FakeContext`` whose ``new_page()`` returns one pre-built page and
@@ -1551,6 +1789,53 @@ class TestCaptureStorageState(unittest.TestCase):
 
         self.assertEqual(page.goto_wait_until, "commit")
         self.assertEqual(storage_state, {"cookies": []})
+
+    def test_verify_reports_a_dead_connection_as_network_error_not_auth(self):
+        """Issue #857, `direct playwright login`'s verify path: the grid
+        `goto` aborted at the network layer used to escape as a raw
+        Playwright traceback reading like a session problem. Same retry +
+        classification as the login flow applies here."""
+        pytest.importorskip("playwright")
+        from direct_cli.browser import session as session_module
+
+        page = _flaky_network_page(
+            0,
+            markers=session_module._DIRECT_PAGE_MARKERS,
+            html="<body>never rendered</body>",
+            always=True,
+        )
+        fake_browser = _FakeBrowser()
+        fake_context = _FakeVerifyContext(page)
+        fake_browser.new_context = lambda **kwargs: fake_context
+        fake_chromium = _FakeChromium(fake_browser)
+        fake_playwright = _FakePlaywright(fake_chromium)
+
+        with (
+            patch("playwright.sync_api.sync_playwright", return_value=fake_playwright),
+            self._patch_decrypt(),
+            patch.object(
+                session_module,
+                "default_chrome_profile_dir",
+                return_value=Path("/fake/chrome/profile"),
+            ),
+            patch.object(Path, "exists", return_value=True),
+        ):
+            with self.assertRaises(session_module.BrowserNetworkError) as ctx:
+                session_module.capture_storage_state()
+
+        message = str(ctx.exception)
+        self.assertNotIsInstance(
+            ctx.exception,
+            BrowserAuthError,
+            "a dead connection was reported as an auth failure",
+        )
+        self.assertIn("network level", message)
+        self.assertIn("not an expired or wrong-account session", message)
+        self.assertEqual(
+            page.goto_attempts,
+            session_module._GOTO_NETWORK_ATTEMPTS,
+            "verify navigation was not retried up to the attempt budget",
+        )
 
     def test_verify_raises_auth_error_when_grid_redirects_to_passport(self):
         """A bad/expired cookie jar redirects the grid URL to Passport

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -904,18 +904,30 @@ class _NetworkFlakyPage(FakePage):
     class would silently not be caught and the test would pass vacuously.
     """
 
-    def __init__(self, failures, *, always=False, message="net::ERR_ABORTED", **kwargs):
+    def __init__(
+        self,
+        failures,
+        *,
+        always=False,
+        message="net::ERR_ABORTED",
+        error_cls=None,
+        **kwargs,
+    ):
         super().__init__(**kwargs)
         self._failures_remaining = failures
         self._always = always
         self._message = message
+        # A goto that times out raises Playwright's own TimeoutError, not a
+        # net::ERR_*-coded Error — tests pass error_cls to model the
+        # slow-connection half of issue #865's review round.
+        self._error_cls = error_cls if error_cls is not None else PlaywrightError
         self.goto_attempts = 0
 
     def goto(self, url, wait_until=None):
         self.goto_attempts += 1
         if self._always or self._failures_remaining > 0:
             self._failures_remaining -= 1
-            raise PlaywrightError(
+            raise self._error_cls(
                 f"Page.goto: {self._message} at {url}\n"
                 "Call log:\n"
                 f'  - navigating to "{url}", waiting until "commit"'
@@ -924,7 +936,14 @@ class _NetworkFlakyPage(FakePage):
 
 
 def _flaky_network_page(
-    failures, *, markers, html, always=False, message="net::ERR_ABORTED", **kwargs
+    failures,
+    *,
+    markers,
+    html,
+    always=False,
+    message="net::ERR_ABORTED",
+    error_cls=None,
+    **kwargs,
 ):
     """A ``_NetworkFlakyPage`` carrying the given page markers once navigated.
 
@@ -936,6 +955,7 @@ def _flaky_network_page(
         failures,
         always=always,
         message=message,
+        error_cls=error_cls,
         locators=_marker_locators(markers),
         html=html,
         **kwargs,
@@ -1732,6 +1752,134 @@ class TestPersistentSession(unittest.TestCase):
             "a non-network Playwright failure was reclassified as a session problem",
         )
         self.assertEqual(login_page.goto_attempts, 1, "a non-network error was retried")
+
+    def test_login_reports_dead_connection_when_budget_is_under_the_failure_limit(self):
+        """#865 review: `masters login --timeout 10` (any budget under the
+        30-tick failure limit) must still diagnose a dead connection as
+        network — every failed tick spends a poll interval of `elapsed_ms`,
+        so the uncapped limit was unreachable and the loop expired into the
+        misleading BrowserAuthError "timed out waiting for login" first."""
+        pytest.importorskip("playwright")
+        from direct_cli.browser import session as session_module
+
+        login_page = _passport_page()
+        probe_page = _flaky_network_page(
+            0,
+            markers=session_module._DIRECT_PAGE_MARKERS,
+            html="<body>never rendered</body>",
+            always=True,
+        )
+        persistent_ctx = _FakePersistentContext(pages=[login_page, probe_page])
+        fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
+        fake_playwright = _FakePlaywright(fake_chromium)
+
+        # 5s budget, limit deliberately NOT patched down: the cap must do
+        # the work — min(30, 5000//1000 - 1) = 4.
+        with patch("playwright.sync_api.sync_playwright", return_value=fake_playwright):
+            with self.assertRaises(session_module.BrowserNetworkError) as ctx:
+                session_module.login_persistent_session(
+                    profile_dir=self.profile_dir, timeout_ms=5_000
+                )
+
+        self.assertNotIsInstance(
+            ctx.exception,
+            BrowserAuthError,
+            "a dead connection was reported as an auth failure",
+        )
+        self.assertEqual(
+            probe_page.goto_attempts,
+            4,
+            "failure limit was not capped by the timeout budget",
+        )
+
+    def test_login_diagnoses_network_on_first_failure_with_a_tiny_timeout(self):
+        """#865 review, floor of the cap: a budget shorter than one poll
+        interval still classifies its only failed tick as network, never
+        lets it expire silently into the auth timeout."""
+        pytest.importorskip("playwright")
+        from direct_cli.browser import session as session_module
+
+        login_page = _passport_page()
+        probe_page = _flaky_network_page(
+            0,
+            markers=session_module._DIRECT_PAGE_MARKERS,
+            html="<body>never rendered</body>",
+            always=True,
+        )
+        persistent_ctx = _FakePersistentContext(pages=[login_page, probe_page])
+        fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
+        fake_playwright = _FakePlaywright(fake_chromium)
+
+        with patch("playwright.sync_api.sync_playwright", return_value=fake_playwright):
+            with self.assertRaises(session_module.BrowserNetworkError):
+                session_module.login_persistent_session(
+                    profile_dir=self.profile_dir, timeout_ms=500
+                )
+
+        self.assertEqual(probe_page.goto_attempts, 1)
+
+    def test_login_treats_a_goto_timeout_as_a_network_failure(self):
+        """#865 review: on a merely *slow* flaky-VPN connection `Page.goto`
+        raises Playwright's own TimeoutError (no net::ERR_* code) — the
+        same connectivity class as ERR_ABORTED, so the poll loop must
+        tolerate and report it as network, not let it escape as a raw
+        traceback."""
+        pytest.importorskip("playwright")
+        from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+        from direct_cli.browser import session as session_module
+
+        login_page = _passport_page()
+        probe_page = _flaky_network_page(
+            0,
+            markers=session_module._DIRECT_PAGE_MARKERS,
+            html="<body>never rendered</body>",
+            always=True,
+            message="Timeout 30000ms exceeded",
+            error_cls=PlaywrightTimeoutError,
+        )
+        persistent_ctx = _FakePersistentContext(pages=[login_page, probe_page])
+        fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
+        fake_playwright = _FakePlaywright(fake_chromium)
+
+        with patch("playwright.sync_api.sync_playwright", return_value=fake_playwright):
+            with self.assertRaises(session_module.BrowserNetworkError) as ctx:
+                session_module.login_persistent_session(
+                    profile_dir=self.profile_dir, timeout_ms=5_000
+                )
+
+        self.assertIn("network level", str(ctx.exception))
+        self.assertEqual(probe_page.goto_attempts, 4)
+
+    def test_login_retries_a_goto_timeout_on_the_passport_navigation(self):
+        """#865 review, first navigation: a slow-connection timeout on the
+        Passport `goto` gets the same bounded retry as an ERR_ABORTED — a
+        blip that clears must not kill the login before any window opens."""
+        pytest.importorskip("playwright")
+        from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+        from direct_cli.browser import session as session_module
+
+        # One timeout, then the login page renders.
+        login_page = _flaky_network_page(
+            1,
+            markers=session_module._PASSPORT_PAGE_MARKERS,
+            html="<body>Войдите с Яндекс ID</body>",
+            message="Timeout 30000ms exceeded",
+            error_cls=PlaywrightTimeoutError,
+        )
+        probe_page = _direct_page()
+        persistent_ctx = _FakePersistentContext(pages=[login_page, probe_page])
+        fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
+        fake_playwright = _FakePlaywright(fake_chromium)
+
+        with patch("playwright.sync_api.sync_playwright", return_value=fake_playwright):
+            session_module.login_persistent_session(
+                profile_dir=self.profile_dir, timeout_ms=5_000
+            )
+
+        self.assertEqual(login_page.goto_attempts, 2, "goto timeout was not retried")
+        self.assertTrue(session_module.PROFILE_POINTER_PATH.exists())
 
 
 class _FakeVerifyContext(_FakeContext):


### PR DESCRIPTION
## Что случилось

`direct masters login` падал сырым необработанным Playwright-трейсбекем, когда `Page.goto` до grid-страницы кампаний обрывался на сетевом уровне (`net::ERR_ABORTED`) — живой репорт #857: нестабильный VPN убивал навигацию ещё до ответа. Предшествующая ошибка «Your Chrome session cookies are expired…» с того же флейки-сети естественно читалась как «протухла сессия», и пользователь гонялся за перелогином, хотя сессия была в порядке.

## Что сделано

- **Классификация.** `_is_network_navigation_error` распознаёт семейство Chromium `net::ERR_*` по единому префиксу (пакет драйвит только `playwright.chromium`) и — по ревью — Playwright `TimeoutError` от `goto` (медленная, а не оборванная сеть: «Page.goto: Timeout 30000ms exceeded», без `net::ERR_`-кода; скоуп ограничен сайтами вызова — классификатор спрашивают только об исключениях из `goto`).
- **Новая `BrowserNetworkError`** (`BrowserSessionError`, намеренно НЕ `BrowserAuthError`) с явным сообщением «connectivity problem (VPN, proxy or unstable network), not an expired or wrong-account session». `masters login` и `playwright login` конвертируют её в чистый `ClickException` уже существующей обработкой.
- **Retry первого goto.** `_goto_with_network_retry`: 3 попытки для навигации на Passport и verify-навигации в `capture_storage_state` (тот же класс краша у `direct playwright login`). Ожидание — `page.wait_for_timeout`, тик-примитив #767.
- **Толерантность poll-цикла.** Зонд логина терпит подряд идущие сетевые обрывы/таймауты — успешная навигация сбрасывает счётчик; блип VPN посреди логина не роняет начатый ввод.
- **Кап лимита бюджетом (ревью).** `network_failure_limit = max(1, min(_LOGIN_NETWORK_FAILURE_LIMIT, timeout_ms // poll_interval - 1))` — при `--timeout` меньше 30 s лимит не был достижим и мёртвая сеть маскировалась под `BrowserAuthError`-таймаут; теперь даже бюджет в один тик диагностирует свой сетевой провал как сеть.
- **Не-сетевые ошибки Playwright** пробрасываются нетронутыми — ретраить можно только сетевой слой.

## Тесты

- `python -m pytest tests/test_masters.py tests/test_playwright_session.py -n0 -q` — 1032 passed.
- `python -m pytest -q` (полный офлайн-сьют) — 3699 passed, 23 skipped.
- `black` / `flake8` — чисто.

Сценарии на `_NetworkFlakyPage` (`net::ERR_ABORTED` и Playwright `TimeoutError`, тот же класс исключений, что ловит продакшн-код): транзиентный обрыв зонда переживается; мёртвая связь → `BrowserNetworkError` (не `BrowserAuthError`); бюджет 5 s стреляет на 4-й попытке (кап), бюджет 500 ms — на первой; retry первого goto (обрыв и таймаут) до успеха и до исчерпания; passthrough не-сетевой ошибки; verify-путь `capture_storage_state`.

## Риски / follow-up

- Лимит 30 подряд обрывов (~30 c при интервале 1 c) — эвристика, переживает короткий блип VPN; при полностью лежащей сети фейлится задолго до 5-минутного окна.
- Смешанная картина (сеть мигает вперемешку с паспорт-редиректами) при маленьком бюджете может всё же истечь по таймауту без сетевого диагноза — компромисс капа, осознанный.
- `masters login` по-прежнему показывает сырой traceback для прочих не-сетевых Playwright-падений — сознательно: это честный сигнал реального бага.

Closes #857

🤖 Generated with [Claude Code](https://claude.com/claude-code)