### PR TITLE
feat(masters): stream per-ID batch results as flushed JSONL (#866)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -788,6 +788,40 @@ Code review on #782/PR #784 found two edge cases in `delete_master`
 
 ### BREAKING CHANGES
 
+**`masters` batch commands stream JSONL instead of a pretty JSON array (#866).**
+
+`masters get|suspend|resume|launch|archive` with several campaign IDs used to
+buffer every per-ID outcome in memory and print a single pretty JSON array
+after the whole loop. A process killed mid-batch (a wrapper's subprocess
+timeout — the Yandex Direct MCP plugin runs these with a 180 s default — or
+OOM/crash) took every already-applied mutation's report with it: a caller of
+irreversible `launch`/`archive` had no way to learn which campaigns had
+already changed, and a blind retry re-applied live mutations. Transport-level
+sibling of #766/#816, which fixed the in-process cases.
+
+- With `--format json` (the default), each ID's outcome — the resulting row,
+  or its `{"CampaignId": ..., "Error": ...}` entry — is printed the moment it
+  is known, as one compact JSON object per line (JSONL), with an explicit
+  `flush()` after every record. stdout in a non-tty subprocess is
+  block-buffered, so without the per-record flush nothing would survive a
+  kill; on POSIX `subprocess.run` attaches the flushed partial stdout to
+  `TimeoutExpired`, so wrappers (and the plugin's
+  `CliTimeoutError.partial_stdout`) can now reconcile a partial batch without
+  any plugin-side change.
+- **Migration:** parse stdout line-by-line instead of as one JSON document
+  (`for line in stdout.splitlines(): json.loads(line)`). Single-ID output
+  remains a single JSON object (one line, still `json.loads`-able whole); a
+  zero-ID batch prints `[]`. An empty batch keeps `json.loads`-compatibility
+  for that case only.
+- `_with_session`'s stale-session self-heal re-runs the whole operation, so
+  IDs completed before the auth failure appear once per real attempt — every
+  line is a genuine outcome, and the trailing lines are the final attempt's.
+- `--output` gets the same per-record durability: the file is opened once and
+  each record is written+flushed into it as its ID completes (previously a
+  single pretty array written at the end).
+- Non-JSON formats (`text`/`table`/`csv`/`tsv`) are unchanged — consolidated
+  end-of-run output; they are human-readable reports, not machine streams.
+
 **`masters add` now requires `--add-target-action` (#777).**
 
 `masters add` previously could not create a campaign at all. Yandex's create

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -76,6 +76,7 @@ from ..browser.masters import DEVICE_OPTION_VALUES as _DEVICE_OPTION_VALUES
 from ..browser.masters import GENDER_CHOICES as _GENDER_CHOICES
 from ..browser.masters import PROMOTION_GOAL_CHOICES as _PROMOTION_GOAL_CHOICES
 from ..output import (
+    format_json,
     format_output,
     handle_api_errors,
     print_error,
@@ -350,9 +351,30 @@ def _run_per_id(
     errored. Each ID's outcome — the resulting row, or an ``Error`` entry —
     goes into the formatted output; if any ID failed, the command exits
     non-zero after printing every outcome, never just the last error.
+
+    For ``--format json`` (the default) each outcome is streamed the moment
+    it is known — one compact JSON object per line, ``flush()`` after every
+    record (issue #866). A killed process (a wrapper's subprocess timeout,
+    OOM, a crash) used to take every already-applied mutation's report with
+    it, leaving an irreversible batch (launch/archive) unreconcilable
+    without a blind retry re-applying live mutations. On POSIX,
+    ``subprocess.run`` attaches the stdout collected before a timeout kill
+    to ``TimeoutExpired``, so a flushed partial stream survives the kill —
+    but stdout in a non-tty subprocess is block-buffered, hence the explicit
+    per-record flush rather than relying on interpreter exit. An empty batch
+    still prints ``[]`` so ``json.loads`` keeps working on a zero-ID call.
+
+    Non-JSON formats keep the consolidated end-of-run output: they are
+    human-readable reports, not machine-consumed streams.
+
+    Note: ``_with_session``'s stale-session retry re-runs the whole
+    operation, so IDs completed before the auth failure appear twice — once
+    for each real attempt. Every line is still a genuine outcome.
     """
 
-    def _all(page):
+    stream_json = output_format == "json"
+
+    def _all(page, emit):
         from ..browser.session import BrowserAuthError, BrowserSessionError
         from ..browser.masters import PlaywrightError
 
@@ -360,7 +382,7 @@ def _run_per_id(
         errors = []
         for campaign_id in ids:
             try:
-                results.append(action(page, campaign_id))
+                row = action(page, campaign_id)
             except BrowserAuthError:
                 # A stale saved session must keep propagating to
                 # _with_session's whole-operation retry (issue #816
@@ -370,12 +392,43 @@ def _run_per_id(
                 raise
             except (BrowserSessionError, PlaywrightError) as exc:
                 errors.append((campaign_id, exc))
-                results.append({"CampaignId": campaign_id, "Error": str(exc)})
+                row = {"CampaignId": campaign_id, "Error": str(exc)}
+            results.append(row)
+            emit(row)
         return results, errors
 
-    results, errors = _with_session(ctx, headful, profile_dir, chrome_profile, _all)
+    if stream_json:
+        # --output gets the same per-record durability as stdout: the file
+        # is opened once up front and each record is written+flushed into it
+        # as soon as its ID completes (closed by `with sink_cm` below).
+        sink_cm = (
+            open(output, "w", encoding="utf-8")  # noqa: SIM115
+            if output
+            else contextlib.nullcontext(sys.stdout)
+        )
+    else:
+        sink_cm = contextlib.nullcontext(None)
 
-    format_output(results if len(results) != 1 else results[0], output_format, output)
+    with sink_cm as sink:
+
+        def emit(row):
+            if sink is None:
+                return
+            sink.write(format_json(row, indent=None))
+            sink.write("\n")
+            sink.flush()
+
+        results, errors = _with_session(
+            ctx, headful, profile_dir, chrome_profile, lambda page: _all(page, emit)
+        )
+
+    if stream_json:
+        if not results:  # empty batch: keep a parseable empty list
+            print(format_json([], indent=None), flush=True)
+    else:
+        format_output(
+            results if len(results) != 1 else results[0], output_format, output
+        )
 
     if errors:
         for campaign_id, exc in errors:

--- a/direct_cli/commands/masters.py
+++ b/direct_cli/commands/masters.py
@@ -370,6 +370,14 @@ def _run_per_id(
     Note: ``_with_session``'s stale-session retry re-runs the whole
     operation, so IDs completed before the auth failure appear twice — once
     for each real attempt. Every line is still a genuine outcome.
+
+    Note: the streamed JSON path does not go through ``format_output``, so
+    its ``raise_for_api_result_errors``/``warn_for_api_result_warnings``
+    pass no longer applies. That is a deliberate no-op here: those checks
+    look for Yandex API ``Errors``/``Warnings`` envelopes, and ``masters``
+    rows are UI-scraped report rows — per-ID failures are surfaced as
+    explicit ``Error`` entries in the stream itself, never as embedded API
+    error structures.
     """
 
     stream_json = output_format == "json"
@@ -422,10 +430,13 @@ def _run_per_id(
             ctx, headful, profile_dir, chrome_profile, lambda page: _all(page, emit)
         )
 
-    if stream_json:
-        if not results:  # empty batch: keep a parseable empty list
-            print(format_json([], indent=None), flush=True)
-    else:
+        if stream_json and not results:
+            # Empty batch: keep a parseable empty list, on the same stream
+            # the records would have gone to (the --output file if given,
+            # stdout otherwise) -- not always stdout.
+            emit([])
+
+    if not stream_json:
         format_output(
             results if len(results) != 1 else results[0], output_format, output
         )

--- a/direct_cli/output.py
+++ b/direct_cli/output.py
@@ -216,7 +216,7 @@ def _error_code(error: dict) -> Optional[int]:
     return None
 
 
-def format_json(data: Any, indent: int = 2) -> str:
+def format_json(data: Any, indent: Optional[int] = 2) -> str:
     """Format data as JSON"""
     return json.dumps(data, ensure_ascii=False, indent=indent, default=str)
 

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -4983,6 +4983,18 @@ class TestRunPerIdJsonlStreaming(unittest.TestCase):
 
         self.assertEqual(self.recorder.value, "[]\n")
 
+    def test_empty_batch_writes_the_empty_list_into_output_file(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "out.json"
+            self._run_per_id([], lambda page, campaign_id: {}, output=str(path))
+
+            # Same stream the records would have gone to: the file gets
+            # "[]", stdout gets nothing.
+            self.assertEqual(path.read_text(encoding="utf-8"), "[]\n")
+        self.assertEqual(self.recorder.value, "")
+
     def test_non_json_formats_keep_the_consolidated_output(self):
         def _suspend(page, campaign_id):
             return {"CampaignId": campaign_id, "Status": "SUSPENDED"}

--- a/tests/test_masters.py
+++ b/tests/test_masters.py
@@ -4879,6 +4879,124 @@ class TestMastersSuspendResumeCommand(unittest.TestCase):
         self.assertIn("Failed to resume 1 of 2 campaign(s)", result.output)
 
 
+class _RecordingSink:
+    """A minimal ``sys.stdout`` stand-in recording every write/flush call."""
+
+    def __init__(self):
+        self.chunks = []
+        self.flushes = 0
+
+    def write(self, text):
+        self.chunks.append(text)
+
+    def flush(self):
+        self.flushes += 1
+
+    @property
+    def value(self):
+        return "".join(self.chunks)
+
+
+class TestRunPerIdJsonlStreaming(unittest.TestCase):
+    """`--format json` batches stream one JSON object per line, flushed per
+    record (issue #866). All per-ID outcomes used to be printed only after
+    the whole loop, so a killed process (a wrapper's subprocess timeout,
+    OOM) left no trace of which irreversible mutations (launch/archive) had
+    already applied.
+    """
+
+    def _run_per_id(self, ids, action, *, output_format="json", output=None):
+        from direct_cli.commands import masters as masters_commands
+
+        with (
+            patch("direct_cli.commands.masters._with_session") as mock_with_session,
+            patch("direct_cli.commands.masters.sys.stdout", self.recorder),
+        ):
+            mock_with_session.side_effect = lambda ctx, hf, pd, cp, op: op(object())
+            return masters_commands._run_per_id(
+                ctx=None,
+                ids=ids,
+                action=action,
+                headful=False,
+                profile_dir=None,
+                chrome_profile="Default",
+                output_format=output_format,
+                output=output,
+                verb="suspend",
+            )
+
+    def setUp(self):
+        self.recorder = _RecordingSink()
+
+    def test_streams_each_record_before_the_next_id_starts(self):
+        snapshots = []
+
+        def _suspend(page, campaign_id):
+            # Snapshot what a killed process would already have seen.
+            snapshots.append(self.recorder.value)
+            return {"CampaignId": campaign_id, "Status": "SUSPENDED"}
+
+        self._run_per_id([1, 2, 3], _suspend)
+
+        # Before ID 2 was attempted, ID 1's outcome was already on the
+        # stream; before ID 3, ID 2's too.
+        self.assertEqual(snapshots[0], "")
+        self.assertIn('"CampaignId": 1', snapshots[1])
+        self.assertNotIn('"CampaignId": 2', snapshots[1])
+        self.assertIn('"CampaignId": 2', snapshots[2])
+        self.assertNotIn('"CampaignId": 3', snapshots[2])
+        # One explicit flush per record: stdout in a non-tty subprocess is
+        # block-buffered, so without it nothing survives the kill.
+        self.assertEqual(self.recorder.flushes, 3)
+        # The final stream is JSONL: every line parses on its own.
+        lines = self.recorder.value.splitlines()
+        self.assertEqual([json.loads(line)["CampaignId"] for line in lines], [1, 2, 3])
+
+    def test_error_rows_stream_as_soon_as_their_id_fails(self):
+        def _suspend(page, campaign_id):
+            if campaign_id == 2:
+                raise BrowserSessionError("boom for 2")
+            return {"CampaignId": campaign_id, "Status": "SUSPENDED"}
+
+        with self.assertRaises(click.ClickException):
+            self._run_per_id([1, 2, 3], _suspend)
+
+        lines = [json.loads(line) for line in self.recorder.value.splitlines()]
+        self.assertEqual(lines[1], {"CampaignId": 2, "Error": "boom for 2"})
+        self.assertEqual(self.recorder.flushes, 3)
+
+    def test_output_file_receives_one_json_object_per_line(self):
+        import tempfile
+
+        def _suspend(page, campaign_id):
+            return {"CampaignId": campaign_id, "Status": "SUSPENDED"}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "out.json"
+            self._run_per_id([1, 2], _suspend, output=str(path))
+
+            lines = path.read_text(encoding="utf-8").splitlines()
+        self.assertEqual([json.loads(line)["CampaignId"] for line in lines], [1, 2])
+
+    def test_empty_batch_still_prints_a_parseable_empty_list(self):
+        self._run_per_id([], lambda page, campaign_id: {})
+
+        self.assertEqual(self.recorder.value, "[]\n")
+
+    def test_non_json_formats_keep_the_consolidated_output(self):
+        def _suspend(page, campaign_id):
+            return {"CampaignId": campaign_id, "Status": "SUSPENDED"}
+
+        self._run_per_id([1, 2], _suspend, output_format="text")
+
+        # Human formats print once at the end, not per record.
+        self.assertEqual(self.recorder.flushes, 0)
+        self.assertEqual(
+            self.recorder.value,
+            "CampaignId: 1\nStatus: SUSPENDED\n\nCampaignId: 2\nStatus: SUSPENDED\n",
+        )
+
+
 class _FakeHydratingPopupHandle(_FakeLocatorHandle):
     """A popup handle whose ``wait_for`` only succeeds after N total clicks
     of the trigger have happened — models issues #723/#725's hydration race,
@@ -22415,6 +22533,17 @@ class TestImageStatusContentIdJsAgainstRealDom(unittest.TestCase):
         self.assertIsNone(self._evaluate(html))
 
 
+def _jsonl_rows(output):
+    """Parse a batch command's streamed JSONL stdout (issue #866).
+
+    Batch `masters` commands print one JSON object per line as each ID
+    completes; with click's mixed stderr the stream can share the captured
+    output with human-readable error text, so only ``{``-prefixed lines are
+    records.
+    """
+    return [json.loads(line) for line in output.splitlines() if line.startswith("{")]
+
+
 class TestMastersGetModerationStatusesFlag(unittest.TestCase):
     """``masters get --moderation-statuses`` — issue #814's CLI surface."""
 
@@ -22494,7 +22623,7 @@ class TestMastersGetModerationStatusesFlag(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertEqual(mock_moderation.call_count, 2)
-        payload = json.loads(result.output)
+        payload = _jsonl_rows(result.output)
         self.assertEqual([row["CampaignId"] for row in payload], [42, 43])
         self.assertTrue(all("RejectedCount" in row for row in payload))
 
@@ -22570,7 +22699,7 @@ class TestMastersGetTrackingParamsFlag(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertEqual(mock_tracking.call_count, 2)
-        payload = json.loads(result.output)
+        payload = _jsonl_rows(result.output)
         self.assertEqual([row["CampaignId"] for row in payload], [42, 43])
         self.assertTrue(all("TrackingParams" in row for row in payload))
 
@@ -22621,9 +22750,7 @@ class TestMastersGetPerCampaignFailureIsolation(unittest.TestCase):
             result = self._invoke(["masters", "get", "1,2,3"])
 
         self.assertEqual(result.exit_code, 2)
-        json_start = result.output.index("[\n")
-        json_end = result.output.rindex("]") + 1
-        payload = json.loads(result.output[json_start:json_end])
+        payload = _jsonl_rows(result.output)
         self.assertEqual([row["CampaignId"] for row in payload], [1, 2, 3])
         self.assertNotIn("Error", payload[0])
         self.assertIn("overview timeout", payload[1]["Error"])
@@ -22638,7 +22765,7 @@ class TestMastersGetPerCampaignFailureIsolation(unittest.TestCase):
             result = self._invoke(["masters", "get", "1,2"])
 
         self.assertEqual(result.exit_code, 1)
-        payload = json.loads(result.output[result.output.index("[\n") :])
+        payload = _jsonl_rows(result.output)
         self.assertEqual([row["CampaignId"] for row in payload], [1, 2])
         self.assertTrue(all("Error" in row for row in payload))
 
@@ -22679,8 +22806,12 @@ class TestMastersGetPerCampaignFailureIsolation(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertTrue(auth_error_raised["done"])
-        payload = json.loads(result.output)
-        self.assertEqual([row["CampaignId"] for row in payload], [1, 2, 3])
+        # Issue #866: records stream per attempt, so ID 1's record from the
+        # aborted first attempt is followed by the retry's full pass — every
+        # line is a real outcome of a real attempt (see _run_per_id's
+        # docstring). The last three lines are the successful retry's [1,2,3].
+        payload = _jsonl_rows(result.output)
+        self.assertEqual([row["CampaignId"] for row in payload], [1, 1, 2, 3])
         for row in payload:
             self.assertNotIn("Error", row)
 


### PR DESCRIPTION
Closes #866

## Problem

`direct masters get|suspend|resume|launch|archive` with several campaign IDs buffered every per-ID outcome in memory and printed one pretty JSON array after the whole loop (`_run_per_id`). A process killed mid-batch — a wrapper's subprocess timeout (the Yandex Direct MCP plugin runs these commands with a 180 s default), OOM, a crash — left **no** per-ID outcome in stdout: a caller of irreversible `launch`/`archive` could not learn which campaigns had already changed, and a blind retry re-applied live mutations.

Transport-level continuation of #766/#816, which fixed the in-process cases (fail-fast abort, batch loss on a read failure); the killed-process case still lost everything.

## Change

With `--format json` (the default), each ID's outcome — the resulting row, or its `{"CampaignId": ..., "Error": ...}` entry — is now printed the moment it is known, as one compact JSON object per line (JSONL), with an explicit `flush()` after every record:

- stdout in a non-tty subprocess is block-buffered, so without the per-record flush nothing would survive a kill. On POSIX, `subprocess.run` attaches the flushed partial stdout to `TimeoutExpired`, so wrappers — and the plugin's `CliTimeoutError.partial_stdout` (axisrow/yandex-direct-mcp-plugin#309) — can reconcile a partial batch without any plugin-side change.
- `--output` gets the same per-record durability: the file is opened once and each record is written+flushed as its ID completes.
- A zero-ID batch still prints `[]`.
- Non-JSON formats (`text`/`table`/`csv`/`tsv`) keep the consolidated end-of-run output — they are human-readable reports, not machine streams.
- `_with_session`'s stale-session self-heal re-runs the whole operation, so IDs completed before the auth failure appear once per real attempt; every line is a genuine outcome (documented in `_run_per_id`'s docstring).

**Breaking:** multi-ID `--format json` stdout is now JSONL, not one pretty array. Migration: parse line-by-line (`for line in stdout.splitlines(): json.loads(line)`). Single-ID output is still a single `json.loads`-able object. Documented under BREAKING CHANGES.

## Tests

- New `TestRunPerIdJsonlStreaming` (5 tests): each record is written+flushed before the next ID starts (snapshot inside the action), error rows stream when their ID fails, `--output` receives one JSON object per line, empty batch prints `[]`, non-JSON formats keep consolidated output.
- Updated the 5 tests that parsed batch stdout as one JSON document (`get --moderation-statuses`/`--tracking-params` multi-ID, failure isolation, auth-retry retry) to the JSONL contract; the auth-retry test now asserts the per-attempt record sequence `[1, 1, 2, 3]`.
- End-to-end kill check (manual): a subprocess streaming 3 records and hard-exiting via `os._exit` mid-batch leaves records 1–2 readable in the captured stdout.
- `pytest`: 3707 passed, 23 skipped (full offline suite); `black`/`flake8` clean.

## Known risks

- Consumers doing `json.loads(stdout)` on a multi-ID batch must switch to line-by-line parsing (breaking, documented).
- `format_json`'s `indent` parameter is widened to `Optional[int]` (json.dumps already accepted `None`) — additive, no behavior change for existing callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)