### PR TITLE
fix(browser): poll masters-login readiness via cookies, not a blinking probe tab (#858)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -330,6 +330,40 @@ Both are handled by polling for a *stable* reading, mirroring
 
 ### Fixed
 
+**`masters login` — no more visible blinking probe tab next to the login
+form (#858).**
+
+`login_persistent_session` (`direct_cli/browser/session.py`) detected a
+completed manual login by keeping a second, visible tab open in the same
+browser window and re-navigating it to the campaigns grid once a second
+(`probe.goto(GRID_URL)` + HTML marker scans in a loop) until the session
+appeared or the timeout hit. Next to the form the user was typing into, that
+tab blinked/reloaded every second with no explanation — the motivation (never
+navigate the page the human is typing into, so a half-filled form or a pending
+2FA prompt is never wiped) was right, but the mechanism was both noisy UX and
+a heavyweight way to ask "is there a session cookie yet".
+
+The wait now polls the shared cookie jar instead: `context.cookies()` is read
+every second for Yandex's SSO session cookies (`Session_id`/`sessionid2` —
+the same jar `_chrome_crypto` copies out of Chrome to authenticate a fresh
+context, so their presence *is* the Direct session). No navigation and no
+second tab happen while the user is still typing. Only when a session-cookie
+signature appears (or changes after a rejected attempt — a stale
+`Session_id` left in a reused profile does not re-trigger the probe every
+second) is a short-lived probe tab opened for a single verification
+navigation, running the same fail-closed checks as before (`commit`
+navigation per #686, marker poll per #692, captcha and login-page content
+scans) on the full marker budget rather than a 1s slice, then closed. The
+page the human is typing into is never navigated, exactly as before.
+
+Verification outcomes are now a tri-state: authenticated (login recorded,
+command exits), login-page-served (conclusive "jar does not add up to a valid
+session" — wait for different cookies), or inconclusive (unrendered page /
+transient network error, retried next tick). A transport failure during the
+one-shot verification — issue #857's `net::ERR_ABORTED` on `probe.goto` — no
+longer crashes the whole login wait: it is treated as inconclusive and
+retried on the next tick.
+
 **`masters` status parsing — read the header status element, not the whole
 page body (#848).**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -358,11 +358,18 @@ page the human is typing into is never navigated, exactly as before.
 
 Verification outcomes are now a tri-state: authenticated (login recorded,
 command exits), login-page-served (conclusive "jar does not add up to a valid
-session" — wait for different cookies), or inconclusive (unrendered page /
-transient network error, retried next tick). A transport failure during the
-one-shot verification — issue #857's `net::ERR_ABORTED` on `probe.goto` — no
-longer crashes the whole login wait: it is treated as inconclusive and
-retried on the next tick.
+session" — wait for different cookies), or inconclusive (unrendered page,
+retried next tick). The one-shot verification's navigation reuses #865's
+`_goto_with_network_retry` unchanged: a transient network-layer abort
+(issue #857's `net::ERR_ABORTED` on a flaky VPN) is retried in place, and a
+connection that stays dead fails as `BrowserNetworkError` — never mistaken
+for an auth problem. A browser/context that dies mid-wait (crash, or the
+user closing the window to abort the login) fails fast with a clean "run
+`direct masters login` again" error instead of a raw PlaywrightError
+traceback — every call such a death can break is CDP-only, so retrying it
+until the timeout could never succeed (review of #858). The session-cookie
+signature also rejects look-alike domains (`notyandex.ru`) that a bare
+`endswith("yandex.ru")` would have accepted.
 
 **`masters` status parsing — read the header status element, not the whole
 page body (#848).**

--- a/direct_cli/browser/session.py
+++ b/direct_cli/browser/session.py
@@ -40,7 +40,7 @@ import contextlib
 import os
 import platform
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Generator, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, Generator, Optional, Sequence, Tuple
 
 from . import _clock
 from .._captcha import find_captcha_marker, find_marker
@@ -88,17 +88,16 @@ _PASSPORT_LOGIN_URL = "https://passport.yandex.ru/auth"
 _LOGIN_WAIT_TIMEOUT_MS = 5 * 60 * 1000
 _LOGIN_POLL_INTERVAL_MS = 1_000
 
-# issue #857: how many *consecutive* network-layer failures of the grid probe
-# the login poll loop tolerates before giving up with a
-# :class:`BrowserNetworkError`. Each failed tick costs one
-# ``_LOGIN_POLL_INTERVAL_MS`` of the login timeout budget (same accounting as
-# a not-yet-authenticated tick), so the default rides out a ~30s VPN blip
-# without killing a login the user may be mid-way through, while still
-# failing well inside the 5-minute window when the connection is properly
-# down. A single successful navigation resets the count. Capped by the
-# caller's ``timeout_ms`` budget inside the poll loop — see
-# ``network_failure_limit`` there.
-_LOGIN_NETWORK_FAILURE_LIMIT = 30
+# Yandex Passport's authenticated-session cookies — the SSO pair shared by
+# every *.yandex.ru host. Their presence in the context's cookie jar is what
+# ``login_persistent_session`` polls for as the "the human finished signing
+# in" signal (issue #858): the same jar is what ``_chrome_crypto`` copies out
+# of Chrome to authenticate a fresh context, so these cookies *are* the
+# Direct session. Deliberately excludes the pre-authentication cookies
+# Passport sets on the very first page load (``yandexuid``, ``gdpr``, csrf
+# tokens) — those appear long before the user has typed anything, so keying
+# the verification probe on them would fire it under the user's fingers.
+_AUTH_SESSION_COOKIE_NAMES = frozenset({"Session_id", "sessionid2"})
 
 
 class BrowserSessionError(RuntimeError):
@@ -282,11 +281,12 @@ def _wait_for_marker(
     whichever network event Playwright happens to fire first.
 
     Accepts multiple selectors (matched as "any of") rather than one,
-    because a single ``goto`` can legitimately land on either page: the
-    ``login_persistent_session`` polling loop re-navigates to the grid every
-    tick, but an unfinished login redirects that same URL back to Passport —
-    waiting on the grid's marker alone would burn ``timeout_ms`` every tick
-    until the user finishes logging in.
+    because a single ``goto`` can legitimately land on either page: an
+    unfinished (or stale) login redirects the grid URL right back to
+    Passport — ``login_persistent_session``'s one-shot verification probe and
+    ``capture_storage_state``'s verify path can both be sent to the grid in
+    that state, and waiting on the grid's marker alone would burn
+    ``timeout_ms`` on every such attempt until the user finishes logging in.
 
     Returns ``True`` once a marker is found, ``False`` on timeout — mirrors
     ``direct_cli/browser/masters.py``'s ``_poll_until`` so a timeout is a
@@ -319,8 +319,12 @@ _NETWORK_NAVIGATION_MARKER = "net::ERR_"
 # out a flaky-VPN blip on a navigation the flow cannot continue without (the
 # Passport login page, ``playwright login``'s verification probe), while still
 # failing fast with a clear network-level message when the connection is
-# genuinely down. The login poll loop has its own, longer tolerance
-# (:data:`_LOGIN_NETWORK_FAILURE_LIMIT`) because the user may be mid-login.
+# genuinely down. The login verification probe
+# (:func:`_grid_shows_authenticated_session`) uses the same budget: while the
+# user is still typing, the cookie poll navigates nothing at all (issue
+# #858), so a network failure can only strike once there is a session to
+# verify — and a rerun after restoring the connection re-verifies the
+# still-saved session instantly.
 _GOTO_NETWORK_ATTEMPTS = 3
 _GOTO_NETWORK_RETRY_INTERVAL_MS = 1_000
 
@@ -377,6 +381,91 @@ def _goto_with_network_retry(page: "Page", url: str) -> None:
                     "session. Restore the connection and retry."
                 ) from exc
             page.wait_for_timeout(_GOTO_NETWORK_RETRY_INTERVAL_MS)
+
+
+def _is_yandex_ru_domain(domain: str) -> bool:
+    """True for ``yandex.ru`` itself and any dotted subdomain of it.
+
+    Covers both forms Playwright reports — host-only (``yandex.ru``,
+    ``passport.yandex.ru``) and the dotted cookie-domain (``.yandex.ru``) —
+    without accepting suffix look-alikes: a naive ``endswith("yandex.ru")``
+    would let ``notyandex.ru`` through (review of #858).
+    """
+    return domain == "yandex.ru" or domain.endswith(".yandex.ru")
+
+
+def _session_cookie_signature(
+    cookies: Sequence[Dict[str, Any]],
+) -> Optional[Tuple[Tuple[str, str], ...]]:
+    """Fingerprint the Yandex SSO session cookies in a ``context.cookies()`` jar.
+
+    Returns the sorted ``(name, value)`` pairs of the authenticated-session
+    cookies (:data:`_AUTH_SESSION_COOKIE_NAMES`) on a :func:`_is_yandex_ru_domain`
+    domain, or ``None`` when the jar holds none — i.e. "no session yet" vs.
+    "some session". ``login_persistent_session`` re-runs its grid
+    verification exactly when this signature *changes*, so a rejected
+    session stays rejected until Passport actually issues different cookies
+    (a stale ``Session_id`` sitting in a reused profile does not re-trigger
+    the probe every second), while a state that was merely inconclusive is
+    retried.
+    """
+    pairs = sorted(
+        (cookie["name"], cookie["value"])
+        for cookie in cookies
+        if cookie.get("name") in _AUTH_SESSION_COOKIE_NAMES
+        and _is_yandex_ru_domain(str(cookie.get("domain", "")))
+    )
+    return tuple(pairs) if pairs else None
+
+
+def _grid_shows_authenticated_session(page: "Page") -> Optional[bool]:
+    """One-shot "is the session real?" check: navigate ``page`` to the grid once.
+
+    Extracted from ``login_persistent_session``'s poll loop (issue #858) so
+    the loop can poll the cookie jar for free and only pay for a navigation
+    when there is a session to verify. The checks are exactly the triad the
+    old per-second loop ran — ``wait_until="commit"`` navigation (issue
+    #686), marker poll (fail-closed on unrendered pages, issue #692), then
+    the captcha and auth content scans.
+
+    Returns a tri-state:
+
+    - ``True`` — the grid rendered with an authenticated session;
+    - ``False`` — Yandex served its login page instead: the cookie jar does
+      not add up to a valid session (expired, or issued mid-login before the
+      human actually finished). Only a *changed* jar is worth re-checking;
+    - ``None`` — inconclusive: the page never rendered far enough to trust
+      ``page.content()``. Retried on the next tick, unlike ``False``.
+    """
+    # Deferred import: GRID_URL's canonical source is masters.py (CLAUDE.md
+    # "No URL literals outside the registry"); imported here rather than at
+    # module load to avoid a session.py <-> masters.py import cycle — same
+    # rationale as `capture_storage_state` below.
+    from .masters import GRID_URL
+
+    # Same retry-and-classify treatment as the Passport navigation and
+    # `capture_storage_state`'s verify path (issues #857/#865): a flaky
+    # VPN/proxy aborts `goto` at the network layer — transient aborts are
+    # retried in place, a connection that stays dead fails as
+    # `BrowserNetworkError`, and non-network Playwright errors are re-raised
+    # untouched for the poll loop's guard to classify.
+    _goto_with_network_retry(page, GRID_URL)
+    # Either marker is a valid landing spot: an unfinished login redirects
+    # the grid URL right back to Passport, so waiting on the grid's own
+    # marker alone would burn the full timeout on a login-page landing (see
+    # `_wait_for_marker`'s docstring). On the verification budget (a
+    # dedicated one-shot page, not a once-a-second shared cadence anymore) a
+    # full `_PAGE_MARKER_TIMEOUT_MS` is affordable and lets a slow first
+    # paint of the grid SPA resolve instead of reporting a false "None".
+    if not _wait_for_marker(page, _DIRECT_OR_PASSPORT_PAGE_MARKERS):
+        return None
+    html = page.content()
+    assert_not_captcha(html)
+    try:
+        assert_authenticated(html)
+    except BrowserAuthError:
+        return False
+    return True
 
 
 def default_chrome_profile_dir() -> Optional[Path]:
@@ -594,15 +683,25 @@ def login_persistent_session(
 ) -> None:
     """Open the CLI's own persistent Chromium profile for a one-time manual login.
 
-    Navigates to Yandex Passport's login page and polls (every
-    :data:`_LOGIN_POLL_INTERVAL_MS`) until :func:`assert_authenticated` no
-    longer raises against ``direct.yandex.ru`` — i.e. until the user has
-    finished logging in by hand in the visible window. Raises
-    :class:`BrowserAuthError` if ``timeout_ms`` elapses first. Navigation
-    aborts at the network layer (unstable VPN/proxy, issue #857) are
-    retried, never mistaken for an auth problem: transient ones are
-    tolerated inside the poll budget, persistent ones raise
-    :class:`BrowserNetworkError`.
+    Navigates to Yandex Passport's login page and waits (up to ``timeout_ms``)
+    for the user to finish logging in by hand in the visible window.
+    Readiness is detected from the shared cookie jar: ``context.cookies()`` is
+    polled every :data:`_LOGIN_POLL_INTERVAL_MS` for Yandex's SSO session
+    cookies (:data:`_AUTH_SESSION_COOKIE_NAMES`) — no navigation and no second
+    browser tab while the user is still typing (issue #858: the previous
+    implementation kept a visible probe tab next to the login form and
+    reloaded the Direct grid on it once a second). Only when a session-cookie
+    signature appears (or changes after a rejected attempt) is a short-lived
+    probe tab opened for a single verification navigation
+    (:func:`_grid_shows_authenticated_session`), then closed immediately; the
+    page the human is typing into is never navigated away from under them.
+    Raises :class:`BrowserAuthError` if ``timeout_ms`` elapses first.
+    Navigation failures keep their #865 classification: a network-layer abort
+    (unstable VPN/proxy, issue #857) is retried by
+    :func:`_goto_with_network_retry`, and a connection that stays dead fails
+    as :class:`BrowserNetworkError` — never mistaken for an auth problem —
+    while a browser window that dies mid-wait fails fast with a clean
+    :class:`BrowserSessionError`.
 
     Deliberately defaults ``headless=False``: a headless window cannot be
     logged into by a human, so ``direct masters login`` always shows the
@@ -611,12 +710,6 @@ def login_persistent_session(
     """
     sync_playwright = _import_sync_playwright()
     resolved_dir = _resolve_persistent_profile_dir(profile_dir)
-
-    # Deferred import: direct_cli/browser/masters.py's GRID_URL is the single
-    # canonical source for this URL (CLAUDE.md "No URL literals outside the
-    # registry"); imported here rather than at module load to avoid a
-    # session.py <-> masters.py import cycle (masters.py imports session.py).
-    from .masters import GRID_URL
 
     with _launch_persistent_context(
         sync_playwright, resolved_dir, headless=headless
@@ -635,100 +728,76 @@ def login_persistent_session(
                 f"Retry `direct masters login`. {_stale_marker_hint()}"
             )
 
-        # Poll on a second page, never on `page`: the human is typing into
-        # that one, and navigating it to the grid once a second would wipe a
-        # half-filled login form or a pending 2FA prompt out from under them.
-        # Both pages share the persistent context's cookie jar, so a login
-        # completed on `page` is immediately visible to `probe`.
-        probe = context.new_page()
+        # Poll the cookie jar, not a page (issue #858). `context.cookies()`
+        # reads the persistent context's jar directly — zero rendering, zero
+        # navigation, invisible to the user — and both pages share that jar,
+        # so a login completed on `page` is visible here immediately. The
+        # human keeps typing into `page` undisturbed for the whole wait: the
+        # verification probe below is a separate tab that exists only for
+        # the duration of one check. That also scopes #857's network
+        # failures to the verification navigation alone — while the user is
+        # still typing, nothing navigates, so a flaky VPN cannot strike.
+        #
+        # A dead context mid-wait is deliberately fatal, not retried: every
+        # PlaywrightError that can escape the verification guard below
+        # (`context.cookies()`, `context.new_page()`, `probe.close()`,
+        # `page.wait_for_timeout()`) comes from a call that talks only to
+        # the local browser over CDP — no Yandex network involved — so an
+        # exception from one of them means the browser process itself is
+        # gone (crashed, or the user closed the window to abort the login).
+        # Retrying that until `timeout_ms` can never succeed, so it is
+        # converted to a clean :class:`BrowserSessionError` instead of a
+        # raw PlaywrightError traceback. The network layer is the opposite
+        # case and stays retryable — see the guard below.
+        deadline = _clock.now() + timeout_ms / 1000
+        rejected_signature: Optional[Tuple[Tuple[str, str], ...]] = None
         try:
-            elapsed_ms = 0
-            # issue #857: a network-layer abort of the grid probe (flaky
-            # VPN/proxy) says nothing about the login's progress, so it must
-            # not crash the flow the user may be mid-way through. Tolerate
-            # consecutive aborts up to _LOGIN_NETWORK_FAILURE_LIMIT — each
-            # consuming one poll interval of the timeout budget, exactly like
-            # a not-yet-authenticated tick — and only then fail with the
-            # distinct BrowserNetworkError, so a dead connection is not
-            # reported as the misleading "timed out waiting for login" below
-            # (or worse, as the raw Playwright traceback that used to escape
-            # the command uncaught). Any successful navigation resets the
-            # count: only *consecutive* failures mean the connection is down.
-            consecutive_network_failures = 0
-            # Cap the failure limit by the caller's timeout budget: every
-            # failed tick spends one poll interval of ``elapsed_ms``, so a
-            # budget shorter than the limit in ticks — e.g. ``masters login
-            # --timeout 10`` — would expire the loop first and report the
-            # dead connection as the misleading "timed out waiting for
-            # login" below, the exact framing this block exists to remove
-            # (#865 review). The floor of 1 keeps a single network failure
-            # diagnosable as network whatever the budget.
-            network_failure_limit = max(
-                1,
-                min(
-                    _LOGIN_NETWORK_FAILURE_LIMIT,
-                    timeout_ms // _LOGIN_POLL_INTERVAL_MS - 1,
-                ),
-            )
-            while elapsed_ms < timeout_ms:
-                try:
-                    probe.goto(GRID_URL, wait_until="commit")
-                except PlaywrightError as exc:
-                    if not _is_network_navigation_error(exc):
-                        raise
-                    consecutive_network_failures += 1
-                    if consecutive_network_failures >= network_failure_limit:
-                        raise BrowserNetworkError(
-                            f"Navigation to {GRID_URL} kept failing at the "
-                            f"network level ({exc}) for "
-                            f"{consecutive_network_failures} consecutive "
-                            "attempts. This is a connectivity problem (VPN, "
-                            "proxy or unstable network), not an expired or "
-                            "wrong-account session. Restore the connection "
-                            "and run `direct masters login` again."
-                        ) from exc
-                    probe.wait_for_timeout(_LOGIN_POLL_INTERVAL_MS)
-                    elapsed_ms += _LOGIN_POLL_INTERVAL_MS
-                    continue
-                consecutive_network_failures = 0
-                # Either marker is a valid landing spot here: an unfinished
-                # login redirects the grid URL right back to Passport, so
-                # waiting on the grid's own marker alone would burn the full
-                # timeout every tick until the user finishes logging in (see
-                # `_wait_for_marker`'s docstring). Capped at the poll
-                # interval, not `_PAGE_MARKER_TIMEOUT_MS`, so a slow-to-paint
-                # page degrades to "try again next tick" rather than
-                # stalling this loop's own cadence.
-                marker_found = _wait_for_marker(
-                    probe,
-                    _DIRECT_OR_PASSPORT_PAGE_MARKERS,
-                    timeout_ms=_LOGIN_POLL_INTERVAL_MS,
-                )
-                if not marker_found:
-                    # Neither page rendered far enough this tick to trust
-                    # `probe.content()` — a blank/in-progress shell can
-                    # contain neither the login-page nor captcha markers, so
-                    # treat this exactly like "not authenticated yet" rather
-                    # than risking `assert_authenticated` passing an
-                    # unrendered page (issue #692 cycle-review). This is the
-                    # expected outcome on a slow tick, not an error.
-                    elapsed_ms += _LOGIN_POLL_INTERVAL_MS
-                    continue
-                html = probe.content()
-                assert_not_captcha(html)
-                try:
-                    assert_authenticated(html)
-                except BrowserAuthError:
-                    probe.wait_for_timeout(_LOGIN_POLL_INTERVAL_MS)
-                    elapsed_ms += _LOGIN_POLL_INTERVAL_MS
-                    continue
-                # Only once the session is real: read commands resolve the
-                # profile through this pointer, so recording an unfinished
-                # login would point them at an empty profile.
-                remember_persistent_profile_dir(resolved_dir)
-                return
-        finally:
-            probe.close()
+            while _clock.now() < deadline:
+                signature = _session_cookie_signature(context.cookies())
+                if signature is not None and signature != rejected_signature:
+                    probe = context.new_page()
+                    try:
+                        verdict = _grid_shows_authenticated_session(probe)
+                    except PlaywrightError as exc:
+                        if not _is_network_navigation_error(exc):
+                            # Not the network layer: the browser/context
+                            # itself is gone — let the outer guard turn it
+                            # into the clean fatal error.
+                            raise
+                        # Defensive: `_goto_with_network_retry` inside the
+                        # verification already retries transient aborts and
+                        # converts persistent ones to `BrowserNetworkError`,
+                        # so a network-classified PlaywrightError can only
+                        # escape from outside the goto itself. Treat it as
+                        # inconclusive — the same signature is retried on
+                        # the next tick.
+                        verdict = None
+                    finally:
+                        # Teardown: a browser that died at the very end of a
+                        # *successful* verification must not turn that
+                        # success into a fatal error.
+                        with contextlib.suppress(PlaywrightError):
+                            probe.close()
+                    if verdict:
+                        # Only once the session is real: read commands
+                        # resolve the profile through this pointer, so
+                        # recording an unfinished login would point them at
+                        # an empty profile.
+                        remember_persistent_profile_dir(resolved_dir)
+                        return
+                    if verdict is False:
+                        # Conclusive "no valid session": don't re-probe this
+                        # jar every second — wait for Passport to issue
+                        # different cookies. `None` (unrendered/transient)
+                        # stays retryable.
+                        rejected_signature = signature
+                page.wait_for_timeout(_LOGIN_POLL_INTERVAL_MS)
+        except PlaywrightError as exc:
+            raise BrowserSessionError(
+                "The browser window was closed (or crashed) while waiting "
+                "for you to log in — there is nothing left to wait for. Run "
+                "`direct masters login` again."
+            ) from exc
 
         raise BrowserAuthError(
             f"Timed out after {timeout_ms // 1000}s waiting for login to "

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -1180,6 +1180,26 @@ class _FakePersistentContext:
         self.closed = True
 
 
+class _DyingPersistentContext(_FakePersistentContext):
+    """A browser process that dies mid-wait (review of #858).
+
+    CDP-only calls — ``context.cookies()`` here — start raising ``Target
+    closed`` from the second poll on. Unlike a verification ``goto``, no
+    Yandex network is involved: an exception from these calls means the
+    browser itself is gone.
+    """
+
+    def __init__(self, pages=None):
+        super().__init__(pages=pages)
+        self.cookie_polls = 0
+
+    def cookies(self, urls=None):
+        self.cookie_polls += 1
+        if self.cookie_polls > 1:
+            raise PlaywrightError("Target closed")
+        return []
+
+
 class _FakeChromium:
     def __init__(self, browser, persistent_context=None):
         self._browser = browser
@@ -1672,6 +1692,24 @@ class TestPersistentSession(unittest.TestCase):
             ),
             "a foreign-domain Session_id is not a Yandex session",
         )
+        # Review of #858: `endswith("yandex.ru")` alone would accept these
+        # suffix look-alikes; the grid content checks would catch the fake
+        # session anyway, but a look-alike must not even trigger a probe.
+        for lookalike in ("notyandex.ru", "fake-yandex.ru", "yandex.ru.com"):
+            self.assertIsNone(
+                _session_cookie_signature(
+                    [{"name": "Session_id", "value": "x", "domain": lookalike}]
+                ),
+                f"a look-alike domain ({lookalike}) must not read as Yandex",
+            )
+        # Host-only forms are genuine Yandex domains and must pass.
+        for genuine in ("yandex.ru", "passport.yandex.ru"):
+            self.assertIsNotNone(
+                _session_cookie_signature(
+                    [{"name": "Session_id", "value": "x", "domain": genuine}]
+                ),
+                f"a host-only Yandex domain ({genuine}) must read as Yandex",
+            )
         signature = _session_cookie_signature(
             [
                 {"name": "yandexuid", "value": "u", "domain": ".yandex.ru"},
@@ -2060,6 +2098,47 @@ class TestPersistentSession(unittest.TestCase):
 
         self.assertEqual(login_page.goto_attempts, 2, "goto timeout was not retried")
         self.assertTrue(session_module.PROFILE_POINTER_PATH.exists())
+
+    def test_login_wait_fails_cleanly_when_the_browser_dies_mid_wait(self):
+        """Review of #858: `context.cookies()`/`context.new_page()` sit
+        outside the transient-verification guard — a browser that dies
+        mid-wait must surface as a clean `BrowserSessionError` (run login
+        again), not a raw PlaywrightError traceback, and must not burn the
+        rest of the timeout retrying calls that can never succeed again."""
+        pytest.importorskip("playwright")
+        from direct_cli.browser import session as session_module
+        from direct_cli.browser.session import BrowserSessionError
+
+        login_page = _passport_page()
+        persistent_ctx = _DyingPersistentContext(pages=[login_page])
+        fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
+        fake_playwright = _FakePlaywright(fake_chromium)
+
+        with patch("playwright.sync_api.sync_playwright", return_value=fake_playwright):
+            with self.assertRaises(BrowserSessionError) as ctx:
+                session_module.login_persistent_session(
+                    profile_dir=self.profile_dir,
+                    timeout_ms=5_000,
+                )
+
+        # Not the timeout error: a dead browser is its own, immediate
+        # failure — waiting out the remaining budget is pointless.
+        self.assertNotIsInstance(
+            ctx.exception,
+            session_module.BrowserAuthError,
+            "a dead browser must fail fast, not as a login timeout",
+        )
+        self.assertIn("browser window", str(ctx.exception))
+        self.assertIn("direct masters login", str(ctx.exception))
+        self.assertEqual(
+            persistent_ctx.cookie_polls,
+            2,
+            "the wait kept polling a dead context",
+        )
+        self.assertFalse(
+            session_module.PROFILE_POINTER_PATH.exists(),
+            "a crashed login wait must not be recorded as a usable profile",
+        )
 
 
 class _FakeVerifyContext(_FakeContext):

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -962,6 +962,16 @@ def _flaky_network_page(
     )
 
 
+def _session_cookies(value="sid", name="Session_id"):
+    """A cookie jar carrying Yandex's SSO session cookies (issue #858).
+
+    Mirrors the dict shape Playwright's ``context.cookies()`` returns, with
+    the ``name``/``value``/``domain`` keys ``_session_cookie_signature``
+    reads — a fresh persistent profile holds nothing else that matters.
+    """
+    return [{"name": name, "value": value, "domain": ".yandex.ru"}]
+
+
 class TestMastersRegistered(unittest.TestCase):
     """The group and its subcommands must be wired into the root CLI."""
 
@@ -1136,14 +1146,32 @@ class _FakePersistentContext:
     Unlike ``_FakeBrowser``/``_FakeContext`` (a separate browser + context
     pair for ``chromium.launch()``), a persistent context IS the return
     value — there is no separate ``Browser`` object to close.
+
+    ``cookies`` scripts what ``context.cookies()`` reports — the jar
+    ``login_persistent_session`` polls for the Yandex SSO session cookies
+    (issue #858). A list holds for the whole run; for a jar that *changes*
+    mid-login (stale ``Session_id`` replaced by a fresh one) pass a callable
+    returning the current jar per call.
     """
 
-    def __init__(self, pages=None):
+    def __init__(self, pages=None, cookies=None):
         self.closed = False
         self.launch_kwargs = None
         self._pages = list(pages or [])
+        self._cookies = cookies if cookies is not None else []
+        # How many tabs the code under test actually opened — the login tab
+        # plus, with cookie-based polling (#858), one short-lived probe tab
+        # per verification attempt and nothing else.
+        self.pages_created = 0
+
+    def cookies(self, urls=None):
+        jar = self._cookies
+        if callable(jar):
+            jar = jar()
+        return list(jar)
 
     def new_page(self):
+        self.pages_created += 1
         if self._pages:
             return self._pages.pop(0)
         return FakePage()
@@ -1417,11 +1445,14 @@ class TestPersistentSession(unittest.TestCase):
         pytest.importorskip("playwright")
         from direct_cli.browser import session as session_module
 
-        # Page 1 is the visible Passport tab; page 2 is the poll probe whose
-        # HTML decides whether login has completed.
+        # Page 1 is the visible Passport tab; page 2 is the one-shot
+        # verification probe, opened only because the cookie jar already
+        # carries a session cookie.
         login_page = _passport_page()
         authed_page = _direct_page()
-        persistent_ctx = _FakePersistentContext(pages=[login_page, authed_page])
+        persistent_ctx = _FakePersistentContext(
+            pages=[login_page, authed_page], cookies=_session_cookies()
+        )
         fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
         fake_playwright = _FakePlaywright(fake_chromium)
 
@@ -1432,12 +1463,22 @@ class TestPersistentSession(unittest.TestCase):
 
         self.assertTrue(persistent_ctx.closed)
         self.assertTrue(self.profile_dir.exists())
+        self.assertTrue(
+            session_module.PROFILE_POINTER_PATH.exists(),
+            "a verified login was never recorded for later `masters` calls",
+        )
+        self.assertEqual(
+            persistent_ctx.pages_created,
+            2,
+            "expected exactly the login tab and one verification probe",
+        )
 
     def test_login_persistent_session_times_out_if_never_authenticated(self):
         pytest.importorskip("playwright")
         from direct_cli.browser import session as session_module
         from direct_cli.browser.session import BrowserAuthError
 
+        # No session cookies in the jar: the user never finishes logging in.
         login_page = _passport_page()
         probe_page = _passport_page()
         persistent_ctx = _FakePersistentContext(pages=[login_page, probe_page])
@@ -1451,16 +1492,28 @@ class TestPersistentSession(unittest.TestCase):
                     timeout_ms=1_000,
                 )
         self.assertIn("Timed out", str(ctx.exception))
-        self.assertTrue(probe_page.closed, "poll probe page was left open")
+        # Issue #858: with no session cookie to verify, no probe tab may be
+        # opened at all — the wait must be invisible, not a blinking tab.
+        self.assertEqual(
+            persistent_ctx.pages_created,
+            1,
+            "opened a probe tab even though there was no session to verify",
+        )
+        self.assertEqual(
+            probe_page.navigated_to,
+            [],
+            "a page the login flow never requested was navigated",
+        )
 
     def test_login_polling_does_not_navigate_the_page_the_user_is_typing_into(self):
         """The visible login page must stay on Passport until login succeeds.
 
-        The poll loop checks authentication by driving the *same* page the
-        human is typing into. Every interval it navigates that page away to
-        the grid, wiping a half-filled login form and any 2FA prompt on it —
-        the user cannot finish signing in against a page that resets under
-        their hands once a second.
+        Even with a session cookie present (so the verification probe is
+        actively running — here it sees Yandex serve the login page, i.e. a
+        jar that does not add up to a valid session), the only page the
+        login flow may navigate is its own short-lived probe tab. Navigating
+        the page the human is typing into would wipe a half-filled login
+        form or a pending 2FA prompt out from under them.
         """
         pytest.importorskip("playwright")
         from direct_cli.browser import session as session_module
@@ -1468,7 +1521,9 @@ class TestPersistentSession(unittest.TestCase):
 
         login_page = _passport_page()
         probe_page = _passport_page()
-        persistent_ctx = _FakePersistentContext(pages=[login_page, probe_page])
+        persistent_ctx = _FakePersistentContext(
+            pages=[login_page, probe_page], cookies=_session_cookies()
+        )
         fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
         fake_playwright = _FakePlaywright(fake_chromium)
 
@@ -1476,23 +1531,29 @@ class TestPersistentSession(unittest.TestCase):
             with self.assertRaises(BrowserAuthError):
                 session_module.login_persistent_session(
                     profile_dir=self.profile_dir,
-                    timeout_ms=3_000,
+                    timeout_ms=1_000,
                 )
 
         # The page the user interacts with is navigated exactly once: to
-        # Passport. Polling must not steer it anywhere else.
+        # Passport. Verification must steer only its own probe tab.
         self.assertEqual(
             login_page.navigated_to,
             [session_module._PASSPORT_LOGIN_URL],
-            "poll loop navigated the user's login page away from Passport",
+            "verification navigated the user's login page away from Passport",
         )
+        self.assertEqual(
+            probe_page.navigated_to,
+            [browser_masters.GRID_URL],
+            "expected exactly one verification navigation on the probe tab",
+        )
+        self.assertTrue(probe_page.closed, "verification probe was left open")
 
     def test_login_navigations_use_commit_not_domcontentloaded(self):
         """Issue #686: both `goto` calls in the login flow (the visible
-        Passport tab and the poll probe) must use `wait_until="commit"`, not
-        `domcontentloaded` — Passport occasionally timed out on
-        `domcontentloaded` during its own slow initial paint. `commit`
-        returns as soon as the navigation is committed, and
+        Passport tab and the verification probe) must use
+        `wait_until="commit"`, not `domcontentloaded` — Passport occasionally
+        timed out on `domcontentloaded` during its own slow initial paint.
+        `commit` returns as soon as the navigation is committed, and
         `_wait_for_marker` polling for a concrete DOM marker afterwards is
         what actually confirms the page rendered (see `_wait_for_marker`'s
         docstring)."""
@@ -1501,7 +1562,9 @@ class TestPersistentSession(unittest.TestCase):
 
         login_page = _passport_page()
         authed_page = _direct_page()
-        persistent_ctx = _FakePersistentContext(pages=[login_page, authed_page])
+        persistent_ctx = _FakePersistentContext(
+            pages=[login_page, authed_page], cookies=_session_cookies()
+        )
         fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
         fake_playwright = _FakePlaywright(fake_chromium)
 
@@ -1553,19 +1616,21 @@ class TestPersistentSession(unittest.TestCase):
         )
 
     def test_login_poll_treats_unrendered_tick_as_not_yet_authenticated(self):
-        """Issue #692 cycle-review: a tick where neither the grid nor
-        Passport marker appears must be treated like "not authenticated
-        yet" (same as an explicit `BrowserAuthError`), not like a
-        successful, verified login — a blank grid response matches neither
-        `_LOGIN_PAGE_MARKERS` nor a captcha marker, so `assert_authenticated`
-        alone would silently accept it."""
+        """Issue #692 cycle-review: a verification attempt where neither the
+        grid nor Passport marker appears must be treated like "not
+        authenticated yet" (same as an explicit `BrowserAuthError`), not
+        like a successful, verified login — a blank grid response matches
+        neither `_LOGIN_PAGE_MARKERS` nor a captcha marker, so
+        `assert_authenticated` alone would silently accept it."""
         pytest.importorskip("playwright")
         from direct_cli.browser import session as session_module
         from direct_cli.browser.session import BrowserAuthError
 
         login_page = _passport_page()
         blank_probe = FakePage(locators={}, html="<html></html>")
-        persistent_ctx = _FakePersistentContext(pages=[login_page, blank_probe])
+        persistent_ctx = _FakePersistentContext(
+            pages=[login_page, blank_probe], cookies=_session_cookies()
+        )
         fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
         fake_playwright = _FakePlaywright(fake_chromium)
 
@@ -1578,25 +1643,115 @@ class TestPersistentSession(unittest.TestCase):
 
         # The unfinished login must never be recorded as a usable profile.
         self.assertFalse(session_module.PROFILE_POINTER_PATH.exists())
+        self.assertTrue(
+            blank_probe.closed,
+            "an inconclusive verification probe was left open",
+        )
+
+    def test_session_cookie_signature_ignores_pre_auth_and_foreign_cookies(self):
+        """Issue #858: only the Yandex SSO session cookies on a yandex.ru
+        domain are a login signal — the cookies Passport sets on the very
+        first page load (yandexuid, csrf) appear before the user has typed
+        anything, and a same-named cookie on an unrelated domain is not a
+        Yandex session at all."""
+        from direct_cli.browser.session import _session_cookie_signature
+
+        self.assertIsNone(_session_cookie_signature([]))
+        self.assertIsNone(
+            _session_cookie_signature(
+                [
+                    {"name": "yandexuid", "value": "u", "domain": ".yandex.ru"},
+                    {"name": "csrf", "value": "c", "domain": ".yandex.ru"},
+                ]
+            ),
+            "pre-authentication cookies must not read as a session",
+        )
+        self.assertIsNone(
+            _session_cookie_signature(
+                [{"name": "Session_id", "value": "x", "domain": "example.com"}]
+            ),
+            "a foreign-domain Session_id is not a Yandex session",
+        )
+        signature = _session_cookie_signature(
+            [
+                {"name": "yandexuid", "value": "u", "domain": ".yandex.ru"},
+                {"name": "Session_id", "value": "sid", "domain": ".yandex.ru"},
+                {"name": "sessionid2", "value": "sid2", "domain": ".yandex.ru"},
+            ]
+        )
+        self.assertEqual(
+            signature,
+            (("Session_id", "sid"), ("sessionid2", "sid2")),
+        )
+        # A different value means a different session — that is what
+        # triggers re-verification after a rejected first attempt.
+        self.assertNotEqual(
+            signature, _session_cookie_signature(_session_cookies("other"))
+        )
+
+    def test_login_reverifies_when_the_session_cookie_changes(self):
+        """A rejected jar must not be re-probed every second, but a *changed*
+        jar must: a stale Session_id left in a reused profile fails
+        verification once, then the user's fresh login issues different
+        cookies and that signature gets its own verification."""
+        pytest.importorskip("playwright")
+        import itertools
+
+        from direct_cli.browser import session as session_module
+
+        jar_calls = itertools.count()
+
+        def jar():
+            return _session_cookies(
+                "fresh-sid" if next(jar_calls) >= 2 else "stale-sid"
+            )
+
+        login_page = _passport_page()
+        stale_probe = _passport_page()  # grid redirects to the login page
+        fresh_probe = _direct_page()  # the real session renders the grid
+        persistent_ctx = _FakePersistentContext(
+            pages=[login_page, stale_probe, fresh_probe], cookies=jar
+        )
+        fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
+        fake_playwright = _FakePlaywright(fake_chromium)
+
+        with patch("playwright.sync_api.sync_playwright", return_value=fake_playwright):
+            session_module.login_persistent_session(
+                profile_dir=self.profile_dir, timeout_ms=5_000
+            )
+
+        self.assertTrue(session_module.PROFILE_POINTER_PATH.exists())
+        self.assertEqual(
+            persistent_ctx.pages_created,
+            3,
+            "expected one probe for the stale jar and one for the fresh one "
+            "in addition to the login tab — the unchanged middle tick must "
+            "not open any",
+        )
+        self.assertTrue(stale_probe.closed)
+        self.assertTrue(fresh_probe.closed)
 
     def test_login_rides_out_a_transient_network_abort_of_the_grid_probe(self):
-        """Issue #857: a flaky VPN aborts the grid probe's `goto` with
-        net::ERR_ABORTED before the login screen flow finishes — that says
-        nothing about the login's progress, so the poll loop must tolerate
-        the blip instead of crashing with the raw Playwright traceback the
-        live report showed."""
+        """Issue #857: a flaky VPN aborts the verification probe's `goto`
+        with net::ERR_ABORTED right as the session cookie appears — that
+        says nothing about the login's progress, so `_goto_with_network_retry`
+        must ride the blip out inside the one-shot verification instead of
+        crashing with the raw Playwright traceback the live report showed."""
         pytest.importorskip("playwright")
         from direct_cli.browser import session as session_module
 
         # The probe fails once (network blip), then navigates fine and sees
-        # an authenticated grid.
+        # an authenticated grid. The cookie jar already carries the session:
+        # verification fires on the first poll tick.
         login_page = _passport_page()
         probe_page = _flaky_network_page(
             1,
             markers=session_module._DIRECT_PAGE_MARKERS,
             html="<body>Кампания остановлена</body>",
         )
-        persistent_ctx = _FakePersistentContext(pages=[login_page, probe_page])
+        persistent_ctx = _FakePersistentContext(
+            pages=[login_page, probe_page], cookies=_session_cookies()
+        )
         fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
         fake_playwright = _FakePlaywright(fake_chromium)
 
@@ -1615,10 +1770,10 @@ class TestPersistentSession(unittest.TestCase):
         self.assertTrue(probe_page.closed)
 
     def test_login_reports_a_dead_connection_as_network_error_not_auth(self):
-        """Issue #857: when the probe never gets through at all, the error
-        must name the network as the cause — the pre-fix raw traceback (and
-        its natural 'your session expired' reading) sent the user re-logging
-        in over a VPN when the session was fine."""
+        """Issue #857: when the verification navigation never gets through at
+        all, the error must name the network as the cause — the pre-fix raw
+        traceback (and its natural 'your session expired' reading) sent the
+        user re-logging in over a VPN when the session was fine."""
         pytest.importorskip("playwright")
         from direct_cli.browser import session as session_module
 
@@ -1629,14 +1784,13 @@ class TestPersistentSession(unittest.TestCase):
             html="<body>never rendered</body>",
             always=True,
         )
-        persistent_ctx = _FakePersistentContext(pages=[login_page, probe_page])
+        persistent_ctx = _FakePersistentContext(
+            pages=[login_page, probe_page], cookies=_session_cookies()
+        )
         fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
         fake_playwright = _FakePlaywright(fake_chromium)
 
-        with (
-            patch("playwright.sync_api.sync_playwright", return_value=fake_playwright),
-            patch.object(session_module, "_LOGIN_NETWORK_FAILURE_LIMIT", 3),
-        ):
+        with patch("playwright.sync_api.sync_playwright", return_value=fake_playwright):
             with self.assertRaises(session_module.BrowserNetworkError) as ctx:
                 session_module.login_persistent_session(
                     profile_dir=self.profile_dir, timeout_ms=30_000
@@ -1651,7 +1805,12 @@ class TestPersistentSession(unittest.TestCase):
         self.assertIn("network level", message)
         self.assertIn("VPN", message)
         self.assertIn("not an expired or wrong-account session", message)
-        self.assertTrue(probe_page.closed, "poll probe page was left open")
+        self.assertEqual(
+            probe_page.goto_attempts,
+            session_module._GOTO_NETWORK_ATTEMPTS,
+            "more attempts were made than the retry budget allows",
+        )
+        self.assertTrue(probe_page.closed, "verification probe was left open")
         self.assertFalse(
             session_module.PROFILE_POINTER_PATH.exists(),
             "an unfinished login must not be recorded as a usable profile",
@@ -1665,14 +1824,17 @@ class TestPersistentSession(unittest.TestCase):
         from direct_cli.browser import session as session_module
 
         # Two aborts, then the login page renders on the third attempt
-        # (_GOTO_NETWORK_ATTEMPTS default).
+        # (_GOTO_NETWORK_ATTEMPTS default). The jar carries the session so
+        # the first poll tick verifies it against the grid.
         login_page = _flaky_network_page(
             2,
             markers=session_module._PASSPORT_PAGE_MARKERS,
             html="<body>Войдите с Яндекс ID</body>",
         )
         probe_page = _direct_page()
-        persistent_ctx = _FakePersistentContext(pages=[login_page, probe_page])
+        persistent_ctx = _FakePersistentContext(
+            pages=[login_page, probe_page], cookies=_session_cookies()
+        )
         fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
         fake_playwright = _FakePlaywright(fake_chromium)
 
@@ -1754,11 +1916,13 @@ class TestPersistentSession(unittest.TestCase):
         self.assertEqual(login_page.goto_attempts, 1, "a non-network error was retried")
 
     def test_login_reports_dead_connection_when_budget_is_under_the_failure_limit(self):
-        """#865 review: `masters login --timeout 10` (any budget under the
-        30-tick failure limit) must still diagnose a dead connection as
-        network — every failed tick spends a poll interval of `elapsed_ms`,
-        so the uncapped limit was unreachable and the loop expired into the
-        misleading BrowserAuthError "timed out waiting for login" first."""
+        """#865 review, ported to the cookie-poll design (#858): a short
+        `--timeout` must still diagnose a dead connection as network, never
+        expire into the misleading BrowserAuthError "timed out waiting for
+        login". The old per-tick failure cap is gone with the per-second
+        probe — the classification now happens inside
+        `_goto_with_network_retry`, which runs its own attempt budget
+        without consulting the outer login deadline."""
         pytest.importorskip("playwright")
         from direct_cli.browser import session as session_module
 
@@ -1769,12 +1933,14 @@ class TestPersistentSession(unittest.TestCase):
             html="<body>never rendered</body>",
             always=True,
         )
-        persistent_ctx = _FakePersistentContext(pages=[login_page, probe_page])
+        persistent_ctx = _FakePersistentContext(
+            pages=[login_page, probe_page], cookies=_session_cookies()
+        )
         fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
         fake_playwright = _FakePlaywright(fake_chromium)
 
-        # 5s budget, limit deliberately NOT patched down: the cap must do
-        # the work — min(30, 5000//1000 - 1) = 4.
+        # 5s budget: the verification fires on the first tick and exhausts
+        # the helper's attempt budget well inside it.
         with patch("playwright.sync_api.sync_playwright", return_value=fake_playwright):
             with self.assertRaises(session_module.BrowserNetworkError) as ctx:
                 session_module.login_persistent_session(
@@ -1788,14 +1954,17 @@ class TestPersistentSession(unittest.TestCase):
         )
         self.assertEqual(
             probe_page.goto_attempts,
-            4,
-            "failure limit was not capped by the timeout budget",
+            session_module._GOTO_NETWORK_ATTEMPTS,
+            "the helper's attempt budget was not respected",
         )
 
     def test_login_diagnoses_network_on_first_failure_with_a_tiny_timeout(self):
-        """#865 review, floor of the cap: a budget shorter than one poll
-        interval still classifies its only failed tick as network, never
-        lets it expire silently into the auth timeout."""
+        """#865 review, floor case ported to the cookie-poll design (#858):
+        a budget shorter than one poll interval still classifies its failed
+        verification as network. The helper's retry budget is not capped by
+        the outer deadline — a tiny `--timeout` burns the same three
+        navigation attempts, then fails as network rather than letting the
+        auth timeout swallow the diagnosis."""
         pytest.importorskip("playwright")
         from direct_cli.browser import session as session_module
 
@@ -1806,7 +1975,9 @@ class TestPersistentSession(unittest.TestCase):
             html="<body>never rendered</body>",
             always=True,
         )
-        persistent_ctx = _FakePersistentContext(pages=[login_page, probe_page])
+        persistent_ctx = _FakePersistentContext(
+            pages=[login_page, probe_page], cookies=_session_cookies()
+        )
         fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
         fake_playwright = _FakePlaywright(fake_chromium)
 
@@ -1816,14 +1987,16 @@ class TestPersistentSession(unittest.TestCase):
                     profile_dir=self.profile_dir, timeout_ms=500
                 )
 
-        self.assertEqual(probe_page.goto_attempts, 1)
+        self.assertEqual(
+            probe_page.goto_attempts, session_module._GOTO_NETWORK_ATTEMPTS
+        )
 
     def test_login_treats_a_goto_timeout_as_a_network_failure(self):
         """#865 review: on a merely *slow* flaky-VPN connection `Page.goto`
         raises Playwright's own TimeoutError (no net::ERR_* code) — the
-        same connectivity class as ERR_ABORTED, so the poll loop must
-        tolerate and report it as network, not let it escape as a raw
-        traceback."""
+        same connectivity class as ERR_ABORTED, so the verification's retry
+        budget must exhaust and report it as network, not let it escape as
+        a raw traceback."""
         pytest.importorskip("playwright")
         from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
@@ -1838,7 +2011,9 @@ class TestPersistentSession(unittest.TestCase):
             message="Timeout 30000ms exceeded",
             error_cls=PlaywrightTimeoutError,
         )
-        persistent_ctx = _FakePersistentContext(pages=[login_page, probe_page])
+        persistent_ctx = _FakePersistentContext(
+            pages=[login_page, probe_page], cookies=_session_cookies()
+        )
         fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
         fake_playwright = _FakePlaywright(fake_chromium)
 
@@ -1849,7 +2024,9 @@ class TestPersistentSession(unittest.TestCase):
                 )
 
         self.assertIn("network level", str(ctx.exception))
-        self.assertEqual(probe_page.goto_attempts, 4)
+        self.assertEqual(
+            probe_page.goto_attempts, session_module._GOTO_NETWORK_ATTEMPTS
+        )
 
     def test_login_retries_a_goto_timeout_on_the_passport_navigation(self):
         """#865 review, first navigation: a slow-connection timeout on the
@@ -1860,7 +2037,8 @@ class TestPersistentSession(unittest.TestCase):
 
         from direct_cli.browser import session as session_module
 
-        # One timeout, then the login page renders.
+        # One timeout, then the login page renders. The jar carries the
+        # session so the first poll tick verifies it against the grid.
         login_page = _flaky_network_page(
             1,
             markers=session_module._PASSPORT_PAGE_MARKERS,
@@ -1869,7 +2047,9 @@ class TestPersistentSession(unittest.TestCase):
             error_cls=PlaywrightTimeoutError,
         )
         probe_page = _direct_page()
-        persistent_ctx = _FakePersistentContext(pages=[login_page, probe_page])
+        persistent_ctx = _FakePersistentContext(
+            pages=[login_page, probe_page], cookies=_session_cookies()
+        )
         fake_chromium = _FakeChromium(_FakeBrowser(), persistent_ctx)
         fake_playwright = _FakePlaywright(fake_chromium)
 


### PR DESCRIPTION
Closes #858

## What

`direct masters login` больше не держит видимую вторую вкладку рядом с формой логина и не перезагружает на ней грид раз в секунду. Ожидание входа теперь опрашивает общий cookie-jar контекста (`context.cookies()`) на SSO-пару Яндекса (`Session_id`/`sessionid2`) — без навигации и без второй вкладки, пока пользователь печатает.

Когда сигнатура сессионных кук появляется (или меняется после отвергнутой попытки — лежащий в профиле устаревший `Session_id` не перезапускает probe каждую секунду), открывается короткоживущая probe-вкладка ровно для одной верификационной навигации с теми же fail-closed проверками, что и раньше (`commit`-навигация (#686), опрос маркеров (#692), captcha/login-page сканы контента), и сразу закрывается. Страница, в которую печатает человек, не навигируется — как и прежде.

## Details

- `_session_cookie_signature()` — фингерпринт SSO-кук: `None` = сессии нет; изменение значения = новая сессия → реверификация. Куки, которые Паспорт выставляет до аутентификации (`yandexuid`, csrf), сигналом не считаются.
- `_grid_shows_authenticated_session()` — одношаговая верификация, вынесенная из старого цикла; tri-state: `True` (вход подтверждён) / `False` (Яндекс отдал логин-страницу — ждать других кук) / `None` (страница не отрендерилась / transient — повтор на следующем тике). Маркерный бюджет верификации — полный `_PAGE_MARKER_TIMEOUT_MS` вместо среза в 1 c: верификация теперь редкое событие на выделенной вкладке, и медленная первая отрисовка грида не даёт ложного «неубедительно» каждые несколько секунд.
- Сетевые сбои навигации (сценарий #857) после ребейза используют механику #865, приземлившегося на main параллельно: верификационная навигация идёт через `_goto_with_network_retry` — transient-аборты ретраятся на месте, стабильно мёртвое соединение фейлится как `BrowserNetworkError` («connectivity, не сессия»). Loop-level лимит `_LOGIN_NETWORK_FAILURE_LIMIT` из #865 удалён: его raison d'être — ежесекундная навигация probe — исчез вместе с probe-вкладкой; пока пользователь печатает, навигаций нет вовсе, так что сеть может подвести только момент верификации, а повторный запуск после восстановления связи верифицирует сохранённую сессию мгновенно.

## Tests

- `TestPersistentSession`: обновлены 5 тестов под новую механику, добавлены 3: фильтр `_session_cookie_signature` (pre-auth/чужие домены игнорируются), реверификация при смене куки (stale → fresh, средний неизменённый тик не открывает вкладок), retry после transient `net::ERR_ABORTED`.
- Фокусно: `pytest tests/test_masters.py tests/test_playwright_session.py -n0` — 1025 passed.
- Полный офлайн-прогон: 3692 passed, 23 skipped. flake8/black чисты.

## Risks / follow-ups

- Сигнал готовности — имя/значение SSO-куки; если Яндекс переименует `Session_id`/`sessionid2`, ожидание уйдёт в таймаут (сообщение об ошибке при этом прежнее, с указанием перезапустить `direct masters login`). Верификация по-прежнему опирается на живой рендер грида, так что на корректность уже сохранённого входа это не влияет.
- Живая интерактивная проверка входа (реальный логин рукой) не выполнялась — сценарий требует человека; механика покрыта фейками на уровне вкладок/кук/навигаций.
